### PR TITLE
Cleanup and add some configure logic for OMPI integration

### DIFF
--- a/config/prrte_check_libnl.m4
+++ b/config/prrte_check_libnl.m4
@@ -2,8 +2,8 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
-dnl Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2020      Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow

--- a/config/prrte_configure_options.m4
+++ b/config/prrte_configure_options.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009-2013 Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl
-dnl Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -300,6 +300,24 @@ AS_IF([test ! -z "$with_prrte_extra_ltlib"],
       [AC_MSG_RESULT([no])
        PRRTE_EXTRA_LTLIB=])
 AC_SUBST(PRRTE_EXTRA_LTLIB)
+
+# Add any extra LDFLAGS for the extra libs?
+AC_ARG_WITH([prrte-extra-lib-ldflags],
+            AC_HELP_STRING([--with-prrte-extra-lib-ldflags=flags],
+                           [Where to find the extra libs]))
+AC_MSG_CHECKING([for extra lib LDFLAGS])
+AS_IF([test ! -z "$with_prrte_extra_lib_ldflags"],
+      [AS_IF([test "$with_prrte_extra_lib_ldflags" = "yes" || test "$with_prrte_extra_lib_ldflags" = "no"],
+             [AC_MSG_RESULT([ERROR])
+              AC_MSG_WARN([Invalid value for --with-prrte-extra-lib-ldflags:])
+              AC_MSG_WARN([    $with_prrte_extra_lib_ldflags])
+              AC_MSG_WARN([Must be path name pointing to the libs to add])
+              AC_MSG_ERROR([Cannot continue])],
+             [AC_MSG_RESULT([$with_prrte_extra_lib_ldflags])
+              PRRTE_EXTRA_LIB_LDFLAGS=$with_prrte_extra_lib_ldflags])],
+      [AC_MSG_RESULT([no])
+       PRRTE_EXTRA_LIB_LDFLAGS=])
+AC_SUBST(PRRTE_EXTRA_LIB_LDFLAGS)
 
 #
 # Package/brand string

--- a/config/prrte_functions.m4
+++ b/config/prrte_functions.m4
@@ -13,7 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
@@ -110,6 +110,9 @@ AC_DEFINE_UNQUOTED([PRRTE_CONFIGURE_HOST], "$PRRTE_CONFIGURE_HOST",
 AC_SUBST(PRRTE_CONFIGURE_DATE)
 AC_DEFINE_UNQUOTED([PRRTE_CONFIGURE_DATE], "$PRRTE_CONFIGURE_DATE",
                    [Date when PMIx was built])
+
+PRRTE_LIBNL_SANITY_INIT
+
 ])dnl
 
 dnl #######################################################################

--- a/config/prrte_setup_hwloc.m4
+++ b/config/prrte_setup_hwloc.m4
@@ -35,7 +35,7 @@ AC_DEFUN([PRRTE_HWLOC_CONFIG],[
               [PRRTE_HWLOC_HEADER="\"$with_hwloc_header\""
                prrte_hwloc_header_given=1])
         prrte_hwloc_support=1
-        prrte_hwloc_source=embedded
+        prrte_hwloc_source="external header"
 
     elif test "$with_hwloc" != "no"; then
         AC_MSG_CHECKING([for hwloc in])

--- a/src/tools/pcc/Makefile.am
+++ b/src/tools/pcc/Makefile.am
@@ -10,7 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -25,6 +25,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = pcc.1
 EXTRA_DIST = $(man_pages:.1=.1in)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
 
 bin_PROGRAMS = pcc
 

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +23,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prte.1
 EXTRA_DIST = $(man_pages:.1=.1in)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
 
 bin_PROGRAMS = prte
 

--- a/src/tools/prted/Makefile.am
+++ b/src/tools/prted/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +23,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prted.1
 EXTRA_DIST = $(man_pages:.1=.1in)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
 
 bin_PROGRAMS = prted
 

--- a/src/tools/prun/Makefile.am
+++ b/src/tools/prun/Makefile.am
@@ -25,6 +25,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prun.1
 EXTRA_DIST = $(man_pages:.1=.1in)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
 
 bin_PROGRAMS = prun
 


### PR DESCRIPTION
OMPI needs to pass us not just the extra libs we need to add, but also
the LDFLAGS required to find them. So add a configure option for that
purpose.

Cleanup a configure warning about libnl by ensuring the libnl-related
configure variables get initialized

Signed-off-by: Ralph Castain <rhc@pmix.org>