### PR TITLE
Fix PRRTE build in ras/lsf module

### DIFF
--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -34,6 +34,7 @@
 #include "src/util/net.h"
 #include "src/hwloc/hwloc-internal.h"
 
+#include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/mca/errmgr/errmgr.h"
 #include "src/runtime/prrte_globals.h"

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -36,6 +36,7 @@
 #include "src/util/printf.h"
 #include "src/mca/mca.h"
 
+#include "src/mca/base/prrte_mca_base_framework.h"
 #include "src/runtime/prrte_globals.h"
 
 #include "src/mca/rmaps/rmaps.h"


### PR DESCRIPTION
`prrte` build  fails with this error, 

```
In file included from ras_lsf_module.c:37:0:
ras_lsf_module.c: In function ‘allocate’:
ras_lsf_module.c:122:67: error: ‘prrte_rmaps_base’ undeclared (first use in this function)
     } else if ((PRRTE_MAPPING_GIVEN & PRRTE_GET_MAPPING_DIRECTIVE(prrte_rmaps_base.mapping)) ||
                                                                   ^
../../../../src/mca/rmaps/rmaps_types.h:103:7: note: in definition of macro ‘PRRTE_GET_MAPPING_DIRECTIVE’
     ((pol) & 0xff00)
       ^
ras_lsf_module.c:122:67: note: each undeclared identifier is reported only once for each function it appears in
     } else if ((PRRTE_MAPPING_GIVEN & PRRTE_GET_MAPPING_DIRECTIVE(prrte_rmaps_base.mapping)) ||
                                                                   ^
../../../../src/mca/rmaps/rmaps_types.h:103:7: note: in definition of macro ‘PRRTE_GET_MAPPING_DIRECTIVE’
     ((pol) & 0xff00)
       ^
make[3]: *** [ras_lsf_module.lo] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory `/nfs_smpi_ci/abd/os/ompi/prrte/src/mca/ras/lsf'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/nfs_smpi_ci/abd/os/ompi/prrte/src'
make[1]: *** [all-recursive] Error 1
```

Looks like some header files are missing in the ```ras/lsf``` module. This PR fixes the issue.