### PR TITLE
Ensure FT is off by default

### DIFF
--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -405,5 +405,22 @@ AC_DEFINE_UNQUOTED([PRTE_ENABLE_GETPWUID], [$prte_want_getpwuid],
 dnl Check for zlib support
 PRTE_ZLIB_CONFIG
 
+dnl Check for FT
+AC_MSG_CHECKING([if want fault tolerance support])
+AC_ARG_ENABLE([prte-ft],
+    [AC_HELP_STRING([--enable-prte-ft],
+        [ENable PRRTE fault tolerance support (default: disabled)])])
+if test "$enable_prte_ft" = "yes"; then
+    AC_MSG_RESULT([yes])
+    prte_enable_ft=1
+    PRTE_SUMMARY_ADD([[Options]],[[Fault tolerance]], [prte_ft], [yes])
+else
+    AC_MSG_RESULT([no])
+    prte_enable_ft=0
+    PRTE_SUMMARY_ADD([[Options]],[[Fault tolerance]], [prte_ft], [no])
+fi
+AC_DEFINE_UNQUOTED([PRTE_ENABLE_FT], [$prte_enable_ft],
+                   [Enable PRRTE fault tolerance support (default: disabled)])
+
 
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,6 @@ AC_SUBST(PRTE_TOP_BUILDDIR)
 # Configuration options
 ############################################################################
 
-PRTE_CONFIGURE_OPTIONS
 PRTE_CHECK_OS_FLAVORS
 PRTE_CONFIGURE_OPTIONS
 

--- a/src/mca/errmgr/base/errmgr_base_frame.c
+++ b/src/mca/errmgr/base/errmgr_base_frame.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
@@ -59,7 +59,7 @@ prte_errmgr_base_module_t prte_errmgr_default_fns = {
     .logfn = prte_errmgr_base_log,
     .abort = prte_errmgr_base_abort,
     .abort_peers = prte_errmgr_base_abort_peers,
-    NULL
+    .enable_detector = NULL
 };
 
 /* NOTE: ABSOLUTELY MUST initialize this

--- a/src/mca/errmgr/detector/configure.m4
+++ b/src/mca/errmgr/detector/configure.m4
@@ -1,0 +1,23 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_errmgr_detector_CONFIG([action-if-can-compile],
+#                            [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_prte_errmgr_detector_CONFIG],[
+    AC_CONFIG_FILES([src/mca/errmgr/detector/Makefile])
+
+    AS_IF([test "$prte_enable_ft" = "1"],
+          [$1],
+          [$2])
+
+])dnl

--- a/src/mca/errmgr/detector/errmgr_detector.c
+++ b/src/mca/errmgr/detector/errmgr_detector.c
@@ -100,8 +100,6 @@ static void fd_heartbeat_recv_cb(int status,
         void *cbdata);
 
 static double Wtime(void );
-//static double prte_errmgr_heartbeat_period = 5;
-//static double prte_errmgr_heartbeat_timeout = 10;
 static prte_event_base_t* fd_event_base = NULL;
 
 static void fd_event_cb(int fd, short flags, void* pdetector);
@@ -328,8 +326,8 @@ static void enable_detector(bool enable_flag)
         else detector->hb_observing = ndmns;
         /* someone is observing us: range [1~n], the observing ring */
         detector->hb_observer = (ndmns+vpid) % ndmns + 1 ;
-        detector->hb_period = prte_errmgr_heartbeat_period;
-        detector->hb_timeout = prte_errmgr_heartbeat_timeout;
+        detector->hb_period = prte_errmgr_detector_component.heartbeat_period;
+        detector->hb_timeout = prte_errmgr_detector_component.heartbeat_timeout;
         detector->hb_sstamp = 0.;
         /* give some slack for MPI_Init */
         detector->hb_rstamp = Wtime()+(double)ndmns;

--- a/src/mca/errmgr/detector/errmgr_detector.h
+++ b/src/mca/errmgr/detector/errmgr_detector.h
@@ -41,7 +41,13 @@ typedef struct {
  * Local Component structures
  */
 
-PRTE_MODULE_EXPORT extern prte_errmgr_base_component_t prte_errmgr_detector_component;
+typedef struct {
+    prte_errmgr_base_component_t super;
+    double heartbeat_period;
+    double heartbeat_timeout;
+} prte_errmgr_detector_component_t;
+
+PRTE_MODULE_EXPORT extern prte_errmgr_detector_component_t prte_errmgr_detector_component;
 
 PRTE_EXPORT extern prte_errmgr_base_module_t prte_errmgr_detector_module;
 

--- a/src/mca/errmgr/detector/errmgr_detector_component.c
+++ b/src/mca/errmgr/detector/errmgr_detector_component.c
@@ -36,34 +36,38 @@ static int errmgr_detector_component_query(prte_mca_base_module_t **module, int 
  * Instantiate the public struct with all of our public information
  * and pointer to our public functions in it
  */
-prte_errmgr_base_component_t prte_errmgr_detector_component = {
-    /* Handle the general mca_component_t struct containing
-     *  meta information about the component detector
-     */
-    .base_version = {
-        PRTE_ERRMGR_BASE_VERSION_3_0_0,
-        /* Component name and version */
-        .mca_component_name = "detector",
-        PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
-                PRTE_RELEASE_VERSION),
+prte_errmgr_detector_component_t prte_errmgr_detector_component = {
+    .super = {
+        /* Handle the general mca_component_t struct containing
+         *  meta information about the component detector
+         */
+        .base_version = {
+            PRTE_ERRMGR_BASE_VERSION_3_0_0,
+            /* Component name and version */
+            .mca_component_name = "detector",
+            PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
+                    PRTE_RELEASE_VERSION),
 
-        /* Component open and close functions */
-        .mca_open_component = errmgr_detector_open,
-        .mca_close_component = errmgr_detector_close,
-        .mca_query_component = errmgr_detector_component_query,
-        .mca_register_component_params = errmgr_detector_register,
+            /* Component open and close functions */
+            .mca_open_component = errmgr_detector_open,
+            .mca_close_component = errmgr_detector_close,
+            .mca_query_component = errmgr_detector_component_query,
+            .mca_register_component_params = errmgr_detector_register,
+        },
+        .base_data = {
+            /* The component is checkpoint ready */
+            PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
     },
-    .base_data = {
-        /* The component is checkpoint ready */
-        PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
-    },
+    .heartbeat_period = 5.0,
+    .heartbeat_timeout = 10.0
 };
 
 static int my_priority;
 
 static int errmgr_detector_register(void)
 {
-    prte_mca_base_component_t *c = &prte_errmgr_detector_component.base_version;
+    prte_mca_base_component_t *c = &prte_errmgr_detector_component.super.base_version;
     if ( PRTE_PROC_IS_DAEMON )
         my_priority = 1005;
     else
@@ -74,26 +78,17 @@ static int errmgr_detector_register(void)
             PRTE_INFO_LVL_9,
             PRTE_MCA_BASE_VAR_SCOPE_READONLY, &my_priority);
 
-    prte_errmgr_detector_enable_flag = false;
-    (void) prte_mca_base_component_var_register(c, "enable",
-            "Enable/disable detector in errmgr component",
-            PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-            PRTE_INFO_LVL_9,
-            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_errmgr_detector_enable_flag);
-
-    prte_errmgr_heartbeat_period = 5.0;
     (void) prte_mca_base_component_var_register(c, "heartbeat_period",
             "Set heartbeat period for ring detector in errmgr component",
             PRTE_MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
             PRTE_INFO_LVL_9,
-            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_errmgr_heartbeat_period);
+            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_errmgr_detector_component.heartbeat_period);
 
-    prte_errmgr_heartbeat_timeout = 10.0;
     (void) prte_mca_base_component_var_register(c, "heartbeat_timeout",
             "Set heartbeat timeout for ring detector in errmgr component",
             PRTE_MCA_BASE_VAR_TYPE_DOUBLE, NULL, 0, 0,
             PRTE_INFO_LVL_9,
-            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_errmgr_heartbeat_timeout);
+            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_errmgr_detector_component.heartbeat_timeout);
 
     return PRTE_SUCCESS;
 }
@@ -111,7 +106,7 @@ static int errmgr_detector_close(void)
 static int errmgr_detector_component_query(prte_mca_base_module_t **module, int *priority)
 {
     /* used by DVM masters */
-    if ( PRTE_PROC_IS_DAEMON && prte_errmgr_detector_enable_flag) {
+    if (prte_enable_ft && PRTE_PROC_IS_DAEMON) {
         *priority = my_priority;
         *module = (prte_mca_base_module_t *)&prte_errmgr_detector_module;
         return PRTE_SUCCESS;

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -8,7 +8,7 @@
  *                         reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * $COPYRIGHT$
  *
@@ -73,7 +73,7 @@ prte_errmgr_base_module_t prte_errmgr_prted_module = {
     .logfn = prte_errmgr_base_log,
     .abort = prted_abort,
     .abort_peers = prte_errmgr_base_abort_peers,
-    NULL
+    .enable_detector = NULL
 };
 
 /* Local functions */

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -213,12 +213,14 @@ int prte_ess_base_prted_setup(void)
         error = "prte_errmgr_base_open";
         goto error;
     }
+#if PRTE_ENABLE_FT
     /* open the propagate */
     if (PRTE_SUCCESS != (ret = prte_mca_base_framework_open(&prte_propagate_base_framework, 0))) {
         PRTE_ERROR_LOG(ret);
         error = "prte_propagate_base_open";
         goto error;
     }
+#endif
     /* some environments allow remote launches - e.g., ssh - so
      * open and select something -only- if we are given
      * a specific module to use
@@ -404,14 +406,14 @@ int prte_ess_base_prted_setup(void)
         error = "prte_errmgr_base_select";
         goto error;
     }
-
+#if PRTE_ENABLE_FT
     /* select the propagate */
     if (PRTE_SUCCESS != (ret = prte_propagate_base_select())) {
         PRTE_ERROR_LOG(ret);
         error = "prte_propagate_base_select";
         goto error;
     }
-
+#endif
     /*
      * Group communications
      */
@@ -552,10 +554,12 @@ int prte_ess_base_prted_finalize(void)
     /* shutdown the pmix server */
     pmix_server_finalize();
 
+#if PRTE_ENABLE_FT
     if ( NULL != prte_propagate.finalize ) {
         prte_propagate.finalize();
     }
     (void) prte_mca_base_framework_close(&prte_propagate_base_framework);
+#endif
 
     if ( NULL != prte_errmgr.finalize ) {
         prte_errmgr.finalize();

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -236,11 +236,13 @@ static int rte_init(int argc, char **argv)
         goto error;
     }
 
+#if PRTE_ENABLE_FT
     /* open the propagator */
     if (PRTE_SUCCESS != (ret = prte_mca_base_framework_open(&prte_propagate_base_framework, 0))) {
         error = "prte_propagate_base_open";
         goto error;
     }
+#endif
 
     /* Since we are the HNP, then responsibility for
      * defining the name falls to the PLM component for our
@@ -376,13 +378,13 @@ static int rte_init(int argc, char **argv)
         error = "prte_errmgr_base_select";
         goto error;
     }
-
+#if PRTE_ENABLE_FT
     /* setup the propagate */
     if (PRTE_SUCCESS != (ret = prte_propagate_base_select())) {
         error = "prte_propagate_base_select";
         goto error;
     }
-
+#endif
     /* get the job data object for the daemons */
     jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->jobid);
 
@@ -651,7 +653,9 @@ static int rte_finalize(void)
     /* first stage shutdown of the errmgr, deregister the handler but keep
      * the required facilities until the rml and oob are offline */
     prte_errmgr.finalize();
+#if PRTE_ENABLE_FT
     (void) prte_mca_base_framework_close(&prte_propagate_base_framework);
+#endif
     /* cleanup the pstat stuff */
     (void) prte_mca_base_framework_close(&prte_pstat_base_framework);
 

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
@@ -51,14 +51,12 @@
 prte_grpcomm_base_t prte_grpcomm_base = {{{0}}};
 
 prte_grpcomm_API_module_t prte_grpcomm = {
-    prte_grpcomm_API_xcast,
-    prte_grpcomm_API_allgather,
-    prte_grpcomm_API_rbcast,
-    prte_grpcomm_API_register_cb,
-    NULL
+    .xcast = prte_grpcomm_API_xcast,
+    .allgather = prte_grpcomm_API_allgather,
+    .rbcast = prte_grpcomm_API_rbcast,
+    .register_cb = prte_grpcomm_API_register_cb,
+    .unregister_cb = NULL
 };
-
-static bool recv_issued = false;
 
 static int base_register(prte_mca_base_register_flag_t flags)
 {
@@ -80,12 +78,11 @@ static int prte_grpcomm_base_close(void)
     size_t size;
     uint32_t *seq_number;
 
-    if (recv_issued) {
-        prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
-        prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_RBCAST);
-        prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_BMGXCAST);
-        recv_issued = false;
-    }
+    prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
+#if PRTE_ENABLE_FT
+    prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_RBCAST);
+    prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_BMGXCAST);
+#endif
 
     /* Close the active modules */
     PRTE_LIST_FOREACH(active, &prte_grpcomm_base.actives, prte_grpcomm_base_active_t) {

--- a/src/mca/grpcomm/bmg/configure.m4
+++ b/src/mca/grpcomm/bmg/configure.m4
@@ -1,0 +1,23 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_grpcomm_bmg_CONFIG([action-if-can-compile],
+#                        [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_prte_grpcomm_bmg_CONFIG],[
+    AC_CONFIG_FILES([src/mca/grpcomm/bmg/Makefile])
+
+    AS_IF([test "$prte_enable_ft" = "1"],
+          [$1],
+          [$2])
+
+])dnl

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_component.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_component.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,8 +79,14 @@ static int bmg_close(void)
 
 static int bmg_query(prte_mca_base_module_t **module, int *priority)
 {
-    *priority = my_priority;
-    *module = (prte_mca_base_module_t *)&prte_grpcomm_bmg_module;
-    return PRTE_SUCCESS;
+    if (prte_enable_ft) {
+        *priority = my_priority;
+        *module = (prte_mca_base_module_t *)&prte_grpcomm_bmg_module;
+        return PRTE_SUCCESS;
+    }
+
+    *priority = 0;
+    *module = NULL;
+    return PRTE_ERROR;
 }
 

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -4,6 +4,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,13 +48,13 @@ static int register_cb_type(prte_grpcomm_rbcast_cb_t callback);
 static int unregister_cb_type(int type);
 /* Module def */
 prte_grpcomm_base_module_t prte_grpcomm_bmg_module = {
-    bmg_init,
-    bmg_finalize,
-    NULL,
-    NULL,
-    rbcast,
-    register_cb_type,
-    unregister_cb_type
+    .init = bmg_init,
+    .finalize = bmg_finalize,
+    .xcast = NULL,
+    .allgather = NULL,
+    .rbcast = rbcast,
+    .register_cb = register_cb_type,
+    .unregister_cb = unregister_cb_type
 };
 
 /* Internal functions */

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -50,13 +50,13 @@ static int allgather(prte_grpcomm_coll_t *coll,
 
 /* Module def */
 prte_grpcomm_base_module_t prte_grpcomm_direct_module = {
-    init,
-    finalize,
-    xcast,
-    allgather,
-    NULL,
-    NULL,
-    NULL
+    .init = init,
+    .finalize = finalize,
+    .xcast = xcast,
+    .allgather = allgather,
+    .rbcast = NULL,
+    .register_cb = NULL,
+    .unregister_cb = NULL
 };
 
 /* internal functions */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1516,7 +1516,6 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
     prte_job_t *jobdat;
     prte_proc_state_t state=PRTE_PROC_STATE_WAITPID_FIRED;
     prte_proc_t *cptr;
-    int rc;
 
     prte_output_verbose(5, prte_odls_base_framework.framework_output,
                         "%s odls:wait_local_proc child process %s pid %ld terminated",
@@ -1710,26 +1709,31 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                              PRTE_NAME_PRINT(&proc->name), strsignal(WTERMSIG(proc->exit_code))));
         proc->exit_code = WTERMSIG(proc->exit_code) + 128;
 
-        /* register an event handler for the PRTE_ERR_PROC_ABORTED event */
-        pmix_proc_t pname, psource;
-        pmix_status_t pcode = prte_pmix_convert_rc(PRTE_ERR_PROC_ABORTED);
-        PRTE_PMIX_CONVERT_NAME(rc, &pname, &proc->name);
-        PRTE_PMIX_CONVERT_NAME(rc, &psource, PRTE_PROC_MY_NAME);
-        pmix_info_t *pinfo;
-        PMIX_INFO_CREATE(pinfo, 1);
-        PMIX_INFO_LOAD(&pinfo[0], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC );
+#if PRTE_ENABLE_FT
+        if (prte_enable_ft) {
+            /* register an event handler for the PRTE_ERR_PROC_ABORTED event */
+            pmix_proc_t pname, psource;
+            int rc;
+            pmix_status_t pcode = prte_pmix_convert_rc(PRTE_ERR_PROC_ABORTED);
+            PRTE_PMIX_CONVERT_NAME(rc, &pname, &proc->name);
+            PRTE_PMIX_CONVERT_NAME(rc, &psource, PRTE_PROC_MY_NAME);
+            pmix_info_t *pinfo;
+            PMIX_INFO_CREATE(pinfo, 1);
+            PMIX_INFO_LOAD(&pinfo[0], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC );
 
-        if (PRTE_SUCCESS != PMIx_Notify_event(pcode, &psource,
-                    PMIX_RANGE_LOCAL, pinfo, 1,
-                    NULL,NULL )) {
+            if (PRTE_SUCCESS != PMIx_Notify_event(pcode, &psource,
+                        PMIX_RANGE_LOCAL, pinfo, 1,
+                        NULL,NULL )) {
+                PRTE_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                            "%s odls:notify failed, release pinfo",PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+                PRTE_RELEASE(pinfo);
+            }
             PRTE_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
-                        "%s odls:notify failed, release pinfo",PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            PRTE_RELEASE(pinfo);
+                        "%s odls:event notify in odls proc %d:%d gone",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), proc->name.jobid, proc->name.vpid));
+            PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_WAITPID);
         }
-        PRTE_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
-                    "%s odls:event notify in odls proc %d:%d gone",
-                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), proc->name.jobid, proc->name.vpid));
-        PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_WAITPID);
+#endif
 
         /* Do not decrement the number of local procs here. That is handled in the errmgr */
     }

--- a/src/mca/propagate/prperror/configure.m4
+++ b/src/mca/propagate/prperror/configure.m4
@@ -1,0 +1,23 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+# Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_propagate_prperror_CONFIG([action-if-can-compile],
+#                               [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_prte_propagate_prperror_CONFIG],[
+    AC_CONFIG_FILES([src/mca/propagate/prperror/Makefile])
+
+    AS_IF([test "$prte_enable_ft" = "1"],
+          [$1],
+          [$2])
+
+])dnl

--- a/src/mca/propagate/prperror/propagate_prperror_component.c
+++ b/src/mca/propagate/prperror/propagate_prperror_component.c
@@ -3,6 +3,7 @@
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
+ * Copyright (c) 2020      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,7 +88,7 @@ static int propagate_prperror_close(void)
 static int propagate_prperror_component_query(prte_mca_base_module_t **module, int *priority)
 {
     /* only daemon propagate */
-    if (PRTE_PROC_IS_DAEMON || PRTE_PROC_IS_MASTER ) {
+    if (prte_enable_ft && (PRTE_PROC_IS_DAEMON || PRTE_PROC_IS_MASTER)) {
         *priority = my_priority;
         *module = (prte_mca_base_module_t *)&prte_propagate_prperror_module;
         return PRTE_SUCCESS;

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -762,8 +762,7 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             parent.vpid = PRTE_VPID_WILDCARD;
 
             /* do not kill send the msg if ft prte is enabled */
-            if(!prte_errmgr_detector_enable_flag)
-            {
+            if (!prte_enable_ft) {
                 _send_notification(PRTE_ERR_PROC_ABORTED, pdata->state, &pdata->name, &parent);
             }
         }

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -186,10 +186,8 @@ bool prte_in_parallel_debugger = false;
 
 char *prte_daemon_cores = NULL;
 
-/* enable/disable value for errmgr error detector */
-bool prte_errmgr_detector_enable_flag = false;
-double prte_errmgr_heartbeat_period = 5;
-double prte_errmgr_heartbeat_timeout = 10;
+/* enable/disable ft */
+bool prte_enable_ft = false;
 
 int prte_dt_init(void)
 {

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -567,10 +567,8 @@ extern char *prte_stacktrace_output_filename;
 extern char *prte_net_private_ipv4;
 extern char *prte_set_max_sys_limits;
 
-/* Detector enable/disable flag */
-PRTE_EXPORT extern bool prte_errmgr_detector_enable_flag;
-PRTE_EXPORT extern double prte_errmgr_heartbeat_period;
-PRTE_EXPORT extern double prte_errmgr_heartbeat_timeout;
+/* Enable/disable ft */
+PRTE_EXPORT extern bool prte_enable_ft;
 
 END_C_DECLS
 

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -349,11 +349,13 @@ int prte_init(int* pargc, char*** pargv, prte_proc_type_t flags)
     prte_cache = PRTE_NEW(prte_pointer_array_t);
     prte_pointer_array_init(prte_cache, 1, INT_MAX, 1);
 
+#if PRTE_ENABLE_FT
     if (PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON) {
-        if(NULL != prte_errmgr.enable_detector){
-            prte_errmgr.enable_detector(prte_errmgr_detector_enable_flag);
+        if (NULL != prte_errmgr.enable_detector){
+            prte_errmgr.enable_detector(prte_enable_ft);
         }
     }
+#endif
 
     /* start listening - will be ignored if no listeners
      * were registered */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -681,5 +681,12 @@ int prte_register_params(void)
                           PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                           &prte_pmix_verbose_output);
 
+    prte_mca_base_var_register("prte", "prte", NULL, "enable_ft",
+                        "Enable/disable fault tolerance",
+                        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                        PRTE_INFO_LVL_9,
+                        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_enable_ft);
+
+
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
Add the --enable-prte-ft configure option that defaults to "disable". Users
wanting to explore the new FT capabilities of PRRTE can enable this
option. We may be able to remove it (or default to enabled) when some of
the bugs have been worked out.

Move some component-specific variables out of the global area and into
that component. They are only used in that one location.

Set a global prte_enable_ft MCA param so that those who configure with
FT support can dynamically turn it on/off for experimentation.

Fixes #631 

Signed-off-by: Ralph Castain <rhc@pmix.org>