### PR TITLE
Fix some race conditions and correct ctrl-c response

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -639,9 +639,6 @@ static int rte_finalize(void)
         free(contact_path);
     }
 
-    /* shutdown the pmix server */
-    pmix_server_finalize();
-
     /* close frameworks */
     (void) prrte_mca_base_framework_close(&prrte_filem_base_framework);
     (void) prrte_mca_base_framework_close(&prrte_grpcomm_base_framework);

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -643,12 +643,10 @@ void prrte_state_base_track_procs(int fd, short argc, void *cbdata)
 
     /* get the job object for this proc */
     if (NULL == (jdata = prrte_get_job_data_object(proc->jobid))) {
-        PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
         goto cleanup;
     }
     pdata = (prrte_proc_t*)prrte_pointer_array_get_item(jdata->procs, proc->vpid);
     if (NULL == pdata) {
-        PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
         goto cleanup;
     }
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -150,13 +150,15 @@ static void _client_finalized(int sd, short args, void *cbdata)
                 break;
             }
         }
-        /* if we came thru this code path, then this client must be an
-         * independent tool that connected to us - i.e., it wasn't
-         * something we spawned. For accounting purposes, we have to
-         * ensure the job complete procedure is run - otherwise, slots
-         * and other resources won't correctly be released */
-        PRRTE_FLAG_SET(p, PRRTE_PROC_FLAG_IOF_COMPLETE);
-        PRRTE_FLAG_SET(p, PRRTE_PROC_FLAG_WAITPID);
+        if (NULL != p) {
+            /* if we came thru this code path, then this client must be an
+             * independent tool that connected to us - i.e., it wasn't
+             * something we spawned. For accounting purposes, we have to
+             * ensure the job complete procedure is run - otherwise, slots
+             * and other resources won't correctly be released */
+            PRRTE_FLAG_SET(p, PRRTE_PROC_FLAG_IOF_COMPLETE);
+            PRRTE_FLAG_SET(p, PRRTE_PROC_FLAG_WAITPID);
+        }
         PRRTE_ACTIVATE_PROC_STATE(&cd->proc, PRRTE_PROC_STATE_TERMINATED);
     }
     if (NULL != p) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1066,7 +1066,7 @@ int prun(int argc, char *argv[])
 
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        rc = 100;
+        rc = 200;
         PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_MAX_RETRIES, &rc, PMIX_INT32);
         prrte_list_append(&tinfo, &ds->super);
 
@@ -1795,7 +1795,7 @@ int prun(int argc, char *argv[])
         PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_TERMINATE, &flag, PMIX_BOOL);
         PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
         ret = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
-        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
+        if (PMIX_SUCCESS == ret || PMIX_OPERATION_SUCCEEDED == ret) {
 #if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
             /* There is a bug in PMIx 3.0.0 up to 3.0.2 that causes the callback never
              * being called when the server successes. The callback might be eventually
@@ -2285,7 +2285,7 @@ static void clean_abort(int fd, short flags, void *arg)
     }
 
     /* tell PRRTE to terminate our job */
-    PMIX_LOAD_PROCID(&target, prrte_process_info.myproc.nspace, PMIX_RANK_WILDCARD);
+    PMIX_LOAD_PROCID(&target, spawnednspace, PMIX_RANK_WILDCARD);
     PMIX_INFO_LOAD(&directive, PMIX_JOB_CTRL_KILL, NULL, PMIX_BOOL);
     rc = PMIx_Job_control_nb(&target, 1, &directive, 1, NULL, NULL);
     prrte_output(0, "JOB CTRL %s", PMIx_Error_string(rc));


### PR DESCRIPTION
 Fix some race conditions
Avoid unnecessary error logs

 Extend rendezvous tries and pass correct nspace to ctrl-c
Give us 200 tries to make the connection as we are cycling quite fast.
Pass the spawned nspace to job_ctrl when given a ctrl-c, and not our
own.

Fixes #454 

Signed-off-by: Ralph Castain <rhc@pmix.org>