### PR TITLE
bind starting at wrong initial offset for localhost

### DIFF
--- a/src/runtime/prrte_globals.c
+++ b/src/runtime/prrte_globals.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -635,7 +635,7 @@ static void prrte_job_construct(prrte_job_t* job)
                             PRRTE_GLOBAL_ARRAY_BLOCK_SIZE);
     job->map = NULL;
     job->bookmark = NULL;
-    job->bkmark_obj = 0;
+    job->bkmark_obj = -1; // so the initial "next" obj is 0
     job->state = PRRTE_JOB_STATE_UNDEF;
 
     job->num_mapped = 0;


### PR DESCRIPTION
Without this change an example run -np 2 gives
% mpirun --np 2 --bind-to core:REPORT --map-by core hostname
> MCW rank 0 bound to socket 0[core 1[hwt 0-3]]: [[<..../BBBB/..../....>]
> MCW rank 1 bound to socket 0[core 2[hwt 0-3]]: [[<..../..../BBBB/....>]

For the local host, prrte_rmaps_rr_byobj() uses
    start = (jdata->bkmark_obj + 1) % nobjs;
as the starting value of its iterator.  I think the initial value of
that bkmark_obj should be -1 so the initial "next" object is 0

Signed-off-by: Mark Allen <markalle@us.ibm.com>