### PR TITLE
Correct typo in mapping-too-low* help messages

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -346,7 +346,7 @@ situation and try again.
 #
 [mapping-too-low]
 A request for multiple cpus-per-proc was given, but a directive
-was also give to map to an object level that has less cpus than
+was also given to map to an object level that has less cpus than
 requested ones:
 
   #cpus-per-proc:  %d
@@ -402,7 +402,7 @@ by specifying "--bind-to none" on your command line.
 #
 [mapping-too-low-init]
 A request for multiple cpus-per-proc was given, but a directive
-was also give to map to an object level that cannot support that
+was also given to map to an object level that cannot support that
 directive.
 
 Please specify a mapping level that has more than one cpu, or

--- a/src/mca/rtc/base/help-prte-rtc-base.txt
+++ b/src/mca/rtc/base/help-prte-rtc-base.txt
@@ -243,7 +243,7 @@ situation and try again.
 #
 [mapping-too-low]
 A request for multiple cpus-per-proc was given, but a directive
-was also give to map to an object level that has less cpus than
+was also given to map to an object level that has less cpus than
 requested ones:
 
   #cpus-per-proc:  %d


### PR DESCRIPTION
Bring over from https://github.com/open-mpi/ompi/pull/7718