### PR TITLE
Correctly account for PRRTE-spawned tools

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -960,7 +960,9 @@ void prrte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
     }
 
     /* did the user request we display output in xterms? */
-    if (NULL != prrte_xterm && !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+    if (NULL != prrte_xterm &&
+        !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+        !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_TOOL)) {
         prrte_list_item_t *nmitem;
         prrte_namelist_t *nm;
         /* see if this rank is one of those requested */
@@ -1020,7 +1022,9 @@ void prrte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
     }
 
     /* if we are indexing the argv by rank, do so now */
-    if (cd->index_argv && !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+    if (cd->index_argv &&
+        !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+        !PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_TOOL)) {
         char *param;
         prrte_asprintf(&param, "%s-%d", cd->argv[0], (int)child->name.vpid);
         free(cd->argv[0]);
@@ -1576,10 +1580,11 @@ void prrte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         goto MOVEON;
     }
 
-    /* if this is a debugger daemon, then just report the state
+    /* if this is a debugger daemon or tool, then just report the state
      * and return as we aren't monitoring it
      */
-    if (PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON))  {
+    if (PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) ||
+        PRRTE_FLAG_TEST(jobdat, PRRTE_JOB_FLAG_TOOL))  {
         goto MOVEON;
     }
 

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -538,7 +538,8 @@ prrte_proc_t* prrte_rmaps_base_setup_proc(prrte_job_t *jdata,
     proc->node = node;
     /* if this is a debugger job, then it doesn't count against
      * available slots - otherwise, it does */
-    if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+    if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+        !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
         node->num_procs++;
         ++node->slots_inuse;
     }

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -730,7 +730,8 @@ void prrte_state_base_track_procs(int fd, short argc, void *cbdata)
              * itself.  This covers the case where the process died abnormally
              * and didn't cleanup its own session directory.
              */
-            if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
+            if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+                !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
                 prrte_session_dir_finalize(proc);
             }
         }
@@ -918,8 +919,11 @@ void prrte_state_base_check_all_complete(int fd, short args, void *cbdata)
                     /* skip procs from another job */
                     continue;
                 }
-                node->slots_inuse--;
-                node->num_procs--;
+                if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+                    !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
+                    node->slots_inuse--;
+                    node->num_procs--;
+                }
                 PRRTE_OUTPUT_VERBOSE((2, prrte_state_base_framework.framework_output,
                                      "%s releasing proc %s from node %s",
                                      PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -586,7 +586,8 @@ static void check_complete(int fd, short args, void *cbdata)
                     /* skip procs from another job */
                     continue;
                 }
-                if (!PRRTE_FLAG_TEST(proc, PRRTE_PROC_FLAG_TOOL)) {
+                if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+                    !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
                     node->slots_inuse--;
                     node->num_procs--;
                     node->next_node_rank--;

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -402,7 +402,10 @@ static void track_procs(int fd, short argc, void *cbdata)
          * itself.  This covers the case where the process died abnormally
          * and didn't cleanup its own session directory.
          */
-        prrte_session_dir_finalize(proc);
+        if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+            !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
+            prrte_session_dir_finalize(proc);
+        }
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs
          * remain (might be some from another job)
@@ -495,7 +498,8 @@ static void track_procs(int fd, short argc, void *cbdata)
                             /* skip procs from another job */
                             continue;
                         }
-                        if (!PRRTE_FLAG_TEST(pptr, PRRTE_PROC_FLAG_TOOL)) {
+                        if (!PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_DEBUGGER_DAEMON) &&
+                            !PRRTE_FLAG_TEST(jdata, PRRTE_JOB_FLAG_TOOL)) {
                             node->slots_inuse--;
                             node->num_procs--;
                         }


### PR DESCRIPTION
Don't count them against available slots. Ensure they don't get a
session directory, and that we don't incorrectly cleanup said directory.

Signed-off-by: Ralph Castain <rhc@pmix.org>