### PR TITLE
Pelist like cgroup

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -208,7 +208,9 @@ int prrte_hwloc_base_open(void)
          * we do bind to the given cpus if provided, otherwise this would be
          * ignored if someone didn't also specify a binding policy
          */
-        PRRTE_SET_BINDING_POLICY(prrte_hwloc_binding_policy, PRRTE_BIND_TO_CPUSET);
+        if (!PRRTE_BINDING_POLICY_IS_SET(prrte_hwloc_binding_policy)) {
+            PRRTE_SET_BINDING_POLICY(prrte_hwloc_binding_policy, PRRTE_BIND_TO_CPUSET);
+        }
     }
 
     /* if we are binding to hwthreads, then we must use hwthreads as cpus */

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -139,6 +140,16 @@ int prrte_hwloc_base_register(void)
                                   PRRTE_MCA_BASE_VAR_SCOPE_READONLY, &prrte_hwloc_base_cpu_list);
     prrte_mca_base_var_register_synonym (varid, "prrte", "hwloc", "base", "slot_list", PRRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     prrte_mca_base_var_register_synonym (varid, "prrte", "hwloc", "base", "cpu_set", PRRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    // Allow an alternate syntax for the separator, using colon
+    // instead of just commas.  Translate here to commas
+    {
+        char *p;
+        p = prrte_hwloc_base_cpu_list;
+        while (p && *p) {
+            if (*p == ':') { *p = ','; }
+            ++p;
+        }
+    }
 
     /* declare hwthreads as independent cpus */
     prrte_hwloc_use_hwthreads_as_cpus = false;

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -227,6 +227,11 @@ int prrte_hwloc_base_filter_cpus(hwloc_topology_t topo)
     /* cache this info */
     sum->available = avail;
 
+    /* Treat PRRTE_MCA_hwloc_base_cpu_list=#,#,# analogously to how
+     * a cgroup is treated, eg make the loaded topology
+     * only contain what is available. */
+    hwloc_topology_restrict(topo, avail, 0);
+
     return PRRTE_SUCCESS;
 }
 

--- a/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -17,6 +17,7 @@
  *                         reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -108,9 +108,7 @@ static int prrte_rmaps_rank_file_register(void)
 static int prrte_rmaps_rank_file_open(void)
 {
     /* ensure we flag mapping by user */
-    if ((PRRTE_BIND_TO_CPUSET == PRRTE_GET_BINDING_POLICY(prrte_hwloc_binding_policy) &&
-        !PRRTE_BIND_ORDERED_REQUESTED(prrte_hwloc_binding_policy)) ||
-         NULL != prrte_rankfile) {
+    if (NULL != prrte_rankfile) {
         if (PRRTE_MAPPING_GIVEN & PRRTE_GET_MAPPING_DIRECTIVE(prrte_rmaps_base.mapping)) {
             /* if a non-default mapping is already specified, then we
              * have an error

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -255,6 +255,14 @@ static int parse_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--cpu-set") ||
              0 == strcmp(option, "--cpu-list") ) {
         prrte_asprintf(&p2, "PE-LIST=%s", pargs[i+1]);
+        // In --cpu-list it's fine to have 1,2,3
+        // but --map-by is already a comma separated list
+        // so use its alternate syntax of colon separated items in the PE-LIST
+        char *p = p2;
+        while (*p) {
+            if (*p == ',') { *p = ':'; }
+            ++p;
+        }
         rc = prrte_schizo_base_convert(argv, i, 2, "--map-by", NULL, p2);
         free(p2);
     }


### PR DESCRIPTION
This has two commits related to PE-LIST, the first has to do with parsing and the fact that PE-LIST is an option inside a comma separated list and it tries to have another comma separated list as its =value:

    PE-LIST parsing workaround, ex: --map-by core:pe=2,PE-LIST=1,2,3

    The PE-LIST option to --map-by doesn't really make sense since the
    items in the list of options to --map-by are comma separated and
    the PE-LIST can also have commas.

    The parsing function uses prrte_argv_split(ck, ',') which for
    the example case of
        --map-by core:pe=2,PE-LIST=1,2,3
    breaks the string into
        core
        pe=2
        PE-LIST=1
        2
        3

    I think this option was better off as --cpu-list, but I'm putting
    a few workarounds in:
    1. as long as PE-LIST is being parsed as a --map-by item, I have
       a special case where it accepts a comma separated list of
       numbers after PE-LIST as being together, not a separate
       --map-by item.
    2. allowing colons for a less ambiguous syntax in the PE-LIST so
       a person could use PE-LIST=1:2:3
    3. in schizo if --cpu-list 1,2,3 is used and it constructs a
       PE-LIST equivalent, it translates to 1:2:3 for less ambiguity

The second commit is about letting PE-LIST be used like a cgroup, to constrain what's available but not specifically force a binding policy itself, rather allow whatever binding the user specifies within the constrained machine, same thing that would happen in a cgroup.  And there was an error check that I think was too aggressive (intended for the rank-file case) that was stopping PE-LIST from being used.

    PE-LIST should't force BIND_TO_CPUSET if a binding is otherwise specified

    If PE-LIST is given then the binding was being set to PRRTE_BIND_TO_CPUSET,
    but I think that should only happen if a binding wasn't otherwise
    specified.  If a binding was given, it can still be used in the presence
    of PE-LIST, it's just that PE-LIST functions equivalently to a cgroup in
    that case, constraining what PU's are allowed.

    This PR uses hwloc_topology_restrict() to make the PE-LIST path work
    exactly like the cgroup case, if a binding was specified.  If a binding
    wasn't specified then it still lets the binding be set to
    PRRTE_BIND_TO_CPUSET like the code was doing before.

    There was also a too-aggressive error check in prrte_rmaps_rank_file_register()
    that was active not only in the case of a rankfile being used, but was also
    active if
        PRRTE_BIND_TO_CPUSET == PRRTE_GET_BINDING_POLICY(prrte_hwloc_binding_policy) &&
        !PRRTE_BIND_ORDERED_REQUESTED(prrte_hwloc_binding_policy)
    which was causing any use of BIND_TO_CPUSET to fail (eg the case of not
    specifying a binding but using PE-LIST, where BIND_TO_CPUSET gets set
    as the binding).

    Example failing command without the change to the above error check:
    % mpirun --np 2 --map-by core:,PE-LIST=4-99 ./pp.x
    > Conflicting directives for mapping policy are causing the policy
    > to be redefined:
    >   New policy:   RANK_FILE
    >   Prior policy:  BYCORE