### PR TITLE
schitzo: make sure to stay in array bounds

### DIFF
--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -311,7 +311,7 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
     ret = PRTE_SUCCESS;
 
     /* check for deprecated cmd line options */
-    for (i=1; NULL != pargs[i]; i++) {
+    for (i=1; i < pargc && NULL != pargs[i]; i++) {
         /* Are we done?  i.e., did we find the special "--" token? */
         if (0 == strcmp(pargs[i], "--")) {
             break;


### PR DESCRIPTION
If a user runs a command without enough params (e.g., "prte
--report-uri"), the bottom of the loop will advance argc beyond the
end of the array (because it advances argc by the number of *expected*
params, not the number of *actual* params).  Make sure to check that i
stays below pargc to prevent memory errors.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>