### PR TITLE
Fix IOF race condition with stdin

### DIFF
--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -17,6 +17,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -244,9 +245,10 @@ static int push_stdin(const prrte_process_name_t* dst_name,
     }
 
     PRRTE_OUTPUT_VERBOSE((1, prrte_iof_base_framework.framework_output,
-                         "%s iof:hnp pushing stdin for process %s",
-                         PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
-                         PRRTE_NAME_PRINT(dst_name)));
+                          "%s iof:hnp pushing stdin for process %s (size %zu)",
+                          PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                          PRRTE_NAME_PRINT(dst_name),
+                          sz));
 
     /* do we already have this process in our list? */
     proct = NULL;
@@ -371,6 +373,11 @@ static int hnp_close(const prrte_process_name_t* peer,
 {
     prrte_iof_proc_t* proct;
     prrte_ns_cmp_bitmask_t mask = PRRTE_NS_CMP_ALL;
+
+    PRRTE_OUTPUT_VERBOSE((1, prrte_iof_base_framework.framework_output,
+                          "%s iof:hnp closing connection to process %s",
+                          PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                          PRRTE_NAME_PRINT(peer)));
 
     PRRTE_LIST_FOREACH(proct, &prrte_iof_hnp_component.procs, prrte_iof_proc_t) {
         if (PRRTE_EQUAL == prrte_util_compare_name_fields(mask, &proct->name, peer)) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -17,6 +17,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,6 +143,22 @@ typedef struct {
     void *cbdata;
 } prrte_pmix_mdx_caddy_t;
 PRRTE_CLASS_DECLARATION(prrte_pmix_mdx_caddy_t);
+
+#define PRRTE_IO_OP(t, nt, b, fn, cfn, cbd)                     \
+    do {                                                        \
+        prrte_pmix_server_op_caddy_t *_cd;                      \
+        _cd = PRRTE_NEW(prrte_pmix_server_op_caddy_t);          \
+        _cd->procs = (t);                                       \
+        _cd->nprocs = (nt);                                     \
+        _cd->server_object = (void*)(b);                        \
+        _cd->cbfunc = (cfn);                                    \
+        _cd->cbdata = (cbd);                                    \
+        prrte_event_set(prrte_event_base, &(_cd->ev), -1,       \
+                        PRRTE_EV_WRITE, (fn), _cd);             \
+        prrte_event_set_priority(&(_cd->ev), PRRTE_MSG_PRI);    \
+        PRRTE_POST_OBJECT(_cd);                                 \
+        prrte_event_active(&(_cd->ev), PRRTE_EV_WRITE, 1);      \
+    } while(0);
 
 #define PRRTE_DMX_REQ(p, i, ni, cf, ocf, ocd)                 \
     do {                                                      \


### PR DESCRIPTION
 * If `prun` is streaming `stdin` to a job and that job terminates
   there exists a race between when the `stdin` is forwarded and
   when the `PRRTE_PROC_STATE_IOF_COMPLETE` is processed. Two
   different threads could be executing each of the actions. Without
   protection the common data structure can be cleared by one thread
   while the other thinks it is safe to use. This leads to a segv.
 * Solution is to move the up call from the PMIx event base to the PRRTE
   event base thus ordering these two actions.
