### PR TITLE
Correctly skip the "mpirun" node when launching orted on it

### DIFF
--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -103,6 +103,7 @@ int prte_ras_base_node_insert(prte_list_t* nodes, prte_job_t *jdata)
                 hnp_node->name = strdup("prte");
                 skiphnp = true;
                 PRTE_SET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping, PRTE_MAPPING_NO_USE_LOCAL);
+                PRTE_FLAG_SET(hnp_node, PRTE_NODE_NON_USABLE);  // leave this node out of mapping operations
             }
         }
     }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -291,8 +291,12 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *tota
         /* the list is empty - if the HNP is allocated, then add it */
         if (prte_hnp_is_allocated) {
             nd = (prte_node_t*)prte_pointer_array_get_item(prte_node_pool, 0);
-            PRTE_RETAIN(nd);
-            prte_list_append(allocated_nodes, &nd->super);
+            if (!PRTE_FLAG_TEST(nd, PRTE_NODE_NON_USABLE)) {
+                PRTE_RETAIN(nd);
+                prte_list_append(allocated_nodes, &nd->super);
+            } else {
+                nd = NULL;
+            }
         } else {
             nd = NULL;
         }


### PR DESCRIPTION
Mark the node as "unusable" so it does not get included when computing
number of procs for the case where the user does not specify -np.

Signed-off-by: Ralph Castain <rhc@pmix.org>