### PR TITLE
Fix timing window in create_jobid

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -454,7 +454,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
             /* check to see if we already have this one */
             if (NULL == prte_get_job_data_object(jdata->jobid)) {
                 /* nope - add it */
-                prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+                prte_set_job_data_object(jdata->jobid, jdata);
             } else {
                 /* yep - so we can drop this copy */
                 jdata->jobid = PRTE_JOBID_INVALID;
@@ -534,7 +534,7 @@ int prte_odls_base_default_construct_child_list(prte_buffer_t *buffer,
             goto REPORT_ERROR;
         }
     } else {
-        prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+        prte_set_job_data_object(jdata->jobid, jdata);
 
         /* ensure the map object is present */
         if (NULL == jdata->map) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -302,8 +302,11 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
          * step required before we launch the daemons. It allows
          * the prte_rmaps_base_setup_virtual_machine routine to
          * search all apps for any hosts to be used by the vm
+         *
+         * Note that the prte_plm_base_create_jobid function will
+         * place the "caddy->jdata" object at the correct position
+         * in the hash table. There is no need to store it again here.
          */
-        prte_hash_table_set_value_uint32(prte_job_data, caddy->jdata->jobid, caddy->jdata);
     }
 
     /* if job recovery is not enabled, set it to default */

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -171,7 +172,8 @@ void prte_plm_base_recv(int status, prte_process_name_t* sender,
         if (PRTE_SUCCESS == rc) {
             job = jb.jobid;
         }
-        PRTE_DESTRUCT(&jb);
+        // The 'jb' object is now stored as reference in the prte_job_data hash
+        // by the prte_plm_base_create_jobid function.
 
         /* setup the response */
         answer = PRTE_NEW(prte_buffer_t);

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -970,7 +970,7 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
                  * is maintained!
                  */
                 if (1 < j) {
-                    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, NULL);
+                    prte_set_job_data_object(jdata->jobid, NULL);
                     PRTE_RELEASE(jdata);
                 }
             }

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -538,7 +538,7 @@ static void track_procs(int fd, short argc, void *cbdata)
             }
 
             /* cleanup the job info */
-            prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, NULL);
+            prte_set_job_data_object(jdata->jobid, NULL);
             PRTE_RELEASE(jdata);
         }
     }

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -8,6 +8,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +77,11 @@ void prte_convert_daemon_nspace(prte_jobid_t *jobid, pmix_nspace_t nspace)
     jobfam = (uint16_t)(((0x0000ffff & (0xffff0000 & hash32) >> 16)) ^ (0x0000ffff & hash32));
     jdata->jobid = (0xffff0000 & ((uint32_t)jobfam << 16));
     *jobid = jdata->jobid;
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+
+    /*
+     * Add this temporary job object to the hash as a placeholder.
+     */
+    prte_set_job_data_object(jdata->jobid, jdata);
 }
 
 int prte_convert_nspace_to_jobid(prte_jobid_t *jobid, pmix_nspace_t nspace)
@@ -128,7 +133,11 @@ int prte_convert_nspace_to_jobid(prte_jobid_t *jobid, pmix_nspace_t nspace)
     jobfam = (uint16_t)(((0x0000ffff & (0xffff0000 & hash32) >> 16)) ^ (0x0000ffff & hash32));
     jdata->jobid = (0xffff0000 & ((uint32_t)jobfam << 16)) | (0x0000ffff & localjob);
     *jobid = jdata->jobid;
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+
+    /*
+     * Add this temporary job object to the hash as a placeholder.
+     */
+    prte_set_job_data_object(jdata->jobid, jdata);
 
     return PRTE_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -745,7 +745,7 @@ void prte_pmix_server_tool_conn_complete(prte_job_t *jdata,
     /* flag that it is not to be monitored */
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_DO_NOT_MONITOR);
     /* store it away */
-    prte_hash_table_set_value_uint32(prte_job_data, jdata->jobid, jdata);
+    prte_set_job_data_object(jdata->jobid, jdata);
 
     /* must create a map for it (even though it has no
      * info in it) so that the job info will be picked

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
@@ -422,6 +422,13 @@ PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_proc_t);
  * service
  */
 PRTE_EXPORT   prte_job_t* prte_get_job_data_object(prte_jobid_t job);
+
+/**
+ * Set a job data object
+ * This will return the 'old' object at the specified location.
+ * If there was none then NULL is returned.
+ */
+PRTE_EXPORT prte_job_t* prte_set_job_data_object(prte_jobid_t jobid, prte_job_t *jdata);
 
 /**
  * Get a proc data object


### PR DESCRIPTION
 * The `prte_plm_base_create_jobid` function will ensure that
   the `prte_job_t` structure passed to it is the one that is
   stored in the `prte_job_data` hash table at the new `jobid`
   position. This tightens up a window of time where the temporary
   object in the hash table (from `prte_convert_nspace_to_jobid`
   since this is a new jobid) is in the hash table instead of the
   actual `jdata` object passed to `prte_plm_base_create_jobid`.
 * `prte_set_job_data_object` helper function will return the
   prior object at the location in the hash table after setting
   that location to a new value.
 * Release children before list in job destruct