### PR TITLE
Start work on tracking available vs allocated slots

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -163,7 +163,8 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
         }
     }
 
-    if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PRTE_BOOL)) {
+    if (4 < prte_output_get_verbosity(prte_ras_base_framework.framework_output) ||
+        prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PRTE_BOOL)) {
         prte_ras_base_display_alloc(caddy->jdata);
     }
     /* ensure we update the routing plan */

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -937,14 +937,9 @@ static void prte_print_node(char **output,
     free(tmp);
     tmp = tmp2;
 
-    prte_asprintf(&tmp2, "%s\n%s            Num slots: %ld\tSlots in use: %ld\tOversubscribed: %s", tmp, pfx2,
-             (long)src->slots, (long)src->slots_inuse,
+    prte_asprintf(&tmp2, "%s\n%s            Num slots: %ld\tMax slots: %ld\tSlots in use: %ld\tOversubscribed: %s", tmp, pfx2,
+             (long)src->slots, (long)src->slots_max, (long)src->slots_inuse,
              PRTE_FLAG_TEST(src, PRTE_NODE_FLAG_OVERSUBSCRIBED) ? "TRUE" : "FALSE");
-    free(tmp);
-    tmp = tmp2;
-
-    prte_asprintf(&tmp2, "%s\n%s            Num slots allocated: %ld\tMax slots: %ld", tmp, pfx2,
-             (long)src->slots, (long)src->slots_max);
     free(tmp);
     tmp = tmp2;
 


### PR DESCRIPTION
We no longer have the option of modifying the base topology to adjust
for things like -host assignment of slots. This must now be done on a
per-job basis. We introduced the "slots_available" field to the
prte_node_t structure, so now begin to use it to track the number of
slots being made available to the job being mapped. This must all be
done within the mapping operation to ensure that the mappers "see" the
same value during a mapping operation as the value will be reset between
jobs.

Signed-off-by: Ralph Castain <rhc@pmix.org>