### PR TITLE
Silence Coverity warnings and enable prun to forward signals

### DIFF
--- a/src/event/event-internal.h
+++ b/src/event/event-internal.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019      Research Organization for Information Science
@@ -33,6 +33,7 @@
 #endif
 
 #include "src/util/output.h"
+#include "src/class/prrte_list.h"
 
 typedef event_callback_fn prrte_event_cbfunc_t;
 
@@ -151,6 +152,12 @@ PRRTE_EXPORT prrte_event_t* prrte_event_new(prrte_event_base_t *b, int fd,
 #define prrte_event_signal_initalized(x) event_initialized((x))
 
 #define prrte_event_loop(b, fg) event_base_loop((b), (fg))
+
+typedef struct {
+    prrte_list_item_t super;
+    prrte_event_t ev;
+} prrte_event_list_item_t;
+PRRTE_EXPORT PRRTE_CLASS_DECLARATION(prrte_event_list_item_t);
 
 END_C_DECLS
 

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -77,3 +77,7 @@ int prrte_event_assign(struct event *ev, prrte_event_base_t *evbase,
 #endif
     return 0;
 }
+
+PRRTE_CLASS_INSTANCE(prrte_event_list_item_t,
+                     prrte_list_item_t,
+                     NULL, NULL);

--- a/src/mca/ess/base/base.h
+++ b/src/mca/ess/base/base.h
@@ -68,6 +68,8 @@ PRRTE_EXPORT int prrte_ess_base_std_prolog(void);
 PRRTE_EXPORT int prrte_ess_base_prted_setup(void);
 PRRTE_EXPORT int prrte_ess_base_prted_finalize(void);
 
+PRRTE_EXPORT int prrte_ess_base_setup_signals(char *signals);
+
 /* Detect whether or not this proc is bound - if not,
  * see if it should bind itself
  */
@@ -84,6 +86,7 @@ typedef struct {
     prrte_list_item_t super;
     char *signame;
     int signal;
+    bool can_forward;
 } prrte_ess_base_signal_t;
 PRRTE_CLASS_DECLARATION(prrte_ess_base_signal_t);
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1862,6 +1862,10 @@ int prrte_plm_base_setup_virtual_machine(prrte_job_t *jdata)
              * have assigned our node to us.
              */
             node = (prrte_node_t*)prrte_pointer_array_get_item(prrte_node_pool, 0);
+            if (NULL == node) {
+                PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+                return PRRTE_ERR_NOT_FOUND;
+            }
             prrte_pointer_array_add(map->nodes, (void*)node);
             ++(map->num_nodes);
             /* maintain accounting */
@@ -1958,6 +1962,10 @@ int prrte_plm_base_setup_virtual_machine(prrte_job_t *jdata)
         if (0 == prrte_list_get_size(&nodes)) {
             /* if the HNP has some procs, then we are still good */
             node = (prrte_node_t*)prrte_pointer_array_get_item(prrte_node_pool, 0);
+            if (NULL == node) {
+                PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+                return PRRTE_ERR_NOT_FOUND;
+            }
             if (0 < node->num_procs) {
                 PRRTE_OUTPUT_VERBOSE((5, prrte_plm_base_framework.framework_output,
                                      "%s plm:base:setup_vm only HNP in use",
@@ -1987,6 +1995,10 @@ int prrte_plm_base_setup_virtual_machine(prrte_job_t *jdata)
          * have assigned our node to us.
          */
         node = (prrte_node_t*)prrte_pointer_array_get_item(prrte_node_pool, 0);
+        if (NULL == node) {
+            PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+            return PRRTE_ERR_NOT_FOUND;
+        }
         prrte_pointer_array_add(map->nodes, (void*)node);
         ++(map->num_nodes);
         /* maintain accounting */
@@ -2196,6 +2208,10 @@ int prrte_plm_base_setup_virtual_machine(prrte_job_t *jdata)
      */
     if (prrte_hnp_is_allocated) {
         node = (prrte_node_t*)prrte_pointer_array_get_item(prrte_node_pool, 0);
+        if (NULL == node) {
+            PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+            return PRRTE_ERR_NOT_FOUND;
+        }
         PRRTE_RETAIN(node);
         prrte_list_prepend(&nodes, &node->super);
     }

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -236,13 +236,15 @@ void prrte_plm_base_recv(int status, prrte_process_name_t* sender,
              */
             app = (prrte_app_context_t*)prrte_pointer_array_get_item(parent->apps, 0);
             child_app = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0);
-            prefix_dir = NULL;
-            if (prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&prefix_dir, PRRTE_STRING) &&
-                !prrte_get_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, NULL, PRRTE_STRING)) {
-                prrte_set_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, prefix_dir, PRRTE_STRING);
-            }
-            if (NULL != prefix_dir) {
-                free(prefix_dir);
+            if (NULL != app && NULL != child_app) {
+                prefix_dir = NULL;
+                if (prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&prefix_dir, PRRTE_STRING) &&
+                    !prrte_get_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, NULL, PRRTE_STRING)) {
+                    prrte_set_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, prefix_dir, PRRTE_STRING);
+                }
+                if (NULL != prefix_dir) {
+                    free(prefix_dir);
+                }
             }
             /* link the spawned job to the spawner */
             PRRTE_RETAIN(jdata);

--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -1086,7 +1086,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
         prrte_show_help("help-plm-rsh.txt", "deadlock-params",
                        true, prrte_plm_rsh_component.num_concurrent, map->num_new_daemons);
         PRRTE_ERROR_LOG(PRRTE_ERR_FATAL);
-        PRRTE_RELEASE(state);
         rc = PRRTE_ERR_SILENT;
         goto cleanup;
     }
@@ -1109,6 +1108,11 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * doing this.
      */
     app = (prrte_app_context_t*)prrte_pointer_array_get_item(state->jdata->apps, 0);
+    if (NULL == app) {
+        PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+        rc = PRRTE_ERR_NOT_FOUND;
+        goto cleanup;
+    }
     if (!prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&prefix_dir, PRRTE_STRING)) {
         /* check to see if enable-prun-prefix-by-default was given - if
          * this is being done by a singleton, then prun will not be there

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -601,6 +601,10 @@ void prrte_rmaps_base_display_map(prrte_job_t *jdata)
          /* test locality - for the first node, print the locality of each proc relative to the first one */
         node = (prrte_node_t*)prrte_pointer_array_get_item(jdata->map->nodes, 0);
         p0 = (prrte_proc_t*)prrte_pointer_array_get_item(node->procs, 0);
+        if (NULL == p0) {
+            PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+            return;
+        }
         p0bitmap = NULL;
         if (prrte_get_attribute(&p0->attributes, PRRTE_PROC_CPU_BITMAP, (void**)&p0bitmap, PRRTE_STRING) &&
             NULL != p0bitmap) {

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -647,6 +647,10 @@ void prrte_state_base_track_procs(int fd, short argc, void *cbdata)
         goto cleanup;
     }
     pdata = (prrte_proc_t*)prrte_pointer_array_get_item(jdata->procs, proc->vpid);
+    if (NULL == pdata) {
+        PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+        goto cleanup;
+    }
 
     if (PRRTE_PROC_STATE_RUNNING == state) {
         /* update the proc state */

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -442,7 +442,7 @@ static void check_complete(int fd, short args, void *cbdata)
                         PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
                         (NULL == jdata) ? "NULL" : PRRTE_JOBID_PRINT(jdata->jobid));
 
-    if (prrte_get_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT, (void**)&timer, PRRTE_PTR)) {
+    if (NULL != jdata && prrte_get_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT, (void**)&timer, PRRTE_PTR)) {
         /* timer is an prrte_timer_t object */
         PRRTE_RELEASE(timer);
         prrte_remove_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT);

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -297,6 +297,10 @@ static void track_procs(int fd, short argc, void *cbdata)
         goto cleanup;
     }
     pdata = (prrte_proc_t*)prrte_pointer_array_get_item(jdata->procs, proc->vpid);
+    if (NULL == pdata) {
+        PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
+        goto cleanup;
+    }
 
     if (PRRTE_PROC_STATE_RUNNING == state) {
         /* update the proc state */

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -180,6 +180,10 @@ static void _query(int sd, short args, void *cbdata)
                         PMIX_INFO_LOAD(&info[0], PMIX_NSPACE, jdata->nspace, PMIX_STRING);
                         /* add the cmd line */
                         app = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0);
+                        if (NULL == app) {
+                            ret = PMIX_ERR_NOT_FOUND;
+                            goto done;
+                        }
                         cmdline = prrte_argv_join(app->argv, ' ');
                         PMIX_INFO_LOAD(&info[1], PMIX_CMD_LINE, cmdline, PMIX_STRING);
                         free(cmdline);


### PR DESCRIPTION
 Silence a slew of Coverity warnings 

 Enable prun to catch/forward user-specified signals 

Fixes #451 

Signed-off-by: Ralph Castain <rhc@pmix.org>