### PR TITLE
ALPS: fix an issue with using setsid with ALPS PLM

### DIFF
--- a/config/prte_check_alps.m4
+++ b/config/prte_check_alps.m4
@@ -16,6 +16,8 @@ dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2019      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2020      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -152,6 +154,14 @@ AC_DEFUN([PRTE_CHECK_ALPS],[
                ])
 
         AC_MSG_RESULT([prte_check_cray_alps_happy = $prte_check_cray_alps_happy])
+
+        AS_IF([test "$prte_check_cray_alps_happy" = "yes"],
+             [prte_have_cray_alps=1],
+             [prte_have_cray_alps=0])
+
+        AC_DEFINE_UNQUOTED([PRTE_HAVE_CRAY_ALPS], 
+                           [$prte_have_cray_alps], 
+                           [defined to 1 if cray alps env, 0 otherwise])
 
         AS_IF([test "$prte_check_cray_alps_happy" = "yes" && test "$enable_static" = "yes"],
               [CRAY_ALPSLLI_LIBS = $CRAY_ALPSLLI_STATIC_LIBS

--- a/src/util/daemon_init.c
+++ b/src/util/daemon_init.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,8 +57,8 @@ int prte_daemon_init_callback(char *working_dir, int (*parent_fn)(pid_t))
     }
 
     /* child continues */
-#if defined(HAVE_SETSID)
-    setsid();  /* become session leader */
+#if defined(HAVE_SETSID) && !(PRTE_HAVE_CRAY_ALPS)
+    setsid();  /* become session leader - doing this confuses Cray aprun in some cases */
 #endif
 
     if (NULL != working_dir) {


### PR DESCRIPTION
Turns out Cray ALPS can be configured such that running aprun
in a different session than the one a user is initially in when
placed on a mom node can cause aprun not to see the reservation
associated with the job.

Disable use of setsid with the --daemonize option when in a
Cray ALPS environment.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>