### PR TITLE
Cleanup handling of envars and fix typo

### DIFF
--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -642,7 +642,7 @@ static int setup_launch(int *argcptr, char ***argvptr,
         /* now check our local environment for MCA params - add them
          * only if they aren't already present
          */
-        if (PRRTE_SUCCESS != (rc = prrte_schizo.parse_env(NULL, NULL, environ, &argv))) {
+        if (PRRTE_SUCCESS != (rc = prrte_schizo.parse_env(NULL, environ, &argv, true))) {
             prrte_argv_free(argv);
             return rc;
         }

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -69,10 +69,10 @@ PRRTE_EXPORT int prrte_schizo_base_parse_cli(int argc, int start, char **argv,
                                              char *personality, char ***target);
 PRRTE_EXPORT void prrte_schizo_base_parse_proxy_cli(prrte_cmd_line_t *cmd_line,
                                                     char ***argv);
-PRRTE_EXPORT int prrte_schizo_base_parse_env(char *path,
-                                             prrte_cmd_line_t *cmd_line,
+PRRTE_EXPORT int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
                                              char **srcenv,
-                                             char ***dstenv);
+                                             char ***dstenv,
+                                             bool cmdline);
 PRRTE_EXPORT int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line);
 PRRTE_EXPORT void prrte_schizo_base_wrap_args(char **args);
 PRRTE_EXPORT int prrte_schizo_base_setup_app(prrte_app_context_t *app);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -66,17 +66,17 @@ void prrte_schizo_base_parse_proxy_cli(prrte_cmd_line_t *cmd_line,
     }
 }
 
-int prrte_schizo_base_parse_env(char *path,
-                               prrte_cmd_line_t *cmd_line,
-                               char **srcenv,
-                               char ***dstenv)
+int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
+                                char **srcenv,
+                                char ***dstenv,
+                                bool cmdline)
 {
     int rc;
     prrte_schizo_base_active_module_t *mod;
 
     PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
         if (NULL != mod->module->parse_env) {
-            rc = mod->module->parse_env(path, cmd_line, srcenv, dstenv);
+            rc = mod->module->parse_env(cmd_line, srcenv, dstenv, cmdline);
             if (PRRTE_SUCCESS != rc && PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
                 PRRTE_ERROR_LOG(rc);
                 return rc;

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -55,10 +55,10 @@ static int parse_cli(int argc, int start, char **argv,
                      char *personality, char ***target);
 static void parse_proxy_cli(prrte_cmd_line_t *cmd_line,
                             char ***argv);
-static int parse_env(char *path,
-                     prrte_cmd_line_t *cmd_line,
+static int parse_env(prrte_cmd_line_t *cmd_line,
                      char **srcenv,
-                     char ***dstenv);
+                     char ***dstenv,
+                     bool cmdline);
 static int allow_run_as_root(prrte_cmd_line_t *cmd_line);
 
 prrte_schizo_base_module_t prrte_schizo_ompi_module = {
@@ -350,10 +350,10 @@ static int parse_cli(int argc, int start, char **argv,
     return PRRTE_SUCCESS;
 }
 
-static int parse_env(char *path,
-                     prrte_cmd_line_t *cmd_line,
+static int parse_env(prrte_cmd_line_t *cmd_line,
                      char **srcenv,
-                     char ***dstenv)
+                     char ***dstenv,
+                     bool cmdline)
 {
     int i, j;
     char *param;
@@ -476,16 +476,6 @@ static int parse_env(char *path,
             prrte_show_help("help-prrterun.txt", "prrterun:conflict-env-set", false);
             return PRRTE_ERR_FATAL;
         }
-    }
-
-    /* If the user specified --path, store it in the user's app
-       environment via the OMPI_exec_path variable. */
-    if (NULL != path) {
-        prrte_asprintf(&value, "OMPI_exec_path=%s", path);
-        prrte_argv_append_nosize(dstenv, value);
-        /* save it for any comm_spawn'd apps */
-        prrte_argv_append_nosize(&prrte_forwarded_envars, value);
-        free(value);
     }
 
     return PRRTE_SUCCESS;

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -73,10 +73,10 @@ typedef void (*prrte_schizo_base_module_parse_proxy_cli_fn_t)(prrte_cmd_line_t *
 /* parse the environment of the
  * tool to extract any personality-specific envars that need to be
  * forward to the app's environment upon execution */
-typedef int (*prrte_schizo_base_module_parse_env_fn_t)(char *path,
-                                                      prrte_cmd_line_t *cmd_line,
-                                                      char **srcenv,
-                                                      char ***dstenv);
+typedef int (*prrte_schizo_base_module_parse_env_fn_t)(prrte_cmd_line_t *cmd_line,
+                                                       char **srcenv,
+                                                       char ***dstenv,
+                                                       bool cmdline);
 
 /* check if running as root is allowed in this environment */
 typedef int (*prrte_schizo_base_module_allow_run_as_root_fn_t)(prrte_cmd_line_t *cmd_line);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -271,7 +271,7 @@ static void eviction_cbfunc(struct prrte_hotel_t *hotel,
         }
         /* fall thru and return an error so the caller doesn't hang */
     } else {
-        prrte_show_help("help-orted.txt", "timedout", true, req->operation);
+        prrte_show_help("help-prted.txt", "timedout", true, req->operation);
     }
 
     /* don't let the caller hang */

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1322,6 +1322,8 @@ int prun(int argc, char *argv[])
                 ++m;
             }
         }
+        /* pickup any relevant envars */
+        prrte_schizo.parse_env(prrte_cmd_line, environ, &papps[n].env, false);
         ++n;
     }
 


### PR DESCRIPTION
We need to distinguish between parsing envars for cmd lines vs
environment. Ensure we pickup envars to include with apps. Fix typo in
name of help file.

Signed-off-by: Ralph Castain <rhc@pmix.org>