### PR TITLE
More OMPI env changes.

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_ranking.c
+++ b/src/mca/rmaps/base/rmaps_base_ranking.c
@@ -152,7 +152,8 @@ static int rank_span(prrte_job_t *jdata,
                         }
                         prrte_output_verbose(5, prrte_rmaps_base_framework.framework_output,
                                             "mca:rmaps:rank_span: assigning vpid %s", PRRTE_VPID_PRINT(vpid));
-                        proc->name.vpid = vpid++;
+                        proc->name.vpid = vpid;
+                        proc->rank = vpid++;
                         if (0 == cnt) {
                             app->first_rank = proc->name.vpid;
                         }
@@ -275,7 +276,8 @@ static int rank_fill(prrte_job_t *jdata,
                     }
                     prrte_output_verbose(5, prrte_rmaps_base_framework.framework_output,
                                         "mca:rmaps:rank_fill: assigning vpid %s", PRRTE_VPID_PRINT(vpid));
-                    proc->name.vpid = vpid++;
+                    proc->name.vpid = vpid;
+                    proc->rank = vpid++;
                     if (0 == cnt) {
                         app->first_rank = proc->name.vpid;
                     }
@@ -433,7 +435,8 @@ static int rank_by(prrte_job_t *jdata,
                             continue;
                         }
                         /* assign the vpid */
-                        proc->name.vpid = vpid++;
+                        proc->name.vpid = vpid;
+                        proc->rank = vpid++;
                         if (0 == cnt) {
                             app->first_rank = proc->name.vpid;
                         }
@@ -641,7 +644,8 @@ int prrte_rmaps_base_compute_vpids(prrte_job_t *jdata)
                         if (PRRTE_VPID_INVALID != proc->name.vpid) {
                             continue;
                         }
-                        proc->name.vpid = vpid++;
+                        proc->name.vpid = vpid;
+                        proc->rank = vpid++;
                         if (0 == cnt) {
                             app->first_rank = proc->name.vpid;
                         }
@@ -708,7 +712,8 @@ int prrte_rmaps_base_compute_vpids(prrte_job_t *jdata)
                         prrte_output_verbose(5, prrte_rmaps_base_framework.framework_output,
                                             "mca:rmaps:base: assigning rank %s to node %s",
                                             PRRTE_VPID_PRINT(vpid), node->name);
-                        proc->name.vpid = vpid++;
+                        proc->name.vpid = vpid;
+                        proc -> rank = vpid++;
                         if (0 == cnt) {
                             app->first_rank = proc->name.vpid;
                         }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -984,7 +984,6 @@ static int setup_child(prrte_job_t *jdata,
     if (PRRTE_LOCAL_RANK_INVALID == child->local_rank ||
         PRRTE_NODE_RANK_INVALID == child->node_rank ||
         PMIX_RANK_INVALID == child->rank) {
-        fprintf(stderr, "%d, %d %d\n", child->local_rank, child->node_rank, child->rank);
         PRRTE_ERROR_LOG(PRRTE_ERR_VALUE_OUT_OF_BOUNDS);
         rc = PRRTE_ERR_VALUE_OUT_OF_BOUNDS;
         return rc;

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -68,6 +68,10 @@ static int detect_proxy(char **argv, char **rfile);
 static int allow_run_as_root(prrte_cmd_line_t *cmd_line);
 
 static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context);
+static int setup_child(prrte_job_t *jdata,
+                       prrte_proc_t *child,
+                       prrte_app_context_t *app,
+                       char ***env);
 
 prrte_schizo_base_module_t prrte_schizo_ompi_module = {
     .define_cli = define_cli,
@@ -76,6 +80,7 @@ prrte_schizo_base_module_t prrte_schizo_ompi_module = {
     .parse_env = parse_env,
     .detect_proxy = detect_proxy,
     .setup_fork   = setup_fork,
+    .setup_child  = setup_child,
     .allow_run_as_root = allow_run_as_root
 };
 
@@ -832,6 +837,7 @@ static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context) {
     char *first_rank_buf = malloc(first_rank_buf_size);
     char *num_ranks_buf  = malloc(num_ranks_buf_size);
     prrte_app_context_t *app = NULL;
+    int rc = PRRTE_SUCCESS;
 
     /* Construct buffers for OMPI_FIRST_RANKS and  OMPI_APP_CTX_NUM_PROCS */
     for(int j= 0; j < jdata->apps->size; j++) {
@@ -870,6 +876,9 @@ static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context) {
             continue;
         }
 
+        /* pass an envar so the proc can find any files it had prepositioned */
+        prrte_setenv("OMPI_FILE_LOCATION", prrte_process_info.proc_session_dir, true, &app->env);
+
         /* Tell all children their cwd */
         prrte_setenv("OMPI_MCA_initial_wdir", app->cwd, true, &app->env);
 
@@ -880,14 +889,21 @@ static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context) {
         prrte_setenv("OMPI_APP_CTX_NUM_PROCS", num_ranks_buf, true, &app->env);
 
         char ompi_env_buf[16] = {0};
-        /* Tell all children the number of procs */
+
+        /* Tell all children the world and world local size */
         snprintf(ompi_env_buf, 16, "%d", jdata->num_procs);
+        prrte_setenv("OMPI_WORLD_SIZE", ompi_env_buf, true, &app->env);
         prrte_setenv("OMPI_MCA_num_procs", ompi_env_buf, true, &app->env);
+        ompi_env_buf[0] = '\0';
+
+        snprintf(ompi_env_buf, 16, "%d", jdata->num_local_procs);
+        prrte_setenv("OMPI_WORLD_LOCAL_SIZE", ompi_env_buf, true, &app->env);
+        ompi_env_buf[0] = '\0';
 
         /* Tell all children number of apps. */
-        ompi_env_buf[0] = '\0';
         snprintf(ompi_env_buf, 16, "%d", jdata->num_apps);
         prrte_setenv("OMPI_NUM_APP_CTX", ompi_env_buf, true, &app->env);
+        ompi_env_buf[0] = '\0';
 
         /* Tell each app its command. */
         if(app->argv[0]) {
@@ -919,7 +935,8 @@ static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context) {
 
         /* Tell each app the arch - if available */
 #ifdef HAVE_SYS_UTSNAME_H
-        struct utsname sysname = {0};
+        struct utsname sysname;
+        memset(&sysname, 0, sizeof(sysname));
         if(-1 < uname(&sysname)) {
             if((sysname.machine[0] != 0) && (sysname.machine[0] != '\0')) {
                 prrte_setenv("OMPI_MCA_cpu_type", (const char *) &sysname.machine, true, &app->env);
@@ -933,5 +950,87 @@ static int setup_fork(prrte_job_t *jdata, prrte_app_context_t *context) {
 
     free(num_ranks_buf); num_ranks_buf = NULL;
 
-    return PRRTE_SUCCESS;
+    return rc;
+}
+
+static int setup_child(prrte_job_t *jdata,
+                       prrte_proc_t *child,
+                       prrte_app_context_t *app,
+                       char ***env)
+{
+    char *param, value[64] = {0};
+    int rc = PRRTE_SUCCESS;
+    int32_t nrestarts = 0, *nrptr;
+    
+    /* although the vpid IS the process' rank within the job, users
+     * would appreciate being given a public environmental variable
+     * that also represents this value - something MPI specific - so
+     * do that here.
+     *
+     * AND YES - THIS BREAKS THE ABSTRACTION BARRIER TO SOME EXTENT.
+     * We know - just live with it
+     */
+    snprintf(value, 64, "%lu", (unsigned long) child->name.jobid);
+    prrte_setenv("OMPI_COMM_WORLD_RANK", value, true, env);
+    value[0] = '\0';
+
+    /* users would appreciate being given a public environmental variable
+     * that also represents the local rank value - something MPI specific - so
+     * do that here.
+     *
+     * AND YES - THIS BREAKS THE ABSTRACTION BARRIER TO SOME EXTENT.
+     * We know - just live with it
+     */
+    if (PRRTE_LOCAL_RANK_INVALID == child->local_rank ||
+        PRRTE_NODE_RANK_INVALID == child->node_rank ||
+        PMIX_RANK_INVALID == child->rank) {
+        fprintf(stderr, "%d, %d %d\n", child->local_rank, child->node_rank, child->rank);
+        PRRTE_ERROR_LOG(PRRTE_ERR_VALUE_OUT_OF_BOUNDS);
+        rc = PRRTE_ERR_VALUE_OUT_OF_BOUNDS;
+        return rc;
+    }
+
+    if (NULL != app->cwd) {
+        /* change to it */
+        if (0 != chdir(app->cwd)) {
+            return PRRTE_ERROR;
+        }
+    }
+
+    snprintf(value, 64, "%lu", (unsigned long) child->rank);
+    prrte_setenv("OMPI_COMM_WORLD_RANK", value, true, env);
+    value[0] = '\0';
+
+    snprintf(value, 64, "%lu", (unsigned long) child->local_rank);
+    prrte_setenv("OMPI_COMM_WORLD_LOCAL_RANK", value, true, env);
+    value[0] = '\0';
+
+    snprintf(value, 64, "%lu", (unsigned long) child->node_rank);
+    prrte_setenv("OMPI_COMM_WORLD_NODE_RANK", value, true, env);
+    value[0] = '\0';
+
+    nrptr = &nrestarts;
+    if (prrte_get_attribute(&child->attributes, PRRTE_PROC_NRESTARTS, (void**)&nrptr, PRRTE_INT32)) {
+        /* pass the number of restarts for this proc - will be zero for
+         * an initial start, but procs would like to know if they are being
+         * restarted so they can take appropriate action
+         */
+        snprintf(value, 64, "%d", nrestarts);
+        prrte_setenv("OMPI_MCA_num_restarts", value, true, env);
+        value[0] = '\0';
+    }
+
+    /* if the proc should not barrier in prte_init, tell it */
+    if (prrte_get_attribute(&child->attributes, PRRTE_PROC_NOBARRIER, NULL, PRRTE_BOOL)
+        || 0 < nrestarts) {
+        prrte_setenv("OMPI_MCA_do_not_barrier", "1", true, env);
+    }
+
+    /* if the proc isn't going to forward IO, then we need to flag that
+     * it has "completed" iof termination as otherwise it will never fire
+     */
+    if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_FORWARD_OUTPUT)) {
+        PRRTE_FLAG_SET(child, PRRTE_PROC_FLAG_IOF_COMPLETE);
+    }
+    return rc;
 }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -569,6 +569,7 @@ static void check_complete(int fd, short args, void *cbdata)
                 if (!PRRTE_FLAG_TEST(proc, PRRTE_PROC_FLAG_TOOL)) {
                     node->slots_inuse--;
                     node->num_procs--;
+                    node->next_node_rank--;
                 }
 
                 PRRTE_OUTPUT_VERBOSE((2, prrte_state_base_framework.framework_output,

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -759,7 +759,6 @@ void prrte_pmix_server_tool_conn_complete(prrte_job_t *jdata,
     proc->local_rank = 0;
     proc->node_rank = 0;
     proc->app_rank = 0;
-    proc->app_idx = 0;
     if (NULL == req->operation) {
         /* it is on my node */
         node = (prrte_node_t*)prrte_pointer_array_get_item(prrte_node_pool, 0);


### PR DESCRIPTION
- Set OMPI_MCA_cpu_type.
- Move setting OMPI_MCA_initial_wdir to schizo/ompi.
- Setup the path before setup_fork() calls.
- Remove double setting of OMPI_COMMAND.
- Remove RM specific "prrte" from OMPI_MCA_prrte_odls_num_procs
  to make it play better with other RM's.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>