### PR TITLE
Improve tool support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ autom4te.cache
 config.log
 config.status
 configure
+configure.log.*
+make.log.*
+make.install.log.*
 libtool
 doxygen
 bin

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -917,7 +917,7 @@ void prrte_plm_base_daemon_topology(int status, prrte_process_name_t* sender,
              */
             rc = prrte_hash_table_get_first_key_uint32(prrte_job_data, &key, (void **)&jdata, &nptr);
             while (PRRTE_SUCCESS == rc) {
-                if (PRRTE_PROC_MY_NAME->jobid != jdata->jobid) {
+                if (PRRTE_PROC_MY_NAME->jobid != jdata->jobid && !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
                     dvm = false;
                     if (PRRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
                         PRRTE_ACTIVATE_JOB_STATE(jdata, PRRTE_JOB_STATE_DAEMONS_REPORTED);
@@ -1342,7 +1342,7 @@ void prrte_plm_base_daemon_callback(int status, prrte_process_name_t* sender,
                  */
                 rc = prrte_hash_table_get_first_key_uint32(prrte_job_data, &key, (void **)&jdata, &nptr);
                 while (PRRTE_SUCCESS == rc) {
-                    if (PRRTE_PROC_MY_NAME->jobid == jdata->jobid) {
+                    if (PRRTE_PROC_MY_NAME->jobid == jdata->jobid || PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
                         goto next;
                     }
                     dvm = false;

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -295,6 +295,11 @@ void prrte_plm_base_recv(int status, prrte_process_name_t* sender,
             }
             /* provide the parent's last object */
             jdata->bkmark_obj = parent->bkmark_obj;
+        }
+
+        if (!prrte_dvm_ready) {
+            prrte_pointer_array_add(prrte_cache, jdata);
+            return;
         }
 
         /* launch it */

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -45,6 +45,7 @@ typedef struct {
     /* list of active modules */
     prrte_list_t active_modules;
     char **personalities;
+    bool test_proxy_launch;
 } prrte_schizo_base_t;
 
 /**
@@ -76,6 +77,8 @@ PRRTE_EXPORT int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
                                              char ***dstenv,
                                              bool cmdline);
 PRRTE_EXPORT int prrte_schizo_base_detect_proxy(char **argv, char **rfile);
+PRRTE_EXPORT int prrte_schizo_base_define_session_dir(char **tmpdir);
+
 PRRTE_EXPORT int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line);
 PRRTE_EXPORT void prrte_schizo_base_wrap_args(char **args);
 PRRTE_EXPORT int prrte_schizo_base_setup_app(prrte_app_context_t *app);

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -43,6 +43,7 @@ prrte_schizo_base_module_t prrte_schizo = {
     .parse_proxy_cli = prrte_schizo_base_parse_proxy_cli,
     .parse_env = prrte_schizo_base_parse_env,
     .detect_proxy = prrte_schizo_base_detect_proxy,
+    .define_session_dir = prrte_schizo_base_define_session_dir,
     .allow_run_as_root = prrte_schizo_base_allow_run_as_root,
     .wrap_args = prrte_schizo_base_wrap_args,
     .setup_app = prrte_schizo_base_setup_app,
@@ -64,6 +65,15 @@ static int prrte_schizo_base_register(prrte_mca_base_register_flag_t flags)
                                 PRRTE_INFO_LVL_9,
                                 PRRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                 &personalities);
+
+    /* test proxy launch */
+    prrte_schizo_base.test_proxy_launch = false;
+    prrte_mca_base_var_register("prrte", "schizo", "base", "test_proxy_launch",
+                                "Test proxy launches",
+                                PRRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                PRRTE_INFO_LVL_9,
+                                PRRTE_MCA_BASE_VAR_SCOPE_READONLY,
+                                &prrte_schizo_base.test_proxy_launch);
     return PRRTE_SUCCESS;
 }
 

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -117,6 +117,27 @@ int prrte_schizo_base_detect_proxy(char **argv, char **rfile)
     return PRRTE_ERR_TAKE_NEXT_OPTION;
 }
 
+int prrte_schizo_base_define_session_dir(char **tmpdir)
+{
+    int rc;
+    prrte_schizo_base_active_module_t *mod;
+
+    *tmpdir = NULL;
+    PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
+        if (NULL != mod->module->define_session_dir) {
+            rc = mod->module->define_session_dir(tmpdir);
+            if (PRRTE_SUCCESS == rc) {
+                return rc;
+            }
+            if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
+                PRRTE_ERROR_LOG(rc);
+                return rc;
+            }
+        }
+    }
+    return PRRTE_SUCCESS;
+}
+
 int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line)
 {
     int rc;

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -72,9 +72,12 @@ typedef void (*prrte_schizo_base_module_parse_deprecated_cli_fn_t)(int *argc, ch
  * Check the environment to determine what, if any, host we are running
  * under. Check the argv to see if we are running as a proxy for some
  * other command and to see which environment we are proxying. Return
- * a unique rendezvous file to use for prun to connect to prte.
+ * a unique rendezvous file to use for prun to connect to prte
  */
 typedef int (*prrte_schizo_base_detect_proxy_fn_t)(char **argv, char **rndfile);
+
+/* define a (hopefully) unique session directory we can use */
+typedef int (*prrte_schizo_base_define_session_dir_fn_t)(char **tmpdir);
 
 /* parse the environment for proxy cmd line entries */
 typedef void (*prrte_schizo_base_module_parse_proxy_cli_fn_t)(prrte_cmd_line_t *cmd_line,
@@ -137,6 +140,7 @@ typedef struct {
     prrte_schizo_base_module_parse_proxy_cli_fn_t        parse_proxy_cli;
     prrte_schizo_base_module_parse_env_fn_t              parse_env;
     prrte_schizo_base_detect_proxy_fn_t                  detect_proxy;
+    prrte_schizo_base_define_session_dir_fn_t            define_session_dir;
     prrte_schizo_base_module_allow_run_as_root_fn_t      allow_run_as_root;
     prrte_schizo_base_module_wrap_args_fn_t              wrap_args;
     prrte_schizo_base_module_setup_app_fn_t              setup_app;

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -29,9 +29,11 @@
 
 static int detect_proxy(char **argv, char **rfile);
 static int get_remaining_time(uint32_t *timeleft);
+static int define_session_dir(char **tmpdir);
 
 prrte_schizo_base_module_t prrte_schizo_slurm_module = {
     .detect_proxy = detect_proxy,
+    .define_session_dir = define_session_dir,
     .get_remaining_time = get_remaining_time
 };
 
@@ -42,11 +44,21 @@ static int detect_proxy(char **argv, char **rfile)
     /* if we are active, then we must be inside a Slurm
      * allocation - set the rendezvous file accordingly */
     jid = getenv("SLURM_JOBID");
-    prrte_asprintf(rfile, "%s.rndz.%s", prrte_tool_basename, jid);
+    prrte_asprintf(rfile, "%s/%s.rndz.%s", prrte_tmp_directory(), prrte_tool_basename, jid);
 
     return PRRTE_SUCCESS;
 }
 
+static int define_session_dir(char **tmpdir)
+{
+    char *jid;
+
+    /* setup a session dir based on our slurm jobid */
+    jid = getenv("SLURM_JOBID");
+    prrte_asprintf(tmpdir, "%s.session.%s", prrte_tool_basename, jid);
+
+    return PRRTE_SUCCESS;
+}
 static int get_remaining_time(uint32_t *timeleft)
 {
     char output[256], *cmd, *jobid, **res;

--- a/src/mca/state/base/base.h
+++ b/src/mca/state/base/base.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -40,6 +40,7 @@ PRRTE_EXPORT void prrte_state_base_print_job_state_machine(void);
 PRRTE_EXPORT void prrte_state_base_print_proc_state_machine(void);
 
 PRRTE_EXPORT extern int prrte_state_base_parent_fd;
+PRRTE_EXPORT extern bool prrte_state_base_ready_msg;
 
 END_C_DECLS
 

--- a/src/mca/state/base/state_base_frame.c
+++ b/src/mca/state/base/state_base_frame.c
@@ -4,7 +4,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,6 +44,7 @@
 prrte_state_base_module_t prrte_state = {0};
 bool prrte_state_base_run_fdcheck = false;
 int prrte_state_base_parent_fd = -1;
+bool prrte_state_base_ready_msg = true;
 
 static int prrte_state_base_register(prrte_mca_base_register_flag_t flags)
 {

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -375,7 +375,9 @@ static void vm_ready(int fd, short args, void *cbdata)
         }
         /* notify that the vm is ready */
         if (0 > prrte_state_base_parent_fd) {
-            fprintf(stdout, "DVM ready\n"); fflush(stdout);
+            if (prrte_state_base_ready_msg) {
+                fprintf(stdout, "DVM ready\n"); fflush(stdout);
+            }
         } else {
             char ok = 'K';
             write(prrte_state_base_parent_fd, &ok, 1);

--- a/src/runtime/prrte_finalize.c
+++ b/src/runtime/prrte_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -89,7 +89,6 @@ int prrte_finalize(void)
     free (prrte_process_info.nodename);
     prrte_process_info.nodename = NULL;
 
+    PRRTE_RELEASE(prrte_cache);
     return PRRTE_SUCCESS;
-
-    return rc;
 }

--- a/src/runtime/prrte_globals.c
+++ b/src/runtime/prrte_globals.c
@@ -72,6 +72,8 @@ prrte_hash_table_t *prrte_coprocessors = NULL;
 char *prrte_topo_signature = NULL;
 char *prrte_data_server_uri = NULL;
 char *prrte_tool_basename = NULL;
+bool prrte_dvm_ready = false;
+prrte_pointer_array_t *prrte_cache = NULL;
 
 /* PRRTE OOB port flags */
 bool prrte_static_ports = false;

--- a/src/runtime/prrte_globals.h
+++ b/src/runtime/prrte_globals.h
@@ -446,6 +446,8 @@ PRRTE_EXPORT extern bool prrte_coprocessors_detected;
 PRRTE_EXPORT extern prrte_hash_table_t *prrte_coprocessors;
 PRRTE_EXPORT extern char *prrte_topo_signature;
 PRRTE_EXPORT extern char *prrte_data_server_uri;
+PRRTE_EXPORT extern bool prrte_dvm_ready;
+PRRTE_EXPORT extern prrte_pointer_array_t *prrte_cache;
 
 /* PRRTE OOB port flags */
 PRRTE_EXPORT extern bool prrte_static_ports;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -87,7 +87,6 @@
 #include "src/mca/rml/base/rml_contact.h"
 #include "src/mca/schizo/base/base.h"
 #include "src/mca/state/base/base.h"
-#include "src/mca/state/base/base.h"
 
 #include "src/runtime/runtime.h"
 #include "src/runtime/prrte_globals.h"
@@ -115,6 +114,10 @@ static prrte_cmd_line_init_t cmd_line_init[] = {
     { '\0', "system-server", 0, PRRTE_CMD_LINE_TYPE_BOOL,
       "Act as system server",
       PRRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "no-ready-msg", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Do not output a \"DVM READY\" message",
+      PRRTE_CMD_LINE_OTYPE_DVM },
+
 
 
     /* Debug options */
@@ -276,6 +279,10 @@ int main(int argc, char *argv[])
 
         /* If someone asks for help, that should be all we do */
         exit(0);
+    }
+
+     if (prrte_cmd_line_is_taken(&cmd_line, "no-ready-msg")) {
+        prrte_state_base_ready_msg = false;
     }
 
     if (prrte_cmd_line_is_taken(&cmd_line, "system-server")) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -978,6 +978,7 @@ int prun(int argc, char *argv[])
         free(param);
         prrte_argv_append_nosize(&papps->argv, "prte");
         prrte_schizo.parse_proxy_cli(prrte_cmd_line, &papps->argv);
+        prrte_argv_append_nosize(&papps->argv, "--no-ready-msg");
         papps->maxprocs = 1;
 
         /* copy our environment */


### PR DESCRIPTION
Utilize the PMIx_Spawn ability to do a fork/exec on our behalf to better
setup the "prte" DVM when running in proxy mode. Let each schizo
component determine if we are running as a proxy so they can use their
own criteria, and let them define a rendezvous file prun can use to
attach to the correct prte instance.

Have the schizo components provide us with a session tmpdir to provide
better isolation between DVM instances. For example, can base the tmpdir
name on the Slurm jobid to isolate between allocations.

Cache spawn requests that arrive prior to the DVM being completely setup
and inject those into the spawn procedure upon DVM ready.

Signed-off-by: Ralph Castain <rhc@pmix.org>