### PR TITLE
Support indirect launch by debuggers

### DIFF
--- a/examples/debugger/debugger.h
+++ b/examples/debugger/debugger.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -87,6 +87,7 @@ typedef struct {
  * nspace terminates */
 typedef struct {
     mylock_t lock;
+    pmix_status_t status;
     char *nspace;
     int exit_code;
     bool exit_code_given;

--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -95,7 +95,7 @@ static void notification_fn(size_t evhdlr_registration_id,
     size_t n;
 
     if (PMIX_ERR_UNREACH == status ||
-        PMIX_ERR_LOST_CONNECTION_TO_SERVER == status) {
+        PMIX_ERR_LOST_CONNECTION == status) {
         /* we should always have info returned to us - if not, there is
          * nothing we can do */
         if (NULL != info) {

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -29,11 +29,15 @@
 #include <unistd.h>
 #include <time.h>
 #include <pthread.h>
+#include <getopt.h>
 
 #include <pmix_tool.h>
 #include "debugger.h"
 
 static pmix_proc_t myproc;
+static volatile bool ilactive = true;
+static volatile bool dbactive = true;
+static volatile char *appnspace = NULL;
 
 /* this is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
@@ -91,76 +95,32 @@ static void notification_fn(size_t evhdlr_registration_id,
                             pmix_event_notification_cbfunc_fn_t cbfunc,
                             void *cbdata)
 {
+    fprintf(stderr, "DEFAULT EVENT HANDLER CALLED WITH STATUS %s\n", PMIx_Error_string(status));
+
     /* this example doesn't do anything with default events */
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
-    }
-}
-
-/* this is an event notification function that we explicitly request
- * be called when the PMIX_ERR_JOB_TERMINATED notification is issued.
- * We could catch it in the general event notification function and test
- * the status to see if it was "job terminated", but it often is simpler
- * to declare a use-specific notification callback point. In this case,
- * we are asking to know whenever a job terminates, and we will then
- * know we can exit */
-static void release_fn(size_t evhdlr_registration_id,
-                       pmix_status_t status,
-                       const pmix_proc_t *source,
-                       pmix_info_t info[], size_t ninfo,
-                       pmix_info_t results[], size_t nresults,
-                       pmix_event_notification_cbfunc_fn_t cbfunc,
-                       void *cbdata)
-{
-    myrel_t *lock;
-    pmix_status_t rc;
-    bool found;
-    int exit_code;
-    size_t n;
-    pmix_proc_t *affected = NULL;
-
-    /* find our return object */
-    lock = NULL;
-    found = false;
-    for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-            lock = (myrel_t*)info[n].value.data.ptr;
-            /* not every RM will provide an exit code, but check if one was given */
-        } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
-            exit_code = info[n].value.data.integer;
-            found = true;
-        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
-            affected = info[n].value.data.proc;
-        }
-    }
-    /* if the object wasn't returned, then that is an error */
-    if (NULL == lock) {
-        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
-        /* let the event handler progress */
-        if (NULL != cbfunc) {
-            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
-        }
-        return;
-    }
-
-    /* see if the code is LAUNCHER_READY */
-    if (PMIX_LAUNCHER_READY == status) {
-            fprintf(stderr, "%d DEBUGGER NOTIFIED THAT LAUNCHER IS READY\n", (int)getpid());
-    } else {
-        fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
-                (NULL == affected) ? "NULL" : affected->nspace);
-        if (found) {
-            lock->exit_code = exit_code;
-            lock->exit_code_given = true;
-        }
-    }
-    DEBUG_WAKEUP_THREAD(&lock->lock);
-
-    /* tell the event handler state machine that we are the last step */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
-    return;
+    ilactive = false;
+    fprintf(stderr, "\tCOMPLETE\n");
+}
+
+/* this is the event notification function we pass down below
+ * when registering for LOST_CONNECTION, thereby indicating
+ * that the intermediate launcher we started has terminated */
+static void terminate_fn(size_t evhdlr_registration_id,
+                         pmix_status_t status,
+                         const pmix_proc_t *source,
+                         pmix_info_t info[], size_t ninfo,
+                         pmix_info_t results[], size_t nresults,
+                         pmix_event_notification_cbfunc_fn_t cbfunc,
+                         void *cbdata)
+{
+    /* this example doesn't do anything further */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    ilactive = false;
 }
 
 /* event handler registration is done asynchronously because it
@@ -184,89 +144,41 @@ static void evhandler_reg_callbk(pmix_status_t status,
     DEBUG_WAKEUP_THREAD(lock);
 }
 
-static void spawn_cbfunc(pmix_status_t status,
-                         pmix_nspace_t nspace, void *cbdata)
+static void spawn_cbfunc(size_t evhdlr_registration_id,
+                         pmix_status_t status,
+                         const pmix_proc_t *source,
+                         pmix_info_t info[], size_t ninfo,
+                         pmix_info_t results[], size_t nresults,
+                         pmix_event_notification_cbfunc_fn_t cbfunc,
+                         void *cbdata)
 {
-    myquery_data_t *mydata = (myquery_data_t*)cbdata;
-    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
-
-    PMIX_INFO_FREE(mydata->info, mydata->ninfo);
-    PMIX_APP_FREE(mydata->apps, mydata->napps);
-    free(mydata);
-    fprintf(stderr, "Debugger daemon job: %s\n", nspace);
-}
-
-static void spawn_debugger(size_t evhdlr_registration_id,
-                           pmix_status_t status,
-                           const pmix_proc_t *source,
-                           pmix_info_t info[], size_t ninfo,
-                           pmix_info_t results[], size_t nresults,
-                           pmix_event_notification_cbfunc_fn_t cbfunc,
-                           void *cbdata)
-{
-    pmix_status_t rc;
     size_t n;
-    char cwd[1024];
-    char *appspace = NULL;
-    myquery_data_t *mydata;
 
     for (n=0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NSPACE)) {
-            appspace = info[n].value.data.string;
+            appnspace = strdup(info[n].value.data.string);
+            fprintf(stderr, "GOT NSPACE %s\n", appnspace);
             break;
         }
     }
-    /* if the namespace of the launched job wasn't returned, then that is an error */
-    if (NULL == appspace) {
-        fprintf(stderr, "LAUNCHED NAMESPACE WASN'T RETURNED IN CALLBACK\n");
-        /* let the event handler progress */
-        if (NULL != cbfunc) {
-            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
-        }
-        return;
-    }
-    fprintf(stderr, "Child job to be debugged: %s\n", appspace);
+    fprintf(stderr, "Debugger daemon job: %s\n", appnspace);
+    dbactive = false;
 
-    /* setup the debugger */
-    mydata = (myquery_data_t*)malloc(sizeof(myquery_data_t));
-    mydata->napps = 1;
-    PMIX_APP_CREATE(mydata->apps, mydata->napps);
-    mydata->apps[0].cmd = strdup("./daemon");
-    PMIX_ARGV_APPEND(rc, mydata->apps[0].argv, "./daemon");
-    getcwd(cwd, 1024);  // point us to our current directory
-    mydata->apps[0].cwd = strdup(cwd);
-    /* provide directives so the daemons go where we want, and
-     * let the RM know these are debugger daemons */
-    mydata->ninfo = 6;
-    PMIX_INFO_CREATE(mydata->info, mydata->ninfo);
-    n=0;
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
-    ++n;
-   // PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_DEBUG_JOB, appspace, PMIX_STRING); // the nspace being debugged
-    ++n;
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
-    ++n;
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_DEBUG_WAITING_FOR_NOTIFY, NULL, PMIX_BOOL);  // tell the daemon that the proc is waiting to be released
-    ++n;
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
-    ++n;
-    PMIX_INFO_LOAD(&mydata->info[n], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
-    /* spawn the daemons */
-    fprintf(stderr, "Debugger: spawning %s\n", mydata->apps[0].cmd);
-    if (PMIX_SUCCESS != (rc = PMIx_Spawn_nb(mydata->info, mydata->ninfo, mydata->apps, mydata->napps, spawn_cbfunc, (void*)mydata))) {
-        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
-        return;
-    }
-
-    /* tell the event handler state machine that we are the last step */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
-    return;
+}
+
+static void cncbfunc(pmix_status_t status, void *cbdata)
+{
+    mylock_t *mylock = (mylock_t*)cbdata;
+    mylock->status = status;
+    DEBUG_WAKEUP_THREAD(mylock);
 }
 
 #define DBGR_LOOP_LIMIT  10
+static int help = 0;
+static int mycmd = 0;
 
 int main(int argc, char **argv)
 {
@@ -283,7 +195,7 @@ int main(int argc, char **argv)
     char cwd[1024];
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     mylock_t mylock;
-    myrel_t myrel, launcher_ready, dbrel;
+    myrel_t launcher_ready, dbrel;
     pid_t pid;
     pmix_envar_t envar;
     char *launchers[] = {
@@ -295,26 +207,46 @@ int main(int argc, char **argv)
     };
     pmix_proc_t proc;
     bool found;
-    pmix_data_array_t darray;
+    pmix_data_array_t darray, d2;
     char *tmp;
-    char clientspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t clientspace, dbnspace;
+    pmix_value_t *val;
+    char *myuri;
+    void *jinfo, *linfo, *dirs;
+    myquery_data_t *mydata;
+
+    /* need to provide args */
+    if (2 > argc) {
+        fprintf(stderr, "Usage: %s [launcher] [app]\n", argv[0]);
+        exit(0);
+    }
+
+    /* check to see if we are using an intermediate launcher - we only
+     * support those we recognize */
+    found = false;
+    for (n=0; NULL != launchers[n]; n++) {
+        if (0 == strcmp(argv[1], launchers[n])) {
+            found = true;
+        }
+    }
+    if (!found) {
+        fprintf(stderr, "Wrong test, dude\n");
+        exit(1);
+    }
 
     pid = getpid();
 
-    /* Process any arguments we were given */
-    for (i=1; i < argc; i++) {
-        if (0 == strcmp(argv[i], "-h") ||
-            0 == strcmp(argv[i], "--help")) {
-            /* print the usage message and exit */
-
-        }
-    }
     info = NULL;
     ninfo = 0;
 
-    /* use the system connection first, if available */
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* do not connect to anyone */
+    ninfo = 2;
+    PMIX_INFO_CREATE(info, ninfo);
+    n = 0;
+    PMIX_INFO_LOAD(&info[n], PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+    ++n;
+    PMIX_INFO_LOAD(&info[n], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+
     /* init as a tool */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
         fprintf(stderr, "PMIx_tool_init failed: %s(%d)\n", PMIx_Error_string(rc), rc);
@@ -324,183 +256,199 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
 
-    /* construct the debugger termination release */
-    DEBUG_CONSTRUCT_LOCK(&dbrel.lock);
+    /* get our URI as we will need it later */
+    rc = PMIx_Get(&myproc, PMIX_SERVER_URI, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to retrieve our URI: %s\n", PMIx_Error_string(rc));
+        PMIx_tool_finalize();
+        exit(rc);
+    }
+    myuri = strdup(val->data.string);
+    PMIX_VALUE_RELEASE(val);
+fprintf(stderr, "DEBUGGER URI: %s\n", myuri);
+
+    /* register an event handler to pickup when the IL
+     * we spawned dies */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    code = PMIX_ERR_LOST_CONNECTION;
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "LOST-CONNECTION", PMIX_STRING);
+    PMIx_Register_event_handler(&code, 1, NULL, 0,
+                                terminate_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 1);
 
     /* register a default event handler */
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "DEFAULT", PMIX_STRING);
+    PMIx_Register_event_handler(NULL, 0, info, 1,
                                 notification_fn, evhandler_reg_callbk, (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 1);
 
-    /* check to see if we are using an intermediate launcher - we only
-     * support those we recognize */
-    found = false;
-    if (1 < argc) {
-        for (n=0; NULL != launchers[n]; n++) {
-            if (0 == strcmp(argv[1], launchers[n])) {
-                found = true;
-            }
-        }
-    }
-    if (!found) {
-        fprintf(stderr, "Wrong test, dude\n");
-        exit(1);
-    }
 
-    /* register to receive the "launcher-ready" event telling us
-     * that the launcher is ready for us to connect to it */
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    code = PMIX_LAUNCHER_READY;
-    /* pass a lock object to release us when the launcher is ready */
-    DEBUG_CONSTRUCT_LOCK(&launcher_ready.lock);
-    PMIX_INFO_CREATE(info, 2);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &launcher_ready, PMIX_POINTER);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_NAME, "LAUNCHER-READY", PMIX_STRING);
-    PMIx_Register_event_handler(&code, 1, info, 2,
-                                release_fn, evhandler_reg_callbk, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    if (PMIX_SUCCESS != mylock.status) {
-        rc = mylock.status;
-        DEBUG_DESTRUCT_LOCK(&mylock);
-        PMIX_INFO_FREE(info, 2);
-        goto done;
-    }
-    DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 2);
-
-    /* register to receive the "launch complete" event telling us
-     * the nspace of the job being debugged so we can spawn the
-     * debugger daemons against it */
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    code = PMIX_LAUNCH_COMPLETE;
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "LAUNCH-COMPLETE", PMIX_STRING);
-    PMIx_Register_event_handler(&code, 1, info, 1,
-                                spawn_debugger, evhandler_reg_callbk, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    if (PMIX_SUCCESS != mylock.status) {
-        rc = mylock.status;
-        DEBUG_DESTRUCT_LOCK(&mylock);
-        PMIX_INFO_FREE(info, 2);
-        goto done;
-    }
-    DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 2);
-
-    /* we are using an intermediate launcher - we will use the
-     * reference server to start it, but tell it to wait after
-     * launch for directive prior to spawning the application */
+    /* we are using an intermediate launcher - we will either use the
+     * reference server to start it or will fork/exec it ourselves,
+     * but either way tell it to wait after launch for directives */
     napps = 1;
     PMIX_APP_CREATE(app, napps);
     /* setup the executable */
     app[0].cmd = strdup(argv[1]);
     PMIX_ARGV_APPEND(rc, app[0].argv, argv[1]);
+    /* pass it the rest of the cmd line as we don't know
+     * how to parse it */
     for (n=2; n < argc; n++) {
         PMIX_ARGV_APPEND(rc, app[0].argv, argv[n]);
     }
     getcwd(cwd, 1024);  // point us to our current directory
     app[0].cwd = strdup(cwd);
-    app[0].maxprocs = 1;
-    /* provide job-level directives so the apps do what the user requested */
-#ifdef PMIX_LAUNCHER_RENDEZVOUS_FILE
-    ninfo = 7;
-#else
-    ninfo = 6;
-#endif
-    PMIX_INFO_CREATE(info, ninfo);
-    n=0;
-    PMIX_INFO_LOAD(&info[n], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
-    n++;
-    asprintf(&tmp, "%s:%d", myproc.nspace, myproc.rank);
-    PMIX_ENVAR_LOAD(&envar, "PMIX_LAUNCHER_PAUSE_FOR_TOOL", tmp, ':');
-    free(tmp);
-    PMIX_INFO_LOAD(&info[n], PMIX_SET_ENVAR, &envar, PMIX_ENVAR);  // launcher is to wait for directives
-    n++;
-    PMIX_ENVAR_DESTRUCT(&envar);
-    cospawn = true;
-    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDOUT, &cospawn, PMIX_BOOL);  // forward stdout to me
-    n++;
-    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDERR, &cospawn, PMIX_BOOL);  // forward stderr to me
-    n++;
-    PMIX_INFO_LOAD(&info[n], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the job completes
-    n++;
-    PMIX_INFO_LOAD(&info[n], PMIX_SPAWN_TOOL, NULL, PMIX_BOOL); // we are spawning a tool
-    n++;
-#ifdef PMIX_LAUNCHER_RENDEZVOUS_FILE
-    PMIX_INFO_LOAD(&info[n], PMIX_LAUNCHER_RENDEZVOUS_FILE, "dbgr.rndz.txt", PMIX_STRING);  // have it output a specific rndz file
-#endif
-    /* spawn the job - the function will return when the launcher
-     * has been launched. Note that this doesn't tell us anything
-     * about the launcher's state - it just means that the launcher
-     * has been fork/exec'd */
-    fprintf(stderr, "Debugger: spawning %s\n", app[0].cmd);
+    app[0].maxprocs = 1;  // only start one instance of the IL
+
+    /* tell the IL how to connect back to us */
+    PMIX_SETENV(rc, PMIX_LAUNCHER_RNDZ_URI, myuri, &app[0].env);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to set URI in app environment: %s\n", PMIx_Error_string(rc));
+        PMIx_tool_finalize();
+        exit(rc);
+    }
+
+    /* provide job-level directives so the launcher does what we want
+     * when it spawns the actual job - note that requesting the stdout
+     * and stderr of the launcher will automatically get us the output
+     * from the application as the launcher will have had it forwarded
+     * to itself */
+    PMIX_INFO_LIST_START(jinfo);
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_SPAWN_TOOL, NULL, PMIX_BOOL); // we are spawning a tool
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL); // stop the IL in init so we can connect to it
+
+    /* setup launch directives - these are directives that we want
+     * the IL to apply to any applications it spawns for us */
+    PMIX_INFO_LIST_START(linfo);
+    PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // have procs stop in init
+    PMIX_INFO_LIST_CONVERT(rc, linfo, &d2);
+    PMIX_INFO_LIST_RELEASE(linfo);
+    /* add it to our job info */
+    PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_LAUNCH_DIRECTIVES, &d2, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&d2);
+
+    /* convert job info to array */
+    PMIX_INFO_LIST_CONVERT(rc, jinfo, &darray);
+    PMIX_INFO_LIST_RELEASE(jinfo);
+    info = (pmix_info_t*)darray.array;
+    ninfo = darray.size;
+
+    /* spawn the launcher - the function will return when the launcher
+     * has been started. */
     rc = PMIx_Spawn(info, ninfo, app, napps, clientspace);
-    PMIX_INFO_FREE(info, ninfo);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_APP_FREE(app, napps);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "Application failed to launch with error: %s(%d)\n", PMIx_Error_string(rc), rc);
+        fprintf(stderr, "Launcher %s failed to start with error: %s(%d)\n", argv[1], PMIx_Error_string(rc), rc);
         goto done;
     }
 
-    /* wait here for the launcher to declare itself ready */
-    DEBUG_WAIT_THREAD(&launcher_ready.lock);
-    DEBUG_DESTRUCT_LOCK(&launcher_ready.lock);
-
-
-    /* register callback for when launcher terminates */
-    code = PMIX_ERR_JOB_TERMINATED;
-    DEBUG_CONSTRUCT_LOCK(&myrel.lock);
-    myrel.nspace = strdup(clientspace);
-    PMIX_INFO_CREATE(info, 2);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
-    /* only call me back when this specific job terminates */
-    PMIX_LOAD_PROCID(&proc, clientspace, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
-
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, info, 2,
-                                release_fn, evhandler_reg_callbk, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    rc = mylock.status;
-    DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 2);
-
-    /* send the launch directives */
-    ninfo = 3;
+    /* set the spawned launcher as our primary server - wait for
+     * it to connect to us but provide a timeout so we don't hang
+     * waiting forever. The launcher shall connect to us prior
+     * to spawning the job we provided it */
+    PMIX_LOAD_PROCID(&proc, clientspace, 0);
+    ninfo = 2;
     PMIX_INFO_CREATE(info, ninfo);
-    PMIX_PROC_LOAD(&proc, clientspace, 0);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);  // deliver to the target launcher
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);  // only non-default handlers
-    /* provide a few job-level directives */
-    darray.type = PMIX_INFO;
-    darray.size = 4;
-    PMIX_INFO_CREATE(darray.array, darray.size);
-    iptr = (pmix_info_t*)darray.array;
-    PMIX_ENVAR_LOAD(&envar, "FOOBAR", "1", ':');
-    PMIX_INFO_LOAD(&iptr[0], PMIX_SET_ENVAR, &envar, PMIX_ENVAR);
-    PMIX_ENVAR_DESTRUCT(&envar);
-    PMIX_ENVAR_LOAD(&envar, "PATH", "/home/common/local/toad", ':');
-    PMIX_INFO_LOAD(&iptr[1], PMIX_PREPEND_ENVAR, &envar, PMIX_ENVAR);
-    PMIX_ENVAR_DESTRUCT(&envar);
-    PMIX_INFO_LOAD(&iptr[2], PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&iptr[3], PMIX_NOTIFY_LAUNCH, NULL, PMIX_BOOL); // notify us when the job is launched
-    /* load the array */
-    PMIX_INFO_LOAD(&info[2], PMIX_DEBUG_JOB_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
-
-    fprintf(stderr, "[%s:%u%lu] Sending launch directives\n", myproc.nspace, myproc.rank, (unsigned long)pid);
-    PMIx_Notify_event(PMIX_LAUNCH_DIRECTIVE,
-                      NULL, PMIX_RANGE_CUSTOM,
-                      info, ninfo, NULL, NULL);
+    n=0;
+    PMIX_INFO_LOAD(&info[n], PMIX_WAIT_FOR_CONNECTION, NULL, PMIX_BOOL);
+    ++n;
+    i = 2;
+    PMIX_INFO_LOAD(&info[n], PMIX_TIMEOUT, &i, PMIX_INT);
+    rc = PMIx_tool_set_server(&proc, info, ninfo);
+    if (PMIX_SUCCESS != rc) {
+        /* connection failed */
+        fprintf(stderr, "Failed to set spawned launcher as primary server: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
     PMIX_INFO_FREE(info, ninfo);
 
-    DEBUG_WAIT_THREAD(&myrel.lock);
+    /* register to receive the launch complete event telling us the
+     * nspace of the child job and alerting us that things are ready
+     * for us to spawn the debugger daemons - this will be registered
+     * with the IL we started */
+    fprintf(stderr, "REGISTERING LAUNCH_COMPLETE HANDLER\n");
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    code = PMIX_LAUNCH_COMPLETE;
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "LAUNCH-COMPLETE", PMIX_STRING);
+    PMIx_Register_event_handler(&code, 1, info, 1,
+                                spawn_cbfunc, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 1);
+
+    fprintf(stderr, "RELEASING PRUN\n");
+    /* release the IL to spawn its job */
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    /* target this notification solely to that one tool */
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
+    PMIx_Notify_event(PMIX_ERR_DEBUGGER_RELEASE, &myproc,
+                      PMIX_RANGE_CUSTOM,
+                      info, 2, NULL, NULL);
+    PMIX_INFO_FREE(info, 2);
+fprintf(stderr, "WAITING FOR APPLICATION LAUNCH\n");
+    /* wait for the IL to have launched its application */
+    while (dbactive) {
+        struct timespec tp = {0, 500000};
+        nanosleep(&tp, NULL);
+    }
+
+
+fprintf(stderr, "APPLICATION HAS LAUNCHED: %s\n", (char*)appnspace);
+
+    /* setup the debugger */
+    mydata = (myquery_data_t*)malloc(sizeof(myquery_data_t));
+    mydata->napps = 1;
+    PMIX_APP_CREATE(mydata->apps, mydata->napps);
+    mydata->apps[0].cmd = strdup("./daemon");
+    PMIX_ARGV_APPEND(rc, mydata->apps[0].argv, "./daemon");
+    getcwd(cwd, 1024);  // point us to our current directory
+    mydata->apps[0].cwd = strdup(cwd);
+    /* provide directives so the daemons go where we want, and
+     * let the RM know these are debugger daemons */
+    PMIX_INFO_LIST_START(dirs);
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_DEBUG_JOB, (void*)appnspace, PMIX_STRING); // the nspace being debugged
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+    PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
+    PMIX_INFO_LIST_RELEASE(dirs);
+    mydata->info = darray.array;
+    mydata->ninfo = darray.size;
+    darray.array = NULL;
+    darray.size = 0;
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    /* spawn the daemons */
+    fprintf(stderr, "Debugger: spawning %s\n", mydata->apps[0].cmd);
+    rc = PMIx_Spawn(mydata->info, mydata->ninfo, mydata->apps, mydata->napps, dbnspace);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* wait for the IL to terminate */
+    fprintf(stderr, "WAITING FOR IL TO TERMINATE\n");
+    while (ilactive) {
+        struct timespec tp = {0, 500000};
+        nanosleep(&tp, NULL);
+    }
 
   done:
-    DEBUG_DESTRUCT_LOCK(&myrel.lock);
-    DEBUG_DESTRUCT_LOCK(&dbrel.lock);
-    PMIx_tool_finalize();
+ //   PMIx_tool_finalize();
 
     return(rc);
 }

--- a/examples/launcher.c
+++ b/examples/launcher.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     mylock_t mylock;
     pmix_status_t code[6] = {PMIX_ERR_PROC_ABORTING, PMIX_ERR_PROC_ABORTED,
                              PMIX_ERR_PROC_REQUESTED_ABORT, PMIX_ERR_JOB_TERMINATED,
-                             PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
+                             PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION};
     pmix_nspace_t appspace;
 
     /* we need to attach to a "system" PMIx server so we

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -95,7 +95,7 @@ PRTE_EXPORT int prte_schizo_base_setup_child(prte_job_t *jobdat,
                                                prte_proc_t *child,
                                                prte_app_context_t *app,
                                                char ***env);
-PRTE_EXPORT void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, prte_list_t *jobinfo);
+PRTE_EXPORT void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 PRTE_EXPORT int prte_schizo_base_get_remaining_time(uint32_t *timeleft);
 PRTE_EXPORT void prte_schizo_base_finalize(void);
 

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -255,7 +255,7 @@ int prte_schizo_base_setup_child(prte_job_t *jdata,
     return PRTE_SUCCESS;
 }
 
-void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, prte_list_t *jobinfo)
+void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, void *jobinfo)
 {
     prte_schizo_base_active_module_t *mod;
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -66,7 +66,7 @@ static int parse_env(prte_cmd_line_t *cmd_line,
                      bool cmdline);
 static int detect_proxy(char **argv);
 static int allow_run_as_root(prte_cmd_line_t *cmd_line);
-static void job_info(prte_cmd_line_t *cmdline, prte_list_t *jobinfo);
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 
 prte_schizo_base_module_t prte_schizo_ompi_module = {
     .define_cli = define_cli,
@@ -1148,11 +1148,11 @@ static int allow_run_as_root(prte_cmd_line_t *cmd_line)
     return PRTE_ERR_TAKE_NEXT_OPTION;
 }
 
-static void job_info(prte_cmd_line_t *cmdline, prte_list_t *jobinfo)
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo)
 {
-    prte_ds_info_t *ds;
     prte_value_t *pval;
     uint16_t u16;
+    pmix_status_t rc;
 
     if (NULL != (pval = prte_cmd_line_get_param(cmdline, "stream-buffering", 0, 0))) {
         u16 = pval->data.integer;
@@ -1161,10 +1161,10 @@ static void job_info(prte_cmd_line_t *cmdline, prte_list_t *jobinfo)
             prte_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, pval->data.integer);
             return;
         }
-        ds = PRTE_NEW(prte_ds_info_t);
-        PMIX_INFO_CREATE(ds->info, 1);
-        PMIX_INFO_LOAD(ds->info, "OMPI_STREAM_BUFFERING", &u16, PMIX_UINT16);
-        prte_list_append(jobinfo, &ds->super);
+        PMIX_INFO_LIST_ADD(rc, jobinfo, "OMPI_STREAM_BUFFERING", &u16, PMIX_UINT16);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
     }
 }
 

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -143,7 +143,7 @@ typedef int (*prte_schizo_base_module_get_rem_time_fn_t)(uint32_t *timeleft);
 
 
 /* give the components a chance to add job info */
-typedef void (*prte_schizo_base_module_job_info_fn_t)(prte_cmd_line_t *cmdline, prte_list_t *jobinfo);
+typedef void (*prte_schizo_base_module_job_info_fn_t)(prte_cmd_line_t *cmdline, void *jobinfo);
 
 /*
  * schizo module version 1.3.0

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -311,9 +311,7 @@ int prte_pmix_convert_status(pmix_status_t status)
     case PMIX_ERR_WOULD_BLOCK:
         return PRTE_ERR_WOULD_BLOCK;
 
-    case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
-    case PMIX_ERR_LOST_PEER_CONNECTION:
-    case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
+    case PMIX_ERR_LOST_CONNECTION:
         return PRTE_ERR_COMM_FAILURE;
 
     case PMIX_EXISTS:

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -922,7 +922,7 @@ static void pmix_server_dmdx_recv(int status, prte_process_name_t* sender,
          * amount of time to start the job */
         PRTE_ADJUST_TIMEOUT(req);
         if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-            prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+            prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
             PRTE_RELEASE(req);
             send_error(rc, &pproc, sender, room_num);
         }
@@ -964,7 +964,7 @@ static void pmix_server_dmdx_recv(int status, prte_process_name_t* sender,
             PMIX_INFO_FREE(info, ninfo);
             /* check us into the hotel */
             if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+                prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
                 PRTE_RELEASE(req);
                 send_error(rc, &pproc, sender, room_num);
             }
@@ -993,7 +993,7 @@ static void pmix_server_dmdx_recv(int status, prte_process_name_t* sender,
      * amount of time to start the job */
     PRTE_ADJUST_TIMEOUT(req);
     if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+        prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
         PRTE_RELEASE(req);
         send_error(rc, &pproc, sender, room_num);
         return;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -131,7 +131,7 @@ static void spawn(int sd, short args, void *cbdata)
     /* add this request to our tracker hotel */
     PRTE_ADJUST_TIMEOUT(req);
     if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+        prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
         goto callback;
     }
 
@@ -197,9 +197,9 @@ static void interim(int sd, short args, void *cbdata)
     uint16_t u16;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s spawn called from proc %s",
+                        "%s spawn called from proc %s with %d apps",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        PRTE_NAME_PRINT(requestor));
+                        PRTE_NAME_PRINT(requestor), (int)cd->napps);
 
     /* create the job object */
     jdata = PRTE_NEW(prte_job_t);
@@ -257,7 +257,7 @@ static void interim(int sd, short args, void *cbdata)
                     } else {
                         /* get the cwd */
                         if (PRTE_SUCCESS != (rc = prte_getcwd(cwd, sizeof(cwd)))) {
-                            prte_show_help("help-orted.txt", "cwd", true, "spawn", rc);
+                            prte_show_help("help-prted.txt", "cwd", true, "spawn", rc);
                             PRTE_RELEASE(jdata);
                             goto complete;
                         }
@@ -313,8 +313,10 @@ static void interim(int sd, short args, void *cbdata)
 #endif
                 } else {
                     /* unrecognized key */
-                    prte_show_help("help-orted.txt", "bad-key",
-                                   true, "spawn", "application", info->key);
+                    if (9 < prte_output_get_verbosity(prte_pmix_server_globals.output)) {
+                        prte_show_help("help-prted.txt", "bad-key",
+                                       true, "spawn", "application", info->key);
+                    }
                 }
             }
         }

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -253,7 +253,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
             /* save the request in the hotel until the
              * data is returned */
             if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+                prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
                 /* can't just return as that would cause the requestor
                  * to hang, so instead execute the callback */
                 prc = prte_pmix_convert_rc(rc);
@@ -288,7 +288,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
             /* save the request in the hotel until the
              * data is returned */
             if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+                prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
                 /* can't just return as that would cause the requestor
                  * to hang, so instead execute the callback */
                 prc = prte_pmix_convert_rc(rc);
@@ -305,7 +305,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
          * that we don't know about yet. In this case, just
          * record the request and we will process it later */
         if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-            prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+            prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
             /* can't just return as that would cause the requestor
              * to hang, so instead execute the callback */
             prc = prte_pmix_convert_rc(rc);
@@ -355,7 +355,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
     /* track the request so we know the function and cbdata
      * to callback upon completion */
     if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+        prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
         prc = prte_pmix_convert_rc(rc);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -682,7 +682,7 @@ static void _toolconn(int sd, short args, void *cbdata)
             prte_pmix_server_tool_conn_complete(jdata, cd);
         } else {
             if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, cd, &cd->room_num))) {
-                prte_show_help("help-orted.txt", "noroom", true, cd->operation, prte_pmix_server_globals.num_rooms);
+                prte_show_help("help-prted.txt", "noroom", true, cd->operation, prte_pmix_server_globals.num_rooms);
                 goto callback;
             }
             /* we need to send this to the HNP for a jobid */

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -159,7 +159,7 @@ static void execute(int sd, short args, void *cbdata)
     if (!prte_pmix_server_globals.pubsub_init) {
         /* we need to initialize our connection to the server */
         if (PRTE_SUCCESS != (rc = init_server())) {
-            prte_show_help("help-orted.txt", "noserver", true,
+            prte_show_help("help-prted.txt", "noserver", true,
                            (NULL == prte_data_server_uri) ?
                            "NULL" : prte_data_server_uri);
             goto callback;
@@ -168,7 +168,7 @@ static void execute(int sd, short args, void *cbdata)
 
     /* add this request to our tracker hotel */
     if (PRTE_SUCCESS != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-orted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
+        prte_show_help("help-prted.txt", "noroom", true, req->operation, prte_pmix_server_globals.num_rooms);
         goto callback;
     }
 

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -72,6 +72,7 @@ int prte_finalize(void)
      * be ignored if no listeners were registered */
     prte_stop_listening();
 
+#if 0
     /* release the cache */
     PRTE_RELEASE(prte_cache);
 
@@ -157,6 +158,15 @@ int prte_finalize(void)
     }
 }
     PRTE_RELEASE(prte_node_pool);
+
+    if (NULL != prte_fork_agent) {
+        prte_argv_free(prte_fork_agent);
+    }
+
+    free (prte_process_info.nodename);
+    prte_process_info.nodename = NULL;
+
+#endif
     /* call the finalize function for this environment */
     if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
         return rc;
@@ -168,15 +178,8 @@ int prte_finalize(void)
     /* Close the general debug stream */
     prte_output_close(prte_debug_output);
 
-    if (NULL != prte_fork_agent) {
-        prte_argv_free(prte_fork_agent);
-    }
-
     /* finalize the class/object system */
     prte_class_finalize();
-
-    free (prte_process_info.nodename);
-    prte_process_info.nodename = NULL;
 
     return PRTE_SUCCESS;
 }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -794,7 +794,7 @@ int main(int argc, char *argv[])
         ++param;
         /* register for the PMIX_LAUNCH_DIRECTIVE event */
         PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        ret = PMIX_LAUNCH_DIRECTIVE;
+//        ret = PMIX_LAUNCH_DIRECTIVE;
         /* setup the myinfo object to capture the returned
          * values - must do so prior to registering in case
          * the event has already arrived */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -447,7 +447,7 @@ int main(int argc, char *argv[])
                 core = strtoul(cores[i], NULL, 10);
                 if (NULL == (pu = prte_hwloc_base_get_pu(prte_hwloc_topology, false, core))) {
                     /* the message will now come out locally */
-                    prte_show_help("help-orted.txt", "orted:cannot-bind",
+                    prte_show_help("help-prted.txt", "orted:cannot-bind",
                                    true, prte_process_info.nodename,
                                    prte_daemon_cores);
                     ret = PRTE_ERR_NOT_SUPPORTED;

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -427,7 +427,7 @@ int main(int argc, char *argv[])
      /* setup a lock to track the connection */
     PRTE_PMIX_CONSTRUCT_LOCK(&rellock);
     /* register to trap connection loss */
-    pmix_status_t code[2] = {PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
+    pmix_status_t code[2] = {PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION};
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
     PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
     PMIx_Register_event_handler(code, 2, &info, 1,


### PR DESCRIPTION
When prun is started under a debugger, it must act as a relay for spawn
and other calls that have to be serviced by prte. There are two
use-cases that have to be considered in that mode:

* the debugger doesn't understand the command line and just passes it
  along to prun for processing. In this case, the launch directives
  impacting prun's behavior must be passed in the job_info.

* the debugger parses its command line. In this case, there are two
  spawn commands issued - the first to start prun without any cmd line
  arguments, and the second to spawn the application.

This commit resolves the first option. Another commit will follow to
address the second case.

NOTE: this commit locks PRRTE to PMIx v4.x

Signed-off-by: Ralph Castain <rhc@pmix.org>