### PR TITLE
Makefiles: remove a little kruft

### DIFF
--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -32,11 +32,6 @@ if PRRTE_ENABLE_MAN_PAGES
 man_MANS = $(man_pages_from_md)
 endif
 
-# Ensure that the man pages are rebuilt if the prrte_config.h file
-# changes; a "good enough" way to know if configure was run again (and
-# therefore the release date or version may have changed)
-$(nodist_man_MANS): $(top_builddir)/src/include/prrte_config.h
-
 prte_SOURCES = \
         prte.c
 

--- a/src/tools/prte_info/Makefile.am
+++ b/src/tools/prte_info/Makefile.am
@@ -72,6 +72,3 @@ prte_info_LDADD = \
     $(prrte_hwloc_LIBS) \
     $(prrte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
-
-clean-local:
-	test -z "$(PRRTE_CXX_TEMPLATE_REPOSITORY)" || rm -rf $(PRRTE_CXX_TEMPLATE_REPOSITORY)


### PR DESCRIPTION
Remove one rule that was missed in the pandoc/Markdown initial PR, and
remove a reference to cleaning C++ template directories that is no
longer relevant.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>