### PR TITLE
Add contrib recipes for Dockerizing PRRTE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ config/ext_no_configure_components.m4
 config/ext_m4_config_include.m4
 config/mca_library_paths.txt
 
+contrib/docker/tmp
+
 examples/alloc
 examples/bad_exit
 examples/client

--- a/contrib/docker/Dockerfile.centos7.ssh
+++ b/contrib/docker/Dockerfile.centos7.ssh
@@ -1,0 +1,185 @@
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+#
+# Base Build box for PRRTE
+# Requires:
+#  - Basic compile tooling and runtime support
+#  - libevent - retrieve v2.1.11-stable from web
+#  - hwloc - retrieve v2.2.0 from web
+#  - curl
+#  - libjansson - retrieve v2.13.1 from web
+#  - PMIx - cloned from 'master' branch
+#  - PRRTE - cloned from 'master' branch
+#
+FROM centos:7
+
+MAINTAINER Ralph Castain <ralph.h.castain@intel.com>
+
+# ------------------------------------------------------------
+# Install required packages
+# ------------------------------------------------------------
+RUN yum -y update && \
+    yum -y install epel-release && \
+    yum repolist && \
+    yum -y install \
+    systemd openssh-server openssh-clients \
+    gcc gdb strace \
+    binutils less wget which sudo \
+    perl perl-Data-Dumper numactl \
+    autoconf automake libtool flex bison \
+    iproute net-tools make git pandoc \
+    libnl3 gtk2 atk cairo tcl tcsh tk pciutils lsof ethtool bc file \
+    valgrind curl curl-devel && \
+    yum clean all
+
+# ------------------------------------------------------------
+# Define support libraries
+# - hwloc
+# - libevent
+# - libjansson
+# ------------------------------------------------------------
+RUN mkdir -p /opt/hpc/local/build
+RUN mkdir -p /opt/hpc/rndvz
+
+ARG LIBEVENT_INSTALL_PATH=/opt/hpc/local/libevent
+ENV LIBEVENT_INSTALL_PATH=$LIBEVENT_INSTALL_PATH
+ARG HWLOC_INSTALL_PATH=/opt/hpc/local/hwloc
+ENV HWLOC_INSTALL_PATH=$HWLOC_INSTALL_PATH
+ARG LIBJANSSON_INSTALL_PATH=/opt/hpc/local/libjansson
+ENV LIBJANSSON_INSTALL_PATH=$LIBJANSSON_INSTALL_PATH
+
+RUN cd /opt/hpc/local/build && \
+    wget https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz && \
+    tar xf libevent-2.1.11-stable.tar.gz && \
+    cd libevent-2.1.11-stable && \
+    ./configure --prefix=${LIBEVENT_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null
+RUN cd /opt/hpc/local/build && \
+    wget https://download.open-mpi.org/release/hwloc/v2.2/hwloc-2.2.0.tar.gz && \
+    tar xf hwloc-2.2.0.tar.gz && \
+    cd hwloc-2.2.0 && \
+    ./configure --prefix=${HWLOC_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/src /opt/hpc/local/build/*
+RUN cd /opt/hpc/local/build && \
+    wget https://digip.org/jansson/releases/jansson-2.13.1.tar.gz && \
+    tar xf jansson-2.13.1.tar.gz && \
+    cd jansson-2.13.1 && \
+    ./configure --prefix=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/build/*
+ENV LD_LIBRARY_PATH="$HWLOC_INSTALL_PATH/bin:$LIBEVENT_INSTALL_PATH/lib:$LIBJANSSON_INSTALL_PATH/lib:${LD_LIBRARY_PATH}"
+
+
+# ------------------------------------------------------------
+# PMIx Install
+# ------------------------------------------------------------
+ENV PMIX_ROOT=/opt/hpc/local/pmix
+ENV LD_LIBRARY_PATH="$PMIX_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/openpmix.git && \
+    cd openpmix && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PMIX_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-curl \
+                --with-jansson=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    cd .. && rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# PRRTE Install
+# ------------------------------------------------------------
+ENV PRRTE_ROOT=/opt/hpc/local/prrte
+ENV PATH="$PRRTE_ROOT/bin:${PATH}"
+ENV LD_LIBRARY_PATH="$PRRTE_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/prrte.git && \
+    cd prrte && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PRRTE_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-pmix=${PMIX_ROOT} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# Fixup the ssh login
+# ------------------------------------------------------------
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" && \
+    ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key  -N "" && \
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key  -N "" && \
+    echo "        LogLevel ERROR" >> /etc/ssh/ssh_config && \
+    echo "        StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
+    echo "        UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+
+# ------------------------------------------------------------
+# Adjust default ulimit for core files
+# ------------------------------------------------------------
+RUN echo '*               hard    core            -1' >> /etc/security/limits.conf && \
+    echo '*               soft    core            -1' >> /etc/security/limits.conf && \
+    echo 'ulimit -c unlimited' >> /root/.bashrc
+
+# ------------------------------------------------------------
+# Create a user account
+# ------------------------------------------------------------
+RUN groupadd -r prteuser && useradd --no-log-init -r -m -b /home -g prteuser -G wheel prteuser
+USER prteuser
+RUN  cd /home/prteuser && \
+        ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa && chmod og+rX . && \
+        cd .ssh && cat id_rsa.pub > authorized_keys && chmod 644 authorized_keys && \
+        exit
+
+# ------------------------------------------------------------
+# Give the user passwordless sudo powers
+# ------------------------------------------------------------
+USER root
+RUN echo "prteuser    ALL = NOPASSWD: ALL" >> /etc/sudoers
+
+# ------------------------------------------------------------
+# Adjust the default environment
+# ------------------------------------------------------------
+USER root
+
+ENV PRRTE_MCA_prrte_default_hostfile=/opt/hpc/etc/hostfile.txt
+ENV PATH=$PATH:/opt/hpc/local/hwloc/bin
+# Need to do this so that the 'prteuser' can have them too, not just root
+RUN echo "export PMIX_ROOT=/opt/hpc/external/pmix" >> /etc/bashrc && \
+    echo "export PRRTE_ROOT=/opt/hpc/external/prrte" >> /etc/bashrc  && \
+    echo "export PATH=\$PRRTE_ROOT/bin:\$PATH" >> /etc/bashrc  && \
+    echo "export LD_LIBRARY_PATH=\$PMIX_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=$HWLOC_INSTALL_PATH/lib:$LIBEVENT_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$LIBJANSSON_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$PRRTE_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export PRRTE_MCA_prrte_default_hostfile=$PRRTE_MCA_prrte_default_hostfile" >> /etc/bashrc && \
+    echo "ulimit -c unlimited" >> /etc/bashrc && \
+    echo "alias pd=pushd" >> /etc/bashrc
+
+# ------------------------------------------------------------
+# Kick off the ssh daemon
+# ------------------------------------------------------------
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+
+# ------------------------------------------------------------
+# Tickle ptrace scope for Mac stacktrace
+# ------------------------------------------------------------
+CMD ["echo", "0", ">", "/proc/sys/kernel/yama/ptrace_scope"]
+
+# ------------------------------------------------------------
+# Kick off the PRRTE daemon
+# ------------------------------------------------------------
+USER prteuser
+
+CMD ["prte"]

--- a/contrib/docker/Dockerfile.centos8.ssh
+++ b/contrib/docker/Dockerfile.centos8.ssh
@@ -1,0 +1,185 @@
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+#
+# Base Build box for PRRTE
+# Requires:
+#  - Basic compile tooling and runtime support
+#  - libevent - retrieve v2.1.11-stable from web
+#  - hwloc - retrieve v2.2.0 from web
+#  - curl
+#  - libjansson - retrieve v2.13.1 from web
+#  - PMIx - cloned from 'master' branch
+#  - PRRTE - cloned from 'master' branch
+#
+FROM centos:8
+
+MAINTAINER Ralph Castain <ralph.h.castain@intel.com>
+
+# ------------------------------------------------------------
+# Install required packages
+# ------------------------------------------------------------
+RUN dnf -y update && \
+    dnf -y install epel-release && \
+    dnf repolist && \
+    dnf -y install \
+    systemd openssh-server openssh-clients \
+    gcc gdb strace \
+    binutils less wget which sudo \
+    perl perl-Data-Dumper numactl \
+    autoconf automake libtool flex bison \
+    iproute net-tools make git \
+    libnl3 gtk2 atk cairo tcl tcsh tk pciutils lsof ethtool bc file \
+    valgrind curl curl-devel && \
+    dnf clean all
+
+# ------------------------------------------------------------
+# Define support libraries
+# - hwloc
+# - libevent
+# - libjansson
+# ------------------------------------------------------------
+RUN mkdir -p /opt/hpc/local/build
+RUN mkdir -p /opt/hpc/rndvz
+
+ARG LIBEVENT_INSTALL_PATH=/opt/hpc/local/libevent
+ENV LIBEVENT_INSTALL_PATH=$LIBEVENT_INSTALL_PATH
+ARG HWLOC_INSTALL_PATH=/opt/hpc/local/hwloc
+ENV HWLOC_INSTALL_PATH=$HWLOC_INSTALL_PATH
+ARG LIBJANSSON_INSTALL_PATH=/opt/hpc/local/libjansson
+ENV LIBJANSSON_INSTALL_PATH=$LIBJANSSON_INSTALL_PATH
+
+RUN cd /opt/hpc/local/build && \
+    wget https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz && \
+    tar xf libevent-2.1.11-stable.tar.gz && \
+    cd libevent-2.1.11-stable && \
+    ./configure --prefix=${LIBEVENT_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null
+RUN cd /opt/hpc/local/build && \
+    wget https://download.open-mpi.org/release/hwloc/v2.2/hwloc-2.2.0.tar.gz && \
+    tar xf hwloc-2.2.0.tar.gz && \
+    cd hwloc-2.2.0 && \
+    ./configure --prefix=${HWLOC_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/src /opt/hpc/local/build/*
+RUN cd /opt/hpc/local/build && \
+    wget https://digip.org/jansson/releases/jansson-2.13.1.tar.gz && \
+    tar xf jansson-2.13.1.tar.gz && \
+    cd jansson-2.13.1 && \
+    ./configure --prefix=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/build/*
+ENV LD_LIBRARY_PATH="$HWLOC_INSTALL_PATH/bin:$LIBEVENT_INSTALL_PATH/lib:$LIBJANSSON_INSTALL_PATH/lib:${LD_LIBRARY_PATH}"
+
+
+# ------------------------------------------------------------
+# PMIx Install
+# ------------------------------------------------------------
+ENV PMIX_ROOT=/opt/hpc/local/pmix
+ENV LD_LIBRARY_PATH="$PMIX_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/openpmix.git && \
+    cd openpmix && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PMIX_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-curl \
+                --with-jansson=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    cd .. && rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# PRRTE Install
+# ------------------------------------------------------------
+ENV PRRTE_ROOT=/opt/hpc/local/prrte
+ENV PATH="$PRRTE_ROOT/bin:${PATH}"
+ENV LD_LIBRARY_PATH="$PRRTE_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/prrte.git && \
+    cd prrte && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PRRTE_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-pmix=${PMIX_ROOT} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# Fixup the ssh login
+# ------------------------------------------------------------
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" && \
+    ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key  -N "" && \
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key  -N "" && \
+    echo "        LogLevel ERROR" >> /etc/ssh/ssh_config && \
+    echo "        StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
+    echo "        UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+
+# ------------------------------------------------------------
+# Adjust default ulimit for core files
+# ------------------------------------------------------------
+RUN echo '*               hard    core            -1' >> /etc/security/limits.conf && \
+    echo '*               soft    core            -1' >> /etc/security/limits.conf && \
+    echo 'ulimit -c unlimited' >> /root/.bashrc
+
+# ------------------------------------------------------------
+# Create a user account
+# ------------------------------------------------------------
+RUN groupadd -r prteuser && useradd --no-log-init -r -m -b /home -g prteuser -G wheel prteuser
+USER prteuser
+RUN  cd /home/prteuser && \
+        ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa && chmod og+rX . && \
+        cd .ssh && cat id_rsa.pub > authorized_keys && chmod 644 authorized_keys && \
+        exit
+
+# ------------------------------------------------------------
+# Give the user passwordless sudo powers
+# ------------------------------------------------------------
+USER root
+RUN echo "prteuser    ALL = NOPASSWD: ALL" >> /etc/sudoers
+
+# ------------------------------------------------------------
+# Adjust the default environment
+# ------------------------------------------------------------
+USER root
+
+ENV PRRTE_MCA_prrte_default_hostfile=/opt/hpc/etc/hostfile.txt
+ENV PATH=$PATH:/opt/hpc/local/hwloc/bin
+# Need to do this so that the 'prteuser' can have them too, not just root
+RUN echo "export PMIX_ROOT=/opt/hpc/external/pmix" >> /etc/bashrc && \
+    echo "export PRRTE_ROOT=/opt/hpc/external/prrte" >> /etc/bashrc  && \
+    echo "export PATH=\$PRRTE_ROOT/bin:\$PATH" >> /etc/bashrc  && \
+    echo "export LD_LIBRARY_PATH=\$PMIX_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=$HWLOC_INSTALL_PATH/lib:$LIBEVENT_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$LIBJANSSON_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$PRRTE_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export PRRTE_MCA_prrte_default_hostfile=$PRRTE_MCA_prrte_default_hostfile" >> /etc/bashrc && \
+    echo "ulimit -c unlimited" >> /etc/bashrc && \
+    echo "alias pd=pushd" >> /etc/bashrc
+
+# ------------------------------------------------------------
+# Kick off the ssh daemon
+# ------------------------------------------------------------
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+
+# ------------------------------------------------------------
+# Tickle ptrace scope for Mac stacktrace
+# ------------------------------------------------------------
+CMD ["echo", "0", ">", "/proc/sys/kernel/yama/ptrace_scope"]
+
+# ------------------------------------------------------------
+# Kick off the PRRTE daemon
+# ------------------------------------------------------------
+USER prteuser
+
+CMD ["prte"]

--- a/contrib/docker/Dockerfile.leap15.ssh
+++ b/contrib/docker/Dockerfile.leap15.ssh
@@ -1,0 +1,189 @@
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+#
+# Base Build box for PRRTE
+# Requires:
+#  - Basic compile tooling and runtime support
+#  - libevent - retrieve v2.1.11-stable from web
+#  - hwloc - retrieve v2.2.0 from web
+#  - curl
+#  - libjansson - retrieve v2.13.1 from web
+#  - PMIx - cloned from 'master' branch
+#  - PRRTE - cloned from 'master' branch
+#
+#
+FROM opensuse/leap
+
+MAINTAINER Ralph Castain <ralph.h.castain@intel.com>
+
+# ------------------------------------------------------------
+# Install required packages
+# ------------------------------------------------------------
+RUN zypper --non-interactive refresh && \
+    zypper --non-interactive update && \
+    zypper --non-interactive install \
+    openssh \
+    gcc gdb strace \
+    binutils less wget which sudo \
+    perl numactl gzip \
+    autoconf automake libtool flex bison \
+    iproute net-tools make git pandoc \
+    atk cairo tcl tcsh tk pciutils lsof ethtool bc file \
+    valgrind curl curl-devel && \
+    zypper --non-interactive clean
+
+# ------------------------------------------------------------
+# Define support libraries
+# - hwloc
+# - libevent
+# - libjansson
+# ------------------------------------------------------------
+RUN mkdir -p /opt/hpc/local/build
+RUN mkdir -p /opt/hpc/rndvz
+
+ARG LIBEVENT_INSTALL_PATH=/opt/hpc/local/libevent
+ENV LIBEVENT_INSTALL_PATH=$LIBEVENT_INSTALL_PATH
+ARG HWLOC_INSTALL_PATH=/opt/hpc/local/hwloc
+ENV HWLOC_INSTALL_PATH=$HWLOC_INSTALL_PATH
+ARG LIBJANSSON_INSTALL_PATH=/opt/hpc/local/libjansson
+ENV LIBJANSSON_INSTALL_PATH=$LIBJANSSON_INSTALL_PATH
+
+RUN cd /opt/hpc/local/build && \
+    wget https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz && \
+    ls && \
+    tar xf libevent-2.1.11-stable.tar.gz && \
+    cd libevent-2.1.11-stable && \
+    ./configure --prefix=${LIBEVENT_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null
+RUN cd /opt/hpc/local/build && \
+    wget https://download.open-mpi.org/release/hwloc/v2.2/hwloc-2.2.0.tar.gz && \
+    tar xf hwloc-2.2.0.tar.gz && \
+    cd hwloc-2.2.0 && \
+    ./configure --prefix=${HWLOC_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/build/*
+RUN cd /opt/hpc/local/build && \
+    wget https://digip.org/jansson/releases/jansson-2.13.1.tar.gz && \
+    tar xf jansson-2.13.1.tar.gz && \
+    cd jansson-2.13.1 && \
+    ./configure --prefix=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make > /dev/null && \
+    make install > /dev/null && \
+    cd .. && \
+    rm -rf /opt/hpc/local/build/*
+
+ENV LD_LIBRARY_PATH="$HWLOC_INSTALL_PATH/bin:$LIBEVENT_INSTALL_PATH/lib:$LIBJANSSON_INSTALL_PATH/lib:${LD_LIBRARY_PATH}"
+
+
+# -----------------------------
+# ------------------------------------------------------------
+# PMIx Install
+# ------------------------------------------------------------
+ENV PMIX_ROOT=/opt/hpc/local/pmix
+ENV LD_LIBRARY_PATH="$PMIX_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/openpmix.git && \
+    cd openpmix && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PMIX_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-curl \
+                --with-jansson=${LIBJANSSON_INSTALL_PATH} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    cd .. && rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# PRRTE Install
+# ------------------------------------------------------------
+ENV PRRTE_ROOT=/opt/hpc/local/prrte
+ENV PATH="$PRRTE_ROOT/bin:${PATH}"
+ENV LD_LIBRARY_PATH="$PRRTE_ROOT/lib:${LD_LIBRARY_PATH}"
+
+RUN cd /opt/hpc/local/build && \
+    git clone -q -b master https://github.com/openpmix/prrte.git && \
+    cd prrte && \
+    ./autogen.pl > /dev/null && \
+    ./configure --prefix=${PRRTE_ROOT} \
+                --with-hwloc=${HWLOC_INSTALL_PATH} \
+                --with-libevent=${LIBEVENT_INSTALL_PATH} \
+                --with-pmix=${PMIX_ROOT} > /dev/null && \
+    make -j 10 > /dev/null && \
+    make -j 10 install > /dev/null && \
+    rm -rf /opt/hpc/local/build/*
+
+# ------------------------------------------------------------
+# Fixup the ssh login
+# ------------------------------------------------------------
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N "" && \
+    ssh-keygen -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key  -N "" && \
+    ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key  -N "" && \
+    echo "        LogLevel ERROR" >> /etc/ssh/ssh_config && \
+    echo "        StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
+    echo "        UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+
+# ------------------------------------------------------------
+# Adjust default ulimit for core files
+# ------------------------------------------------------------
+RUN echo '*               hard    core            -1' >> /etc/security/limits.conf && \
+    echo '*               soft    core            -1' >> /etc/security/limits.conf && \
+    echo 'ulimit -c unlimited' >> /root/.bashrc
+
+# ------------------------------------------------------------
+# Create a user account
+# ------------------------------------------------------------
+RUN groupadd -r prteuser && useradd -r -m -b /home -g prteuser prteuser
+USER prteuser
+RUN  cd /home/prteuser && \
+        ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa && chmod og+rX . && \
+        cd .ssh && cat id_rsa.pub > authorized_keys && chmod 644 authorized_keys && \
+        exit
+
+# ------------------------------------------------------------
+# Give the user passwordless sudo powers
+# ------------------------------------------------------------
+USER root
+RUN echo "prteuser    ALL = NOPASSWD: ALL" >> /etc/sudoers
+
+# ------------------------------------------------------------
+# Adjust the default environment
+# ------------------------------------------------------------
+USER root
+
+ENV PRRTE_MCA_prrte_default_hostfile=/opt/hpc/etc/hostfile.txt
+ENV PATH=$PATH:/opt/hpc/local/hwloc/bin
+# Need to do this so that the 'prteuser' can have them too, not just root
+RUN echo "export PMIX_ROOT=/opt/hpc/install/pmix" >> /etc/bashrc && \
+    echo "export PRRTE_ROOT=/opt/hpc/install/prrte" >> /etc/bashrc  && \
+    echo "export PATH=\$PRRTE_ROOT/bin:\$PATH" >> /etc/bashrc  && \
+    echo "export LD_LIBRARY_PATH=\$PMIX_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=$HWLOC_INSTALL_PATH/lib:$LIBEVENT_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$LIBJANSSON_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export LD_LIBRARY_PATH=\$PRRTE_ROOT/lib:\$LD_LIBRARY_PATH" >> /etc/bashrc && \
+    echo "export PRRTE_MCA_prrte_default_hostfile=$PRRTE_MCA_prrte_default_hostfile" >> /etc/bashrc && \
+    echo "ulimit -c unlimited" >> /etc/bashrc && \
+    echo "alias pd=pushd" >> /etc/bashrc
+
+# ------------------------------------------------------------
+# Kick off the ssh daemon
+# ------------------------------------------------------------
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]
+
+# ------------------------------------------------------------
+# Tickle ptrace scope for Mac stacktrace
+# ------------------------------------------------------------
+CMD ["echo", "0", ">", "/proc/sys/kernel/yama/ptrace_scope"]
+
+# ------------------------------------------------------------
+# Kick off the PRRTE daemon
+# ------------------------------------------------------------
+USER prteuser
+
+CMD ["prte"]
+

--- a/contrib/docker/Makefile
+++ b/contrib/docker/Makefile
@@ -1,0 +1,13 @@
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+
+all: leap15 centos7 centos8
+
+leap15: Dockerfile.leap15.ssh
+	docker build -t prrte/leap15:latest -f Dockerfile.leap15.ssh .
+
+centos7: Dockerfile.centos7.ssh
+	docker build -t prrte/centos7:latest -f Dockerfile.centos7.ssh .
+
+centos8: Dockerfile.centos8.ssh
+	docker build -t prrte/centos8:latest -f Dockerfile.centos8.ssh .

--- a/contrib/docker/drop-in.sh
+++ b/contrib/docker/drop-in.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+
+docker exec -it -u prteuser -w  /home/prteuser/ --env COLUMNS=`tput cols` --env LINES=`tput lines` $USER-node00 bash

--- a/contrib/docker/prte.service
+++ b/contrib/docker/prte.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=PRRTE persistent service.
+
+[Service]
+Type=simple
+ExecStart=/opt/hpc/local/prrte/bin/prte
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/docker/startdaemon.sh
+++ b/contrib/docker/startdaemon.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Copyright (c) 2020      Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
+
+#
+# Default values
+#
+IMAGE_NAME=prrte/leap15:latest
+OVERLAY_NETWORK=prte-net
+RNDVZ_DIR=
+
+COMMON_PREFIX=$USER"-"
+
+SHUTDOWN_FILE=$PWD/tmp/shutdown-`hostname -s`.sh
+
+DRYRUN=0
+
+#
+# Argument parsing
+#
+while [[ $# -gt 0 ]] ; do
+    case $1 in
+        "-h" | "--help")
+            printf "Usage: %s [option]
+    -i | --image NAME          Name of the container image (Required)
+    -r | --rndvz DIR           Full path to the 'rendezvous' directory
+    -d | --dryrun              Dry run. Do not actually start anything.
+    -h | --help                Print this help message\n" \
+        `basename $0`
+            exit 0
+            ;;
+        "-i" | "--image" | "-img")
+            shift
+            IMAGE_NAME=$1
+            ;;
+        "--rndvz")
+            shift
+            RNDVZ_DIR=$1
+            ;;
+        "-d" | "--dryrun")
+            DRYRUN=1
+            ;;
+        *)
+            printf "Unkonwn option: %s\n" $1
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ "x$IMAGE_NAME" == "x" ] ; then
+    echo "Error: --image must be specified"
+    exit 1
+fi
+
+#
+# Spin up the container
+#
+
+ALL_CONTAINERS=()
+
+startup_container()
+{
+    C_ID=0
+    C_HOSTNAME=`printf "%s%s%02d" $COMMON_PREFIX "node" $C_ID`
+
+    if [ 0 != $DRYRUN ] ; then
+        echo ""
+        echo "Starting: $C_HOSTNAME"
+        echo "---------------------"
+    else
+        echo "Starting: $C_HOSTNAME"
+    fi
+
+    # Add other volume mounts here
+    _OTHER_ARGS=""
+
+    if [ "x" != "x$RNDVZ_DIR" ] ; then
+        _OTHER_ARGS+=" -v $RNDVZ_DIR:/opt/hpc/rndvz"
+    fi
+
+    CMD="docker run --rm \
+        --cap-add=SYS_NICE --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+        $_OTHER_ARGS \
+        --network $OVERLAY_NETWORK \
+        -h $C_HOSTNAME --name $C_HOSTNAME \
+        --detach $IMAGE_NAME"
+    echo $CMD
+    if [ 0 != $DRYRUN ] ; then
+        return
+    fi
+
+    C_FULL_ID=`$CMD`
+    RTN=$?
+    if [ 0 != $RTN ] ; then
+        echo "Error: Failed to create $C_HOSTNAME"
+        echo $C_FULL_ID
+        exit 1
+    fi
+
+    C_SHORT_ID=`echo $C_FULL_ID | cut -c -12`
+    ALL_CONTAINERS+=($C_SHORT_ID)
+}
+
+mkdir -p tmp
+
+# Create network
+CMD="docker network create --driver overlay --attachable $OVERLAY_NETWORK"
+if [ 0 == $DRYRUN ] ; then
+    echo "Establish network: $OVERLAY_NETWORK"
+    RTN=`$CMD`
+else
+    echo ""
+    echo "Establish network: $OVERLAY_NETWORK"
+    echo "---------------------"
+    echo $CMD
+fi
+
+startup_container
+
+if [ 0 != $DRYRUN ] ; then
+    exit 0
+fi
+
+#
+# Create a shutdown file to help when we cleanup
+rm -f $SHUTDOWN_FILE
+
+touch $SHUTDOWN_FILE
+chmod +x $SHUTDOWN_FILE
+for cid in "${ALL_CONTAINERS[@]}" ; do
+    echo "docker stop $cid" >> $SHUTDOWN_FILE
+done
+
+CMD="docker network rm $OVERLAY_NETWORK"
+if [ 0 == $DRYRUN ] ; then
+    echo $CMD >> $SHUTDOWN_FILE
+else
+    echo ""
+    echo "Remove network: $OVERLAY_NETWORK"
+    echo "---------------------"
+    echo $CMD
+fi


### PR DESCRIPTION
Provide recipes for opensuse/leap15, centos7, and centos8. Create a
container that holds the required support libraries (including libevent,
hwloc, and libjansson) at specified revision levels. Clone and build the
PMIx and PRRTE master branches. Setup the container to start "prte" and
let it run. The rendezvous points for any required shared files can be
provided in a mounted volume.

Signed-off-by: Ralph Castain <rhc@pmix.org>