### PR TITLE
Fix support for "-x" cmd line option

### DIFF
--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -952,9 +952,8 @@ int prun(int argc, char *argv[])
     /* now initialize PMIx - we have to indicate we are a launcher so that we
      * will provide rendezvous points for tools to connect to us */
     if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
-        PRRTE_ERROR_LOG(ret);
-        prrte_progress_thread_finalize(NULL);
-        return ret;
+        fprintf(stderr, "%s failed to initialize, likely due to no DVM being available\n", prrte_tool_basename);
+        exit(1);
     }
     PMIX_INFO_FREE(iptr, ninfo);
 

--- a/test/double-get.c
+++ b/test/double-get.c
@@ -24,35 +24,35 @@ int pmi_set_string(const char *key, void *data, size_t size)
     value.type = PMIX_BYTE_OBJECT;
     value.data.bo.bytes = data;
     value.data.bo.size  = size;
-    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
-        ERR("Client ns %s rank %d: PMIx_Put failed: %d\n", myproc.nspace, myproc.rank, rc);
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, key, &value))) {
+        ERR("Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        ERR("Client ns %s rank %d: PMIx_Commit failed: %d\n", myproc.nspace, myproc.rank, rc);
+        ERR("Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     }
 
     /* protect the data */
     value.data.bo.bytes = NULL;
     value.data.bo.size  = 0;
     PMIX_VALUE_DESTRUCT(&value);
-    printf("PMIx_Put on %s\n", key);
+    printf("%s:%d PMIx_Put on %s\n", myproc.nspace, myproc.rank, key);
 
 
     return 0;
 }
 
-int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out, size_t *data_size_out)
+int pmi_get_string(uint32_t peer_rank, const char *key, bool refresh, void **data_out, size_t *data_size_out)
 {
     int rc;
     pmix_proc_t proc;
     pmix_value_t *pvalue;
+    pmix_info_t info;
 
-    PMIX_PROC_CONSTRUCT(&proc);
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = peer_rank;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, key, NULL, 0, &pvalue))) {
-        ERR("Client ns %s rank %d: PMIx_Get %s: %d\n", myproc.nspace, myproc.rank, key, rc);
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, peer_rank);
+    PMIX_INFO_LOAD(&info, PMIX_GET_REFRESH_CACHE, &refresh, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, key, &info, 1, &pvalue))) {
+        ERR("Client ns %s rank %d: PMIx_Get on rank %u %s: %s\n", myproc.nspace, myproc.rank, peer_rank, key, PMIx_Error_string(rc));
     }
     if(pvalue->type != PMIX_BYTE_OBJECT){
         ERR("Client ns %s rank %d: PMIx_Get %s: got wrong data type\n", myproc.nspace, myproc.rank, key);
@@ -66,34 +66,27 @@ int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out, size_t 
     PMIX_VALUE_RELEASE(pvalue);
     PMIX_PROC_DESTRUCT(&proc);
 
-    printf("PMIx_get %s returned %zi bytes\n", key, data_size_out[0]);
+    printf("%s:%d PMIx_get %s returned %zi bytes\n", myproc.nspace, myproc.rank, key, data_size_out[0]);
 
     return 0;
 }
 
-static volatile int fence_active = 0;
-static void fence_status_cb(pmix_status_t status, void *cbdata)
-{
-    fence_active = 0;
-}
-    
 int pmix_exchange(bool flag)
 {
     int rc;
     pmix_info_t info;
 
-    fence_active = 1;
+    fprintf(stderr, "Execute fence\n");
     PMIX_INFO_CONSTRUCT(&info);
     PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-    if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(&allproc, 1, &info, 1, fence_status_cb, NULL))){
+    rc = PMIx_Fence(&allproc, 1, &info, 1);
+    if (PMIX_SUCCESS != rc){
         fprintf(stderr, "Client ns %s rank %d: PMIx_Fence_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
         exit(1);
     }
     PMIX_INFO_DESTRUCT(&info);
-        
-    /* wait for completion */
-    while(fence_active);
-    
+
+
     return 0;
 }
 
@@ -114,9 +107,7 @@ int main(int argc, char *argv[])
     /* job-related info is found in our nspace, assigned to the
      * wildcard rank as it doesn't relate to a specific rank. Setup
      * a name to retrieve such values */
-    PMIX_PROC_CONSTRUCT(&allproc);
-    (void)strncpy(allproc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    allproc.rank = PMIX_RANK_WILDCARD;
+    PMIX_LOAD_PROCID(&allproc, myproc.nspace, PMIX_RANK_WILDCARD);
 
     /* get the number of procs in our job */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&allproc, PMIX_JOB_SIZE, NULL, 0, &pvalue))) {
@@ -127,19 +118,23 @@ int main(int argc, char *argv[])
     PMIX_VALUE_RELEASE(pvalue);
 
     /* the below two lines break the subsequent PMIx_Get query on a key set later */
+    sprintf(data, "FIRST TIME rank %d", myproc.rank);
     pmi_set_string("test-key-1", data, 256);
- 
-    sprintf(data, "rank %d", myproc.rank);
+    pmix_exchange(true);
+
+    sprintf(data, "SECOND TIME rank %d", myproc.rank);
     pmi_set_string("test-key-2", data, 256);
-    
+
     /* An explicit Fence has to be called again to read the `test-key-2` */
     // pmix_exchange(false);
 
-    pmi_get_string((myproc.rank+1)%2, "test-key-2", (void**)&data_out, &size_out);
+    pmi_get_string((myproc.rank+1)%2, "test-key-2", true, (void**)&data_out, &size_out);
     printf("%d: obtained data \"%s\"\n", myproc.rank, data_out);
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
         ERR("Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     }
     if(myproc.rank == 0) printf("PMIx finalized\n");
+
+    exit(0);
 }


### PR DESCRIPTION
Fix support for "-x" cmd line option

Also extend it to support wildcards - e.g., "-x foo*" to forward all
envars starting with "foo"

Fixes #304 

Signed-off-by: Ralph Castain <rhc@pmix.org>