### PR TITLE
Fix shifting signed integer

### DIFF
--- a/src/util/arch.c
+++ b/src/util/arch.c
@@ -69,7 +69,7 @@ static inline int32_t prte_arch_ldisintel( void )
             j = j-1;
         }
     }
-    return (pui[j] & (1 << i) ? 1 : 0);
+    return ((pui[j] & (1u << i)) ? 1 : 0);
 }
 
 static inline void prte_arch_setmask ( uint32_t *var, uint32_t mask)


### PR DESCRIPTION
Shifting signed int will lead to undefined behavior in case of 1<<31 here

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>