### PR TITLE
Fix "make dist" by including headers

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -27,8 +27,10 @@ headers = prrte_config.h \
 		  prefetch.h \
 		  prrte_config_top.h \
 		  prrte_config_bottom.h \
+		  prrte_portable_platform.h \
 		  prrte_stdint.h \
 		  prrte_stdatomic.h \
+		  prrte_socket_errno.h \
 		  align.h
 
 nodist_headers = \

--- a/src/util/hostfile/Makefile.am
+++ b/src/util/hostfile/Makefile.am
@@ -40,6 +40,7 @@ $(nodist_man_MANS): $(am__dirstamp) $(top_builddir)/src/include/prrte_config.h
 libprrteutilhostfile_la_SOURCES = \
 	hostfile_lex.h \
         hostfile_lex.l \
+        hostfile.h \
         hostfile.c
 
 maintainer-clean-local:


### PR DESCRIPTION
A couple of headers were missing from the tarball generated
by "make dist", which makes running nightly built / Coverity
difficult.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>