### PR TITLE
Support stop-on-exec behavior

### DIFF
--- a/config/prrte_check_ptrace.m4
+++ b/config/prrte_check_ptrace.m4
@@ -1,0 +1,97 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# See if there is support for ptrace options required for
+# "stop-on-exec" behavior.
+
+AC_DEFUN([PRRTE_CHECK_PTRACE],[
+
+    PRRTE_VAR_SCOPE_PUSH(prrte_have_ptrace_traceme prrte_have_ptrace_detach prrte_have_ptrace_header prrte_have_ptrace prrte_want_stop_on_exec prrte_traceme_cmd prrte_detach_cmd)
+
+    prrte_have_ptrace_traceme=no
+    prrte_have_ptrace_detach=no
+    prrte_traceme_cmd=
+    prrte_detach_cmd=
+
+    AC_CHECK_HEADER([sys/ptrace.h],
+                    [prrte_have_ptrace_header=1],
+                    [prrte_have_ptrace_header=0])
+    # must manually define the header protection since check_header doesn't know it
+    AC_DEFINE_UNQUOTED([HAVE_SYS_PTRACE_H], [$prrte_have_ptrace_header], [Whether or not we have the ptrace header])
+
+    AC_CHECK_FUNC([ptrace],
+                  [prrte_have_ptrace=yes],
+                  [prrte_have_ptrace=no])
+
+    if test "$prrte_have_ptrace_header" == "1" && test "$prrte_have_ptrace" == "yes"; then
+        AC_MSG_CHECKING([PTRACE_TRACEME])
+        AC_EGREP_CPP([yes],
+                     [#include <sys/ptrace.h>
+                      #ifdef PTRACE_TRACEME
+                        yes
+                      #endif
+                     ],
+                     [AC_MSG_RESULT(yes)
+                      prrte_have_ptrace_traceme=yes
+                      prrte_traceme_cmd=PTRACE_TRACEME],
+                     [AC_MSG_RESULT(no)
+                      AC_MSG_CHECKING([PT_TRACE_ME])
+                      AC_EGREP_CPP([yes],
+                                   [#include <sys/ptrace.h>
+                                    #ifdef PT_TRACE_ME
+                                      yes
+                                    #endif
+                                   ],
+                                   [AC_MSG_RESULT(yes)
+                                    prrte_have_ptrace_traceme=yes
+                                    prrte_traceme_cmd=PT_TRACE_ME],
+                                   [AC_MSG_RESULT(no)
+                                    prrte_have_ptrace_traceme=no])
+                     ])
+
+        AC_MSG_CHECKING([PTRACE_DETACH])
+        AC_EGREP_CPP([yes],
+                     [#include <sys/ptrace.h>
+                      #ifdef PTRACE_DETACH
+                        yes
+                      #endif
+                     ],
+                     [AC_MSG_RESULT(yes)
+                      prrte_have_ptrace_detach=yes
+                      prrte_detach_cmd=PTRACE_DETACH],
+                     [AC_MSG_RESULT(no)
+                      AC_MSG_CHECKING(PT_DETACH)
+                      AC_EGREP_CPP([yes],
+                                   [#include <sys/ptrace.h>
+                                    #ifdef PT_DETACH
+                                      yes
+                                    #endif
+                                   ],
+                                   [AC_MSG_RESULT(yes)
+                                    prrte_have_ptrace_detach=yes
+                                    prrte_detach_cmd=PT_DETACH],
+                                   [AC_MSG_RESULT(no)
+                                    prrte_have_ptrace_detach=no])
+                     ])
+    fi
+
+    AC_MSG_CHECKING(ptrace stop-on-exec will be supported)
+    AS_IF([test "$prrte_have_ptrace_traceme" == "yes" && test "$prrte_have_ptrace_detach" == "yes"],
+          [AC_MSG_RESULT(yes)
+           prrte_want_stop_on_exec=1],
+          [AC_MSG_RESULT(no)
+           prrte_want_stop_on_exec=0])
+
+    AC_DEFINE_UNQUOTED([PRRTE_HAVE_STOP_ON_EXEC], [$prrte_want_stop_on_exec], [Whether or not we have stop-on-exec support])
+    AC_DEFINE_UNQUOTED([PRRTE_TRACEME], [$prrte_traceme_cmd], [Command for declaring that process expects to be traced by parent])
+    AC_DEFINE_UNQUOTED([PRRTE_DETACH], [$prrte_detach_cmd], [Command to detach from process being traced])
+
+    PRRTE_VAR_SCOPE_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -986,6 +986,15 @@ prrte_show_title "Symbol visibility feature"
 
 PRRTE_CHECK_VISIBILITY
 
+##################################
+# STOP-ON-EXEC
+##################################
+# Check ptrace support for stop-on-exec
+
+prrte_show_title "Ptrace stop-on-exec support"
+
+PRRTE_CHECK_PTRACE
+
 ############################################################################
 # Final top-level PRTE configuration
 ############################################################################

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1705,12 +1705,12 @@ void prrte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
          * the termination code to exit status translation the
          * same way
          */
+        PRRTE_OUTPUT_VERBOSE((5, prrte_odls_base_framework.framework_output,
+                             "%s odls:waitpid_fired child process %s terminated with signal %s",
+                             PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                             PRRTE_NAME_PRINT(&proc->name), strsignal(WTERMSIG(proc->exit_code))));
         proc->exit_code = WTERMSIG(proc->exit_code) + 128;
 
-        PRRTE_OUTPUT_VERBOSE((5, prrte_odls_base_framework.framework_output,
-                             "%s odls:waitpid_fired child process %s terminated with signal",
-                             PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
-                             PRRTE_NAME_PRINT(&proc->name) ));
         /* Do not decrement the number of local procs here. That is handled in the errmgr */
     }
 

--- a/src/tools/prun/help-prrterun.txt
+++ b/src/tools/prun/help-prrterun.txt
@@ -692,3 +692,10 @@ Conflicting requests for timeout were given:
 
 Only one method should be provided, or else they must agree. Please
 correct and retry.
+#
+[prrterun:stop-on-exec]
+%s was unable to stop the executable at first instruction:
+
+  Error:     %s
+  Nodename:  %s
+  Rank:      %lu

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -262,11 +262,14 @@ static prrte_cmd_line_init_t cmd_line_init[] = {
 
 
     /* User-level debugger arguments */
-    { '\0', "debug", 1, PRRTE_CMD_LINE_TYPE_BOOL,
+    { '\0', "debug", 1, PRRTE_CMD_LINE_TYPE_STRING,
       "Invoke the indicated user-level debugger (provide a comma-delimited list of debuggers to search for)",
       PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { '\0', "output-proctable", 1, PRRTE_CMD_LINE_TYPE_BOOL,
+    { '\0', "output-proctable", 1, PRRTE_CMD_LINE_TYPE_STRING,
       "Print the complete proctable to stdout [-], stderr [+], or a file [anything else] after launch",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "stop-on-exec", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "If supported, stop each process at start of execution",
       PRRTE_CMD_LINE_OTYPE_DEBUG },
 
 
@@ -1180,6 +1183,15 @@ int prun(int argc, char *argv[])
         PMIX_INFO_CREATE(ds->info, 1);
         flag = true;
         PMIX_INFO_LOAD(ds->info, PMIX_JOB_CONTINUOUS, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* if stop-on-exec was specified */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "stop-on-exec")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_DEBUG_STOP_ON_EXEC, &flag, PMIX_BOOL);
         prrte_list_append(&job_info, &ds->super);
     }
 

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
@@ -388,6 +388,8 @@ const char *prrte_attr_key_to_str(prrte_attribute_key_t key)
             return "PRRTE_JOB_APP_SETUP_DATA";
         case PRRTE_JOB_OUTPUT_TO_DIRECTORY:
             return "PRRTE_JOB_OUTPUT_TO_DIRECTORY";
+        case PRRTE_JOB_STOP_ON_EXEC:
+            return "JOB_STOP_ON_EXEC";
 
 
         case PRRTE_PROC_NOBARRIER:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -156,7 +156,7 @@ typedef uint16_t prrte_job_flags_t;
 #define PRRTE_JOB_INFO_CACHE             (PRRTE_JOB_START_KEY + 52)    // prrte_list_t - list of prrte_value_t to be included in job_info
 #define PRRTE_JOB_FULLY_DESCRIBED        (PRRTE_JOB_START_KEY + 53)    // bool - job is fully described in launch msg
 #define PRRTE_JOB_SILENT_TERMINATION     (PRRTE_JOB_START_KEY + 54)    // bool - do not generate an event notification when job
-                                                                     //        normally terminates
+                                                                       //        normally terminates
 #define PRRTE_JOB_SET_ENVAR              (PRRTE_JOB_START_KEY + 55)    // prrte_envar_t - set the given envar to the specified value
 #define PRRTE_JOB_UNSET_ENVAR            (PRRTE_JOB_START_KEY + 56)    // string - name of envar to unset, if present
 #define PRRTE_JOB_PREPEND_ENVAR          (PRRTE_JOB_START_KEY + 57)    // prrte_envar_t - prepend the specified value to the given envar
@@ -164,6 +164,7 @@ typedef uint16_t prrte_job_flags_t;
 #define PRRTE_JOB_ADD_ENVAR              (PRRTE_JOB_START_KEY + 59)    // prrte_envar_t - add envar, do not override pre-existing one
 #define PRRTE_JOB_APP_SETUP_DATA         (PRRTE_JOB_START_KEY + 60)    // prrte_byte_object_t - blob containing app setup data
 #define PRRTE_JOB_OUTPUT_TO_DIRECTORY    (PRRTE_JOB_START_KEY + 61)    // string - path of directory to which stdout/err is to be directed
+#define PRRTE_JOB_STOP_ON_EXEC           (PRRTE_JOB_START_KEY + 62)    // bool - stop procs on first instruction for debugger attach
 
 #define PRRTE_JOB_MAX_KEY   300
 


### PR DESCRIPTION
Allow the user to request that the application's processes be stopped on
first executable, thereby allowing a debugger to attach at the very
start of execution.

Signed-off-by: Ralph Castain <rhc@pmix.org>