### PR TITLE
Add support for Cobalt scheduler on Theta

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -141,10 +141,11 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
         }
     }
 
-    /* if this is an unmanaged allocation, then set the default
+    /* if this is an unmanaged allocation or a managed allocation that
+     * did not specify the #slots/node, then set the default
      * slots on each node as directed or using default
      */
-    if (!prte_managed_allocation) {
+    if (!prte_managed_allocation || !prte_managed_slots_given) {
         if (NULL != prte_set_slots &&
             0 != strncmp(prte_set_slots, "none", strlen(prte_set_slots))) {
             caddy->jdata->total_slots_alloc = 0;

--- a/src/mca/ras/alps/ras_alps_component.c
+++ b/src/mca/ras/alps/ras_alps_component.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2008      UT-Battelle, LLC
  * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Triad National Security, LLC. All rights
@@ -205,7 +205,8 @@ prte_ras_alps_component_query(prte_mca_base_module_t **module,
      * on some systems
      */
     if ((NULL == (jid_str = getenv("OMPI_ALPS_RESID"))) &&
-        (NULL == (jid_str = getenv("BASIL_RESERVATION_ID")))) {
+        (NULL == (jid_str = getenv("BASIL_RESERVATION_ID"))) &&
+        (NULL == (jid_str = getenv("COBALT_JOBID")))) {
             prte_ras_alps_res_id = get_res_id();
     }
     else {

--- a/src/mca/ras/alps/ras_alps_module.c
+++ b/src/mca/ras/alps/ras_alps_module.c
@@ -315,6 +315,8 @@ prte_ras_alps_allocate(prte_job_t *jdata, prte_list_t *nodes)
     if (NULL != (nodelist = getenv("COBALT_PARTNAME"))) {
         /* looks just like a -host string */
         ret = prte_util_add_dash_host_nodes(nodes, nodelist, true);
+        /* set a flag so we know to discover the #slots on the nodes */
+        prte_managed_slots_given = false;
         goto cleanup;
     }
 

--- a/src/mca/ras/alps/ras_alps_module.c
+++ b/src/mca/ras/alps/ras_alps_module.c
@@ -26,6 +26,7 @@
 #include "constants.h"
 
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
+#include "src/util/dash_host/dash_host.h"
 #include "src/util/output.h"
 #include "src/util/show_help.h"
 #include "src/mca/errmgr/errmgr.h"
@@ -307,6 +308,15 @@ prte_ras_alps_allocate(prte_job_t *jdata, prte_list_t *nodes)
 {
     int ret;
     char *appinfo_path = NULL;
+    char *nodelist;
+
+    /* this could be a Cobalt job - if it is, then the node list will
+     * be in the COBALT_PARTNAME envar */
+    if (NULL != (nodelist = getenv("COBALT_PARTNAME"))) {
+        /* looks just like a -host string */
+        ret = prte_util_add_dash_host_nodes(nodes, nodelist, true);
+        goto cleanup;
+    }
 
     if (0 == prte_ras_alps_res_id) {
         prte_show_help("help-ras-alps.txt", "alps-env-var-not-found", 1);

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -189,7 +189,7 @@ int prte_ras_base_node_insert(prte_list_t* nodes, prte_job_t *jdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  (NULL == node->name) ? "NULL" : node->name,
                                  node->slots));
-            if (prte_managed_allocation) {
+            if (prte_managed_allocation && prte_managed_slots_given) {
                 /* the slots are always treated as sacred
                  * in managed allocations
                  */

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -96,6 +96,7 @@ char **prte_launch_environ = NULL;
 bool prte_hnp_is_allocated = false;
 bool prte_allocation_required = false;
 bool prte_managed_allocation = false;
+bool prte_managed_slots_given = true;
 char *prte_set_slots = NULL;
 bool prte_nidmap_communicated = false;
 bool prte_node_info_communicated = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -480,6 +480,7 @@ PRTE_EXPORT extern char **prte_launch_environ;
 PRTE_EXPORT extern bool prte_hnp_is_allocated;
 PRTE_EXPORT extern bool prte_allocation_required;
 PRTE_EXPORT extern bool prte_managed_allocation;
+PRTE_EXPORT extern bool prte_managed_slots_given;
 PRTE_EXPORT extern char *prte_set_slots;
 PRTE_EXPORT extern bool prte_hnp_connected;
 PRTE_EXPORT extern bool prte_nidmap_communicated;


### PR DESCRIPTION
Use the COBALT_PARTNAME envar that contains the list of allocated nodes
so that the rest of the ALPS support can function.

Fixes https://github.com/openpmix/prrte/issues/577

Signed-off-by: Ralph Castain <rhc@pmix.org>