### PR TITLE
configure: use -iquote for non-system include paths

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -4,7 +4,7 @@
 # Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      IBM Corporation.  All rights reserved.
@@ -275,7 +275,7 @@ sub mca_generate_framework_header(\$\@) {
 #ifndef $ifdef_string
 #define $ifdef_string
 
-#include <src/mca/base/prrte_mca_base_framework.h>
+#include \"src/mca/base/prrte_mca_base_framework.h\"
 
 $framework_decl_output
 static prrte_mca_base_framework_t *prrte_frameworks[] = {

--- a/config/prrte_setup_cc.m4
+++ b/config/prrte_setup_cc.m4
@@ -16,7 +16,7 @@ dnl Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015-2019 Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
-dnl Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -120,6 +120,28 @@ AC_DEFUN([PRRTE_PROG_CC_C11],[
 ])
 
 
+# PRRTE_CHECK_CC_IQUOTE()
+# ----------------------
+# Check if the compiler supports the -iquote option. This options
+# removes the specified directory from the search path when using
+# #include <>. This check works around an issue caused by C++20
+# which added a <version> header. This conflicts with the
+# VERSION file at the base of our source directory on case-
+# insensitive filesystems.
+AC_DEFUN([PRRTE_CHECK_CC_IQUOTE],[
+    PRRTE_VAR_SCOPE_PUSH([prrte_check_cc_iquote_CFLAGS_save])
+    prrte_check_cc_iquote_CFLAGS_save=${CFLAGS}
+    CFLAGS="${CFLAGS} -iquote ."
+    AC_MSG_CHECKING([for $CC option to add a directory only to the search path for the quote form of include])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[])],
+              [prrte_cc_iquote="-iquote"],
+              [prrte_cc_iquote="-I"])
+    CFLAGS=${prrte_check_cc_iquote_CFLAGS_save}
+    PRRTE_VAR_SCOPE_POP
+    AC_MSG_RESULT([$prrte_cc_iquote])
+])
+
+
 # PRRTE_SETUP_CC()
 # ---------------
 # Do everything required to setup the C compiler.  Safe to AC_REQUIRE
@@ -141,6 +163,7 @@ AC_DEFUN([PRRTE_SETUP_CC],[
     AC_SUBST([WRAPPER_CC])
 
     PRRTE_PROG_CC_C11
+    PRRTE_CHECK_CC_IQUOTE
 
     if test $prrte_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the

--- a/configure.ac
+++ b/configure.ac
@@ -1078,10 +1078,12 @@ if test "$PRRTE_TOP_BUILDDIR" != "$PRRTE_TOP_SRCDIR"; then
     # rather than have successive assignments to these shell
     # variables, lest the $(foo) names try to get evaluated here.
     # Yuck!
-    CPPFLAGS='-I$(top_srcdir) -I$(top_builddir) -I$(top_srcdir)/src/include -I$(top_builddir)/src/include'" $CPPFLAGS"
+    cpp_includes="$PRRTE_TOP_SRCDIR $PRRTE_TOP_BUILDDIR $PRRTE_TOP_SRCDIR/src/include $PRRTE_TOP_BUILDDIR/src/include"
 else
-    CPPFLAGS='-I$(top_srcdir) -I$(top_srcdir)/src/include'" $CPPFLAGS"
+    cpp_includes="$PRRTE_TOP_SRCDIR $PRRTE_TOP_SRCDIR/src/include"
 fi
+CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$prrte_cc_iquote"'&/g')"
+CPPFLAGS="$CPP_INCLUDES $CPPFLAGS"
 
 #
 # Delayed the substitution of CFLAGS and CXXFLAGS until now because

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -32,9 +32,9 @@
 
 #include PRRTE_PMIX_HEADER
 #if ! PRRTE_PMIX_HEADER_GIVEN
-#include "pmix_server.h"
-#include "pmix_tool.h"
-#include "pmix_version.h"
+#include <pmix_server.h>
+#include <pmix_tool.h>
+#include <pmix_version.h>
 #endif
 
 BEGIN_C_DECLS

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -73,8 +73,8 @@
 #include "src/runtime/prrte_globals.h"
 #include "src/runtime/prrte_data_server.h"
 
-#include "pmix_server.h"
-#include "pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 /*
  * Local utility functions

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -44,8 +44,8 @@
 #include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/rml/rml.h"
 
-#include "pmix_server_internal.h"
-#include "pmix_server.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server.h"
 
 static void relcb(void *cbdata)
 {

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -52,7 +52,7 @@
 #include "src/mca/plm/plm.h"
 #include "src/mca/plm/base/plm_private.h"
 
-#include "pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 static void pmix_server_stdin_push(int sd, short args, void *cbdata);
 

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -46,7 +46,7 @@
 #include "src/mca/rml/rml.h"
 #include "src/mca/rml/base/rml_contact.h"
 
-#include "pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 static int init_server(void)
 {

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -51,7 +51,7 @@
 #include "src/mca/plm/plm.h"
 #include "src/mca/plm/base/plm_private.h"
 
-#include "pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 static void qrel(void *cbdata)
 {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -50,8 +50,8 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/rmaps/base/base.h"
 
-#include "pmix_server_internal.h"
-#include "pmix_server.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+#include "src/prted/pmix/pmix_server.h"
 
 static void opcbfunc(pmix_status_t status, void *cbdata);
 


### PR DESCRIPTION
This fixes a bug in the configuration system identified by a
change in the C++ standard. C++20 adds a new mandatory header
named version. This (and any system) header will always be
included with <> and not "". On case-insensitive filesystems
this new header conflicts with the VERSION file at the top
level of the build tree.

To fix this issue PRRTE needs to use -iquote instead of -I
for non-system include paths to ensure that these include are
only searched for the quote form of include. This commit also
adds a check to ensure that if the compiler does not support
-iquote that it falls back to -I until support can be added.

Tracks https://github.com/open-mpi/ompi/pull/7169

Fixes #481

Signed-off-by: Ralph Castain <rhc@pmix.org>