### PR TITLE
support for cmdline "--mca prrte_tools_entry lib"

### DIFF
--- a/src/mca/schizo/entry/Makefile.am
+++ b/src/mca/schizo/entry/Makefile.am
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2016      Intel, Inc.  All rights reserved.
+# Copyright (c) 2017-2020 IBM Corporation. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+          schizo_entry_component.c \
+          schizo_entry.h \
+          schizo_entry.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prrte_schizo_entry_DSO
+component_noinst =
+component_install = mca_schizo_entry.la
+else
+component_noinst = libmca_schizo_entry.la
+component_install =
+endif
+
+mcacomponentdir = $(prrtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_schizo_entry_la_SOURCES = $(sources)
+mca_schizo_entry_la_LDFLAGS = -module -avoid-version
+mca_schizo_entry_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_schizo_entry_la_SOURCES = $(sources)
+libmca_schizo_entry_la_LDFLAGS = -module -avoid-version
+

--- a/src/mca/schizo/entry/schizo_entry.c
+++ b/src/mca/schizo/entry/schizo_entry.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2019-2020 IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "prrte_config.h"
+#include "src/include/types.h"
+#include "opal/types.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <ctype.h>
+
+#include "src/util/argv.h"
+#include "src/util/basename.h"
+#include "src/util/prrte_environ.h"
+
+#include "src/runtime/prrte_globals.h"
+#include "src/util/name_fns.h"
+#include "src/mca/schizo/base/base.h"
+
+#include "schizo_entry.h"
+
+#include "src/util/parse_entry.h"
+
+/* Cmd-line option for OMPI's -entry feature */
+static prrte_cmd_line_init_t cmd_line_init[] = {
+    { '\0', "entry", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "PMPI layering options",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "entrybase", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "PMPI layering options",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* End of list */
+    { '\0', NULL, 0, PRRTE_CMD_LINE_TYPE_NULL, NULL }
+};
+
+static int define_cli(prrte_cmd_line_t *cli);
+static int parse_env(prrte_cmd_line_t *cmd_line,
+                     char **srcenv,
+                     char ***dstenv,
+                     bool cmdline);
+static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context);
+
+prrte_schizo_base_module_t prrte_schizo_entry_module = {
+    .define_cli = define_cli,
+    .parse_env = parse_env,
+    .setup_fork = setup_fork
+};
+
+static int
+define_cli(prrte_cmd_line_t *cli)
+{
+    int rc;
+
+    prrte_output_verbose(1, prrte_schizo_base_framework.framework_output,
+                        "%s schizo:entry: define_cli",
+                        PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME));
+
+    /* protect against bozo error */
+    if (NULL == cli) {
+        return PRRTE_ERR_BAD_PARAM;
+    }
+
+    rc = prrte_cmd_line_add(cli, cmd_line_init);
+    if (PRRTE_SUCCESS != rc){
+        return rc;
+    }
+
+    return PRRTE_SUCCESS;
+}
+
+/*
+ *  Look for var in a char **env list
+ */
+static char *
+getenv_from_list(char *var, char **env)
+{
+    char **penv;
+    char *p;
+    int len;
+
+    if (!var || !*var) { return NULL; }
+    len = strlen(var);
+
+    penv = env;
+    while (penv && *penv) {
+        p = *penv;
+        if (0 == strncmp(p, var, len) && p[len] == '=') {
+            p += (len + 1);
+            if (!*p) { return NULL; }
+            return p;
+        }
+        ++penv;
+    }
+
+    return NULL;
+}
+
+static int
+setup_fork(prrte_job_t *jdata, prrte_app_context_t *context)
+{
+    int entry_is_active;
+    char *preload_string;
+    char *ompi_root;
+    opal_envar_t envar;
+
+    prrte_entry_parse_mca(
+        getenv_from_list("OMPI_MCA_ompi_tools_entry", context->env),
+        getenv_from_list("OMPI_MCA_ompi_tools_entrybase", context->env),
+        &entry_is_active, NULL, &preload_string,
+        NULL, NULL, NULL, NULL);
+
+    if (entry_is_active) {
+        prrte_app_context_t *app;
+
+        ompi_root = getenv("OPAL_PREFIX");
+        if (!ompi_root) { ompi_root = getenv("MPI_ROOT"); }
+
+        /* looking only at app[0] for a prefix */
+        char *app_prefix_dir = NULL;
+        if ((app = (prrte_app_context_t*) prrte_pointer_array_get_item(jdata->apps, 0))) {
+            prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&app_prefix_dir, OPAL_STRING);
+        }
+        if (app_prefix_dir) {
+            ompi_root = app_prefix_dir;
+        }
+
+/* 
+ * Set OMPI_ENTRY_LD_PRELOAD and OMPI_ENTRY_LD_LIBRARY_PATH and use
+ * MPI_ROOT/bin/profilesupport in front of the exe
+ *
+ * Reason for this argv prepend method instead of PRRTE_JOB_PREPEND_ENVAR:
+ * The PRRTE_JOB_PREPEND_ENVAR is almost what we want, but it's not
+ * really forceful about being the last prepend, so it doesn't guarantee
+ * an MPI_ROOT/lib won't be prepended in front of what it does
+ */
+        if (ompi_root) {
+            char *str = malloc(strlen(ompi_root) + 64);
+            if (!str) { return PRRTE_ERR_OUT_OF_RESOURCE; }
+
+            sprintf(str, "%s/bin/profilesupport", ompi_root);
+            prrte_argv_insert_element(&context->argv, 0, str);
+            if (context->app) { free(context->app); }
+            context->app = strdup(context->argv[0]);
+
+            sprintf(str, "%s/lib/profilesupport", ompi_root);
+            prrte_setenv("OMPI_ENTRY_LD_LIBRARY_PATH", str, true, &context->env);
+            if (preload_string) {
+                prrte_setenv("OMPI_ENTRY_LD_PRELOAD", preload_string, true, &context->env);
+            }
+
+            free(str);
+        }
+    }
+
+    return PRRTE_SUCCESS;
+}
+
+static int
+parse_env(prrte_cmd_line_t *cmd_line,
+          char **srcenv,
+          char ***dstenv,
+          bool cmdline)
+{
+    int entry_is_active;
+    int verbose;
+    char **lib_names, **baselib_names;
+    int nlib_names, nbaselib_names;
+
+    /*
+     *  Accept any of
+     *    -entry on cmdline
+     *    --mca ompi_tools_entry
+     *    OMPI_MCA_ompi_tools_entry env var
+     */
+    prrte_value_t *pval;
+    if (NULL != (pval = prrte_cmd_line_get_param(cmd_line, "entry", 0, 0))) {
+        prrte_setenv("OMPI_MCA_ompi_tools_entry", pval->data.string, true, dstenv);
+    }
+    if (NULL != (pval = prrte_cmd_line_get_param(cmd_line, "entrybase", 0, 0))) {
+        prrte_setenv("OMPI_MCA_ompi_tools_entrybase", pval->data.string, true, dstenv);
+    }
+    /* If it was on the cmdline as an --mca , it should be in dstenv by now */
+    char *p;
+    p = getenv("OMPI_MCA_ompi_tools_entry");
+    if (p && *p) {
+        prrte_setenv("OMPI_MCA_ompi_tools_entry", p, true, dstenv);
+    }
+    p = getenv("OMPI_MCA_ompi_tools_entrybase");
+    if (p && *p) {
+        prrte_setenv("OMPI_MCA_ompi_tools_entrybase", p, true, dstenv);
+    }
+
+    prrte_entry_parse_mca(
+        getenv_from_list("OMPI_MCA_ompi_tools_entry", *dstenv),
+        getenv_from_list("OMPI_MCA_ompi_tools_entrybase", *dstenv),
+        &entry_is_active, &verbose, NULL,
+        &lib_names, &nlib_names, &baselib_names, &nbaselib_names);
+
+    if (entry_is_active) {
+        if (verbose) {
+            int has_fort_specified = 0;
+            int i;
+            printf("Entrypoint MPI wrapper levels:\n");
+            for (i=0; i<nlib_names; ++i) {
+                if (0 == strcmp(lib_names[i], "fort") ||
+                    0 == strcmp(lib_names[i], "fortran"))
+                {
+                    has_fort_specified = 1;
+                }
+            }
+
+            int level;
+            level = 0;
+            if (!has_fort_specified) {
+                printf("  [%d] : fortran from base product\n", level);
+                ++level;
+            }
+            for (i=0; i<nlib_names; ++i) {
+                if (0 == strcmp(lib_names[i], "fort") ||
+                    0 == strcmp(lib_names[i], "fortran"))
+                {
+                    printf("  [%d] : fortran from base product\n", level);
+                } else {
+                    printf("  [%d] : %s\n", level, lib_names[i]);
+                }
+                ++level;
+            }
+            printf("  [%d] : base product\n", level);
+
+            printf("Entrypoint MPI base product:\n");
+            level = 0;
+            for (i=0; i<nbaselib_names; ++i) {
+                printf("  [%d] : %s\n", level, baselib_names[i]);
+                ++level;
+            }
+            fflush(stdout);
+        }
+        free(lib_names);
+        free(baselib_names);
+    }
+
+    return PRRTE_SUCCESS;
+}

--- a/src/mca/schizo/entry/schizo_entry.h
+++ b/src/mca/schizo/entry/schizo_entry.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _MCA_SCHIZO_ENTRY_H_
+#define _MCA_SCHIZO_ENTRY_H_
+
+#include "prrte_config.h"
+
+#include "src/include/types.h"
+
+#include "src/mca/base/base.h"
+#include "src/mca/schizo/schizo.h"
+
+
+BEGIN_C_DECLS
+
+PRRTE_MODULE_EXPORT extern prrte_schizo_base_component_t prrte_schizo_entry_component;
+extern prrte_schizo_base_module_t prrte_schizo_entry_module;
+
+END_C_DECLS
+
+#endif /* MCA_SCHIZO_ENTRY_H_ */
+

--- a/src/mca/schizo/entry/schizo_entry_component.c
+++ b/src/mca/schizo/entry/schizo_entry_component.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prrte_config.h"
+#include "src/include/types.h"
+#include "opal/types.h"
+
+#include "opal/util/show_help.h"
+
+#include "src/mca/schizo/schizo.h"
+#include "schizo_entry.h"
+
+static int component_query(prrte_mca_base_module_t **module, int *priority);
+
+/*
+ * Struct of function pointers and all that to let us be initialized
+ */
+prrte_schizo_base_component_t prrte_schizo_entry_component = {
+    .base_version = {
+        PRRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+        .mca_component_name = "entry",
+        PRRTE_MCA_BASE_MAKE_VERSION(component, PRRTE_MAJOR_VERSION, PRRTE_MINOR_VERSION,
+                              PRRTE_RELEASE_VERSION),
+        .mca_query_component = component_query,
+    },
+    .base_data = {
+        /* The component is checkpoint ready */
+        PRRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+};
+
+static int component_query(prrte_mca_base_module_t **module, int *priority)
+{
+    *module = (prrte_mca_base_module_t*)&prrte_schizo_entry_module;
+    *priority = 20;
+    return PRRTE_SUCCESS;
+}
+

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -16,7 +16,7 @@
 #                         reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
+# Copyright (c) 2016-2020 IBM Corporation. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -70,6 +70,7 @@ headers = \
         os_dirpath.h \
         os_path.h \
         output.h \
+        parse_entry.h \
         parse_options.h \
         path.h \
         printf.h \
@@ -115,6 +116,7 @@ libprrteutil_la_SOURCES = \
         os_dirpath.c \
         os_path.c \
         output.c \
+        parse_entry.c \
         parse_options.c \
         path.c \
         printf.c \

--- a/src/util/parse_entry.c
+++ b/src/util/parse_entry.c
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2019-2020 IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#ifndef _WIN32
+#include <dlfcn.h>
+#include <pthread.h>
+#else
+#include <windows.h>
+#endif
+
+#include "src/util/parse_entry.h"
+#include "src/mca/base/base.h"
+#include "src/mca/base/prrte_mca_base_var.h"
+#include "src/mca/base/prrte_mca_base_vari.h"
+
+static char *
+my_get_mca_string(char *name, char *entry_string, char *entry_base_string) {
+    char *rv = NULL;
+
+    if (0 == strcmp(name, "entry") && entry_string) {
+        rv = strdup(entry_string);
+    }
+    if (0 == strcmp(name, "entry_base") && entry_base_string) {
+        rv = strdup(entry_base_string);
+    }
+
+    /* Supply a default for "entry_base" */
+    if (!rv && 0 == strcmp(name, "entry_base")) {
+        /* note: I really want to code the below strings as
+         * something like "lib" OMPI_LIBMPI_NAME "." OPAL_DYN_LIB_SUFFIX
+         * etc, but those don't seem to be visible from C. If they are
+         * visible and I've just missed it, the below could be updated.
+         */
+        rv = strdup("libmpi.so,libmpi_mpifh.so");
+        /*rv = strdup("libmpi_ibm.so,libmpi_ibm_mpifh.so");*/
+    }
+    return rv;
+}
+
+/*
+ * Reads OMPI_MCA_tools_entry for
+ *   lib,lib,lib
+ *   v,vv
+ *   preload,nopreload
+ *   fort,fortran
+ * Reads OMPI_MCA_tools_entry_base for
+ *   lib,lib,lib
+ *
+ * All the strings-related arguments need to be freed by the caller.
+ * But not each entry in an array of strings, just the top level pointer.
+ * Eg if the caller does
+ *     char **libs;
+ *     ompi_entry_parse_mca(,,&libs,,,)
+ * they would need to free(libs);
+ */
+void
+prrte_entry_parse_mca(char *entry_string, char *entry_base_string,
+    int *entry_is_active,
+    int *verbose,
+    char **preload_string,
+    char ***libs, int *nlibs, /* leave "fortran" items in this list, remove v/preload */
+    char ***baselibs, int *nbaselibs)
+{
+    char *list, *p;
+    char *strtok_state;
+    int i, max;
+    int myverbose, myusepreload;
+    char *mypreload_string;
+    char **mylibs, **mybaselibs;
+    int mynlibs, mynbaselibs;
+
+    list = my_get_mca_string("entry", entry_string, entry_base_string);
+    if (!list) {
+        if (entry_is_active) { *entry_is_active = 0; }
+        return;
+    }
+    if (entry_is_active) { *entry_is_active = 1; }
+
+/* Initial walk to get a max size, then allocate */
+    p = NULL;
+    if (list) {
+        list = strdup(list);
+        p = strtok_r(list, ",", &strtok_state);
+    }
+    max = 2*sizeof(char*);
+    for (i=0; p; ++i) {
+        max += (strlen(p) + 1 + sizeof(char*));
+        p = strtok_r(NULL, ",", &strtok_state);
+    }
+    mylibs = malloc(max);
+    mylibs[0] = (char*)mylibs + i*sizeof(char*);
+    mynlibs = 0;
+    mypreload_string = malloc(max + 64); /* ex libmpiprofilesupport.so:libfoo.so */
+    if (list) { free(list); }
+
+    list = my_get_mca_string("entry_base", entry_string, entry_base_string);
+    p = NULL;
+    if (list) {
+        list = strdup(list);
+        p = strtok_r(list, ",", &strtok_state);
+    }
+    max = 2*sizeof(char*);
+    for (i=0; p; ++i) {
+        max += (strlen(p) + 1 + sizeof(char*));
+        p = strtok_r(NULL, ",", &strtok_state);
+    }
+    mybaselibs = malloc(max);
+    mybaselibs[0] = (char*)mybaselibs + i*sizeof(char*);
+    mynbaselibs = 0;
+    if (list) { free(list); }
+
+/* Maintain the arrays of strings so the next one is ready to write into */
+    myverbose = 0;
+    myusepreload = 0;
+
+/* Parse the entries from OMPI_MCA_tools_entry */
+    list = my_get_mca_string("entry", entry_string, entry_base_string); p = NULL;
+    if (list) {
+        p = strtok_r(list, ",", &strtok_state);
+    }
+    for (i=0; p; ++i) {
+        char *lib_to_add = NULL;
+
+        if (0==strcmp(p, "v")) {
+            myverbose = 1;
+        }
+        else if (0==strcmp(p, "vv")) {
+            myverbose = 2;
+        }
+        else if (0==strcmp(p, "preload")) {
+            myusepreload = 1;
+        }
+        else if (0==strcmp(p, "nopreload")) {
+            myusepreload = 0;
+        }
+        else if (0==strcmp(p, "fort")) {
+            lib_to_add = strdup(p); /* fort and fortran stay as entries in the libs[] output list */
+        }
+        else if (0==strcmp(p, "fortran")) {
+            lib_to_add = strdup(p);
+        }
+        else {
+            /* if the string contains exclusively chars [a-zA-Z0-9_-], morph it into lib<string>.so */
+            if (strspn(p, "abcdefghijklmnopqrstuvwxyz"
+                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                          "0123456789_-")
+                == strlen(p))
+            {
+                lib_to_add = malloc(strlen(p) + 16);;
+                sprintf(lib_to_add, "lib%s.so", p);
+            } else {
+                lib_to_add = strdup(p); /* so it can be freed */
+            }
+        }
+
+        if (lib_to_add) {
+            if (mynlibs>0) {
+                mylibs[mynlibs] = mylibs[mynlibs-1] + strlen(mylibs[mynlibs-1]) + 1;
+            }
+            strcpy(mylibs[mynlibs++], lib_to_add);
+            free(lib_to_add);
+        }
+
+        p = strtok_r(NULL, ",", &strtok_state);
+    }
+    if (list) { free(list); }
+
+/* Parse the entries from OMPI_MCA_tools_entry_base */
+    list = my_get_mca_string("entry_base", entry_string, entry_base_string); p = NULL;
+    p = strtok_r(list, ",", &strtok_state);
+    for (i=0; p; ++i) {
+        if (mynbaselibs>0) {
+            mybaselibs[mynbaselibs] = mybaselibs[mynbaselibs-1] + strlen(mybaselibs[mynbaselibs-1]) + 1;
+        }
+        strcpy(mybaselibs[mynbaselibs++], p);
+
+        p = strtok_r(NULL, ",", &strtok_state);
+    }
+    if (list) { free(list); }
+
+/* Put results into preload too
+ * skipping over the fort/fortran entries
+ */
+    if (myusepreload) {
+        strcpy(mypreload_string, "libmpiprofilesupport.so");
+        for (i=0; i<mynlibs; ++i) {
+            p = mylibs[i];
+            if (0!=strcmp(p, "fort") && 0!=strcmp(p, "fortran")) {
+                strcat(mypreload_string, " ");
+                strcat(mypreload_string, p);
+            }
+        }
+    }
+
+/* Put final results in the function's output args
+ * Free items that aren't going into the output args
+ */
+    if (verbose) { *verbose = myverbose; }
+    if (preload_string) {
+        if (myusepreload && preload_string) {
+            *preload_string = mypreload_string;
+        } else {
+            if (preload_string) { *preload_string = NULL; }
+            free(mypreload_string);
+        }
+    }
+
+    if (libs) {
+        *libs = mylibs;
+        *nlibs = mynlibs;
+    } else {
+        free(mylibs);
+    }
+
+    if (baselibs) {
+        *baselibs = mybaselibs;
+        *nbaselibs = mynbaselibs;
+    } else {
+        free(mybaselibs);
+    }
+}

--- a/src/util/parse_entry.h
+++ b/src/util/parse_entry.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019-2020 IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ */
+
+/*
+ * Reads OMPI_MCA_tools_entry for
+ *   lib,lib,lib
+ *   v,vv
+ *   preload,nopreload
+ *   fort,fortran
+ * Reads OMPI_MCA_tools_entry_base for
+ *   lib,lib,lib
+ */
+void
+prrte_entry_parse_mca(char *entry_string, char *entry_base_String,
+    int *entry_is_active, int *verbose, char **preload_string,
+    char ***libs, int *nlibs, /* leave "fortran" items in this list, remove v/preload */
+    char ***baselibs, int *nbaselibs);


### PR DESCRIPTION
Another schizo directory registers a couple --mca variables
and uses them to modify LD_LIBRARY_PATH and possibly LD_PRELOAD.

This supports a larger checkin in OMPI where a new library
intercepts all the MPI calls and allows dynamic layering of
PMPI wrappers.