### PR TITLE
Cleanup some configury

### DIFF
--- a/config/prrte_config_asm.m4
+++ b/config/prrte_config_asm.m4
@@ -774,7 +774,7 @@ AC_DEFUN([PRRTE_CHECK_ASM_GNU_STACKEXEC], [
 int testfunc() {return 0; }
 EOF
              PRRTE_LOG_COMMAND([$CC $CFLAGS -c conftest.c -o conftest.$OBJEXT],
-                 [$OBJDUMP -x conftest.$OBJEXT | $GREP '\.note\.GNU-stack' > /dev/null && prrte_cv_asm_gnu_stack_result=yes],
+                 [$OBJDUMP -x conftest.$OBJEXT 2>&1 | $GREP '\.note\.GNU-stack' &> /dev/null && prrte_cv_asm_gnu_stack_result=yes],
                  [PRRTE_LOG_MSG([the failed program was:], 1)
                   PRRTE_LOG_FILE([conftest.c])
                   prrte_cv_asm_gnu_stack_result=no])

--- a/config/prrte_setup_pmix.m4
+++ b/config/prrte_setup_pmix.m4
@@ -176,20 +176,21 @@ AC_DEFUN([PRRTE_CHECK_PMIX],[
                AC_MSG_ERROR([cannot continue])])
 
         AS_IF([test "$pmix_ext_install_dir" != "/usr"],
-              [CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
-               LDFLAGS="-L$pmix_ext_install_libdir $LDFLAGS"])
+              [prrte_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
+               prrte_pmix_LDFLAGS="-L$pmix_ext_install_libdir"])
 
-        PRRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, -I$pmix_ext_install_dir/include)
-        PRRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include])
+        PRRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prrte_pmix_CPPFLAGS)
+        PRRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [$prrte_pmix_CPPFLAGS])
 
         AS_IF([test "$enable_pmix_devel_support" = "yes"],
               [PRRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include/pmix -I$pmix_ext_install_dir/include/pmix/src -I$pmix_ext_install_dir/include/pmix/src/include])])
 
-        PRRTE_FLAGS_APPEND_UNIQ(LDFLAGS, -L$pmix_ext_install_libdir)
-        PRRTE_WRAPPER_FLAGS_ADD([LDFLAGS], [-L$pmix_ext_install_libdir])
+        PRRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prrte_pmix_LDFLAGS)
+        PRRTE_WRAPPER_FLAGS_ADD([LDFLAGS], [$prrte_pmix_LDFLAGS])
 
-        PRRTE_FLAGS_APPEND_UNIQ(LIBS, -lpmix)
-        PRRTE_WRAPPER_FLAGS_ADD(LIBS, -lpmix)
+        prrte_pmix_LIBS=-lpmix
+        PRRTE_FLAGS_APPEND_UNIQ(LIBS, $prrte_pmix_LIBS)
+        PRRTE_WRAPPER_FLAGS_ADD(LIBS, $prrte_pmix_LIBS)
     fi
 
     AC_DEFINE_UNQUOTED([PRRTE_PMIX_HEADER], [$PRRTE_PMIX_HEADER], [PMIx header to use])

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -332,12 +332,14 @@ static int process_deprecated_cli(prrte_cmd_line_t *cmdline,
             prrte_asprintf(&pargs[i], "-%s", p2);
             /* if it is the special "-np" option, we silently
              * change it and don't emit an error */
-            if (0 != strcmp(p2, "-np")) {
+            if (0 == strcmp(p2, "-np")) {
+                free(p2);
+            } else {
                 prrte_show_help("help-schizo-base.txt", "single-dash-error", true,
                                 p2, pargs[i]);
+                free(p2);
+                ret = PRRTE_OPERATION_SUCCEEDED;
             }
-            free(p2);
-            ret = PRRTE_OPERATION_SUCCEEDED;
         }
 
         /* is this an argument someone needs to convert? */

--- a/src/tools/pcc/Makefile.am
+++ b/src/tools/pcc/Makefile.am
@@ -25,7 +25,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = pcc.1
 EXTRA_DIST = $(man_pages:.1=.1in)
-AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
 
 bin_PROGRAMS = pcc
 
@@ -45,6 +45,9 @@ pcc_SOURCES = \
 
 pcc_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 distclean-local:

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -23,7 +23,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prte.1
 EXTRA_DIST = $(man_pages:.1=.1in)
-AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
 
 bin_PROGRAMS = prte
 
@@ -39,6 +39,9 @@ prte_SOURCES = \
 
 prte_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 distclean-local:

--- a/src/tools/prte_info/Makefile.am
+++ b/src/tools/prte_info/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -42,6 +42,8 @@ AM_CFLAGS = \
             -DPRRTE_WRAPPER_EXTRA_LDFLAGS="\"@PRRTE_WRAPPER_EXTRA_LDFLAGS@\"" \
             -DPRRTE_WRAPPER_EXTRA_LIBS="\"@PRRTE_WRAPPER_EXTRA_LIBS@\""
 
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
+
 include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prte_info.1
@@ -68,6 +70,9 @@ prte_info_SOURCES = \
 
 prte_info_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 clean-local:

--- a/src/tools/prted/Makefile.am
+++ b/src/tools/prted/Makefile.am
@@ -23,7 +23,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prted.1
 EXTRA_DIST = $(man_pages:.1=.1in)
-AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
 
 bin_PROGRAMS = prted
 
@@ -44,6 +44,9 @@ prted_SOURCES = prted.c
 prted_LDFLAGS =
 prted_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 distclean-local:

--- a/src/tools/prun/Makefile.am
+++ b/src/tools/prun/Makefile.am
@@ -25,7 +25,7 @@ include $(top_srcdir)/Makefile.prrte-rules
 
 man_pages = prun.1
 EXTRA_DIST = $(man_pages:.1=.1in)
-AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS)
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
 
 bin_PROGRAMS = prun
 
@@ -45,6 +45,9 @@ prun_SOURCES = \
 
 prun_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 distclean-local:

--- a/src/tools/pterm/Makefile.am
+++ b/src/tools/pterm/Makefile.am
@@ -23,6 +23,8 @@
 
 include $(top_srcdir)/Makefile.prrte-rules
 
+AM_LDFLAGS = $(PRRTE_EXTRA_LIB_LDFLAGS) $(prrte_hwloc_LDFLAGS) $(prrte_libevent_LDFLAGS) $(prrte_pmix_LDFLAGS)
+
 man_pages = pterm.1
 EXTRA_DIST = $(man_pages:.1=.1in)
 
@@ -42,6 +44,9 @@ pterm_SOURCES = \
 
 pterm_LDADD = \
     $(PRRTE_EXTRA_LTLIB) \
+    $(prrte_libevent_LIBS) \
+    $(prrte_hwloc_LIBS) \
+    $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
 
 distclean-local:


### PR DESCRIPTION
Redirect stderr of a conftest so we don't print errors when not needed.
Cache the PMIx library flags for later use. Explicitly link the
executables against the external dependencies.

Signed-off-by: Ralph Castain <rhc@pmix.org>