### PR TITLE
Fix a segfault when generic MCA params are given

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -112,7 +112,8 @@ static char *frameworks[] = {
     "memheap",
     "scoll",
     "spml",
-    "sshmem"
+    "sshmem",
+    NULL,
 };
 
 

--- a/src/mca/schizo/pmix/schizo_pmix.c
+++ b/src/mca/schizo/pmix/schizo_pmix.c
@@ -103,7 +103,8 @@ static char *frameworks[] = {
     "psensor",
     "pshmem",
     "psquash",
-    "ptl"
+    "ptl",
+    NULL,
 };
 
 

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -170,7 +170,8 @@ static char *frameworks[] = {
     "routed",
     "rtc",
     "schizo",
-    "state"
+    "state",
+    NULL,
 };
 
 


### PR DESCRIPTION
Ensure that we terminate the array of frameworks with NULL

Signed-off-by: Ralph Castain <rhc@pmix.org>