### PR TITLE
Correct typo in common/alps library version name

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -85,5 +85,5 @@ libprrte_so_version=2:0:0
 # well.  Yuck; this somewhat breaks the
 # components-don't-affect-the-build-system abstraction.
 
-libprtemca_common_alps_so_version=2:0:0
+libprrtemca_common_alps_so_version=2:0:0
 


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>