### PR TITLE
connect cmdlines to MCA settings

### DIFF
--- a/src/util/argv.h
+++ b/src/util/argv.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
  *
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -293,6 +294,30 @@ PRRTE_EXPORT  int prrte_argv_insert(char ***target, int start, char **source);
  * target).
  */
 PRRTE_EXPORT  int prrte_argv_insert_element(char ***target, int location, char *source);
+
+/*
+ * This is used to parse the argument in cases like
+ *   --map-by core:pe=2,PE-LIST=4-63
+ * Here the input arg is "core:pe=2,PE-LIST=4-63"
+ *
+ * The list_item might be "pe" in which case want the output
+ * to be *str = strdup of "2"
+ *
+ * The list_item_separators string specifies where the list
+ * begins, and what separates items.
+ *
+ * Also though I don't think it's allowed elsewhere, here we'll
+ * allow --map-by pe=2 for example, so if arg starts with the
+ * string being searched for, it will accept it without requiring
+ * that it be after an expected initial colon.
+ *
+ * returns 1 if it found the setting listed, 0 if it didn't
+ */
+PRRTE_EXPORT  int prrte_parse_arg_for_a_listed_setting(
+    char *arg,
+    char *list_item,
+    char *list_item_term,
+    char **str);
 
 END_C_DECLS
 

--- a/src/util/cmd_line.h
+++ b/src/util/cmd_line.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -258,6 +258,24 @@ typedef struct prrte_cmd_line_init_t {
     /** Category for --help output */
     prrte_cmd_line_otype_t ocl_otype;
 } prrte_cmd_line_init_t;
+
+/*
+ * Keep track of command line options imply what MCA settings.  This is
+ * needed for options like --bind-to where hwloc initialization happens
+ * before the cmdline is parsed, and mca_var_register() calls start saving
+ * settings that aren't visible yet.  And more generally whenever settings
+ * are queried with mca_var_register() the cmdline options don't
+ * necessarily cause those MCA settings to be visible.
+ */
+typedef struct {
+  char *cmdline_arg;
+  char *list_item;
+  char *list_item_separators;
+  char *mca_name;
+  int is_required_early;
+} prrte_cmdline_equivalencies_t;
+
+extern prrte_cmdline_equivalencies_t prrte_cmd_line_equivalencies[];
 
 /**
  * Top-level command line handle.
@@ -561,6 +579,16 @@ PRRTE_EXPORT int prrte_cmd_line_get_ninsts(prrte_cmd_line_t *cmd,
  */
 PRRTE_EXPORT prrte_value_t *prrte_cmd_line_get_param(prrte_cmd_line_t *cmd,
                                                      const char *opt,
+                                                     int instance_num,
+                                                     int param_num);
+
+/**
+ * The next function is a wrapper of the above that additionally checks
+ * if the setting is available at the specified MCA setting env var
+ */
+PRRTE_EXPORT prrte_value_t *prrte_cmd_line_get_param_or_env(prrte_cmd_line_t *cmd,
+                                                     const char *opt,
+                                                     const char *env,
                                                      int instance_num,
                                                      int param_num);
 


### PR DESCRIPTION
This PR may need some discussion about what's the best way to fix this.  This PR feels a bit like a band-aid, but I think it's pretty good as far as band-aids go.  If you try to use the various map-by bind-to rank-by options via cmdline and via MCA settings the instructions take two different paths for where they get stored and the parts of the code that care about those settings half are looking in one place and half the other.

--------------------------------------------------------------------------
There's a disconnect between command line options and MCA settings in
two ways:

1. settings are queried through completely different mechanisms in
   different parts of the code:
   a. prrte_cmd_line_get_param(prrte_cmd_line, "bind-to",,)
   b. prrte_mca_base_var_register("prrte", "hwloc", "base", "binding_policy",)
   those settings diverge depending on how the bind-to option is specified.
2. there's an ordering issue at least in hwloc where initialization happens
   very early so even if --prtemca hwloc_base_binding_policy .. is on the
   cmdline, prrte_mca_base_var_register() won't see it because it happens
   too early where the cmdline hasn't been processed yet.

An extension of the same problem is --bind-to something:REPORT where the
parsing of the --bind-to argument creates a PMIX_BINDTO setting that controls
whether reporting happens, but PRRTE_MCA_hwloc_base_report_bindings is a
step further removed, because the prte.c cmdline parsing that processes
"bind-to" is separate from the later code that looks at its value, and
that's the code that needs to see :REPORT

This checkin has three locations in prte.c where it adds creation of MCA
settings based on cmdlines, and modifies the processing of command lines
based on MCA settings.

- observe the cmdline for options like --bind-to .. and
  --prtemca hwloc_base_binding_policy .. and set an equivalent MCA
  such as PRRTE_MCA_hwloc_base_binding_policy

  This is done extra early for some MCA settings because they will be
  read during rte_init() before the cmdline is looked at otherwise,
  for example hwloc init happens in rte_init() and it looks at quite
  a few MCAs like the binding policy, and mapping policy's PE-LIST

- a little later do the same thing for the rest of the cmdline options
  that didn't need to be handled extra early.  A second purpose of
  this section is that the cmdline could have additions by schizo
  for example, so we need to re-examine it anyway

- when the cmdline options are processed with prrte_cmd_line_get_param()
  I've added a prrte_cmd_line_get_param_or_env() that lets some of
  them notice if there's an MCA setting filling the same role.
  In that area there's also one case that's more complex, where the
  "bind-to" option is being looked at, and not only does it look for
  "PRRTE_MCA_hwloc_base_binding_policy" but it also looks for
  "PRRTE_MCA_hwloc_base_report_bindings" and if it finds that then
  it adds :REPORT to the existing setting (or makes one if there isn't
  an existing setting).

Related to the above, in prted.c a small portion of the above is done.
There the command lines are simpler, with just things like
    --prtemca hwloc_base_binding_policy stuff
which will eventually go into the environment and be visible to
prrte_mca_base_var_register(), but like before hwloc for example
is intiailized too early so we need to scan the cmdline early for
some of those options.
