### PR TITLE
Fix a typo in parsing locality string

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -2011,7 +2011,7 @@ char* prte_hwloc_base_get_location(char *locality,
             } else if (2 == index) {
                 srch = "L2";
             } else {
-                srch = "L0";
+                srch = "L1";
             }
             break;
 #else
@@ -2022,7 +2022,7 @@ char* prte_hwloc_base_get_location(char *locality,
             srch = "L2";
             break;
         case HWLOC_OBJ_L1CACHE:
-            srch = "L0";
+            srch = "L1";
             break;
 #endif
         case HWLOC_OBJ_CORE:


### PR DESCRIPTION
Fix a typo in parsing locality string: L0 changed to L1. As far as I understand, `prte_hwloc_base_get_locality_string` never returns locality string with L0.

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>