### PR TITLE
plm/rsh: Fix segv on missing agent.

### DIFF
--- a/src/mca/errmgr/base/errmgr_base_fns.c
+++ b/src/mca/errmgr/base/errmgr_base_fns.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -113,7 +114,9 @@ void prrte_errmgr_base_abort(int error_code, char *fmt, ...)
     /* if I am a daemon or the HNP... */
     if (PRRTE_PROC_IS_MASTER || PRRTE_PROC_IS_DAEMON) {
         /* whack my local procs */
-        prrte_odls.kill_local_procs(NULL);
+        if( NULL != prrte_odls.kill_local_procs ) {
+            prrte_odls.kill_local_procs(NULL);
+        }
         /* whack any session directories */
         prrte_session_dir_cleanup(PRRTE_JOBID_WILDCARD);
     }

--- a/src/mca/plm/rsh/plm_rsh_component.c
+++ b/src/mca/plm/rsh/plm_rsh_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights
  *                         reserved.
  * Copyright (c) 2009-2018 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2011-2019 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -372,6 +372,10 @@ char **prrte_plm_rsh_search(const char* agent_list, const char *path)
     char **tokens, *tmp;
     char cwd[PRRTE_PATH_MAX];
 
+    if (NULL == agent_list && NULL == prrte_plm_rsh_component.agent) {
+        return NULL;
+    }
+
     if (NULL == path) {
         getcwd(cwd, PRRTE_PATH_MAX);
     } else {
@@ -421,6 +425,14 @@ static int rsh_launch_agent_lookup(const char *agent_list, char *path)
 {
     char *bname;
     int i;
+
+    if (NULL == agent_list && NULL == prrte_plm_rsh_component.agent) {
+        PRRTE_OUTPUT_VERBOSE((5, prrte_plm_base_framework.framework_output,
+                             "%s plm:rsh_lookup on agent (null) path %s - No agent specified.",
+                              PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                             (NULL == path) ? "NULL" : path));
+        return PRRTE_ERR_NOT_FOUND;
+    }
 
     PRRTE_OUTPUT_VERBOSE((5, prrte_plm_base_framework.framework_output,
                          "%s plm:rsh_lookup on agent %s path %s",


### PR DESCRIPTION
 * Additionally, fixes the `NULL` option to `OMPI_MCA_plm_rsh_agent`
   which would also lead to a segv. There is no `isolated` PLM component
   in PRRTE as there is in ORTE, so this still fails but now without a
   core file. We can address the missing `isolated` PLM component in
   a separate activity.
