### PR TITLE
Consolidate and cleanup close_fd functionality

### DIFF
--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -79,6 +79,7 @@
 #include "src/runtime/prrte_globals.h"
 #include "src/util/name_fns.h"
 #include "src/util/proc_info.h"
+#include "src/util/fd.h"
 #include "src/threads/threads.h"
 
 #include "src/mca/rml/rml.h"
@@ -714,7 +715,6 @@ static void ssh_child(int argc, char **argv)
 {
     char** env;
     char* var;
-    long fd, fdmax = sysconf(_SC_OPEN_MAX);
     char *exec_path;
     char **exec_argv;
     int fdin;
@@ -743,8 +743,7 @@ static void ssh_child(int argc, char **argv)
     close(fdin);
 
     /* close all file descriptors w/ exception of stdin/stdout/stderr */
-    for(fd=3; fd<fdmax; fd++)
-        close(fd);
+    prrte_close_open_file_descriptors(-1);
 
     /* Set signal handlers back to the default.  Do this close
      to the execve() because the event library may (and likely

--- a/src/util/fd.h
+++ b/src/util/fd.h
@@ -105,6 +105,12 @@ PRRTE_EXPORT bool prrte_fd_is_blkdev(int fd);
  */
 PRRTE_EXPORT const char *prrte_fd_get_peer_name(int fd);
 
+/**
+ * Close all open sockets other than stdin/out/err prior to
+ * exec'ing a new binary
+ */
+PRRTE_EXPORT void prrte_close_open_file_descriptors(int protected_fd);
+
 END_C_DECLS
 
 #endif


### PR DESCRIPTION
Since it gets used multiple times, put the code in one place. Provide a fast and slow path depending on available support

Closes https://github.com/open-mpi/ompi/pull/7257

Signed-off-by: Ralph Castain <rhc@pmix.org>