### PR TITLE
Various cleanups

### DIFF
--- a/src/dss/dss_types.h
+++ b/src/dss/dss_types.h
@@ -118,8 +118,6 @@ typedef struct {
 #define    PRTE_ENVAR               (prte_data_type_t)   39 /**< corresponds to PMIx envar type */
 #define    PRTE_LIST                (prte_data_type_t)   40 /**< an prte list */
 
-/* General PRTE types - support handled within DSS */
-#define    PRTE_STD_CNTR            (prte_data_type_t)   41 /**< standard counter type */
     /* State-related types */
 #define    PRTE_NODE_STATE          (prte_data_type_t)   42 /**< node status flag */
 #define    PRTE_JOB_STATE           (prte_data_type_t)   43 /**< job status flag */

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -51,12 +51,6 @@
  * Supported datatypes for messaging and storage operations.
  */
 
-typedef int32_t prte_std_cntr_t;  /** standard counters used in PRTE */
-#define PRTE_STD_CNTR_T         PRTE_INT32
-#define PRTE_STD_CNTR_MAX       INT32_MAX
-#define PRTE_STD_CNTR_MIN       INT32_MIN
-#define PRTE_STD_CNTR_INVALID   -1
-
 /** rank on node, used for both local and node rank. We
  * don't send these around on their own, so don't create
  * dedicated type support for them - we are defining them

--- a/src/mca/errmgr/base/errmgr_base_fns.c
+++ b/src/mca/errmgr/base/errmgr_base_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
@@ -137,7 +137,7 @@ void prte_errmgr_base_abort(int error_code, char *fmt, ...)
 }
 
 int prte_errmgr_base_abort_peers(prte_process_name_t *procs,
-                                 prte_std_cntr_t num_procs,
+                                 int32_t num_procs,
                                  int error_code)
 {
     return PRTE_ERR_NOT_IMPLEMENTED;

--- a/src/mca/errmgr/base/errmgr_private.h
+++ b/src/mca/errmgr/base/errmgr_private.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011      Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -66,7 +66,7 @@ PRTE_EXPORT void prte_errmgr_base_log(int error_code, char *filename, int line);
 PRTE_EXPORT void prte_errmgr_base_abort(int error_code, char *fmt, ...)
     __prte_attribute_format__(__printf__, 2, 3);
 PRTE_EXPORT int prte_errmgr_base_abort_peers(prte_process_name_t *procs,
-                                               prte_std_cntr_t num_procs,
+                                               int32_t num_procs,
                                                int error_code);
 
 END_C_DECLS

--- a/src/mca/errmgr/errmgr.h
+++ b/src/mca/errmgr/errmgr.h
@@ -114,7 +114,7 @@ __prte_attribute_format_funcptr__(__printf__, 2, 3);
  *  communicator group before aborting itself.
  */
 typedef int (*prte_errmgr_base_module_abort_peers_fn_t)(prte_process_name_t *procs,
-                                                        prte_std_cntr_t num_procs,
+                                                        int32_t num_procs,
                                                         int error_code);
 
 /*

--- a/src/mca/ess/base/base.h
+++ b/src/mca/ess/base/base.h
@@ -78,8 +78,8 @@ PRTE_EXPORT int prte_ess_base_proc_binding(void);
 /*
  * Put functions
  */
-PRTE_EXPORT int prte_ess_env_put(prte_std_cntr_t num_procs,
-                                   prte_std_cntr_t num_local_procs,
+PRTE_EXPORT int prte_ess_env_put(int32_t num_procs,
+                                   int32_t num_local_procs,
                                    char ***env);
 
 typedef struct {

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -367,7 +367,6 @@ int prte_ess_base_prted_setup(void)
 
     if (NULL != prte_process_info.my_hnp_uri) {
         pmix_value_t val;
-        pmix_proc_t proc;
 
         /* extract the HNP's name so we can update the routing table */
         if (PRTE_SUCCESS != (ret = prte_rml_base_parse_uris(prte_process_info.my_hnp_uri,
@@ -381,13 +380,7 @@ int prte_ess_base_prted_setup(void)
          * if/when we attempt to send to it
          */
         PMIX_VALUE_LOAD(&val, prte_process_info.my_hnp_uri, PRTE_STRING);
-        PRTE_PMIX_CONVERT_NAME(ret, &proc, PRTE_PROC_MY_HNP);
-        if (PRTE_SUCCESS != ret) {
-            PRTE_ERROR_LOG(ret);
-            error = "convert_name";
-            goto error;
-        }
-        if (PMIX_SUCCESS != PMIx_Store_internal(&proc, PMIX_PROC_URI, &val)) {
+        if (PMIX_SUCCESS != PMIx_Store_internal(PRTE_PROC_MY_PROCID, PMIX_PROC_URI, &val)) {
             PMIX_VALUE_DESTRUCT(&val);
             error = "store HNP URI";
             ret = PRTE_ERROR;

--- a/src/mca/filem/base/filem_base_receive.c
+++ b/src/mca/filem/base/filem_base_receive.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -126,7 +126,7 @@ void prte_filem_base_recv(int status, prte_process_name_t* sender,
                         void* cbdata)
 {
     prte_filem_cmd_flag_t command;
-    prte_std_cntr_t count;
+    int32_t count;
     int rc;
 
     PRTE_OUTPUT_VERBOSE((5, prte_filem_base_framework.framework_output,
@@ -165,7 +165,7 @@ static void filem_base_process_get_proc_node_name_cmd(prte_process_name_t* sende
                                                       prte_buffer_t* buffer)
 {
     prte_buffer_t *answer;
-    prte_std_cntr_t count;
+    int32_t count;
     prte_job_t *jdata = NULL;
     prte_proc_t *proc = NULL;
     prte_process_name_t name;
@@ -229,7 +229,7 @@ static void filem_base_process_get_remote_path_cmd(prte_process_name_t* sender,
                                                    prte_buffer_t* buffer)
 {
     prte_buffer_t *answer;
-    prte_std_cntr_t count;
+    int32_t count;
     char *filename = NULL;
     char *tmp_name = NULL;
     char cwd[PRTE_PATH_MAX];

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -396,7 +396,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
                                                 prte_jobid_t *job)
 {
     int rc;
-    prte_std_cntr_t cnt;
+    int32_t cnt;
     prte_job_t *jdata=NULL, *daemons;
     prte_node_t *node;
     prte_vpid_t dmnvpid, v;

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -409,7 +409,6 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
     pmix_info_t *info = NULL;
     size_t ninfo=0;
     pmix_status_t ret;
-    pmix_proc_t pproc;
     pmix_data_buffer_t pbuf;
     prte_byte_object_t *bo;
     size_t m;
@@ -595,15 +594,9 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
         bo->bytes = NULL;
         bo->size = 0;
         free(bo);
-        /* setup the daemon job */
-        PRTE_PMIX_CONVERT_NAME(rc, &pproc, PRTE_PROC_MY_NAME);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            goto REPORT_ERROR;
-        }
         /* unpack the number of info structs */
         cnt = 1;
-        ret = PMIx_Data_unpack(&pproc, &pbuf, &ninfo, &cnt, PMIX_SIZE);
+        ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbuf, &ninfo, &cnt, PMIX_SIZE);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
@@ -612,7 +605,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
         }
         PMIX_INFO_CREATE(info, ninfo);
         cnt = ninfo;
-        ret = PMIx_Data_unpack(&pproc, &pbuf, info, &cnt, PMIX_INFO);
+        ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbuf, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             PMIX_INFO_FREE(info, ninfo);

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -185,7 +185,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     int proc_vpid_index;
     prte_app_context_t *app;
     prte_node_t *node;
-    prte_std_cntr_t nnode;
+    int32_t nnode;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t*)cbdata;
     char *ltmp;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2053,12 +2053,9 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             if (NULL == (app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, i))) {
                 continue;
             }
-            /* if the app provided a dash-host, and we are not treating
-             * them as requested or "soft" locations, then use those nodes
-             */
+            /* if the app provided a dash-host, then use those nodes */
             hosts = NULL;
-            if (!prte_soft_locations &&
-                prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
+            if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
                 PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                                      "%s using dash_host",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -127,7 +127,7 @@ void prte_plm_base_recv(int status, prte_process_name_t* sender,
                         void* cbdata)
 {
     prte_plm_cmd_flag_t command;
-    prte_std_cntr_t count;
+    int32_t count;
     prte_jobid_t job;
     prte_job_t *jdata, *parent, jb;
     prte_buffer_t *answer;

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -173,7 +173,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     bool failed_launch = true;
     prte_app_context_t *app;
     prte_node_t *node;
-    prte_std_cntr_t nnode;
+    int32_t nnode;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t*)cbdata;
     prte_job_t *jdata;

--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -107,15 +107,15 @@ static int rsh_terminate_prteds(void);
 static int rsh_finalize(void);
 
 prte_plm_base_module_t prte_plm_rsh_module = {
-    rsh_init,
-    prte_plm_base_set_hnp_name,
-    rsh_launch,
-    remote_spawn,
-    prte_plm_base_prted_terminate_job,
-    rsh_terminate_prteds,
-    prte_plm_base_prted_kill_local_procs,
-    prte_plm_base_prted_signal_local_procs,
-    rsh_finalize
+    .init = rsh_init,
+    .set_hnp_name = prte_plm_base_set_hnp_name,
+    .spawn = rsh_launch,
+    .remote_spawn = remote_spawn,
+    .terminate_job = prte_plm_base_prted_terminate_job,
+    .terminate_orteds = rsh_terminate_prteds,
+    .terminate_procs = prte_plm_base_prted_kill_local_procs,
+    .signal_job = prte_plm_base_prted_signal_local_procs,
+    .finalize = rsh_finalize
 };
 
 typedef struct {

--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -1003,7 +1003,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     int rc;
     prte_app_context_t *app;
     prte_node_t *node, *nd;
-    prte_std_cntr_t nnode;
+    int32_t nnode;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t*)cbdata;
     prte_plm_rsh_caddy_t *caddy;

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -172,7 +172,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 {
     prte_app_context_t *app;
     prte_node_t *node;
-    prte_std_cntr_t n;
+    int32_t n;
     prte_job_map_t *map;
     char *jobid_string = NULL;
     char *param;

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -92,7 +92,7 @@ static int plm_tm_finalize(void);
 /*
  * Local "global" variables
  */
-static prte_std_cntr_t launched = 0;
+static int32_t launched = 0;
 static bool connected = false;
 
 /*
@@ -178,7 +178,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char **argv = NULL;
     int argc = 0;
     int rc;
-    prte_std_cntr_t i;
+    int32_t i;
     char *bin_base = NULL, *lib_base = NULL;
     tm_event_t *tm_events = NULL;
     tm_task_id *tm_task_ids = NULL;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -334,15 +334,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         if (NULL == (app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, i))) {
             continue;
         }
-        if (!prte_soft_locations &&
-            prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
-            /* if we are using soft locations, then any dash-host would
-             * just include desired nodes and not required. We don't want
-             * to pick them up here as this would mean the request was
-             * always satisfied - instead, we want to allow the request
-             * to fail later on and use whatever nodes are actually
-             * available
-             */
+        if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
             PRTE_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
                                  "%s ras:base:allocate adding dash_hosts",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -167,7 +167,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
     prte_job_t *jdata;
     prte_list_t nodes;
     prte_node_t *node;
-    prte_std_cntr_t i;
+    int32_t i;
     prte_app_context_t *app;
     prte_state_caddy_t *caddy = (prte_state_caddy_t*)cbdata;
     char *hosts=NULL;

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -46,7 +46,7 @@
 int prte_ras_base_node_insert(prte_list_t* nodes, prte_job_t *jdata)
 {
     prte_list_item_t* item;
-    prte_std_cntr_t num_nodes;
+    int32_t num_nodes;
     int rc, i;
     prte_node_t *node, *hnp_node, *nptr;
     char *ptr;
@@ -57,7 +57,7 @@ int prte_ras_base_node_insert(prte_list_t* nodes, prte_job_t *jdata)
     prte_job_t *djob;
 
     /* get the number of nodes */
-    num_nodes = (prte_std_cntr_t)prte_list_get_size(nodes);
+    num_nodes = (int32_t)prte_list_get_size(nodes);
     if (0 == num_nodes) {
         return PRTE_SUCCESS;  /* nothing to do */
     }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -191,7 +191,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         if (NULL != (app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, i))) {
             if (0 == app->num_procs) {
                 prte_list_t nodes;
-                prte_std_cntr_t slots;
+                int32_t slots;
                 PRTE_CONSTRUCT(&nodes, prte_list_t);
                 prte_rmaps_base_get_target_nodes(&nodes, &slots, app, PRTE_MAPPING_BYNODE, true, true);
                 if (pernode) {

--- a/src/mca/rmaps/base/rmaps_base_ranking.c
+++ b/src/mca/rmaps/base/rmaps_base_ranking.c
@@ -761,7 +761,7 @@ int prte_rmaps_base_compute_vpids(prte_job_t *jdata)
 
 int prte_rmaps_base_compute_local_ranks(prte_job_t *jdata)
 {
-    prte_std_cntr_t i;
+    int32_t i;
     int j, k;
     prte_node_t *node;
     prte_proc_t *proc, *psave, *psave2;

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -136,14 +136,14 @@ int prte_rmaps_base_filter_nodes(prte_app_context_t *app,
 /*
  * Query the registry for all nodes allocated to a specified app_context
  */
-int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, prte_std_cntr_t *total_num_slots,
+int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *total_num_slots,
                                      prte_app_context_t *app, prte_mapping_policy_t policy,
                                      bool initial_map, bool silent)
 {
     prte_list_item_t *item;
     prte_node_t *node, *nd, *nptr, *next;
-    prte_std_cntr_t num_slots;
-    prte_std_cntr_t i;
+    int32_t num_slots;
+    int32_t i;
     int rc;
     prte_job_t *daemons;
     bool novm;
@@ -449,7 +449,7 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, prte_std_cntr
                 continue;
             }
             if (node->slots > node->slots_inuse) {
-                prte_std_cntr_t s;
+                int32_t s;
                 /* check for any -host allocations */
                 if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
                     s = prte_util_dash_host_compute_slots(node, hosts);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -96,8 +96,7 @@ int prte_rmaps_base_filter_nodes(prte_app_context_t *app,
         free(hosts);
     }
     /* now filter the list through any -host specification */
-    if (!prte_soft_locations &&
-        prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
+    if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
         if (PRTE_SUCCESS != (rc = prte_util_filter_dash_host_nodes(nodes, hosts, remove))) {
             PRTE_ERROR_LOG(rc);
             free(hosts);
@@ -164,12 +163,9 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *tota
      */
     if (!prte_managed_allocation) {
         PRTE_CONSTRUCT(&nodes, prte_list_t);
-        /* if the app provided a dash-host, and we are not treating
-         * them as requested or "soft" locations, then use those nodes
-         */
+        /* if the app provided a dash-host, then use those nodes */
         hosts = NULL;
-        if (!prte_soft_locations &&
-            prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
+        if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void**)&hosts, PRTE_STRING)) {
             PRTE_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
                                  "%s using dash_host %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), hosts));

--- a/src/mca/rmaps/base/rmaps_private.h
+++ b/src/mca/rmaps/base/rmaps_private.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +44,7 @@ BEGIN_C_DECLS
 /* LOCAL FUNCTIONS for use by RMAPS components */
 
 PRTE_EXPORT int prte_rmaps_base_get_target_nodes(prte_list_t* node_list,
-                                                   prte_std_cntr_t *total_num_slots,
+                                                   int32_t *total_num_slots,
                                                    prte_app_context_t *app,
                                                    prte_mapping_policy_t policy,
                                                    bool initial_map, bool silent);

--- a/src/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/src/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -70,7 +70,7 @@ static int mindist_map(prte_job_t *jdata)
     prte_proc_t *proc;
     int nprocs_mapped;
     int navg=0, nextra=0;
-    prte_std_cntr_t num_nodes, num_slots;
+    int32_t num_nodes, num_slots;
     unsigned int npus, total_npus, num_procs_to_assign=0, required;
     int rc;
     prte_mca_base_component_t *c = &prte_rmaps_mindist_component.base_version;
@@ -210,7 +210,7 @@ static int mindist_map(prte_job_t *jdata)
             oversubscribed = true;
         }
 
-        num_nodes = (prte_std_cntr_t)prte_list_get_size(&node_list);
+        num_nodes = (int32_t)prte_list_get_size(&node_list);
         /* flag that all subsequent requests should not reset the node->mapped flag */
         initial_map = false;
 

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -85,7 +85,7 @@ static int ppr_mapper(prte_job_t *jdata)
     prte_hwloc_level_t level;
     prte_list_t node_list;
     prte_list_item_t *item;
-    prte_std_cntr_t num_slots;
+    int32_t num_slots;
     prte_app_idx_t idx;
     char **ppr_req, **ck, *jobppr=NULL;
     size_t len;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -77,14 +77,14 @@ static int prte_rmaps_rf_map(prte_job_t *jdata)
 {
     prte_job_map_t *map;
     prte_app_context_t *app=NULL;
-    prte_std_cntr_t i, k;
+    int32_t i, k;
     prte_list_t node_list;
     prte_list_item_t *item;
     prte_node_t *node, *nd, *root_node;
     prte_vpid_t rank, vpid_start;
-    prte_std_cntr_t num_slots;
+    int32_t num_slots;
     prte_rmaps_rank_file_map_t *rfmap;
-    prte_std_cntr_t relative_index, tmp_cnt;
+    int32_t relative_index, tmp_cnt;
     int rc;
     prte_proc_t *proc;
     prte_mca_base_component_t *c = &prte_rmaps_rank_file_component.super.base_version;

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -60,13 +60,13 @@ struct prte_job_map_t {
     /* number of new daemons required to be launched
      * to support this job map
      */
-    prte_std_cntr_t num_new_daemons;
+    int32_t num_new_daemons;
     /* starting vpid of the new daemons - they will
      * be sequential from that point
      */
     prte_vpid_t daemon_vpid_start;
     /* number of nodes participating in this job */
-    prte_std_cntr_t num_nodes;
+    int32_t num_nodes;
     /* array of pointers to nodes in this map for this job */
     prte_pointer_array_t *nodes;
 };

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -49,7 +49,7 @@ static int prte_rmaps_rr_map(prte_job_t *jdata)
     int i;
     prte_list_t node_list;
     prte_list_item_t *item;
-    prte_std_cntr_t num_slots;
+    int32_t num_slots;
     int rc;
     prte_mca_base_component_t *c = &prte_rmaps_round_robin_component.base_version;
     bool initial_map=true;

--- a/src/mca/rmaps/round_robin/rmaps_rr.h
+++ b/src/mca/rmaps/round_robin/rmaps_rr.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -42,17 +42,17 @@ extern prte_rmaps_base_module_t prte_rmaps_round_robin_module;
 PRTE_MODULE_EXPORT int prte_rmaps_rr_bynode(prte_job_t *jdata,
                                               prte_app_context_t *app,
                                               prte_list_t *node_list,
-                                              prte_std_cntr_t num_slots,
+                                              int32_t num_slots,
                                               prte_vpid_t nprocs);
 PRTE_MODULE_EXPORT int prte_rmaps_rr_byslot(prte_job_t *jdata,
                                               prte_app_context_t *app,
                                               prte_list_t *node_list,
-                                              prte_std_cntr_t num_slots,
+                                              int32_t num_slots,
                                               prte_vpid_t nprocs);
 
 PRTE_MODULE_EXPORT int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                                              prte_list_t *node_list,
-                                             prte_std_cntr_t num_slots,
+                                             int32_t num_slots,
                                              prte_vpid_t num_procs,
                                              hwloc_obj_type_t target, unsigned cache_level);
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -40,7 +40,7 @@
 int prte_rmaps_rr_byslot(prte_job_t *jdata,
                          prte_app_context_t *app,
                          prte_list_t *node_list,
-                         prte_std_cntr_t num_slots,
+                         int32_t num_slots,
                          prte_vpid_t num_procs)
 {
     int i, nprocs_mapped;
@@ -218,7 +218,7 @@ int prte_rmaps_rr_byslot(prte_job_t *jdata,
 int prte_rmaps_rr_bynode(prte_job_t *jdata,
                          prte_app_context_t *app,
                          prte_list_t *node_list,
-                         prte_std_cntr_t num_slots,
+                         int32_t num_slots,
                          prte_vpid_t num_procs)
 {
     int j, nprocs_mapped, nnodes;
@@ -437,7 +437,7 @@ int prte_rmaps_rr_bynode(prte_job_t *jdata,
 static  int byobj_span(prte_job_t *jdata,
                        prte_app_context_t *app,
                        prte_list_t *node_list,
-                       prte_std_cntr_t num_slots,
+                       int32_t num_slots,
                        prte_vpid_t num_procs,
                        hwloc_obj_type_t target, unsigned cache_level);
 
@@ -448,7 +448,7 @@ static  int byobj_span(prte_job_t *jdata,
 int prte_rmaps_rr_byobj(prte_job_t *jdata,
                         prte_app_context_t *app,
                         prte_list_t *node_list,
-                        prte_std_cntr_t num_slots,
+                        int32_t num_slots,
                         prte_vpid_t num_procs,
                         hwloc_obj_type_t target, unsigned cache_level)
 {
@@ -713,7 +713,7 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata,
 static int byobj_span(prte_job_t *jdata,
                       prte_app_context_t *app,
                       prte_list_t *node_list,
-                      prte_std_cntr_t num_slots,
+                      int32_t num_slots,
                       prte_vpid_t num_procs,
                       hwloc_obj_type_t target, unsigned cache_level)
 {

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -95,12 +95,12 @@ static int prte_rmaps_seq_map(prte_job_t *jdata)
     prte_job_map_t *map;
     prte_app_context_t *app;
     int i, n;
-    prte_std_cntr_t j;
+    int32_t j;
     prte_list_item_t *item;
     prte_node_t *node, *nd;
     seq_node_t *sq, *save=NULL, *seq;;
     prte_vpid_t vpid;
-    prte_std_cntr_t num_nodes;
+    int32_t num_nodes;
     int rc;
     prte_list_t default_seq_list;
     prte_list_t node_list, *seq_list, sq_list;
@@ -355,7 +355,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata)
             }
         }
 
-        if (NULL == seq_list || 0 == (num_nodes = (prte_std_cntr_t)prte_list_get_size(seq_list))) {
+        if (NULL == seq_list || 0 == (num_nodes = (int32_t)prte_list_get_size(seq_list))) {
             prte_show_help("help-prte-rmaps-base.txt",
                            "prte-rmaps-base:no-available-resources",
                            true);

--- a/src/mca/routed/base/routed_base_fns.c
+++ b/src/mca/routed/base/routed_base_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,7 +91,7 @@ int prte_routed_base_process_callback(prte_jobid_t job, prte_buffer_t *buffer)
 {
     prte_proc_t *proc;
     prte_job_t *jdata;
-    prte_std_cntr_t cnt;
+    int32_t cnt;
     char *rml_uri;
     prte_vpid_t vpid;
     int rc;

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -790,11 +790,11 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
     prte_job_t *jdata;
     prte_proc_t *proc;
     int i;
-    prte_std_cntr_t j;
+    int32_t j;
     prte_job_t *job;
     prte_node_t *node;
     prte_job_map_t *map;
-    prte_std_cntr_t index;
+    int32_t index;
     bool one_still_alive;
     prte_vpid_t lowest=0;
     int32_t i32, *i32ptr;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -241,7 +241,13 @@ static void init_complete(int sd, short args, void *cbdata)
 
     /* nothing to do here but move along - if it is the
      * daemon job, then next step is allocate */
-    PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_ALLOCATE);
+    if (PRTE_PROC_MY_NAME->jobid == caddy->jdata->jobid) {
+        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_ALLOCATE);
+    } else {
+        /* we already did an allocation when we launched the DVM,
+         * so skip that step */
+        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_ALLOCATION_COMPLETE);
+    }
     PRTE_RELEASE(caddy);
 }
 

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -422,7 +422,7 @@ static void check_complete(int fd, short args, void *cbdata)
     int i, rc;
     prte_node_t *node;
     prte_job_map_t *map;
-    prte_std_cntr_t index;
+    int32_t index;
     pmix_proc_t pname;
     prte_pmix_lock_t lock;
     uint8_t command = PRTE_PMIX_PURGE_PROC_CMD;

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -276,7 +276,7 @@ static void track_procs(int fd, short argc, void *cbdata)
     prte_buffer_t *alert;
     int rc, i;
     prte_plm_cmd_flag_t cmd;
-    prte_std_cntr_t index;
+    int32_t index;
     prte_job_map_t *map;
     prte_node_t *node;
     prte_process_name_t target;

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -51,7 +51,6 @@
 static int init_server(void)
 {
     char *server;
-    pmix_proc_t proc;
     pmix_value_t val;
     char input[1024], *filename;
     FILE *fp;
@@ -113,9 +112,8 @@ static int init_server(void)
             return rc;
         }
         /* setup our route to the server */
-        PRTE_PMIX_CONVERT_NAME(rc, &proc, &prte_pmix_server_globals.server);
         PMIX_VALUE_LOAD(&val, server, PMIX_STRING);
-        if (PMIX_SUCCESS != (ret = PMIx_Store_internal(&proc, PMIX_PROC_URI, &val))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Store_internal(PRTE_PROC_MY_PROCID, PMIX_PROC_URI, &val))) {
             PMIX_ERROR_LOG(ret);
             PMIX_VALUE_DESTRUCT(&val);
             return rc;

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -108,7 +108,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
     prte_daemon_cmd_flag_t command;
     prte_buffer_t *relay_msg;
     int ret;
-    prte_std_cntr_t n;
+    int32_t n;
     int32_t signal, cnt;
     prte_jobid_t job;
     prte_buffer_t data, *answer;
@@ -119,7 +119,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
     prte_proc_t *proct;
     char *cmd_str = NULL;
     prte_pointer_array_t *procs_to_kill = NULL;
-    prte_std_cntr_t num_procs, num_new_procs = 0, p;
+    int32_t num_procs, num_new_procs = 0, p;
     prte_proc_t *cur_proc = NULL, *prev_proc = NULL;
     bool found = false;
     prte_node_t *node;
@@ -360,7 +360,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
 
         /* Number of processes */
         n = 1;
-        if (PRTE_SUCCESS != (ret = prte_dss.unpack(buffer, &num_procs, &n, PRTE_STD_CNTR)) ) {
+        if (PRTE_SUCCESS != (ret = prte_dss.unpack(buffer, &num_procs, &n, PRTE_INT32)) ) {
             PRTE_ERROR_LOG(ret);
             goto CLEANUP;
         }

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -137,7 +137,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
     void *nptr;
     prte_pmix_lock_t lk;
     pmix_data_buffer_t pbkt;
-    pmix_proc_t pdmn, pname;
+    pmix_proc_t pname;
     prte_byte_object_t *bo, *bo2;
     prte_process_name_t dmn;
     pmix_status_t pstatus;
@@ -293,7 +293,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
                     PMIX_DATA_BUFFER_LOAD(&pbkt, bo2->bytes, bo2->size);
                     /* unpack the number of info's provided */
                     cnt = 1;
-                    if (PMIX_SUCCESS != (pstatus = PMIx_Data_unpack(&prte_process_info.myproc, &pbkt, &ninfo, &cnt, PMIX_SIZE))) {
+                    if (PMIX_SUCCESS != (pstatus = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &ninfo, &cnt, PMIX_SIZE))) {
                         PMIX_ERROR_LOG(pstatus);
                         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                         ret = PRTE_ERR_UNPACK_FAILURE;
@@ -302,7 +302,7 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
                     /* unpack the infos */
                     PMIX_INFO_CREATE(info, ninfo);
                     cnt = ninfo;
-                    if (PMIX_SUCCESS != (pstatus = PMIx_Data_unpack(&prte_process_info.myproc, &pbkt, info, &cnt, PMIX_INFO))) {
+                    if (PMIX_SUCCESS != (pstatus = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, info, &cnt, PMIX_INFO))) {
                         PMIX_ERROR_LOG(pstatus);
                         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                         PMIX_INFO_FREE(info, ninfo);
@@ -311,9 +311,8 @@ void prte_daemon_recv(int status, prte_process_name_t* sender,
                     }
 
                     /* store them locally */
-                    PRTE_PMIX_CONVERT_NAME(ret, &pdmn, &dmn);
                     for (n2=0; n2 < ninfo; n2++) {
-                        pstatus = PMIx_Store_internal(&pdmn, info[n2].key, &info[n2].value);
+                        pstatus = PMIx_Store_internal(PRTE_PROC_MY_PROCID, info[n2].key, &info[n2].value);
                         if (PMIX_SUCCESS != pstatus) {
                             PMIX_ERROR_LOG(pstatus);
                             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);

--- a/src/runtime/data_type_support/prte_dt_compare_fns.c
+++ b/src/runtime/data_type_support/prte_dt_compare_fns.c
@@ -9,7 +9,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -27,15 +27,6 @@
 #include "src/mca/grpcomm/grpcomm.h"
 
 #include "src/runtime/data_type_support/prte_dt_support.h"
-
-int prte_dt_compare_std_cntr(prte_std_cntr_t *value1, prte_std_cntr_t *value2, prte_data_type_t type)
-{
-    if (*value1 > *value2) return PRTE_VALUE1_GREATER;
-
-    if (*value2 > *value1) return PRTE_VALUE2_GREATER;
-
-    return PRTE_EQUAL;
-}
 
 /**
  * JOB

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -33,23 +33,6 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/runtime/data_type_support/prte_dt_support.h"
 
-/* PRTE_STD_CNTR */
-int prte_dt_copy_std_cntr(prte_std_cntr_t **dest, prte_std_cntr_t *src, prte_data_type_t type)
-{
-    prte_std_cntr_t *val;
-
-    val = (prte_std_cntr_t*)malloc(sizeof(prte_std_cntr_t));
-    if (NULL == val) {
-        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-
-    *val = *src;
-    *dest = val;
-
-    return PRTE_SUCCESS;
-}
-
 /**
  * JOB
  */
@@ -194,7 +177,7 @@ int prte_dt_copy_exit_code(prte_exit_code_t **dest, prte_exit_code_t *src, prte_
  */
 int prte_dt_copy_map(prte_job_map_t **dest, prte_job_map_t *src, prte_data_type_t type)
 {
-    prte_std_cntr_t i;
+    int32_t i;
 
     if (NULL == src) {
         *dest = NULL;

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -37,23 +37,6 @@
 #include "src/runtime/data_type_support/prte_dt_support.h"
 
 /*
- * PRTE_STD_CNTR
- */
-int prte_dt_pack_std_cntr(prte_buffer_t *buffer, const void *src,
-                            int32_t num_vals, prte_data_type_t type)
-{
-    int ret;
-
-    /* Turn around and pack the real type */
-    if (PRTE_SUCCESS != (
-                         ret = prte_dss_pack_buffer(buffer, src, num_vals, PRTE_STD_CNTR_T))) {
-        PRTE_ERROR_LOG(ret);
-    }
-
-    return ret;
-}
-
-/*
  * JOB
  * NOTE: We do not pack all of the job object's fields as many of them have no
  * value in sending them to another location. The only purpose in packing and
@@ -106,7 +89,7 @@ int prte_dt_pack_job(prte_buffer_t *buffer, const void *src,
                 ++count;
             }
         }
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -126,7 +109,7 @@ int prte_dt_pack_job(prte_buffer_t *buffer, const void *src,
              * of prte_value_t's on a list. So first pack the number
              * of list elements */
             count = prte_list_get_size(cache);
-            if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+            if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
                 PRTE_ERROR_LOG(rc);
                 return rc;
             }
@@ -140,7 +123,7 @@ int prte_dt_pack_job(prte_buffer_t *buffer, const void *src,
         } else {
             /* pack a zero to indicate no job info is being passed */
             count = 0;
-            if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+            if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
                 PRTE_ERROR_LOG(rc);
                 return rc;
             }
@@ -216,7 +199,7 @@ int prte_dt_pack_job(prte_buffer_t *buffer, const void *src,
 
         /* pack the total slots allocated to the job */
         if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer,
-                         (void*)(&(jobs[i]->total_slots_alloc)), 1, PRTE_STD_CNTR))) {
+                         (void*)(&(jobs[i]->total_slots_alloc)), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -234,7 +217,7 @@ int prte_dt_pack_job(prte_buffer_t *buffer, const void *src,
             j = 1;
         }
         if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer,
-                            (void*)&j, 1, PRTE_STD_CNTR))) {
+                            (void*)&j, 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -334,7 +317,7 @@ int prte_dt_pack_node(prte_buffer_t *buffer, const void *src,
                 ++count;
             }
         }
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -402,7 +385,7 @@ int prte_dt_pack_proc(prte_buffer_t *buffer, const void *src,
 
         /* pack the app context index */
         if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer,
-                         (void*)(&(procs[i]->app_idx)), 1, PRTE_STD_CNTR))) {
+                         (void*)(&(procs[i]->app_idx)), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -421,7 +404,7 @@ int prte_dt_pack_proc(prte_buffer_t *buffer, const void *src,
                 ++count;
             }
         }
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -455,7 +438,7 @@ int prte_dt_pack_app_context(prte_buffer_t *buffer, const void *src,
     for (i=0; i < num_vals; i++) {
         /* pack the application index (for multiapp jobs) */
         if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer,
-                                                       (void*)(&(app_context[i]->idx)), 1, PRTE_STD_CNTR))) {
+                                                       (void*)(&(app_context[i]->idx)), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -469,7 +452,7 @@ int prte_dt_pack_app_context(prte_buffer_t *buffer, const void *src,
 
         /* pack the number of processes */
         if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer,
-                                                       (void*)(&(app_context[i]->num_procs)), 1, PRTE_STD_CNTR))) {
+                                                       (void*)(&(app_context[i]->num_procs)), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -483,7 +466,7 @@ int prte_dt_pack_app_context(prte_buffer_t *buffer, const void *src,
 
         /* pack the number of entries in the argv array */
         count = prte_argv_count(app_context[i]->argv);
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -499,7 +482,7 @@ int prte_dt_pack_app_context(prte_buffer_t *buffer, const void *src,
 
         /* pack the number of entries in the enviro array */
         count = prte_argv_count(app_context[i]->env);
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -527,7 +510,7 @@ int prte_dt_pack_app_context(prte_buffer_t *buffer, const void *src,
                 ++count;
             }
         }
-        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_pack_buffer(buffer, (void*)(&count), 1, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -125,10 +125,6 @@ int prte_dt_std_print(char **output, char *prefix, void *src, prte_data_type_t t
     *output = NULL;
 
     switch(type) {
-        case PRTE_STD_CNTR:
-            prte_dt_quick_print(output, "PRTE_STD_CNTR", prefix, src, PRTE_STD_CNTR_T);
-            break;
-
         case PRTE_PROC_STATE:
             prte_dt_quick_print(output, "PRTE_PROC_STATE", prefix, src, PRTE_PROC_STATE_T);
             break;

--- a/src/runtime/data_type_support/prte_dt_support.h
+++ b/src/runtime/data_type_support/prte_dt_support.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -46,7 +46,7 @@
 BEGIN_C_DECLS
 
 /** Data type compare functions */
-int prte_dt_compare_std_cntr(prte_std_cntr_t *value1, prte_std_cntr_t *value2, prte_data_type_t type);
+int prte_dt_compare_std_cntr(int32_t *value1, int32_t *value2, prte_data_type_t type);
 int prte_dt_compare_job(prte_job_t *value1, prte_job_t *value2, prte_data_type_t type);
 int prte_dt_compare_node(prte_node_t *value1, prte_node_t *value2, prte_data_type_t type);
 int prte_dt_compare_proc(prte_proc_t *value1, prte_proc_t *value2, prte_data_type_t type);
@@ -73,7 +73,7 @@ int prte_dt_compare_attr(prte_attribute_t *value1, prte_attribute_t *value2, prt
 int prte_dt_compare_sig(prte_grpcomm_signature_t *value1, prte_grpcomm_signature_t *value2, prte_data_type_t type);
 
 /** Data type copy functions */
-int prte_dt_copy_std_cntr(prte_std_cntr_t **dest, prte_std_cntr_t *src, prte_data_type_t type);
+int prte_dt_copy_std_cntr(int32_t **dest, int32_t *src, prte_data_type_t type);
 int prte_dt_copy_job(prte_job_t **dest, prte_job_t *src, prte_data_type_t type);
 int prte_dt_copy_node(prte_node_t **dest, prte_node_t *src, prte_data_type_t type);
 int prte_dt_copy_proc(prte_proc_t **dest, prte_proc_t *src, prte_data_type_t type);

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -35,22 +35,6 @@
 #include "src/runtime/data_type_support/prte_dt_support.h"
 
 /*
- * PRTE_STD_CNTR
- */
-int prte_dt_unpack_std_cntr(prte_buffer_t *buffer, void *dest,
-                             int32_t *num_vals, prte_data_type_t type)
-{
-    int ret;
-
-    /* Turn around and unpack the real type */
-    if (PRTE_SUCCESS != (ret = prte_dss_unpack_buffer(buffer, dest, num_vals, PRTE_STD_CNTR_T))) {
-        PRTE_ERROR_LOG(ret);
-    }
-
-    return ret;
-}
-
-/*
  * JOB
  * NOTE: We do not pack all of the job object's fields as many of them have no
  * value in sending them to another location. The only purpose in packing and
@@ -107,7 +91,7 @@ int prte_dt_unpack_job(prte_buffer_t *buffer, void *dest,
         /* unpack the attributes */
         n=1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count,
-                                                         &n, PRTE_STD_CNTR))) {
+                                                         &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -124,7 +108,7 @@ int prte_dt_unpack_job(prte_buffer_t *buffer, void *dest,
         /* unpack any job info */
         n=1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count,
-                                                         &n, PRTE_STD_CNTR))) {
+                                                         &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -222,7 +206,7 @@ int prte_dt_unpack_job(prte_buffer_t *buffer, void *dest,
         /* unpack the total slots allocated to the job */
         n = 1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer,
-                         (&(jobs[i]->total_slots_alloc)), &n, PRTE_STD_CNTR))) {
+                         (&(jobs[i]->total_slots_alloc)), &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -232,7 +216,7 @@ int prte_dt_unpack_job(prte_buffer_t *buffer, void *dest,
          * the map is included */
         n = 1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer,
-                                            &j, &n, PRTE_STD_CNTR))) {
+                                            &j, &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -345,7 +329,7 @@ int prte_dt_unpack_node(prte_buffer_t *buffer, void *dest,
         /* unpack the attributes */
         n=1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count,
-                                                         &n, PRTE_STD_CNTR))) {
+                                                         &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -428,7 +412,7 @@ int prte_dt_unpack_proc(prte_buffer_t *buffer, void *dest,
         /* unpack the app context index */
         n = 1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer,
-                         (&(procs[i]->app_idx)), &n, PRTE_STD_CNTR))) {
+                         (&(procs[i]->app_idx)), &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -444,7 +428,7 @@ int prte_dt_unpack_proc(prte_buffer_t *buffer, void *dest,
         /* unpack the attributes */
         n=1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count,
-                                                         &n, PRTE_STD_CNTR))) {
+                                                         &n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -487,7 +471,7 @@ int prte_dt_unpack_app_context(prte_buffer_t *buffer, void *dest,
         /* get the app index number */
         max_n = 1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &(app_context[i]->idx),
-                                                         &max_n, PRTE_STD_CNTR))) {
+                                                         &max_n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -503,7 +487,7 @@ int prte_dt_unpack_app_context(prte_buffer_t *buffer, void *dest,
         /* get the number of processes */
         max_n = 1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &(app_context[i]->num_procs),
-                                                         &max_n, PRTE_STD_CNTR))) {
+                                                         &max_n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -518,7 +502,7 @@ int prte_dt_unpack_app_context(prte_buffer_t *buffer, void *dest,
 
         /* get the number of argv strings that were packed */
         max_n = 1;
-        if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count, &max_n, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count, &max_n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -542,7 +526,7 @@ int prte_dt_unpack_app_context(prte_buffer_t *buffer, void *dest,
 
         /* get the number of env strings */
         max_n = 1;
-        if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count, &max_n, PRTE_STD_CNTR))) {
+        if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count, &max_n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
@@ -575,7 +559,7 @@ int prte_dt_unpack_app_context(prte_buffer_t *buffer, void *dest,
         /* unpack the attributes */
         max_n=1;
         if (PRTE_SUCCESS != (rc = prte_dss_unpack_buffer(buffer, &count,
-                                                         &max_n, PRTE_STD_CNTR))) {
+                                                         &max_n, PRTE_INT32))) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -52,7 +52,7 @@ typedef struct {
     /* base object */
     prte_object_t super;
     /* index of this object in the storage array */
-    prte_std_cntr_t index;
+    int32_t index;
     /* process that owns this data - only the
     * owner can remove it
     */
@@ -167,7 +167,7 @@ int prte_data_server_init(void)
 
 void prte_data_server_finalize(void)
 {
-    prte_std_cntr_t i;
+    int32_t i;
     prte_data_object_t *data;
 
     if (!initialized) {
@@ -189,7 +189,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
                       void* cbdata)
 {
     uint8_t command;
-    prte_std_cntr_t count;
+    int32_t count;
     prte_data_object_t *data;
     prte_byte_object_t bo, *boptr;
     prte_buffer_t *answer, *reply;

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -204,7 +204,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
     pmix_data_buffer_t pbkt;
     pmix_byte_object_t pbo;
     pmix_status_t ret;
-    pmix_proc_t psender, requestor;
+    pmix_proc_t requestor;
     prte_ds_info_t *rinfo;
     size_t n, nanswers;
     pmix_info_t *info;
@@ -255,20 +255,13 @@ void prte_data_server(int status, prte_process_name_t* sender,
     boptr->bytes = NULL;
     free(boptr);
 
-    /* convert the sender */
-    PRTE_PMIX_CONVERT_NAME(rc, &psender, sender);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        goto SEND_ERROR;
-    }
-
     switch(command) {
     case PRTE_PMIX_PUBLISH_CMD:
         data = PRTE_NEW(prte_data_object_t);
 
         /* unpack the publisher */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &data->owner, &count, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &data->owner, &count, PMIX_PROC))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             PRTE_RELEASE(data);
@@ -283,7 +276,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack the number of infos they published */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &data->ninfo, &count, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &data->ninfo, &count, PMIX_SIZE))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             PRTE_RELEASE(data);
@@ -306,7 +299,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack into it */
         count = data->ninfo;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, data->info, &count, PMIX_INFO))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, data->info, &count, PMIX_INFO))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             PRTE_RELEASE(data);
@@ -407,7 +400,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
                 PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
 
                 /* pack the number of returned info's */
-                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, &n, 1, PMIX_SIZE))) {
+                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, &n, 1, PMIX_SIZE))) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                     rc = PRTE_ERR_PACK_FAILURE;
@@ -419,14 +412,14 @@ void prte_data_server(int status, prte_process_name_t* sender,
                  * array */
                 while (NULL != (rinfo = (prte_ds_info_t*)prte_list_remove_first(&req->answers))) {
                     /* pack the data owner */
-                    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, &rinfo->source, 1, PMIX_PROC))) {
+                    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, &rinfo->source, 1, PMIX_PROC))) {
                         PMIX_ERROR_LOG(ret);
                         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                         rc = PRTE_ERR_PACK_FAILURE;
                         goto SEND_ERROR;
                     }
                     /* pack the data */
-                    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, rinfo->info, 1, PMIX_INFO))) {
+                    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, rinfo->info, 1, PMIX_INFO))) {
                         PMIX_ERROR_LOG(ret);
                         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                         rc = PRTE_ERR_PACK_FAILURE;
@@ -475,7 +468,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack the requestor */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &requestor, &count, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &requestor, &count, PMIX_PROC))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -484,7 +477,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack the number of keys */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &ninfo, &count, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &ninfo, &count, PMIX_SIZE))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -501,7 +494,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
         /* unpack the keys */
         for (n=0; n < ninfo; n++) {
             count = 1;
-            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &str, &count, PRTE_STRING))) {
+            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &str, &count, PRTE_STRING))) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 rc = PRTE_ERR_UNPACK_FAILURE;
@@ -514,7 +507,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack the number of directives, if any */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &ninfo, &count, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &ninfo, &count, PMIX_SIZE))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -523,7 +516,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
         if (0 < ninfo) {
             PMIX_INFO_CREATE(info, ninfo);
             count = ninfo;
-            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, info, &count, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, info, &count, PMIX_INFO))) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 PMIX_INFO_FREE(info, ninfo);
@@ -603,7 +596,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         if (0 < (nanswers = prte_list_get_size(&answers))) {
             /* pack the number of data items found */
-            if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, &nanswers, 1, PMIX_SIZE))) {
+            if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, &nanswers, 1, PMIX_SIZE))) {
                 PMIX_ERROR_LOG(ret);
                 rc = PRTE_ERR_PACK_FAILURE;
                 PRTE_LIST_DESTRUCT(&answers);
@@ -616,14 +609,14 @@ void prte_data_server(int status, prte_process_name_t* sender,
              * array */
             PRTE_LIST_FOREACH(rinfo, &answers, prte_ds_info_t) {
                 /* pack the data owner */
-                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, &rinfo->source, 1, PMIX_PROC))) {
+                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, &rinfo->source, 1, PMIX_PROC))) {
                     PMIX_ERROR_LOG(ret);
                     rc = PRTE_ERR_PACK_FAILURE;
                     PRTE_LIST_DESTRUCT(&answers);
                     prte_argv_free(keys);
                     goto SEND_ERROR;
                 }
-                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(&psender, &pbkt, rinfo->info, 1, PMIX_INFO))) {
+                if (PMIX_SUCCESS != (ret = PMIx_Data_pack(PRTE_PROC_MY_PROCID, &pbkt, rinfo->info, 1, PMIX_INFO))) {
                     PMIX_ERROR_LOG(ret);
                     rc = PRTE_ERR_PACK_FAILURE;
                     PRTE_LIST_DESTRUCT(&answers);
@@ -711,7 +704,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
     case PRTE_PMIX_UNPUBLISH_CMD:
         /* unpack the requestor */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &requestor, &count, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &requestor, &count, PMIX_PROC))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -725,7 +718,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
 
         /* unpack the number of keys */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &ninfo, &count, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &ninfo, &count, PMIX_SIZE))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -742,7 +735,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
         /* unpack the keys */
         for (n=0; n < ninfo; n++) {
             count = 1;
-            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &str, &count, PRTE_STRING))) {
+            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &str, &count, PRTE_STRING))) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 rc = PRTE_ERR_UNPACK_FAILURE;
@@ -756,7 +749,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
         /* unpack the number of directives, if any */
         range = PMIX_RANGE_SESSION;  // default
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &ninfo, &count, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &ninfo, &count, PMIX_SIZE))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;
@@ -765,7 +758,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
         if (0 < ninfo) {
             PMIX_INFO_CREATE(info, ninfo);
             count = ninfo;
-            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, info, &count, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, info, &count, PMIX_INFO))) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 PMIX_INFO_FREE(info, ninfo);
@@ -841,7 +834,7 @@ void prte_data_server(int status, prte_process_name_t* sender,
          * data is purged by providing a requestor whose rank
          * is wildcard */
         count = 1;
-        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(&psender, &pbkt, &requestor, &count, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(PRTE_PROC_MY_PROCID, &pbkt, &requestor, &count, PMIX_PROC))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_UNPACK_FAILURE;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -205,19 +205,6 @@ int prte_dt_init(void)
         }
     }
 
-    /** register the base system types with the DSS */
-    tmp = PRTE_STD_CNTR;
-    if (PRTE_SUCCESS != (rc = prte_dss.register_type(prte_dt_pack_std_cntr,
-                                                     prte_dt_unpack_std_cntr,
-                                                     (prte_dss_copy_fn_t)prte_dt_copy_std_cntr,
-                                                     (prte_dss_compare_fn_t)prte_dt_compare_std_cntr,
-                                                     (prte_dss_print_fn_t)prte_dt_std_print,
-                                                     PRTE_DSS_UNSTRUCTURED,
-                                                     "PRTE_STD_CNTR", &tmp))) {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
-
     tmp = PRTE_JOB;
     if (PRTE_SUCCESS != (rc = prte_dss.register_type(prte_dt_pack_job,
                                                      prte_dt_unpack_job,
@@ -851,7 +838,7 @@ static void prte_job_map_construct(prte_job_map_t* map)
 
 static void prte_job_map_destruct(prte_job_map_t* map)
 {
-    prte_std_cntr_t i;
+    int32_t i;
     prte_node_t *node;
 
     if (NULL != map->req_mapper) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -97,7 +97,6 @@ bool prte_hnp_is_allocated = false;
 bool prte_allocation_required = false;
 bool prte_managed_allocation = false;
 char *prte_set_slots = NULL;
-bool prte_soft_locations = false;
 bool prte_nidmap_communicated = false;
 bool prte_node_info_communicated = false;
 
@@ -733,6 +732,7 @@ static void prte_node_construct(prte_node_t* node)
 
     node->state = PRTE_NODE_STATE_UNKNOWN;
     node->slots = 0;
+    node->slots_available = 0;
     node->slots_inuse = 0;
     node->slots_max = 0;
     node->topology = NULL;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -215,7 +215,7 @@ typedef struct {
     /** Absolute pathname of argv[0] */
     char   *app;
     /** Number of copies of this process that are to be launched */
-    prte_std_cntr_t num_procs;
+    int32_t num_procs;
     /** Array of pointers to the proc objects for procs of this app_context
      * NOTE - not always used
      */
@@ -248,7 +248,7 @@ typedef struct {
     /** Base object so this can be put on a list */
     prte_list_item_t super;
     /* index of this node object in global array */
-    prte_std_cntr_t index;
+    int32_t index;
     /** String node name */
     char *name;
     /* daemon on this node */
@@ -265,10 +265,10 @@ typedef struct {
         This will typically correspond to the number of physical CPUs
         that we have been allocated on this note and would be the
         "ideal" number of processes for us to launch. */
-    prte_std_cntr_t slots;
+    int32_t slots;
     /** How many processes have already been launched, used by one or
         more jobs on this node. */
-    prte_std_cntr_t slots_inuse;
+    int32_t slots_inuse;
     /** A "hard" limit (if set -- a value of 0 implies no hard limit)
         on the number of slots that can be allocated on a given
         node. This is for some environments (e.g. grid) there may be
@@ -279,7 +279,7 @@ typedef struct {
         other words allow the node to be oversubscribed up to a
         specified limit.  For example, if we have two processors, we
         may want to allow up to four processes but no more. */
-    prte_std_cntr_t slots_max;
+    int32_t slots_max;
     /* system topology for this node */
     prte_topology_t *topology;
     /* flags */
@@ -311,7 +311,7 @@ typedef struct {
      */
     prte_vpid_t stdin_target;
     /* total slots allocated to this job */
-    prte_std_cntr_t total_slots_alloc;
+    int32_t total_slots_alloc;
     /* number of procs in this job */
     prte_vpid_t num_procs;
     /* array of pointers to procs in this job */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -86,6 +86,7 @@ PRTE_EXPORT extern prte_process_name_t prte_name_wildcard;  /** instantiated in 
 PRTE_EXPORT extern prte_process_name_t prte_name_invalid;  /** instantiated in src/runtime/prte_init.c */
 
 #define PRTE_PROC_MY_NAME       (&prte_process_info.my_name)
+#define PRTE_PROC_MY_PROCID     (&prte_process_info.myproc)
 
 /* define a special name that point to my parent (aka the process that spawned me) */
 #define PRTE_PROC_MY_PARENT     (&prte_process_info.my_parent)
@@ -266,6 +267,10 @@ typedef struct {
         that we have been allocated on this note and would be the
         "ideal" number of processes for us to launch. */
     int32_t slots;
+    /** Slots available for use in the current mapping operation. This
+     *  may differ on a per-job basis from the overall allocated slots
+     *  thru use of the -host option and possibly other means */
+    int32_t slots_available;
     /** How many processes have already been launched, used by one or
         more jobs on this node. */
     int32_t slots_inuse;
@@ -476,7 +481,6 @@ PRTE_EXPORT extern bool prte_hnp_is_allocated;
 PRTE_EXPORT extern bool prte_allocation_required;
 PRTE_EXPORT extern bool prte_managed_allocation;
 PRTE_EXPORT extern char *prte_set_slots;
-PRTE_EXPORT extern bool prte_soft_locations;
 PRTE_EXPORT extern bool prte_hnp_connected;
 PRTE_EXPORT extern bool prte_nidmap_communicated;
 PRTE_EXPORT extern bool prte_node_info_communicated;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -643,21 +643,11 @@ int prte_register_params(void)
     (void) prte_mca_base_var_register ("prte", "prte", NULL, "set_default_slots",
                                   "Set the number of slots on nodes that lack such info to the"
                                   " number of specified objects [a number, \"cores\" (default),"
-                                  " \"numas\", \"sockets\", \"hwthreads\" (default if hwthreads_as_cpus is set),"
+                                  " \"packages\", \"hwthreads\" (default if hwthreads_as_cpus is set),"
                                   " or \"none\" to skip this option]",
                                   PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
                                   PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                   &prte_set_slots);
-
-    /* should we treat any -host directives as "soft" - i.e., desired
-     * but not required
-     */
-    prte_soft_locations = false;
-    (void) prte_mca_base_var_register ("prte", "prte", NULL, "soft_locations",
-                                  "Treat -host directives as desired, but not required",
-                                  PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                  &prte_soft_locations);
 
     /* allow specification of the cores to be used by daemons */
     prte_daemon_cores = NULL;

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -295,7 +295,7 @@ static char* print_aborted_job(prte_job_t *job,
 char* prte_dump_aborted_procs(prte_job_t *jdata)
 {
     prte_job_t *job, *launcher;
-    prte_std_cntr_t i;
+    int32_t i;
     prte_proc_t *proc, *pptr;
     prte_app_context_t *approc;
     prte_node_t *node;

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -83,7 +83,7 @@ int prte_util_add_dash_host_nodes(prte_list_t *nodes,
                                   char *hosts, bool allocating)
 {
     prte_list_item_t *item, *itm;
-    prte_std_cntr_t i, j, k;
+    int32_t i, j, k;
     int rc, nodeidx;
     char **host_argv=NULL;
     char **mapped_nodes = NULL, **mini_map, *ndname;
@@ -352,7 +352,7 @@ int prte_util_add_dash_host_nodes(prte_list_t *nodes,
  */
 static int parse_dash_host(char ***mapped_nodes, char *hosts)
 {
-    prte_std_cntr_t j, k;
+    int32_t j, k;
     int rc=PRTE_SUCCESS;
     char **mini_map=NULL, *cptr;
     int nodeidx;
@@ -453,7 +453,7 @@ int prte_util_filter_dash_host_nodes(prte_list_t *nodes,
 {
     prte_list_item_t* item;
     prte_list_item_t *next;
-    prte_std_cntr_t i, j, len_mapped_node=0;
+    int32_t i, j, len_mapped_node=0;
     int rc, test;
     char **mapped_nodes = NULL;
     prte_node_t *node;

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -1094,7 +1094,7 @@ int prte_util_generate_ppn(prte_job_t *jdata,
                     }
                 }
                 if (0 < ppn) {
-                    if (PRTE_SUCCESS != (rc = prte_dss.pack(&bucket, &nptr->index, 1, PRTE_STD_CNTR))) {
+                    if (PRTE_SUCCESS != (rc = prte_dss.pack(&bucket, &nptr->index, 1, PRTE_INT32))) {
                         goto cleanup;
                     }
                     if (PRTE_SUCCESS != (rc = prte_dss.pack(&bucket, &ppn, 1, PRTE_UINT16))) {
@@ -1147,7 +1147,7 @@ int prte_util_generate_ppn(prte_job_t *jdata,
 int prte_util_decode_ppn(prte_job_t *jdata,
                          prte_buffer_t *buf)
 {
-    prte_std_cntr_t index;
+    int32_t index;
     prte_app_idx_t n;
     int cnt, rc=PRTE_SUCCESS, m;
     prte_byte_object_t *boptr;
@@ -1220,7 +1220,7 @@ int prte_util_decode_ppn(prte_job_t *jdata,
 
         /* unpack each node and its ppn */
         cnt = 1;
-        while (PRTE_SUCCESS == (rc = prte_dss.unpack(&bucket, &index, &cnt, PRTE_STD_CNTR))) {
+        while (PRTE_SUCCESS == (rc = prte_dss.unpack(&bucket, &index, &cnt, PRTE_INT32))) {
             /* get the corresponding node object */
             if (NULL == (node = (prte_node_t*)prte_pointer_array_get_item(prte_node_pool, index))) {
                 rc = PRTE_ERR_NOT_FOUND;


### PR DESCRIPTION
Remove stale prte_std_cntr_t type
Replace it with int32_t

Avoid unnecessary name conversions and remove stale param
No need to convert daemon names as we can just use our own proc ID.

Remove the prte_soft_locations param as we really don't support it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
