### PR TITLE
Protect against DVM collisions

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -73,6 +73,7 @@ PRRTE_EXPORT int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
                                              char **srcenv,
                                              char ***dstenv,
                                              bool cmdline);
+PRRTE_EXPORT int prrte_schizo_base_detect_proxy(char **argv, char **rfile);
 PRRTE_EXPORT int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line);
 PRRTE_EXPORT void prrte_schizo_base_wrap_args(char **args);
 PRRTE_EXPORT int prrte_schizo_base_setup_app(prrte_app_context_t *app);

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -41,6 +41,7 @@ prrte_schizo_base_module_t prrte_schizo = {
     .parse_cli = prrte_schizo_base_parse_cli,
     .parse_proxy_cli = prrte_schizo_base_parse_proxy_cli,
     .parse_env = prrte_schizo_base_parse_env,
+    .detect_proxy = prrte_schizo_base_detect_proxy,
     .allow_run_as_root = prrte_schizo_base_allow_run_as_root,
     .wrap_args = prrte_schizo_base_wrap_args,
     .setup_app = prrte_schizo_base_setup_app,

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -86,6 +86,26 @@ int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
     return PRRTE_SUCCESS;
 }
 
+int prrte_schizo_base_detect_proxy(char **argv, char **rfile)
+{
+    int rc;
+    prrte_schizo_base_active_module_t *mod;
+
+    PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
+        if (NULL != mod->module->detect_proxy) {
+            rc = mod->module->detect_proxy(argv, rfile);
+            if (PRRTE_SUCCESS == rc) {
+                return rc;
+            }
+            if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
+                PRRTE_ERROR_LOG(rc);
+                return rc;
+            }
+        }
+    }
+    return PRRTE_ERR_TAKE_NEXT_OPTION;
+}
+
 int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line)
 {
     int rc;

--- a/src/mca/schizo/ompi/schizo_ompi_component.c
+++ b/src/mca/schizo/ompi/schizo_ompi_component.c
@@ -45,7 +45,7 @@ prrte_schizo_base_component_t prrte_schizo_ompi_component = {
 static int component_query(prrte_mca_base_module_t **module, int *priority)
 {
     *module = (prrte_mca_base_module_t*)&prrte_schizo_ompi_module;
-    *priority = 15;
+    *priority = 40;
     return PRRTE_SUCCESS;
 }
 

--- a/src/mca/schizo/prrte/schizo_prrte_component.c
+++ b/src/mca/schizo/prrte/schizo_prrte_component.c
@@ -45,7 +45,7 @@ prrte_schizo_base_component_t prrte_schizo_prrte_component = {
 static int component_query(prrte_mca_base_module_t **module, int *priority)
 {
     *module = (prrte_mca_base_module_t*)&prrte_schizo_prrte_module;
-    *priority = 15;
+    *priority = 5;
     return PRRTE_SUCCESS;
 }
 

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -66,6 +66,14 @@ typedef int (*prrte_schizo_base_module_parse_cli_fn_t)(int argc, int start,
                                                       char *personality,
                                                       char ***target);
 
+/* detect if we are running as a proxy
+ * Check the environment to determine what, if any, host we are running
+ * under. Check the argv to see if we are running as a proxy for some
+ * other command and to see which environment we are proxying. Return
+ * a unique rendezvous file to use for prun to connect to prte.
+ */
+typedef int (*prrte_schizo_base_detect_proxy_fn_t)(char **argv, char **rndfile);
+
 /* parse the environment for proxy cmd line entries */
 typedef void (*prrte_schizo_base_module_parse_proxy_cli_fn_t)(prrte_cmd_line_t *cmd_line,
                                                               char ***argv);
@@ -125,6 +133,7 @@ typedef struct {
     prrte_schizo_base_module_parse_cli_fn_t              parse_cli;
     prrte_schizo_base_module_parse_proxy_cli_fn_t        parse_proxy_cli;
     prrte_schizo_base_module_parse_env_fn_t              parse_env;
+    prrte_schizo_base_detect_proxy_fn_t                  detect_proxy;
     prrte_schizo_base_module_allow_run_as_root_fn_t      allow_run_as_root;
     prrte_schizo_base_module_wrap_args_fn_t              wrap_args;
     prrte_schizo_base_module_setup_app_fn_t              setup_app;

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies Ltd.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -27,11 +27,25 @@
 
 #include "schizo_slurm.h"
 
+static int detect_proxy(char **argv, char **rfile);
 static int get_remaining_time(uint32_t *timeleft);
 
 prrte_schizo_base_module_t prrte_schizo_slurm_module = {
+    .detect_proxy = detect_proxy,
     .get_remaining_time = get_remaining_time
 };
+
+static int detect_proxy(char **argv, char **rfile)
+{
+    char *jid;
+
+    /* if we are active, then we must be inside a Slurm
+     * allocation - set the rendezvous file accordingly */
+    jid = getenv("SLURM_JOBID");
+    prrte_asprintf(rfile, "%s.rndz.%s", prrte_tool_basename, jid);
+
+    return PRRTE_SUCCESS;
+}
 
 static int get_remaining_time(uint32_t *timeleft)
 {

--- a/src/sys/atomic.h
+++ b/src/sys/atomic.h
@@ -164,8 +164,6 @@ enum {
  *********************************************************************/
 #if defined(DOXYGEN)
 /* don't include system-level gorp when generating doxygen files */
-#elif PRRTE_ASSEMBLY_BUILTIN == PRRTE_BUILTIN_SYNC
-#include "src/sys/sync_builtin/atomic.h"
 #elif PRRTE_ASSEMBLY_BUILTIN == PRRTE_BUILTIN_GCC
 #include "src/sys/gcc_builtin/atomic.h"
 #elif PRRTE_ASSEMBLY_ARCH == PRRTE_X86_64

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -173,42 +173,17 @@ static int _setup_jobfam_session_dir(prrte_process_name_t *proc)
     /* construct the top_session_dir if we need */
     if (NULL == prrte_process_info.jobfam_session_dir) {
         if (PRRTE_SUCCESS != (rc = prrte_setup_top_session_dir())) {
+            PRRTE_ERROR_LOG(rc);
             return rc;
         }
 
-        if (PRRTE_PROC_IS_MASTER) {
-            if (0 > prrte_asprintf(&prrte_process_info.jobfam_session_dir,
-                             "%s/dvm", prrte_process_info.top_session_dir)) {
-                rc = PRRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        } else if (PRRTE_PROC_IS_MASTER) {
-            if (0 > prrte_asprintf(&prrte_process_info.jobfam_session_dir,
-                             "%s/pid.%lu", prrte_process_info.top_session_dir,
-                             (unsigned long)prrte_process_info.pid)) {
-                rc = PRRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        } else {
-            /* we were not given one, so define it */
-            if (NULL == proc || (PRRTE_JOBID_INVALID == proc->jobid)) {
-                if (0 > prrte_asprintf(&prrte_process_info.jobfam_session_dir,
-                                 "%s/jobfam", prrte_process_info.top_session_dir) ) {
-                    rc = PRRTE_ERR_OUT_OF_RESOURCE;
-                    goto exit;
-                }
-            } else {
-                if (0 > prrte_asprintf(&prrte_process_info.jobfam_session_dir,
-                                 "%s/jf.%d", prrte_process_info.top_session_dir,
-                                 PRRTE_JOB_FAMILY(proc->jobid))) {
-                    prrte_process_info.jobfam_session_dir = NULL;
-                    rc = PRRTE_ERR_OUT_OF_RESOURCE;
-                    goto exit;
-                }
-            }
+        if (0 > prrte_asprintf(&prrte_process_info.jobfam_session_dir,
+                         "%s/dvm.%lu", prrte_process_info.top_session_dir,
+                         (unsigned long)prrte_process_info.pid)) {
+            rc = PRRTE_ERR_OUT_OF_RESOURCE;
         }
     }
-exit:
+
     if( PRRTE_SUCCESS != rc ){
         PRRTE_ERROR_LOG(rc);
     }


### PR DESCRIPTION
Ensure the DVM is unique by appending its pid to the "dvm" job-level
session directory name. Add a new entry point to "schizo" to detect prun
operating as a proxy so we aren't solely depending upon the name
"mpirun". Adjust schizo component priorities so we detect the first
proxy and stop.

Signed-off-by: Ralph Castain <rhc@pmix.org>