### PR TITLE
Extend tool support for queries

### DIFF
--- a/examples/tool.c
+++ b/examples/tool.c
@@ -37,16 +37,28 @@ static void cbfunc(pmix_status_t status,
                    pmix_release_cbfunc_t release_fn,
                    void *release_cbdata)
 {
-    myquery_data_t *mydata = (myquery_data_t*)cbdata;
+    myquery_data_t *mq = (myquery_data_t*)cbdata;
+    size_t n;
 
-    /* do something with the returned info - it will be
+    mq->lock.status = status;
+
+    /* save the returned info - it will be
      * released in the release_fn */
-    fprintf(stderr, "Query returned %s\n", PMIx_Error_string(status));
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(mq->info, ninfo);
+        mq->ninfo = ninfo;
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&mq->info[n], &info[n]);
+        }
+    }
 
+    /* let the library release the data */
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
-    DEBUG_WAKEUP_THREAD(&mydata->lock);
+
+    /* release the block */
+    DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
 int main(int argc, char **argv)
@@ -54,40 +66,117 @@ int main(int argc, char **argv)
     pmix_status_t rc;
     pmix_proc_t myproc;
     pmix_query_t *query;
-    size_t nq;
+    size_t nq, ninfo = 0, n, m, p;
     myquery_data_t mydata;
-    pmix_info_t info;
+    pmix_info_t *info = NULL, *iptr;
+    char *server_uri = NULL;
+    char *nspace = NULL;
+    char **actives = NULL;
+    pmix_data_array_t *darray, *dptr;
 
-    if (argc != 2) {
-        fprintf(stderr, "Must provide server URI as argument\n");
-        exit(1);
+    for (n=1; n < argc; n++) {
+        if (0 == strcmp("-u", argv[n]) || 0 == strcmp("--url", argv[n])) {
+            if (NULL == argv[n+1]) {
+                fprintf(stderr, "Must provide URI argument to %s option\n", argv[n]);
+                exit(1);
+            }
+            server_uri = argv[n+1];
+        } else if (0 == strcmp("-nspace", argv[n]) || 0 == strcmp("--nspace", argv[n])) {
+            if (NULL == argv[n+1]) {
+                fprintf(stderr, "Must provide nspace argument to %s option\n", argv[n]);
+                exit(1);
+            }
+            nspace = argv[n+1];
+        }
     }
 
-    PMIX_INFO_LOAD(&info, PMIX_SERVER_URI, argv[1], PMIX_STRING);
-    fprintf(stderr, "Connecting to %s\n", argv[1]);
+    if (NULL != server_uri) {
+        ninfo = 1;
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, server_uri, PMIX_STRING);
+        fprintf(stderr, "Connecting to %s\n", server_uri);
+    }
 
     /* init us */
-    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, &info, 1))) {
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
         fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
         exit(rc);
     }
-    fprintf(stderr, "Connected\n");
-
-    /* query something */
-    nq = 2;
-    PMIX_QUERY_CREATE(query, nq);
-    query[0].keys = (char**)malloc(2 * sizeof(char*));
-    query[0].keys[0] = strdup("foobar");
-    query[0].keys[1] = NULL;
-    query[1].keys = (char**)malloc(2 * sizeof(char*));
-    query[1].keys[0] = strdup("spastic");
-    query[1].keys[1] = NULL;
-    DEBUG_CONSTRUCT_MYQUERY(&mydata);
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&mydata))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
-        goto done;
+    if (NULL != info) {
+        PMIX_INFO_FREE(info, ninfo);
     }
-    DEBUG_WAIT_THREAD(&mydata.lock);
+
+    if (NULL == nspace) {
+        /* query the list of active nspaces */
+        nq = 1;
+        PMIX_QUERY_CREATE(query, nq);
+        PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACE_INFO);
+        DEBUG_CONSTRUCT_MYQUERY(&mydata);
+        if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&mydata))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        DEBUG_WAIT_THREAD(&mydata.lock);
+        /* find the response */
+        if (PMIX_SUCCESS == mydata.lock.status) {
+            /* should be in the first key */
+            if (PMIX_CHECK_KEY(&mydata.info[0], PMIX_QUERY_NAMESPACE_INFO)) {
+                darray = mydata.info[0].value.data.darray;
+                fprintf(stderr, "ACTIVE NSPACES:\n");
+                if (NULL == darray || 0 == darray->size || NULL == darray->array) {
+                    fprintf(stderr, "\tNone\n");
+                } else {
+                    info = (pmix_info_t*)darray->array;
+                    if (NULL == info) {
+                        fprintf(stderr, "Error\n");
+                    } else {
+                        for (n=0; n < darray->size; n++) {
+                            dptr = info[n].value.data.darray;
+                            if (NULL == dptr || 0 == dptr->size || NULL == dptr->array) {
+                                fprintf(stderr, "Error in array %s\n", (NULL == dptr) ? "NULL" : "NON-NULL");
+                                break;
+                            }
+                            iptr = (pmix_info_t*)dptr->array;
+                            for (m=0; m < darray->size; m++) {
+                                fprintf(stderr, "\t%s", iptr[m].value.data.string);
+                            }
+                            fprintf(stderr, "\n");
+                        }
+                    }
+                }
+            } else {
+                fprintf(stderr, "Query returned wrong info key at first posn: %s\n", mydata.info[0].key);
+            }
+        } else {
+            fprintf(stderr, "Query returned error: %s\n", PMIx_Error_string(mydata.lock.status));
+        }
+        DEBUG_DESTRUCT_MYQUERY(&mydata);
+    } else {
+        nq = 1;
+        PMIX_QUERY_CREATE(query, nq);
+        PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_JOB_SIZE);
+        PMIX_INFO_CREATE(query[0].qualifiers, 1);
+        query[0].nqual = 1;
+        PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_NSPACE, nspace, PMIX_STRING);
+        DEBUG_CONSTRUCT_MYQUERY(&mydata);
+        if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&mydata))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        DEBUG_WAIT_THREAD(&mydata.lock);
+        /* find the response */
+        if (PMIX_SUCCESS == mydata.lock.status) {
+            /* should be in the first key */
+            if (PMIX_CHECK_KEY(&mydata.info[0], PMIX_JOB_SIZE)) {
+                fprintf(stderr, "JOB SIZE FOR NSPACE %s: %lu\n", nspace, (unsigned long)mydata.info[0].value.data.uint32);
+            } else {
+                fprintf(stderr, "Query returned wrong info key at first posn: %s\n", mydata.info[0].key);
+            }
+        } else {
+            fprintf(stderr, "Query returned error: %s\n", PMIx_Error_string(mydata.lock.status));
+        }
+        DEBUG_DESTRUCT_MYQUERY(&mydata);
+    }
 
  done:
     /* finalize us */

--- a/orte/orted/pmix/Makefile.am
+++ b/orte/orted/pmix/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -18,4 +18,5 @@ lib@ORTE_LIB_PREFIX@open_rte_la_SOURCES += \
           orted/pmix/pmix_server_register_fns.c \
           orted/pmix/pmix_server_dyn.c \
           orted/pmix/pmix_server_pub.c \
-          orted/pmix/pmix_server_gen.c
+          orted/pmix/pmix_server_gen.c \
+          orted/pmix/pmix_server_queries.c

--- a/orte/orted/pmix/pmix_server.c
+++ b/orte/orted/pmix/pmix_server.c
@@ -853,6 +853,7 @@ static void rqcon(pmix_server_req_t *p)
 {
     p->operation = NULL;
     p->flag = true;
+    p->launcher = false;
     p->uid = 0;
     p->gid = 0;
     p->pid = 0;

--- a/orte/orted/pmix/pmix_server_internal.h
+++ b/orte/orted/pmix/pmix_server_internal.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
@@ -68,11 +68,13 @@ BEGIN_C_DECLS
     opal_object_t super;
     opal_event_t ev;
     char *operation;
+    char *cmdline;
     int status;
     int timeout;
     int room_num;
     int remote_room_num;
     bool flag;
+    bool launcher;
     uid_t uid;
     gid_t gid;
     pid_t pid;

--- a/orte/orted/pmix/pmix_server_queries.c
+++ b/orte/orted/pmix/pmix_server_queries.c
@@ -1,0 +1,520 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "orte_config.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include "opal/util/argv.h"
+#include "opal/util/output.h"
+#include "opal/dss/dss.h"
+#include "opal/hwloc/hwloc-internal.h"
+#include "opal/mca/pstat/pstat.h"
+
+#include "orte/mca/errmgr/errmgr.h"
+#include "orte/mca/iof/iof.h"
+#include "orte/mca/rmaps/rmaps_types.h"
+#include "orte/mca/schizo/schizo.h"
+#include "orte/mca/state/state.h"
+#include "orte/util/name_fns.h"
+#include "orte/util/show_help.h"
+#include "orte/util/threads.h"
+#include "orte/runtime/orte_globals.h"
+#include "orte/mca/rml/rml.h"
+#include "orte/mca/plm/plm.h"
+#include "orte/mca/plm/base/plm_private.h"
+
+#include "pmix_server_internal.h"
+
+static void qrel(void *cbdata)
+{
+    orte_pmix_server_op_caddy_t *cd = (orte_pmix_server_op_caddy_t*)cbdata;
+    if (NULL != cd->info) {
+        PMIX_INFO_FREE(cd->info, cd->ninfo);
+    }
+    OBJ_RELEASE(cd);
+}
+
+static void _query(int sd, short args, void *cbdata)
+{
+    orte_pmix_server_op_caddy_t *cd = (orte_pmix_server_op_caddy_t*)cbdata;
+    orte_pmix_server_op_caddy_t *rcd;
+    pmix_query_t *q;
+    pmix_status_t ret = PMIX_SUCCESS;
+    opal_info_item_t *kv;
+    orte_jobid_t jobid;
+    orte_job_t *jdata;
+    int rc;
+    opal_list_t results, stack;
+    size_t m, n, p;
+    uint32_t key;
+    void *nptr;
+    char nspace[PMIX_MAX_NSLEN+1], *cmdline, **nspaces;
+    char **ans, *tmp;
+    orte_process_name_t requestor;
+    orte_app_context_t *app;
+#if OPAL_PMIX_VERSION >= 3
+    opal_pstats_t pstat;
+    float pss;
+    bool local_only;
+    orte_namelist_t *nm;
+    opal_list_t targets;
+    int i, k, num_replies;
+    orte_proc_t *proct;
+    pmix_proc_info_t *procinfo;
+    pmix_info_t *info;
+    pmix_data_array_t *darray;
+#endif
+#if OPAL_PMIX_VERSION >= 4
+    size_t sz;
+#endif
+
+    ORTE_ACQUIRE_OBJECT(cd);
+
+    opal_output_verbose(2, orte_pmix_server_globals.output,
+                        "%s processing query",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    OBJ_CONSTRUCT(&results, opal_list_t);
+
+    OPAL_PMIX_CONVERT_PROCT(rc, &requestor, cd->procs);
+    if (OPAL_SUCCESS != rc) {
+        ORTE_ERROR_LOG(rc);
+    }
+
+    /* see what they wanted */
+    for (m=0; m < cd->nqueries; m++) {
+        q = &cd->queries[m];
+        /* default to the requestor's jobid */
+        jobid = requestor.jobid;
+        /* see if they provided any qualifiers */
+        if (NULL != q->qualifiers && 0 < q->nqual) {
+            for (n=0; n < q->nqual; n++) {
+                if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_NSPACE)) {
+                    OPAL_PMIX_CONVERT_NSPACE(rc, &jobid, q->qualifiers[n].value.data.string);
+                    if (ORTE_JOBID_INVALID == jobid) {
+                        rc = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
+                }
+            }
+        }
+        for (n=0; NULL != q->keys[n]; n++) {
+            opal_output_verbose(2, orte_pmix_server_globals.output,
+                                "%s processing key %s",
+                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), q->keys[n]);
+            if (0 == strcmp(q->keys[n], PMIX_QUERY_NAMESPACES)) {
+                /* get the current jobids */
+                nspaces = NULL;
+                OBJ_CONSTRUCT(&stack, opal_list_t);
+                rc = opal_hash_table_get_first_key_uint32(orte_job_data, &key, (void **)&jdata, &nptr);
+                while (OPAL_SUCCESS == rc) {
+                    /* don't show the requestor's job or non-launcher tools */
+                    if (ORTE_PROC_MY_NAME->jobid != jdata->jobid &&
+                        (!ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_TOOL) || ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_LAUNCHER))) {
+                        memset(nspace, 0, PMIX_MAX_NSLEN);
+                        OPAL_PMIX_CONVERT_JOBID(nspace, jdata->jobid);
+                        opal_argv_append_nosize(&nspaces, nspace);
+                    }
+                    rc = opal_hash_table_get_next_key_uint32(orte_job_data, &key, (void **)&jdata, nptr, &nptr);
+                }
+                /* join the results into a single comma-delimited string */
+                kv = OBJ_NEW(opal_info_item_t);
+                tmp = opal_argv_join(nspaces, ',');
+                opal_argv_free(nspaces);
+                PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_NAMESPACES, tmp, PMIX_STRING);
+                free(tmp);
+                opal_list_append(&results, &kv->super);
+#if OPAL_PMIX_VERSION >= 4
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_NAMESPACE_INFO)) {
+                /* get the current jobids */
+                OBJ_CONSTRUCT(&stack, opal_list_t);
+                rc = opal_hash_table_get_first_key_uint32(orte_job_data, &key, (void **)&jdata, &nptr);
+                while (OPAL_SUCCESS == rc) {
+                    /* don't show the requestor's job or non-launcher tools */
+                    if (ORTE_PROC_MY_NAME->jobid != jdata->jobid &&
+                        (!ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_TOOL) || ORTE_FLAG_TEST(jdata, ORTE_JOB_FLAG_LAUNCHER))) {
+                        kv = OBJ_NEW(opal_info_item_t);
+                        (void)strncpy(kv->info.key, PMIX_QUERY_NAMESPACE_INFO, PMIX_MAX_KEYLEN);
+                        opal_list_append(&stack, &kv->super);
+                        /* create the array to hold the nspace and the cmd */
+                        PMIX_DATA_ARRAY_CREATE(darray, 2, PMIX_INFO);
+                        kv->info.value.type = PMIX_DATA_ARRAY;
+                        kv->info.value.data.darray = darray;
+                        PMIX_INFO_CREATE(info, 2);
+                        darray->array = info;
+                        /* add the nspace name */
+                        memset(nspace, 0, PMIX_MAX_NSLEN);
+                        OPAL_PMIX_CONVERT_JOBID(nspace, jdata->jobid);
+                        PMIX_INFO_LOAD(&info[0], PMIX_NSPACE, nspace, PMIX_STRING);
+                        /* add the cmd line */
+                        app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, 0);
+                        cmdline = opal_argv_join(app->argv, ' ');
+                        PMIX_INFO_LOAD(&info[1], PMIX_CMD_LINE, cmdline, PMIX_STRING);
+                        free(cmdline);
+                    }
+                    rc = opal_hash_table_get_next_key_uint32(orte_job_data, &key, (void **)&jdata, nptr, &nptr);
+                }
+                kv = OBJ_NEW(opal_info_item_t);
+                (void)strncpy(kv->info.key, PMIX_QUERY_NAMESPACE_INFO, PMIX_MAX_KEYLEN);
+                kv->info.value.type = PMIX_DATA_ARRAY;
+                m = opal_list_get_size(&stack);
+                PMIX_DATA_ARRAY_CREATE(darray, m, PMIX_INFO);
+                kv->info.value.data.darray = darray;
+                opal_list_append(&results, &kv->super);
+                /* join the results into an array */
+                if (0 < m) {
+                    PMIX_INFO_CREATE(info, m);
+                    darray->array = info;
+                    p=0;
+                    while (NULL != (kv = (opal_info_item_t*)opal_list_remove_first(&stack))) {
+                        PMIX_INFO_XFER(&info[p], &kv->info);
+                        OBJ_RELEASE(kv);
+                        ++p;
+                    }
+                }
+                OPAL_LIST_DESTRUCT(&stack);
+#endif
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_SPAWN_SUPPORT)) {
+                ans = NULL;
+                opal_argv_append_nosize(&ans, PMIX_HOST);
+                opal_argv_append_nosize(&ans, PMIX_HOSTFILE);
+                opal_argv_append_nosize(&ans, PMIX_ADD_HOST);
+                opal_argv_append_nosize(&ans, PMIX_ADD_HOSTFILE);
+                opal_argv_append_nosize(&ans, PMIX_PREFIX);
+                opal_argv_append_nosize(&ans, PMIX_WDIR);
+                opal_argv_append_nosize(&ans, PMIX_MAPPER);
+                opal_argv_append_nosize(&ans, PMIX_PPR);
+                opal_argv_append_nosize(&ans, PMIX_MAPBY);
+                opal_argv_append_nosize(&ans, PMIX_RANKBY);
+                opal_argv_append_nosize(&ans, PMIX_BINDTO);
+                opal_argv_append_nosize(&ans, PMIX_COSPAWN_APP);
+                /* create the return kv */
+                kv = OBJ_NEW(opal_info_item_t);
+                tmp = opal_argv_join(ans, ',');
+                opal_argv_free(ans);
+                PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_SPAWN_SUPPORT, tmp, PMIX_STRING);
+                free(tmp);
+                opal_list_append(&results, &kv->super);
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_DEBUG_SUPPORT)) {
+                ans = NULL;
+                opal_argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_INIT);
+                opal_argv_append_nosize(&ans, PMIX_DEBUG_JOB);
+                opal_argv_append_nosize(&ans, PMIX_DEBUG_WAIT_FOR_NOTIFY);
+                /* create the return kv */
+                kv = OBJ_NEW(opal_info_item_t);
+                tmp = opal_argv_join(ans, ',');
+                opal_argv_free(ans);
+                PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_DEBUG_SUPPORT, tmp, PMIX_STRING);
+                free(tmp);
+                opal_list_append(&results, &kv->super);
+#if PMIX_VERSION_MAJOR >= 3
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_MEMORY_USAGE)) {
+                OBJ_CONSTRUCT(&targets, opal_list_t);
+                /* scan the qualifiers */
+                local_only = false;
+                for (k=0; k < (int)q->nqual; k++) {
+                    if (0 == strncmp(q->qualifiers[k].key, PMIX_QUERY_LOCAL_ONLY, PMIX_MAX_KEYLEN)) {
+                        local_only = PMIX_INFO_TRUE(&q->qualifiers[k]);
+                    } else if (0 == strncmp(q->qualifiers[k].key, PMIX_PROCID, PMIX_MAX_KEYLEN)) {
+                        /* save this directive on our list of targets */
+                        nm = OBJ_NEW(orte_namelist_t);
+                        OPAL_PMIX_CONVERT_PROCT(rc, &nm->name, q->qualifiers[n].value.data.proc);
+                        if (OPAL_SUCCESS != rc) {
+                            ORTE_ERROR_LOG(rc);
+                        }
+                        opal_list_append(&targets, &nm->super);
+                    }
+                }
+                /* if they have asked for only our local procs or daemon,
+                 * then we can just get the data directly */
+                if (local_only) {
+                    if (0 == opal_list_get_size(&targets)) {
+                        kv = OBJ_NEW(opal_info_item_t);
+                        (void)strncpy(kv->info.key, PMIX_QUERY_PROC_TABLE, PMIX_MAX_KEYLEN);
+                        opal_list_append(&results, &kv->super);
+                        /* create an entry for myself plus the avg of all local procs */
+                        PMIX_DATA_ARRAY_CREATE(darray, 2, PMIX_INFO);
+                        kv->info.value.type = PMIX_DATA_ARRAY;
+                        kv->info.value.data.darray = darray;
+                        PMIX_INFO_CREATE(info, 2);
+                        darray->array = info;
+                        /* collect my memory usage */
+                        OBJ_CONSTRUCT(&pstat, opal_pstats_t);
+                        opal_pstat.query(orte_process_info.pid, &pstat, NULL);
+                        PMIX_INFO_LOAD(&info[0], PMIX_DAEMON_MEMORY, &pstat.pss, PMIX_FLOAT);
+                        OBJ_DESTRUCT(&pstat);
+                        /* collect the memory usage of all my children */
+                        pss = 0.0;
+                        num_replies = 0;
+                        for (i=0; i < orte_local_children->size; i++) {
+                            if (NULL != (proct = (orte_proc_t*)opal_pointer_array_get_item(orte_local_children, i)) &&
+                                ORTE_FLAG_TEST(proct, ORTE_PROC_FLAG_ALIVE)) {
+                                /* collect the stats on this proc */
+                                OBJ_CONSTRUCT(&pstat, opal_pstats_t);
+                                if (OPAL_SUCCESS == opal_pstat.query(proct->pid, &pstat, NULL)) {
+                                    pss += pstat.pss;
+                                    ++num_replies;
+                                }
+                                OBJ_DESTRUCT(&pstat);
+                            }
+                        }
+                        /* compute the average value */
+                        if (0 < num_replies) {
+                            pss /= (float)num_replies;
+                        }
+                        PMIX_INFO_LOAD(&info[1], PMIX_CLIENT_AVG_MEMORY, &pss, PMIX_FLOAT);
+                    }
+                }
+#endif
+            } else if (0 == strcmp(q->keys[n], PMIX_TIME_REMAINING)) {
+                if (ORTE_SUCCESS == orte_schizo.get_remaining_time(&key)) {
+                    kv = OBJ_NEW(opal_info_item_t);
+                    PMIX_INFO_LOAD(&kv->info, PMIX_TIME_REMAINING, &key, PMIX_UINT32);
+                    opal_list_append(&results, &kv->super);
+                }
+            } else if (0 == strcmp(q->keys[n], PMIX_HWLOC_XML_V1)) {
+                if (NULL != opal_hwloc_topology) {
+                    char *xmlbuffer=NULL;
+                    int len;
+                    kv = OBJ_NEW(opal_info_item_t);
+            #if HWLOC_API_VERSION < 0x20000
+                    /* get this from the v1.x API */
+                    if (0 != hwloc_topology_export_xmlbuffer(opal_hwloc_topology, &xmlbuffer, &len)) {
+                        OBJ_RELEASE(kv);
+                        continue;
+                    }
+            #else
+                    /* get it from the v2 API */
+                    if (0 != hwloc_topology_export_xmlbuffer(opal_hwloc_topology, &xmlbuffer, &len,
+                                                             HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
+                        OBJ_RELEASE(kv);
+                        continue;
+                    }
+            #endif
+                    PMIX_INFO_LOAD(&kv->info, PMIX_HWLOC_XML_V1, xmlbuffer, PMIX_STRING);
+                    free(xmlbuffer);
+                    opal_list_append(&results, &kv->super);
+                }
+            } else if (0 == strcmp(q->keys[n], PMIX_HWLOC_XML_V2)) {
+                /* we cannot provide it if we are using v1.x */
+            #if HWLOC_API_VERSION >= 0x20000
+                if (NULL != opal_hwloc_topology) {
+                    char *xmlbuffer=NULL;
+                    int len;
+                    kv = OBJ_NEW(opal_info_item_t);
+                    if (0 != hwloc_topology_export_xmlbuffer(opal_hwloc_topology, &xmlbuffer, &len, 0)) {
+                        OBJ_RELEASE(kv);
+                        continue;
+                    }
+                    PMIX_INFO_LOAD(&kv->info, PMIX_HWLOC_XML_V2, xmlbuffer, PMIX_STRING);
+                    free(xmlbuffer);
+                    opal_list_append(&results, &kv->super);
+                }
+            #endif
+            } else if (0 == strcmp(q->keys[n], PMIX_PROC_URI)) {
+                /* they want our URI */
+                kv = OBJ_NEW(opal_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_PROC_URI, orte_process_info.my_hnp_uri, PMIX_STRING);
+                opal_list_append(&results, &kv->super);
+            } else if (0 == strcmp(q->keys[n], PMIX_SERVER_URI)) {
+                /* they want our PMIx URI */
+                kv = OBJ_NEW(opal_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_SERVER_URI, orte_process_info.my_hnp_uri, PMIX_STRING);
+                opal_list_append(&results, &kv->super);
+    #if PMIX_VERSION_MAJOR >= 3
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_PROC_TABLE)) {
+                /* construct a list of values with opal_proc_info_t
+                 * entries for each proc in the indicated job */
+                jdata = orte_get_job_data_object(jobid);
+                if (NULL == jdata) {
+                    ret = PMIX_ERR_NOT_FOUND;
+                    goto done;
+                }
+                /* setup the reply */
+                kv = OBJ_NEW(opal_info_item_t);
+                (void)strncpy(kv->info.key, PMIX_QUERY_PROC_TABLE, PMIX_MAX_KEYLEN);
+                opal_list_append(&results, &kv->super);
+                 /* cycle thru the job and create an entry for each proc */
+                PMIX_DATA_ARRAY_CREATE(darray, jdata->num_procs, PMIX_PROC_INFO);
+                kv->info.value.type = PMIX_DATA_ARRAY;
+                kv->info.value.data.darray = darray;
+                PMIX_PROC_INFO_CREATE(procinfo, jdata->num_local_procs);
+                darray->array = procinfo;
+                p = 0;
+                for (k=0; k < jdata->procs->size; k++) {
+                    if (NULL == (proct = (orte_proc_t*)opal_pointer_array_get_item(jdata->procs, k))) {
+                        continue;
+                    }
+                    OPAL_PMIX_CONVERT_NAME(&procinfo[p].proc, &proct->name);
+                    if (NULL != proct->node && NULL != proct->node->name) {
+                        procinfo[p].hostname = strdup(proct->node->name);
+                    }
+                    app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, proct->app_idx);
+                    if (NULL != app && NULL != app->app) {
+                        procinfo[p].executable_name = strdup(app->app);
+                    }
+                    procinfo[p].pid = proct->pid;
+                    procinfo[p].exit_code = proct->exit_code;
+                    procinfo[p].state = opal_pmix_convert_state(proct->state);
+                    ++p;
+                }
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_LOCAL_PROC_TABLE)) {
+                /* construct a list of values with opal_proc_info_t
+                 * entries for each LOCAL proc in the indicated job */
+                jdata = orte_get_job_data_object(jobid);
+                if (NULL == jdata) {
+                    rc = ORTE_ERR_NOT_FOUND;
+                    goto done;
+                }
+                /* setup the reply */
+                kv = OBJ_NEW(opal_info_item_t);
+                (void)strncpy(kv->info.key, PMIX_QUERY_LOCAL_PROC_TABLE, PMIX_MAX_KEYLEN);
+                opal_list_append(&results, &kv->super);
+                /* cycle thru the job and create an entry for each proc */
+                PMIX_DATA_ARRAY_CREATE(darray, jdata->num_local_procs, PMIX_PROC_INFO);
+                kv->info.value.type = PMIX_DATA_ARRAY;
+                kv->info.value.data.darray = darray;
+                PMIX_PROC_INFO_CREATE(procinfo, jdata->num_local_procs);
+                darray->array = procinfo;
+                p = 0;
+                for (k=0; k < jdata->procs->size; k++) {
+                    if (NULL == (proct = (orte_proc_t*)opal_pointer_array_get_item(jdata->procs, k))) {
+                        continue;
+                    }
+                    if (ORTE_FLAG_TEST(proct, ORTE_PROC_FLAG_LOCAL)) {
+                        OPAL_PMIX_CONVERT_NAME(&procinfo[p].proc, &proct->name);
+                        if (NULL != proct->node && NULL != proct->node->name) {
+                            procinfo[p].hostname = strdup(proct->node->name);
+                        }
+                        app = (orte_app_context_t*)opal_pointer_array_get_item(jdata->apps, proct->app_idx);
+                        if (NULL != app && NULL != app->app) {
+                            procinfo[p].executable_name = strdup(app->app);
+                        }
+                        procinfo[p].pid = proct->pid;
+                        procinfo[p].exit_code = proct->exit_code;
+                        procinfo[p].state = opal_pmix_convert_state(proct->state);
+                        ++p;
+                    }
+                }
+    #endif
+    #if PMIX_VERSION_MAJOR >= 4
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_NUM_PSETS)) {
+                kv = OBJ_NEW(opal_info_item_t);
+                sz = opal_list_get_size(&orte_pmix_server_globals.psets);
+                PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_NUM_PSETS, &sz, PMIX_SIZE);
+                opal_list_append(&results, &kv->super);
+            } else if (0 == strcmp(q->keys[n], PMIX_QUERY_PSET_NAMES)) {
+                pmix_server_pset_t *ps;
+                ans = NULL;
+                OPAL_LIST_FOREACH(ps, &orte_pmix_server_globals.psets, pmix_server_pset_t) {
+                    opal_argv_append_nosize(&ans, ps->name);
+                }
+                tmp = opal_argv_join(ans, ',');
+                opal_argv_free(ans);
+                ans = NULL;
+                kv = OBJ_NEW(opal_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
+                opal_list_append(&results, &kv->super);
+                free(tmp);
+    #endif
+            } else if (0 == strcmp(q->keys[n], PMIX_JOB_SIZE)) {
+                jdata = orte_get_job_data_object(jobid);
+                if (NULL == jdata) {
+                    rc = ORTE_ERR_NOT_FOUND;
+                    goto done;
+                }
+                /* setup the reply */
+                kv = OBJ_NEW(opal_info_item_t);
+                (void)strncpy(kv->info.key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+                key = jdata->num_procs;
+                PMIX_INFO_LOAD(&kv->info, PMIX_JOB_SIZE, &key, PMIX_UINT32);
+                opal_list_append(&results, &kv->super);
+            } else {
+                fprintf(stderr, "Query for unrecognized attribute: %s\n", q->keys[n]);
+            }
+        } // for
+    } // for
+
+#if OPAL_PMIX_VERSION >= 3
+  done:
+#endif
+    rcd = OBJ_NEW(orte_pmix_server_op_caddy_t);
+    if (PMIX_SUCCESS == ret) {
+        if (0 == opal_list_get_size(&results)) {
+            ret = PMIX_ERR_NOT_FOUND;
+        } else {
+            if (opal_list_get_size(&results) < cd->ninfo) {
+                ret = PMIX_QUERY_PARTIAL_SUCCESS;
+            } else {
+                ret = PMIX_SUCCESS;
+            }
+            /* convert the list of results to an info array */
+            rcd->ninfo = opal_list_get_size(&results);
+            PMIX_INFO_CREATE(rcd->info, rcd->ninfo);
+            n=0;
+            OPAL_LIST_FOREACH(kv, &results, opal_info_item_t) {
+                PMIX_INFO_XFER(&rcd->info[n], &kv->info);
+                n++;
+            }
+        }
+    }
+    OPAL_LIST_DESTRUCT(&results);
+    cd->infocbfunc(ret, rcd->info, rcd->ninfo, cd->cbdata, qrel, rcd);
+    OBJ_RELEASE(cd);
+}
+
+pmix_status_t pmix_server_query_fn(pmix_proc_t *proct,
+                                   pmix_query_t *queries, size_t nqueries,
+                                   pmix_info_cbfunc_t cbfunc,
+                                   void *cbdata)
+{
+    orte_pmix_server_op_caddy_t *cd;
+
+    if (NULL == queries || NULL == cbfunc) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* need to threadshift this request */
+    cd = OBJ_NEW(orte_pmix_server_op_caddy_t);
+    cd->procs = proct;
+    cd->queries = queries;
+    cd->nqueries = nqueries;
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+
+    opal_event_set(orte_event_base, &(cd->ev), -1,
+                   OPAL_EV_WRITE, _query, cd);
+    opal_event_set_priority(&(cd->ev), ORTE_MSG_PRI);
+    ORTE_POST_OBJECT(cd);
+    opal_event_active(&(cd->ev), OPAL_EV_WRITE, 1);
+
+    return PMIX_SUCCESS;
+}

--- a/orte/util/attr.h
+++ b/orte/util/attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -99,6 +99,7 @@ typedef uint16_t orte_job_flags_t;
 #define ORTE_JOB_FLAG_PROCS_MIGRATING    0x0400   // some procs in job are migrating from one node to another
 #define ORTE_JOB_FLAG_OVERSUBSCRIBED     0x0800   // at least one node in the job is oversubscribed
 #define ORTE_JOB_FLAG_TOOL               0x1000   // job is a tool
+#define ORTE_JOB_FLAG_LAUNCHER           0x2000   // job is also a launcher
 
 /***   JOB ATTRIBUTE KEYS   ***/
 #define ORTE_JOB_START_KEY   ORTE_NODE_MAX_KEY


### PR DESCRIPTION
Update the ```examples/tool.c``` example to query the active namespaces and return the job size for a given nspace. Move the query support in PRRTE to a separate file as things are getting a little long. Add support for the ```PMIX_NSPACE``` qualifier.

Refs https://github.com/pmix/pmix/issues/907