### PR TITLE
Fix bug where prun would return the wrong exit code to prrte.

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -676,9 +676,8 @@ static void dvm_notify(int sd, short args, void *cbdata)
     } else {
         rc = jdata->exit_code;
     }
-    ret = prrte_pmix_convert_rc(rc);
 
-    if (0 == ret && prrte_get_attribute(&jdata->attributes, PRRTE_JOB_SILENT_TERMINATION, NULL, PRRTE_BOOL)) {
+    if (0 == rc && prrte_get_attribute(&jdata->attributes, PRRTE_JOB_SILENT_TERMINATION, NULL, PRRTE_BOOL)) {
         notify = false;
     }
     /* if the jobid matches that of the requestor, then don't notify */
@@ -710,7 +709,7 @@ static void dvm_notify(int sd, short args, void *cbdata)
         flag = true;
         PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, &flag, PMIX_BOOL);
         /* provide the status */
-        PMIX_INFO_LOAD(&info[1], PMIX_JOB_TERM_STATUS, &ret, PMIX_STATUS);
+        PMIX_INFO_LOAD(&info[1], PMIX_JOB_TERM_STATUS, &rc, PMIX_STATUS);
         /* tell the requestor which job or proc  */
         PMIX_LOAD_NSPACE(pname.nspace, jdata->nspace);
         if (NULL != pptr) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1699,8 +1699,8 @@ int prun(int argc, char *argv[])
         flag = true;
         PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_TERMINATE, &flag, PMIX_BOOL);
         PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        rc = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
-        if (PMIX_SUCCESS == rc) {
+        ret = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
+        if (PMIX_SUCCESS == ret) {
 #if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
             /* There is a bug in PMIx 3.0.0 up to 3.0.2 that causes the callback never
              * being called when the server successes. The callback might be eventually
@@ -1722,8 +1722,11 @@ int prun(int argc, char *argv[])
 
     /* cleanup and leave */
     ret = PMIx_tool_finalize();
-    if (PRRTE_SUCCESS == rc && PMIX_SUCCESS != ret) {
-        rc = ret;
+    if (PMIX_SUCCESS != ret) {
+        // Since the user job has probably exited by
+        // now, let's preserve its return code and print
+        // a warning here, if prrte logging is on.
+        prrte_output(0, "PMIx_tool_finalize() failed. Status = %d", ret);
     }
     return rc;
 }


### PR DESCRIPTION
- Don't convert the return of the exited rank to a pmix status.
- Don't blow away the return code in prun main.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>