### PR TITLE
Update report of bindings

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -469,7 +469,6 @@ PRRTE_EXPORT int prrte_hwloc_base_topology_export_xmlbuffer(hwloc_topology_t top
 
 PRRTE_EXPORT int prrte_hwloc_base_topology_set_flags (hwloc_topology_t topology, unsigned long flags, bool io);
 
-
 PRRTE_EXPORT int prrte_hwloc_base_open(void);
 PRRTE_EXPORT void prrte_hwloc_base_close(void);
 PRRTE_EXPORT int prrte_hwloc_base_register(void);

--- a/src/prted/prted_main.c
+++ b/src/prted/prted_main.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2009      Institut National de Recherche en Informatique
  *                         et Automatique. All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -632,9 +632,11 @@ int prrte_daemon(int argc, char *argv[])
      * and won't hurt anything */
     if (PRRTE_SUCCESS != (ret = prrte_dss.pack(buffer, &prrte_topo_signature, 1, PRRTE_STRING))) {
         PRRTE_ERROR_LOG(ret);
+        PRRTE_RELEASE(buffer);
+        goto DONE;
     }
 
-    /* if we are rank=1, then send our topology back - otherwise, mpirun
+    /* if we are rank=1, then send our topology back - otherwise, prte
      * will request it if necessary */
     if (1 == PRRTE_PROC_MY_NAME->vpid) {
         prrte_buffer_t data;
@@ -647,6 +649,8 @@ int prrte_daemon(int argc, char *argv[])
 
         if (PRRTE_SUCCESS != (ret = prrte_dss.pack(&data, &prrte_hwloc_topology, 1, PRRTE_HWLOC_TOPO))) {
             PRRTE_ERROR_LOG(ret);
+            PRRTE_RELEASE(buffer);
+            goto DONE;
         }
         if (prrte_compress.compress_block((uint8_t*)data.base_ptr, data.bytes_used,
                                          &cmpdata, &cmplen)) {


### PR DESCRIPTION
Provide --report-bindings output as per @markalle's description. This
ports the functionality in the cited PR to PRRTE, modified to conform
to OMPI/PRRTE coding standards. I also eliminated having two different
ways of reporting the bindings so we don't confuse users, and extended
the original work to support HWLOC 1.x as well as 2.x.

Note that the topology tree always includes the "complete" cpuset for
each object along with the allowed cpuset (in the "cpuset" field). So
printing the binding map with all processors shown simply requires using
the "complete" cpuset field - you don't need to collect the
"whole_system" topology.

For detection purposes, pass the "signature" containing the list form of
both the complete and cpuset fields. Only include the complete field if
the two differ - otherwise, just leave that field blank. We don't
actually use the signature for anything other than detecting that there
is a difference between two machines, so this will suffice - if two
machines have different cgroups, then we will treat the topologies as
different.

Refs https://github.com/open-mpi/ompi/pull/6760

Signed-off-by: Ralph Castain <rhc@pmix.org>