### PR TITLE
Print the appropriate help message if the users executable is not found.

### DIFF
--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -225,8 +225,7 @@ void prrte_plm_base_recv(int status, prrte_process_name_t* sender,
         }
 
         /* get the parent's job object */
-        if (NULL != (parent = prrte_get_job_data_object(name.jobid)) &&
-            !PRRTE_FLAG_TEST(parent, PRRTE_JOB_FLAG_TOOL)) {
+        if (NULL != (parent = prrte_get_job_data_object(name.jobid))) {
             /* if the prefix was set in the parent's job, we need to transfer
              * that prefix to the child's app_context so any further launch of
              * orteds can find the correct binary. There always has to be at

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -509,6 +509,12 @@ static void check_complete(int fd, short args, void *cbdata)
         /* update our exit status */
         PRRTE_UPDATE_EXIT_STATUS(jdata->exit_code);
         /* just shut us down */
+        if(PRRTE_SUCCESS != jdata -> exit_code) {
+            char *output = prrte_dump_aborted_procs(jdata);
+            if(output) {
+              fprintf(stderr, "%s", output);
+            }
+        }
         prrte_plm.terminate_orteds();
         PRRTE_RELEASE(caddy);
         return;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -925,10 +925,13 @@ int main(int argc, char *argv[])
     /* see if they want to run an application - let's parse
      * the cmd line to get it */
     rc = parse_locals(&apps, pargc, pargv);
-
+    size_t apps_size = prrte_list_get_size(&apps);
     /* did they provide an app? */
-    if (PMIX_SUCCESS != rc || 0 == prrte_list_get_size(&apps)) {
+    if (PMIX_SUCCESS != rc || 0 == apps_size) {
         /* nope - just need to wait for instructions */
+        if(0 == apps_size) {
+            prrte_output(0, "No application specified!");
+        }
         goto proceed;
     }
     /* mark that we are not a persistent DVM */


### PR DESCRIPTION
- Fixes non-persistent and persistent cases.
    - For the non-persistent case: Make sure we print
        the help message on non-zero exit.
    - For persistent case: prte was attempting to print
        an error message, but the parent->children list was
        not getting populated.


Signed-off-by: Austen Lauria <awlauria@us.ibm.com>