### PR TITLE
Fix ability to display errors

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -90,8 +90,8 @@ Valid values are limited to 0, 1, or 2. Your application will continue, but
 please correct your command line in the future.
 #
 [duplicate-value]
-WARNING: an MCA parameter was listed more than once on the command line,
-but with conflicting values:
+WARNING: an MCA parameter was listed more than once on the command line, or
+multiple times in one or more files, but with conflicting values:
 
   Param:  %s
   Value:  %s

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -905,17 +905,17 @@ static int show_help(const char *filename, const char *topic,
     /* Not already displayed */
     else if (PRRTE_ERR_NOT_FOUND == rc) {
         if (NULL != prrte_iof.output) {
+            /* send it to any connected tools */
             prrte_iof.output(sender, PRRTE_IOF_STDDIAG, output);
+        }
+        if (prrte_xml_output) {
+            char *tmp;
+            tmp = xml_format((unsigned char*)output);
+            fprintf(prrte_xml_fp, "%s", tmp);
+            fflush(prrte_xml_fp);
+            free(tmp);
         } else {
-            if (prrte_xml_output) {
-                char *tmp;
-                tmp = xml_format((unsigned char*)output);
-                fprintf(prrte_xml_fp, "%s", tmp);
-                fflush(prrte_xml_fp);
-                free(tmp);
-            } else {
-                prrte_output(output_stream, "%s", output);
-            }
+            prrte_output(output_stream, "%s", output);
         }
         if (!show_help_timer_set) {
             show_help_time_last_displayed = now;


### PR DESCRIPTION
show_help needs to both send the msg to attached tools AND display it
locally. Ensure prte reports errors and cleans up before exit.

Signed-off-by: Ralph Castain <rhc@pmix.org>