### PR TITLE
Modify the schizo "detect_proxy" interface

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -82,7 +82,7 @@ PRRTE_EXPORT int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
                                              char **srcenv,
                                              char ***dstenv,
                                              bool cmdline);
-PRRTE_EXPORT int prrte_schizo_base_detect_proxy(char **argv, char **rfile);
+PRRTE_EXPORT int prrte_schizo_base_detect_proxy(char **argv);
 PRRTE_EXPORT int prrte_schizo_base_define_session_dir(char **tmpdir);
 
 PRRTE_EXPORT int prrte_schizo_base_allow_run_as_root(prrte_cmd_line_t *cmd_line);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -113,24 +113,23 @@ int prrte_schizo_base_parse_env(prrte_cmd_line_t *cmd_line,
     return PRRTE_SUCCESS;
 }
 
-int prrte_schizo_base_detect_proxy(char **argv, char **rfile)
+int prrte_schizo_base_detect_proxy(char **argv)
 {
-    int rc;
+    int rc, ret = PRRTE_ERR_TAKE_NEXT_OPTION;
     prrte_schizo_base_active_module_t *mod;
 
     PRRTE_LIST_FOREACH(mod, &prrte_schizo_base.active_modules, prrte_schizo_base_active_module_t) {
         if (NULL != mod->module->detect_proxy) {
-            rc = mod->module->detect_proxy(argv, rfile);
+            rc = mod->module->detect_proxy(argv);
             if (PRRTE_SUCCESS == rc) {
-                return rc;
-            }
-            if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
+                ret = PRRTE_SUCCESS;  // indicate we are running as a proxy
+            } else if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
                 PRRTE_ERROR_LOG(rc);
                 return rc;
             }
         }
     }
-    return PRRTE_ERR_TAKE_NEXT_OPTION;
+    return ret;
 }
 
 int prrte_schizo_base_define_session_dir(char **tmpdir)

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -64,7 +64,7 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                      char **srcenv,
                      char ***dstenv,
                      bool cmdline);
-static int detect_proxy(char **argv, char **rfile);
+static int detect_proxy(char **argv);
 static int allow_run_as_root(prrte_cmd_line_t *cmd_line);
 static void job_info(prrte_cmd_line_t *cmdline, prrte_list_t *jobinfo);
 
@@ -1104,19 +1104,14 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
     return PRRTE_SUCCESS;
 }
 
-static int detect_proxy(char **argv, char **rfile)
+static int detect_proxy(char **argv)
 {
-    pid_t mypid;
-
     /* if the basename of the cmd was "mpirun" or "mpiexec",
      * we default to us */
     if (prrte_schizo_base.test_proxy_launch ||
         0 == strcmp(prrte_tool_basename, "mpirun") ||
         0 == strcmp(prrte_tool_basename, "mpiexec") ||
         0 == strcmp(prrte_tool_basename, "oshrun")) {
-        /* create a rendezvous file */
-        mypid = getpid();
-        prrte_asprintf(rfile, "%s.rndz.%lu", prrte_tool_basename, (unsigned long)mypid);
         /* add us to the personalities */
         prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
         if (0 == strcmp(prrte_tool_basename, "oshrun")) {

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -62,7 +62,6 @@ static int parse_env(prrte_cmd_line_t *cmd_line,
                      bool cmdline);
 static int setup_fork(prrte_job_t *jdata,
                       prrte_app_context_t *context);
-static int detect_proxy(char **argv, char **rfile);
 static int define_session_dir(char **tmpdir);
 static int allow_run_as_root(prrte_cmd_line_t *cmd_line);
 static void wrap_args(char **args);
@@ -74,7 +73,6 @@ prrte_schizo_base_module_t prrte_schizo_prrte_module = {
     .parse_proxy_cli = parse_proxy_cli,
     .parse_env = parse_env,
     .setup_fork = setup_fork,
-    .detect_proxy = detect_proxy,
     .define_session_dir = define_session_dir,
     .allow_run_as_root = allow_run_as_root,
     .wrap_args = wrap_args
@@ -577,33 +575,6 @@ static int setup_fork(prrte_job_t *jdata,
     }
 
     return PRRTE_SUCCESS;
-}
-
-static int detect_proxy(char **argv, char **rfile)
-{
-    pid_t mypid;
-
-    /* if the basename isn't prun, and nobody before us recognized
-     * it, then we need to treat it as a proxy */
-    if (prrte_schizo_base.test_proxy_launch) {
-        /* create a rendezvous file */
-        mypid = getpid();
-        prrte_asprintf(rfile, "%s.rndz.%lu", prrte_tool_basename, (unsigned long)mypid);
-        if (prrte_schizo_base.test_proxy_launch ||
-            0 == strcmp(prrte_tool_basename, "mpirun") ||
-            0 == strcmp(prrte_tool_basename, "mpiexec") ||
-            0 == strcmp(prrte_tool_basename, "oshrun")) {
-            /* add to the personalities */
-            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
-            if (0 == strcmp(prrte_tool_basename, "oshrun")) {
-                /* add oshmem to the personalities */
-                prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
-            }
-        }
-        return PRRTE_SUCCESS;
-    }
-
-    return PRRTE_ERR_TAKE_NEXT_OPTION;
 }
 
 static int define_session_dir(char **tmpdir)

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -83,10 +83,9 @@ typedef void (*prrte_schizo_base_module_register_deprecated_cli_fn_t)(prrte_list
 /* detect if we are running as a proxy
  * Check the environment to determine what, if any, host we are running
  * under. Check the argv to see if we are running as a proxy for some
- * other command and to see which environment we are proxying. Return
- * a unique rendezvous file to use for prun to connect to prte
+ * other command and to see which environment we are proxying.
  */
-typedef int (*prrte_schizo_base_detect_proxy_fn_t)(char **argv, char **rndfile);
+typedef int (*prrte_schizo_base_detect_proxy_fn_t)(char **argv);
 
 /* define a (hopefully) unique session directory we can use */
 typedef int (*prrte_schizo_base_define_session_dir_fn_t)(char **tmpdir);

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -27,38 +27,13 @@
 
 #include "schizo_slurm.h"
 
-static int detect_proxy(char **argv, char **rfile);
 static int get_remaining_time(uint32_t *timeleft);
 static int define_session_dir(char **tmpdir);
 
 prrte_schizo_base_module_t prrte_schizo_slurm_module = {
-    .detect_proxy = detect_proxy,
     .define_session_dir = define_session_dir,
     .get_remaining_time = get_remaining_time
 };
-
-static int detect_proxy(char **argv, char **rfile)
-{
-    char *jid;
-
-    /* if we are active, then we must be inside a Slurm
-     * allocation - set the rendezvous file accordingly */
-    jid = getenv("SLURM_JOBID");
-    prrte_asprintf(rfile, "%s/%s.rndz.%s", prrte_tmp_directory(), prrte_tool_basename, jid);
-    if (prrte_schizo_base.test_proxy_launch ||
-        0 == strcmp(prrte_tool_basename, "mpirun") ||
-        0 == strcmp(prrte_tool_basename, "mpiexec") ||
-        0 == strcmp(prrte_tool_basename, "oshrun")) {
-        /* add to the personalities */
-        prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "ompi5");
-        if (0 == strcmp(prrte_tool_basename, "oshrun")) {
-            /* add oshmem to the personalities */
-            prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, "oshmem");
-        }
-    }
-
-    return PRRTE_SUCCESS;
-}
 
 static int define_session_dir(char **tmpdir)
 {

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -512,7 +512,6 @@ int main(int argc, char *argv[])
 #endif
     prrte_value_t *pval;
     uint32_t ui32;
-    char *rfile = NULL;
     char *mytmpdir;
     char **pargv;
     int pargc;
@@ -575,15 +574,13 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* detect if we are running as a proxy and setup the rendezvous
-     * and session directory files */
-    if (PRRTE_SUCCESS != (rc = prrte_schizo.detect_proxy(pargv, &rfile))) {
-        if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
-            PRRTE_ERROR_LOG(rc);
-            return rc;
-        }
-    } else {
+    /* detect if we are running as a proxy */
+    rc = prrte_schizo.detect_proxy(pargv);
+    if (PRRTE_SUCCESS == rc) {
         proxyrun = true;
+    } else if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
+        PRRTE_ERROR_LOG(rc);
+        return rc;
     }
 
     /* get our session directory */

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -639,7 +639,6 @@ int prun(int argc, char *argv[])
     prrte_value_t *pval;
     uint32_t ui32;
     pid_t pid;
-    char *rfile = NULL;
     char *mytmpdir;
     char **pargv;
     int pargc;
@@ -739,14 +738,6 @@ int prun(int argc, char *argv[])
                 prrte_argv_append_unique_nosize(&prrte_schizo_base.personalities, tmp[m]);
             }
             prrte_argv_free(tmp);
-        }
-    }
-
-    /* setup the rendezvous and session directory files */
-    if (PRRTE_SUCCESS != (rc = prrte_schizo.detect_proxy(pargv, &rfile))) {
-        if (PRRTE_ERR_TAKE_NEXT_OPTION != rc) {
-            PRRTE_ERROR_LOG(rc);
-            return rc;
         }
     }
 


### PR DESCRIPTION
We no longer need to define a rendezvous file as proxy execution is
being performed directly by prte. Allow all the components to look at
the argv and decide if they need to add themselves to the list of
personalities.

Signed-off-by: Ralph Castain <rhc@pmix.org>