### PR TITLE
Fix command line deprecation parsing

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -73,7 +73,8 @@ PRRTE_EXPORT int prrte_schizo_base_convert(char ***argv, int idx, int ntodelete,
 PRRTE_EXPORT int prrte_schizo_base_define_cli(prrte_cmd_line_t *cli);
 PRRTE_EXPORT int prrte_schizo_base_parse_cli(int argc, int start, char **argv,
                                              char *personality, char ***target);
-PRRTE_EXPORT int prrte_schizo_base_parse_deprecated_cli(int *argc, char ***argv);
+PRRTE_EXPORT int prrte_schizo_base_parse_deprecated_cli(prrte_cmd_line_t *cmdline,
+                                                        int *argc, char ***argv);
 
 PRRTE_EXPORT void prrte_schizo_base_parse_proxy_cli(prrte_cmd_line_t *cmd_line,
                                                     char ***argv);

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -24,6 +24,8 @@
 
 #include "prrte_config.h"
 #include "types.h"
+
+#include "src/class/prrte_list.h"
 #include "src/util/cmd_line.h"
 
 #include "src/mca/mca.h"
@@ -32,6 +34,15 @@
 
 
 BEGIN_C_DECLS
+
+typedef int (*prrte_schizo_convertor_fn_t)(char *option, char ***argv, int idx);
+
+typedef struct {
+    prrte_list_item_t super;
+    char **options;
+    prrte_schizo_convertor_fn_t convert;
+} prrte_convertor_t;
+PRRTE_EXPORT PRRTE_CLASS_DECLARATION(prrte_convertor_t);
 
 /*
  * schizo module functions
@@ -67,7 +78,7 @@ typedef int (*prrte_schizo_base_module_parse_cli_fn_t)(int argc, int start,
                                                       char *personality,
                                                       char ***target);
 
-typedef int (*prrte_schizo_base_module_parse_deprecated_cli_fn_t)(int *argc, char ***argv);
+typedef void (*prrte_schizo_base_module_register_deprecated_cli_fn_t)(prrte_list_t *convertors);
 
 /* detect if we are running as a proxy
  * Check the environment to determine what, if any, host we are running
@@ -134,25 +145,46 @@ typedef int (*prrte_schizo_base_module_get_rem_time_fn_t)(uint32_t *timeleft);
  * schizo module version 1.3.0
  */
 typedef struct {
-    prrte_schizo_base_module_init_fn_t                   init;
-    prrte_schizo_base_module_define_cli_fn_t             define_cli;
-    prrte_schizo_base_module_parse_cli_fn_t              parse_cli;
-    prrte_schizo_base_module_parse_deprecated_cli_fn_t   parse_deprecated_cli;
-    prrte_schizo_base_module_parse_proxy_cli_fn_t        parse_proxy_cli;
-    prrte_schizo_base_module_parse_env_fn_t              parse_env;
-    prrte_schizo_base_detect_proxy_fn_t                  detect_proxy;
-    prrte_schizo_base_define_session_dir_fn_t            define_session_dir;
-    prrte_schizo_base_module_allow_run_as_root_fn_t      allow_run_as_root;
-    prrte_schizo_base_module_wrap_args_fn_t              wrap_args;
-    prrte_schizo_base_module_setup_app_fn_t              setup_app;
-    prrte_schizo_base_module_setup_fork_fn_t             setup_fork;
-    prrte_schizo_base_module_setup_child_fn_t            setup_child;
-    prrte_schizo_base_module_get_rem_time_fn_t           get_remaining_time;
-    prrte_schizo_base_module_finalize_fn_t               finalize;
+    prrte_schizo_base_module_init_fn_t                      init;
+    prrte_schizo_base_module_define_cli_fn_t                define_cli;
+    prrte_schizo_base_module_parse_cli_fn_t                 parse_cli;
+    prrte_schizo_base_module_register_deprecated_cli_fn_t   register_deprecated_cli;
+    prrte_schizo_base_module_parse_proxy_cli_fn_t           parse_proxy_cli;
+    prrte_schizo_base_module_parse_env_fn_t                 parse_env;
+    prrte_schizo_base_detect_proxy_fn_t                     detect_proxy;
+    prrte_schizo_base_define_session_dir_fn_t               define_session_dir;
+    prrte_schizo_base_module_allow_run_as_root_fn_t         allow_run_as_root;
+    prrte_schizo_base_module_wrap_args_fn_t                 wrap_args;
+    prrte_schizo_base_module_setup_app_fn_t                 setup_app;
+    prrte_schizo_base_module_setup_fork_fn_t                setup_fork;
+    prrte_schizo_base_module_setup_child_fn_t               setup_child;
+    prrte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
+    prrte_schizo_base_module_finalize_fn_t                  finalize;
 } prrte_schizo_base_module_t;
 
-PRRTE_EXPORT extern prrte_schizo_base_module_t prrte_schizo;
 
+typedef int (*prrte_schizo_base_API_parse_deprecated_cli_fn_t)(prrte_cmd_line_t *cmdline,
+                                                               int *argc, char ***argv);
+
+typedef struct {
+    prrte_schizo_base_module_init_fn_t                      init;
+    prrte_schizo_base_module_define_cli_fn_t                define_cli;
+    prrte_schizo_base_module_parse_cli_fn_t                 parse_cli;
+    prrte_schizo_base_API_parse_deprecated_cli_fn_t         parse_deprecated_cli;
+    prrte_schizo_base_module_parse_proxy_cli_fn_t           parse_proxy_cli;
+    prrte_schizo_base_module_parse_env_fn_t                 parse_env;
+    prrte_schizo_base_detect_proxy_fn_t                     detect_proxy;
+    prrte_schizo_base_define_session_dir_fn_t               define_session_dir;
+    prrte_schizo_base_module_allow_run_as_root_fn_t         allow_run_as_root;
+    prrte_schizo_base_module_wrap_args_fn_t                 wrap_args;
+    prrte_schizo_base_module_setup_app_fn_t                 setup_app;
+    prrte_schizo_base_module_setup_fork_fn_t                setup_fork;
+    prrte_schizo_base_module_setup_child_fn_t               setup_child;
+    prrte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
+    prrte_schizo_base_module_finalize_fn_t                  finalize;
+} prrte_schizo_API_module_t;
+
+PRRTE_EXPORT extern prrte_schizo_API_module_t prrte_schizo;
 /*
  * schizo component
  */

--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -90,8 +90,6 @@ static char special_empty_token[] = {
  */
 static int make_opt(prrte_cmd_line_t *cmd, prrte_cmd_line_init_t *e);
 static void free_parse_results(prrte_cmd_line_t *cmd);
-static prrte_cmd_line_option_t *find_option(prrte_cmd_line_t *cmd,
-                                            prrte_cmd_line_init_t *e) __prrte_attribute_nonnull__(1) __prrte_attribute_nonnull__(2);
 static prrte_value_t*  set_dest(prrte_cmd_line_option_t *option, char *sval);
 static void fill(const prrte_cmd_line_option_t *a, char result[3][BUFSIZ]);
 static int qsort_callback(const void *a, const void *b);
@@ -229,7 +227,7 @@ int prrte_cmd_line_parse(prrte_cmd_line_t *cmd, bool ignore_unknown,
     /* Check up front: do we have a --help option? */
     memset(&e, 0, sizeof(prrte_cmd_line_init_t));
     e.ocl_cmd_long_name = "help";
-    option = find_option(cmd, &e);
+    option = prrte_cmd_line_find_option(cmd, &e);
     if (NULL != option) {
         have_help_option = true;
     }
@@ -274,7 +272,7 @@ int prrte_cmd_line_parse(prrte_cmd_line_t *cmd, bool ignore_unknown,
             is_option = true;
             memset(&e, 0, sizeof(prrte_cmd_line_init_t));
             e.ocl_cmd_long_name = &cmd->lcl_argv[i][2];
-            option = find_option(cmd, &e);
+            option = prrte_cmd_line_find_option(cmd, &e);
         }
 
         /* Is it the special-cased "-np" name? */
@@ -282,7 +280,7 @@ int prrte_cmd_line_parse(prrte_cmd_line_t *cmd, bool ignore_unknown,
             is_option = true;
             memset(&e, 0, sizeof(prrte_cmd_line_init_t));
             e.ocl_cmd_long_name = &cmd->lcl_argv[i][1];
-            option = find_option(cmd, &e);
+            option = prrte_cmd_line_find_option(cmd, &e);
         }
 
         /* It could be a short name.  Is it? */
@@ -293,7 +291,7 @@ int prrte_cmd_line_parse(prrte_cmd_line_t *cmd, bool ignore_unknown,
             } else {
                 memset(&e, 0, sizeof(prrte_cmd_line_init_t));
                 e.ocl_cmd_short_name = cmd->lcl_argv[i][1];
-                option = find_option(cmd, &e);
+                option = prrte_cmd_line_find_option(cmd, &e);
 
                 /* If we didn't find it, then it is an unknown option */
                 if (NULL == option) {
@@ -719,7 +717,7 @@ int prrte_cmd_line_get_ninsts(prrte_cmd_line_t *cmd, const char *opt)
     } else {
         e.ocl_cmd_short_name = opt[0];
     }
-    option = find_option(cmd, &e);
+    option = prrte_cmd_line_find_option(cmd, &e);
     if (NULL != option) {
         PRRTE_LIST_FOREACH(param, &cmd->lcl_params, prrte_cmd_line_param_t) {
             if (param->clp_option == option) {
@@ -764,7 +762,7 @@ prrte_value_t *prrte_cmd_line_get_param(prrte_cmd_line_t *cmd,
     } else {
         e.ocl_cmd_short_name = opt[0];
     }
-    option = find_option(cmd, &e);
+    option = prrte_cmd_line_find_option(cmd, &e);
     if (NULL != option) {
         ninst = 0;
         /* scan thru the found params */
@@ -913,7 +911,7 @@ static int make_opt(prrte_cmd_line_t *cmd, prrte_cmd_line_init_t *e)
     }
 
     /* see if the option already exists */
-    if (NULL != find_option(cmd, e)) {
+    if (NULL != prrte_cmd_line_find_option(cmd, e)) {
         prrte_output(0, "Duplicate cmd line entry %c:%s",
                      ('\0' == e->ocl_cmd_short_name) ? ' ' : e->ocl_cmd_short_name,
                      (NULL == e->ocl_cmd_long_name) ? "NULL" : e->ocl_cmd_long_name);
@@ -972,8 +970,8 @@ static void free_parse_results(prrte_cmd_line_t *cmd)
 }
 
 
-static prrte_cmd_line_option_t *find_option(prrte_cmd_line_t *cmd,
-                                            prrte_cmd_line_init_t *e)
+prrte_cmd_line_option_t *prrte_cmd_line_find_option(prrte_cmd_line_t *cmd,
+                                                    prrte_cmd_line_init_t *e)
 {
     int i;
     prrte_cmd_line_option_t *option;

--- a/src/util/cmd_line.h
+++ b/src/util/cmd_line.h
@@ -594,6 +594,9 @@ PRRTE_EXPORT prrte_value_t *prrte_cmd_line_get_param(prrte_cmd_line_t *cmd,
 PRRTE_EXPORT int prrte_cmd_line_get_tail(prrte_cmd_line_t *cmd, int *tailc,
                                          char ***tailv);
 
+PRRTE_EXPORT prrte_cmd_line_option_t *prrte_cmd_line_find_option(prrte_cmd_line_t *cmd,
+                                                                 prrte_cmd_line_init_t *e) __prrte_attribute_nonnull__(1) __prrte_attribute_nonnull__(2);
+
 END_C_DECLS
 
 


### PR DESCRIPTION
Avoid stepping on options passed to the application itself as they don't
belong to us. Output each deprecated option warning and show the final
corrected cmd line.

Fixes https://github.com/openpmix/prrte/issues/435

Signed-off-by: Ralph Castain <rhc@pmix.org>