### PR TITLE
Fix memory leak in configure, which prevents leak sanitizer usage

### DIFF
--- a/config/c_get_alignment.m4
+++ b/config/c_get_alignment.m4
@@ -45,6 +45,7 @@ AC_DEFUN([PRTE_C_GET_ALIGNMENT],[
     FILE *f=fopen("conftestval", "w");
     if (!f) exit(1);
     diff = ((char *)&p->x) - ((char *)&p->c);
+    free(p);
     fprintf(f, "%d\n", (diff >= 0) ? diff : -diff);
 ]])],                         [AS_TR_SH([prte_cv_c_align_$1])=`cat conftestval`],
                                [AC_MSG_WARN([*** Problem running configure test!])


### PR DESCRIPTION
If building Open MPI with sanitizers, e.g
$ configure CC=clang CFLAGS=-fsanitize=address ....
configure test programs are also build with the sanitizers and will
report errors resulting in configure to fail.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>