### PR TITLE
Fix processing for prterun --display-map and related options

### DIFF
--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -359,8 +359,12 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
                          * to deprecate i */
                         rc = PRTE_SUCCESS;
                     } else if (PRTE_OPERATION_SUCCEEDED == rc) {
-                        /* we did not do a conversion but don't
-                         * want to deprecate i */
+                        /* Advance past any command line option
+                         * parameters */
+                        memset(&e, 0, sizeof(prte_cmd_line_init_t));
+                        e.ocl_cmd_long_name = &pargs[i][2];
+                        option = prte_cmd_line_find_option(cmdline, &e);
+                        i += option->clo_num_params;
                         rc = PRTE_ERR_SILENT;
                     } else {
                         --i;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1123,15 +1123,6 @@ int main(int argc, char *argv[])
         PMIX_INFO_LOAD(ds->info, PMIX_BINDTO, pval->data.string, PMIX_STRING);
         prte_list_append(&job_info, &ds->super);
     }
-
-    if (prte_cmd_line_is_taken(prte_cmd_line, "report-bindings")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        flag = true;
-        PMIX_INFO_LOAD(ds->info, PMIX_REPORT_BINDINGS, &flag, PMIX_BOOL);
-        prte_list_append(&job_info, &ds->super);
-    }
-
     /* mark if recovery was enabled on the cmd line */
     if (prte_cmd_line_is_taken(prte_cmd_line, "enable-recovery")) {
         ds = PRTE_NEW(prte_ds_info_t);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1178,14 +1178,6 @@ int prun(int argc, char *argv[])
         prte_list_append(&job_info, &ds->super);
     }
 
-    if (prte_cmd_line_is_taken(prte_cmd_line, "report-bindings")) {
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        flag = true;
-        PMIX_INFO_LOAD(ds->info, PMIX_REPORT_BINDINGS, &flag, PMIX_BOOL);
-        prte_list_append(&job_info, &ds->super);
-    }
-
     /* mark if recovery was enabled on the cmd line */
     if (prte_cmd_line_is_taken(prte_cmd_line, "enable-recovery")) {
         ds = PRTE_NEW(prte_ds_info_t);


### PR DESCRIPTION
The prterun command intermittently failed to display output for the --display-map, --display-devel-map, display-allocation and display-devel-allocation options.

This was dependent on the placement of these options relative to the --map-by option. If these options were placed before the --map-by option then the options displayed output. If these options followed the --display-map option, no output was displayed.

The problem was within the process_deprecated_cli() function. This function expected the command line argument index to be incremented to skip over option parameters, for instance, **--map-by **core**. The code failed to do this, so the processing loop found the core keyword with no leading '-' and exited the options processing loop prematurely.

This loop processed similar remappings for --bind-to, where the --report-bindings option is converted to --bind-to :report. There was still code in prun.c and prte.c that recognized and processed the --report-bindings option so I removed that code as redundant.