### PR TITLE
ALPS OOB: fix alps oob visibility problem

### DIFF
--- a/src/mca/oob/alps/oob_alps_component.c
+++ b/src/mca/oob/alps/oob_alps_component.c
@@ -18,6 +18,8 @@
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,7 +90,7 @@ static bool component_is_reachable(char *routed, prte_process_name_t *peer);
 /*
  * Struct of function pointers and all that to let us be initialized
  */
-prte_oob_base_component_t prte_oob_alps_component = {
+PRTE_MODULE_EXPORT prte_oob_base_component_t prte_oob_alps_component = {
     .oob_base = {
         PRTE_OOB_BASE_VERSION_2_0_0,
         .mca_component_name = "alps",


### PR DESCRIPTION
when using prrte within Open MPI, and on systems where alps oob
component would build, one would observe this warning from the
mca component base:

[nid05410:03240] mca_base_component_repository_open: "mca_oob_alps" does not appear to be a valid oob MCA dynamic component (ignored): /global/homes/h/hpp/ompi/install_master/lib/prte/mca_oob_alps.so: undefined symbol: prte_oob_alps_component. ret -1

This commit fixes the visibility issue.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>