### PR TITLE
Protect against badly formed envar

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -772,6 +772,17 @@ int main(int argc, char *argv[])
      * on the daemon executable, the fork/exec agent to be used by
      * the daemons, or other directives impacting the DVM itself */
     if (NULL != (param = getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL"))) {
+        /* check against bad param */
+        ptr = strdup(param);
+        param = strchr(ptr, ':');
+        if (NULL == param) {
+            prrte_show_help("help-prun.txt", "bad-pause-for-tool", true,
+                           prrte_tool_basename, ptr, prrte_tool_basename);
+            PRRTE_UPDATE_EXIT_STATUS(PRRTE_ERR_FATAL);
+            goto DONE;
+        }
+        *param = '\0';
+        ++param;
         /* register for the PMIX_LAUNCH_DIRECTIVE event */
         PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
         ret = PMIX_LAUNCH_DIRECTIVE;
@@ -785,10 +796,6 @@ int main(int argc, char *argv[])
         PRRTE_PMIX_WAIT_THREAD(&lock);
         PRRTE_PMIX_DESTRUCT_LOCK(&lock);
         /* notify the tool that we are ready */
-        ptr = strdup(param);
-        param = strchr(ptr, ':');
-        *param = '\0';
-        ++param;
         (void)strncpy(controller.nspace, ptr, PMIX_MAX_NSLEN);
         controller.rank = strtoul(param, NULL, 10);
         PMIX_INFO_CREATE(iptr, 2);

--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -703,3 +703,13 @@ correct and retry.
 [use-pterm]
 Use of %s to terminate the PRRTE DVM has been deprecated. Please use
 the "pterm" tool instead in the future.
+#
+[bad-pause-for-tool]
+%s detected the presence of the PMIX_LAUNCHER_PAUSE_FOR_TOOL environmental
+variable, but the value of the variable is in an improper form:
+
+  PMIX_LAUNCHER_PAUSE_FOR_TOOL:  %s
+
+The variable must be of the form (nspace:rank) of the tool requesting that
+%s pause for it to connect. Please reset the value of the variable and try
+again.

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1339,6 +1339,16 @@ int prun(int argc, char *argv[])
      * operation, then we need to pause here and give it
      * a chance to tell us what we need to do */
     if (NULL != (param = getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL"))) {
+        ptr = strdup(param);
+        param = strchr(ptr, ':');
+        if (NULL == param) {
+            prrte_show_help("help-prun.txt", "bad-pause-for-tool", true,
+                           prrte_tool_basename, ptr, prrte_tool_basename);
+            PRRTE_UPDATE_EXIT_STATUS(PRRTE_ERR_FATAL);
+            goto DONE;
+        }
+        *param = '\0';
+        ++param;
         /* register for the PMIX_LAUNCH_DIRECTIVE event */
         PRRTE_PMIX_CONSTRUCT_LOCK(&lock);
         ret = PMIX_LAUNCH_DIRECTIVE;
@@ -1352,10 +1362,6 @@ int prun(int argc, char *argv[])
         PRRTE_PMIX_WAIT_THREAD(&lock);
         PRRTE_PMIX_DESTRUCT_LOCK(&lock);
         /* notify the tool that we are ready */
-        ptr = strdup(param);
-        param = strchr(ptr, ':');
-        *param = '\0';
-        ++param;
         (void)strncpy(controller.nspace, ptr, PMIX_MAX_NSLEN);
         controller.rank = strtoul(param, NULL, 10);
         PMIX_INFO_CREATE(iptr, 2);


### PR DESCRIPTION
Check PMIX_LAUNCHER_PAUSE_FOR_TOOL and print a show_help message if it
doesn't contain the correct information.

Fixes https://github.com/openpmix/prrte/issues/516

Thanks to @dirk-schubert-arm for the report

Signed-off-by: Ralph Castain <rhc@pmix.org>