### PR TITLE
Initialize global prrte personalities statically

### DIFF
--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -55,12 +55,11 @@ prte_schizo_API_module_t prte_schizo = {
     .finalize = prte_schizo_base_finalize
 };
 
-static char *personalities = NULL;
+static char *personalities = "prte";
 
 static int prte_schizo_base_register(prte_mca_base_register_flag_t flags)
 {
     /* pickup any defined personalities */
-    personalities = strdup("prte");
     prte_mca_base_var_register("prte", "schizo", "base", "personalities",
                                 "Comma-separated list of personalities",
                                 PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,


### PR DESCRIPTION
This prevents address-sanitizer from reporting a memory leak.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>