### PR TITLE
prun: man: document --host +e feature for empty nodes and fix formatting

### DIFF
--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -145,7 +145,9 @@ the psrvr to run on.
 
 `-H, -host, --host <host1,host2,...,hostN>`
 
-:   List of hosts on which to invoke processes.
+:   List of hosts on which to invoke processes. Pass +e to allocate only
+    onto empty nodes or +e:N to allocate onto nodes at least N of which
+    are empty (i.e. exclusive to this prun instance).
 
 `-hostfile, --hostfile <hostfile>`
 

--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -110,8 +110,7 @@ further details.
 
 `-N <num>`
 
-:
-    Launch num processes per node on all allocated nodes (synonym for
+:   Launch num processes per node on all allocated nodes (synonym for
     npernode).
 
 `-display-map, --display-map`


### PR DESCRIPTION
https://www.mail-archive.com/users@lists.open-mpi.org/msg34164.html

About  the `--host +e` feature:

To request nodes exclusive to a prun instance. For example, on a resource allocation from RM (Cobalt/ALPS) of two nodes with 64 cores each, the following launches each prun instance of size 1 core on a separate node, as opposed to the default (without `--host +e`), which launches the two prun instances on two cores of the same node.
```
prte --daemonize
prun --map-by ppr:64:node --host +e -n 1  ./mpitest &
prun --map-by ppr:64:node --host +e -n 1  ./mpitest &

        MPI World size = 1 processes
        Hello World from rank 0 running on nid03835 (hostname nid03835)!

        MPI World size = 1 processes
        Hello World from rank 0 running on nid03834 (hostname nid03834)!
pterm
```

I found `--host +e` does not work with `--map-by core` (see below). Is this expected? Should a note about this be added to the --host entry in the manpage ("not compatible with --map-by core" or "compatible with --map-by ppr:N:node"?)?

```
acolin@thetamom1 mpitest $ prte --daemonize
acolin@thetamom1 mpitest $ prun -v --bind-to none --map-by ppr:64:node:NOLOCAL --host +e -n 1  ./mpitest
[thetamom1:46852] Calling PMIx_Spawn
[thetamom1:46852] JOB [46576,2] EXECUTING
host nid03834: initing MPI...
MPI World size = 1 processes
Hello World from rank 0 running on nid03834 (hostname nid03834)!
[thetamom1:46852] PRUN: EVHANDLER WITH STATUS JOB ENDED(-145)
[thetamom1:46852] JOB [46576,2] COMPLETED WITH STATUS 0

acolin@thetamom1 mpitest $ prun -v --bind-to none --map-by core:NOLOCAL --host +e -n 1  ./mpitest
[thetamom1:47347] Calling PMIx_Spawn
--------------------------------------------------------------------------
There are not enough slots available in the system to satisfy the 1
slots that were requested by the application:

  ./mpitest

Either request fewer slots for your application, or make more slots
available for use.

A "slot" is the PRTE term for an allocatable unit where we can
launch a process.  The number of slots available are defined by the
environment in which PRTE processes are run:

  1. Hostfile, via "slots=N" clauses (N defaults to number of
     processor cores if not provided)
  2. The --host command line parameter, via a ":N" suffix on the
     hostname (N defaults to 1 if not provided)
  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
  4. If none of a hostfile, the --host command line parameter, or an
     RM is present, PRTE defaults to the number of processor cores

In all the above cases, if you want PRTE to default to the number
of hardware threads instead of the number of processor cores, use the
--use-hwthread-cpus option.

Alternatively, you can use the --map-by :OVERSUBSCRIBE option to ignore the
number of available slots when deciding the number of processes to
launch.
--------------------------------------------------------------------------
[thetamom1:47347] PMIx_Spawn failed (-179): JOB FAILED TO MAP
```