### PR TITLE
Fix typo - check for correct allow-run-as-root option

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1111,7 +1111,7 @@ static int allow_run_as_root(prrte_cmd_line_t *cmd_line)
     /* we always run last */
     char *r1, *r2;
 
-    if (prrte_cmd_line_is_taken(cmd_line, "allow_run_as_root")) {
+    if (prrte_cmd_line_is_taken(cmd_line, "allow-run-as-root")) {
         return PRRTE_SUCCESS;
     }
 

--- a/src/mca/schizo/prrte/schizo_prrte.c
+++ b/src/mca/schizo/prrte/schizo_prrte.c
@@ -588,7 +588,7 @@ static int allow_run_as_root(prrte_cmd_line_t *cmd_line)
     /* we always run last */
     char *r1, *r2;
 
-    if (prrte_cmd_line_is_taken(cmd_line, "allow_run_as_root")) {
+    if (prrte_cmd_line_is_taken(cmd_line, "allow-run-as-root")) {
         return PRRTE_SUCCESS;
     }
 


### PR DESCRIPTION
Refs https://github.com/open-mpi/ompi/issues/7704

Signed-off-by: Ralph Castain <rhc@pmix.org>