### PR TITLE
Protect MCA parameter

### DIFF
--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -681,12 +681,13 @@ int prte_register_params(void)
                           PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                           &prte_pmix_verbose_output);
 
+#if PRTE_ENABLE_FT
     prte_mca_base_var_register("prte", "prte", NULL, "enable_ft",
                         "Enable/disable fault tolerance",
                         PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
                         PRTE_INFO_LVL_9,
                         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_enable_ft);
-
+#endif
 
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
Bad things happen if someone leaves the prte_enable_ft MCA param set in
their environ and PRRTE isn't configured with --enable-prte-ft. So
protect the param so it isn't recognized unless we are configured for
it.

Signed-off-by: Ralph Castain <rhc@pmix.org>