### PR TITLE
ras: alps: fix error in script installation

### DIFF
--- a/src/mca/ras/alps/Makefile.am
+++ b/src/mca/ras/alps/Makefile.am
@@ -26,7 +26,7 @@ dist_prtedata_DATA = help-ras-alps.txt \
 		  ras-alps-command.sh
 
 install-data-hook:
-	chmod +x $(prtedatadir)/ras-alps-command.sh
+	chmod +x $(DESTDIR)$(prtedatadir)/ras-alps-command.sh
 
 sources = \
         ras_alps.h \


### PR DESCRIPTION
Fix error in script installation when building with ALPS.

Encountered in 4.0.3 official tarball release, and in master b532564643

Steps to reproduce:

        ./autogen.pl
        ./configure --prefix /home/user/somewhere/ompi-prefix --disable-man-pages

Note:

        Resource Managers
        -----------------------
        Cray Alps: yes

Build:

        make -j14
        make DESTDIR=/home/user/somewhere/ompi-destdir install

Before patch:

        make  install-data-hook
        make[5]: Entering directory '/home/user/somewhere/ompi/prrte/src/mca/ras/alps'
        chmod +x /home/user/somewhere/ompi-prefix/share/prte/ras-alps-command.sh
        chmod: cannot access '/home/user/somewhere/ompi-prefix/share/prte/ras-alps-command.sh': No such file or directory
        make[5]: *** [Makefile:1206: install-data-hook] Error 1
        make[5]: Leaving directory '/home/user/somewhere/ompi/prrte/src/mca/ras/alps'
        make[4]: *** [Makefile:1135: install-data-am] Error 2

After patch:

        make  install-data-hook
        make[5]: Entering directory '/home/user/somewhere/ompi/prrte/src/mca/ras/alps'
        chmod +x /home/user/somewhere/ompi-destdir/lus/theta-fs0/projects/CASPER/acolin/upstream/ompi-prefix/share/prte/ras-alps-command.sh
        make[5]: Leaving directory '/home/user/somewhere/ompi/prrte/src/mca/ras/alps'