### PR TITLE
Cleanup use of gethostname

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -51,6 +51,7 @@
 #include "src/util/argv.h"
 #include "src/util/output.h"
 #include "src/util/os_dirpath.h"
+#include "src/util/proc_info.h"
 #include "src/util/show_help.h"
 #include "src/util/printf.h"
 #include "src/threads/tsd.h"
@@ -548,11 +549,9 @@ int prrte_hwloc_base_report_bind_failure(const char *file,
 
     if (!already_reported &&
         PRRTE_HWLOC_BASE_MBFA_SILENT != prrte_hwloc_base_mbfa) {
-        char hostname[PRRTE_MAXHOSTNAMELEN];
-        gethostname(hostname, sizeof(hostname));
 
         prrte_show_help("help-prrte-hwloc-base.txt", "mbind failure", true,
-                       hostname, getpid(), file, line, msg,
+                       prrte_process_info.nodename, getpid(), file, line, msg,
                        (PRRTE_HWLOC_BASE_MBFA_WARN == prrte_hwloc_base_mbfa) ?
                        "Warning -- your job will continue, but possibly with degraded performance" :
                        "ERROR -- your job may abort or behave erraticly");

--- a/src/mca/base/prrte_mca_base_component_find.c
+++ b/src/mca/base/prrte_mca_base_component_find.c
@@ -48,6 +48,7 @@
 
 #include "src/mca/installdirs/installdirs.h"
 #include "src/util/prrte_environ.h"
+#include "src/util/proc_info.h"
 #include "src/util/output.h"
 #include "src/util/argv.h"
 #include "src/util/show_help.h"
@@ -331,11 +332,9 @@ static int component_find_check (prrte_mca_base_framework_t *framework, char **r
         }
 
         if (!found) {
-            char h[PRRTE_MAXHOSTNAMELEN];
-            gethostname(h, sizeof(h));
             prrte_show_help("help-prrte-mca-base.txt",
                            "find-available:not-valid", true,
-                           h, framework->framework_name, requested_component_names[i]);
+                           prrte_process_info.nodename, framework->framework_name, requested_component_names[i]);
             return PRRTE_ERR_NOT_FOUND;
         }
     }

--- a/src/mca/base/prrte_mca_base_open.c
+++ b/src/mca/base/prrte_mca_base_open.c
@@ -40,6 +40,7 @@
 #include "src/mca/installdirs/installdirs.h"
 #include "src/util/output.h"
 #include "src/util/printf.h"
+#include "src/util/proc_info.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 #include "src/mca/base/prrte_mca_base_component_repository.h"
@@ -75,7 +76,6 @@ int prrte_mca_base_open(void)
 {
     char *value;
     prrte_output_stream_t lds;
-    char hostname[PRRTE_MAXHOSTNAMELEN];
 
     if (prrte_mca_base_opened++) {
         return PRRTE_SUCCESS;
@@ -152,8 +152,7 @@ int prrte_mca_base_open(void)
     } else {
         set_defaults(&lds);
     }
-    gethostname(hostname, sizeof(hostname));
-    prrte_asprintf(&lds.lds_prefix, "[%s:%05d] ", hostname, getpid());
+    prrte_asprintf(&lds.lds_prefix, "[%s:%05d] ", prrte_process_info.nodename, getpid());
     prrte_output_reopen(0, &lds);
     prrte_output_verbose (PRRTE_MCA_BASE_VERBOSE_COMPONENT, 0, "mca: base: opening components");
     free(lds.lds_prefix);

--- a/src/mca/if/linux_ipv6/if_linux_ipv6.c
+++ b/src/mca/if/linux_ipv6/if_linux_ipv6.c
@@ -51,6 +51,7 @@
 #include "constants.h"
 #include "src/util/if.h"
 #include "src/util/output.h"
+#include "src/util/proc_info.h"
 #include "src/util/show_help.h"
 #include "src/util/string_copy.h"
 #include "src/mca/if/if.h"
@@ -130,11 +131,9 @@ static int if_linux_ipv6_open(void)
             prrte_if_t *intf;
 
             if (!hexdecode(addrhex, a6.s6_addr, sizeof a6.s6_addr)) {
-                char hostname[PRRTE_MAXHOSTNAMELEN];
-                gethostname(hostname, sizeof(hostname));
-                prrte_show_help("help-prrte-if-linux-ipv6.txt",
+                 prrte_show_help("help-prrte-if-linux-ipv6.txt",
                                "fail to parse if_inet6", true,
-                               hostname, ifname, addrhex);
+                               prrte_process_info.nodename, ifname, addrhex);
                 continue;
             };
             inet_ntop(AF_INET6, a6.s6_addr, addrstr, sizeof addrstr);

--- a/src/mca/oob/alps/oob_alps_component.c
+++ b/src/mca/oob/alps/oob_alps_component.c
@@ -71,6 +71,7 @@
 #include "src/mca/common/alps/common_alps.h"
 #include "src/util/name_fns.h"
 #include "src/util/parse_options.h"
+#include "src/util/proc_info.h"
 #include "src/util/show_help.h"
 #include "src/runtime/prrte_globals.h"
 
@@ -157,16 +158,14 @@ static int component_send(prrte_rml_send_t *msg)
 
 static char* component_get_addr(void)
 {
-    char hn[PRRTE_MAXHOSTNAMELEN], *cptr;
+    char *cptr;
 
     /*
      * TODO: for aries want to plug in GNI addr here instead to
      * eventually be able to support connect/accept using aprun.
      */
 
-    gethostname(hn, sizeof(hn));
-
-    prrte_asprintf(&cptr, "gni://%s:%d", hn, getpid());
+    prrte_asprintf(&cptr, "gni://%s:%d", prrte_process_info.nodename, getpid());
 
     prrte_output_verbose(10, prrte_oob_base_framework.framework_output,
                         "%s oob:alps: component_get_addr invoked - %s",

--- a/src/mca/pstat/test/pstat_test.c
+++ b/src/mca/pstat/test/pstat_test.c
@@ -33,6 +33,7 @@
 
 #include "src/mca/pstat/pstat.h"
 #include "src/mca/pstat/base/base.h"
+#include "src/util/proc_info.h"
 #include "src/util/string_copy.h"
 
 #include "pstat_test.h"
@@ -67,7 +68,6 @@ static int query(pid_t pid,
                  prrte_node_stats_t *nstats)
 {
     double dtime;
-    char hostname[PRRTE_MAXHOSTNAMELEN];
 
     if (NULL != stats) {
         /* record the time of this sample */
@@ -85,8 +85,7 @@ static int query(pid_t pid,
     }
 
     if (NULL != stats) {
-        gethostname(hostname, sizeof(hostname));
-        prrte_string_copy(stats->node, hostname, PRRTE_PSTAT_MAX_STRING_LEN);
+        prrte_string_copy(stats->node, prrte_process_info.nodename, PRRTE_PSTAT_MAX_STRING_LEN);
 
         stats->pid = pid;
         prrte_string_copy(stats->cmd, "UNKNOWN", PRRTE_PSTAT_MAX_STRING_LEN);

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -33,6 +33,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/util/name_fns.h"
+#include "src/util/proc_info.h"
 #include "src/runtime/prrte_globals.h"
 
 #include "src/mca/ras/base/ras_private.h"
@@ -88,7 +89,7 @@ int prrte_ras_base_node_insert(prrte_list_t* nodes, prrte_job_t *jdata)
     if (prrte_ras_base.launch_orted_on_hn) {
         if (NULL != hnp_node) {
             PRRTE_LIST_FOREACH(node, nodes, prrte_node_t) {
-                if (prrte_ifislocal(node->name)) {
+                if (prrte_check_host_is_local(node->name)) {
                     prrte_hnp_is_allocated = true;
                     break;
                 }
@@ -113,7 +114,7 @@ int prrte_ras_base_node_insert(prrte_list_t* nodes, prrte_job_t *jdata)
          * first position since it is the first one entered. We need to check to see
          * if this node is the same as the HNP's node so we don't double-enter it
          */
-        if (!skiphnp && NULL != hnp_node && prrte_ifislocal(node->name)) {
+        if (!skiphnp && NULL != hnp_node && prrte_check_host_is_local(node->name)) {
             PRRTE_OUTPUT_VERBOSE((5, prrte_ras_base_framework.framework_output,
                                  "%s ras:base:node_insert updating HNP [%s] info to %ld slots",
                                  PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -39,6 +39,7 @@
 #include "src/util/argv.h"
 #include "src/util/if.h"
 #include "src/util/net.h"
+#include "src/util/proc_info.h"
 #include "src/class/prrte_pointer_array.h"
 #include "src/hwloc/hwloc-internal.h"
 
@@ -517,7 +518,7 @@ static int prrte_rmaps_rank_file_parse(const char *rankfile)
                             goto unlock;
                         }
                         /* check if this is the local node */
-                        if (prrte_ifislocal(node_name)) {
+                        if (prrte_check_host_is_local(node_name)) {
                             rfmap->node_name = strdup(hnp_node->name);
                         } else {
                             rfmap->node_name = strdup(node_name);

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -44,6 +44,7 @@
 #include "src/util/hostfile/hostfile.h"
 #include "src/util/dash_host/dash_host.h"
 #include "src/util/name_fns.h"
+#include "src/util/proc_info.h"
 #include "src/runtime/prrte_globals.h"
 
 #include "src/mca/rmaps/base/rmaps_private.h"
@@ -336,7 +337,7 @@ static int prrte_rmaps_seq_map(prrte_job_t *jdata)
                  * hostfile may not have been FQDN, while name returned
                  * by gethostname may have been (or vice versa)
                  */
-                if (prrte_ifislocal(seq->hostname)) {
+                if (prrte_check_host_is_local(seq->hostname)) {
                     prrte_output_verbose(5, prrte_rmaps_base_framework.framework_output,
                                         "mca:rmaps:seq: removing head node %s", seq->hostname);
                     prrte_list_remove_item(seq_list, item);

--- a/src/runtime/prrte_init.c
+++ b/src/runtime/prrte_init.c
@@ -214,7 +214,9 @@ int prrte_init_util(void)
                 __FILE__, __LINE__, ret);
         return ret;
     }
-
+    /* add network aliases to our list of alias hostnames */
+    prrte_ifgetaliases(&prrte_process_info.aliases);
+    
     /* open hwloc */
     prrte_hwloc_base_open();
 

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -52,8 +52,7 @@ int prrte_util_dash_host_compute_slots(prrte_node_t *node, char *hosts)
 
     /* see if this node appears in the list */
     for (n=0; NULL != specs[n]; n++) {
-        if (prrte_check_host_is_local(specs[n]) ||
-            (prrte_ifislocal(node->name) && prrte_ifislocal(specs[n]))) {
+        if (prrte_check_host_is_local(specs[n])) {
             /* check if the #slots was specified */
             if (NULL != (cptr = strchr(specs[n], ':'))) {
                 *cptr = '\0';
@@ -236,21 +235,17 @@ int prrte_util_add_dash_host_nodes(prrte_list_t *nodes,
         }
 
         /* check for local name */
-        if (prrte_ifislocal(mini_map[i])) {
+        if (prrte_check_host_is_local(mini_map[i])) {
             ndname = prrte_process_info.nodename;
         } else {
             ndname = mini_map[i];
-        }
 
-        // Strip off the FQDN if present, ignore IP addresses
-        if( !prrte_keep_fqdn_hostnames && !prrte_net_isaddr(ndname) ) {
-            if (NULL != (ptr = strchr(ndname, '.'))) {
-                *ptr = '\0';
+            // Strip off the FQDN if present, ignore IP addresses
+            if( !prrte_keep_fqdn_hostnames && !prrte_net_isaddr(ndname) ) {
+                if (NULL != (ptr = strchr(ndname, '.'))) {
+                    *ptr = '\0';
+                }
             }
-        }
-        /* remove any modifier */
-        if (NULL != (ptr = strchr(ndname, ':'))) {
-            *ptr = '\0';
         }
         /* see if the node is already on the list */
         found = false;
@@ -427,7 +422,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                     *cptr = '\0';
                 }
                 /* check for local alias */
-                if (prrte_ifislocal(mini_map[k])) {
+                if (prrte_check_host_is_local(mini_map[k])) {
                     prrte_argv_append_nosize(mapped_nodes, prrte_process_info.nodename);
                 } else {
                     prrte_argv_append_nosize(mapped_nodes, mini_map[k]);

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -191,7 +191,7 @@ static int hostfile_parse_line(int token, prrte_list_t* updates,
                                  PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME), node_name));
 
             /* see if this is another name for us */
-            if (prrte_ifislocal(node_name)) {
+            if (prrte_check_host_is_local(node_name)) {
                 /* Nodename has been allocated, that is for sure */
                 free (node_name);
                 node_name = strdup(prrte_process_info.nodename);
@@ -215,7 +215,7 @@ static int hostfile_parse_line(int token, prrte_list_t* updates,
         /* this is not a node to be excluded, so we need to process it and
          * add it to the "include" list. See if this host is actually us.
          */
-        if (prrte_ifislocal(node_name)) {
+        if (prrte_check_host_is_local(node_name)) {
             /* Nodename has been allocated, that is for sure */
             free (node_name);
             node_name = strdup(prrte_process_info.nodename);

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -49,6 +49,7 @@
 #include "src/util/output.h"
 #include "src/util/string_copy.h"
 #include "src/util/printf.h"
+#include "src/util/proc_info.h"
 #include "src/threads/mutex.h"
 #include "src/runtime/runtime.h"
 #include "src/pmix/pmix-internal.h"
@@ -137,7 +138,6 @@ PRRTE_CLASS_INSTANCE(prrte_output_stream_t, prrte_object_t, construct, destruct)
 bool prrte_output_init(void)
 {
     int i;
-    char hostname[PRRTE_MAXHOSTNAMELEN];
     char *str;
 
     if (initialized) {
@@ -193,8 +193,7 @@ bool prrte_output_init(void)
             verbose.lds_want_stderr = true;
         }
     }
-    gethostname(hostname, sizeof(hostname));
-    prrte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid());
+    prrte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", prrte_process_info.nodename, getpid());
 
     for (i = 0; i < PRRTE_OUTPUT_MAX_STREAMS; ++i) {
         info[i].ldi_used = false;
@@ -271,7 +270,6 @@ bool prrte_output_switch(int output_id, bool enable)
 void prrte_output_reopen_all(void)
 {
     char *str;
-    char hostname[PRRTE_MAXHOSTNAMELEN];
 
     str = getenv("PRRTE_OUTPUT_STDERR_FD");
     if (NULL != str) {
@@ -280,12 +278,11 @@ void prrte_output_reopen_all(void)
         default_stderr_fd = -1;
     }
 
-    gethostname(hostname, sizeof(hostname));
     if( NULL != verbose.lds_prefix ) {
         free(verbose.lds_prefix);
         verbose.lds_prefix = NULL;
     }
-    prrte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", hostname, getpid());
+    prrte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", prrte_process_info.nodename, getpid());
 #if 0
     int i;
     prrte_output_stream_t lds;

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -130,7 +130,7 @@ void prrte_setup_hostname(void)
     /* we have to strip node names here, if user directs, to ensure that
      * the names exchanged in the modex match the names found locally
      */
-    if (NULL != prrte_strip_prefix) {
+    if (NULL != prrte_strip_prefix && !prrte_net_isaddr(hostname)) {
         prefixes = prrte_argv_split(prrte_strip_prefix, ',');
         match = false;
         for (i=0; NULL != prefixes[i]; i++) {


### PR DESCRIPTION
Refer to the global name of the host (taking into account fqdn retention flags, localhost alias, and network interface names).

Signed-off-by: Ralph Castain <rhc@pmix.org>