### PR TITLE
Clear pending dmodex operations on terminated jobs

### DIFF
--- a/src/prted/pmix/pmix_server.h
+++ b/src/prted/pmix/pmix_server.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -25,6 +25,9 @@
 
 #include "prrte_config.h"
 
+#include "src/pmix/pmix-internal.h"
+#include "src/runtime/prrte_globals.h"
+
 BEGIN_C_DECLS
 
 PRRTE_EXPORT int pmix_server_init(void);
@@ -34,6 +37,9 @@ PRRTE_EXPORT void pmix_server_register_params(void);
 
 
 PRRTE_EXPORT int prrte_pmix_server_register_nspace(prrte_job_t *jdata);
+
+PRRTE_EXPORT void prrte_pmix_server_clear(pmix_proc_t *pname);
+
 
 END_C_DECLS
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
@@ -352,6 +352,8 @@ void pmix_server_notify(int status, prrte_process_name_t* sender,
     pmix_data_range_t range = PMIX_RANGE_SESSION;
     pmix_status_t code, ret;
     size_t ninfo;
+    prrte_jobid_t jobid;
+    prrte_job_t *jdata;
 
     prrte_output_verbose(2, prrte_pmix_server_globals.output,
                         "%s PRRTE Notification received from %s",
@@ -442,6 +444,12 @@ void pmix_server_notify(int status, prrte_process_name_t* sender,
             PMIX_INFO_FREE(cd->info, cd->ninfo);
         }
         PRRTE_RELEASE(cd);
+    }
+
+    if (PMIX_ERR_JOB_TERMINATED == code) {
+        PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, source.nspace);
+        jdata = prrte_get_job_data_object(jobid);
+        PRRTE_ACTIVATE_JOB_STATE(jdata, PRRTE_JOB_STATE_TERMINATED);
     }
 }
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -90,7 +90,6 @@ BEGIN_C_DECLS
     int remote_room_num;
     bool flag;
     bool launcher;
-    bool wait_for_key;
     uid_t uid;
     gid_t gid;
     pid_t pid;

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2009      Sun Microsystems, Inc. All rights reserved.
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -54,6 +54,7 @@
 #include "src/dss/dss.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/mca/compress/compress.h"
+#include "src/prted/pmix/pmix_server.h"
 
 #include "src/util/proc_info.h"
 #include "src/util/session_dir.h"
@@ -611,6 +612,10 @@ void prrte_daemon_recv(int status, prrte_process_name_t* sender,
         PMIx_server_deregister_nspace(pname.nspace, _notify_release, &lk);
         PRRTE_PMIX_WAIT_THREAD(&lk);
         PRRTE_PMIX_DESTRUCT_LOCK(&lk);
+
+        /* cleanup any pending server ops */
+        pname.rank = PMIX_RANK_WILDCARD;
+        prrte_pmix_server_clear(&pname);
 
         PRRTE_RELEASE(jdata);
         break;


### PR DESCRIPTION
If a job terminates, we need all daemons to clear all pending dmodex
operations for that job so the hotel doesn't endlessly cycle on them.

Make double-get post PMIX_GLOBAL scope

Allow single-node tests to succeed

Signed-off-by: Ralph Castain <rhc@pmix.org>