### PR TITLE
Point to the correct file that wasn't found

### DIFF
--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -198,15 +198,19 @@ AC_ARG_ENABLE([show-load-errors-by-default],
                      MCA-variable-setting mechansism).  This MCA variable
                      controls whether warnings are displayed when an MCA
                      component fails to load at run time due to an error.
-                     (default: enabled, meaning that
+                     (default: enabled in --enable-debug builds, meaning that
                       mca_base_component_show_load_errors is enabled
-                      by default])])
+                      by default when configured with --enable-debug])])
 if test "$enable_show_load_errors_by_default" = "no" ; then
     PRTE_SHOW_LOAD_ERRORS_DEFAULT=0
     AC_MSG_RESULT([disabled by default])
 else
-    PRTE_SHOW_LOAD_ERRORS_DEFAULT=1
-    AC_MSG_RESULT([enabled by default])
+    PRTE_SHOW_LOAD_ERRORS_DEFAULT=$WANT_DEBUG
+    if test "$WANT_DEBUG" = "1"; then
+        AC_MSG_RESULT([enabled by default])
+    else
+        AC_MSG_RESULT([disabled by default])
+    fi
 fi
 AC_DEFINE_UNQUOTED(PRTE_SHOW_LOAD_ERRORS_DEFAULT, $PRTE_SHOW_LOAD_ERRORS_DEFAULT,
                    [Default value for mca_base_component_show_load_errors MCA variable])

--- a/src/mca/base/prte_mca_base_component_repository.c
+++ b/src/mca/base/prte_mca_base_component_repository.c
@@ -421,31 +421,34 @@ int prte_mca_base_component_repository_open (prte_mca_base_framework_t *framewor
     char *err_msg = NULL;
     if (PRTE_SUCCESS != prte_dl_open(ri->ri_path, true, false, &ri->ri_dlhandle, &err_msg)) {
         if (NULL == err_msg) {
-            err_msg = "prte_dl_open() error message was NULL!";
+            err_msg = strdup("prte_dl_open() error message was NULL!");
+        } else if (file_exists(ri->ri_path, "lo") ||
+                   file_exists(ri->ri_path, "so") ||
+                   file_exists(ri->ri_path, "dylib") ||
+                   file_exists(ri->ri_path, "dll")) {
+            /* Because libltdl erroneously says "file not found" for any
+             * type of error -- which is especially misleading when the file
+             * is actually there but cannot be opened for some other reason
+             * (e.g., missing symbol) -- do some simple huersitics and if
+             * the file [probably] does exist, print a slightly better error
+             * message. */
+            err_msg = strdup("perhaps a missing symbol, or compiled for a different version of PRRTE?");
         }
-        /* Because libltdl erroneously says "file not found" for any
-           type of error -- which is especially misleading when the file
-           is actually there but cannot be opened for some other reason
-           (e.g., missing symbol) -- do some simple huersitics and if
-           the file [probably] does exist, print a slightly better error
-           message. */
-        if (0 == strcasecmp("file not found", err_msg) &&
-            (file_exists(ri->ri_path, "lo") ||
-             file_exists(ri->ri_path, "so") ||
-             file_exists(ri->ri_path, "dylib") ||
-             file_exists(ri->ri_path, "dll"))) {
-            err_msg = "perhaps a missing symbol, or compiled for a different version of PRTE?";
-        }
-        prte_output_verbose(vl, 0, "mca_base_component_repository_open: unable to open %s: %s (ignored)",
+        prte_output_verbose(vl, 0, "prte_mca_base_component_repository_open: unable to open %s: %s (ignored)",
                             ri->ri_base, err_msg);
 
         if( prte_mca_base_component_track_load_errors ) {
             prte_mca_base_failed_component_t *f_comp = PRTE_NEW(prte_mca_base_failed_component_t);
             f_comp->comp = ri;
-            prte_asprintf(&(f_comp->error_msg), "%s", err_msg);
+            if (0 > asprintf(&(f_comp->error_msg), "%s", err_msg)) {
+                PRTE_RELEASE(f_comp);
+                free(err_msg);
+                return PRTE_ERR_BAD_PARAM;
+            }
             prte_list_append(&framework->framework_failed_components, &f_comp->super);
         }
 
+        free(err_msg);
         return PRTE_ERR_BAD_PARAM;
     }
 

--- a/src/mca/iof/base/iof_base_frame.c
+++ b/src/mca/iof/base/iof_base_frame.c
@@ -109,8 +109,6 @@ static int prte_iof_base_close(void)
  */
 static int prte_iof_base_open(prte_mca_base_open_flag_t flags)
 {
-    int xmlfd;
-
     /* daemons do not need to do this as they do not write out stdout/err */
     if (!PRTE_PROC_IS_DAEMON) {
         /* setup the stdout event */

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
@@ -71,7 +71,7 @@ static int dlopen_open(const char *fname, bool use_ext, bool private_namespace,
        them */
     void *local_handle = NULL;
     if (use_ext && NULL != fname) {
-        int i;
+        int i, rc;
         char *ext;
 
         for (i = 0, ext = prte_prtedl_dlopen_component.filename_suffixes[i];
@@ -87,10 +87,14 @@ static int dlopen_open(const char *fname, bool use_ext, bool private_namespace,
             /* Does the file exist? */
             struct stat buf;
             if (stat(name, &buf) < 0) {
-                free(name);
                 if (NULL != err_msg) {
-                    *err_msg = "File not found";
+                    rc = asprintf(err_msg, "File %s not found", name);
+                    if (0 > rc) {
+                        free(name);
+                        return PRTE_ERR_OUT_OF_RESOURCE;
+                    }
                 }
+                free(name);
                 continue;
             }
 

--- a/src/mca/prtedl/libltdl/prtedl_libltdl_module.c
+++ b/src/mca/prtedl/libltdl/prtedl_libltdl_module.c
@@ -68,7 +68,7 @@ static int libltdl_open(const char *fname, bool use_ext, bool private_namespace,
     }
 
     if (NULL != err_msg) {
-        *err_msg = (char*) lt_dlerror();
+        *err_msg = strdup((char*) lt_dlerror());
     }
     return PRTE_ERROR;
 }

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -578,10 +578,9 @@ int prte_dt_print_app_context(char **output, char *prefix, prte_app_context_t *s
 int prte_dt_print_map(char **output, char *prefix, prte_job_map_t *src, prte_data_type_t type)
 {
     char *tmp=NULL, *tmp2, *tmp3, *pfx, *pfx2;
-    int32_t i, j;
+    int32_t i;
     int rc;
     prte_node_t *node;
-    prte_proc_t *proc;
 
     /* set default result */
     *output = NULL;

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -663,7 +663,6 @@ static void show_accumulated_duplicates(int fd, short event, void *context)
 {
     time_t now = time(NULL);
     tuple_list_item_t *tli;
-    char *tmp, *output;
 
     /* Loop through all the messages we've displayed and see if any
        processes have sent duplicates that have not yet been displayed


### PR DESCRIPTION
When doing a dlopen, we apparently strip the extension from the actual
filename to identify the component it relates to, and then add accepted
extensions back to the filename when checking for file existence prior
to loading. Unfortunately, some 3rd party packages (e.g., debuggers)
take our libraries, do a little magic, and then output a copy of the
results into our lib directory - only with a new suffix. So we might get
something like "ourcomponent.so.dbg". We then strip the ".dbg" and add
".so" to it again - and complain that "ourcomponent.so is not found" when
it was actually "ourcomponent.so.so" that wasn't found.

Fix the error message so it reports the name of the file it actually
couldn't find, not the name of the component, so it doesn't totally
confuse people.

Signed-off-by: Ralph Castain <rhc@pmix.org>