### PR TITLE
Avoid adding external libs until done with configure

### DIFF
--- a/config/prrte_setup_libev.m4
+++ b/config/prrte_setup_libev.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # $COPYRIGHT$
@@ -15,7 +15,7 @@
 # MCA_libev_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PRRTE_LIBEV_CONFIG],[
-    PRRTE_VAR_SCOPE_PUSH([prrte_libev_dir prrte_libev_libdir prrte_libev_standard_header_location prrte_libev_standard_lib_location])
+    PRRTE_VAR_SCOPE_PUSH([prrte_libev_dir prrte_libev_libdir prrte_libev_standard_header_location prrte_libev_standard_lib_location prrte_check_libev_save_CPPFLAGS prrte_check_libev_save_LDFLAGS prrte_check_libev_save_LIBS])
 
     AC_ARG_WITH([libev],
                 [AC_HELP_STRING([--with-libev=DIR],
@@ -32,7 +32,7 @@ AC_DEFUN([PRRTE_LIBEV_CONFIG],[
     AS_IF([test -n "$with_libev" && test "$with_libev" != "no"],
           [AC_MSG_CHECKING([for libev in])
            prrte_check_libev_save_CPPFLAGS="$CPPFLAGS"
-           prrte_check_libeve_save_LDFLAGS="$LDFLAGS"
+           prrte_check_libev_save_LDFLAGS="$LDFLAGS"
            prrte_check_libev_save_LIBS="$LIBS"
            if test "$with_libev" != "yes"; then
                prrte_libev_dir=$with_libev/include
@@ -72,14 +72,14 @@ AC_DEFUN([PRRTE_LIBEV_CONFIG],[
            LIBS="$prrte_check_libev_save_LIBS"])
 
     AS_IF([test $prrte_libev_support -eq 1],
-          [LIBS="$LIBS $prrte_libev_LIBS"
+          [PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_LIBS, $prrte_libev_LIBS)
            PRRTE_WRAPPER_FLAGS_ADD(LIBS, $prrte_libev_LIBS)
 
            AS_IF([test "$prrte_libev_standard_header_location" != "yes"],
-                 [CPPFLAGS="$CPPFLAGS $prrte_libev_CPPFLAGS"]
-                  PRRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prrte_libev_CPPFLAGS))
+                 [PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_CPPFLAGS, $prrte_libev_CPPFLAGS)
+                  PRRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prrte_libev_CPPFLAGS)])
            AS_IF([test "$prrte_libev_standard_lib_location" != "yes"],
-                 [LDFLAGS="$LDFLAGS $prrte_libev_LDFLAGS"
+                 [PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_LDFLAGS $prrte_libev_LDFLAGS)
                   PRRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prrte_libev_LDFLAGS)])])
 
     AC_MSG_CHECKING([will libev support be built])

--- a/config/prrte_setup_pmix.m4
+++ b/config/prrte_setup_pmix.m4
@@ -164,6 +164,11 @@ AC_DEFUN([PRRTE_CHECK_PMIX],[
                                    AC_MSG_WARN([that was dead on arrival])
                                    AC_MSG_ERROR([Please select another version and configure again])])])
 
+        # restore the global flags
+        CPPFLAGS=$prrte_external_pmix_save_CPPFLAGS
+        LDFLAGS=$prrte_external_pmix_save_LDFLAGS
+        LIBS=$prrte_external_pmix_save_LIBS
+
         AS_IF([test "$prrte_external_pmix_version_found" = "0"],
               [AC_MSG_WARN([PRTE does not support PMIx versions])
                AC_MSG_WARN([less than v3.0 as only PMIx-based tools can])
@@ -179,17 +184,17 @@ AC_DEFUN([PRRTE_CHECK_PMIX],[
               [prrte_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
                prrte_pmix_LDFLAGS="-L$pmix_ext_install_libdir"])
 
-        PRRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prrte_pmix_CPPFLAGS)
+        PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_CPPFLAGS, $prrte_pmix_CPPFLAGS)
         PRRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [$prrte_pmix_CPPFLAGS])
 
         AS_IF([test "$enable_pmix_devel_support" = "yes"],
               [PRRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include/pmix -I$pmix_ext_install_dir/include/pmix/src -I$pmix_ext_install_dir/include/pmix/src/include])])
 
-        PRRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prrte_pmix_LDFLAGS)
+        PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_LDFLAGS, $prrte_pmix_LDFLAGS)
         PRRTE_WRAPPER_FLAGS_ADD([LDFLAGS], [$prrte_pmix_LDFLAGS])
 
         prrte_pmix_LIBS=-lpmix
-        PRRTE_FLAGS_APPEND_UNIQ(LIBS, $prrte_pmix_LIBS)
+        PRRTE_FLAGS_APPEND_UNIQ(PRRTE_FINAL_LIBS, $prrte_pmix_LIBS)
         PRRTE_WRAPPER_FLAGS_ADD(LIBS, $prrte_pmix_LIBS)
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1088,7 +1088,9 @@ else
     cpp_includes="$PRRTE_TOP_SRCDIR $PRRTE_TOP_SRCDIR/src/include"
 fi
 CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$prrte_cc_iquote"'&/g')"
-CPPFLAGS="$CPP_INCLUDES $CPPFLAGS"
+CPPFLAGS="$CPP_INCLUDES $CPPFLAGS $PRRTE_FINAL_CPPFLAGS"
+LDFLAGS="$LDFLAGS $PRRTE_FINAL_LDFLAGS"
+LIBS="$LIBS $PRRTE_FINAL_LIBS"
 
 #
 # Delayed the substitution of CFLAGS and CXXFLAGS until now because


### PR DESCRIPTION
The PMIx, HWLOC, libevent, and libev libraries are all external
dependencies. However, we need to delay adding any required CPPFLAGS,
LDFLAGS, and LIBS until we are done with configure so we don't interfere
with any configure tests.

Signed-off-by: Ralph Castain <rhc@pmix.org>