### PR TITLE
Fix implicit declaration of mca_base_var_env_name

### DIFF
--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -295,7 +295,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     env = prrte_argv_copy(prrte_launch_environ);
 
     /* enable local launch by the orteds */
-    (void) mca_base_var_env_name ("plm", &var);
+    (void) prrte_mca_base_var_env_name ("plm", &var);
     prrte_setenv(var, "rsh", true, &env);
     free(var);
 


### PR DESCRIPTION
Implicit declaration encountered when building with torque/pbs support.

Signed-off-by: Michael Karo mike0042@gmail.com