### PR TITLE
Check outcome of malloc calls

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -786,6 +786,9 @@ static void modex_resp(pmix_status_t status,
         /* we need to preserve the data as the caller
          * will free it upon our return */
         req->data = (char*)malloc(sz);
+        if (NULL == req->data) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        }
         memcpy(req->data, data, sz);
         req->sz = sz;
     }
@@ -1069,6 +1072,9 @@ static void pmix_server_dmdx_resp(int status, prte_process_name_t* sender,
         if (0 < psz) {
             d->ndata = psz;
             d->data = (char*)malloc(psz);
+            if (NULL == d->data) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            }
             cnt = psz;
             if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(&prte_process_info.myproc, &pbuf, d->data, &cnt, PMIX_BYTE))) {
                 PMIX_ERROR_LOG(prc);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1324,6 +1324,9 @@ pmix_status_t pmix_server_stdin_fn(const pmix_proc_t *source,
     // so they would go out of scope after we return from this function.
     PMIX_BYTE_OBJECT_CREATE(bo_cpy, 1);
     bo_cpy->bytes = pmix_malloc(bo->size * sizeof(char));
+    if (NULL == bo_cpy->bytes) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+    }
     memcpy(bo_cpy->bytes, bo->bytes, bo->size);
     bo_cpy->size = bo->size;
 


### PR DESCRIPTION
I had a look into the pmix_server code and found some malloc calls where the returned pointer is not checked. I added some checks for places where the size of the malloced memory is not constant.