### PR TITLE
Cleanup/detector

### DIFF
--- a/examples/daemon_error_notify.c
+++ b/examples/daemon_error_notify.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 -2020  The University of Tennessee and The University
- *                           of Tennessee Research Foundation.  All rights
- *                           reserved.
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,16 +35,21 @@ static void notification_fn(size_t evhdlr_registration_id,
     int i;
     char name[255];
     gethostname(name, 255);
-    for(i=0; i<ninfo; i++)
+    if( (info[0].value.data.proc!=NULL) && strcmp(info[0].value.data.proc->nspace, myproc.nspace)==0)
     {
-        fprintf(stderr, "%s Client %s:%d NOTIFIED with status %d and error proc %s:%d key %s \n",
-                name, myproc.nspace, myproc.rank, status,
-                info[i].value.data.proc->nspace, info[i].value.data.proc->rank,info[i].key);
+        for(i=0; i<ninfo; i++)
+        {
+            fprintf(stderr, "%s Client %s:%d NOTIFIED with status %d and error proc %s:%d key %s \n",
+                    name, myproc.nspace, myproc.rank, status,
+                    info[i].value.data.proc->nspace, info[i].value.data.proc->rank,info[i].key);
+        }
+        completed = true;
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
     }
-    completed = true;
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
-    }
+    else
+        fprintf(stderr, "Not from my namespace");
 }
 
 static void op_callbk(pmix_status_t status,

--- a/examples/error_notify.c
+++ b/examples/error_notify.c
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018 - 2020 The University of Tennessee and The University
- *                           of Tennessee Research Foundation.  All rights
- *                           reserved.
+ * Copyright (c) 2018-2020 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,13 +32,19 @@ static void notification_fn(size_t evhdlr_registration_id,
                             void *cbdata)
 {
     gettimeofday(&end,NULL);
-    fprintf(stderr, "Client %s:%d NOTIFIED with status %d and error proc %s:%d key %s \n",
-            myproc.nspace, myproc.rank, status,
-            info[0].value.data.proc->nspace, info[0].value.data.proc->rank,info[0].key);
-    completed = true;
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    fprintf(stderr, "New notification comes\n");
+    if( (info[0].value.data.proc!=NULL) && strcmp(info[0].value.data.proc->nspace, myproc.nspace)==0)
+    {
+        fprintf(stderr, "Client %s:%d NOTIFIED with status %d and error proc %s:%d key %s \n",
+                myproc.nspace, myproc.rank, status,
+                info[0].value.data.proc->nspace, info[0].value.data.proc->rank,info[0].key);
+        completed = true;
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
     }
+    else
+        fprintf(stderr, "Not from my namespace \n");
 }
 
 static void op_callbk(pmix_status_t status,

--- a/src/mca/errmgr/detector/errmgr_detector.c
+++ b/src/mca/errmgr/detector/errmgr_detector.c
@@ -339,7 +339,7 @@ static void enable_detector(bool enable_flag)
         }
 
         PRTE_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
-                    "errmgr:detector daemon %d observering %d observer %d",
+                    "errmgr:detector daemon %d observing %d; observed by %d",
                     vpid,
                     detector->hb_observing,
                     detector->hb_observer));
@@ -410,7 +410,7 @@ static int fd_heartbeat_request(prte_errmgr_detector_t* detector) {
         break;
     }
     PRTE_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
-                "errmgr:detector updated ring daemon %d observering %d observer %d",
+                "errmgr:detector updated ring daemon %d observing %d; observed by %d",
                 PRTE_PROC_MY_NAME->vpid,
                 detector->hb_observing,
                 detector->hb_observer));

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -79,10 +79,6 @@ static int prte_grpcomm_base_close(void)
     uint32_t *seq_number;
 
     prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
-#if PRTE_ENABLE_FT
-    prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_RBCAST);
-    prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_BMGXCAST);
-#endif
 
     /* Close the active modules */
     PRTE_LIST_FOREACH(active, &prte_grpcomm_base.actives, prte_grpcomm_base_active_t) {

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -40,12 +40,10 @@
 /* Static API's */
 static int bmg_init(void);
 static void bmg_finalize(void);
-
 static int rbcast(prte_buffer_t *buf);
-
 static int register_cb_type(prte_grpcomm_rbcast_cb_t callback);
-
 static int unregister_cb_type(int type);
+
 /* Module def */
 prte_grpcomm_base_module_t prte_grpcomm_bmg_module = {
     .init = bmg_init,
@@ -70,7 +68,7 @@ static prte_list_t tracker;
 #define RBCAST_CB_TYPE_MAX 7
 static prte_grpcomm_rbcast_cb_t prte_grpcomm_rbcast_cb[RBCAST_CB_TYPE_MAX+1];
 
-int register_cb_type(prte_grpcomm_rbcast_cb_t callback) {
+static int register_cb_type(prte_grpcomm_rbcast_cb_t callback) {
     int i;
 
     for(i = 0; i < RBCAST_CB_TYPE_MAX; i++) {
@@ -82,7 +80,7 @@ int register_cb_type(prte_grpcomm_rbcast_cb_t callback) {
     return PRTE_ERR_OUT_OF_RESOURCE;
 }
 
-int unregister_cb_type(int type) {
+static int unregister_cb_type(int type) {
     if( RBCAST_CB_TYPE_MAX < type || 0 > type ) {
         return PRTE_ERR_BAD_PARAM;
     }

--- a/src/mca/propagate/base/propagate_base_select.c
+++ b/src/mca/propagate/base/propagate_base_select.c
@@ -26,6 +26,8 @@ int prte_propagate_base_select(void)
     int exit_status = PRTE_SUCCESS;
     prte_propagate_base_component_t *best_component = NULL;
     prte_propagate_base_module_t *best_module = NULL;
+    /* early bailout. */
+    if (!prte_enable_ft) return PRTE_SUCCESS;
     /*
      * Select the best component
      */

--- a/src/mca/propagate/prperror/propagate_prperror.c
+++ b/src/mca/propagate/prperror/propagate_prperror.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 The University of Tennessee and The University
+ * Copyright (c) 2017-2020 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -72,7 +72,7 @@ static int register_prp_callback(void);
 static int prte_propagate_prperror(prte_jobid_t *job, prte_process_name_t *source,
         prte_process_name_t *errorproc, prte_proc_state_t state);
 
-int prte_propagate_prperror_recv(prte_buffer_t* buffer);
+static int prte_propagate_prperror_recv(prte_buffer_t* buffer);
 
 /* flag use to register callback for grpcomm rbcast forward */
 int enable_callback_register_flag = 1;
@@ -443,7 +443,7 @@ static int _prte_propagate_prperror(prte_jobid_t *job, prte_process_name_t *sour
 }
 
 
-int prte_propagate_prperror_recv(prte_buffer_t* buffer)
+static int prte_propagate_prperror_recv(prte_buffer_t* buffer)
 {
     int ret, cnt, state;
     prte_process_name_t errorproc;

--- a/src/mca/rml/rml_types.h
+++ b/src/mca/rml/rml_types.h
@@ -185,9 +185,6 @@ BEGIN_C_DECLS
 
 /* error propagate  */
 #define PRTE_RML_TAG_RBCAST                 66
-#define PRTE_RML_TAG_BMGXCAST               67
-#define PRTE_RML_TAG_ALLGATHER_BMG          68
-#define PRTE_RML_TAG_BMG_COLL_RELEASE       69
 
 /* heartbeat request */
 #define PRTE_RML_TAG_HEARTBEAT_REQUEST      70

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -761,7 +761,8 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             parent.jobid = jdata->jobid;
             parent.vpid = PRTE_VPID_WILDCARD;
 
-            /* do not kill send the msg if ft prte is enabled */
+            /* if ft prte is enabled, a PMIx event has already been produced
+             * and this is redundant. */
             if (!prte_enable_ft) {
                 _send_notification(PRTE_ERR_PROC_ABORTED, pdata->state, &pdata->name, &parent);
             }

--- a/src/tools/prte_info/param.c
+++ b/src/tools/prte_info/param.c
@@ -349,6 +349,7 @@ void prte_info_do_config(bool want_all)
     char *prun_prefix_by_default;
     char *symbol_visibility;
     char *manpages;
+    char *resilience;
 
     /* setup the strings that don't require allocations*/
     debug = PRTE_ENABLE_DEBUG ? "yes" : "no";
@@ -356,6 +357,7 @@ void prte_info_do_config(bool want_all)
     prun_prefix_by_default = PRTE_WANT_PRTE_PREFIX_BY_DEFAULT ? "yes" : "no";
     symbol_visibility = PRTE_C_HAVE_VISIBILITY ? "yes" : "no";
     manpages = PRTE_ENABLE_MAN_PAGES ? "yes" : "no";
+    resilience = PRTE_ENABLE_FT ? "yes" : "no";
 
     /* output values */
     prte_info_out("Configured by", "config:user", PRTE_CONFIGURE_USER);
@@ -411,5 +413,6 @@ void prte_info_do_config(bool want_all)
                   prun_prefix_by_default);
     prte_info_out("Symbol vis. support", "options:visibility", symbol_visibility);
     prte_info_out("Manpages built", "options:man-pages", manpages);
+    prte_info_out("Resilience support", "options:ft", resilience);
 
 }


### PR DESCRIPTION
This PR continues the cleanup of the initialization of the prte detector.

* correct the detector infrastructure so that it does not crash during startup when compiled-in
* Correct the examples
* remove unused variables and reduce scope of locals and functions (static)

I have removed the part that makes this feature compiled-in by default, in order to get things moving.

There is a crippling bug in the detector as-is and we need this quickly.