### PR TITLE
Cleanup error reporting in persistent operations

### DIFF
--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -225,25 +225,26 @@ void prrte_plm_base_recv(int status, prrte_process_name_t* sender,
         }
 
         /* get the parent's job object */
-        if (NULL != (parent = prrte_get_job_data_object(name.jobid)) &&
-            !PRRTE_FLAG_TEST(parent, PRRTE_JOB_FLAG_TOOL)) {
-            /* if the prefix was set in the parent's job, we need to transfer
-             * that prefix to the child's app_context so any further launch of
-             * orteds can find the correct binary. There always has to be at
-             * least one app_context in both parent and child, so we don't
-             * need to check that here. However, be sure not to overwrite
-             * the prefix if the user already provided it!
-             */
-            app = (prrte_app_context_t*)prrte_pointer_array_get_item(parent->apps, 0);
-            child_app = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0);
-            if (NULL != app && NULL != child_app) {
-                prefix_dir = NULL;
-                if (prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&prefix_dir, PRRTE_STRING) &&
-                    !prrte_get_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, NULL, PRRTE_STRING)) {
-                    prrte_set_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, prefix_dir, PRRTE_STRING);
-                }
-                if (NULL != prefix_dir) {
-                    free(prefix_dir);
+        if (NULL != (parent = prrte_get_job_data_object(name.jobid))) {
+            if (!PRRTE_FLAG_TEST(parent, PRRTE_JOB_FLAG_TOOL)) {
+                /* if the prefix was set in the parent's job, we need to transfer
+                 * that prefix to the child's app_context so any further launch of
+                 * orteds can find the correct binary. There always has to be at
+                 * least one app_context in both parent and child, so we don't
+                 * need to check that here. However, be sure not to overwrite
+                 * the prefix if the user already provided it!
+                 */
+                app = (prrte_app_context_t*)prrte_pointer_array_get_item(parent->apps, 0);
+                child_app = (prrte_app_context_t*)prrte_pointer_array_get_item(jdata->apps, 0);
+                if (NULL != app && NULL != child_app) {
+                    prefix_dir = NULL;
+                    if (prrte_get_attribute(&app->attributes, PRRTE_APP_PREFIX_DIR, (void**)&prefix_dir, PRRTE_STRING) &&
+                        !prrte_get_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, NULL, PRRTE_STRING)) {
+                        prrte_set_attribute(&child_app->attributes, PRRTE_APP_PREFIX_DIR, PRRTE_ATTR_GLOBAL, prefix_dir, PRRTE_STRING);
+                    }
+                    if (NULL != prefix_dir) {
+                        free(prefix_dir);
+                    }
                 }
             }
             /* link the spawned job to the spawner */

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -632,7 +632,7 @@ int pmix_server_spawn_fn(const pmix_proc_t *proc,
     int rc;
 
     prrte_output_verbose(2, prrte_pmix_server_globals.output,
-                        "%s spawn upcalled from proc %s:%u",
+                        "%s spawn upcalled on behalf of proc %s:%u",
                         PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
                         proc->nspace, proc->rank);
 

--- a/src/runtime/prrte_quit.c
+++ b/src/runtime/prrte_quit.c
@@ -54,6 +54,7 @@
 #include "src/mca/routed/routed.h"
 #include "src/mca/state/state.h"
 
+#include "src/util/output.h"
 #include "src/util/session_dir.h"
 #include "src/util/show_help.h"
 #include "src/threads/threads.h"
@@ -317,7 +318,7 @@ char* prrte_dump_aborted_procs(prrte_job_t *jdata)
         /* cycle through and count the number that were killed or aborted */
         for (i=0; i < job->procs->size; i++) {
             if (NULL == (pptr = (prrte_proc_t*)prrte_pointer_array_get_item(job->procs, i))) {
-                /* array is left-justfied - we are done */
+                /* array is left-justified - we are done */
                 break;
             }
             if (PRRTE_PROC_STATE_FAILED_TO_START == pptr->state ||

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -937,6 +937,8 @@ int main(int argc, char *argv[])
     /* did they provide an app? */
     if (PMIX_SUCCESS != rc || 0 == prrte_list_get_size(&apps)) {
         if (proxyrun) {
+            prrte_show_help("help-prun.txt", "prun:executable-not-specified",
+                           true, prrte_tool_basename, prrte_tool_basename);
             PRRTE_UPDATE_EXIT_STATUS(rc);
             goto DONE;
         }
@@ -1435,8 +1437,6 @@ static int create_app(int argc, char* argv[],
     /* See if we have anything left */
     if (0 == count) {
         rc = PRRTE_ERR_NOT_FOUND;
-        prrte_show_help("help-prun.txt", "prun:executable-not-specified",
-                       true, prrte_tool_basename, prrte_tool_basename);
         goto cleanup;
     }
 


### PR DESCRIPTION
Ensure we link the parent to the child in all cases (tool or
non-persistent launch). Move the error report about no executable on cmd
line to a place where it only gets reported in the non-persistent case.

Signed-off-by: Ralph Castain <rhc@pmix.org>