### PR TITLE
Add configure options for proxy versions

### DIFF
--- a/config/prrte_configure_options.m4
+++ b/config/prrte_configure_options.m4
@@ -213,24 +213,49 @@ AC_DEFINE_UNQUOTED(PRRTE_SHOW_LOAD_ERRORS_DEFAULT, $PRRTE_SHOW_LOAD_ERRORS_DEFAU
 
 
 #
-# Heterogeneous support
+# Handle embedded version strings
 #
-
-AC_MSG_CHECKING([if want heterogeneous support])
-AC_ARG_ENABLE([heterogeneous],
-    [AC_HELP_STRING([--enable-heterogeneous],
-                    [Enable features required for heterogeneous
-                     platform support (default: disabled)])])
-if test "$enable_heterogeneous" = "yes" ; then
-     AC_MSG_RESULT([yes])
-     prrte_want_heterogeneous=1
+AC_MSG_CHECKING([if a proxy version string for prte is required])
+AC_ARG_WITH(proxy-version-string,
+    AC_HELP_STRING([--with-proxy-version-string],
+                   [Return the provided string when prte is used in proxy mode and the version is requested]))
+if test -n "$with_proxy_version_string"; then
+    AC_MSG_RESULT([yes])
+    PRRTE_PROXY_VERSION_STRING=$with_proxy_version_string
 else
-     AC_MSG_RESULT([no])
-     prrte_want_heterogeneous=0
+    AC_MSG_RESULT([no])
+    PRRTE_PROXY_VERSION_STRING=$PRRTE_VERSION
 fi
-AC_DEFINE_UNQUOTED([PRRTE_ENABLE_HETEROGENEOUS_SUPPORT],
-                   [$prrte_want_heterogeneous],
-                   [Enable features required for heterogeneous support])
+AC_DEFINE_UNQUOTED(PRRTE_PROXY_VERSION_STRING, "$PRRTE_PROXY_VERSION_STRING",
+                   [Version string to be returned by prte when in proxy mode])
+
+AC_MSG_CHECKING([if a proxy package name for prte is required])
+AC_ARG_WITH(proxy-package-name,
+    AC_HELP_STRING([--with-proxy-package-name],
+                   [Return the provided string when prte is used in proxy mode and the package name is requested]))
+if test -n "$with_proxy_package_name"; then
+    AC_MSG_RESULT([yes])
+    PRRTE_PROXY_PACKAGE_NAME=$with_proxy_package_name
+else
+    AC_MSG_RESULT([no])
+    PRRTE_PROXY_PACKAGE_NAME="PMIx Reference RunTime Environment"
+fi
+AC_DEFINE_UNQUOTED(PRRTE_PROXY_PACKAGE_NAME, "$PRRTE_PROXY_PACKAGE_NAME",
+                   [Package name to be returned by prte when in proxy mode])
+
+AC_MSG_CHECKING([if a proxy bugreport path for prte is required])
+AC_ARG_WITH(proxy-bugreport,
+    AC_HELP_STRING([--with-proxy-bugreport],
+                   [Return the provided string when prte is used in proxy mode and the PACKAGE_BUGREPORT is requested]))
+if test -n "$with_proxy_bugreport"; then
+    AC_MSG_RESULT([yes])
+    PRRTE_PROXY_BUGREPORT=$with_proxy_bugreport
+else
+    AC_MSG_RESULT([no])
+    PRRTE_PROXY_BUGREPORT=https://github.com/openpmix/prrte/
+fi
+AC_DEFINE_UNQUOTED(PRRTE_PROXY_BUGREPORT, "$PRRTE_PROXY_BUGREPORT",
+                   [Bugreport string to be returned by prte when in proxy mode])
 
 
 #

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,12 +44,6 @@
 #include "src/util/output.h"
 #endif
 
-#if PRRTE_ENABLE_HETEROGENEOUS_SUPPORT
-#include <arpa/inet.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
 #include "src/dss/dss_types.h"
 
 /**
@@ -84,7 +78,7 @@ typedef uint32_t prrte_app_idx_t;
 
 /* general typedefs & structures */
 
-#if PRRTE_ENABLE_HETEROGENEOUS_SUPPORT && !defined(WORDS_BIGENDIAN)
+#if !defined(WORDS_BIGENDIAN)
 #define PRRTE_PROCESS_NAME_NTOH(guid) prrte_process_name_ntoh_intr(&(guid))
 static inline __prrte_attribute_always_inline__ void
 prrte_process_name_ntoh_intr(prrte_process_name_t *name)

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1518,24 +1518,6 @@ void prrte_plm_base_daemon_callback(int status, prrte_process_name_t* sender,
                 free(sig);
                 break;
             }
-#if !PRRTE_ENABLE_HETEROGENEOUS_SUPPORT
-              else {
-                /* check if the difference is due to the endianness */
-                ptr = strrchr(sig, ':');
-                ++ptr;
-                if (0 != strcmp(ptr, myendian)) {
-                    /* we don't currently handle multi-endian operations in the
-                     * MPI support */
-                    prrte_show_help("help-plm-base", "multi-endian", true,
-                                   nodename, ptr, myendian);
-                    prted_failed_launch = true;
-                    if (NULL != topo) {
-                        hwloc_topology_destroy(topo);
-                    }
-                    goto CLEANUP;
-                }
-            }
-#endif
         }
 
         if (!found) {

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -654,9 +654,15 @@ int main(int argc, char *argv[])
      * check for help so that --version --help works as
      * one might expect. */
      if (prrte_cmd_line_is_taken(prrte_cmd_line, "version")) {
-        fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
-                prrte_tool_basename, "PMIx Reference RunTime Environment",
-                PRRTE_VERSION, PACKAGE_BUGREPORT);
+        if (proxyrun) {
+            fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
+                    prrte_tool_basename, PRRTE_PROXY_PACKAGE_NAME,
+                    PRRTE_PROXY_VERSION_STRING, PRRTE_PROXY_BUGREPORT);
+        } else {
+            fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
+                    prrte_tool_basename, "PMIx Reference RunTime Environment",
+                    PRRTE_VERSION, PACKAGE_BUGREPORT);
+        }
         exit(0);
     }
 

--- a/src/tools/prte_info/param.c
+++ b/src/tools/prte_info/param.c
@@ -344,14 +344,12 @@ void prrte_info_do_hostname()
  */
 void prrte_info_do_config(bool want_all)
 {
-    char *heterogeneous;
     char *debug;
     char *have_dl;
     char *prun_prefix_by_default;
     char *symbol_visibility;
 
     /* setup the strings that don't require allocations*/
-    heterogeneous = PRRTE_ENABLE_HETEROGENEOUS_SUPPORT ? "yes" : "no";
     debug = PRRTE_ENABLE_DEBUG ? "yes" : "no";
     have_dl = PRRTE_HAVE_DL_SUPPORT ? "yes" : "no";
     prun_prefix_by_default = PRRTE_WANT_PRRTE_PREFIX_BY_DEFAULT ? "yes" : "no";
@@ -414,7 +412,6 @@ void prrte_info_do_config(bool want_all)
 
     prrte_info_out("Internal debug support", "option:debug", debug);
     prrte_info_out("dl support", "option:dlopen", have_dl);
-    prrte_info_out("Heterogeneous support", "options:heterogeneous", heterogeneous);
     prrte_info_out("prun default --prefix", "prun:prefix_by_default",
                   prun_prefix_by_default);
     prrte_info_out("Symbol vis. support", "options:visibility", symbol_visibility);


### PR DESCRIPTION
Allow someone to configure prte to report an alternative package name,
version, and bugrepot string. Remove stale heterogeneous flag as PRRTE
always supports heterogeneity

Signed-off-by: Ralph Castain <rhc@pmix.org>