### PR TITLE
Enable schizo components to add to the job info

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -94,6 +94,7 @@ PRRTE_EXPORT int prrte_schizo_base_setup_child(prrte_job_t *jobdat,
                                                prrte_proc_t *child,
                                                prrte_app_context_t *app,
                                                char ***env);
+PRRTE_EXPORT void prrte_schizo_base_job_info(prrte_cmd_line_t *cmdline, prrte_list_t *jobinfo);
 PRRTE_EXPORT int prrte_schizo_base_get_remaining_time(uint32_t *timeleft);
 PRRTE_EXPORT void prrte_schizo_base_finalize(void);
 

--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -80,3 +80,11 @@ the number of procs for each resource and the type of resource to be used.
   Specified option:  %s
 
 We are not able to proceed. Please correct your command line.
+#
+[bad-stream-buffering-value]
+An incorrect value for the "--stream-buffering" option was given:
+
+  Specified value:  %d
+
+Valid values are limited to 0, 1, or 2. Your application will continue, but
+please correct your command line in the future.

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -49,6 +49,7 @@ prrte_schizo_API_module_t prrte_schizo = {
     .setup_app = prrte_schizo_base_setup_app,
     .setup_fork = prrte_schizo_base_setup_fork,
     .setup_child = prrte_schizo_base_setup_child,
+    .job_info = prrte_schizo_base_job_info,
     .get_remaining_time = prrte_schizo_base_get_remaining_time,
     .finalize = prrte_schizo_base_finalize
 };

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -256,6 +256,17 @@ int prrte_schizo_base_setup_child(prrte_job_t *jdata,
     return PRRTE_SUCCESS;
 }
 
+void prrte_schizo_base_job_info(prrte_cmd_line_t *cmdline, prrte_list_t *jobinfo)
+{
+    prrte_schizo_base_active_module_t *mod;
+
+    PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
+        if (NULL != mod->module->job_info) {
+            mod->module->job_info(cmdline, jobinfo);
+        }
+    }
+}
+
 int prrte_schizo_base_get_remaining_time(uint32_t *timeleft)
 {
     int rc;

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -141,6 +141,10 @@ typedef void (*prrte_schizo_base_module_finalize_fn_t)(void);
  * another module should be tried */
 typedef int (*prrte_schizo_base_module_get_rem_time_fn_t)(uint32_t *timeleft);
 
+
+/* give the components a chance to add job info */
+typedef void (*prrte_schizo_base_module_job_info_fn_t)(prrte_cmd_line_t *cmdline, prrte_list_t *jobinfo);
+
 /*
  * schizo module version 1.3.0
  */
@@ -159,6 +163,7 @@ typedef struct {
     prrte_schizo_base_module_setup_fork_fn_t                setup_fork;
     prrte_schizo_base_module_setup_child_fn_t               setup_child;
     prrte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
+    prrte_schizo_base_module_job_info_fn_t                  job_info;
     prrte_schizo_base_module_finalize_fn_t                  finalize;
 } prrte_schizo_base_module_t;
 
@@ -181,6 +186,7 @@ typedef struct {
     prrte_schizo_base_module_setup_fork_fn_t                setup_fork;
     prrte_schizo_base_module_setup_child_fn_t               setup_child;
     prrte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
+    prrte_schizo_base_module_job_info_fn_t                  job_info;
     prrte_schizo_base_module_finalize_fn_t                  finalize;
 } prrte_schizo_API_module_t;
 

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1521,6 +1521,8 @@ int prun(int argc, char *argv[])
         prrte_list_append(&job_info, &ds->super);
     }
 
+    /* give the schizo components a chance to add to the job info */
+    prrte_schizo.job_info(prrte_cmd_line, &job_info);
 
     /* pickup any relevant envars */
     flag = true;


### PR DESCRIPTION
Use that new interface to support OMPI's "--stream-buffering" cmd line
option

Fixes #452 

Signed-off-by: Ralph Castain <rhc@pmix.org>