### PR TITLE
Utilize the prtereachable framework in oob/tcp

### DIFF
--- a/src/mca/oob/tcp/oob_tcp_component.h
+++ b/src/mca/oob/tcp/oob_tcp_component.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,6 +75,8 @@ typedef struct {
     char**             ipv6ports;
 
     /* connection support */
+    prrte_list_t       local_ifs;              /**< prrte list of local prrte_if_t interfaces */
+    char**             if_masks;
     char*              my_uri;                 /**< uri for connecting to the TCP module */
     int                num_hnp_ports;          /**< number of ports the HNP should listen on */
     prrte_list_t        listeners;              /**< List of sockets being monitored by event or thread */

--- a/src/mca/oob/tcp/oob_tcp_connection.c
+++ b/src/mca/oob/tcp/oob_tcp_connection.c
@@ -507,7 +507,7 @@ out:
         free(results);
     }
     if (NULL != remote_list) {
-        OBJ_RELEASE(remote_list);
+        PRRTE_RELEASE(remote_list);
     }
 }
 

--- a/src/mca/oob/tcp/oob_tcp_peer.h
+++ b/src/mca/oob/tcp/oob_tcp_peer.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,7 +39,8 @@ typedef struct {
     prrte_list_item_t super;
     struct sockaddr_storage addr; // an address where a peer can be found
     int retries;                  // number of times we have tried to connect to this address
-    prrte_oob_tcp_state_t state;    // state of this address
+    prrte_oob_tcp_state_t state;  // state of this address
+    int if_mask;                  // if mask of this address
 } prrte_oob_tcp_addr_t;
 PRRTE_CLASS_DECLARATION(prrte_oob_tcp_addr_t);
 


### PR DESCRIPTION
Improves selection of local and remote interfaces based
on reachability output when selecting addresses.

This patch adds to the uri-like string in order to
add a required mask field. It also manually binds
the socket created in prrte_oob_tcp_peer_try_connect

Previously:
tcp://\<addresses\>:\<ports\>

Now:
tcp://\<addresses\>:\<ports\>:\<masks\>

Signed-off-by: William Zhang <wilzhang@amazon.com>