### PR TITLE
Ensure proper termination when non-persistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,8 @@ src/tools/pterm/pterm
 
 src/util/hostfile/hostfile_lex.c
 src/util/keyval/keyval_lex.c
+
+test/double-get
+test/get-nofence
+test/attachtest/app
+test/attachtest/tool

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -434,6 +434,8 @@ static void check_complete(int fd, short args, void *cbdata)
     prte_pointer_array_t procs;
     char *tmp;
     prte_timer_t *timer;
+    void *nptr;
+    uint32_t u32;
 
     PRTE_ACQUIRE_OBJECT(caddy);
     jdata = caddy->jdata;
@@ -518,7 +520,26 @@ static void check_complete(int fd, short args, void *cbdata)
                 free(msg);
             }
         }
-        /* just shut us down */
+        /* if all of the jobs we are running are done, then shut us down */
+        rc = prte_hash_table_get_first_key_uint32(prte_job_data, &u32, (void **)&jptr, &nptr);
+        while (PRTE_SUCCESS == rc) {
+            /* skip the daemon job */
+            if (jptr->jobid == PRTE_PROC_MY_NAME->jobid) {
+                goto next;
+            }
+            /* if the job is flagged to not be monitored, skip it */
+            if (PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_DO_NOT_MONITOR)) {
+                goto next;
+            }
+            if (jptr->state < PRTE_JOB_STATE_TERMINATED) {
+                /* still alive - finish processing this job's termination */
+                goto release;
+            }
+          next:
+            rc = prte_hash_table_get_next_key_uint32(prte_job_data, &u32, (void **)&jptr, nptr, &nptr);
+        }
+        /* if we fell thru to this point, then nobody is still
+         * alive except the daemons, so just shut us down */
         prte_plm.terminate_orteds();
         PRTE_RELEASE(caddy);
         return;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -742,6 +742,8 @@ void prte_pmix_server_tool_conn_complete(prte_job_t *jdata,
         /* flag that it is also a launcher */
         PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_LAUNCHER);
     }
+    /* flag that it is not to be monitored */
+    PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_DO_NOT_MONITOR);
     /* store it away */
     prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -34,7 +34,9 @@ CFLAGS = -g
 
 TESTS = \
 	double-get \
-	get-nofence
+	get-nofence \
+	attachtest/app.c \
+	attachtest/tool.c
 
 all: $(TESTS)
 

--- a/test/attachtest/app.c
+++ b/test/attachtest/app.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pmix.h>
+
+int main(int argc, char** argv)
+{
+    int pause = 0;
+    if (argc > 1)
+    {
+        pause = atoi(argv[1]);
+    }
+
+    pmix_proc_t proc;
+    pmix_status_t rc = PMIX_ERROR;
+
+    rc = PMIx_Init(&proc, NULL, 0);
+    if (rc != PMIX_SUCCESS) {
+        fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return EXIT_FAILURE;
+    }
+
+    printf("Hello\n");
+
+    sleep(pause);
+
+    printf("Bye\n");
+
+    rc = PMIx_Finalize(NULL, 0);
+    if (rc != PMIX_SUCCESS) {
+        fprintf(stderr, "PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}

--- a/test/attachtest/tool.c
+++ b/test/attachtest/tool.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pmix_tool.h>
+
+int main(int argc, char** argv)
+{
+    pmix_proc_t proc;
+    pmix_status_t rc = PMIX_ERROR;
+
+    rc = PMIx_tool_init(&proc, NULL, 0);
+    if (rc != PMIX_SUCCESS) {
+        fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return EXIT_FAILURE;
+    }
+
+    rc = PMIx_tool_finalize();
+    if (rc != PMIX_SUCCESS) {
+        fprintf(stderr, "PMIx_tool_finalize failed: %s\n", PMIx_Error_string(rc));
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
When executing as a one-shot DVM (e.g., when running as an 'mpirun'
proxy), only exit when ALL monitored (e.g., non-debugger) jobs have
completed. Add a provided test that runs a simple "sleep" while a tool
connects/disconnects to verify that 'mpirun' continues to operate.

Fixes #545 

Signed-off-by: Ralph Castain <rhc@pmix.org>