### PR TITLE
Protect against systems that forward environment and silence warnings

### DIFF
--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -128,7 +128,6 @@ static int rte_finalize(void)
 
 static int env_set_name(void)
 {
-    int rc;
     prrte_vpid_t vpid;
 
     if (NULL == prrte_ess_base_nspace) {

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -109,7 +109,6 @@ static int rte_finalize(void)
 
 static int lsf_set_name(void)
 {
-    int rc;
     int lsf_nodeid;
     prrte_vpid_t vpid;
 

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -108,7 +108,6 @@ static int slurm_set_name(void)
     int slurm_nodeid;
     prrte_vpid_t vpid;
     char *tmp;
-    int rc;
 
     PRRTE_OUTPUT_VERBOSE((1, prrte_ess_base_framework.framework_output,
                          "ess:slurm setting name"));

--- a/src/mca/ess/tm/ess_tm_module.c
+++ b/src/mca/ess/tm/ess_tm_module.c
@@ -109,7 +109,6 @@ static int rte_finalize(void)
 
 static int tm_set_name(void)
 {
-    int rc;
     prrte_vpid_t vpid;
 
     PRRTE_OUTPUT_VERBOSE((1, prrte_ess_base_framework.framework_output,

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -255,6 +255,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * ALPS aprun  OPTIONS
      */
 
+    /* protect against launchers that forward the entire environment */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
+    }
+    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
+        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
+    }
+
     /* add the aprun command */
     prrte_argv_append(&argc, &argv, prrte_plm_alps_component.aprun_cmd);
 

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -261,6 +261,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * PRRTED OPTIONS
      */
 
+    /* protect against launchers that forward the entire environment */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
+    }
+    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
+        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
+    }
+
     /* add the daemon command (as specified by user) */
     prrte_plm_base_setup_prted_cmd(&argc, &argv);
 

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -292,6 +292,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
      */
     prrte_setenv("SLURM_CPU_BIND", "none", true, &env);
 
+    /* protect against launchers that forward the entire environment */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
+    }
+    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
+        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
+    }
+
 #if SLURM_CRAY_ENV
     /*
      * If in a SLURM/Cray env. make sure that Cray PMI is not pulled in,

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -285,6 +285,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
         connected = true;
     }
 
+    /* protect against launchers that forward the entire environment */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
+    }
+    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
+        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
+    }
+
     /* Figure out the basenames for the libdir and bindir.  There is a
        lengthy comment about this in plm_rsh_module.c explaining all
        the rationale for how / why we're doing this. */

--- a/src/util/name_fns.c
+++ b/src/util/name_fns.c
@@ -340,7 +340,6 @@ int prrte_util_convert_string_to_process_name(prrte_process_name_t *name,
                                              const char* name_string)
 {
     char *p;
-    int rc;
 
     /* check for NULL string - error */
     if (NULL == name_string) {


### PR DESCRIPTION
Protect against systems that forward environment
Some systems forward the _entire_ environment when launching, thus
causing problems when some envars should be local-only. Protect against
those cases by "unsetting" the envars prior to launch.

Note that this modifies the user's environment, so they will have to
reset those envars if they want to reuse them. The current envars are,
however, single-shot ones that get reset anyway, so hopefully it won't
prove overly onerous.

Silence warnings

Fixes #540 

Signed-off-by: Ralph Castain <rhc@pmix.org>
