### PR TITLE
mpirun doesn't request topology for hosts with different cgroups

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -2175,7 +2175,7 @@ char* prrte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
     complete = (hwloc_bitmap_t)hwloc_topology_get_complete_cpuset(topo);
     allowed = (hwloc_bitmap_t)hwloc_topology_get_allowed_cpuset(topo);
     pus = NULL;
-    if (0 != hwloc_bitmap_list_asprintf(&pus, allowed)) {
+    if (0 >= hwloc_bitmap_list_asprintf(&pus, allowed)) {
         if (NULL != pus) {
             free(pus);
         }
@@ -2185,7 +2185,7 @@ char* prrte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
         cpus = strdup("");
     } else {
         cpus = NULL;
-        if (0 != hwloc_bitmap_list_asprintf(&cpus, complete)) {
+        if (0 >= hwloc_bitmap_list_asprintf(&cpus, complete)) {
             if (NULL != cpus) {
                 free(cpus);
             }


### PR DESCRIPTION
If I have two machines with one using a cgroup 0,1,2,3 and the
other 4,5,6,7 without this checkin on my machines both report a
signature of "1N:1S:1L3:1L2:1L1:1C:4H:unknown:unknown:ppc64le:le"
which isn't enough information to distinguish different cgroups

So in plm_base_launch_support.c in prrte_plm_base_daemon_callback()
when mpirun walks the list of signatures, it concludes that it already
has the incoming topology in its list and sets found=true.

With this checkin the different cgroups come up with different
signatures, specifically:
"1N:1S:1L3:1L2:1L1:1C:4H:H0-3:ppc64le:le"
"1N:1S:1L3:1L2:1L1:1C:4H:H4-7:ppc64le:le"

This checkin uses the conservative approach of hwloc_bitmap_list_asprintf()
to come up with that list "0-3" and "4-7" in the above examples.  I've
still left all my code in for an alternate "mycompress()" that produces
shorter strings than hwloc_bitmap_list_asprintf(), but it's a bunch of
code so I understand reluctance to use it.

Signed-off-by: Mark Allen <markalle@us.ibm.com>