### PR TITLE
Fix tree-based launch

### DIFF
--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -611,6 +611,7 @@ static int setup_launch(int *argcptr, char ***argvptr,
          (prrte_plm_rsh_component.using_qrsh && prrte_plm_rsh_component.daemonize_qrsh)) &&
         ((!prrte_plm_rsh_component.using_llspawn) ||
          (prrte_plm_rsh_component.using_llspawn && prrte_plm_rsh_component.daemonize_llspawn))) {
+        prrte_argv_append(&argc, &argv, "--daemonize");
     }
 
     /*

--- a/src/mca/schizo/pmix/schizo_pmix.c
+++ b/src/mca/schizo/pmix/schizo_pmix.c
@@ -244,9 +244,10 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                      char ***dstenv,
                      bool cmdline)
 {
-    int i;
+    int i, n;
     char *param, *p1;
     char *value;
+    char **env = *dstenv;
 
     prrte_output_verbose(1, prrte_schizo_base_framework.framework_output,
                         "%s schizo:pmix: parse_env",
@@ -266,6 +267,13 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
             *value = '\0';
             value++;
             if (cmdline) {
+                /* check if it is already present */
+                for (n=0; NULL != env[n]; n++) {
+                    if (0 == strcmp(env[n], p1)) {
+                        /* this param is already given */
+                        goto next;
+                    }
+                }
                 prrte_output_verbose(1, prrte_schizo_base_framework.framework_output,
                                      "%s schizo:pmix:parse_env adding %s %s to cmd line",
                                      PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME), p1, value);
@@ -287,6 +295,8 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                     prrte_setenv(param, value, true, dstenv);
                 }
             }
+          next:
+            env = *dstenv;
         }
     }
     return PRRTE_SUCCESS;

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -382,9 +382,10 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                      char ***dstenv,
                      bool cmdline)
 {
-    int i;
+    int i, n;
     char *param, *p1;
     char *value;
+    char **env = *dstenv;
 
     prrte_output_verbose(1, prrte_schizo_base_framework.framework_output,
                         "%s schizo:prrte: parse_env",
@@ -404,6 +405,13 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
             *value = '\0';
             value++;
             if (cmdline) {
+                /* check if it is already present */
+                for (n=0; NULL != env[n]; n++) {
+                    if (0 == strcmp(env[n], p1)) {
+                        /* this param is already given */
+                        goto next;
+                    }
+                }
                 prrte_output_verbose(1, prrte_schizo_base_framework.framework_output,
                                      "%s schizo:prrte:parse_env adding %s %s to cmd line",
                                      PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME), p1, value);
@@ -425,7 +433,9 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                     prrte_setenv(param, value, true, dstenv);
                 }
             }
+          next:
             free(param);
+            env = *dstenv;
         }
     }
 


### PR DESCRIPTION
Fix the rollup of information. Avoid copying cmd line options on top of
each other as that was leading to confusion over things like the daemon
vpid, which is why tree spawn was failing.

Signed-off-by: Ralph Castain <rhc@pmix.org>