### PR TITLE
Fix attach assert in finalize

### DIFF
--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -61,7 +61,12 @@ int prte_plm_base_set_hnp_name(void)
         return PRTE_SUCCESS;
     }
 
-    /* for our nspace, we will use the nodename+pid */
+    /* for our nspace, we will use the nodename+pid
+     * Note that we do not add the .0 suffix to the namespace as we do with
+     * the children namespaces. The daemon jobfamily is always "0".
+     * The PRTE_PMIX_CONVERT_NSPACE routine will create the prte_job_t structre
+     * and add it to the prte_job_data hash table at position "0".
+     */
     prte_asprintf(&evar, "%s-%s%u", prte_tool_basename, prte_process_info.nodename, (uint32_t)prte_process_info.pid);
 
     PRTE_PMIX_CONVERT_NSPACE(rc, &PRTE_PROC_MY_NAME->jobid, evar);
@@ -78,7 +83,6 @@ int prte_plm_base_set_hnp_name(void)
     /* set the nspace */
     PMIX_LOAD_NSPACE(prte_process_info.myproc.nspace, evar);
     prte_process_info.myproc.rank = 0;
-
 
     /* done */
     free(evar);
@@ -135,6 +139,8 @@ int prte_plm_base_create_jobid(prte_job_t *jdata)
     prte_asprintf(&tmp, "%s.%u", prte_process_info.myproc.nspace, (unsigned)prte_plm_globals.next_jobid);
     PMIX_LOAD_NSPACE(jdata->nspace, tmp);
     free(tmp);
+    // This routine will create a new prte_job_t structure and add it to the
+    // prte_job_data hash table at the ".N" position.
     PRTE_PMIX_CONVERT_NSPACE(rc, &jdata->jobid, jdata->nspace);
     if (PRTE_SUCCESS != rc) {
         return rc;

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -18,6 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,7 +90,7 @@ static void _query(int sd, short args, void *cbdata)
     bool local_only;
     prte_namelist_t *nm;
     prte_list_t targets;
-    int i, num_replies;
+    int i, num_replies, matched;
     pmix_proc_info_t *procinfo;
     pmix_info_t *info;
     pmix_data_array_t *darray;
@@ -123,7 +124,38 @@ static void _query(int sd, short args, void *cbdata)
         /* see if they provided any qualifiers */
         if (NULL != q->qualifiers && 0 < q->nqual) {
             for (n=0; n < q->nqual; n++) {
+                prte_output_verbose(2, prte_pmix_server_globals.output,
+                                    "%s qualifier key \"%s\" : value \"%s\"",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    q->qualifiers[n].key,
+                                    (q->qualifiers[n].value.type == PMIX_STRING ? q->qualifiers[n].value.data.string : "(not a string)"));
                 if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_NSPACE)) {
+                    /* Never trust the namespace string that is provided.
+                     * First check to see if we know about this namespace. If
+                     * not then return an error. If so then continue on.
+                     * Note that the "PRTE_PMIX_CONVERT_NSPACE" function will create
+                     * a new prte_job_t structure an add it to the list.
+                     */
+                    /* Make sure the qualifier namespace exists */
+                    matched = 0;
+                    PRTE_HASH_TABLE_FOREACH(key, uint32, jdata, prte_job_data) {
+                        if (NULL != jdata &&
+                            PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string,
+                                              jdata->nspace)) {
+                            matched = 1;
+                            break;
+                        }
+                    }
+                    if (0 == matched) {
+                        prte_output_verbose(2, prte_pmix_server_globals.output,
+                                            "%s qualifier key \"%s\" : value \"%s\" is an unknown namespace",
+                                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                            q->qualifiers[n].key,
+                                            q->qualifiers[n].value.data.string);
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
+
                     PRTE_PMIX_CONVERT_NSPACE(rc, &jobid, q->qualifiers[n].value.data.string);
                     if (PRTE_JOBID_INVALID == jobid || PRTE_SUCCESS != rc) {
                         ret = PMIX_ERR_BAD_PARAM;


### PR DESCRIPTION
A few items all related to cause this error.
 * In finalize we destruct the `prte_job_data` in a loop. Since we cannot know the order in which job items will be popped off of the hash it is possible that this tries to finalize the child job before the parent job. In a debug build this causes an assert in `prte_list_item_destruct` since we are destructing a list item that is a member of another list - namely the `children` list of the parent.
   - To fix this we need to first clear the children list from all jobs, before we destroy the job structures.
 * If the tool calls `PMIx_Query_info` with the qualifier `PMIX_NSPACE` that contains an unknown namespace (or bogus namespace) then the query function will create a job structure for it and add it to the list. If the `PMIX_NSPACE` is of the form `prterun-c712f6n0132359.0` then it will replace the `prte`/`prterun` daemon's entry in the `prte_job_data` hash orphaning the prior object. The prior object is the one that has a `children` list containing the application that was launched.
   - To fix this we need to (1) check the validity of the namespace passed to this function and return an error. (2) Make sure we do not create a new job structure for this bogus namespace which can confuse or, worse, overwrite good job structures in the hash table.
 * The `prte_plm_base_create_jobid` function will ensure that the `prte_job_t` structure passed to it is the one that is stored in the `prte_job_data` hash table at the new `jobid` position. This tightens up a window of time where the temporary object in the hash table (from `prte_convert_nspace_to_jobid` since this is a new jobid) is in the hash table instead of the actual `jdata` object passed to `prte_plm_base_create_jobid`.
 * Add some helper functions for the `prte_job_data` structure
   - `prte_set_job_data_object`
   - `prte_display_prte_job_data` debugging helper
