### PR TITLE
Report binding whole machine

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1788,8 +1788,6 @@ int prrte_hwloc_base_cset2mapstr(char *str, int len,
     hwloc_obj_t socket, core, pu;
     hwloc_obj_t root;
     prrte_hwloc_topo_data_t *sum;
-    bool fake_on_first_socket;
-    bool fake_on_first_core;
     hwloc_cpuset_t cpuset_for_socket;
     hwloc_cpuset_t cpuset_for_core;
     hwloc_obj_t prev_numa = NULL;
@@ -1832,12 +1830,8 @@ int prrte_hwloc_base_cset2mapstr(char *str, int len,
     type_under_numa = first_type_under_a_numa(topo);
 
     /* Iterate over all existing sockets */
-    fake_on_first_socket = true;
     socket = hwloc_get_obj_by_type(topo, HWLOC_OBJ_SOCKET, 0);
     do {
-        fake_on_first_socket = false;
-        strncat(str, "[", len - strlen(str) - 1);
-
         // if numas contain sockets, example output <[../..][../..]><[../..][../..]>
         if (HWLOC_OBJ_SOCKET == type_under_numa) {
             prev_numa = cur_numa;
@@ -1858,14 +1852,11 @@ int prrte_hwloc_base_cset2mapstr(char *str, int len,
         }
 
         /* Iterate over all existing cores in this socket */
-        fake_on_first_core = true;
         core_index = 0;
         core = hwloc_get_obj_inside_cpuset_by_type(topo,
                                                    cpuset_for_socket,
                                                    HWLOC_OBJ_CORE, core_index);
-        while (NULL != core || fake_on_first_core) {
-            fake_on_first_core = false;
-
+        do {
             /* if numas contain cores and are contained by sockets,
              * example output [<../..><../..>][<../../../..>]
              */
@@ -1936,7 +1927,7 @@ int prrte_hwloc_base_cset2mapstr(char *str, int len,
             core = hwloc_get_obj_inside_cpuset_by_type(topo,
                                                         cpuset_for_socket,
                                                         HWLOC_OBJ_CORE, ++core_index);
-        } /* end while core */
+        } while (NULL != core);
         if (HWLOC_OBJ_CORE == type_under_numa) {
             if (a_numa_marker_is_open) {
                 strncat(str, ">", len - strlen(str) - 1);
@@ -1947,7 +1938,7 @@ int prrte_hwloc_base_cset2mapstr(char *str, int len,
             strncat(str, "]", len - strlen(str) - 1);
             socket = socket->next_cousin;
         }
-    } while (NULL != socket || fake_on_first_socket);
+    } while (NULL != socket);
 
     if (HWLOC_OBJ_SOCKET == type_under_numa) {
         if (a_numa_marker_is_open) {


### PR DESCRIPTION
The main thing this PR does is load a topology with WHOLE_MACHINE (just for use within the printing function):

    report whole machine in --bind-to :REPORT output

```
    Example without this change:
        cgset -r cpuset.cpus=8,9,10,11,12,13,14,15 mycgroup
        cgexec -g cpuset:mycgroup \
            $MPI_ROOT/bin/mpirun --np 2 --bind-to hwthread:REPORT ./x
        MCW rank 0 bound to socket 0[core 0[hwt 0]]: [<B.../....>][]
        MCW rank 1 bound to socket 0[core 0[hwt 1]]: [<.B../....>][]
    Same example with this change:
        cgexec -g cpuset:mycgroup \
            $MPI_ROOT/bin/mpirun --np 2 --bind-to hwthread:REPORT ./x
        MCW rank 0 bound to socket 0[core 2[hwt 0]]: [<~~~~/~~~~/B.../....>][<~~~~/~~~~/~~~~/~~~~>]
        MCW rank 1 bound to socket 0[core 2[hwt 1]]: [<~~~~/~~~~/.B../....>][<~~~~/~~~~/~~~~/~~~~>]
```

    For completeness if you want to test it, here's a brief description
    on how to setup cgroups by hand:
```
      whoami=`whoami`
      mygroup=`id -gn`
      sudo cgcreate -t $whoami:$mygroup -a $whoami:$mygroup -g cpuset:mycgroup
      mems=`cat /sys/fs/cgroup/cpuset/cpuset.mems`
      cgset -r cpuset.mems=$mems mycgroup
      cgset -r cpuset.cpus=0,1,2,3 mycgroup
      cgclassify -g cpuset:mycgroup --sticky $$  # to affect everything under this shell
      sudo cgdelete -g cpuset:mycgroup
```

There's also as second tiny fix in the print binding:

    remove extra [ in cset2mapstr (--bind-to :REPORT output)
```
    There was an extra [ being printed showing hosts as
      [[<../..>][<../..>]
    for example instead of
      [<../..>][<../..>]
```
    Also there are some loops that need to iterate at least once regardless
    of whether a socket or a core object is found, and I agree with whoever
    started to change those from "while" to "do while".  I had initially used
    a "fake_on_first_socket" and "fake_on_first_core" variable, and somebody
    partially changed it to "do while" which makes more sense for this
    usage.  So I completed the change to "do while" and removed the "fake_*"
    vars completely.