### PR TITLE
Fix the daemon name issue

### DIFF
--- a/src/mca/ess/alps/ess_alps_module.c
+++ b/src/mca/ess/alps/ess_alps_module.c
@@ -123,19 +123,14 @@ static int alps_set_name(void)
 {
     int rc;
     int rank;
-    prrte_jobid_t jobid;
 
     if (NULL == prrte_ess_base_nspace) {
         PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);
         return PRRTE_ERR_NOT_FOUND;
     }
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, prrte_ess_base_nspace);
-    if (PRRTE_SUCCESS != rc) {
-        return rc;
-    }
+    PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, prrte_ess_base_nspace);
     PMIX_LOAD_NSPACE(prrte_process_info.myproc.nspace, prrte_ess_base_nspace);
-    PRRTE_PROC_MY_NAME->jobid = jobid;
 
     if (NULL == prrte_ess_base_vpid) {
         PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -129,7 +129,6 @@ static int rte_finalize(void)
 static int env_set_name(void)
 {
     int rc;
-    prrte_jobid_t jobid;
     prrte_vpid_t vpid;
 
     if (NULL == prrte_ess_base_nspace) {
@@ -137,10 +136,7 @@ static int env_set_name(void)
         return PRRTE_ERR_NOT_FOUND;
     }
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, prrte_ess_base_nspace);
-    if (PRRTE_SUCCESS != rc) {
-        return rc;
-    }
+    PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, prrte_ess_base_nspace);
     PMIX_LOAD_NSPACE(prrte_process_info.myproc.nspace, prrte_ess_base_nspace);
 
     if (NULL == prrte_ess_base_vpid) {
@@ -149,8 +145,6 @@ static int env_set_name(void)
     }
     vpid = strtoul(prrte_ess_base_vpid, NULL, 10);
     prrte_process_info.myproc.rank = vpid;
-
-    PRRTE_PROC_MY_NAME->jobid = jobid;
     PRRTE_PROC_MY_NAME->vpid = vpid;
 
     PRRTE_OUTPUT_VERBOSE((1, prrte_ess_base_framework.framework_output,

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -111,7 +111,6 @@ static int lsf_set_name(void)
 {
     int rc;
     int lsf_nodeid;
-    prrte_jobid_t jobid;
     prrte_vpid_t vpid;
 
     if (NULL == prrte_ess_base_nspace) {
@@ -119,12 +118,8 @@ static int lsf_set_name(void)
         return PRRTE_ERR_NOT_FOUND;
     }
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, prrte_ess_base_nspace);
-    if (PRRTE_SUCCESS != rc) {
-        return rc;
-    }
+    PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, prrte_ess_base_nspace);
     PMIX_LOAD_NSPACE(prrte_process_info.myproc.nspace, prrte_ess_base_nspace);
-    PRRTE_PROC_MY_NAME->jobid = jobid;
 
     if (NULL == prrte_ess_base_vpid) {
         PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -106,7 +106,6 @@ static int rte_finalize(void)
 static int slurm_set_name(void)
 {
     int slurm_nodeid;
-    prrte_jobid_t jobid;
     prrte_vpid_t vpid;
     char *tmp;
     int rc;
@@ -119,12 +118,8 @@ static int slurm_set_name(void)
         return PRRTE_ERR_NOT_FOUND;
     }
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, prrte_ess_base_nspace);
-    if (PRRTE_SUCCESS != rc) {
-        return rc;
-    }
+    PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, prrte_ess_base_nspace);
     PMIX_LOAD_NSPACE(prrte_process_info.myproc.nspace, prrte_ess_base_nspace);
-    PRRTE_PROC_MY_NAME->jobid = jobid;
 
     if (NULL == prrte_ess_base_vpid) {
         PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);

--- a/src/mca/ess/tm/ess_tm_module.c
+++ b/src/mca/ess/tm/ess_tm_module.c
@@ -110,7 +110,6 @@ static int rte_finalize(void)
 static int tm_set_name(void)
 {
     int rc;
-    prrte_jobid_t jobid;
     prrte_vpid_t vpid;
 
     PRRTE_OUTPUT_VERBOSE((1, prrte_ess_base_framework.framework_output,
@@ -121,12 +120,8 @@ static int tm_set_name(void)
         return PRRTE_ERR_NOT_FOUND;
     }
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &jobid, prrte_ess_base_nspace);
-    if (PRRTE_SUCCESS != rc) {
-        return rc;
-    }
+    PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, prrte_ess_base_nspace);
     PMIX_LOAD_NSPACE(prrte_process_info.myproc.nspace, prrte_ess_base_nspace);
-    PRRTE_PROC_MY_NAME->jobid = jobid;
 
     if (NULL == prrte_ess_base_vpid) {
         PRRTE_ERROR_LOG(PRRTE_ERR_NOT_FOUND);

--- a/src/mca/oob/base/oob_base_stubs.c
+++ b/src/mca/oob/base/oob_base_stubs.c
@@ -83,6 +83,10 @@ void prrte_oob_base_send_nb(int fd, short args, void *cbdata)
                                                                      ui64, (void**)&pr) ||
                     NULL == pr) {
                     /* that is just plain wrong */
+                    prrte_output_verbose(5, prrte_oob_base_framework.framework_output,
+                                        "%s oob:base:send addressee unknown %s",
+                                        PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME),
+                                        PRRTE_NAME_PRINT(&msg->dst));
                     PRRTE_ERROR_LOG(PRRTE_ERR_ADDRESSEE_UNKNOWN);
                     msg->status = PRRTE_ERR_ADDRESSEE_UNKNOWN;
                     PRRTE_RML_SEND_COMPLETE(msg);
@@ -298,6 +302,10 @@ static void process_uri(char *uri)
     int rc;
     uint64_t ui64;
     prrte_oob_base_peer_t *pr;
+
+    prrte_output_verbose(5, prrte_oob_base_framework.framework_output,
+                        "%s:set_addr processing uri %s",
+                        PRRTE_NAME_PRINT(PRRTE_PROC_MY_NAME), uri);
 
     /* find the first semi-colon in the string */
     cptr = strchr(uri, ';');

--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -47,10 +47,8 @@ int prrte_plm_base_set_hnp_name(void)
         PMIX_LOAD_PROCID(&prrte_process_info.myproc, evar, 0);
         /* setup the corresponding numerical jobid and add the
          * job to the hash table */
-        PRRTE_PMIX_CONVERT_NSPACE(rc, &PRRTE_PROC_MY_NAME->jobid, evar);
-        if (PRRTE_SUCCESS != rc) {
-            return rc;
-        }
+        PRRTE_PMIX_REGISTER_DAEMON_NSPACE(&PRRTE_PROC_MY_NAME->jobid, evar);
+
         if (NULL != (evar = getenv("PMIX_SERVER_RANK"))) {
             PRRTE_PROC_MY_NAME->vpid = strtoul(evar, NULL, 10);
         } else {

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -62,6 +62,23 @@ int prrte_convert_jobid_to_nspace(pmix_nspace_t nspace, prrte_jobid_t jobid)
 }
 
 
+void prrte_convert_daemon_nspace(prrte_jobid_t *jobid, pmix_nspace_t nspace)
+{
+    prrte_job_t *jdata;
+    uint32_t hash32, localjob = 0;
+    uint16_t jobfam;
+
+    jdata = PRRTE_NEW(prrte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);  // ensure we do this first so create_jobid can use the nspace
+    PRRTE_HASH_STR(nspace, hash32);
+
+    /* now compress to 16-bits */
+    jobfam = (uint16_t)(((0x0000ffff & (0xffff0000 & hash32) >> 16)) ^ (0x0000ffff & hash32));
+    jdata->jobid = (0xffff0000 & ((uint32_t)jobfam << 16));
+    *jobid = jdata->jobid;
+    prrte_hash_table_set_value_uint32(prrte_job_data, jdata->jobid, jdata);
+}
+
 int prrte_convert_nspace_to_jobid(prrte_jobid_t *jobid, pmix_nspace_t nspace)
 {
     uint32_t key;

--- a/src/util/name_fns.c
+++ b/src/util/name_fns.c
@@ -339,14 +339,8 @@ int prrte_util_convert_string_to_vpid(prrte_vpid_t *vpid, const char* vpidstring
 int prrte_util_convert_string_to_process_name(prrte_process_name_t *name,
                                              const char* name_string)
 {
-    char *temp, *token;
-    prrte_jobid_t job;
-    prrte_vpid_t vpid;
+    char *p;
     int rc;
-
-    /* set default */
-    name->jobid = PRRTE_JOBID_INVALID;
-    name->vpid = PRRTE_VPID_INVALID;
 
     /* check for NULL string - error */
     if (NULL == name_string) {
@@ -354,29 +348,17 @@ int prrte_util_convert_string_to_process_name(prrte_process_name_t *name,
         return PRRTE_ERR_BAD_PARAM;
     }
 
-    temp = strdup(name_string);  /** copy input string as the strtok process is destructive */
-    token = strchr(temp, PRRTE_SCHEMA_DELIMITER_CHAR); /** get first field -> jobid */
+    p = strrchr(name_string, PRRTE_SCHEMA_DELIMITER_CHAR); /** get last field -> vpid */
 
     /* check for error */
-    if (NULL == token) {
+    if (NULL == p) {
         PRRTE_ERROR_LOG(PRRTE_ERR_BAD_PARAM);
-        free(temp);
         return PRRTE_ERR_BAD_PARAM;
     }
-    *token = '\0';
-    token++;
+    p++;
 
-    PRRTE_PMIX_CONVERT_NSPACE(rc, &job, temp);
-    if (PRRTE_SUCCESS != rc) {
-        free(temp);
-        return rc;
-    }
-    vpid = strtoul(token, NULL, 10);
-
-    name->jobid = job;
-    name->vpid = vpid;
-
-    free(temp);
+    name->jobid = PRRTE_PROC_MY_NAME->jobid;
+    name->vpid = strtoul(p, NULL, 10);
 
     return PRRTE_SUCCESS;
 }

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -42,7 +42,10 @@
 
 #include "src/dss/dss_types.h"
 #include "src/hwloc/hwloc-internal.h"
-#include "src/pmix/pmix-internal.h"
+#include PRRTE_PMIX_HEADER
+#if ! PRRTE_PMIX_HEADER_GIVEN
+#include <pmix_common.h>
+#endif
 
 BEGIN_C_DECLS
 


### PR DESCRIPTION
When assigned a name by an external body (e.g., when fork/exec'd by PMIx
or directly by a tool), the format of the name is outside of PRRTE's
control. In particular, it could contain a '.' in it, which is what
PRRTE uses to delimit the job family from the local jobid when
converting to/from string.

We know when we are registering the job family, so take advantage of
that knowledge to avoid looking for the '.'. When we are converting the
jobid of one of our children, then search the nspace backwards for the
first '.' and use that as the delimiter.

Signed-off-by: Ralph Castain <rhc@pmix.org>