### PR TITLE
ALPS RAS: add COBALT_JOBID to list of vars

### DIFF
--- a/src/mca/ras/alps/ras_alps_component.c
+++ b/src/mca/ras/alps/ras_alps_component.c
@@ -111,7 +111,13 @@ get_res_id(void)
     if (NULL != (id = getenv("BATCH_PARTITION_ID"))) {
         return strtoul(id, NULL, 10);
     }
-    if (NULL != (id = getenv("PBS_JOBID"))) {
+
+     id = getenv("PBS_JOBID");
+     if (NULL == id) {
+         id = getenv("COBALT_JOBID");
+     }
+ 
+    if (NULL != id) {
         char *prepped_jid = prep_job_id(id);
         if (NULL == prepped_jid) {
             /* out of resources */


### PR DESCRIPTION
to search for to get the batch scheduler's job id.
This job id shows up in the apsched -r output, which can then
be groked to get the alps resid, which in turns gives prte
the reservation information.

Related to #577

double checked on a alps/pbspro system.
prte and prun run nominally on the alps/pbspro system.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>