### PR TITLE
Fix multithreaded launch race on remote node

### DIFF
--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -711,6 +712,15 @@ void prrte_state_base_track_procs(int fd, short argc, void *cbdata)
             PRRTE_ACTIVATE_PROC_STATE(proc, PRRTE_PROC_STATE_TERMINATED);
         }
     } else if (PRRTE_PROC_STATE_TERMINATED == state) {
+        if (pdata->state == state) {
+            prrte_output_verbose(5, prrte_state_base_framework.framework_output,
+                                 "%s state:base:track_procs proc %s already in state %s. Skip transition.",
+                                 PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                                 PRRTE_NAME_PRINT(proc),
+                                 prrte_proc_state_to_str(state));
+            goto cleanup;
+        }
+
         /* update the proc state */
         PRRTE_FLAG_UNSET(pdata, PRRTE_PROC_FLAG_ALIVE);
         if (pdata->state < PRRTE_PROC_STATE_TERMINATED) {

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2011-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -207,8 +208,13 @@ static void track_jobs(int fd, short argc, void *cbdata)
                     PRRTE_RELEASE(alert);
                     goto cleanup;
                 }
-                /* if this proc failed to start, then send that info */
-                if (PRRTE_PROC_STATE_UNTERMINATED < child->state) {
+                /* If this proc failed to start, then send that info.
+                 * However if it normally terminated then do not send the info.
+                 * Instead report it as running here, and the child waitpid
+                 * function will send back the normal terminated state when the
+                 * the job is complete.
+                 */
+                if (PRRTE_PROC_STATE_TERMINATED < child->state) {
                     if (PRRTE_SUCCESS != (rc = prrte_dss.pack(alert, &child->state, 1, PRRTE_PROC_STATE))) {
                         PRRTE_ERROR_LOG(rc);
                         PRRTE_RELEASE(alert);


### PR DESCRIPTION
 * On two nodes if I ran `prun --map-by ppr:80:node:OVERSUBSCRIBE /bin/true`
   then the remote node would report back in the job launch message
   (state `PRRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE`) will include not only
   processes in the running state but also those that ran and entered the
   normally terminated state.
   - This would confuse the HNP since its accounting for those processes will
     be off (the `num_launched` count on the job data).
   - Additionally, the remote node would send the normal termination state for
     those processes that were already known to the HNP as normally terminated
     from the 'local launch complete' notice. The HNP will count them twice
     in the `num_terminated` portion of the job data.
 * To resolve this I addressed the two points above:
   - In the 'local launch complete' message only send back non-running
     state if the job is abnormally (not normally) terminated. This is
     important as it might trigger a job shutdown so we want that early
     notice for abnormal termination. For normal termination we can
     wait for all of the local processes to terminate.
   - Add a check in the termination state in the HNP that checks if
     it has already transitioned this process into the specified state.
     If so then it skips that update. With the fix above this should not
     happen, but I left the check with a warning message just in case.
