### PR TITLE
Fix libev support

### DIFF
--- a/config/prte_setup_libev.m4
+++ b/config/prte_setup_libev.m4
@@ -5,6 +5,7 @@
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -15,89 +16,103 @@
 # MCA_libev_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PRTE_LIBEV_CONFIG],[
-    PRTE_VAR_SCOPE_PUSH([prte_libev_dir prte_libev_libdir prte_libev_standard_header_location prte_libev_standard_lib_location prte_check_libev_save_CPPFLAGS prte_check_libev_save_LDFLAGS prte_check_libev_save_LIBS])
+    PRTE_VAR_SCOPE_PUSH([prte_event_dir prte_event_libdir prte_event_defaults prte_check_libev_save_CPPFLAGS prte_check_libev_save_LDFLAGS prte_check_libev_save_LIBS])
 
     AC_ARG_WITH([libev],
                 [AC_HELP_STRING([--with-libev=DIR],
                                 [Search for libev headers and libraries in DIR ])])
-    PRTE_CHECK_WITHDIR([libev], [$with_libev], [include/event.h])
-
     AC_ARG_WITH([libev-libdir],
                 [AC_HELP_STRING([--with-libev-libdir=DIR],
                                 [Search for libev libraries in DIR ])])
-    PRTE_CHECK_WITHDIR([libev-libdir], [$with_livev_libdir], [libev.*])
 
     prte_libev_support=0
+    prte_event_defaults=yes
 
-    AS_IF([test -n "$with_libev" && test "$with_libev" != "no"],
-          [AC_MSG_CHECKING([for libev in])
-           prte_check_libev_save_CPPFLAGS="$CPPFLAGS"
-           prte_check_libev_save_LDFLAGS="$LDFLAGS"
-           prte_check_libev_save_LIBS="$LIBS"
-           if test "$with_libev" != "yes"; then
-               prte_libev_dir=$with_libev/include
-               prte_libev_standard_header_location=no
-               prte_libev_standard_lib_location=no
-               AS_IF([test -z "$with_libev_libdir" || test "$with_libev_libdir" = "yes"],
-                     [if test -d $with_libev/lib; then
-                          prte_libev_libdir=$with_libev/lib
-                      elif test -d $with_libev/lib64; then
-                          prte_libev_libdir=$with_libev/lib64
-                      else
-                          AC_MSG_RESULT([Could not find $with_libev/lib or $with_libev/lib64])
-                          AC_MSG_ERROR([Can not continue])
-                      fi
-                      AC_MSG_RESULT([$prte_libev_dir and $prte_libev_libdir])],
-                     [AC_MSG_RESULT([$with_libev_libdir])])
-           else
-               AC_MSG_RESULT([(default search paths)])
-               prte_libev_standard_header_location=yes
-               prte_libev_standard_lib_location=yes
-           fi
-           AS_IF([test ! -z "$with_libev_libdir" && test "$with_libev_libdir" != "yes"],
-                 [prte_libev_libdir="$with_libev_libdir"
-                  prte_libev_standard_lib_location=no])
+    prte_check_libev_save_CPPFLAGS="$CPPFLAGS"
+    prte_check_libev_save_LDFLAGS="$LDFLAGS"
+    prte_check_libev_save_LIBS="$LIBS"
 
-           PRTE_CHECK_PACKAGE([prte_libev],
-                              [event.h],
-                              [ev],
-                              [ev_async_send],
-                              [],
-                              [$prte_libev_dir],
-                              [$prte_libev_libdir],
-                              [prte_libev_support=1],
-                              [prte_libev_support=0])
-           CPPFLAGS="$prte_check_libev_save_CPPFLAGS"
-           LDFLAGS="$prte_check_libev_save_LDFLAGS"
-           LIBS="$prte_check_libev_save_LIBS"])
+    # get rid of any trailing slash(es)
+    libev_prefix=$(echo $with_libev | sed -e 'sX/*$XXg')
+    libevdir_prefix=$(echo $with_libev_libdir | sed -e 'sX/*$XXg')
 
-    AS_IF([test $prte_libev_support -eq 1],
-          [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_libev_LIBS)
-           PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_libev_LIBS)
+    if test "$libev_prefix" != "no"; then
+        AC_MSG_CHECKING([for libev in])
+        if test ! -z "$libev_prefix" && test "$libev_prefix" != "yes"; then
+            prte_event_defaults=no
+            prte_event_dir=$libev_prefix
+            if test -d $libev_prefix/lib64; then
+                prte_event_libdir=$libev_prefix/lib64
+            elif test -d $libev_prefix/lib; then
+                prte_event_libdir=$libev_prefix/lib
+            elif test -d $libev_prefix; then
+                prte_event_libdir=$libev_prefix
+            else
+                AC_MSG_RESULT([Could not find $libev_prefix/lib64, $libev_prefix/lib, or $libev_prefix])
+                AC_MSG_ERROR([Can not continue])
+            fi
+            AC_MSG_RESULT([$prte_event_dir and $prte_event_libdir])
+        else
+            prte_event_defaults=yes
+            prte_event_dir=/usr
+            if test -d /usr/lib64; then
+                prte_event_libdir=/usr/lib64
+                AC_MSG_RESULT([(default search paths)])
+            elif test -d /usr/lib; then
+                prte_event_libdir=/usr/lib
+                AC_MSG_RESULT([(default search paths)])
+            else
+                AC_MSG_RESULT([default paths not found])
+                prte_libev_support=0
+            fi
+        fi
+        AS_IF([test ! -z "$libevdir_prefix" && "$libevdir_prefix" != "yes"],
+              [prte_event_libdir="$libevdir_prefix"])
 
-           AS_IF([test "$prte_libev_standard_header_location" != "yes"],
-                 [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_libev_CPPFLAGS)
-                  PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_libev_CPPFLAGS)])
-           AS_IF([test "$prte_libev_standard_lib_location" != "yes"],
-                 [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS $prte_libev_LDFLAGS)
-                  PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_libev_LDFLAGS)])])
+        PRTE_CHECK_PACKAGE([prte_libev],
+                           [event.h],
+                           [ev],
+                           [ev_async_send],
+                           [],
+                           [$prte_event_dir],
+                           [$prte_event_libdir],
+                           [prte_libev_support=1],
+                           [prte_libev_support=0])
+
+        # need to add resulting flags to global ones so we can
+        # test for thread support
+        AS_IF([test "$prte_event_defaults" = "no"],
+              [PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_libev_CPPFLAGS)
+               PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_libev_LDFLAGS)])
+        PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_libev_LIBS)
+    fi
+    prte_libev_source=$prte_event_dir
 
     AC_MSG_CHECKING([will libev support be built])
     if test $prte_libev_support -eq 1; then
         AC_MSG_RESULT([yes])
+        AS_IF([test "$prte_event_defaults" = "no"],
+              [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_libev_CPPFLAGS)
+               PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_libev_CPPFLAGS)
+               PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_libev_LDFLAGS)
+               PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_libev_LDFLAGS)])
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_libev_LIBS)
+        PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_libev_LIBS)
         PRTE_EVENT_HEADER="<event.h>"
+        # Set output variables
         AC_DEFINE_UNQUOTED([PRTE_EVENT_HEADER], [$PRTE_EVENT_HEADER],
                            [Location of event.h])
-        PRTE_SUMMARY_ADD([[Required Packages]],[[libev]],[libev],[$prte_libev_dir])
+        PRTE_SUMMARY_ADD([[Required Packages]],[[Libev]], [prte_libev], [yes ($prte_libev_source)])
     else
         AC_MSG_RESULT([no])
-        # if they asked us to use it, then this is an error
-        AS_IF([test -n "$with_libev" && test "$with_libev" != "no"],
-              [AC_MSG_WARN([LIBEV SUPPORT REQUESTED AND NOT FOUND])
-               AC_MSG_ERROR([CANNOT CONTINUE])])
     fi
+
+    # restore global flags
+    CPPFLAGS="$prte_check_libev_save_CPPFLAGS"
+    LDFLAGS="$prte_check_libev_save_LDFLAGS"
+    LIBS="$prte_check_libev_save_LIBS"
 
     AC_DEFINE_UNQUOTED([PRTE_HAVE_LIBEV], [$prte_libev_support], [Whether we are building against libev])
 
     PRTE_VAR_SCOPE_POP
-])dnl
+])

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -55,10 +55,10 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
             if test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"; then
                 prte_event_defaults=no
                 prte_event_dir=$libevent_prefix
-                if test -d $libevent_prefix/lib; then
-                    prte_event_libdir=$libevent_prefix/lib
-                elif test -d $libevent_prefix/lib64; then
+                if test -d $libevent_prefix/lib64; then
                     prte_event_libdir=$libevent_prefix/lib64
+                elif test -d $libevent_prefix/lib; then
+                    prte_event_libdir=$libevent_prefix/lib
                 elif test -d $libevent_prefix; then
                     prte_event_libdir=$libevent_prefix
                 else
@@ -69,11 +69,11 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
             else
                 prte_event_defaults=yes
                 prte_event_dir=/usr
-                if test -d /usr/lib; then
-                    prte_event_libdir=/usr/lib
-                    AC_MSG_RESULT([(default search paths)])
-                elif test -d /usr/lib64; then
+                if test -d /usr/lib64; then
                     prte_event_libdir=/usr/lib64
+                    AC_MSG_RESULT([(default search paths)])
+                elif test -d /usr/lib; then
+                    prte_event_libdir=/usr/lib
                     AC_MSG_RESULT([(default search paths)])
                 else
                     AC_MSG_RESULT([default paths not found])

--- a/configure.ac
+++ b/configure.ac
@@ -927,9 +927,12 @@ AC_CACHE_SAVE
 # Libevent
 ##################################
 
-prte_show_title "Configure libevent"
+prte_show_title "Configure event library support - libev"
 
 PRTE_LIBEV_CONFIG
+
+prte_show_title "Configure event library support - libevent"
+
 PRTE_LIBEVENT_CONFIG
 
 AS_IF([test $prte_libevent_support -eq 1 && test $prte_libev_support -eq 1],

--- a/src/event/event-internal.h
+++ b/src/event/event-internal.h
@@ -83,8 +83,6 @@ PRTE_EXPORT prte_event_t* prte_event_alloc(void);
 
 #define prte_event_base_init_common_timeout (b, t) event_base_init_common_timeout((b), (t))
 
-#define prte_event_base_loopexit(b) event_base_loopexit(b, NULL)
-
 #if PRTE_HAVE_LIBEV
 #define prte_event_use_threads()
 #define prte_event_free(b) free(b)
@@ -93,7 +91,6 @@ PRTE_EXPORT prte_event_t* prte_event_alloc(void);
 
 /* thread support APIs */
 #define prte_event_use_threads() evthread_use_pthreads()
-#define prte_event_base_loopbreak(b) event_base_loopbreak(b)
 #define prte_event_free(x) event_free(x)
 #define prte_event_get_signal(x) event_get_signal(x)
 #endif
@@ -115,12 +112,12 @@ PRTE_EXPORT int prte_event_assign(struct event *ev, prte_event_base_t *evbase,
 PRTE_EXPORT int prte_event_add(struct event *ev, struct timeval *tv);
 PRTE_EXPORT int prte_event_del(struct event *ev);
 PRTE_EXPORT void prte_event_active (struct event *ev, int res, short ncalls);
-PRTE_EXPORT void prte_event_base_loopbreak (prte_event_base_t *b);
+PRTE_EXPORT void prte_event_base_loopexit (prte_event_base_t *b);
 #else
 #define prte_event_add(ev, tv) event_add((ev), (tv))
 #define prte_event_del(ev) event_del((ev))
 #define prte_event_active(x, y, z) event_active((x), (y), (z))
-#define prte_event_base_loopbreak(b) event_base_loopbreak(b)
+#define prte_event_base_loopexit(b) event_base_loopexit(b, NULL)
 
 #endif
 

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -95,7 +95,7 @@ void prte_quit(int fd, short args, void *cbdata)
     PRTE_POST_OBJECT(prte_event_base_active);
     /* break the event loop - this will cause the loop to exit upon
        completion of any current event */
-    prte_event_base_loopbreak(prte_event_base);
+    prte_event_base_loopexit(prte_event_base);
 }
 
 static char* print_aborted_job(prte_job_t *job,


### PR DESCRIPTION
Correct the handling of non-standard locations for libev installation.
Add some missing support functions. Change references to "loopbreak" to
"loopexit".

Signed-off-by: Ralph Castain <rhc@pmix.org>