### PR TITLE
Eagerly wait for launch directives if using prte directly

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -816,7 +816,7 @@ int main(int argc, char *argv[])
                           iptr, 2, NULL, NULL);
         /* now wait for the launch directives to arrive */
         while (prte_event_base_active && myinfo.lock.active) {
-            prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+            prte_event_loop(prte_event_base, PRTE_EVLOOP_NONBLOCK);
         }
         PMIX_INFO_FREE(iptr, 2);
         /* process the returned directives */


### PR DESCRIPTION
 * Make the event loop eager (`PRTE_EVLOOP_NONBLOCK`) when waiting for
   the launch directives from the tool. Otherwise it might block
   indefinitely eventhough `myinfo.lock.active == false`.
 * Found while working on the mpir-shim with `mpirun`
