### PR TITLE
configury: fix getdate woes

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -29,6 +29,7 @@ EXTRA_DIST = \
         ltmain_pgi_tp.diff \
         prte_mca_priority_sort.pl \
         find_common_syms \
+        getdate.sh \
         make_manpage.pl \
         md2nroff.pl
 

--- a/config/prte_functions.m4
+++ b/config/prte_functions.m4
@@ -96,6 +96,12 @@ EOF
 
 PRTE_CONFIGURE_USER="${USER:-`whoami`}"
 PRTE_CONFIGURE_HOST="${HOSTNAME:-`(hostname || uname -n) 2> /dev/null | sed 1q`}"
+# Note: it's ok to use $srcdir here because this macro is called at
+# the very beginning of configure.ac:
+#
+# a) before $PRTE_TOP_SRCDIR is set, and
+# b) from the top-level build directory (i.e., so $srcdir actually
+#    points to the top source directory)
 PRTE_CONFIGURE_DATE="`$srcdir/config/getdate.sh`"
 
 #

--- a/config/prte_get_version.m4
+++ b/config/prte_get_version.m4
@@ -91,7 +91,7 @@ m4_define([PRTE_GET_VERSION],[
                     $2_REPO_REV=`git describe --tags --always`
                 fi
             else
-                $2_REPO_REV=date`$srcdir/getdate.sh '+%Y-%m-%d'`
+                $2_REPO_REV=date`$srcdir/config/getdate.sh '+%Y-%m-%d'`
             fi
         fi
 

--- a/config/prte_get_version.sh
+++ b/config/prte_get_version.sh
@@ -92,7 +92,7 @@ else
                     PRTE_REPO_REV=`git describe --tags --always`
                 fi
             else
-                PRTE_REPO_REV=date`$srcdir/getdate.sh '+%Y-%m-%d'`
+                PRTE_REPO_REV=date`$srcdir/config/getdate.sh '+%Y-%m-%d'`
             fi
         fi
 


### PR DESCRIPTION
- Ensure getdate.sh is in the dist tarball
- Use the right path to config/getdate.sh
- Add a comment explaining why it's ok to use $srcdir
  (vs. $PRTE_TOP_SRCDIR)

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs https://github.com/open-mpi/ompi/issues/8182