### PR TITLE
Reduce complexity for proxy executions

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -434,8 +434,7 @@ int pmix_server_init(void)
      * PMIx connection point - only do this for the HNP as, in
      * at least one case, a daemon can be colocated with the
      * HNP and would overwrite the server rendezvous file */
-    if (prrte_pmix_server_globals.system_server &&
-        (PRRTE_PROC_IS_MASTER || PRRTE_PROC_IS_MASTER)) {
+    if (prrte_pmix_server_globals.system_server && PRRTE_PROC_IS_MASTER) {
         kv = PRRTE_NEW(prrte_value_t);
         kv->key = strdup(PMIX_SERVER_SYSTEM_SUPPORT);
         kv->type = PRRTE_BOOL;
@@ -468,6 +467,16 @@ int pmix_server_init(void)
     kv->type = PRRTE_BOOL;
     kv->data.flag = true;
     prrte_list_append(&ilist, &kv->super);
+
+    /* if we were launched by a debugger, then we need to have
+     * notification of our termination sent */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        kv = PRRTE_NEW(prrte_value_t);
+        kv->key = strdup(PMIX_EVENT_SILENT_TERMINATION);
+        kv->type = PRRTE_BOOL;
+        kv->data.flag = false;
+        prrte_list_append(&ilist, &kv->super);
+    }
 
     /* convert to an info array */
     ninfo = prrte_list_get_size(&ilist) + 2;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -160,8 +160,8 @@ static void spawn(int sd, short args, void *cbdata)
 
     /* send it to the HNP for processing - might be myself! */
     if (PRRTE_SUCCESS != (rc = prrte_rml.send_buffer_nb(PRRTE_PROC_MY_HNP, buf,
-                                                      PRRTE_RML_TAG_PLM,
-                                                      prrte_rml_send_callback, NULL))) {
+                                                        PRRTE_RML_TAG_PLM,
+                                                        prrte_rml_send_callback, NULL))) {
         PRRTE_ERROR_LOG(rc);
         prrte_hotel_checkout(&prrte_pmix_server_globals.reqs, req->room_num);
         PRRTE_RELEASE(buf);

--- a/src/runtime/prrte_globals.c
+++ b/src/runtime/prrte_globals.c
@@ -72,6 +72,7 @@ char *prrte_data_server_uri = NULL;
 char *prrte_tool_basename = NULL;
 bool prrte_dvm_ready = false;
 prrte_pointer_array_t *prrte_cache = NULL;
+bool prrte_persistent = true;
 
 /* PRRTE OOB port flags */
 bool prrte_static_ports = false;

--- a/src/runtime/prrte_globals.h
+++ b/src/runtime/prrte_globals.h
@@ -447,6 +447,7 @@ PRRTE_EXPORT extern char *prrte_topo_signature;
 PRRTE_EXPORT extern char *prrte_data_server_uri;
 PRRTE_EXPORT extern bool prrte_dvm_ready;
 PRRTE_EXPORT extern prrte_pointer_array_t *prrte_cache;
+PRRTE_EXPORT extern bool prrte_persistent;
 
 /* PRRTE OOB port flags */
 PRRTE_EXPORT extern bool prrte_static_ports;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -12,11 +12,12 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
- * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2019      Research Organization for Information Science
+ * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -26,7 +27,8 @@
  */
 
 #include "prrte_config.h"
-#include "constants.h"
+#include "src/include/constants.h"
+#include "src/include/version.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -56,104 +58,411 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif
 
 #include "src/event/event-internal.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/mca/base/base.h"
-
 #include "src/util/argv.h"
 #include "src/util/basename.h"
 #include "src/util/cmd_line.h"
 #include "src/util/daemon_init.h"
 #include "src/util/fd.h"
-#include "src/util/output.h"
-#include "src/util/os_dirpath.h"
 #include "src/util/os_path.h"
+#include "src/util/output.h"
 #include "src/util/path.h"
+#include "src/util/printf.h"
 #include "src/util/prrte_environ.h"
 #include "src/util/prrte_getcwd.h"
-#include "src/util/session_dir.h"
 #include "src/util/show_help.h"
+#include "src/sys/atomic.h"
 
-#include "src/include/version.h"
-#include "src/class/prrte_pointer_array.h"
 #include "src/runtime/prrte_progress_threads.h"
-
-#include "src/mca/errmgr/errmgr.h"
-#include "src/mca/grpcomm/grpcomm.h"
-#include "src/mca/odls/odls.h"
-#include "src/mca/oob/base/base.h"
-#include "src/mca/rml/rml.h"
-#include "src/mca/rml/base/rml_contact.h"
-#include "src/mca/schizo/base/base.h"
-#include "src/mca/state/base/base.h"
+#include "src/class/prrte_pointer_array.h"
+#include "src/dss/dss.h"
 
 #include "src/runtime/runtime.h"
 #include "src/runtime/prrte_globals.h"
-#include "src/threads/threads.h"
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/ess/base/base.h"
+#include "src/mca/rml/rml.h"
+#include "src/mca/schizo/base/base.h"
+#include "src/mca/state/base/base.h"
 
 #include "src/prted/prted.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
-/*
- * Globals
- */
+typedef struct {
+    prrte_object_t super;
+    prrte_pmix_lock_t lock;
+    pmix_info_t *info;
+    size_t ninfo;
+} myinfo_t;
+static void mcon(myinfo_t *p)
+{
+    PRRTE_PMIX_CONSTRUCT_LOCK(&p->lock);
+    p->info = NULL;
+    p->ninfo = 0;
+}
+static void mdes(myinfo_t *p)
+{
+    PRRTE_PMIX_DESTRUCT_LOCK(&p->lock);
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+}
+static PRRTE_CLASS_INSTANCE(myinfo_t, prrte_object_t,
+                            mcon, mdes);
+
+typedef struct {
+    prrte_list_item_t super;
+    pmix_app_t app;
+    prrte_list_t info;
+} prrte_pmix_app_t;
+static void acon(prrte_pmix_app_t *p)
+{
+    PMIX_APP_CONSTRUCT(&p->app);
+    PRRTE_CONSTRUCT(&p->info, prrte_list_t);
+}
+static void ades(prrte_pmix_app_t *p)
+{
+    PMIX_APP_DESTRUCT(&p->app);
+    PRRTE_LIST_DESTRUCT(&p->info);
+}
+static PRRTE_CLASS_INSTANCE(prrte_pmix_app_t,
+                          prrte_list_item_t,
+                          acon, ades);
+
+typedef struct {
+    prrte_pmix_lock_t lock;
+    pmix_info_t *info;
+    size_t ninfo;
+} mylock_t;
+
+static prrte_list_t job_info;
+static prrte_jobid_t myjobid = PRRTE_JOBID_INVALID;
+static myinfo_t myinfo;
+static pmix_nspace_t spawnednspace;
+
+static int create_app(int argc, char* argv[],
+                      prrte_list_t *jdata,
+                      prrte_pmix_app_t **app,
+                      bool *made_app, char ***app_env);
+static int parse_locals(prrte_list_t *jdata, int argc, char* argv[]);
+static void set_classpath_jar_file(prrte_pmix_app_t *app, int index, char *jarfile);
+static bool verbose = false;
+static prrte_cmd_line_t *prrte_cmd_line = NULL;
 static bool want_prefix_by_default = (bool) PRRTE_WANT_PRRTE_PREFIX_BY_DEFAULT;
 
-/* prte-specific command line options */
+/* prun-specific options */
 static prrte_cmd_line_init_t cmd_line_init[] = {
-    /* DVM-specific options */
 
-    /* uri of PMIx publish/lookup server, or at least where to get it */
-    { '\0', "prrte-server", 1, PRRTE_CMD_LINE_TYPE_STRING,
-      "Specify the URI of the publish/lookup server, or the name of the file (specified as file:filename) that contains that info",
+    /* DVM options */
+    /* tell the dvm to terminate */
+    { '\0', "terminate", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Terminate the DVM", PRRTE_CMD_LINE_OTYPE_DVM },
+    /* look first for a system server */
+    { '\0', "system-server-first", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "First look for a system server and connect to it if found",
       PRRTE_CMD_LINE_OTYPE_DVM },
-    /* fwd mpirun port */
-    { '\0', "fwd-mpirun-port", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Forward mpirun port to compute node daemons so all will use it",
+    /* connect only to a system server */
+    { '\0', "system-server-only", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Connect only to a system-level server",
       PRRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "system-server", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Act as system server",
+    /* do not connect */
+    { '\0', "do-not-connect", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Do not connect to a server",
       PRRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "no-ready-msg", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Do not output a \"DVM READY\" message",
+    /* wait to connect */
+    { '\0', "wait-to-connect", 0, PRRTE_CMD_LINE_TYPE_INT,
+      "Delay specified number of seconds before trying to connect",
       PRRTE_CMD_LINE_OTYPE_DVM },
+    /* number of times to try to connect */
+    { '\0', "num-connect-retries", 0, PRRTE_CMD_LINE_TYPE_INT,
+      "Max number of times to try to connect",
+      PRRTE_CMD_LINE_OTYPE_DVM },
+    /* provide a connection PID */
+    { '\0', "pid", 1, PRRTE_CMD_LINE_TYPE_INT,
+      "PID of the session-level daemon to which we should connect",
+      PRRTE_CMD_LINE_OTYPE_DVM },
+    /* uri of the dvm, or at least where to get it */
+    { '\0', "dvm-uri", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Specify the URI of the DVM master, or the name of the file (specified as file:filename) that contains that info",
+      PRRTE_CMD_LINE_OTYPE_DVM },
+    /* forward signals */
+    { '\0', "forward-signals", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Comma-delimited list of additional signals (names or integers) to forward to "
+      "application processes [\"none\" => forward nothing]. Signals provided by "
+      "default include SIGTSTP, SIGUSR1, SIGUSR2, SIGABRT, SIGALRM, and SIGCONT",
+      PRRTE_CMD_LINE_OTYPE_DVM},
+
+
+    /* testing options */
+    { '\0', "timeout", 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Timeout the job after the specified number of seconds",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "report-state-on-timeout", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Report all job and process states upon timeout",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "get-stack-traces", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Get stack traces of all application procs on timeout",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+
+
+    /* Conventional options - for historical compatibility, support
+     * both single and multi dash versions */
+    /* Number of processes; -c, -n, --n, -np, and --np are all
+       synonyms */
+    { 'c', "np", 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Number of processes to run",
+      PRRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'n', "n", 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Number of processes to run",
+      PRRTE_CMD_LINE_OTYPE_GENERAL },
+    /* Use an appfile */
+    { '\0',  "app", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Provide an appfile; ignore all other command line options",
+      PRRTE_CMD_LINE_OTYPE_GENERAL },
+
+
+      /* Output options */
+    /* exit status reporting */
+    { '\0', "report-child-jobs-separately", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Return the exit status of the primary job only",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* select XML output */
+    { '\0', "xml", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Provide all output in XML format",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "xml-file", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Provide all output in XML format to the specified file",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* tag output */
+    { '\0', "tag-output", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Tag all output with [job,rank]",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "timestamp-output", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Timestamp all application process output",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-directory", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOJOBID (do not include a job-id directory level) and NOCOPY (do not copy the output to the stdout/err streams)",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-filename", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Redirect output from application processes into filename.rank. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOCOPY (do not copy the output to the stdout/err streams)",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "merge-stderr-to-stdout", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Merge stderr to stdout for each process",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "xterm", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Create a new xterm window and display output from the specified ranks there",
+      PRRTE_CMD_LINE_OTYPE_OUTPUT },
+
+    /* select stdin option */
+    { '\0', "stdin", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Specify procs to receive stdin [rank, all, none] (default: 0, indicating rank 0)",
+      PRRTE_CMD_LINE_OTYPE_INPUT },
+
+
+    /* User-level debugger arguments */
+    { '\0', "debug", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Invoke the indicated user-level debugger (provide a comma-delimited list of debuggers to search for)",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "output-proctable", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Print the complete proctable to stdout [-], stderr [+], or a file [anything else] after launch",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "stop-on-exec", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "If supported, stop each process at start of execution",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+
+
+    /* Launch options */
+    /* request that argv[0] be indexed */
+    { '\0', "index-argv-by-rank", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Uniquely index argv[0] for each process using its rank",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload the binary on the remote machine */
+    { 's', "preload-binary", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Preload the binary on the remote machine before starting the remote process.",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload files on the remote machine */
+    { '\0', "preload-files", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Preload the comma separated list of files to the remote machines current working directory before starting the remote process.",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Export environment variables; potentially used multiple times,
+       so it does not make sense to set into a variable */
+    { 'x', NULL, 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes; \"-x foo*\" exports all current environmental variables starting with \"foo\")",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wdir", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Set the working directory of the started processes",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wd", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Synonym for --wdir",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "set-cwd-to-session-dir", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Set the working directory of the started processes to their session directory",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "path", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "PATH to be used to look for executables to start processes",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "show-progress", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Output a brief periodic report on launch progress",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "pset", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "User-specified name assigned to the processes in their given application",
+      PRRTE_CMD_LINE_OTYPE_LAUNCH },
 
 
 
-    /* Debug options */
-    { '\0', "debug", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Debug PRRTE",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { '\0', "debug-daemons", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Debug daemons",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { 'd', "debug-devel", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Enable debugging of PRRTE",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { '\0', "debug-daemons-file", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Enable debugging of any PRRTE daemons used by this application, storing output in files",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { '\0', "leave-session-attached", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Do not discard stdout/stderr of remote PRTE daemons",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-    { '\0',  "test-suicide", 1, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Suicide instead of clean abort after delay",
-      PRRTE_CMD_LINE_OTYPE_DEBUG },
-
-
-
+    /* Developer options */
     { '\0', "do-not-resolve", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Do not attempt to resolve interfaces",
+      "Do not attempt to resolve interfaces - usually used to determine proposed process placement/binding prior to obtaining an allocation",
       PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "do-not-launch", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Perform all necessary operations to prepare to launch the application, but do not actually launch it (usually used to test mapping patterns)",
+      PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-map", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+       "Display a detailed process map (mostly intended for developers) just before launch",
+       PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-topo", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+       "Display the topology as part of the process map (mostly intended for developers) just before launch",
+       PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-diffable-map", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+       "Display a diffable process map (mostly intended for developers) just before launch",
+       PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "report-bindings", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Whether to report process bindings to stderr",
+      PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-allocation", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Display a detailed list (mostly intended for developers) of the allocation being used by this job",
+      PRRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-map", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Display the process map just before launch",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "display-allocation", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Display the allocation being used by this job",
+      PRRTE_CMD_LINE_OTYPE_DEBUG },
 
 
-    { '\0', "remote-tools", 0, PRRTE_CMD_LINE_TYPE_BOOL,
-      "Enable connections from remote tools",
-      PRRTE_CMD_LINE_OTYPE_DVM },
+    /* Mapping options */
+    { '\0', "map-by", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Mapping Policy [slot | hwthread | core (default:np<=2) | l1cache | l2cache | l3cache | socket | numa (default:np>2) | board | node | seq | dist | ppr(:N:RESOURCE) | rankfile(:FILENAME)], with allowed modifiers :PE=y:PE-LIST=a,b:SPAN:OVERSUBSCRIBE:NOOVERSUBSCRIBE:NOLOCAL",
+      PRRTE_CMD_LINE_OTYPE_MAPPING },
+
+
+      /* Ranking options */
+    { '\0', "rank-by", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Ranking Policy [slot (default) | hwthread | core | socket | numa | board | node], with allowed modifiers :SPAN",
+      PRRTE_CMD_LINE_OTYPE_RANKING },
+
+
+      /* Binding options */
+    { '\0', "bind-to", 1, PRRTE_CMD_LINE_TYPE_STRING,
+      "Policy for binding processes [none (default:oversubscribed), hwthread, core (default:np<=2), l1cache, l2cache, l3cache, socket, numa] Allowed qualifiers: OVERLOAD:IF-SUPPORTED",
+      PRRTE_CMD_LINE_OTYPE_BINDING },
+
+
+    /* Fault Tolerance options */
+    { '\0', "enable-recovery", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Enable recovery from process failure [Default = disabled]",
+      PRRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "max-restarts", 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Max number of times to restart a failed process",
+      PRRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "disable-recovery", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Disable recovery (resets all recovery options to off)",
+      PRRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "continuous", 0, PRRTE_CMD_LINE_TYPE_BOOL,
+      "Job is to run until explicitly terminated",
+      PRRTE_CMD_LINE_OTYPE_FT },
+
 
     /* End of list */
     { '\0', NULL, 0, PRRTE_CMD_LINE_TYPE_NULL, NULL }
 };
+
+
+static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
+{
+    prrte_pmix_lock_t *lock = (prrte_pmix_lock_t*)cbdata;
+    PRRTE_ACQUIRE_OBJECT(lock);
+    PRRTE_PMIX_WAKEUP_THREAD(lock);
+}
+
+static void setupcbfunc(pmix_status_t status,
+                        pmix_info_t info[], size_t ninfo,
+                        void *provided_cbdata,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    mylock_t *mylock = (mylock_t*)provided_cbdata;
+    size_t n;
+
+    if (NULL != info) {
+        mylock->ninfo = ninfo;
+        PMIX_INFO_CREATE(mylock->info, mylock->ninfo);
+        /* cycle across the provided info */
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&mylock->info[n], &info[n]);
+        }
+    } else {
+        mylock->info = NULL;
+        mylock->ninfo = 0;
+    }
+
+    /* release the caller */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+
+    PRRTE_PMIX_WAKEUP_THREAD(&mylock->lock);
+}
+
+static void launchhandler(size_t evhdlr_registration_id,
+                          pmix_status_t status,
+                          const pmix_proc_t *source,
+                          pmix_info_t info[], size_t ninfo,
+                          pmix_info_t *results, size_t nresults,
+                          pmix_event_notification_cbfunc_fn_t cbfunc,
+                          void *cbdata)
+{
+    size_t n;
+
+    /* the info list will include the launch directives, so
+     * transfer those to the myinfo_t for return to the main thread */
+    if (NULL != info) {
+        myinfo.ninfo = ninfo;
+        PMIX_INFO_CREATE(myinfo.info, myinfo.ninfo);
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&myinfo.info[n], &info[n]);
+        }
+    }
+
+    /* we _always_ have to execute the evhandler callback or
+     * else the event progress engine will hang */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    /* now release the thread */
+    PRRTE_PMIX_WAKEUP_THREAD(&myinfo.lock);
+}
+
+static void spcbfunc(pmix_status_t status,
+                     char nspace[], void *cbdata)
+{
+    prrte_pmix_lock_t *lock = (prrte_pmix_lock_t*)cbdata;
+
+    PRRTE_ACQUIRE_OBJECT(lock);
+    lock->status = status;
+    if (PMIX_SUCCESS == status) {
+        lock->msg = strdup(nspace);
+    }
+    PRRTE_PMIX_WAKEUP_THREAD(lock);
+}
+
 
 static int wait_pipe[2];
 
@@ -180,34 +489,58 @@ static int wait_dvm(pid_t pid) {
 
 int main(int argc, char *argv[])
 {
-    int rc, i, j;
-    ssize_t param_len;
-    prrte_cmd_line_t cmd_line;
-    char *param, *tpath;
-    prrte_job_t *jdata=NULL;
-    prrte_app_context_t *app;
+    int rc=1, i, j;
+    char *param, *ptr, *tpath;
+    prrte_pmix_lock_t lock;
+    prrte_list_t apps;
+    prrte_pmix_app_t *app;
+    pmix_info_t info, *iptr;
+    pmix_proc_t pname, controller;
+    pmix_status_t ret;
+    bool flag;
+    prrte_ds_info_t *ds;
+    size_t m, n, ninfo, param_len;
+    pmix_app_t *papps;
+    size_t napps;
+    mylock_t mylock;
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+    bool notify_launch = false;
+#endif
     prrte_value_t *pval;
+    uint32_t ui32;
+    char *rfile = NULL;
+    char *mytmpdir;
+    char **pargv;
+    int pargc;
+    char **tmp;
+    prrte_job_t *jdata;
+    prrte_app_context_t *dapp;
+
+    /* init the globals */
+    PRRTE_CONSTRUCT(&job_info, prrte_list_t);
+    PRRTE_CONSTRUCT(&apps, prrte_list_t);
 
     /* init the tiny part of PRRTE we use */
     prrte_init_util();
 
-    /* find our basename (the name of the executable) so that we can
-       use it in pretty-print error messages */
     prrte_tool_basename = prrte_basename(argv[0]);
+    pargc = argc;
+    pargv = prrte_argv_copy(argv);
 
     /* because we have to use the schizo framework prior to parsing the
      * incoming argv for cmd line options, do a hacky search to support
-     * passing of verbosity option for schizo debugging */
+     * passing of options (e.g., verbosity) for schizo */
     for (i=1; NULL != argv[i]; i++) {
-        if (0 == strcmp(argv[i], "schizo_base_verbose")) {
-            /* the next option is the verbosity level */
-            prrte_setenv("PRRTE_MCA_schizo_base_verbose", argv[i+1], true, &environ);
-            break;
+        if (0 == strncmp(argv[i], "schizo", 6)) {
+            prrte_asprintf(&param, "PRRTE_MCA_%s", argv[i]);
+            prrte_setenv(param, argv[i+1], true, &environ);
+            free(param);
         }
     }
 
-    rc = prrte_cmd_line_create(&cmd_line, cmd_line_init);
-    if (PRRTE_SUCCESS != rc) {
+    /* setup our cmd line */
+    prrte_cmd_line = PRRTE_NEW(prrte_cmd_line_t);
+    if (PRRTE_SUCCESS != (rc = prrte_cmd_line_add(prrte_cmd_line, cmd_line_init))) {
         PRRTE_ERROR_LOG(rc);
         return rc;
     }
@@ -222,43 +555,84 @@ int main(int argc, char *argv[])
         PRRTE_ERROR_LOG(rc);
         return rc;
     }
-    /* scan for personalities */
+    /* setup our common personalities */
     prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "prrte");
     prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "pmix");
+    /* add anything they specified */
     for (i=0; NULL != argv[i]; i++) {
         if (0 == strcmp(argv[i], "--personality")) {
-            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, argv[i+1]);
+            tmp = prrte_argv_split(argv[i+1], ',');
+            for (m=0; NULL != tmp[m]; m++) {
+                prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, tmp[m]);
+            }
+            prrte_argv_free(tmp);
         }
     }
 
-    /* setup the rest of the cmd line only once */
-    if (PRRTE_SUCCESS != (rc = prrte_schizo.define_cli(&cmd_line))) {
+    /* detect if we are running as a proxy and setup the rendezvous
+     * and session directory files */
+    if (PRRTE_SUCCESS != (rc = prrte_schizo.detect_proxy(pargv, &rfile))) {
+        if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
+            PRRTE_ERROR_LOG(rc);
+            return rc;
+        }
+    }
+
+    /* get our session directory */
+    if (PRRTE_SUCCESS != (rc = prrte_schizo.define_session_dir(&mytmpdir))) {
         PRRTE_ERROR_LOG(rc);
         return rc;
     }
 
-    if (PRRTE_SUCCESS != (rc = prrte_cmd_line_parse(&cmd_line, true, false,
-                                                  argc, argv)) ) {
+    /* setup the rest of the cmd line only once */
+    if (PRRTE_SUCCESS != (rc = prrte_schizo.define_cli(prrte_cmd_line))) {
+        PRRTE_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* handle deprecated options */
+    if (PRRTE_SUCCESS != (rc = prrte_schizo.parse_deprecated_cli(prrte_cmd_line, &pargc, &pargv))) {
+        if (PRRTE_OPERATION_SUCCEEDED == rc) {
+            /* the cmd line was restructured - show them the end result */
+            param = prrte_argv_join(pargv, ' ');
+            fprintf(stderr, "\n******* Corrected cmd line: %s\n\n\n", param);
+            free(param);
+        } else {
+            return rc;
+        }
+    }
+
+    /* parse the result to get values - this will not include MCA params */
+    if (PRRTE_SUCCESS != (rc = prrte_cmd_line_parse(prrte_cmd_line,
+                                                    true, false, pargc, pargv)) ) {
         if (PRRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+            fprintf(stderr, "%s: command line error (%s)\n",
+                    prrte_tool_basename,
+                    prrte_strerror(rc));
+        }
+       return rc;
+    }
+
+    /* let the schizo components take a pass at it to get the MCA params - this
+     * will include whatever default/user-level param files each schizo component
+     * supports */
+    if (PRRTE_SUCCESS != (rc = prrte_schizo.parse_cli(pargc, 0, pargv, NULL, NULL))) {
+        if (PRRTE_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n",
+                    prrte_tool_basename,
                     prrte_strerror(rc));
         }
         return rc;
     }
 
-    /* now let the schizo components take a pass at it to get the MCA params */
-    if (PRRTE_SUCCESS != (rc = prrte_schizo.parse_cli(argc, 0, argv, NULL, NULL))) {
-        if (PRRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
-                    prrte_strerror(rc));
-        }
-         PRRTE_ERROR_LOG(rc);
-       return rc;
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "verbose")) {
+        verbose = true;
     }
 
-    /* print version if requested.  Do this before check for help so
-       that --version --help works as one might expect. */
-     if (prrte_cmd_line_is_taken(&cmd_line, "version")) {
+    /* see if print version is requested. Do this before
+     * check for help so that --version --help works as
+     * one might expect. */
+     if (prrte_cmd_line_is_taken(prrte_cmd_line, "version")) {
         fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
                 prrte_tool_basename, "PMIx Reference RunTime Environment",
                 PRRTE_VERSION, PACKAGE_BUGREPORT);
@@ -270,16 +644,15 @@ int main(int argc, char *argv[])
      * exit with a giant warning flag
      */
     if (0 == geteuid()) {
-        prrte_schizo.allow_run_as_root(&cmd_line);  // will exit us if not allowed
+        prrte_schizo.allow_run_as_root(prrte_cmd_line);  // will exit us if not allowed
     }
 
     /* Check for help request */
-     if (prrte_cmd_line_is_taken(&cmd_line, "help")) {
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "help")) {
         char *str, *args = NULL;
-        char *project_name = "PMIx Reference RTE";
-        args = prrte_cmd_line_get_usage_msg(&cmd_line, false);
+        args = prrte_cmd_line_get_usage_msg(prrte_cmd_line, false);
         str = prrte_show_help_string("help-prun.txt", "prun:usage", false,
-                                    prrte_tool_basename, project_name, PRRTE_VERSION,
+                                    prrte_tool_basename, "PRRTE", PRRTE_VERSION,
                                     prrte_tool_basename, args,
                                     PACKAGE_BUGREPORT);
         if (NULL != str) {
@@ -292,21 +665,42 @@ int main(int argc, char *argv[])
         exit(0);
     }
 
-     if (prrte_cmd_line_is_taken(&cmd_line, "no-ready-msg")) {
+    /* detach from controlling terminal
+     * otherwise, remain attached so output can get to us
+     */
+    prrte_debug_flag = prrte_cmd_line_is_taken(prrte_cmd_line, "debug");
+    prrte_debug_daemons_flag = prrte_cmd_line_is_taken(prrte_cmd_line, "debug-daemons");
+    if (!prrte_debug_flag &&
+        !prrte_debug_daemons_flag &&
+        prrte_cmd_line_is_taken(prrte_cmd_line, "daemonize")) {
+        pipe(wait_pipe);
+        prrte_state_base_parent_fd = wait_pipe[1];
+        prrte_daemon_init_callback(NULL, wait_dvm);
+        close(wait_pipe[0]);
+    } else {
+#if defined(HAVE_SETSID)
+        /* see if we were directed to separate from current session */
+        if (prrte_cmd_line_is_taken(prrte_cmd_line, "set-sid")) {
+            setsid();
+        }
+#endif
+    }
+
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "no-ready-msg")) {
         prrte_state_base_ready_msg = false;
     }
 
-    if (prrte_cmd_line_is_taken(&cmd_line, "system-server")) {
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "system-server")) {
         /* we should act as system-level PMIx server */
         prrte_setenv("PRRTE_MCA_pmix_system_server", "1", true, &environ);
     }
     /* always act as session-level PMIx server */
     prrte_setenv("PRRTE_MCA_pmix_session_server", "1", true, &environ);
     /* if we were asked to report a uri, set the MCA param to do so */
-     if (NULL != (pval = prrte_cmd_line_get_param(&cmd_line, "report-uri", 0, 0))) {
+     if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "report-uri", 0, 0))) {
         prrte_setenv("PMIX_MCA_ptl_tcp_report_uri", pval->data.string, true, &environ);
     }
-    if (prrte_cmd_line_is_taken(&cmd_line, "remote-tools")) {
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "remote-tools")) {
         prrte_setenv("PMIX_MCA_ptl_tcp_remote_connections", "1", true, &environ);
     }
     /* don't aggregate help messages as that will apply job-to-job */
@@ -323,34 +717,87 @@ int main(int argc, char *argv[])
      */
     prrte_launch_environ = prrte_argv_copy(environ);
 
-#if defined(HAVE_SETSID)
-    /* see if we were directed to separate from current session */
-    if (prrte_cmd_line_is_taken(&cmd_line, "set-sid")) {
-        setsid();
+    /* setup PRRTE infrastructure */
+    if (PRRTE_SUCCESS != (ret = prrte_init(&pargc, &pargv, PRRTE_PROC_MASTER))) {
+        PRRTE_ERROR_LOG(ret);
+        return ret;
     }
+
+    /* if we were launched by a tool wanting to direct our
+     * operation, then we need to pause here and give it
+     * a chance to tell us what we need to do - this needs to be
+     * done prior to starting the DVM as it may include instructions
+     * on the daemon executable, the fork/exec agent to be used by
+     * the daemons, or other directives impacting the DVM itself */
+    if (NULL != (param = getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL"))) {
+        /* register for the PMIX_LAUNCH_DIRECTIVE event */
+        PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        ret = PMIX_LAUNCH_DIRECTIVE;
+        /* setup the myinfo object to capture the returned
+         * values - must do so prior to registering in case
+         * the event has already arrived */
+        PRRTE_CONSTRUCT(&myinfo, myinfo_t);
+
+        /* go ahead and register */
+        PMIx_Register_event_handler(&ret, 1, NULL, 0, launchhandler, regcbfunc, &lock);
+        PRRTE_PMIX_WAIT_THREAD(&lock);
+        PRRTE_PMIX_DESTRUCT_LOCK(&lock);
+        /* notify the tool that we are ready */
+        ptr = strdup(param);
+        param = strchr(ptr, ':');
+        *param = '\0';
+        ++param;
+        (void)strncpy(controller.nspace, ptr, PMIX_MAX_NSLEN);
+        controller.rank = strtoul(param, NULL, 10);
+        PMIX_INFO_CREATE(iptr, 1);
+        /* target this notification solely to that one tool */
+        PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_CUSTOM_RANGE, &controller, PMIX_PROC);
+
+        PMIx_Notify_event(PMIX_LAUNCHER_READY, &pname, PMIX_RANGE_CUSTOM,
+                          iptr, 1, NULL, NULL);
+        /* now wait for the launch directives to arrive */
+        PRRTE_PMIX_WAIT_THREAD(&myinfo.lock);
+        PMIX_INFO_FREE(iptr, 1);
+
+        /* process the returned directives */
+        if (NULL != myinfo.info) {
+            for (n=0; n < myinfo.ninfo; n++) {
+                if (0 == strncmp(myinfo.info[n].key, PMIX_DEBUG_JOB_DIRECTIVES, PMIX_MAX_KEYLEN)) {
+                    /* there will be a pmix_data_array containing the directives */
+                    iptr = (pmix_info_t*)myinfo.info[n].value.data.darray->array;
+                    ninfo = myinfo.info[n].value.data.darray->size;
+                    for (m=0; m < ninfo; m++) {
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+                        if (PMIX_CHECK_KEY(&iptr[m], PMIX_NOTIFY_LAUNCH)) {
+                            /* we don't pass this along - it is aimed at us */
+                            notify_launch = true;
+                            continue;
+                        }
 #endif
-
-    /* detach from controlling terminal
-     * otherwise, remain attached so output can get to us
-     */
-    prrte_debug_flag = prrte_cmd_line_is_taken(&cmd_line, "debug");
-    prrte_debug_daemons_flag = prrte_cmd_line_is_taken(&cmd_line, "debug-daemons");
-    if (!prrte_debug_flag &&
-        !prrte_debug_daemons_flag &&
-        prrte_cmd_line_is_taken(&cmd_line, "daemonize")) {
-        pipe(wait_pipe);
-        prrte_state_base_parent_fd = wait_pipe[1];
-        prrte_daemon_init_callback(NULL, wait_dvm);
-        close(wait_pipe[0]);
+                        ds = PRRTE_NEW(prrte_ds_info_t);
+                        ds->info = &iptr[m];
+                        prrte_list_append(&job_info, &ds->super);
+                    }
+                    free(myinfo.info[n].value.data.darray);  // protect the info structs
+                } else if (0 == strncmp(myinfo.info[n].key, PMIX_DEBUG_APP_DIRECTIVES, PMIX_MAX_KEYLEN)) {
+                    /* there will be a pmix_data_array containing the directives */
+                    iptr = (pmix_info_t*)myinfo.info[n].value.data.darray->array;
+                    ninfo = myinfo.info[n].value.data.darray->size;
+                    for (m=0; m < ninfo; m++) {
+                        PRRTE_LIST_FOREACH(app, &apps, prrte_pmix_app_t) {
+                            /* the value can only be on one list at a time, so replicate it */
+                            ds = PRRTE_NEW(prrte_ds_info_t);
+                            ds->info = &iptr[n];
+                            prrte_list_append(&app->info, &ds->super);
+                        }
+                    }
+                    free(myinfo.info[n].value.data.darray);  // protect the info structs
+                }
+            }
+        }
     }
 
-    /* Intialize our environment */
-    if (PRRTE_SUCCESS != (rc = prrte_init(&argc, &argv, PRRTE_PROC_MASTER))) {
-        /* cannot call PRRTE_ERROR_LOG as it could be the errmgr
-         * never got loaded!
-         */
-        return rc;
-    }
+    /* start the DVM */
 
      /* get the daemon job object - was created by ess/hnp component */
     if (NULL == (jdata = prrte_get_job_data_object(PRRTE_PROC_MY_NAME->jobid))) {
@@ -359,14 +806,14 @@ int main(int argc, char *argv[])
         exit(0);
     }
     /* also should have created a daemon "app" */
-    if (NULL == (app = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0))) {
+    if (NULL == (dapp = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0))) {
         prrte_show_help("help-prun.txt", "bad-app-object", true,
                        prrte_tool_basename);
         exit(0);
     }
 
     /* Did the user specify a prefix, or want prefix by default? */
-    if (NULL != (pval = prrte_cmd_line_get_param(&cmd_line, "prefix", 0, 0)) || want_prefix_by_default) {
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "prefix", 0, 0)) || want_prefix_by_default) {
         if (NULL != pval) {
             param = strdup(pval->data.string);
         } else {
@@ -384,7 +831,7 @@ int main(int argc, char *argv[])
                 return PRRTE_ERR_FATAL;
             }
         }
-        prrte_set_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, param, PRRTE_STRING);
+        prrte_set_attribute(&dapp->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, param, PRRTE_STRING);
         free(param);
     } else {
         /* Check if called with fully-qualified path to prte.
@@ -410,7 +857,7 @@ int main(int argc, char *argv[])
                 }
                 free(tmp_basename);
             }
-            prrte_set_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, tpath, PRRTE_STRING);
+            prrte_set_attribute(&dapp->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, tpath, PRRTE_STRING);
         }
     }
 
@@ -418,40 +865,39 @@ int main(int argc, char *argv[])
      * hostfile and machine file.
      * We can only deal with one hostfile per app context, otherwise give an error.
      */
-    if (0 < (j = prrte_cmd_line_get_ninsts(&cmd_line, "hostfile"))) {
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "hostfile"))) {
         if(1 < j) {
             prrte_show_help("help-prun.txt", "prun:multiple-hostfiles",
                            true, prrte_tool_basename, NULL);
             return PRRTE_ERR_FATAL;
         } else {
-            pval = prrte_cmd_line_get_param(&cmd_line, "hostfile", 0, 0);
-            prrte_set_attribute(&app->attributes, PRRTE_APP_HOSTFILE, PRRTE_ATTR_LOCAL, pval->data.string, PRRTE_STRING);
+            pval = prrte_cmd_line_get_param(prrte_cmd_line, "hostfile", 0, 0);
+            prrte_set_attribute(&dapp->attributes, PRRTE_APP_HOSTFILE, PRRTE_ATTR_LOCAL, pval->data.string, PRRTE_STRING);
         }
     }
-    if (0 < (j = prrte_cmd_line_get_ninsts(&cmd_line, "machinefile"))) {
-        if(1 < j || prrte_get_attribute(&app->attributes, PRRTE_APP_HOSTFILE, NULL, PRRTE_STRING)) {
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "machinefile"))) {
+        if(1 < j || prrte_get_attribute(&dapp->attributes, PRRTE_APP_HOSTFILE, NULL, PRRTE_STRING)) {
             prrte_show_help("help-prun.txt", "prun:multiple-hostfiles",
                            true, prrte_tool_basename, NULL);
             return PRRTE_ERR_FATAL;
         } else {
-            pval = prrte_cmd_line_get_param(&cmd_line, "machinefile", 0, 0);
-            prrte_set_attribute(&app->attributes, PRRTE_APP_HOSTFILE, PRRTE_ATTR_LOCAL, pval->data.string, PRRTE_STRING);
+            pval = prrte_cmd_line_get_param(prrte_cmd_line, "machinefile", 0, 0);
+            prrte_set_attribute(&dapp->attributes, PRRTE_APP_HOSTFILE, PRRTE_ATTR_LOCAL, pval->data.string, PRRTE_STRING);
         }
     }
 
     /* Did the user specify any hosts? */
-    if (0 < (j = prrte_cmd_line_get_ninsts(&cmd_line, "host"))) {
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "host"))) {
         char **targ=NULL, *tval;
         for (i = 0; i < j; ++i) {
-            pval = prrte_cmd_line_get_param(&cmd_line, "host", i, 0);
+            pval = prrte_cmd_line_get_param(prrte_cmd_line, "host", i, 0);
             prrte_argv_append_nosize(&targ, pval->data.string);
         }
         tval = prrte_argv_join(targ, ',');
-        prrte_set_attribute(&app->attributes, PRRTE_APP_DASH_HOST, PRRTE_ATTR_LOCAL, tval, PRRTE_STRING);
+        prrte_set_attribute(&dapp->attributes, PRRTE_APP_DASH_HOST, PRRTE_ATTR_LOCAL, tval, PRRTE_STRING);
         prrte_argv_free(targ);
         free(tval);
     }
-    PRRTE_DESTRUCT(&cmd_line);
 
     /* setup to listen for commands sent specifically to me, even though I would probably
      * be the one sending them! Unfortunately, since I am a participating daemon,
@@ -465,17 +911,808 @@ int main(int argc, char *argv[])
      * isn't a user-level application */
     PRRTE_ACTIVATE_JOB_STATE(jdata, PRRTE_JOB_STATE_ALLOCATE);
 
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "daemonize")) {
+        /* cannot be any apps */
+        goto proceed;
+    }
+
+    /* see if they want to run an application - let's parse
+     * the cmd line to get it */
+    if (PRRTE_SUCCESS != (rc = parse_locals(&apps, pargc, pargv))) {
+        PRRTE_ERROR_LOG(rc);
+        PRRTE_LIST_DESTRUCT(&apps);
+        goto DONE;
+    }
+
+    /* did they provide an app? */
+    if (0 == prrte_list_get_size(&apps)) {
+        /* nope - just need to wait for instructions */
+        goto proceed;
+    }
+    /* mark that we are not a persistent DVM */
+    prrte_persistent = false;
+
+    /* pass the personality */
+    for (i=0; NULL != prrte_schizo_base.personalities[i]; i++) {
+        tmp = NULL;
+        if (0 != strcmp(prrte_schizo_base.personalities[i], "prrte") &&
+            0 != strcmp(prrte_schizo_base.personalities[i], "pmix")) {
+            prrte_argv_append_nosize(&tmp, prrte_schizo_base.personalities[i]);
+        }
+        if (NULL != tmp) {
+            param = prrte_argv_join(tmp, ',');
+            prrte_argv_free(tmp);
+            ds = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(ds->info, 1);
+            PMIX_INFO_LOAD(ds->info, PMIX_PERSONALITY, param, PMIX_STRING);
+            free(param);
+            prrte_list_append(&job_info, &ds->super);
+        }
+    }
+
+    /* check for stdout/err directives */
+    /* if we were asked to tag output, mark it so */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "tag-output")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+    /* if we were asked to timestamp output, mark it so */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "timestamp-output")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+    /* cannot have both files and directory set for output */
+    param = NULL;
+    ptr = NULL;
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "output-filename", 0, 0))) {
+        param = pval->data.string;
+    }
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "output-directory", 0, 0))) {
+        ptr = pval->data.string;
+    }
+    if (NULL != param && NULL != ptr) {
+        prrte_show_help("help-prted.txt", "both-file-and-dir-set", true,
+                        param, ptr);
+        return PRRTE_ERR_FATAL;
+    } else if (NULL != param) {
+        /* if we were asked to output to files, pass it along. */
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        /* if the given filename isn't an absolute path, then
+         * convert it to one so the name will be relative to
+         * the directory where prun was given as that is what
+         * the user will have seen */
+        if (!prrte_path_is_absolute(param)) {
+            char cwd[PRRTE_PATH_MAX];
+            if (NULL == getcwd(cwd, sizeof(cwd))) {
+                return PRRTE_ERR_FATAL;
+            }
+            ptr = prrte_os_path(false, cwd, param, NULL);
+        } else {
+            ptr = strdup(param);
+        }
+        PMIX_INFO_LOAD(ds->info, PMIX_OUTPUT_TO_FILE, ptr, PMIX_STRING);
+        free(ptr);
+        prrte_list_append(&job_info, &ds->super);
+    } else if (NULL != ptr) {
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+        /* if we were asked to output to a directory, pass it along. */
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        /* If the given filename isn't an absolute path, then
+         * convert it to one so the name will be relative to
+         * the directory where prun was given as that is what
+         * the user will have seen */
+        if (!prrte_path_is_absolute(ptr)) {
+            char cwd[PRRTE_PATH_MAX];
+            if (NULL == getcwd(cwd, sizeof(cwd))) {
+                return PRRTE_ERR_FATAL;
+            }
+            param = prrte_os_path(false, cwd, ptr, NULL);
+        } else {
+            param = strdup(ptr);
+        }
+        PMIX_INFO_LOAD(ds->info, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
+        free(param);
+#endif
+    }
+    /* if we were asked to merge stderr to stdout, mark it so */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "merge-stderr-to-stdout")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* check what user wants us to do with stdin */
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "stdin", 0, 0))) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_STDIN_TGT, pval->data.string, PMIX_STRING);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* if we want the argv's indexed, indicate that */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "index-argv-by-rank")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_INDEX_ARGV, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "map-by", 0, 0))) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_MAPBY, pval->data.string, PMIX_STRING);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* if the user specified a ranking policy, then set it */
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "rank-by", 0, 0))) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_RANKBY, pval->data.string, PMIX_STRING);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* if the user specified a binding policy, then set it */
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "bind-to", 0, 0))) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_BINDTO, pval->data.string, PMIX_STRING);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "report-bindings")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_REPORT_BINDINGS, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* mark if recovery was enabled on the cmd line */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "enable-recovery")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_JOB_RECOVERABLE, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+    /* record the max restarts */
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "max-restarts", 0, 0)) &&
+        0 < pval->data.integer) {
+        ui32 = pval->data.integer;
+        PRRTE_LIST_FOREACH(app, &apps, prrte_pmix_app_t) {
+            ds = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(ds->info, 1);
+            PMIX_INFO_LOAD(ds->info, PMIX_MAX_RESTARTS, &ui32, PMIX_UINT32);
+            prrte_list_append(&app->info, &ds->super);
+        }
+    }
+    /* if continuous operation was specified */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "continuous")) {
+        /* mark this job as continuously operating */
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_JOB_CONTINUOUS, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* if stop-on-exec was specified */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "stop-on-exec")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_DEBUG_STOP_ON_EXEC, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* check for a job timeout specification, to be provided in seconds
+     * as that is what MPICH used
+     */
+    param = NULL;
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "timeout", 0, 0)) ||
+        NULL != (param = getenv("MPIEXEC_TIMEOUT"))) {
+        if (NULL != param) {
+            i = strtol(param, NULL, 10);
+            /* both cannot be present, or they must agree */
+            if (NULL != pval && i != pval->data.integer) {
+                prrte_show_help("help-prun.txt", "prun:timeoutconflict", false,
+                               prrte_tool_basename, pval->data.integer, param);
+                exit(1);
+            }
+        } else {
+            i = pval->data.integer;
+        }
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        PMIX_INFO_LOAD(ds->info, PMIX_TIMEOUT, &i, PMIX_INT);
+        prrte_list_append(&job_info, &ds->super);
+    }
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "get-stack-traces")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_TIMEOUT_STACKTRACES, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "report-state-on-timeout")) {
+        ds = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(ds->info, 1);
+        flag = true;
+        PMIX_INFO_LOAD(ds->info, PMIX_TIMEOUT_REPORT_STATE, &flag, PMIX_BOOL);
+        prrte_list_append(&job_info, &ds->super);
+    }
+
+    /* give the schizo components a chance to add to the job info */
+    prrte_schizo.job_info(prrte_cmd_line, &job_info);
+
+    /* pickup any relevant envars */
+    flag = true;
+    PMIX_INFO_LOAD(&info, PMIX_SETUP_APP_ENVARS, &flag, PMIX_BOOL);
+
+    PRRTE_PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    ret = PMIx_server_setup_application(prrte_process_info.myproc.nspace, &info, 1, setupcbfunc, &mylock);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PRRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
+        goto DONE;
+    }
+    PRRTE_PMIX_WAIT_THREAD(&mylock.lock);
+    PRRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
+    /* transfer any returned ENVARS to the job_info */
+    if (NULL != mylock.info) {
+        for (n=0; n < mylock.ninfo; n++) {
+            if (0 == strncmp(mylock.info[n].key, PMIX_SET_ENVAR, PMIX_MAX_KEYLEN) ||
+                0 == strncmp(mylock.info[n].key, PMIX_ADD_ENVAR, PMIX_MAX_KEYLEN) ||
+                0 == strncmp(mylock.info[n].key, PMIX_UNSET_ENVAR, PMIX_MAX_KEYLEN) ||
+                0 == strncmp(mylock.info[n].key, PMIX_PREPEND_ENVAR, PMIX_MAX_KEYLEN) ||
+                0 == strncmp(mylock.info[n].key, PMIX_APPEND_ENVAR, PMIX_MAX_KEYLEN)) {
+                ds = PRRTE_NEW(prrte_ds_info_t);
+                PMIX_INFO_CREATE(ds->info, 1);
+                PMIX_INFO_XFER(&ds->info[0], &mylock.info[n]);
+                prrte_list_append(&job_info, &ds->super);
+            }
+        }
+        PMIX_INFO_FREE(mylock.info, mylock.ninfo);
+    }
+
+    /* convert the job info into an array */
+    ninfo = prrte_list_get_size(&job_info);
+    iptr = NULL;
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(iptr, ninfo);
+        n=0;
+        PRRTE_LIST_FOREACH(ds, &job_info, prrte_ds_info_t) {
+            PMIX_INFO_XFER(&iptr[n], ds->info);
+            ++n;
+        }
+    }
+
+    /* convert the apps to an array */
+    napps = prrte_list_get_size(&apps);
+    PMIX_APP_CREATE(papps, napps);
+    n = 0;
+    PRRTE_LIST_FOREACH(app, &apps, prrte_pmix_app_t) {
+        size_t fbar;
+
+        papps[n].cmd = strdup(app->app.cmd);
+        papps[n].argv = prrte_argv_copy(app->app.argv);
+        papps[n].env = prrte_argv_copy(app->app.env);
+        papps[n].cwd = strdup(app->app.cwd);
+        papps[n].maxprocs = app->app.maxprocs;
+        fbar = prrte_list_get_size(&app->info);
+        if (0 < fbar) {
+            papps[n].ninfo = fbar;
+            PMIX_INFO_CREATE(papps[n].info, fbar);
+            m = 0;
+            PRRTE_LIST_FOREACH(ds, &app->info, prrte_ds_info_t) {
+                PMIX_INFO_XFER(&papps[n].info[m], ds->info);
+                ++m;
+            }
+        }
+        /* pickup any relevant envars */
+        prrte_schizo.parse_env(prrte_cmd_line, environ, &papps[n].env, false);
+        ++n;
+    }
+
+    if (verbose) {
+        prrte_output(0, "Spawning job");
+    }
+
+    PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
+    pmix_server_spawn_fn(&prrte_process_info.myproc, iptr, ninfo, papps, napps, spcbfunc, &lock);
+    if (PRRTE_SUCCESS != ret) {
+        prrte_output(0, "PMIx_Spawn failed (%d): %s", ret, PMIx_Error_string(ret));
+        rc = ret;
+        goto DONE;
+    }
+    /* we have to cycle the event library here so we can process
+     * the spawn request */
+    while (prrte_event_base_active && lock.active) {
+        prrte_event_loop(prrte_event_base, PRRTE_EVLOOP_ONCE);
+    }
+    PRRTE_ACQUIRE_OBJECT(&lock.lock);
+    if (PMIX_SUCCESS != lock.status) {
+        goto DONE;
+    }
+    PMIX_LOAD_NSPACE(spawnednspace, lock.msg);
+    PRRTE_PMIX_DESTRUCT_LOCK(&lock);
+    PRRTE_PMIX_CONVERT_NSPACE(rc, &myjobid, spawnednspace);
+
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+    if (notify_launch) {
+        /* direct an event back to our controller telling them
+         * the namespace of the spawned job */
+        PMIX_INFO_CREATE(iptr, 3);
+        /* do not cache this event - the tool is waiting for us */
+        flag = true;
+        PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_DO_NOT_CACHE, &flag, PMIX_BOOL);
+        /* target this notification solely to that one tool */
+        PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_CUSTOM_RANGE, &controller, PMIX_PROC);
+        /* pass the nspace of the spawned job */
+        PMIX_INFO_LOAD(&iptr[2], PMIX_NSPACE, spawnednspace, PMIX_STRING);
+        PMIx_Notify_event(PMIX_LAUNCH_COMPLETE, &controller, PMIX_RANGE_CUSTOM,
+                          iptr, 3, NULL, NULL);
+    }
+#endif
+
+
+    if (verbose) {
+        prrte_output(0, "JOB %s EXECUTING", PRRTE_JOBID_PRINT(myjobid));
+    }
+
+  proceed:
     /* loop the event lib until an exit event is detected */
     while (prrte_event_base_active) {
         prrte_event_loop(prrte_event_base, PRRTE_EVLOOP_ONCE);
     }
     PRRTE_ACQUIRE_OBJECT(prrte_event_base_active);
 
+  DONE:
+    /* cleanup and leave */
     prrte_finalize();
 
     if (prrte_debug_flag) {
         fprintf(stderr, "exiting with status %d\n", prrte_exit_status);
     }
     exit(prrte_exit_status);
+}
 
+static int parse_locals(prrte_list_t *jdata, int argc, char* argv[])
+{
+    int i, rc;
+    int temp_argc;
+    char **temp_argv, **env;
+    prrte_pmix_app_t *app;
+    bool made_app;
+
+    /* Make the apps */
+    temp_argc = 0;
+    temp_argv = NULL;
+    prrte_argv_append(&temp_argc, &temp_argv, argv[0]);
+
+    /* NOTE: This bogus env variable is necessary in the calls to
+       create_app(), below.  See comment immediately before the
+       create_app() function for an explanation. */
+
+    env = NULL;
+    for (i = 1; i < argc; ++i) {
+        if (0 == strcmp(argv[i], ":")) {
+            /* Make an app with this argv */
+            if (prrte_argv_count(temp_argv) > 1) {
+                if (NULL != env) {
+                    prrte_argv_free(env);
+                    env = NULL;
+                }
+                app = NULL;
+                rc = create_app(temp_argc, temp_argv, jdata, &app, &made_app, &env);
+                if (PRRTE_SUCCESS != rc) {
+                    /* Assume that the error message has already been
+                       printed; */
+                    return rc;
+                }
+                if (made_app) {
+                    prrte_list_append(jdata, &app->super);
+                }
+
+                /* Reset the temps */
+
+                temp_argc = 0;
+                temp_argv = NULL;
+                prrte_argv_append(&temp_argc, &temp_argv, argv[0]);
+            }
+        } else {
+            prrte_argv_append(&temp_argc, &temp_argv, argv[i]);
+        }
+    }
+
+    if (prrte_argv_count(temp_argv) > 1) {
+        app = NULL;
+        rc = create_app(temp_argc, temp_argv, jdata, &app, &made_app, &env);
+        if (PRRTE_SUCCESS != rc) {
+            return rc;
+        }
+        if (made_app) {
+            prrte_list_append(jdata, &app->super);
+        }
+    }
+    if (NULL != env) {
+        prrte_argv_free(env);
+    }
+    prrte_argv_free(temp_argv);
+
+    /* All done */
+
+    return PRRTE_SUCCESS;
+}
+
+
+/*
+ * This function takes a "char ***app_env" parameter to handle the
+ * specific case:
+ *
+ *   prun --mca foo bar -app appfile
+ *
+ * That is, we'll need to keep foo=bar, but the presence of the app
+ * file will cause an invocation of parse_appfile(), which will cause
+ * one or more recursive calls back to create_app().  Since the
+ * foo=bar value applies globally to all apps in the appfile, we need
+ * to pass in the "base" environment (that contains the foo=bar value)
+ * when we parse each line in the appfile.
+ *
+ * This is really just a special case -- when we have a simple case like:
+ *
+ *   prun --mca foo bar -np 4 hostname
+ *
+ * Then the upper-level function (parse_locals()) calls create_app()
+ * with a NULL value for app_env, meaning that there is no "base"
+ * environment that the app needs to be created from.
+ */
+static int create_app(int argc, char* argv[],
+                      prrte_list_t *jdata,
+                      prrte_pmix_app_t **app_ptr,
+                      bool *made_app, char ***app_env)
+{
+    char cwd[PRRTE_PATH_MAX];
+    int i, j, count, rc;
+    char *param, *value;
+    prrte_pmix_app_t *app = NULL;
+    bool found = false;
+    char *appname = NULL;
+    prrte_ds_info_t *val;
+    prrte_value_t *pvalue;
+
+    *made_app = false;
+
+    /* parse the cmd line - do this every time thru so we can
+     * repopulate the globals */
+    if (PRRTE_SUCCESS != (rc = prrte_cmd_line_parse(prrte_cmd_line, true, false,
+                                                    argc, argv)) ) {
+        if (PRRTE_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    prrte_strerror(rc));
+        }
+        return rc;
+    }
+
+    /* Setup application context */
+    app = PRRTE_NEW(prrte_pmix_app_t);
+    prrte_cmd_line_get_tail(prrte_cmd_line, &count, &app->app.argv);
+
+    /* See if we have anything left */
+    if (0 == count) {
+        prrte_show_help("help-prun.txt", "prun:executable-not-specified",
+                       true, "prun", "prun");
+        rc = PRRTE_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* Did the user request a specific wdir? */
+    if (NULL != (pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "wdir", 0, 0))) {
+        param = pvalue->data.string;
+        /* if this is a relative path, convert it to an absolute path */
+        if (prrte_path_is_absolute(param)) {
+            app->app.cwd = strdup(param);
+        } else {
+            /* get the cwd */
+            if (PRRTE_SUCCESS != (rc = prrte_getcwd(cwd, sizeof(cwd)))) {
+                prrte_show_help("help-prun.txt", "prun:init-failure",
+                               true, "get the cwd", rc);
+                goto cleanup;
+            }
+            /* construct the absolute path */
+            app->app.cwd = prrte_os_path(false, cwd, param, NULL);
+        }
+    } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "set-cwd-to-session-dir")) {
+        val = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(val->info, 1);
+        PMIX_INFO_LOAD(val->info, PMIX_SET_SESSION_CWD, NULL, PMIX_BOOL);
+        prrte_list_append(&app->info, &val->super);
+    } else {
+        if (PRRTE_SUCCESS != (rc = prrte_getcwd(cwd, sizeof(cwd)))) {
+            prrte_show_help("help-prun.txt", "prun:init-failure",
+                           true, "get the cwd", rc);
+            goto cleanup;
+        }
+        app->app.cwd = strdup(cwd);
+    }
+
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+    /* if they specified a process set name, then pass it along */
+    if (NULL != (pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "pset", 0, 0))) {
+        val = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(val->info, 1);
+        PMIX_INFO_LOAD(val->info, PMIX_PSET_NAME, pvalue->data.string, PMIX_STRING);
+        prrte_list_append(&app->info, &val->super);
+    }
+#endif
+
+    /* Did the user specify a hostfile. Need to check for both
+     * hostfile and machine file.
+     * We can only deal with one hostfile per app context, otherwise give an error.
+     */
+    found = false;
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "hostfile"))) {
+        if (1 < j) {
+            prrte_show_help("help-prun.txt", "prun:multiple-hostfiles",
+                           true, "prun", NULL);
+            return PRRTE_ERR_FATAL;
+        } else {
+            pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "hostfile", 0, 0);
+            val = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(val->info, 1);
+            PMIX_INFO_LOAD(val->info, PMIX_HOSTFILE, pvalue->data.string, PMIX_STRING);
+            prrte_list_append(&app->info, &val->super);
+            found = true;
+        }
+    }
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "machinefile"))) {
+        if (1 < j || found) {
+            prrte_show_help("help-prun.txt", "prun:multiple-hostfiles",
+                           true, "prun", NULL);
+            return PRRTE_ERR_FATAL;
+        } else {
+            pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "machinefile", 0, 0);
+            val = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(val->info, 1);
+            PMIX_INFO_LOAD(val->info, PMIX_HOSTFILE, pvalue->data.string, PMIX_STRING);
+            prrte_list_append(&app->info, &val->super);
+        }
+    }
+
+    /* Did the user specify any hosts? */
+    if (0 < (j = prrte_cmd_line_get_ninsts(prrte_cmd_line, "host"))) {
+        char **targ=NULL, *tval;
+        for (i = 0; i < j; ++i) {
+            pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "host", i, 0);
+            prrte_argv_append_nosize(&targ, pvalue->data.string);
+        }
+        tval = prrte_argv_join(targ, ',');
+        val = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(val->info, 1);
+        PMIX_INFO_LOAD(val->info, PMIX_HOST, tval, PMIX_STRING);
+        prrte_list_append(&app->info, &val->super);
+        free(tval);
+    }
+
+    /* check for bozo error */
+    if (NULL != (pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "np", 0, 0)) ||
+        NULL != (pvalue = prrte_cmd_line_get_param(prrte_cmd_line, "n", 0, 0))) {
+        if (0 > pvalue->data.integer) {
+            prrte_show_help("help-prun.txt", "prun:negative-nprocs",
+                           true, "prun", app->app.argv[0],
+                           pvalue->data.integer, NULL);
+            return PRRTE_ERR_FATAL;
+        }
+    }
+    if (NULL != pvalue) {
+        /* we don't require that the user provide --np or -n because
+         * the cmd line might stipulate a mapping policy that computes
+         * the number of procs - e.g., a map-by ppr option */
+        app->app.maxprocs = pvalue->data.integer;
+    }
+
+    /* see if we need to preload the binary to
+     * find the app - don't do this for java apps, however, as we
+     * can't easily find the class on the cmd line. Java apps have to
+     * preload their binary via the preload_files option
+     */
+    if (NULL == strstr(app->app.argv[0], "java")) {
+        if (prrte_cmd_line_is_taken(prrte_cmd_line, "preload-binaries")) {
+            val = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(val->info, 1);
+            PMIX_INFO_LOAD(val->info, PMIX_SET_SESSION_CWD, NULL, PMIX_BOOL);
+            prrte_list_append(&app->info, &val->super);
+            val = PRRTE_NEW(prrte_ds_info_t);
+            PMIX_INFO_CREATE(val->info, 1);
+            PMIX_INFO_LOAD(val->info, PMIX_PRELOAD_BIN, NULL, PMIX_BOOL);
+            prrte_list_append(&app->info, &val->super);
+        }
+    }
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "preload-files")) {
+        val = PRRTE_NEW(prrte_ds_info_t);
+        PMIX_INFO_CREATE(val->info, 1);
+        PMIX_INFO_LOAD(val->info, PMIX_PRELOAD_FILES, NULL, PMIX_BOOL);
+        prrte_list_append(&app->info, &val->super);
+    }
+
+    /* Do not try to find argv[0] here -- the starter is responsible
+       for that because it may not be relevant to try to find it on
+       the node where prun is executing.  So just strdup() argv[0]
+       into app. */
+
+    app->app.cmd = strdup(app->app.argv[0]);
+    if (NULL == app->app.cmd) {
+        prrte_show_help("help-prun.txt", "prun:call-failed",
+                       true, "prun", "library", "strdup returned NULL", errno);
+        rc = PRRTE_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    /* if this is a Java application, we have a bit more work to do. Such
+     * applications actually need to be run under the Java virtual machine
+     * and the "java" command will start the "executable". So we need to ensure
+     * that all the proper java-specific paths are provided
+     */
+    appname = prrte_basename(app->app.cmd);
+    if (0 == strcmp(appname, "java")) {
+        /* see if we were given a library path */
+        found = false;
+        for (i=1; NULL != app->app.argv[i]; i++) {
+            if (NULL != strstr(app->app.argv[i], "java.library.path")) {
+                char *dptr;
+                /* find the '=' that delineates the option from the path */
+                if (NULL == (dptr = strchr(app->app.argv[i], '='))) {
+                    /* that's just wrong */
+                    rc = PRRTE_ERR_BAD_PARAM;
+                    goto cleanup;
+                }
+                /* step over the '=' */
+                ++dptr;
+                /* yep - but does it include the path to the mpi libs? */
+                found = true;
+                if (NULL == strstr(app->app.argv[i], prrte_install_dirs.libdir)) {
+                    /* doesn't appear to - add it to be safe */
+                    if (':' == app->app.argv[i][strlen(app->app.argv[i]-1)]) {
+                        prrte_asprintf(&value, "-Djava.library.path=%s%s", dptr, prrte_install_dirs.libdir);
+                    } else {
+                        prrte_asprintf(&value, "-Djava.library.path=%s:%s", dptr, prrte_install_dirs.libdir);
+                    }
+                    free(app->app.argv[i]);
+                    app->app.argv[i] = value;
+                }
+                break;
+            }
+        }
+        if (!found) {
+            /* need to add it right after the java command */
+            prrte_asprintf(&value, "-Djava.library.path=%s", prrte_install_dirs.libdir);
+            prrte_argv_insert_element(&app->app.argv, 1, value);
+            free(value);
+        }
+
+        /* see if we were given a class path */
+        found = false;
+        for (i=1; NULL != app->app.argv[i]; i++) {
+            if (NULL != strstr(app->app.argv[i], "cp") ||
+                NULL != strstr(app->app.argv[i], "classpath")) {
+                /* yep - but does it include the path to the mpi libs? */
+                found = true;
+                /* check if mpi.jar exists - if so, add it */
+                value = prrte_os_path(false, prrte_install_dirs.libdir, "mpi.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    set_classpath_jar_file(app, i+1, "mpi.jar");
+                }
+                free(value);
+                /* check for oshmem support */
+                value = prrte_os_path(false, prrte_install_dirs.libdir, "shmem.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    set_classpath_jar_file(app, i+1, "shmem.jar");
+                }
+                free(value);
+                /* always add the local directory */
+                prrte_asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[i+1]);
+                free(app->app.argv[i+1]);
+                app->app.argv[i+1] = value;
+                break;
+            }
+        }
+        if (!found) {
+            /* check to see if CLASSPATH is in the environment */
+            found = false;  // just to be pedantic
+            for (i=0; NULL != environ[i]; i++) {
+                if (0 == strncmp(environ[i], "CLASSPATH", strlen("CLASSPATH"))) {
+                    value = strchr(environ[i], '=');
+                    ++value; /* step over the = */
+                    prrte_argv_insert_element(&app->app.argv, 1, value);
+                    /* check for mpi.jar */
+                    value = prrte_os_path(false, prrte_install_dirs.libdir, "mpi.jar", NULL);
+                    if (access(value, F_OK ) != -1) {
+                        set_classpath_jar_file(app, 1, "mpi.jar");
+                    }
+                    free(value);
+                    /* check for shmem.jar */
+                    value = prrte_os_path(false, prrte_install_dirs.libdir, "shmem.jar", NULL);
+                    if (access(value, F_OK ) != -1) {
+                        set_classpath_jar_file(app, 1, "shmem.jar");
+                    }
+                    free(value);
+                    /* always add the local directory */
+                    prrte_asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[1]);
+                    free(app->app.argv[1]);
+                    app->app.argv[1] = value;
+                    prrte_argv_insert_element(&app->app.argv, 1, "-cp");
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                /* need to add it right after the java command - have
+                 * to include the working directory and trust that
+                 * the user set cwd if necessary
+                 */
+                char *str, *str2;
+                /* always start with the working directory */
+                str = strdup(app->app.cwd);
+                /* check for mpi.jar */
+                value = prrte_os_path(false, prrte_install_dirs.libdir, "mpi.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    prrte_asprintf(&str2, "%s:%s", str, value);
+                    free(str);
+                    str = str2;
+                }
+                free(value);
+                /* check for shmem.jar */
+                value = prrte_os_path(false, prrte_install_dirs.libdir, "shmem.jar", NULL);
+                if (access(value, F_OK ) != -1) {
+                    prrte_asprintf(&str2, "%s:%s", str, value);
+                    free(str);
+                    str = str2;
+                }
+                free(value);
+                prrte_argv_insert_element(&app->app.argv, 1, str);
+                free(str);
+                prrte_argv_insert_element(&app->app.argv, 1, "-cp");
+            }
+        }
+    }
+
+    *app_ptr = app;
+    app = NULL;
+    *made_app = true;
+
+    /* All done */
+
+  cleanup:
+    if (NULL != app) {
+        PRRTE_RELEASE(app);
+    }
+    if (NULL != appname) {
+        free(appname);
+    }
+    return rc;
+}
+
+static void set_classpath_jar_file(prrte_pmix_app_t *app, int index, char *jarfile)
+{
+    if (NULL == strstr(app->app.argv[index], jarfile)) {
+        /* nope - need to add it */
+        char *fmt = ':' == app->app.argv[index][strlen(app->app.argv[index]-1)]
+                    ? "%s%s/%s" : "%s:%s/%s";
+        char *str;
+        prrte_asprintf(&str, fmt, app->app.argv[index], prrte_install_dirs.libdir, jarfile);
+        free(app->app.argv[index]);
+        app->app.argv[index] = str;
+    }
 }

--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -699,3 +699,7 @@ correct and retry.
   Error:     %s
   Nodename:  %s
   Rank:      %lu
+#
+[use-pterm]
+Use of %s to terminate the PRRTE DVM has been deprecated. Please use
+the "pterm" tool instead in the future.

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -156,10 +156,8 @@ static bool forcibly_die=false;
 static prrte_event_t term_handler;
 static int term_pipe[2];
 static prrte_atomic_lock_t prun_abort_inprogress_lock = PRRTE_ATOMIC_LOCK_INIT;
-static bool proxyrun = false;
 static bool verbose = false;
 static prrte_cmd_line_t *prrte_cmd_line = NULL;
-static bool want_prefix_by_default = (bool) PRRTE_WANT_PRRTE_PREFIX_BY_DEFAULT;
 static prrte_list_t forwarded_signals;
 
 /* prun-specific options */
@@ -621,7 +619,7 @@ static void launchhandler(size_t evhdlr_registration_id,
 int prun(int argc, char *argv[])
 {
     int rc=1, i;
-    char *param, *ptr, *tpath;
+    char *param, *ptr;
     prrte_pmix_lock_t lock, rellock;
     prrte_list_t apps;
     prrte_pmix_app_t *app;
@@ -645,10 +643,8 @@ int prun(int argc, char *argv[])
     char *mytmpdir;
     char **pargv;
     int pargc;
-    pmix_rank_t zero;
     char **tmp;
     prrte_ess_base_signal_t *sig;
-    pmix_nspace_t dvmnspace;
     prrte_event_list_item_t *evitm;
 
     /* init the globals */
@@ -745,16 +741,12 @@ int prun(int argc, char *argv[])
         }
     }
 
-    /* detect if we are running as a proxy and setup the rendezvous
-     * and session directory files */
+    /* setup the rendezvous and session directory files */
     if (PRRTE_SUCCESS != (rc = prrte_schizo.detect_proxy(pargv, &rfile))) {
         if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
             PRRTE_ERROR_LOG(rc);
             return rc;
         }
-    }
-    if (PRRTE_SUCCESS == rc) {
-        proxyrun = true;
     }
 
     /* get our session directory */
@@ -865,434 +857,180 @@ int prun(int argc, char *argv[])
         return rc;
     }
 
-    if (proxyrun) {
-        /* we need to start our own private DVM - start by initializing
-         * PMIx tool support, indicating that we don't want to connect
-         * to anyone */
-        PRRTE_CONSTRUCT(&tinfo, prrte_list_t);
+    /* setup options */
+    PRRTE_CONSTRUCT(&tinfo, prrte_list_t);
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "do-not-connect")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
         PMIX_INFO_LOAD(ds->info, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
-
-        /* we have to provide an nspace/rank for ourselves */
+    } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "system-server-first")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        prrte_asprintf(&param, "%lu.%lu", (unsigned long)getpid(), (unsigned long)geteuid());
-        PMIX_INFO_LOAD(ds->info, PMIX_TOOL_NSPACE, param, PMIX_STRING);
-        free(param);
+        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
-
+    } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "system-server-only")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        zero=0;
-        PMIX_INFO_LOAD(ds->info, PMIX_TOOL_RANK, &zero, PMIX_PROC_RANK);
+        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
-
-        /* pass our hostname so the PMIx library agrees with us */
+    }
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "wait-to-connect", 0, 0)) &&
+        0 < pval->data.integer) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_HOSTNAME, prrte_process_info.nodename, PMIX_STRING);
+        ui32 = pval->data.integer;
+        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
         prrte_list_append(&tinfo, &ds->super);
-
-        /* set our session directory to something hopefully unique so
-         * our rendezvous files don't conflict with other prun/prte
-         * instances */
+    }
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "num-connect-retries", 0, 0)) &&
+        0 < pval->data.integer) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TMPDIR, mytmpdir, PMIX_STRING);
+        ui32 = pval->data.integer;
+        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_MAX_RETRIES, &ui32, PMIX_UINT32);
         prrte_list_append(&tinfo, &ds->super);
-
-        /* if we were launched by a debugger, then we need to have
-         * notification of our termination sent */
-        if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            flag = false;
-            PMIX_INFO_LOAD(ds->info, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-
-        /* ensure we don't try to use the usock PTL component */
+    }
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "pid", 0, 0)) &&
+        0 < pval->data.integer) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_USOCK_DISABLE, NULL, PMIX_BOOL);
+        pid = pval->data.integer;
+        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
         prrte_list_append(&tinfo, &ds->super);
+    }
+    /* ensure we don't try to use the usock PTL component */
+    ds = PRRTE_NEW(prrte_ds_info_t);
+    PMIX_INFO_CREATE(ds->info, 1);
+    PMIX_INFO_LOAD(ds->info, PMIX_USOCK_DISABLE, NULL, PMIX_BOOL);
+    prrte_list_append(&tinfo, &ds->super);
 
-        /* we are also a launcher, so pass that down so PMIx knows
-         * to setup rendezvous points */
+    /* set our session directory to something hopefully unique so
+     * our rendezvous files don't conflict with other prun/prte
+     * instances */
+    ds = PRRTE_NEW(prrte_ds_info_t);
+    PMIX_INFO_CREATE(ds->info, 1);
+    PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TMPDIR, mytmpdir, PMIX_STRING);
+    prrte_list_append(&tinfo, &ds->super);
+
+    /* we are also a launcher, so pass that down so PMIx knows
+     * to setup rendezvous points */
+    ds = PRRTE_NEW(prrte_ds_info_t);
+    PMIX_INFO_CREATE(ds->info, 1);
+    PMIX_INFO_LOAD(ds->info, PMIX_LAUNCHER, NULL, PMIX_BOOL);
+    prrte_list_append(&tinfo, &ds->super);
+    /* we always support session-level rendezvous */
+    ds = PRRTE_NEW(prrte_ds_info_t);
+    PMIX_INFO_CREATE(ds->info, 1);
+    PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
+    prrte_list_append(&tinfo, &ds->super);
+    /* use only one listener */
+    ds = PRRTE_NEW(prrte_ds_info_t);
+    PMIX_INFO_CREATE(ds->info, 1);
+    PMIX_INFO_LOAD(ds->info, PMIX_SINGLE_LISTENER, NULL, PMIX_BOOL);
+    prrte_list_append(&tinfo, &ds->super);
+
+    /* setup any output format requests */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "tag-output")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_LAUNCHER, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(ds->info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
-        /* we always support session-level rendezvous */
+    }
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "timestamp-output")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(ds->info, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
-        /* use only one listener */
+    }
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "xml")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SINGLE_LISTENER, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(ds->info, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
+    }
 
-        /* convert to array of info */
-        ninfo = prrte_list_get_size(&tinfo);
-        PMIX_INFO_CREATE(iptr, ninfo);
-        n = 0;
-        PRRTE_LIST_FOREACH(ds, &tinfo, prrte_ds_info_t) {
-            PMIX_INFO_XFER(&iptr[n], ds->info);
-            ++n;
-        }
-        PRRTE_LIST_DESTRUCT(&tinfo);
-
-        if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
-            fprintf(stderr, "%s failed to initialize\n", prrte_tool_basename);
-            exit(1);
-        }
-        PMIX_INFO_FREE(iptr, ninfo);
-        /* now setup the DVM "app" so we can PMIx_Spawn it - this will
-         * simply fork/exec on our behalf */
-        tpath = NULL;
-        char *tmp_basename;
-        if ('/' == argv[0][0]) {
-            tpath = prrte_dirname(pargv[0]);
-        } else if (!prrte_cmd_line_is_taken(prrte_cmd_line, "prefix")) {
-            /* get the absolute path of our command for relative paths */
-            param = prrte_find_absolute_path(pargv[0]);
-            if (NULL == param) {
-                fprintf(stderr, "%s was unable to determine the absolute path for its command\n", prrte_tool_basename);
-                exit(1);
-            }
-            tpath = prrte_dirname(param);
-            free(param);
-            param = NULL;
-        }
-
-        if (NULL != tpath) {
-            /* Quick sanity check to ensure we got
-               something/bin/<exec_name> and that the installation
-               tree is at least more or less what we expect it to
-               be */
-            tmp_basename = prrte_basename(tpath);
-            if (0 == strcmp("bin", tmp_basename)) {
-                char* tmp = tpath;
-                tpath = prrte_dirname(tmp);
-                free(tmp);
-            } else {
-                free(tpath);
-                tpath = NULL;
-            }
-            free(tmp_basename);
-        }
-
-        /* see if they told us a prefix to use */
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "prefix") &&
-            NULL != tpath) {
-            /* if they don't match, then that merits a warning */
-            pval = prrte_cmd_line_get_param(prrte_cmd_line, "prefix", 0, 0);
-            param = strdup(pval->data.string);
-            /* ensure we strip any trailing '/' */
-            if (0 == strcmp(PRRTE_PATH_SEP, &(param[strlen(param)-1]))) {
-                param[strlen(param)-1] = '\0';
-            }
-            tmp_basename = strdup(tpath);
-            if (0 == strcmp(PRRTE_PATH_SEP, &(tmp_basename[strlen(tmp_basename)-1]))) {
-                tmp_basename[strlen(tmp_basename)-1] = '\0';
-            }
-            if (0 != strcmp(param, tmp_basename)) {
-                prrte_show_help("help-prun.txt", "prun:double-prefix",
-                                true, prrte_tool_basename, prrte_tool_basename,
-                                param, tmp_basename, prrte_tool_basename);
-            }
-            /* use the prefix over the path-to-argv[0] so that
-             * people can specify the backend prefix as different
-             * from the local one
-             */
-            free(tpath);
-            tpath = NULL;
-            free(tmp_basename);
-        } else if (NULL != tpath) {
-            param = strdup(tpath);
-            free(tpath);
-        } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "prefix")){
-            /* must be --prefix alone */
-            pval = prrte_cmd_line_get_param(prrte_cmd_line, "prefix", 0, 0);
-            param = strdup(pval->data.string);
-        } else if (want_prefix_by_default) {
-            /* --enable-prrte-prefix-default was given to prun */
-            param = strdup(prrte_install_dirs.prefix);
-        }
-
-        size_t param_len;
-        /* "Parse" the param, aka remove superfluous path_sep. */
-        param_len = strlen(param);
-        while (0 == strcmp (PRRTE_PATH_SEP, &(param[param_len-1]))) {
-            param[param_len-1] = '\0';
-            param_len--;
-            if (0 == param_len) {
-                prrte_show_help("help-prun.txt", "prun:empty-prefix",
-                                true, prrte_tool_basename, prrte_tool_basename);
-                free(param);
-                return PRRTE_ERR_FATAL;
-            }
-        }
-
-        /* param now contains the full path executable for prte */
-        PMIX_APP_CREATE(papps, 1);
-        prrte_asprintf(&papps->cmd, "%s/bin/prte", param);
-        free(param);
-        prrte_argv_append_nosize(&papps->argv, "prte");
-        prrte_schizo.parse_proxy_cli(prrte_cmd_line, &papps->argv);
-        prrte_argv_append_nosize(&papps->argv, "--no-ready-msg");
-        papps->maxprocs = 1;
-
-        /* copy our environment */
-        papps->env = prrte_argv_copy(environ);
-
-        /* pass along a rendezvous file to use that we will attach to */
-        prrte_setenv("PMIX_LAUNCHER_RENDEZVOUS_FILE", rfile, true, &papps->env);
-
-        /* set our session directory to something hopefully unique so
-         * our rendezvous files don't conflict with other prun/prte
-         * instances */
-        prrte_setenv("PMIX_SERVER_TMPDIR", mytmpdir, true, &papps->env);
-
-        /* start the DVM */
-        ret = PMIx_Spawn(NULL, 0, papps, 1, dvmnspace);
-        PMIX_APP_RELEASE(papps);
-        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
-            fprintf(stderr, "DVM failed to start on error %s\n", PMIx_Error_string(ret));
-            PMIx_tool_finalize();
-            exit(1);
-        }
-        /* register to hear if/when prte terminates */
-
-        /* connect to it */
-        PRRTE_CONSTRUCT(&tinfo, prrte_list_t);
+    /* if they specified the URI, then pass it along */
+    if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "dvm-uri", 0, 0))) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_TOOL_ATTACHMENT_FILE, rfile, PMIX_STRING);
+        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_URI, pval->data.string, PMIX_STRING);
         prrte_list_append(&tinfo, &ds->super);
+    }
 
+    /* if we were launched by a debugger, then we need to have
+     * notification of our termination sent */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
         ds = PRRTE_NEW(prrte_ds_info_t);
         PMIX_INFO_CREATE(ds->info, 1);
-        rc = 200;
-        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_MAX_RETRIES, &rc, PMIX_INT32);
+        flag = false;
+        PMIX_INFO_LOAD(ds->info, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
         prrte_list_append(&tinfo, &ds->super);
+    }
 
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        rc = 0;
-        PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_RETRY_DELAY, &rc, PMIX_INT32);
-        prrte_list_append(&tinfo, &ds->super);
+    /* convert to array of info */
+    ninfo = prrte_list_get_size(&tinfo);
+    PMIX_INFO_CREATE(iptr, ninfo);
+    n = 0;
+    PRRTE_LIST_FOREACH(ds, &tinfo, prrte_ds_info_t) {
+        PMIX_INFO_XFER(&iptr[n], ds->info);
+        ++n;
+    }
+    PRRTE_LIST_DESTRUCT(&tinfo);
 
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_TOOL_NSPACE, myproc.nspace, PMIX_STRING);
-        prrte_list_append(&tinfo, &ds->super);
+    /* now initialize PMIx - we have to indicate we are a launcher so that we
+     * will provide rendezvous points for tools to connect to us */
+    if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
+        fprintf(stderr, "%s failed to initialize, likely due to no DVM being available\n", prrte_tool_basename);
+        exit(1);
+    }
+    PMIX_INFO_FREE(iptr, ninfo);
 
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_TOOL_RANK, &myproc.rank, PMIX_PROC_RANK);
-        prrte_list_append(&tinfo, &ds->super);
-
-        /* convert to array of info */
-        ninfo = prrte_list_get_size(&tinfo);
-        PMIX_INFO_CREATE(iptr, ninfo);
-        n = 0;
-        PRRTE_LIST_FOREACH(ds, &tinfo, prrte_ds_info_t) {
-            PMIX_INFO_XFER(&iptr[n], ds->info);
-            ++n;
-        }
-        PRRTE_LIST_DESTRUCT(&tinfo);
-
-        ret = PMIx_tool_connect_to_server(&myproc, iptr, ninfo);
-        PMIX_INFO_FREE(iptr, ninfo);
-        if (PMIX_SUCCESS != ret) {
-            fprintf(stderr, "Could not connect to prte at nspace %s: %s\n", dvmnspace, PMIx_Error_string(ret));
-            PMIx_tool_finalize();
-            exit(1);
-        }
-
-    } else {
-
-        /* setup options */
-        PRRTE_CONSTRUCT(&tinfo, prrte_list_t);
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "do-not-connect")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "system-server-first")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        } else if (prrte_cmd_line_is_taken(prrte_cmd_line, "system-server-only")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "wait-to-connect", 0, 0)) &&
-            0 < pval->data.integer) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            ui32 = pval->data.integer;
-            PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "num-connect-retries", 0, 0)) &&
-            0 < pval->data.integer) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            ui32 = pval->data.integer;
-            PMIX_INFO_LOAD(ds->info, PMIX_CONNECT_MAX_RETRIES, &ui32, PMIX_UINT32);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "pid", 0, 0)) &&
-            0 < pval->data.integer) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            pid = pval->data.integer;
-            PMIX_INFO_LOAD(ds->info, PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        /* ensure we don't try to use the usock PTL component */
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_USOCK_DISABLE, NULL, PMIX_BOOL);
-        prrte_list_append(&tinfo, &ds->super);
-
-        /* set our session directory to something hopefully unique so
-         * our rendezvous files don't conflict with other prun/prte
-         * instances */
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TMPDIR, mytmpdir, PMIX_STRING);
-        prrte_list_append(&tinfo, &ds->super);
-
-        /* we are also a launcher, so pass that down so PMIx knows
-         * to setup rendezvous points */
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_LAUNCHER, NULL, PMIX_BOOL);
-        prrte_list_append(&tinfo, &ds->super);
-        /* we always support session-level rendezvous */
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
-        prrte_list_append(&tinfo, &ds->super);
-        /* use only one listener */
-        ds = PRRTE_NEW(prrte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_SINGLE_LISTENER, NULL, PMIX_BOOL);
-        prrte_list_append(&tinfo, &ds->super);
-
-        /* setup any output format requests */
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "tag-output")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "timestamp-output")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "xml")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-
-        /* if they specified the URI, then pass it along */
-        if (NULL != (pval = prrte_cmd_line_get_param(prrte_cmd_line, "dvm-uri", 0, 0))) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            PMIX_INFO_LOAD(ds->info, PMIX_SERVER_URI, pval->data.string, PMIX_STRING);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-
-        /* if we were launched by a debugger, then we need to have
-         * notification of our termination sent */
-        if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
-            ds = PRRTE_NEW(prrte_ds_info_t);
-            PMIX_INFO_CREATE(ds->info, 1);
-            flag = false;
-            PMIX_INFO_LOAD(ds->info, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
-            prrte_list_append(&tinfo, &ds->super);
-        }
-
-        /* convert to array of info */
-        ninfo = prrte_list_get_size(&tinfo);
-        PMIX_INFO_CREATE(iptr, ninfo);
-        n = 0;
-        PRRTE_LIST_FOREACH(ds, &tinfo, prrte_ds_info_t) {
-            PMIX_INFO_XFER(&iptr[n], ds->info);
-            ++n;
-        }
-        PRRTE_LIST_DESTRUCT(&tinfo);
-
-        /* now initialize PMIx - we have to indicate we are a launcher so that we
-         * will provide rendezvous points for tools to connect to us */
-        if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
-            fprintf(stderr, "%s failed to initialize, likely due to no DVM being available\n", prrte_tool_basename);
-            exit(1);
-        }
-        PMIX_INFO_FREE(iptr, ninfo);
-
-        /* if the user just wants us to terminate a DVM, then do so */
-        if (prrte_cmd_line_is_taken(prrte_cmd_line, "terminate")) {
-            /* setup a lock to track the connection */
-            PRRTE_PMIX_CONSTRUCT_LOCK(&rellock);
-            /* register to trap connection loss */
-            pmix_status_t code[2] = {PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
-            PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
-            PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
-            PMIx_Register_event_handler(code, 2, &info, 1,
-                                        evhandler, regcbfunc, &lock);
+    /* if the user just wants us to terminate a DVM, then do so */
+    if (prrte_cmd_line_is_taken(prrte_cmd_line, "terminate")) {
+        /* advise the user to utilize "pterm" in the future */
+        prrte_show_help("help-prun.txt", "use-pterm", true, prrte_tool_basename);
+        /* setup a lock to track the connection */
+        PRRTE_PMIX_CONSTRUCT_LOCK(&rellock);
+        /* register to trap connection loss */
+        pmix_status_t code[2] = {PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
+        PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
+        PMIx_Register_event_handler(code, 2, &info, 1,
+                                    evhandler, regcbfunc, &lock);
+        PRRTE_PMIX_WAIT_THREAD(&lock);
+        PRRTE_PMIX_DESTRUCT_LOCK(&lock);
+        flag = true;
+        PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_TERMINATE, &flag, PMIX_BOOL);
+        fprintf(stderr, "TERMINATING DVM...");
+        PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        rc = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            goto DONE;
+        } else if (PMIX_SUCCESS == rc) {
+    #if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
+            /* There is a bug in PMIx 3.0.0 up to 3.0.2 that causes the callback never
+             * being called when the server terminates. The callback might be eventually
+             * called though then the connection to the server closes with
+             * status PMIX_ERR_COMM_FAILURE */
+            poll(NULL, 0, 1000);
+            infocb(PMIX_SUCCESS, NULL, 0, (void *)&lock, NULL, NULL);
+    #endif
             PRRTE_PMIX_WAIT_THREAD(&lock);
             PRRTE_PMIX_DESTRUCT_LOCK(&lock);
-            flag = true;
-            PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_TERMINATE, &flag, PMIX_BOOL);
-            if (!proxyrun) {
-                fprintf(stderr, "TERMINATING DVM...");
-            }
-            PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
-            rc = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
-            if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
-                goto DONE;
-            } else if (PMIX_SUCCESS == rc) {
-        #if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
-                /* There is a bug in PMIx 3.0.0 up to 3.0.2 that causes the callback never
-                 * being called when the server terminates. The callback might be eventually
-                 * called though then the connection to the server closes with
-                 * status PMIX_ERR_COMM_FAILURE */
-                poll(NULL, 0, 1000);
-                infocb(PMIX_SUCCESS, NULL, 0, (void *)&lock, NULL, NULL);
-        #endif
-                PRRTE_PMIX_WAIT_THREAD(&lock);
-                PRRTE_PMIX_DESTRUCT_LOCK(&lock);
-                /* wait for connection to depart */
-                PRRTE_PMIX_WAIT_THREAD(&rellock);
-                PRRTE_PMIX_DESTRUCT_LOCK(&rellock);
-                /* wait for the connection to go away */
-            }
-            if (!proxyrun) {
-                fprintf(stderr, "DONE\n");
-            }
-#if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
-            return rc;
-    #else
-            goto DONE;
-    #endif
+            /* wait for connection to depart */
+            PRRTE_PMIX_WAIT_THREAD(&rellock);
+            PRRTE_PMIX_DESTRUCT_LOCK(&rellock);
+            /* wait for the connection to go away */
         }
+        fprintf(stderr, "DONE\n");
+#if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
+        return rc;
+#else
+        goto DONE;
+#endif
     }
+
 
     /* register a default event handler and pass it our release lock
      * so we can cleanly exit if the server goes away */
@@ -1793,41 +1531,6 @@ int prun(int argc, char *argv[])
 #endif
 
   DONE:
-    if (proxyrun) {
-        /* setup a lock to track the connection */
-        PRRTE_PMIX_CONSTRUCT_LOCK(&rellock);
-        /* register to trap connection loss */
-        pmix_status_t code[2] = {PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
-        PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
-        PMIx_Register_event_handler(code, 2, &info, 1,
-                                    evhandler, regcbfunc, &lock);
-        PRRTE_PMIX_WAIT_THREAD(&lock);
-        PRRTE_PMIX_DESTRUCT_LOCK(&lock);
-        flag = true;
-        PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_TERMINATE, &flag, PMIX_BOOL);
-        PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        ret = PMIx_Job_control_nb(NULL, 0, &info, 1, infocb, (void*)&lock);
-        if (PMIX_SUCCESS == ret || PMIX_OPERATION_SUCCEEDED == ret) {
-#if PMIX_VERSION_MAJOR == 3 && PMIX_VERSION_MINOR == 0 && PMIX_VERSION_RELEASE < 3
-            /* There is a bug in PMIx 3.0.0 up to 3.0.2 that causes the callback never
-             * being called when the server successes. The callback might be eventually
-             * called though then the connection to the server closes with
-             * status PMIX_ERR_COMM_FAILURE */
-            poll(NULL, 0, 1000);
-            infocb(PMIX_SUCCESS, NULL, 0, (void *)&lock, NULL, NULL);
-#endif
-            PRRTE_PMIX_WAIT_THREAD(&lock);
-            PRRTE_PMIX_DESTRUCT_LOCK(&lock);
-            /* wait for connection to depart */
-            PRRTE_PMIX_WAIT_THREAD(&rellock);
-            PRRTE_PMIX_DESTRUCT_LOCK(&rellock);
-        } else {
-            PRRTE_PMIX_DESTRUCT_LOCK(&lock);
-            PRRTE_PMIX_DESTRUCT_LOCK(&rellock);
-        }
-    }
-
     PRRTE_LIST_FOREACH(evitm, &forwarded_signals, prrte_event_list_item_t) {
         prrte_event_signal_del(&evitm->ev);
     }


### PR DESCRIPTION
Use "prte" instead of "prun" for proxy execution of cmds like mpirun.
This avoids the fork/exec-rendezvous complexities and should result in
more reliable operation.

Also advise users to use "pterm" instead of "prun --terminate"

Signed-off-by: Ralph Castain <rhc@pmix.org>