### PR TITLE
Cleanup termination of pterm and add support for PMIx v3

### DIFF
--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -36,9 +36,8 @@
 pmix_status_t prrte_pmix_convert_rc(int rc)
 {
     switch (rc) {
-    case PRRTE_ERR_FAILED_TO_START:
-        return PMIX_ERR_JOB_FAILED_TO_START;
 
+#if PMIX_NUMERIC_VERSION >= 0x00040000
     case PRRTE_ERR_HEARTBEAT_ALERT:
     case PRRTE_ERR_FILE_ALERT:
     case PRRTE_ERR_HEARTBEAT_LOST:
@@ -54,6 +53,7 @@ pmix_status_t prrte_pmix_convert_rc(int rc)
 
     case PRRTE_ERR_JOB_CANCELLED:
         return PMIX_ERR_JOB_CANCELLED;
+#endif
 
     case PRRTE_ERR_DEBUGGER_RELEASE:
         return PMIX_ERR_DEBUGGER_RELEASE;
@@ -131,6 +131,7 @@ pmix_status_t prrte_pmix_convert_rc(int rc)
         return PMIX_ERROR;
     case PRRTE_SUCCESS:
         return PMIX_SUCCESS;
+
     default:
         return PMIX_ERROR;
     }
@@ -321,6 +322,8 @@ int prrte_pmix_convert_pstate(pmix_proc_state_t state)
 pmix_status_t prrte_pmix_convert_job_state_to_error(int state)
 {
     switch(state) {
+
+#if PMIX_NUMERIC_VERSION >= 0x00040000
         case PRRTE_JOB_STATE_ALLOC_FAILED:
             return PMIX_ERR_JOB_ALLOC_FAILED;
 
@@ -339,9 +342,6 @@ pmix_status_t prrte_pmix_convert_job_state_to_error(int state)
         case PRRTE_JOB_STATE_CANNOT_LAUNCH:
             return PMIX_ERR_JOB_CANNOT_LAUNCH;
 
-        case PRRTE_JOB_STATE_TERMINATED:
-            return PMIX_ERR_JOB_TERMINATED;
-
         case PRRTE_JOB_STATE_KILLED_BY_CMD:
             return PMIX_ERR_JOB_CANCELLED;
 
@@ -355,6 +355,10 @@ pmix_status_t prrte_pmix_convert_job_state_to_error(int state)
 
         case PRRTE_JOB_STATE_ABORTED_WO_SYNC:
             return PMIX_ERR_JOB_TERM_WO_SYNC;
+#endif
+
+        case PRRTE_JOB_STATE_TERMINATED:
+            return PMIX_ERR_JOB_TERMINATED;
 
         default:
             return PMIX_ERROR;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -779,6 +779,7 @@ static void pmix_server_dmdx_recv(int status, prrte_process_name_t* sender,
     }
     prrte_dss.load(buffer, data, sz);  // restore the buffer as we are done with it
 
+#if PMIX_VERSION_MAJOR >=4
     /* see if they want us to await a particular key before sending
      * the response */
     if (NULL != info) {
@@ -789,6 +790,7 @@ static void pmix_server_dmdx_recv(int status, prrte_process_name_t* sender,
             }
         }
     }
+#endif
 
     /* is this proc one of mine? */
     PRRTE_PMIX_CONVERT_PROCT(rc, &name, &pproc);

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -205,7 +205,6 @@ static void dmodex_req(int sd, short args, void *cbdata)
     pmix_proc_t myproc;
     pmix_status_t prc;
     bool refresh_cache = false;
-    size_t n;
     pmix_value_t *pval;
 
     PRRTE_ACQUIRE_OBJECT(rq);
@@ -222,8 +221,10 @@ static void dmodex_req(int sd, short args, void *cbdata)
         return;
     }
 
+#if PMIX_NUMERIC_VERSION >= 0x00040000
     /* check if they want us to refresh the cache */
     if (NULL != req->info) {
+        size_t n;
         for (n=0; n < req->ninfo; n++) {
             if (PMIX_CHECK_KEY(&req->info[n], PMIX_GET_REFRESH_CACHE)) {
                 refresh_cache = PMIX_INFO_TRUE(&req->info[n]);
@@ -232,6 +233,8 @@ static void dmodex_req(int sd, short args, void *cbdata)
             }
         }
     }
+#endif
+
     prrte_output_verbose(2, prrte_pmix_server_globals.output,
                          "%s DMODX REQ REFRESH %s REQUIRED KEY %s",
                          PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -436,8 +436,6 @@ static void defhandler(size_t evhdlr_registration_id,
 {
     prrte_pmix_lock_t *lock = NULL;
     size_t n;
-    pmix_proc_t target;
-    pmix_info_t directive;
 
     if (verbose) {
         prrte_output(0, "PRUN: DEFHANDLER WITH STATUS %s(%d)", PMIx_Error_string(status), status);
@@ -445,6 +443,9 @@ static void defhandler(size_t evhdlr_registration_id,
 
 #if PMIX_NUMERIC_VERSION >= 0x00040000
     if (PMIX_ERR_IOF_FAILURE == status) {
+        pmix_proc_t target;
+        pmix_info_t directive;
+
         /* tell PRRTE to terminate our job */
         PRRTE_PMIX_CONVERT_JOBID(target.nspace, myjobid);
         target.rank = PMIX_RANK_WILDCARD;
@@ -478,8 +479,9 @@ static void defhandler(size_t evhdlr_registration_id,
         /* release the lock */
         PRRTE_PMIX_WAKEUP_THREAD(lock);
     }
-
+#if PMIX_NUMERIC_VERSION >= 0x00040000
   progress:
+#endif
     /* we _always_ have to execute the evhandler callback or
      * else the event progress engine will hang */
     if (NULL != cbfunc) {
@@ -621,7 +623,9 @@ int prun(int argc, char *argv[])
     size_t napps;
     char nspace[PMIX_MAX_NSLEN+1];
     mylock_t mylock;
+#if PMIX_NUMERIC_VERSION >= 0x00040000
     bool notify_launch = false;
+#endif
     char **prteargs = NULL;
     FILE *fp;
     char buf[2048];
@@ -1160,6 +1164,7 @@ int prun(int argc, char *argv[])
         free(ptr);
         prrte_list_append(&job_info, &ds->super);
     } else if (NULL != ptr) {
+#if PMIX_NUMERIC_VERSION >= 0x00040000
         /* if we were asked to output to a directory, pass it along. */
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
@@ -1178,6 +1183,7 @@ int prun(int argc, char *argv[])
         }
         PMIX_INFO_LOAD(ds->info, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
         free(param);
+#endif
     }
     /* if we were asked to merge stderr to stdout, mark it so */
     if (prrte_cmd_line_is_taken(prrte_cmd_line, "merge-stderr-to-stdout")) {

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -473,15 +473,11 @@ int main(int argc, char *argv[])
 
 static void clean_abort(int fd, short flags, void *arg)
 {
-    pmix_proc_t target;
-    pmix_info_t directive;
-
     /* if we have already ordered this once, don't keep
      * doing it to avoid race conditions
      */
     if (prrte_atomic_trylock(&prun_abort_inprogress_lock)) { /* returns 1 if already locked */
         if (forcibly_die) {
-            PMIx_tool_finalize();
             /* exit with a non-zero status */
             exit(1);
         }
@@ -489,6 +485,7 @@ static void clean_abort(int fd, short flags, void *arg)
         forcibly_die = true;
         /* reset the event */
         prrte_event_add(&term_handler, NULL);
+        PMIx_tool_finalize();
         return;
     }
 }


### PR DESCRIPTION
 Cleanup ctrl-c termination of pterm tool
Try to properly finalize and then just exit upon mult-signal.

 Support PMIx v3
Protect all references to v4 definitions

Signed-off-by: Ralph Castain <rhc@pmix.org>