### PR TITLE
Ensure we see schizo verbosity and pass node aliases

### DIFF
--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -192,6 +192,14 @@ int prrte_pmix_server_register_nspace(prrte_job_t *jdata)
             kv = PRRTE_NEW(prrte_info_item_t);
             PMIX_INFO_LOAD(&kv->info, PMIX_HOSTNAME, node->name, PMIX_STRING);
             prrte_list_append(&iarray->infolist, &kv->super);
+            /* add any aliases */
+            if (prrte_get_attribute(&node->attributes, PRRTE_NODE_ALIAS, (void**)&regex, PRRTE_STRING) &&
+                NULL != regex) {
+                kv = PRRTE_NEW(prrte_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_HOSTNAME_ALIASES, regex, PMIX_STRING);
+                prrte_list_append(&iarray->infolist, &kv->super);
+                free(regex);
+            }
             /* pass the node ID */
             kv = PRRTE_NEW(prrte_info_item_t);
             PMIX_INFO_LOAD(&kv->info, PMIX_NODEID, &node->index, PMIX_UINT32);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -195,6 +195,17 @@ int main(int argc, char *argv[])
        use it in pretty-print error messages */
     prrte_tool_basename = prrte_basename(argv[0]);
 
+    /* because we have to use the schizo framework prior to parsing the
+     * incoming argv for cmd line options, do a hacky search to support
+     * passing of verbosity option for schizo debugging */
+    for (i=1; NULL != argv[i]; i++) {
+        if (0 == strcmp(argv[i], "schizo_base_verbose")) {
+            /* the next option is the verbosity level */
+            prrte_setenv("PRRTE_MCA_schizo_base_verbose", argv[i+1], true, &environ);
+            break;
+        }
+    }
+
     rc = prrte_cmd_line_create(&cmd_line, cmd_line_init);
     if (PRRTE_SUCCESS != rc) {
         PRRTE_ERROR_LOG(rc);

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -259,6 +259,17 @@ int main(int argc, char *argv[])
     prrte_init_util();
     prrte_tool_basename = prrte_basename(argv[0]);
 
+    /* because we have to use the schizo framework prior to parsing the
+     * incoming argv for cmd line options, do a hacky search to support
+     * passing of verbosity option for schizo debugging */
+    for (i=1; NULL != argv[i]; i++) {
+        if (0 == strcmp(argv[i], "schizo_base_verbose")) {
+            /* the next option is the verbosity level */
+            prrte_setenv("PRRTE_MCA_schizo_base_verbose", argv[i+1], true, &environ);
+            break;
+        }
+    }
+
     /* setup our cmd line */
     prrte_cmd_line = PRRTE_NEW(prrte_cmd_line_t);
     if (PRRTE_SUCCESS != (ret = prrte_cmd_line_add(prrte_cmd_line, prrte_cmd_line_opts))) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -701,6 +701,17 @@ int prun(int argc, char *argv[])
     /* setup callback for SIGPIPE */
     signal(SIGPIPE, epipe_signal_callback);
 
+    /* because we have to use the schizo framework prior to parsing the
+     * incoming argv for cmd line options, do a hacky search to support
+     * passing of verbosity option for schizo debugging */
+    for (i=1; NULL != argv[i]; i++) {
+        if (0 == strcmp(argv[i], "schizo_base_verbose")) {
+            /* the next option is the verbosity level */
+            prrte_setenv("PRRTE_MCA_schizo_base_verbose", argv[i+1], true, &environ);
+            break;
+        }
+    }
+
     /* setup our cmd line */
     prrte_cmd_line = PRRTE_NEW(prrte_cmd_line_t);
     if (PRRTE_SUCCESS != (rc = prrte_cmd_line_add(prrte_cmd_line, cmd_line_init))) {


### PR DESCRIPTION
Because we have to use the schizo framework prior to parsing the
incoming argv for cmd line options, do a hacky search to support
passing of verbosity option for schizo debugging

Pass known hostname aliases to register_nspace so nodes can identify
each other

Signed-off-by: Ralph Castain <rhc@pmix.org>