### PR TITLE
Do not manually loop event base

### DIFF
--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1372,9 +1372,7 @@ int prun(int argc, char *argv[])
         PMIx_Notify_event(PMIX_LAUNCHER_READY, &prrte_process_info.myproc, PMIX_RANGE_CUSTOM,
                           iptr, 2, NULL, NULL);
         /* now wait for the launch directives to arrive */
-        while (prrte_event_base_active && myinfo.lock.active) {
-            prrte_event_loop(prrte_event_base, PRRTE_EVLOOP_ONCE);
-        }
+        PRRTE_PMIX_WAIT_THREAD(&myinfo.lock);
         PMIX_INFO_FREE(iptr, 1);
 
         /* process the returned directives */


### PR DESCRIPTION
The progress thread is automatically looped for us, so don't manually
loop it while waiting for the debugger to connect.

Fixes https://github.com/openpmix/prrte/issues/514

Thanks to @dirk-schubert-arm for the report

Signed-off-by: Ralph Castain <rhc@pmix.org>