### PR TITLE
Detect invalid --map-by option PE=<n> parameter

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -501,3 +501,10 @@ not enough cpus are available to meet the request:
   CPUs per proc:   %d
 
 Please adjust your request and try again.
+[invalid-value]
+A %s was given that requires a value, but the provided value is invalid:
+
+  Policy:  %s
+  Given:   %s
+
+Please provide a valid value for this policy, or remove it.

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -327,15 +327,20 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
                                 "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == (ptr = strchr(ck2[i], '='))) {
-                /* missing the value */
+            /* Should be processing PE=<n>, verify '=' is present then that following value
+             * is numeric */
+            if ('=' != ck2[i][2]) {
+                prte_argv_free(ck2);
+                return PRTE_ERR_BAD_PARAM;
+            }
+            u16 = strtol(&ck2[i][3], &ptr, 10);
+            if (((&ck2[i][3]) == ptr) || ('\0' != *ptr)) {
+                /* missing the value or value is invalid */
                 prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
                                 "mapping policy", "PE", ck2[i]);
                 prte_argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            ptr++;
-            u16 = strtol(ptr, NULL, 10);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL,
                                 &u16, PRTE_UINT16);
 

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -154,7 +154,7 @@ PRTE_CLASS_INSTANCE(prte_rmaps_base_selected_module_t,
 static int check_modifiers(char *ck, prte_job_t *jdata,
                            prte_mapping_policy_t *tmp)
 {
-    char **ck2, *ptr;
+    char **ck2, *ptr, *temp_parm, *temp_token, *parm_delimiter;
     int i;
     uint16_t u16;
     bool inherit_given = false;
@@ -296,20 +296,28 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, PRTE_ATTR_GLOBAL,
                                 NULL, PRTE_BOOL);
 
-        } else if (0 == strncasecmp(ck2[i], "PE-LIST", 7)) {
+        } else if (0 == strncasecmp(ck2[i], "PE-LIST=", 8)) {
             if (NULL == jdata) {
                 prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                 "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == (ptr = strchr(ck2[i], '='))) {
-                /* missing the value */
-                prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
-                                "mapping policy", "PE-LIST", ck2[i]);
-                prte_argv_free(ck2);
-                return PRTE_ERR_SILENT;
+            ptr = &ck2[i][8];
+            /* Verify the option parmeter is a list of numeric tokens */
+            temp_parm = strdup(ptr);
+            temp_token = strtok(temp_parm, ",");
+            while (NULL != temp_token) {
+                u16 = strtol(temp_token, &parm_delimiter, 10);
+                if ('\0' != *parm_delimiter) {
+                    prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                                    "mapping policy", "PE", ck2[i]);
+                    prte_argv_free(ck2);
+                    free(temp_parm);
+                    return PRTE_ERR_SILENT;
+                }
+                temp_token = strtok(NULL, ",");
             }
-            ptr++;
+            free(temp_parm);
             /* quick check - if it matches the default, then don't set it */
             if (NULL != prte_hwloc_default_cpu_list) {
                 if (0 != strcmp(prte_hwloc_default_cpu_list, ptr)) {
@@ -321,22 +329,17 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
                                     PRTE_ATTR_GLOBAL, ptr, PRTE_STRING);
             }
 
-        } else if (0 == strncasecmp(ck2[i], "PE", 2)) {
+        } else if (0 == strncasecmp(ck2[i], "PE=", 3)) {
             if (NULL == jdata) {
                 prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                 "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            /* Should be processing PE=<n>, verify '=' is present then that following value
-             * is numeric */
-            if ('=' != ck2[i][2]) {
-                prte_argv_free(ck2);
-                return PRTE_ERR_BAD_PARAM;
-            }
+            /* Numeric value must immediately follow '=' (PE=2) */
             u16 = strtol(&ck2[i][3], &ptr, 10);
-            if (((&ck2[i][3]) == ptr) || ('\0' != *ptr)) {
+            if ('\0' != *ptr) {
                 /* missing the value or value is invalid */
-                prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
+                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                 "mapping policy", "PE", ck2[i]);
                 prte_argv_free(ck2);
                 return PRTE_ERR_SILENT;


### PR DESCRIPTION
This fixes issue #678 

Parameter option parsing in the check_modifiers function for the --map-by :PE=<n> option was not properly parsing the option.
It accepted anything after the 'PE' substring, which allowed **--map-by :PE_LIST=1,2,3,4** to be processed as if it was **--map-by :PE=1**

I changed the code handling the PE string to explicitly check for an '=' immediately after *PE* and then to validate the text following the '=' as present and as entirely numeric. 