### PR TITLE
plm_base: add friendly timeout message

### DIFF
--- a/src/mca/plm/base/help-plm-base.txt
+++ b/src/mca/plm/base/help-plm-base.txt
@@ -11,6 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -173,3 +174,12 @@ detected that the following node differs in endianness:
   Local endian:  %s
 
 Please correct the situation and try again.
+#
+[timeout]
+The user-provided time limit for job execution has been reached:
+
+  Timeout: %d seconds
+
+The job will now be aborted.  Please check your code and/or
+adjust/remove the job execution time limit (as specified by --timeout
+command line option oror MPIEXEC_TIMEOUT environment variable).

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2007-2017 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2009      Institut National de Recherche en Informatique
  *                         et Automatique. All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
@@ -741,12 +741,22 @@ static void timeout_cb(int fd, short event, void *cbdata)
     prrte_job_t *jdata = (prrte_job_t*)cbdata;
     prrte_timer_t *timer=NULL;
     prrte_proc_t *proc;
-    int i, rc;
+    int i, rc, timeout, *tp;
     prrte_pointer_array_t parray;
 
     PRRTE_ACQUIRE_OBJECT(jdata);
 
-prrte_output(0, "JOB TIMEOUT");
+    /* Display a useful message to the user */
+    tp = &timeout;
+    if (!prrte_get_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT,
+                             (void**)&tp, PRRTE_INT)) {
+        /* This shouldn't happen, but at least don't segv / display
+           *something* if it does */
+        timeout = -1;
+    }
+    prrte_show_help("help-plm-base.txt", "timeout",
+                    true, timeout);
+
     /* clear the timer */
     if (prrte_get_attribute(&jdata->attributes, PRRTE_JOB_TIMEOUT_EVENT, (void**)&timer, PRRTE_PTR)) {
         /* timer is an prrte_timer_t object */


### PR DESCRIPTION
If the user-specified timeout is reached, emit a show_help-style
message (vs. a prrte_output()-style message, which looks like it was
temporary / meant as a placeholder, anyway).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>