### PR TITLE
Fix the output modifier cmd line options

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -206,12 +206,6 @@ static int rte_init(int argc, char **argv)
         }
     }
 
-    /* if we are using xml for output, put an mpirun start tag */
-    if (prte_xml_output) {
-        fprintf(prte_xml_fp, "<mpirun>\n");
-        fflush(prte_xml_fp);
-    }
-
     /* open and setup the prte_pstat framework so we can provide
      * process stats if requested
      */
@@ -672,15 +666,6 @@ static int rte_finalize(void)
     prte_session_dir_finalize(PRTE_PROC_MY_NAME);
     /* ensure we scrub the session directory tree */
     prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
-
-    /* close the xml output file, if open */
-    if (prte_xml_output) {
-        fprintf(prte_xml_fp, "</mpirun>\n");
-        fflush(prte_xml_fp);
-        if (stdout != prte_xml_fp) {
-            fclose(prte_xml_fp);
-        }
-    }
 
     free(prte_topo_signature);
 

--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * $COPYRIGHT$
  *
@@ -55,6 +55,10 @@ int prte_iof_base_write_output(const prte_process_name_t *name, prte_iof_tag_t s
     int i, j, k, starttaglen, endtaglen, num_buffered;
     bool endtagged;
     char qprint[10];
+    prte_job_t *jdata;
+    bool prte_xml_output;
+    bool prte_timestamp_output;
+    bool prte_tag_output;
 
     PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                          "%s write:output setting up to write %d bytes to %s for %s on fd %d",
@@ -65,6 +69,12 @@ int prte_iof_base_write_output(const prte_process_name_t *name, prte_iof_tag_t s
 
     /* setup output object */
     output = PRTE_NEW(prte_iof_write_output_t);
+
+    /* get the job object for this process */
+    jdata = prte_get_job_data_object(name->jobid);
+    prte_timestamp_output = prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PRTE_BOOL);
+    prte_tag_output = prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PRTE_BOOL);
+    prte_xml_output = prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PRTE_BOOL);
 
     /* write output data to the corresponding tag */
     if (PRTE_IOF_STDIN & stream) {

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -462,22 +462,19 @@ static int finalize(void)
             PRTE_RELEASE(output);
         }
     }
-    if (!prte_xml_output) {
-        /* we only opened stderr channel if we are NOT doing xml output */
-        wev = prte_iof_base.iof_write_stderr->wev;
-        if (!prte_list_is_empty(&wev->outputs)) {
-            dump = false;
-            /* make one last attempt to write this out */
-            while (NULL != (output = (prte_iof_write_output_t*)prte_list_remove_first(&wev->outputs))) {
-                if (!dump) {
-                    num_written = write(wev->fd, output->data, output->numbytes);
-                    if (num_written < output->numbytes) {
-                        /* don't retry - just cleanout the list and dump it */
-                        dump = true;
-                    }
+    wev = prte_iof_base.iof_write_stderr->wev;
+    if (!prte_list_is_empty(&wev->outputs)) {
+        dump = false;
+        /* make one last attempt to write this out */
+        while (NULL != (output = (prte_iof_write_output_t*)prte_list_remove_first(&wev->outputs))) {
+            if (!dump) {
+                num_written = write(wev->fd, output->data, output->numbytes);
+                if (num_written < output->numbytes) {
+                    /* don't retry - just cleanout the list and dump it */
+                    dump = true;
                 }
-                PRTE_RELEASE(output);
             }
+            PRTE_RELEASE(output);
         }
     }
 
@@ -660,7 +657,7 @@ static int hnp_output(const prte_process_name_t* peer,
         return ret;
     } else {
         /* output this to our local output */
-        if (PRTE_IOF_STDOUT & source_tag || prte_xml_output) {
+        if (PRTE_IOF_STDOUT & source_tag) {
             prte_iof_base_write_output(peer, source_tag, (const unsigned char*)msg, strlen(msg), prte_iof_base.iof_write_stdout->wev);
         } else {
             prte_iof_base_write_output(peer, source_tag, (const unsigned char*)msg, strlen(msg), prte_iof_base.iof_write_stderr->wev);

--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -342,7 +342,7 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         if (NULL != proct->subscribers) {
             if (!exclusive) {
                 /* output this to our local output */
-                if (PRTE_IOF_STDOUT & rev->tag || prte_xml_output) {
+                if (PRTE_IOF_STDOUT & rev->tag) {
                     prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, prte_iof_base.iof_write_stdout->wev);
                 } else {
                     prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, prte_iof_base.iof_write_stderr->wev);
@@ -350,7 +350,7 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
             }
         } else {
             /* output this to our local output */
-            if (PRTE_IOF_STDOUT & rev->tag || prte_xml_output) {
+            if (PRTE_IOF_STDOUT & rev->tag) {
                 prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, prte_iof_base.iof_write_stdout->wev);
             } else {
                 prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, prte_iof_base.iof_write_stderr->wev);

--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -315,7 +315,7 @@ void prte_iof_hnp_recv(int status, prte_process_name_t* sender,
 
     /* output this to our local output unless one of the sinks was exclusive */
     if (!exclusive) {
-        if (PRTE_IOF_STDOUT & stream || prte_xml_output) {
+        if (PRTE_IOF_STDOUT & stream) {
             prte_iof_base_write_output(&origin, stream, data, numbytes, prte_iof_base.iof_write_stdout->wev);
         } else {
             prte_iof_base_write_output(&origin, stream, data, numbytes, prte_iof_base.iof_write_stderr->wev);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -150,8 +150,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
         }
     }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PRTE_BOOL)) {
-        fprintf(prte_xml_fp, "%s</allocation>\n", tmp);
-        fflush(prte_xml_fp);
+        prte_output(prte_clean_output, "%s</allocation>\n", tmp);
     } else {
         prte_output(prte_clean_output, "%s=================================================================\n", tmp);
     }

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -260,6 +260,24 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         } else if (0 == strcasecmp(ck2[i], "NOLOCAL")) {
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_USE_LOCAL);
 
+        } else if (0 == strcasecmp(ck2[i], "TAGOUTPUT")) {
+            if (NULL == jdata) {
+                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                                "mapping policy", ck2[i]);
+                return PRTE_ERR_SILENT;
+            }
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL,
+                                NULL, PRTE_BOOL);
+
+        } else if (0 == strcasecmp(ck2[i], "TIMESTAMPOUTPUT")) {
+            if (NULL == jdata) {
+                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                                "mapping policy", ck2[i]);
+                return PRTE_ERR_SILENT;
+            }
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL,
+                                NULL, PRTE_BOOL);
+
         } else if (0 == strcasecmp(ck2[i], "XMLOUTPUT")) {
             if (NULL == jdata) {
                 prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -701,12 +701,7 @@ void prte_rmaps_base_display_map(prte_job_t *jdata)
         }
     } else {
         prte_print_map(&output, jdata);
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PRTE_BOOL)) {
-            fprintf(prte_xml_fp, "%s\n", output);
-            fflush(prte_xml_fp);
-        } else {
-            prte_output(prte_clean_output, "%s", output);
-        }
+        prte_output(prte_clean_output, "%s\n", output);
         free(output);
     }
 }

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -295,7 +295,7 @@ static int parse_cli(int argc, int start, char **argv,
 
 static int parse_deprecated_cli(char *option, char ***argv, int i)
 {
-    int rc = PRTE_SUCCESS;
+    int rc = PRTE_ERR_NOT_FOUND;
     char **pargs = *argv;
     char *p2, *tmp, *tmp2, *output;
 
@@ -327,8 +327,16 @@ static int parse_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--do-not-launch")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "DONOTLAUNCH");
     }
-    /* --xml-output  ->  --map-by :xmloutput */
-    else if (0 == strcmp(option, "--xml-output")) {
+    /* --tag-output  ->  --map-by :tagoutput */
+    else if (0 == strcmp(option, "--tag-output")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "TAGOUTPUT");
+    }
+    /* --timestamp-output  ->  --map-by :timestampoutput */
+    else if (0 == strcmp(option, "--timestamp-output")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "TIMESTAMPOUTPUT");
+    }
+    /* --xml  ->  --map-by :xmloutput */
+    else if (0 == strcmp(option, "--xml")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "XMLOUTPUT");
     }
     /* -N ->   map-by ppr:N:node */
@@ -436,7 +444,9 @@ static void register_deprecated_cli(prte_list_t *convertors)
         "--report-bindings",
         "--display-allocation",
         "--do-not-launch",
-        "--xml-output",
+        "--tag-output",
+        "--timestamp-output",
+        "--xml",
         "-N",
         "--map-by",
         "--rank-by",

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -487,15 +487,23 @@ static void interim(int sd, short args, void *cbdata)
         /***   THE INITIAL JOB-INFO DELIVERED TO PROCS                          ***/
 
         /***   TAG STDOUT   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_TAG_OUTPUT)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_TAG_OUTPUT) ||
+                   PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT,
                                PRTE_ATTR_GLOBAL, &flag, PRTE_BOOL);
 
         /***   TIMESTAMP OUTPUT   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_TIMESTAMP_OUTPUT)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_TIMESTAMP_OUTPUT) ||
+                   PMIX_CHECK_KEY(info, PMIX_IOF_TIMESTAMP_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT,
+                               PRTE_ATTR_GLOBAL, &flag, PRTE_BOOL);
+
+        /***   XML OUTPUT   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_XML_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT,
                                PRTE_ATTR_GLOBAL, &flag, PRTE_BOOL);
 
         /***   OUTPUT TO FILES   ***/

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -275,30 +275,6 @@ int prte_dt_print_node(char **output, char *prefix, prte_node_t *src, prte_data_
         prte_asprintf(&pfx2, "%s", prefix);
     }
 
-    if (prte_xml_output) {
-        /* need to create the output in XML format */
-        prte_asprintf(&tmp, "%s<host name=\"%s\" slots=\"%d\" max_slots=\"%d\">\n", pfx2,
-                 (NULL == src->name) ? "UNKNOWN" : src->name,
-                 (int)src->slots, (int)src->slots_max);
-        /* does this node have any aliases? */
-        tmp3 = NULL;
-        if (prte_get_attribute(&src->attributes, PRTE_NODE_ALIAS, (void**)&tmp3, PRTE_STRING)) {
-            alias = prte_argv_split(tmp3, ',');
-            for (i=0; NULL != alias[i]; i++) {
-                prte_asprintf(&tmp2, "%s%s\t<noderesolve resolved=\"%s\"/>\n", tmp, pfx2, alias[i]);
-                free(tmp);
-                tmp = tmp2;
-            }
-            prte_argv_free(alias);
-        }
-        if (NULL != tmp3) {
-            free(tmp3);
-        }
-        *output = tmp;
-        free(pfx2);
-        return PRTE_SUCCESS;
-    }
-
     if (!prte_devel_level_output) {
         /* just provide a simple output for users */
         if (0 == src->num_procs) {
@@ -459,19 +435,6 @@ int prte_dt_print_proc(char **output, char *prefix, prte_proc_t *src, prte_data_
         prte_asprintf(&pfx2, "%s", prefix);
     }
 
-    if (prte_xml_output) {
-        /* need to create the output in XML format */
-        if (0 == src->pid) {
-            prte_asprintf(output, "%s<process rank=\"%s\" status=\"%s\"/>\n", pfx2,
-                     PRTE_VPID_PRINT(src->name.vpid), prte_proc_state_to_str(src->state));
-        } else {
-            prte_asprintf(output, "%s<process rank=\"%s\" pid=\"%d\" status=\"%s\"/>\n", pfx2,
-                     PRTE_VPID_PRINT(src->name.vpid), (int)src->pid, prte_proc_state_to_str(src->state));
-        }
-        free(pfx2);
-        return PRTE_SUCCESS;
-    }
-
     if (!prte_devel_level_output) {
         if (prte_get_attribute(&src->attributes, PRTE_PROC_CPU_BITMAP, (void**)&cpu_bitmap, PRTE_STRING) &&
             NULL != src->node->topology && NULL != src->node->topology->topo) {
@@ -628,42 +591,6 @@ int prte_dt_print_map(char **output, char *prefix, prte_job_map_t *src, prte_dat
         prte_asprintf(&pfx2, " ");
     } else {
         prte_asprintf(&pfx2, "%s", prefix);
-    }
-
-    if (prte_xml_output) {
-        /* need to create the output in XML format */
-        prte_asprintf(&tmp, "<map>\n");
-        /* loop through nodes */
-        for (i=0; i < src->nodes->size; i++) {
-            if (NULL == (node = (prte_node_t*)prte_pointer_array_get_item(src->nodes, i))) {
-                continue;
-            }
-            prte_dt_print_node(&tmp2, "\t", node, PRTE_NODE);
-            prte_asprintf(&tmp3, "%s%s", tmp, tmp2);
-            free(tmp2);
-            free(tmp);
-            tmp = tmp3;
-            /* for each node, loop through procs and print their rank */
-            for (j=0; j < node->procs->size; j++) {
-                if (NULL == (proc = (prte_proc_t*)prte_pointer_array_get_item(node->procs, j))) {
-                    continue;
-                }
-                prte_dt_print_proc(&tmp2, "\t\t", proc, PRTE_PROC);
-                prte_asprintf(&tmp3, "%s%s", tmp, tmp2);
-                free(tmp2);
-                free(tmp);
-                tmp = tmp3;
-            }
-            prte_asprintf(&tmp3, "%s\t</host>\n", tmp);
-            free(tmp);
-            tmp = tmp3;
-        }
-        prte_asprintf(&tmp2, "%s</map>\n", tmp);
-        free(tmp);
-        free(pfx2);
-        *output = tmp2;
-        return PRTE_SUCCESS;
-
     }
 
     prte_asprintf(&pfx, "%s\t", pfx2);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -129,8 +129,6 @@ prte_pointer_array_t *prte_local_children = NULL;
 prte_vpid_t prte_total_procs = 0;
 
 /* IOF controls */
-bool prte_tag_output = false;
-bool prte_timestamp_output = false;
 /* generate new xterm windows to display output from specified ranks */
 char *prte_xterm = NULL;
 
@@ -178,8 +176,6 @@ int prte_max_vm_size = -1;
 
 int prte_debug_output = -1;
 bool prte_debug_daemons_flag = false;
-bool prte_xml_output = false;
-FILE *prte_xml_fp = NULL;
 char *prte_job_ident = NULL;
 bool prte_execute_quiet = false;
 bool prte_report_silent_errors = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -62,8 +62,6 @@ BEGIN_C_DECLS
 
 PRTE_EXPORT extern int prte_debug_verbosity;  /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern char *prte_prohibited_session_dirs;  /* instantiated in src/runtime/prte_init.c */
-PRTE_EXPORT extern bool prte_xml_output;  /* instantiated in src/runtime/prte_globals.c */
-PRTE_EXPORT extern FILE *prte_xml_fp;   /* instantiated in src/runtime/prte_globals.c */
 PRTE_EXPORT extern bool prte_help_want_aggregate;  /* instantiated in src/util/show_help.c */
 PRTE_EXPORT extern char *prte_job_ident;  /* instantiated in src/runtime/prte_globals.c */
 PRTE_EXPORT extern bool prte_create_session_dirs;  /* instantiated in src/runtime/prte_init.c */
@@ -508,8 +506,6 @@ PRTE_EXPORT extern prte_pointer_array_t *prte_local_children;
 PRTE_EXPORT extern prte_vpid_t prte_total_procs;
 
 /* IOF controls */
-PRTE_EXPORT extern bool prte_tag_output;
-PRTE_EXPORT extern bool prte_timestamp_output;
 /* generate new xterm windows to display output from specified ranks */
 PRTE_EXPORT extern char *prte_xterm;
 

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -50,7 +50,6 @@
 
 static bool passed_thru = false;
 static int prte_progress_thread_debug_level = -1;
-static char *prte_xml_file = NULL;
 static char *prte_fork_agent_string = NULL;
 static char *prte_tmpdir_base = NULL;
 static char *prte_local_tmpdir_base = NULL;
@@ -474,57 +473,6 @@ int prte_register_params(void)
                                   PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                   PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                   &prte_use_hostname_alias);
-
-    prte_xml_output = false;
-    (void) prte_mca_base_var_register ("prte", "prte", NULL, "xml_output",
-                                  "Display all output in XML format (default: false)",
-                                  PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prte_xml_output);
-
-    /* whether to tag output */
-    /* if we requested xml output, be sure to tag the output as well */
-    prte_tag_output = prte_xml_output;
-    (void) prte_mca_base_var_register ("prte", "prte", NULL, "tag_output",
-                                  "Tag all output with [job,rank] (default: false)",
-                                  PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prte_tag_output);
-    if (prte_xml_output) {
-        prte_tag_output = true;
-    }
-
-
-    prte_xml_file = NULL;
-    (void) prte_mca_base_var_register ("prte", "prte", NULL, "xml_file",
-                                  "Provide all output in XML format to the specified file",
-                                  PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
-                                  PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prte_xml_file);
-    if (NULL != prte_xml_file) {
-        if (PRTE_PROC_IS_MASTER && NULL == prte_xml_fp) {
-            /* only the HNP opens this file! Make sure it only happens once */
-            prte_xml_fp = fopen(prte_xml_file, "w");
-            if (NULL == prte_xml_fp) {
-                prte_output(0, "Could not open specified xml output file: %s", prte_xml_file);
-                return PRTE_ERROR;
-            }
-        }
-        /* ensure we set the flags to tag output */
-        prte_xml_output = true;
-        prte_tag_output = true;
-    } else {
-        /* default to stdout */
-        prte_xml_fp = stdout;
-    }
-
-    /* whether to timestamp output */
-    prte_timestamp_output = false;
-    (void) prte_mca_base_var_register ("prte", "prte", NULL, "timestamp_output",
-                                  "Timestamp all application process output (default: false)",
-                                  PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prte_timestamp_output);
 
     prte_show_resolved_nodenames = false;
     (void) prte_mca_base_var_register ("prte", "prte", NULL, "show_resolved_nodenames",

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -262,9 +262,6 @@ static prte_cmd_line_init_t cmd_line_init[] = {
     { '\0', "xml", 0, PRTE_CMD_LINE_TYPE_BOOL,
       "Provide all output in XML format",
       PRTE_CMD_LINE_OTYPE_OUTPUT },
-    { '\0', "xml-file", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Provide all output in XML format to the specified file",
-      PRTE_CMD_LINE_OTYPE_OUTPUT },
     /* tag output */
     { '\0', "tag-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
       "Tag all output with [job,rank]",
@@ -1021,23 +1018,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* check for stdout/err directives */
-    /* if we were asked to tag output, mark it so */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "tag-output")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        flag = true;
-        PMIX_INFO_LOAD(ds->info, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
-        prte_list_append(&job_info, &ds->super);
-    }
-    /* if we were asked to timestamp output, mark it so */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "timestamp-output")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        flag = true;
-        PMIX_INFO_LOAD(ds->info, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
-        prte_list_append(&job_info, &ds->super);
-    }
     /* cannot have both files and directory set for output */
     param = NULL;
     ptr = NULL;

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -248,9 +248,6 @@ static prte_cmd_line_init_t cmd_line_init[] = {
     { '\0', "xml", 0, PRTE_CMD_LINE_TYPE_BOOL,
       "Provide all output in XML format",
       PRTE_CMD_LINE_OTYPE_OUTPUT },
-    { '\0', "xml-file", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Provide all output in XML format to the specified file",
-      PRTE_CMD_LINE_OTYPE_OUTPUT },
     /* tag output */
     { '\0', "tag-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
       "Tag all output with [job,rank]",
@@ -943,26 +940,6 @@ int prun(int argc, char *argv[])
     PMIX_INFO_CREATE(ds->info, 1);
     PMIX_INFO_LOAD(ds->info, PMIX_SINGLE_LISTENER, NULL, PMIX_BOOL);
     prte_list_append(&tinfo, &ds->super);
-
-    /* setup any output format requests */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "tag-output")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
-        prte_list_append(&tinfo, &ds->super);
-    }
-    if (prte_cmd_line_is_taken(prte_cmd_line, "timestamp-output")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
-        prte_list_append(&tinfo, &ds->super);
-    }
-    if (prte_cmd_line_is_taken(prte_cmd_line, "xml")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
-        prte_list_append(&tinfo, &ds->super);
-    }
 
     /* if they specified the URI, then pass it along */
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "dvm-uri", 0, 0))) {


### PR DESCRIPTION
Reconnect --tag-output, --timestamp-output, and --xml options and report
their deprecation in favor of --map-by modifiers

Fixes https://github.com/open-mpi/ompi/issues/7710

Signed-off-by: Ralph Castain <rhc@pmix.org>