### PR TITLE
Initialize the bookmark object to a recognizable flag

### DIFF
--- a/src/mca/rmaps/round_robin/rmaps_rr_assign.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_assign.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -128,7 +128,8 @@ int prrte_rmaps_rr_assign_byobj(prrte_job_t *jdata,
 
             /* if this is a comm_spawn situation, start with the object
              * where the parent left off and increment */
-            if (PRRTE_JOBID_INVALID != jdata->originator.jobid) {
+            if (PRRTE_JOBID_INVALID != jdata->originator.jobid &&
+                UINT_MAX != jdata->bkmark_obj) {
                 start = (jdata->bkmark_obj + 1) % nobjs;
             } else {
                 start = 0;
@@ -163,6 +164,8 @@ int prrte_rmaps_rr_assign_byobj(prrte_job_t *jdata,
                     return PRRTE_ERR_SILENT;
                 }
                 prrte_set_attribute(&proc->attributes, PRRTE_PROC_HWLOC_LOCALE, PRRTE_ATTR_LOCAL, obj, PRRTE_PTR);
+                /* track the bookmark */
+                jdata->bkmark_obj = (j + start) % nobjs;
             }
         }
     }

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2009-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -540,7 +540,8 @@ int prrte_rmaps_rr_byobj(prrte_job_t *jdata,
 
             /* if this is a comm_spawn situation, start with the object
              * where the parent left off and increment */
-            if (PRRTE_JOBID_INVALID != jdata->originator.jobid) {
+            if (PRRTE_JOBID_INVALID != jdata->originator.jobid &&
+                UINT_MAX != jdata->bkmark_obj) {
                 start = (jdata->bkmark_obj + 1) % nobjs;
             }
             /* compute the number of procs to go on this node */
@@ -605,7 +606,9 @@ int prrte_rmaps_rr_byobj(prrte_job_t *jdata,
                     nprocs_mapped++;
                     nmapped++;
                     prrte_set_attribute(&proc->attributes, PRRTE_PROC_HWLOC_LOCALE, PRRTE_ATTR_LOCAL, obj, PRRTE_PTR);
-                }
+                     /* track the bookmark */
+                    jdata->bkmark_obj = (i + start) % nobjs;
+               }
             } while (nmapped < nprocs && nprocs_mapped < (int)app->num_procs);
             add_one = true;
             /* not all nodes are equal, so only set oversubscribed for

--- a/src/runtime/prrte_globals.c
+++ b/src/runtime/prrte_globals.c
@@ -635,7 +635,7 @@ static void prrte_job_construct(prrte_job_t* job)
                             PRRTE_GLOBAL_ARRAY_BLOCK_SIZE);
     job->map = NULL;
     job->bookmark = NULL;
-    job->bkmark_obj = 0;
+    job->bkmark_obj = UINT_MAX;  // mark that we haven't assigned a bkmark yet
     job->state = PRRTE_JOB_STATE_UNDEF;
 
     job->num_mapped = 0;


### PR DESCRIPTION
Ensure that we know if the bookmark object has not previously been set
by initializing it to UINT_MAX. Check for that value prior to use and
set our starting point to zero if we haven't previously established a
bookmark.

Closes #527 

Signed-off-by: Ralph Castain <rhc@pmix.org>