### PR TITLE
Cleanup few errors associated with tool support

### DIFF
--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -572,6 +572,14 @@ static void _send_notification(int status,
 
     /* insert into prrte_buffer_t */
     buf = PRRTE_NEW(prrte_buffer_t);
+    /* we need to add a flag indicating this came from an invalid proc so that we will
+     * inject it into our own PMIx server library */
+    if (PRRTE_SUCCESS != (rc = prrte_dss.pack(buf, &PRRTE_NAME_INVALID->vpid, 1, PRRTE_VPID))) {
+        PRRTE_ERROR_LOG(rc);
+        free(bo.bytes);
+        PRRTE_RELEASE(buf);
+        return;
+    }
     boptr = &bo;
     if (PRRTE_SUCCESS != (rc = prrte_dss.pack(buf, &boptr, 1, PRRTE_BYTE_OBJECT))) {
         PRRTE_ERROR_LOG(rc);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -791,6 +791,14 @@ static void dvm_notify(int sd, short args, void *cbdata)
 
         /* insert into prrte_buffer_t */
         reply = PRRTE_NEW(prrte_buffer_t);
+        /* we need to add a flag indicating this came from an invalid proc so that we will
+         * inject it into our own PMIx server library */
+        if (PRRTE_SUCCESS != (rc = prrte_dss.pack(reply, &PRRTE_NAME_INVALID->vpid, 1, PRRTE_VPID))) {
+            PRRTE_ERROR_LOG(rc);
+            free(bo.bytes);
+            PRRTE_RELEASE(reply);
+            return;
+        }
         boptr = &bo;
         if (PRRTE_SUCCESS != (rc = prrte_dss.pack(reply, &boptr, 1, PRRTE_BYTE_OBJECT))) {
             PRRTE_ERROR_LOG(rc);


### PR DESCRIPTION
Properly mark/detect that a daemon sourced the event broadcast to avoid
reinjecting it into the PMIx server library. Correct the source field
for the event notify call on launcher ready.

Signed-off-by: Ralph Castain <rhc@pmix.org>