### PR TITLE
Print abnormal termination messages when running as proxy

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -508,6 +508,13 @@ static void check_complete(int fd, short args, void *cbdata)
     if (!prrte_persistent) {
         /* update our exit status */
         PRRTE_UPDATE_EXIT_STATUS(jdata->exit_code);
+        /* if this is an abnormal termination, report it */
+        if (jdata->state > PRRTE_JOB_STATE_ERROR) {
+            char *msg;
+            msg = prrte_dump_aborted_procs(jdata);
+            prrte_output(prrte_clean_output, "%s", msg);
+            free(msg);
+        }
         /* just shut us down */
         prrte_plm.terminate_orteds();
         PRRTE_RELEASE(caddy);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -519,6 +519,7 @@ int main(int argc, char *argv[])
     char **tmp;
     prrte_job_t *jdata;
     prrte_app_context_t *dapp;
+    bool proxyrun = false;
 
     /* init the globals */
     PRRTE_CONSTRUCT(&job_info, prrte_list_t);
@@ -580,6 +581,8 @@ int main(int argc, char *argv[])
             PRRTE_ERROR_LOG(rc);
             return rc;
         }
+    } else {
+        proxyrun = true;
     }
 
     /* get our session directory */
@@ -933,6 +936,10 @@ int main(int argc, char *argv[])
 
     /* did they provide an app? */
     if (PMIX_SUCCESS != rc || 0 == prrte_list_get_size(&apps)) {
+        if (proxyrun) {
+            PRRTE_UPDATE_EXIT_STATUS(rc);
+            goto DONE;
+        }
         /* nope - just need to wait for instructions */
         goto proceed;
     }
@@ -1428,6 +1435,8 @@ static int create_app(int argc, char* argv[],
     /* See if we have anything left */
     if (0 == count) {
         rc = PRRTE_ERR_NOT_FOUND;
+        prrte_show_help("help-prun.txt", "prun:executable-not-specified",
+                       true, prrte_tool_basename, prrte_tool_basename);
         goto cleanup;
     }
 


### PR DESCRIPTION
When running as a proxy, be sure to print out the abnormal termination
messages should something go wrong.

Signed-off-by: Ralph Castain <rhc@pmix.org>