### PR TITLE
Few missing prrte prefixes and fix -hostfile/-host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,11 @@ env:
         - LD_LIBRARY_PATH="$HOME/bogus/lib"
     matrix:
         - GCC_VERSION=default
-        - GCC_VERSION=6
         - GCC_VERSION=7
 
 before_install:
     - env
-    - if [[ "GCC_VERSION" == "6" ]]; then COMPILERS="CC=gcc-6 CXX=g++-6 FC=gfortran-6"; elif [[ "GCC_VERSION" == "7" ]]; then COMPILERS="CC=gcc-7 CXX=g++-7 FC=gfortran-7"; elif [[ "$CC" == "clang" ]]; then COMPILERS="CC=`which clang`"; fi
+    - if [[ "GCC_VERSION" == "7" ]]; then COMPILERS="CC=gcc-7 CXX=g++-7 FC=gfortran-7"; elif [[ "$CC" == "clang" ]]; then COMPILERS="CC=`which clang`"; fi
     - export CONFIGURE_ARGS="--prefix=$HOME/bogus --enable-prrterun-prefix-by-default $COMPILERS" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - if [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 g++-6 gfortran-6; elif [[ "$GCC_VERSION" == "7" ]] ; then sudo apt-get --assume-yes install gcc-7 g++-7 gfortran-7; fi

--- a/src/mca/if/bsdx_ipv4/if_bsdx.c
+++ b/src/mca/if/bsdx_ipv4/if_bsdx.c
@@ -27,7 +27,7 @@ static int if_bsdx_open(void);
  * OpenBSD
  * DragonFly
  */
-prrte_if_base_component_t mca_if_bsdx_ipv4_component = {
+prrte_if_base_component_t prrte_if_bsdx_ipv4_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
     {

--- a/src/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
+++ b/src/mca/if/bsdx_ipv6/if_bsdx_ipv6.c
@@ -63,7 +63,7 @@ static int if_bsdx_ipv6_open(void);
  * bsdi
  * Apple
  */
-prrte_if_base_component_t mca_if_bsdx_ipv6_component = {
+prrte_if_base_component_t prrte_if_bsdx_ipv6_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
     {

--- a/src/mca/if/solaris_ipv6/if_solaris_ipv6.c
+++ b/src/mca/if/solaris_ipv6/if_solaris_ipv6.c
@@ -22,7 +22,7 @@
 static int if_solaris_ipv6_open(void);
 
 /* Discovers Solaris IPv6 interfaces */
-prrte_if_base_component_t mca_if_solaris_ipv6_component = {
+prrte_if_base_component_t prrte_if_solaris_ipv6_component = {
     /* First, the mca_component_t struct containing meta information
        about the component itself */
     {

--- a/src/runtime/prrte_init.c
+++ b/src/runtime/prrte_init.c
@@ -112,7 +112,6 @@ int prrte_init_util(void)
 {
     int ret;
     char *error = NULL;
-    char hostname[PRRTE_MAXHOSTNAMELEN];
 
     if (0 < prrte_initialized) {
         /* track number of times we have been called */
@@ -121,12 +120,8 @@ int prrte_init_util(void)
     }
     prrte_initialized++;
 
-    /* set the nodename right away so anyone who needs it has it. Note
-     * that we don't bother with fqdn and prefix issues here - we let
-     * the RTE later replace this with a modified name if the user
-     * requests it */
-    gethostname(hostname, sizeof(hostname));
-    prrte_process_info.nodename = strdup(hostname);
+    /* set the nodename right away so anyone who needs it has it */
+    prrte_setup_hostname();
 
     /* initialize the memory allocator */
     prrte_malloc_init();

--- a/src/runtime/prrte_mca_params.c
+++ b/src/runtime/prrte_mca_params.c
@@ -523,14 +523,6 @@ int prrte_register_params(void)
         prrte_default_dash_host = NULL;
     }
 
-    /* whether or not to keep FQDN hostnames */
-    prrte_keep_fqdn_hostnames = false;
-    (void) prrte_mca_base_var_register ("prrte", "prrte", NULL, "keep_fqdn_hostnames",
-                                  "Whether or not to keep FQDN hostnames [default: no]",
-                                  PRRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PRRTE_INFO_LVL_9, PRRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prrte_keep_fqdn_hostnames);
-
     /* whether or not to retain aliases of hostnames */
     prrte_retain_aliases = false;
     (void) prrte_mca_base_var_register ("prrte", "prrte", NULL, "retain_aliases",

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -33,11 +33,11 @@
 #include "src/util/argv.h"
 #include "src/util/if.h"
 #include "src/util/net.h"
+#include "src/util/proc_info.h"
 
 #include "src/mca/ras/base/base.h"
 #include "src/mca/plm/plm_types.h"
 #include "src/mca/errmgr/errmgr.h"
-#include "src/util/proc_info.h"
 #include "src/runtime/prrte_globals.h"
 
 #include "dash_host.h"
@@ -52,7 +52,7 @@ int prrte_util_dash_host_compute_slots(prrte_node_t *node, char *hosts)
 
     /* see if this node appears in the list */
     for (n=0; NULL != specs[n]; n++) {
-        if (0 == strncmp(node->name, specs[n], strlen(node->name)) ||
+        if (prrte_check_host_is_local(specs[n]) ||
             (prrte_ifislocal(node->name) && prrte_ifislocal(specs[n]))) {
             /* check if the #slots was specified */
             if (NULL != (cptr = strchr(specs[n], ':'))) {
@@ -66,7 +66,6 @@ int prrte_util_dash_host_compute_slots(prrte_node_t *node, char *hosts)
             } else {
                 ++slots;
             }
-
         }
     }
     prrte_argv_free(specs);

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -139,6 +139,10 @@ PRRTE_EXPORT int prrte_proc_info(void);
 
 PRRTE_EXPORT int prrte_proc_info_finalize(void);
 
+PRRTE_EXPORT void prrte_setup_hostname(void);
+
+PRRTE_EXPORT bool prrte_check_host_is_local(char *name);
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
Couple of places were missed when prefixing MCA component structs.

Collect all hostfile and -host options and pass them to "prte". Currently passing the hostfile as a comma-separated list of filenames - need to check and see if that is correctly handled

Fix problem with matching hostnames (e.g., "localhost" to the actual "hostname")

Signed-off-by: Ralph Castain <rhc@pmix.org>