### PR TITLE
prte is not allowed to accept an application

### DIFF
--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -63,6 +63,7 @@ static int parse_env(prte_cmd_line_t *cmd_line,
 static int setup_fork(prte_job_t *jdata,
                       prte_app_context_t *context);
 static int define_session_dir(char **tmpdir);
+static int detect_proxy(char **argv);
 static int allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void wrap_args(char **args);
 
@@ -74,6 +75,7 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .parse_env = parse_env,
     .setup_fork = setup_fork,
     .define_session_dir = define_session_dir,
+    .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
     .wrap_args = wrap_args
 };
@@ -684,6 +686,20 @@ static int define_session_dir(char **tmpdir)
                    (unsigned long)mypid);
 
     return PRTE_SUCCESS;
+}
+
+static int detect_proxy(char **argv)
+{
+    /* if the basename of the cmd was "mpirun" or "mpiexec",
+     * we default to us */
+    if (prte_schizo_base.test_proxy_launch ||
+        0 == strcmp(prte_tool_basename, "prterun")) {
+        /* add us to the personalities */
+        prte_argv_append_unique_nosize(&prte_schizo_base.personalities, "prte");
+        return PRTE_SUCCESS;
+    }
+
+    return PRTE_ERR_TAKE_NEXT_OPTION;
 }
 
 static int allow_run_as_root(prte_cmd_line_t *cmd_line)

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -874,7 +874,17 @@ int main(int argc, char *argv[])
         }
         /* nope - just need to wait for instructions */
         goto proceed;
+    } else {
+        /* they did provide an app - this is only allowed
+         * when running as a proxy! */
+        if (!proxyrun) {
+            prte_show_help("help-prun.txt", "prun:executable-incorrectly-given",
+                           true, prte_tool_basename, prte_tool_basename);
+            PRTE_UPDATE_EXIT_STATUS(rc);
+            goto DONE;
+        }
     }
+
     /* mark that we are not a persistent DVM */
     prte_persistent = false;
     /* setup to capture job-level info */

--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -713,3 +713,7 @@ variable, but the value of the variable is in an improper form:
 The variable must be of the form (nspace:rank) of the tool requesting that
 %s pause for it to connect. Please reset the value of the variable and try
 again.
+#
+[prun:executable-incorrectly-given]
+The %s command was given with an application specified. %s is only used
+to start the persistent DVM - it cannot be used with an application.


### PR DESCRIPTION
The prte command is solely used for starting the DVM - it is not allowed
to accept an application as an argument.

However, prterun is an acceptable proxy, so detect and allow it.

Signed-off-by: Ralph Castain <rhc@pmix.org>