### PR TITLE
Silence errors coming out of libtool config check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ env:
 
 before_install:
     - env
-    - if [[ "GCC_VERSION" == "7" ]]; then COMPILERS="CC=gcc-7 CXX=g++-7 FC=gfortran-7"; elif [[ "$CC" == "clang" ]]; then COMPILERS="CC=`which clang`"; fi
+    - if [[ "GCC_VERSION" == "7" ]]; then COMPILERS="CC=gcc-7 "; elif [[ "$CC" == "clang" ]]; then COMPILERS="CC=`which clang`"; fi
     - export CONFIGURE_ARGS="--prefix=$HOME/bogus --enable-prrterun-prefix-by-default $COMPILERS" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
-    - if [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 g++-6 gfortran-6; elif [[ "$GCC_VERSION" == "7" ]] ; then sudo apt-get --assume-yes install gcc-7 g++-7 gfortran-7; fi
+    - if [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 ; elif [[ "$GCC_VERSION" == "7" ]] ; then sudo apt-get --assume-yes install gcc-7 ; fi
     - echo COMPILERS=$COMPILERS
     - ./contrib/travis/install-pmix.sh $COMPILERS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
     - if [[ "GCC_VERSION" == "7" ]]; then COMPILERS="CC=gcc-7 "; elif [[ "$CC" == "clang" ]]; then COMPILERS="CC=`which clang`"; fi
     - export CONFIGURE_ARGS="--prefix=$HOME/bogus --enable-prrterun-prefix-by-default $COMPILERS" DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
     - export DISTCHECK_CONFIGURE_FLAGS="$CONFIGURE_ARGS"
-    - if [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 ; elif [[ "$GCC_VERSION" == "7" ]] ; then sudo apt-get --assume-yes install gcc-7 ; fi
+    - if [[ "$GCC_VERSION" == "6" ]] ; then sudo apt-get --assume-yes install gcc-6 ; elif [[ "$GCC_VERSION" == "7" ]] ; then sudo apt-get --assume-yes install gcc-7 ; else sudo apt-get --assume-yes install gcc-6 ; fi
     - echo COMPILERS=$COMPILERS
     - ./contrib/travis/install-pmix.sh $COMPILERS
 

--- a/config/prrte_setup_wrappers.m4
+++ b/config/prrte_setup_wrappers.m4
@@ -148,10 +148,15 @@ AC_DEFUN([PRRTE_LIBTOOL_CONFIG],[
 # (because if script A sources script B, and B calls "exit", then both
 # B and A will exit).  Instead, we have to send the output to a file
 # and then source that.
-$PRRTE_TOP_BUILDDIR/libtool $3 --config > $rpath_outfile
-
-chmod +x $rpath_outfile
-. ./$rpath_outfile
+prrte_eval="libtool --config 2>&1 > /dev/null"
+prrte_found=`eval $prrte_eval`
+status=$?
+if test "$status" = "0"; then
+    libtool $3 --config 2>&1 > $rpath_outfile
+    chmod +x $rpath_outfile
+    . ./$rpath_outfile
+else
+    exit 1
 rm -f $rpath_outfile
 
 # Evaluate \$$1, and substitute in LIBDIR for \$libdir

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1108,7 +1108,6 @@ static int detect_proxy(char **argv, char **rfile)
 {
     pid_t mypid;
 
-    mypid = getpid();
     /* if the basename of the cmd was "mpirun" or "mpiexec",
      * we default to us */
     if (prrte_schizo_base.test_proxy_launch ||
@@ -1116,12 +1115,13 @@ static int detect_proxy(char **argv, char **rfile)
         0 == strcmp(prrte_tool_basename, "mpiexec") ||
         0 == strcmp(prrte_tool_basename, "oshrun")) {
         /* create a rendezvous file */
+        mypid = getpid();
         prrte_asprintf(rfile, "%s.rndz.%lu", prrte_tool_basename, (unsigned long)mypid);
         /* add us to the personalities */
         prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
         if (0 == strcmp(prrte_tool_basename, "oshrun")) {
             /* add oshmem to the personalities */
-        prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
+            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
         }
         return PRRTE_SUCCESS;
     }

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -583,12 +583,23 @@ static int detect_proxy(char **argv, char **rfile)
 {
     pid_t mypid;
 
-    mypid = getpid();
     /* if the basename isn't prun, and nobody before us recognized
      * it, then we need to treat it as a proxy */
     if (prrte_schizo_base.test_proxy_launch) {
         /* create a rendezvous file */
+        mypid = getpid();
         prrte_asprintf(rfile, "%s.rndz.%lu", prrte_tool_basename, (unsigned long)mypid);
+        if (prrte_schizo_base.test_proxy_launch ||
+            0 == strcmp(prrte_tool_basename, "mpirun") ||
+            0 == strcmp(prrte_tool_basename, "mpiexec") ||
+            0 == strcmp(prrte_tool_basename, "oshrun")) {
+            /* add to the personalities */
+            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
+            if (0 == strcmp(prrte_tool_basename, "oshrun")) {
+                /* add oshmem to the personalities */
+                prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
+            }
+        }
         return PRRTE_SUCCESS;
     }
 

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -45,6 +45,17 @@ static int detect_proxy(char **argv, char **rfile)
      * allocation - set the rendezvous file accordingly */
     jid = getenv("SLURM_JOBID");
     prrte_asprintf(rfile, "%s/%s.rndz.%s", prrte_tmp_directory(), prrte_tool_basename, jid);
+    if (prrte_schizo_base.test_proxy_launch ||
+        0 == strcmp(prrte_tool_basename, "mpirun") ||
+        0 == strcmp(prrte_tool_basename, "mpiexec") ||
+        0 == strcmp(prrte_tool_basename, "oshrun")) {
+        /* add to the personalities */
+        prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
+        if (0 == strcmp(prrte_tool_basename, "oshrun")) {
+            /* add oshmem to the personalities */
+            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
+        }
+    }
 
     return PRRTE_SUCCESS;
 }


### PR DESCRIPTION
When running on a Mac, Apple's libtool does not support the "--config"
option. This leads to configure generating an error that can be
misleading. We _could_ use "glibtool" to perform the check, but we are
actually using Apple's libtool to do the build, so best to just silently
return the error

Signed-off-by: Ralph Castain <rhc@pmix.org>