### PR TITLE
icc: suppress no_long_double

### DIFF
--- a/config/prte_setup_cc.m4
+++ b/config/prte_setup_cc.m4
@@ -321,7 +321,7 @@ AC_DEFUN([PRTE_SETUP_CC],[
                       prte_cv_cc_wno_long_double="yes"
                       if test -s conftest.err ; then
                           dnl Yes, it should be "ignor", in order to catch ignoring and ignore
-                          for i in unknown invalid ignor unrecognized ; do
+                          for i in unknown invalid ignor unrecognized 'not supported'; do
                               $GREP -iq $i conftest.err
                               if test "$?" = "0" ; then
                                   prte_cv_cc_wno_long_double="no"


### PR DESCRIPTION
equivalent to OMPI PR https://github.com/open-mpi/ompi/pull/8015

suppress 100s of the following messages from icc:

icc: command line warning #10148: option '-Wno-long-double' not supported

Signed-off-by: Ralph Castain <rhc@pmix.org>