### PR TITLE
Ensure the spawning process always is released

### DIFF
--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -94,6 +94,7 @@ PRRTE_EXPORT void prrte_plm_base_reset_job(prrte_job_t *jdata);
 PRRTE_EXPORT int prrte_plm_base_setup_prted_cmd(int *argc, char ***argv);
 PRRTE_EXPORT void prrte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRRTE_EXPORT int prrte_plm_base_setup_virtual_machine(prrte_job_t *jdata);
+PRRTE_EXPORT int prrte_plm_base_spawn_reponse(int32_t status, prrte_job_t *jdata);
 
 /**
  * Utilities for plm components that use proxy daemons

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -390,7 +390,8 @@ const char *prrte_attr_key_to_str(prrte_attribute_key_t key)
             return "PRRTE_JOB_OUTPUT_TO_DIRECTORY";
         case PRRTE_JOB_STOP_ON_EXEC:
             return "JOB_STOP_ON_EXEC";
-
+        case PRRTE_JOB_SPAWN_NOTIFIED:
+            return "JOB_SPAWN_NOTIFIED";
 
         case PRRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -165,6 +165,7 @@ typedef uint16_t prrte_job_flags_t;
 #define PRRTE_JOB_APP_SETUP_DATA         (PRRTE_JOB_START_KEY + 60)    // prrte_byte_object_t - blob containing app setup data
 #define PRRTE_JOB_OUTPUT_TO_DIRECTORY    (PRRTE_JOB_START_KEY + 61)    // string - path of directory to which stdout/err is to be directed
 #define PRRTE_JOB_STOP_ON_EXEC           (PRRTE_JOB_START_KEY + 62)    // bool - stop procs on first instruction for debugger attach
+#define PRRTE_JOB_SPAWN_NOTIFIED         (PRRTE_JOB_START_KEY + 63)    // bool - process requesting a spawn operation has been notified of result
 
 #define PRRTE_JOB_MAX_KEY   300
 


### PR DESCRIPTION
Regardless of the result of a launch (running, proc failed, job failed),
we need to ensure that the launcher is released from their call to
PMIx_Spawn.

Signed-off-by: Ralph Castain <rhc@pmix.org>