### PR TITLE
Re-enable the timeout feature

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -432,6 +432,7 @@ static void check_complete(int fd, short args, void *cbdata)
     pmix_status_t ret;
     prrte_pointer_array_t procs;
     char *tmp;
+    prrte_timer_t *timer;
 
     PRRTE_ACQUIRE_OBJECT(caddy);
     jdata = caddy->jdata;
@@ -440,6 +441,12 @@ static void check_complete(int fd, short args, void *cbdata)
                         "%s state:dvm:check_job_complete on job %s",
                         PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
                         (NULL == jdata) ? "NULL" : PRRTE_JOBID_PRINT(jdata->jobid));
+
+    if (prrte_get_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT, (void**)&timer, PRRTE_PTR)) {
+        /* timer is an prrte_timer_t object */
+        PRRTE_RELEASE(timer);
+        prrte_remove_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT);
+    }
 
     if (NULL == jdata || jdata->jobid == PRRTE_PROC_MY_NAME->jobid) {
         /* just check to see if the daemons are complete */

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -548,6 +548,24 @@ static void interim(int sd, short args, void *cbdata)
 #if PMIX_NUMERIC_VERSION >= 0x00040000
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRRTE_FLAG_SET(jdata, PRRTE_JOB_FLAG_TOOL);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
+            prrte_add_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT,
+                               PRRTE_ATTR_GLOBAL, &info->value.data.integer, PRRTE_INT);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT_STACKTRACES)) {
+            flag = PMIX_INFO_TRUE(info);
+            if (flag) {
+                prrte_add_attribute(&jdata->attributes, PRRTE_JOB_STACKTRACES,
+                                   PRRTE_ATTR_GLOBAL, &flag, PRRTE_BOOL);
+            }
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT_REPORT_STATE)) {
+            flag = PMIX_INFO_TRUE(info);
+            if (flag) {
+                prrte_add_attribute(&jdata->attributes, PRRTE_JOB_REPORT_STATE,
+                                   PRRTE_ATTR_GLOBAL, &flag, PRRTE_BOOL);
+            }
 #endif
         /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -426,6 +426,16 @@ const char *prrte_attr_key_to_str(prrte_attribute_key_t key)
             return "DO_NOT_LAUNCH";
         case PRRTE_JOB_XML_OUTPUT:
             return "XML_OUTPUT";
+        case PRRTE_JOB_TIMEOUT:
+            return "JOB_TIMEOUT";
+        case PRRTE_JOB_STACKTRACES:
+            return "JOB_STACKTRACES";
+        case PRRTE_JOB_REPORT_STATE:
+            return "JOB_REPORT_STATE";
+        case PRRTE_JOB_TIMEOUT_EVENT:
+            return "JOB_TIMEOUT_EVENT";
+        case PRRTE_JOB_TRACE_TIMEOUT_EVENT:
+            return "JOB_TRACE_TIMEOUT_EVENT";
 
         case PRRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -173,6 +173,11 @@ typedef uint16_t prrte_job_flags_t;
 #define PRRTE_JOB_DISPLAY_ALLOC          (PRRTE_JOB_START_KEY + 68)    // bool - display allocation
 #define PRRTE_JOB_DO_NOT_LAUNCH          (PRRTE_JOB_START_KEY + 69)    // bool - do not launch job
 #define PRRTE_JOB_XML_OUTPUT             (PRRTE_JOB_START_KEY + 70)    // bool - print in xml format
+#define PRRTE_JOB_TIMEOUT                (PRRTE_JOB_START_KEY + 71)    // int32 - number of seconds job can run before terminating it as timed out
+#define PRRTE_JOB_STACKTRACES            (PRRTE_JOB_START_KEY + 72)    // bool - include process stack traces in timeout report
+#define PRRTE_JOB_REPORT_STATE           (PRRTE_JOB_START_KEY + 73)    // bool - include process state in timeout report
+#define PRRTE_JOB_TIMEOUT_EVENT          (PRRTE_JOB_START_KEY + 74)    // prrte_ptr (prrte_timer_t*) - timer event for job timeout
+#define PRRTE_JOB_TRACE_TIMEOUT_EVENT    (PRRTE_JOB_START_KEY + 75)    // prrte_ptr (prrte_timer_t*) - timer event for stacktrace collection
 
 #define PRRTE_JOB_MAX_KEY   300
 


### PR DESCRIPTION
Allow specification of a timeout for the submitted job to protect
against stalled applications. Support request for process state and
stacktraces, where available.

Fixes #438 

Signed-off-by: Ralph Castain <rhc@pmix.org>