### PR TITLE
Drop support for aggregated single char cmd line options

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -43,7 +43,7 @@ WARNING: Multi-character cmd line options must be prefixed with double dashes,
 not a single dash:
 
   Deprecated option:   %s
-  Corrected option:    %s
+  Corrected option:   %s
 
 We have updated this for you and will proceed. However, this will be treated
 as an error in a future release. Please update your cmd line.

--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -37,3 +37,13 @@ An environmental variable was requested to be forwarded, but was not found:
   Variable:  %s
 
 This may result in unexpected behavior.
+#
+[single-dash-error]
+WARNING: Multi-character cmd line options must be prefixed with double dashes,
+not a single dash:
+
+  Deprecated option:   %s
+  Corrected option:    %s
+
+We have updated this for you and will proceed. However, this will be treated
+as an error in a future release. Please update your cmd line.

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -218,6 +218,20 @@ static void parse_deprecated_cli(int *argc, char ***argv)
     pargc = *argc;
     /* check for deprecated cmd line options */
     for (i=0; NULL != pargs[i]; i++) {
+        /* check for option */
+        if ('-' != pargs[i][0]) {
+            continue;
+        }
+        /* check for single-dash errors */
+        if ('-' != pargs[i][1] && 2 < strlen(pargs[i])) {
+            /* we know this is incorrect */
+            p2 = strdup(pargs[i]);
+            free(pargs[i]);
+            prrte_asprintf(&pargs[i], "-%s", p2);
+            prrte_show_help("help-schizo-base.txt", "single-dash-error", true,
+                            p2, pargs[i]);
+            free(p2);
+        }
         if (0 == strcmp(pargs[i], "--oversubscribe")) {
             /* did they give the map-by option? */
             found = false;

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -213,6 +213,21 @@ static void parse_deprecated_cli(int *argc, char ***argv)
     int i, j, pargc;
     bool found;
     char **pargs, *p2;
+    bool takeus = false;
+
+    /* if they gave us a list of personalities,
+     * see if we are included */
+    if (NULL != prrte_schizo_base.personalities) {
+        for (i=0; NULL != prrte_schizo_base.personalities[i]; i++) {
+            if (0 == strcmp(prrte_schizo_base.personalities[i], "ompi")) {
+                takeus = true;
+                break;
+            }
+        }
+        if (!takeus) {
+            return;
+        }
+    }
 
     pargs = *argv;
     pargc = *argc;

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -715,7 +715,6 @@ int prun(int argc, char *argv[])
                     prrte_tool_basename,
                     prrte_strerror(rc));
         }
-         PRRTE_ERROR_LOG(rc);
        return rc;
     }
 


### PR DESCRIPTION
No longer parse "-abc" as "-a -b -c" - instead treat it as "-abc"
  Generating a warning is rather hard to do, so reject it instead.

Check for deprecated single-dash OMPI options
  Warn and show corrected option

Fixes https://github.com/openpmix/prrte/issues/412

Signed-off-by: Ralph Castain <rhc@pmix.org>