### PR TITLE
Deal with deprecated cmd line options and rndz files

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -67,6 +67,8 @@ PRRTE_CLASS_DECLARATION(prrte_schizo_base_active_module_t);
 PRRTE_EXPORT int prrte_schizo_base_define_cli(prrte_cmd_line_t *cli);
 PRRTE_EXPORT int prrte_schizo_base_parse_cli(int argc, int start, char **argv,
                                              char *personality, char ***target);
+PRRTE_EXPORT void prrte_schizo_base_parse_deprecated_cli(int *argc, char ***argv);
+
 PRRTE_EXPORT void prrte_schizo_base_parse_proxy_cli(prrte_cmd_line_t *cmd_line,
                                                     char ***argv);
 PRRTE_EXPORT int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -39,6 +39,7 @@ prrte_schizo_base_t prrte_schizo_base = {{{0}}};
 prrte_schizo_base_module_t prrte_schizo = {
     .define_cli = prrte_schizo_base_define_cli,
     .parse_cli = prrte_schizo_base_parse_cli,
+    .parse_deprecated_cli = prrte_schizo_base_parse_deprecated_cli,
     .parse_proxy_cli = prrte_schizo_base_parse_proxy_cli,
     .parse_env = prrte_schizo_base_parse_env,
     .detect_proxy = prrte_schizo_base_detect_proxy,

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -54,6 +54,17 @@ int prrte_schizo_base_parse_cli(int argc, int start, char **argv,
     return PRRTE_SUCCESS;
 }
 
+void prrte_schizo_base_parse_deprecated_cli(int *argc, char ***argv)
+{
+    prrte_schizo_base_active_module_t *mod;
+
+    PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
+        if (NULL != mod->module->parse_deprecated_cli) {
+            mod->module->parse_deprecated_cli(argc, argv);
+        }
+    }
+}
+
 void prrte_schizo_base_parse_proxy_cli(prrte_cmd_line_t *cmd_line,
                                        char ***argv)
 {

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -66,6 +66,8 @@ typedef int (*prrte_schizo_base_module_parse_cli_fn_t)(int argc, int start,
                                                       char *personality,
                                                       char ***target);
 
+typedef void (*prrte_schizo_base_module_parse_deprecated_cli_fn_t)(int *argc, char ***argv);
+
 /* detect if we are running as a proxy
  * Check the environment to determine what, if any, host we are running
  * under. Check the argv to see if we are running as a proxy for some
@@ -131,6 +133,7 @@ typedef struct {
     prrte_schizo_base_module_init_fn_t                   init;
     prrte_schizo_base_module_define_cli_fn_t             define_cli;
     prrte_schizo_base_module_parse_cli_fn_t              parse_cli;
+    prrte_schizo_base_module_parse_deprecated_cli_fn_t   parse_deprecated_cli;
     prrte_schizo_base_module_parse_proxy_cli_fn_t        parse_proxy_cli;
     prrte_schizo_base_module_parse_env_fn_t              parse_env;
     prrte_schizo_base_detect_proxy_fn_t                  detect_proxy;


### PR DESCRIPTION
Detect if we are launching as a proxy for "prun" and will therefore be
starting our own "prte" - if so, then define a rendezvous file to ensure
that prun connects to the correct prte.

First cut at a way of dealing with deprecated CLI - in this case, deal
with the --oversubscribe option as that is causing numerous MTT
failures.

Signed-off-by: Ralph Castain <rhc@pmix.org>