### PR TITLE
Fixed ordering of included paths when building outside the src dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1078,7 +1078,7 @@ if test "$PRRTE_TOP_BUILDDIR" != "$PRRTE_TOP_SRCDIR"; then
     # rather than have successive assignments to these shell
     # variables, lest the $(foo) names try to get evaluated here.
     # Yuck!
-    cpp_includes="$PRRTE_TOP_SRCDIR $PRRTE_TOP_BUILDDIR $PRRTE_TOP_SRCDIR/src/include $PRRTE_TOP_BUILDDIR/src/include"
+    cpp_includes="$PRRTE_TOP_BUILDDIR $PRRTE_TOP_SRCDIR $PRRTE_TOP_BUILDDIR/src/include $PRRTE_TOP_SRCDIR/src/include"
 else
     cpp_includes="$PRRTE_TOP_SRCDIR $PRRTE_TOP_SRCDIR/src/include"
 fi


### PR DESCRIPTION
We experienced the build failure when build the OMPI master nightly snapshot:
```bash
jazz10: /labhome/user/src/ompi/prrte/src/include/prrte_stdatomic.h:35:23: fatal error: stdatomic.h: No such file or directory
jazz10:  #include <stdatomic.h>
jazz10:                        ^
jazz10: compilation terminated.
```
Build is performed outside of the source directory and generates the new `prrte_config.h`. But since `prrte_config.h` which delivered with the nightly snapshot, was found first in the included paths and did not match the new `prrte_config.h`, this led to a build failure.