### PR TITLE
Restore support for several options

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -575,11 +575,11 @@ static int check_modifiers(char *ck, prrte_job_t *jdata,
                                 PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
                                 prrte_rmaps_base.cpus_per_rank);
             found = true;
-        } else if (0 == strncasecmp(ck2[i], "oversubscribe", strlen(ck2[i]))) {
+        } else if (0 == strncasecmp(ck2[i], "OVERSUBSCRIBE", strlen(ck2[i]))) {
             PRRTE_UNSET_MAPPING_DIRECTIVE(*tmp, PRRTE_MAPPING_NO_OVERSUBSCRIBE);
             PRRTE_SET_MAPPING_DIRECTIVE(*tmp, PRRTE_MAPPING_SUBSCRIBE_GIVEN);
             found = true;
-        } else if (0 == strncasecmp(ck2[i], "nooversubscribe", strlen(ck2[i]))) {
+        } else if (0 == strncasecmp(ck2[i], "NOOVERSUBSCRIBE", strlen(ck2[i]))) {
             PRRTE_SET_MAPPING_DIRECTIVE(*tmp, PRRTE_MAPPING_NO_OVERSUBSCRIBE);
             PRRTE_SET_MAPPING_DIRECTIVE(*tmp, PRRTE_MAPPING_SUBSCRIBE_GIVEN);
             found = true;
@@ -616,6 +616,9 @@ static int check_modifiers(char *ck, prrte_job_t *jdata,
             ptr++;
             prrte_set_attribute(&jdata->attributes, PRRTE_JOB_CPU_LIST, PRRTE_ATTR_GLOBAL,
                                 ptr, PRRTE_STRING);
+        } else if (0 == strncasecmp(ck2[i], "INHERIT", strlen(ck2[i]))) {
+            prrte_set_attribute(&jdata->attributes, PRRTE_JOB_INHERIT, PRRTE_ATTR_GLOBAL,
+                                NULL, PRRTE_BOOL);
         } else {
             /* unrecognized modifier */
             prrte_argv_free(ck2);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -347,12 +347,14 @@ static int process_deprecated_cli(prrte_cmd_line_t *cmdline,
             for (n=0; NULL != cv->options[n]; n++) {
                 if (0 == strcmp(pargs[i], cv->options[n])) {
                     rc = cv->convert(cv->options[n], argv, i);
-                    if (PRRTE_SUCCESS != rc) {
+                    if (PRRTE_SUCCESS != rc && PRRTE_ERR_SILENT != rc) {
                         return rc;
                     }
                     --i;
                     found = true;
-                    ret = PRRTE_OPERATION_SUCCEEDED;
+                    if (PRRTE_ERR_SILENT != rc) {
+                        ret = PRRTE_OPERATION_SUCCEEDED;
+                    }
                     pargs = *argv;
                     pargc = prrte_argv_count(pargs);
                     break;  // for loop

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -312,7 +312,7 @@ static int parse_deprecated_cli(char *option, char ***argv, int i)
         rc = prrte_schizo_base_convert(argv, i, 1, "--map-by", "ppr:1:node", NULL);
     }
     else if (0 == strcmp(option, "--npersocket")) {
-        prrte_asprintf(&p2, "ppr:%s:node", pargs[i+1]);
+        prrte_asprintf(&p2, "ppr:%s:socket", pargs[i+1]);
         rc = prrte_schizo_base_convert(argv, i, 2, "--map-by", p2, NULL);
         free(p2);
    }

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -296,6 +296,8 @@ static int parse_cli(int argc, int start, char **argv,
 static int parse_deprecated_cli(char *option, char ***argv, int i)
 {
     int rc = PRRTE_SUCCESS;
+    char **pargs = *argv;
+    char *p2;
 
     /* --display-devel-map  ->  PRRTE_MCA_rmaps_base_display_devel_map */
     if (0 == strcmp(option, "--display-devel-map")) {
@@ -329,6 +331,12 @@ static int parse_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--xml-output")) {
         rc = prrte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "XMLOUTPUT");
     }
+    /* -N ->   map-by ppr:N:node */
+    else if (0 == strcmp(option, "-N")) {
+        prrte_asprintf(&p2, "ppr:%s:node", pargs[i+1]);
+        rc = prrte_schizo_base_convert(argv, i, 2, "--map-by", p2, NULL);
+        free(p2);
+    }
 
     return rc;
 }
@@ -345,6 +353,7 @@ static void register_deprecated_cli(prrte_list_t *convertors)
         "--display-allocation",
         "--do-not-launch",
         "--xml-output",
+        "-N",
         NULL
     };
 

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -730,7 +730,9 @@ void prrte_state_base_track_procs(int fd, short argc, void *cbdata)
              * itself.  This covers the case where the process died abnormally
              * and didn't cleanup its own session directory.
              */
-            prrte_session_dir_finalize(proc);
+            if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+                prrte_session_dir_finalize(proc);
+            }
         }
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -239,6 +239,9 @@ static prrte_cmd_line_init_t cmd_line_init[] = {
     { 'n', "n", 1, PRRTE_CMD_LINE_TYPE_INT,
       "Number of processes to run",
       PRRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'N', NULL, 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Number of processes to run per node",
+      PRRTE_CMD_LINE_OTYPE_GENERAL },
     /* Use an appfile */
     { '\0',  "app", 1, PRRTE_CMD_LINE_TYPE_STRING,
       "Provide an appfile; ignore all other command line options",

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -225,6 +225,9 @@ static prrte_cmd_line_init_t cmd_line_init[] = {
     { 'n', "n", 1, PRRTE_CMD_LINE_TYPE_INT,
       "Number of processes to run",
       PRRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'N', NULL, 1, PRRTE_CMD_LINE_TYPE_INT,
+      "Number of processes to run per node",
+      PRRTE_CMD_LINE_OTYPE_GENERAL },
     /* Use an appfile */
     { '\0',  "app", 1, PRRTE_CMD_LINE_TYPE_STRING,
       "Provide an appfile; ignore all other command line options",

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -436,6 +436,8 @@ const char *prrte_attr_key_to_str(prrte_attribute_key_t key)
             return "JOB_TIMEOUT_EVENT";
         case PRRTE_JOB_TRACE_TIMEOUT_EVENT:
             return "JOB_TRACE_TIMEOUT_EVENT";
+        case PRRTE_JOB_INHERIT:
+            return "JOB_INHERIT";
 
         case PRRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -178,6 +178,7 @@ typedef uint16_t prrte_job_flags_t;
 #define PRRTE_JOB_REPORT_STATE           (PRRTE_JOB_START_KEY + 73)    // bool - include process state in timeout report
 #define PRRTE_JOB_TIMEOUT_EVENT          (PRRTE_JOB_START_KEY + 74)    // prrte_ptr (prrte_timer_t*) - timer event for job timeout
 #define PRRTE_JOB_TRACE_TIMEOUT_EVENT    (PRRTE_JOB_START_KEY + 75)    // prrte_ptr (prrte_timer_t*) - timer event for stacktrace collection
+#define PRRTE_JOB_INHERIT                (PRRTE_JOB_START_KEY + 76)    // bool - job inherits parent's mapping/ranking/binding policies
 
 #define PRRTE_JOB_MAX_KEY   300
 


### PR DESCRIPTION
* -N for ppr:N:node
* INHERIT modifier for --map-by option, indicating that
  the spawned job should inherit the placement options
  of its parent. Only applicable to dynamically spawned
  jobs

Signed-off-by: Ralph Castain <rhc@pmix.org>