### PR TITLE
Fix SIGSEGV in prted when local proctable is empty

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -417,6 +417,11 @@ static void _query(int sd, short args, void *cbdata)
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
+                /* Check if there are any entries in global proctable */
+                if (0 == jdata->num_procs) {
+                    rc = PRTE_ERR_NOT_FOUND;
+                    goto done;
+                }
                 /* setup the reply */
                 kv = PRTE_NEW(prte_info_item_t);
                 (void)strncpy(kv->info.key, PMIX_QUERY_PROC_TABLE, PMIX_MAX_KEYLEN);
@@ -452,6 +457,11 @@ static void _query(int sd, short args, void *cbdata)
                  * entries for each LOCAL proc in the indicated job */
                 jdata = prte_get_job_data_object(jobid);
                 if (NULL == jdata) {
+                    rc = PRTE_ERR_NOT_FOUND;
+                    goto done;
+                }
+                /* Check if there are any entries in local proctable */
+                if (0 == jdata->num_local_procs) {
                     rc = PRTE_ERR_NOT_FOUND;
                     goto done;
                 }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -419,7 +419,7 @@ static void _query(int sd, short args, void *cbdata)
                 }
                 /* Check if there are any entries in global proctable */
                 if (0 == jdata->num_procs) {
-                    rc = PRTE_ERR_NOT_FOUND;
+                    ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
                 /* setup the reply */
@@ -457,12 +457,12 @@ static void _query(int sd, short args, void *cbdata)
                  * entries for each LOCAL proc in the indicated job */
                 jdata = prte_get_job_data_object(jobid);
                 if (NULL == jdata) {
-                    rc = PRTE_ERR_NOT_FOUND;
+                    ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
                 /* Check if there are any entries in local proctable */
                 if (0 == jdata->num_local_procs) {
-                    rc = PRTE_ERR_NOT_FOUND;
+                    ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
                 /* setup the reply */


### PR DESCRIPTION
I got a SIGSEGV in prted when running **prte --report-uri + system-server** and then attempting to run the prrte/examples/debugger/attach.c example which I have been working on. 

I should have specified the namespace of the target application process, but mistakenly entered the namespace displayed by prte due to the --report-uri flag. There were no processes running under control of this daemon, so no entries in the process table.

The SIGSEGV occurred at line 476 of prrte/src/prted/pmix/pmix_server_queries.c since the debugger daemon called PMIx_Query_info with PMIX_QUERY_LOCAL_PROC_TABLE.:
PRTE_PMIX_CONVERT_NAME(rc, &procinfo[p].proc, &proct->name);

This is due to the procinfo array being empty, which in turn is because the call to prte_get_job_data_object() returned jdata->num_local_procs = 0 and an empty proctable array was created.

I fixed this by returning PRTE_ERR_NOT_FOUND in this case. I also fixed handling for PMIX_QUERY_PROC_TABLE the same way

Signed-off-by: David Wootton <dwootton@us.ibm.com>