### PR TITLE
Updates to tools/debugger examples

### DIFF
--- a/examples/debugger/attach.c
+++ b/examples/debugger/attach.c
@@ -24,8 +24,10 @@
  */
 
 #define _GNU_SOURCE
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <time.h>
 #include <pthread.h>
@@ -33,11 +35,13 @@
 #include <pmix_tool.h>
 #include "debugger.h"
 
-
 static int attach_to_running_job(char *nspace);
-static pmix_proc_t myproc;
+static int query_application_namespace(char *nspace);
 
-/* this is a callback function for the PMIx_Query
+static pmix_proc_t myproc;
+static char application_namespace[PMIX_MAX_NSLEN + 1];
+
+/* This is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
  * if the request could be fully satisfied, partially
  * satisfied, or completely failed. The info parameter
@@ -58,30 +62,31 @@ static void cbfunc(pmix_status_t status,
     myquery_data_t *mq = (myquery_data_t*)cbdata;
     size_t n;
 
+    printf("Called %s as callback for PMIx_Query\n", __FUNCTION__);
     mq->status = status;
-    /* save the returned info - the PMIx library "owns" it
-     * and will release it and perform other cleanup actions
-     * when release_fn is called */
+    /* Save the returned info - the PMIx library "owns" it and will release it
+     * and perform other cleanup actions when release_fn is called */
     if (0 < ninfo) {
         PMIX_INFO_CREATE(mq->info, ninfo);
         mq->ninfo = ninfo;
         for (n=0; n < ninfo; n++) {
-            fprintf(stderr, "Key %s Type %s(%d)\n", info[n].key, PMIx_Data_type_string(info[n].value.type), info[n].value.type);
+            printf("Key %s Type %s(%d)\n", info[n].key,
+                    PMIx_Data_type_string(info[n].value.type),
+                                          info[n].value.type);
             PMIX_INFO_XFER(&mq->info[n], &info[n]);
         }
     }
 
-    /* let the library release the data and cleanup from
-     * the operation */
+    /* Let the library release the data and cleanup from the operation */
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
 
-    /* release the block */
+    /* Release the lock */
     DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
-/* this is the event notification function we pass down below
+/* This is the event notification function we pass down below
  * when registering for general events - i.e.,, the default
  * handler. We don't technically need to register one, but it
  * is usually good practice to catch any events that occur */
@@ -93,13 +98,15 @@ static void notification_fn(size_t evhdlr_registration_id,
                             pmix_event_notification_cbfunc_fn_t cbfunc,
                             void *cbdata)
 {
-    /* this example doesn't do anything with default events */
+    printf("%s called as callback for event=%s\n", __FUNCTION__,
+           PMIx_Error_string(status));
+    /* This example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
-/* this is an event notification function that we explicitly request
+/* This is an event notification function that we explicitly request
  * be called when the PMIX_ERR_JOB_TERMINATED notification is issued.
  * We could catch it in the general event notification function and test
  * the status to see if it was "job terminated", but it often is simpler
@@ -121,39 +128,44 @@ static void release_fn(size_t evhdlr_registration_id,
     size_t n;
     pmix_proc_t *affected = NULL;
 
-    /* find our return object */
+    printf("%s called as callback for event=%s\n", __FUNCTION__,
+           PMIx_Error_string(status));
+    /* Find our return object */
     lock = NULL;
     found = false;
     for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT,
+                         PMIX_MAX_KEYLEN)) {
             lock = (myrel_t*)info[n].value.data.ptr;
-            /* not every RM will provide an exit code, but check if one was given */
+            /* Not every RM will provide an exit code, but check if one was
+             * given */
         } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
             exit_code = info[n].value.data.integer;
             found = true;
-        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC,
+                                PMIX_MAX_KEYLEN)) {
             affected = info[n].value.data.proc;
         }
     }
-    /* if the object wasn't returned, then that is an error */
+    /* If the lock object wasn't returned, then that is an error */
     if (NULL == lock) {
         fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
-        /* let the event handler progress */
+        /* Let the event handler progress */
         if (NULL != cbfunc) {
             cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
         }
         return;
     }
 
-    fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
-            (NULL == affected) ? "NULL" : affected->nspace);
+    printf("DEBUGGER NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n",
+            lock->nspace, (NULL == affected) ? "NULL" : affected->nspace);
     if (found) {
         lock->exit_code = exit_code;
         lock->exit_code_given = true;
     }
     DEBUG_WAKEUP_THREAD(&lock->lock);
 
-    /* tell the event handler state machine that we are the last step */
+    /* Tell the event handler state machine that we are the last step */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
@@ -162,7 +174,7 @@ static void release_fn(size_t evhdlr_registration_id,
     return;
 }
 
-/* event handler registration is done asynchronously because it
+/* Event handler registration is done asynchronously because it
  * may involve the PMIx server registering with the host RM for
  * external events. So we provide a callback function that returns
  * the status of the request (success or an error), plus a numerical index
@@ -175,173 +187,62 @@ static void evhandler_reg_callbk(pmix_status_t status,
 {
     mylock_t *lock = (mylock_t*)cbdata;
 
+    printf("%s called to register callback\n", __FUNCTION__);
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
-                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+                myproc.nspace, myproc.rank, status,
+                (unsigned long)evhandler_ref);
     }
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
 }
 
-static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
-{
-    pmix_status_t rc;
-    pmix_info_t *dinfo;
-    pmix_app_t *debugger;
-    size_t dninfo;
-    char cwd[1024];
-    char dspace[PMIX_MAX_NSLEN+1];
-    mylock_t mylock;
-    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
-
-    /* setup the debugger */
-    PMIX_APP_CREATE(debugger, 1);
-    debugger[0].cmd = strdup("./debuggerd");
-    PMIX_ARGV_APPEND(rc, debugger[0].argv, "./debuggerd");
-    getcwd(cwd, 1024);  // point us to our current directory
-    debugger[0].cwd = strdup(cwd);
-    /* provide directives so the daemons go where we want, and
-     * let the RM know these are debugger daemons */
-    dninfo = 6;
-    PMIX_INFO_CREATE(dinfo, dninfo);
-    PMIX_INFO_LOAD(&dinfo[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
-    PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
-    PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUG_JOB, appspace, PMIX_STRING); // the nspace being debugged
-    PMIX_INFO_LOAD(&dinfo[2], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
-    PMIX_INFO_LOAD(&dinfo[3], PMIX_DEBUG_WAITING_FOR_NOTIFY, NULL, PMIX_BOOL);  // tell the daemon that the proc is waiting to be released
-    PMIX_INFO_LOAD(&dinfo[4], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
-    PMIX_INFO_LOAD(&dinfo[5], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
-    /* spawn the daemons */
-    fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
-    if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
-        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
-        PMIX_INFO_FREE(dinfo, dninfo);
-        PMIX_APP_FREE(debugger, 1);
-        return rc;
-    }
-    /* cleanup */
-    PMIX_INFO_FREE(dinfo, dninfo);
-    PMIX_APP_FREE(debugger, 1);
-
-    /* register callback for when this job terminates */
-    myrel->nspace = strdup(dspace);
-    PMIX_INFO_CREATE(dinfo, 2);
-    PMIX_INFO_LOAD(&dinfo[0], PMIX_EVENT_RETURN_OBJECT, myrel, PMIX_POINTER);
-    /* only call me back when this specific job terminates */
-    PMIX_INFO_LOAD(&dinfo[1], PMIX_NSPACE, dspace, PMIX_STRING);
-
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, dinfo, 2,
-                                release_fn, evhandler_reg_callbk, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    rc = mylock.status;
-    DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(dinfo, 2);
-
-    return rc;
-}
-
-#define DBGR_LOOP_LIMIT  10
-
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
-    pmix_info_t *info, *iptr;
-    pmix_app_t *app;
-    size_t ninfo, napps;
+    pmix_info_t *info;
+    size_t ninfo;
     char *nspace = NULL;
-    int i;
-    pmix_query_t *query;
-    size_t nq, n;
-    myquery_data_t myquery_data;
-    bool cospawn = false, stop_on_exec = false, cospawn_reqd = false;
-    char cwd[1024];
-    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     mylock_t mylock;
-    myrel_t myrel, launcher_ready, dbrel;
     pid_t pid;
-    pmix_envar_t envar;
-    char *launchers[] = {
-        "prun",
-        "mpirun",
-        "mpiexec",
-        "prterun",
-        NULL
-    };
-    pmix_proc_t proc;
-    bool found;
-    pmix_data_array_t darray;
-    char *tmp;
-    char clientspace[PMIX_MAX_NSLEN+1];
+    int n;
 
     pid = getpid();
 
-    /* Process any arguments we were given */
-    for (i=1; i < argc; i++) {
-        if (0 == strcmp(argv[i], "-h") ||
-            0 == strcmp(argv[i], "--help")) {
-            /* print the usage message and exit */
-
-        }
-        if (0 == strcmp(argv[i], "-a") ||
-            0 == strcmp(argv[i], "--attach")) {
-            if (NULL != nspace) {
-                /* can only support one */
-                fprintf(stderr, "Cannot attach to more than one nspace\n");
-                exit(1);
-            }
-            /* the next argument must be the nspace */
-            ++i;
-            if (argc == i) {
-                /* they goofed */
-                fprintf(stderr, "The %s option requires an <nspace> argument\n", argv[i]);
-                exit(1);
-            }
-            nspace = strdup(argv[i]);
-        } else if (0 == strcmp(argv[i], "-c") ||
-                   0 == strcmp(argv[i], "--cospawn")){
-            cospawn_reqd = true;
-            break;
-        }
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <attach_namespace>\n", argv[0]);
+        exit(1);
     }
+    nspace = strdup(argv[1]);
     info = NULL;
-    ninfo = 0;
+    ninfo = 1;
+    n = 0;
 
-    /* use the system connection first, if available */
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
-    /* init as a tool */
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[n], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+
+    /* Initialize as a tool */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
-        fprintf(stderr, "PMIx_tool_init failed: %s(%d)\n", PMIx_Error_string(rc), rc);
+        fprintf(stderr, "PMIx_tool_init failed: %s(%d)\n",
+                PMIx_Error_string(rc), rc);
         exit(rc);
     }
     PMIX_INFO_FREE(info, ninfo);
 
-    fprintf(stderr, "Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    printf("Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace,
+           myproc.rank, (unsigned long)pid);
 
-    /* construct the debugger termination release */
-    DEBUG_CONSTRUCT_LOCK(&dbrel.lock);
-
-    /* register a default event handler */
+    /* Register a default event handler */
     DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+                                notification_fn, evhandler_reg_callbk,
+                                (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);
-
-    /* if we are attaching to a running job, then attach to it */
-    if (NULL != nspace) {
-        if (PMIX_SUCCESS != (rc = attach_to_running_job(nspace))) {
-            fprintf(stderr, "Failed to attach to nspace %s: error code %d\n",
-                    nspace, rc);
-            goto done;
-        }
+    if (PMIX_SUCCESS != (rc = attach_to_running_job(nspace))) {
+        fprintf(stderr, "Failed to attach to nspace %s: error code %d\n",
+                nspace, rc);
     }
-
-
-  done:
-    DEBUG_DESTRUCT_LOCK(&myrel.lock);
-    DEBUG_DESTRUCT_LOCK(&dbrel.lock);
     PMIx_tool_finalize();
 
     return(rc);
@@ -352,108 +253,162 @@ static int attach_to_running_job(char *nspace)
     pmix_status_t rc;
     pmix_proc_t myproc;
     pmix_query_t *query;
+    pmix_info_t *info;
+    pmix_app_t *app;
+    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
+    size_t ninfo;
     size_t nq;
+    int n;
     myquery_data_t *q;
+    mylock_t mylock;
+    myrel_t myrel;
+    char cwd[_POSIX_PATH_MAX];
+    char dspace[PMIX_MAX_NSLEN + 1];
 
-    /* query the active nspaces so we can verify that the
-     * specified one exists */
-    nq = 1;
-    PMIX_QUERY_CREATE(query, nq);
-    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
-
-    q = (myquery_data_t*)malloc(sizeof(myquery_data_t));
-    DEBUG_CONSTRUCT_LOCK(&q->lock);
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)q))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
-        return -1;
-    }
-    DEBUG_WAIT_THREAD(&q->lock);
-    DEBUG_DESTRUCT_LOCK(&q->lock);
-
-    if (NULL == q->info) {
-        fprintf(stderr, "Query returned no info\n");
-        return -1;
-    }
-    /* the query should have returned a comma-delimited list of nspaces */
-    if (PMIX_STRING != q->info[0].value.type) {
-        fprintf(stderr, "Query returned incorrect data type: %d\n", q->info[0].value.type);
-        return -1;
-    }
-    if (NULL == q->info[0].value.data.string) {
-        fprintf(stderr, "Query returned no active nspaces\n");
-        return -1;
-    }
-
-    fprintf(stderr, "Query returned %s\n", q->info[0].value.data.string);
-    return 0;
-
-#if 0
-    /* split the returned string and look for the given nspace */
-
-    /* if not found, then we have an error */
-    PMIX_INFO_FREE(info, ninfo);
-
-    /* get the proctable for this nspace */
-    ninfo = 1;
-    PMIX_INFO_CREATE(info, ninfo);
-    (void)strncpy(info[0].key, PMIX_QUERY_PROC_TABLE, PMIX_MAX_KEYLEN);
-    (void)strncpy(info[0].qualifier, nspace, PMIX_MAX_KEYLEN);
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(info, ninfo, infocbfunc, (void*)&active))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
-        return -1;
-    }
-    /* wait to get a response */
-
-    /* the query should have returned a data_array */
-    if (PMIX_DATA_ARRAY != info[0].type) {
-        fprintf(stderr, "Query returned incorrect data type: %d\n", info[0].type);
-        return -1;
-    }
-    if (NULL == info[0].data.darray.array) {
-        fprintf(stderr, "Query returned no proctable info\n");
-        return -1;
-    }
-    /* the data array consists of a struct:
-     *     size_t size;
-     *     void* array;
-     *
-     * In this case, the array is composed of pmix_proc_info_t structs:
-     *     pmix_proc_t proc;   // contains the nspace,rank of this proc
-     *     char* hostname;
-     *     char* executable_name;
-     *     pid_t pid;
-     *     int exit_code;
-     *     pmix_proc_state_t state;
-     */
-
-    /* this is where a debugger tool would process the proctable to
+    printf("%s called to attach to application with namespace %s\n",
+           __FUNCTION__, nspace);
+    /* This is where a debugger tool would process the proctable to
      * create whatever blob it needs to provide to its daemons */
+
+    /* We are given the namespace of the launcher. The debugger daemon needs
+     * the namespace of the application so it can interact with and control
+     * execution of the application tasks.
+     *
+     * Query the namespaces known to the launcher to get the application
+     * namespace. */
+    query_application_namespace(nspace);
+    printf("Spawn debugger daemon\n");
+    /* Set up the debugger daemon spawn request */
+    PMIX_APP_CREATE(app, 1);
+    /* Set up the name of the daemon executable to launch */
+    app->cmd = strdup("./daemon");
+    app->argv = (char**)malloc(2*sizeof(char*));
+    /* Set up the debuger daemon arguments, in this case, just argv[0] */
+    app->argv[0] = strdup("./daemon");
+    app->argv[1] = NULL;
+    /* No environment variables */
+    app->env = NULL;
+    /* Set the daemon's working directory to our current directory */
+    getcwd(cwd, _POSIX_PATH_MAX);
+    app->cwd = strdup(cwd);
+    /* No attributes set in the pmix_app_t structure */
+    app->info = NULL;
+    app->ninfo = 0;
+    /* One debugger daemon */
+    app->maxprocs = 1;
+    /* Provide directives so the daemon goes where we want, and
+     * let the RM know this is a debugger daemon */
+    ninfo = 6;
+    n = 0;
+    PMIX_INFO_CREATE(info, ninfo);
+    /* Map debugger daemon processes by node */
+    PMIX_INFO_LOAD(&info[n], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);
+    n++;
+    /* Indicate this is a debugger daemon */
+    PMIX_INFO_LOAD(&info[n], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL);
+    n++;
+    /* Set the namespace to attach to */
+    PMIX_INFO_LOAD(&info[n], PMIX_DEBUG_JOB, application_namespace, PMIX_STRING);
+    n++;
+    /* Forward stdout to this process */
+    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);
+    n++;
+    /* Forward stderr to this process */
+    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDERR, NULL, PMIX_BOOL);
+    n++;
+    /* Indicate the requestor is a tool process */
+    PMIX_INFO_LOAD(&info[n], PMIX_REQUESTOR_IS_TOOL, NULL, PMIX_BOOL);
+
+    /* Spawn the daemon */
+    rc = PMIx_Spawn(info, ninfo, app, 1, dspace);
+    PMIX_APP_FREE(app, 1);
     PMIX_INFO_FREE(info, ninfo);
+    printf("Debugger daemon namespace '%s'\n", dspace);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Error spawning debugger daemon, %s\n",
+                PMIx_Error_string(rc));
+        return -1;
+    }
+    /* This is where a debugger tool would wait until the debug operation is
+     * complete */
+    /* Register callback for when the debugger daemon terminates */
+    DEBUG_CONSTRUCT_LOCK(&myrel.lock);
+    myrel.nspace = strdup(dspace);
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    /* Only call me back when this specific job terminates */
+    PMIX_INFO_LOAD(&info[1], PMIX_NSPACE, dspace, PMIX_STRING);
 
-    /* setup the debugger daemon spawn request */
-    napps = 1;
-    PMIX_APP_CREATE(app, napps);
-    /* setup the name of the daemon executable to launch */
-    app[0].cmd = strdup("debuggerdaemon");
-    app[0].argc = 1;
-    app[0].argv = (char**)malloc(2*sizeof(char*));
-    app[0].argv[0] = strdup("debuggerdaemon");
-    app[0].argv[1] = NULL;
-    /* provide directives so the daemons go where we want, and
-     * let the RM know these are debugger daemons */
-    ninfo = 3;
-    PMIX_INFO_CREATE(app[0].info, ninfo);
-    PMIX_INFO_LOAD(&app[0].info[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
-    PMIX_INFO_LOAD(&app[0].info[1], PMIX_DEBUGGER_DAEMONS, true, PMIX_BOOL); // these are debugger daemons
-    PMIX_INFO_LOAD(&app[0].info[2], PMIX_DEBUG_TARGET, nspace, PMIX_STRING); // the "jobid" of the application to be debugged
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, info, 2, release_fn,
+                                evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 2);
+    printf("Waiting for debugger daemon namespace %s to complete\n", dspace);
+    DEBUG_WAIT_THREAD(&myrel.lock);
+    printf("Debugger daemon namespace %s terminated\n", dspace);
+    return rc;
+}
 
-    /* spawn the daemons */
-    PMIx_Spawn(NULL, 0, app, napps, dspace);
-    /* cleanup */
-    PMIX_APP_FREE(app, napps);
+int query_application_namespace(char *nspace)
+{
+    pmix_info_t *namespace_query_data;
+    char *p;
+    size_t namespace_query_size;
+    pmix_status_t rc;
+    pmix_query_t namespace_query;
+    int wildcard_rank = PMIX_RANK_WILDCARD;
+    int ninfo;
+    int n;
+    int len;
 
-    /* this is where a debugger tool would wait until the debug operation is complete */
-
+    printf("%s called to get application namespace\n", __FUNCTION__);
+    PMIX_QUERY_CONSTRUCT(&namespace_query);
+    PMIX_ARGV_APPEND(rc, namespace_query.keys, PMIX_QUERY_NAMESPACES);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "An error occurred creating namespace query.");
+        PMIX_QUERY_DESTRUCT(&namespace_query);
+        return -1;
+    }
+    PMIX_INFO_CREATE(namespace_query.qualifiers, 2);
+    ninfo = 2;
+    n = 0;
+    PMIX_INFO_LOAD(&namespace_query.qualifiers[n], PMIX_NSPACE, nspace,
+                   PMIX_STRING);
+    n++;
+    PMIX_INFO_LOAD(&namespace_query.qualifiers[n], PMIX_RANK, &wildcard_rank,
+                   PMIX_INT32);
+    namespace_query.nqual = ninfo;
+    rc = PMIx_Query_info(&namespace_query, 1, &namespace_query_data,
+                         &namespace_query_size);
+    PMIX_QUERY_DESTRUCT(&namespace_query);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr,
+                "An error occurred querying application namespace: %s.\n",
+                PMIx_Error_string(rc));
+        return -1;
+    }
+    if ((1 != namespace_query_size) ||
+              (PMIX_STRING != namespace_query_data->value.type)) {
+        fprintf(stderr, "The response to namespace query has wrong format.\n");
+        return -1;
+    }
+      /* The query retruns a comma-delimited list of namespaces. If there are
+       * multple namespaces in the list, then assume the first is the 
+       * application namespace and the second is the daemon namespace.
+       * Copy only the application namespace and terminate the name with '\0' */
+    p = strchr(namespace_query_data->value.data.string, ',');
+    if (NULL == p) {
+        len = strlen(namespace_query_data->value.data.string);
+    }
+    else {
+        len = p - namespace_query_data->value.data.string;
+    }
+    strncpy(application_namespace, namespace_query_data->value.data.string,
+            len);
+    application_namespace[len] = '\0';
+    printf("Application namespace is '%s'\n", application_namespace);
     return 0;
-#endif
 }

--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -33,10 +33,16 @@
 
 #include <pmix_tool.h>
 #include "debugger.h"
+/*
+ * This module is an example of a PMIx debugger daemon. The debugger daemon
+ * handles interactions with application processes on a node in behalf of the
+ * front end debugger process.
+ */
 
 static pmix_proc_t myproc;
+static char *target_namespace = NULL;
 
-/* this is a callback function for the PMIx_Query
+/* This is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
  * if the request could be fully satisfied, partially
  * satisfied, or completely failed. The info parameter
@@ -59,29 +65,29 @@ static void cbfunc(pmix_status_t status,
 
     mq->status = status;
 
-    /* save the returned info - it will be
-     * released in the release_fn */
+    printf("%s called as daemon callback for PMIx_Query\n", __FUNCTION__);
+    /* Save the returned info - it will be * released in the release_fn */
     if (0 < ninfo) {
         PMIX_INFO_CREATE(mq->info, ninfo);
         mq->ninfo = ninfo;
         for (n=0; n < ninfo; n++) {
-            fprintf(stderr, "Transferring %s\n", info[n].key);
+            printf("Transferring %s\n", info[n].key);
             PMIX_INFO_XFER(&mq->info[n], &info[n]);
         }
     }
 
-    /* let the library release the data */
+    /* Let the library release the data */
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
 
-    /* release the block */
+    /* Release the lock */
     DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
-/* this is the event notification function we pass down below
+/* This is the event notification function we pass down below
  * when registering for general events - i.e.,, the default
- * handler. We don't technically need to register one, but it
+  handler. We don't technically need to register one, but it
  * is usually good practice to catch any events that occur */
 static void notification_fn(size_t evhdlr_registration_id,
                             pmix_status_t status,
@@ -91,12 +97,14 @@ static void notification_fn(size_t evhdlr_registration_id,
                             pmix_event_notification_cbfunc_fn_t cbfunc,
                             void *cbdata)
 {
+    printf("%s called as daemon default event handler for event=%s\n", __FUNCTION__,
+           PMIx_Error_string(status));
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
-/* this is an event notification function that we explicitly request
+/* This is an event notification function that we explicitly request
  * be called when the PMIX_ERR_JOB_TERMINATED notification is issued.
  * We could catch it in the general event notification function and test
  * the status to see if it was "job terminated", but it often is simpler
@@ -118,21 +126,37 @@ static void release_fn(size_t evhdlr_registration_id,
     size_t n;
     pmix_proc_t *affected = NULL;
 
-    /* find our return object */
+    printf("%s called as daemon callback for event=%s\n", __FUNCTION__,
+           PMIx_Error_string(status));
+
+    /* Be sure notification is for our application process namespace */
+    if (0 != strcmp(target_namespace, source->nspace)) {
+        printf("Ignoring termination notification for '%s'\n", source->nspace);
+        /* Tell the event handler state machine that we are the last step */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+    /* Find our return object */
     lock = NULL;
     found = false;
     for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+        /* Retrieve the lock that needs to be released by this callback. */
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT,
+                         PMIX_MAX_KEYLEN)) {
             lock = (myrel_t*)info[n].value.data.ptr;
-            /* not every RM will provide an exit code, but check if one was given */
+            /* Not every RM will provide an exit code, but check if one was
+             * given */
         } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
             exit_code = info[n].value.data.integer;
             found = true;
-        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC,
+                                PMIX_MAX_KEYLEN)) {
             affected = info[n].value.data.proc;
         }
     }
-    /* if the object wasn't returned, then that is an error */
+    /* if the lock object wasn't returned, then that is an error */
     if (NULL == lock) {
         fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
         /* let the event handler progress */
@@ -142,23 +166,26 @@ static void release_fn(size_t evhdlr_registration_id,
         return;
     }
 
-    fprintf(stderr, "DEBUGGER DAEMON %s NOTIFIED THAT JOB TERMINATED - AFFECTED %s\n", lock->nspace,
-            (NULL == affected) ? "NULL" : affected->nspace);
+    printf("DEBUGGER DAEMON NAMESPACE %s NOTIFIED THAT JOB TERMINATED - AFFECTED %s\n",
+           lock->nspace, (NULL == affected) ? "NULL" : affected->nspace);
 
+    /* If the lock object was found then store return status in the lock
+     * object. */
     if (found) {
         lock->exit_code = exit_code;
         lock->exit_code_given = true;
     }
 
-    /* tell the event handler state machine that we are the last step */
+    /* Tell the event handler state machine that we are the last step */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
 
+    /* Wake up the thread that is waiting for this callback to complete */
     DEBUG_WAKEUP_THREAD(&lock->lock);
 }
 
-/* event handler registration is done asynchronously because it
+/* Event handler registration is done asynchronously because it
  * may involve the PMIx server registering with the host RM for
  * external events. So we provide a callback function that returns
  * the status of the request (success or an error), plus a numerical index
@@ -171,9 +198,11 @@ static void evhandler_reg_callbk(pmix_status_t status,
 {
     mylock_t *lock = (mylock_t*)cbdata;
 
+    printf("%s called by daemon as registration callback\n", __FUNCTION__);
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
-                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+                   myproc.nspace, myproc.rank, status,
+                   (unsigned long)evhandler_ref);
     }
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
@@ -187,30 +216,35 @@ int main(int argc, char **argv)
     pmix_info_t *info;
     size_t ninfo;
     pmix_query_t *query;
-    size_t nq, n;
+    pmix_proc_info_t *proctable;
+    size_t nq;
+    size_t n;
     myquery_data_t myquery_data;
     pid_t pid;
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     mylock_t mylock;
     myrel_t myrel;
     uint16_t localrank;
-    char *target = NULL;
+    int i;
+    int cospawned_namespace = 0;
 
     pid = getpid();
 
-    /* init us - since we were launched by the RM, our connection info
-     * will have been provided at startup. */
+    /* Initialize this daemon - since we were launched by the RM, our
+     * connection info * will have been provided at startup. */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Debugger daemon: PMIx_tool_init failed: %d\n", rc);
+        fprintf(stderr, "Debugger daemon: PMIx_tool_init failed: %s\n",
+                PMIx_Error_string(rc));
         exit(0);
     }
-    fprintf(stderr, "Debugger daemon ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    printf("Debugger daemon ns %s rank %d pid %lu: Running\n", myproc.nspace,
+           myproc.rank, (unsigned long)pid);
 
-
-    /* register our default event handler */
+    /* Register our default event handler */
     DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+                                notification_fn, evhandler_reg_callbk,
+                                (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
     if (PMIX_SUCCESS != mylock.status) {
         rc = mylock.status;
@@ -219,7 +253,19 @@ int main(int argc, char **argv)
     }
     DEBUG_DESTRUCT_LOCK(&mylock);
 
-    /* get the nspace of the job we are to debug - it will be in our JOB info */
+    /*
+     * Get the namespace of the job we are to debug. If the application and the
+     * debugger daemons are spawned separately or if the debugger is attaching
+     * to a running application, the debugger will set the application
+     * namespace in the PMIX_DEBUG_JOB attribute, and the daemon retrieves
+     * it by calling PMIx_Get.
+     *
+     * If the application processes and debugger daemons are spawned together
+     * (cospawn), then the debugger cannot pass the application namespace since
+     * that is not known until after the PMIx_Spawn call completes. However,
+     * the applicaton processes and the debugger daemons have the same
+     * namespace, so this module uses the debugger namespace, which it knows.
+     */
 #ifdef PMIX_LOAD_PROCID
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
 #else
@@ -227,141 +273,225 @@ int main(int argc, char **argv)
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_KEYLEN);
     proc.rank = PMIX_RANK_WILDCARD;
 #endif
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_DEBUG_JOB, NULL, 0, &val))) {
-        fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - error %s\n",
-                myproc.nspace, myproc.rank,
-                (unsigned long)pid, PMIx_Error_string(rc));
+    rc = PMIx_Get(&proc, PMIX_DEBUG_JOB, NULL, 0, &val);
+    if (PMIX_ERR_NOT_FOUND == rc) {
+        /* Save the application namespace for later */
+        target_namespace = strdup(myproc.nspace);
+        cospawned_namespace = 1;
+    } else if (rc != PMIX_SUCCESS) {
+        fprintf(stderr,
+                "[%s:%d:%lu] Failed to get job being debugged - error %s\n",
+                myproc.nspace, myproc.rank, (unsigned long) pid,
+                PMIx_Error_string(rc));
         goto done;
     }
-    if (NULL == val || PMIX_STRING != val->type || NULL == val->data.string) {
-        fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - NULL data returned\n",
-                myproc.nspace, myproc.rank, (unsigned long)pid);
-        goto done;
+    else {
+        /* Verify that the expected data structures were returned */
+        if (NULL == val || PMIX_STRING != val->type ||
+                           NULL == val->data.string) {
+            fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - NULL data returned\n",
+                    myproc.nspace, myproc.rank, (unsigned long)pid);
+            goto done;
+        }
+        printf("[%s:%d:%lu] PMIX_DEBUG_JOB is '%s'\n", proc.nspace, proc.rank,
+               (unsigned long) pid, val->data.string);
+        /* Save the application namespace for later */
+        target_namespace = strdup(val->data.string);
+        PMIX_VALUE_RELEASE(val);
     }
-    /* save it for later */
-    target = strdup(val->data.string);
-    PMIX_VALUE_RELEASE(val);
 
-    fprintf(stderr, "[%s:%d:%lu] Debugging %s\n", myproc.nspace, myproc.rank,
-            (unsigned long)pid, target);
+    printf("[%s:%d:%lu] Debugging '%s'\n", myproc.nspace, myproc.rank,
+            (unsigned long)pid, target_namespace);
 
-    /* get my local rank so I can determine which local proc is "mine"
-     * to debug */
+    /* Get my local rank so I can determine which local proc is "mine" to
+     * debug */
     val = NULL;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0,
+                                       &val))) {
         fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - error %s\n",
-                myproc.nspace, myproc.rank,
-                (unsigned long)pid, PMIx_Error_string(rc));
+                myproc.nspace, myproc.rank, (unsigned long)pid,
+                PMIx_Error_string(rc));
         goto done;
     }
+
+    /* Verify the expected data object was returned */
     if (NULL == val) {
-        fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - NULL data returned\n",
-                myproc.nspace, myproc.rank, (unsigned long)pid);
+        fprintf(stderr,
+               "[%s:%d:%lu] Failed to get my local rank - NULL data returned\n",
+               myproc.nspace, myproc.rank, (unsigned long)pid);
         goto done;
     }
     if (PMIX_UINT16 != val->type) {
-        fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - returned wrong type %s\n",
-                myproc.nspace, myproc.rank, (unsigned long)pid, PMIx_Data_type_string(val->type));
+        fprintf(stderr,
+           "[%s:%d:%lu] Failed to get my local rank - returned wrong type %s\n",
+           myproc.nspace, myproc.rank, (unsigned long)pid,
+           PMIx_Data_type_string(val->type));
         goto done;
     }
-    /* save the data */
+
+    /* Save the rank */
     localrank = val->data.uint16;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "[%s:%d:%lu] my local rank %d\n", myproc.nspace, myproc.rank,
+    printf("[%s:%d:%lu] my local rank %d\n", myproc.nspace, myproc.rank,
             (unsigned long)pid, (int)localrank);
 
-    /* register another handler specifically for when the target
-     * job completes */
+    /* Register an event handler specifically for when the target job
+     * completes */
     DEBUG_CONSTRUCT_LOCK(&myrel.lock);
     myrel.nspace = strdup(proc.nspace);
-    PMIX_INFO_CREATE(info, 2);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
-    /* only call me back when this specific job terminates */
-    PMIX_LOAD_PROCID(&proc, target, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
 
-    fprintf(stderr, "[%s:%d:%lu] registering for termination of %s\n", myproc.nspace, myproc.rank,
-            (unsigned long)pid, proc.nspace);
+    PMIX_LOAD_PROCID(&proc, target_namespace, PMIX_RANK_WILDCARD);
 
+    ninfo = 2;
+    PMIX_INFO_CREATE(info, ninfo);
+    n = 0;
+    /* Pass the lock we will use to wait for notification of the
+     * PMIX_ERR_JOB_TERMINATED event */
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    n++;
+    /* Only call me back when this specific job terminates */
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
 
+    printf("[%s:%d:%lu] registering for termination of '%s'\n",
+           myproc.nspace, myproc.rank, (unsigned long)pid, proc.nspace);
+
+    /* Create a lock to wait for completion of the event registration
+     * callback */
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, info, 2,
-                                release_fn, evhandler_reg_callbk, (void*)&mylock);
+    PMIx_Register_event_handler(&code, 1, info, ninfo,
+                                release_fn, evhandler_reg_callbk,
+                                (void*) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
+    PMIX_INFO_FREE(info, ninfo);
     if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr,
+                "Failed to register handler for PMIX_ERR_JOB_TERMINATED: %s\n",
+                PMIx_Error_string(mylock.status));
         rc = mylock.status;
         DEBUG_DESTRUCT_LOCK(&mylock);
-        PMIX_INFO_FREE(info, 2);
         goto done;
     }
     DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 2);
 
-    /* get our local proctable - for scalability reasons, we don't want to
+    /* Get our local proctable - for scalability reasons, we don't want to
      * have our "root" debugger process get the proctable for everybody and
      * send it out to us. So ask the local PMIx server for the pid's of
-     * our local target processes */
+     * our local target processes
+     */
     nq = 1;
     PMIX_QUERY_CREATE(query, nq);
     PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_LOCAL_PROC_TABLE);
-    query[0].nqual = 1;
-    PMIX_INFO_CREATE(query[0].qualifiers, 1);
-    PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_NSPACE, target, PMIX_STRING);  // the nspace we are enquiring about
-    /* setup the caddy to retrieve the data */
+    n = 0;
+    ninfo = 1;
+    query[0].nqual = ninfo;
+    PMIX_INFO_CREATE(query[0].qualifiers, ninfo);
+    /* Set the namespace to query */
+    PMIX_INFO_LOAD(&query[0].qualifiers[n], PMIX_NSPACE, target_namespace,
+                   PMIX_STRING);
+
+    /* Create the lock used to wait for query completion */
     DEBUG_CONSTRUCT_LOCK(&myquery_data.lock);
     myquery_data.info = NULL;
     myquery_data.ninfo = 0;
-    /* execute the query */
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&myquery_data))) {
+
+    /* Execute the query */
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc,
+                                                 (void*)&myquery_data))) {
         fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
         goto done;
     }
+
+    /* Wait for the query to complete */
     DEBUG_WAIT_THREAD(&myquery_data.lock);
     DEBUG_DESTRUCT_LOCK(&myquery_data.lock);
     PMIX_QUERY_FREE(query, nq);
     if (PMIX_SUCCESS != myquery_data.status) {
         rc = myquery_data.status;
+        fprintf(stderr, "Error querying proc table for '%s': %s\n",
+                target_namespace, PMIx_Error_string(myquery_data.status));
         goto done;
     }
 
-    fprintf(stderr, "[%s:%d:%lu] Local proctable received\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    /* Display the process table */
+    printf("[%s:%d:%lu] Local proctable received for nspace '%s' has %d entries\n",
+            myproc.nspace, myproc.rank, (unsigned long)pid, target_namespace,
+            myquery_data.info[0].value.data.darray->size);
 
+    proctable = myquery_data.info[0].value.data.darray->array;
+    for (i = 0; i < myquery_data.info[0].value.data.darray->size; i++) {
+        printf("Proctable[%d], namespace %s rank %d exec %s\n", i,
+               proctable[i].proc.nspace, proctable[i].proc.rank,
+               basename(proctable[i].executable_name));
+    }
 
-    /* now that we have the proctable for our local processes, we can do our
-     * magic debugger stuff and attach to them. We then send a "release" event
-     * to them - i.e., it's the equivalent to setting the MPIR breakpoint. We
-     * do this with the event notification system. For this example, we just
-     * send it to all local procs of the job being debugged */
-    (void)strncpy(proc.nspace, target, PMIX_MAX_NSLEN);
+    /* Now that we have the proctable for our local processes, this daemon can
+     * interact with application processes, such as setting initial breakpoints,
+     * or other setup for the debugging * session.
+     * If the application was launched by the debugger, then all application
+     * tasks should be suspended in PMIx_Init, usually within the application's
+     * MPI_Init call.
+     * Once initial setup is complete, the daemon sends a release event to the
+     * application processes and those processes resume execution.
+     */
+    (void)strncpy(proc.nspace, target_namespace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
+    n = 0;
     ninfo = 2;
     PMIX_INFO_CREATE(info, ninfo);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);  // deliver to the target nspace
-    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);  // deliver to the target nspace
-    fprintf(stderr, "[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+
+    /* Send release notification to application namespace */
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
+    n++;
+
+    /* Don't send notification to default event handlers */
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL); 
+
+    printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank,
+           (unsigned long)pid);
     rc = PMIx_Notify_event(PMIX_ERR_DEBUGGER_RELEASE,
                            NULL, PMIX_RANGE_CUSTOM,
                            info, ninfo, NULL, NULL);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "%s[%s:%u:%lu] Sending release failed with error %s(%d)\n",
-                myproc.nspace, myproc.rank, (unsigned long)pid, PMIx_Error_string(rc), rc);
+        fprintf(stderr,
+                "%s[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                myproc.nspace, myproc.rank, (unsigned long)pid,
+                PMIx_Error_string(rc), rc);
         goto done;
     }
 
-    /* do some debugger magic while waiting for the job to terminate */
-    DEBUG_WAIT_THREAD(&myrel.lock);
+    /* At this point the application processes should be running under debugger
+     * control. The daemons can interact further with application processes as
+     * needed, or just wait for the application * termination.
+     * This example just waits for application termination.
+     * Note that if the application processes and daemon processes are spawned
+     * by the same PMIx_Spawn call, then no PMIX_ERR_JOB_TERMINATED
+     * notifications are sent since the daemons are part of the same namespace
+     * and are still running.
+     */
+    if (0 == cospawned_namespace) {
+        printf("Waiting for application namespace %s to terminate\n",
+               proc.nspace);
+        DEBUG_WAIT_THREAD(&myrel.lock);
+        printf("Application namespace %s terminated\n", proc.nspace);
+    }
 
   done:
-    if (NULL != target) {
-        free(target);
+    if (NULL != target_namespace) {
+        free(target_namespace);
     }
-    /* finalize us */
-    fprintf(stderr, "Debugger daemon ns %s rank %d pid %lu: Finalizing\n", myproc.nspace, myproc.rank, (unsigned long)pid);
-    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Debugger daemon ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+    /* Call PMIx_tool_finalize to shut down the PMIx runtime */
+    printf("Debugger daemon ns %s rank %d pid %lu: Finalizing\n",
+           myproc.nspace, myproc.rank, (unsigned long)pid);
+    if (PMIX_SUCCESS != (rc = PMIx_tool_finalize())) {
+        fprintf(stderr,
+               "Debugger daemon ns %s rank %d:PMIx_Finalize failed: %s\n",
+               myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     } else {
-        fprintf(stderr, "Debugger daemon ns %s rank %d pid %lu:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+        printf("Debugger daemon ns %s rank %d pid %lu:PMIx_Finalize successfully completed\n",
+               myproc.nspace, myproc.rank, (unsigned long)pid);
     }
-    fflush(stderr);
+    fclose(stdout);
+    fclose(stderr);
+    sleep(1);
     return(0);
 }

--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -24,6 +24,7 @@
  */
 
 #define _GNU_SOURCE
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -34,6 +35,9 @@
 #include "debugger.h"
 
 static pmix_proc_t myproc;
+static bool stop_on_exec = false;
+static char client_nspace[PMIX_MAX_NSLEN + 1];
+static char daemon_nspace[PMIX_MAX_NSLEN + 1];
 
 /* this is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
@@ -56,6 +60,7 @@ static void cbfunc(pmix_status_t status,
     myquery_data_t *mq = (myquery_data_t*)cbdata;
     size_t n;
 
+    printf("Called %s as callback for PMIx_Query\n", __FUNCTION__);
     mq->status = status;
     /* save the returned info - the PMIx library "owns" it
      * and will release it and perform other cleanup actions
@@ -64,7 +69,7 @@ static void cbfunc(pmix_status_t status,
         PMIX_INFO_CREATE(mq->info, ninfo);
         mq->ninfo = ninfo;
         for (n=0; n < ninfo; n++) {
-            fprintf(stderr, "Key %s Type %s(%d)\n", info[n].key, PMIx_Data_type_string(info[n].value.type), info[n].value.type);
+            printf("Key %s Type %s(%d)\n", info[n].key, PMIx_Data_type_string(info[n].value.type), info[n].value.type);
             PMIX_INFO_XFER(&mq->info[n], &info[n]);
         }
     }
@@ -94,6 +99,9 @@ static void notification_fn(size_t evhdlr_registration_id,
     myrel_t *lock;
     size_t n;
 
+    printf("%s called as callback for event=%s\n", __FUNCTION__,
+           PMIx_Error_string(status));
+    lock = NULL;
     if (PMIX_ERR_UNREACH == status ||
         PMIX_ERR_LOST_CONNECTION == status) {
         /* we should always have info returned to us - if not, there is
@@ -106,12 +114,13 @@ static void notification_fn(size_t evhdlr_registration_id,
             }
         }
 
-        /* save the status */
-        lock->exit_code = status;
-        lock->exit_code_given = true;
-        /* always release the lock if we lose connection
-         * to our host server */
-        DEBUG_WAKEUP_THREAD(&lock->lock);
+        /* If a pointer to a lock was passed then save status and
+         * release the lock */
+        if (NULL != lock) {
+            lock->exit_code = status;
+            lock->exit_code_given = true;
+            DEBUG_WAKEUP_THREAD(&lock->lock);
+        }
     }
 
     /* this example doesn't do anything with default events */
@@ -142,6 +151,8 @@ static void release_fn(size_t evhdlr_registration_id,
     size_t n;
     pmix_proc_t *affected = NULL;
 
+    printf("%s called as callback for event=%s source=%s:%d\n", __FUNCTION__,
+           PMIx_Error_string(status), source->nspace, source->rank);
     /* find the return object */
     lock = NULL;
     found = false;
@@ -161,12 +172,12 @@ static void release_fn(size_t evhdlr_registration_id,
         fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
         /* let the event handler progress */
         if (NULL != cbfunc) {
-            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
         }
         return;
     }
 
-    fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED \n",
+    printf("DEBUGGER NOTIFIED THAT JOB %s TERMINATED \n",
             (NULL == affected) ? "NULL" : affected->nspace);
     if (found) {
         if (!lock->exit_code_given) {
@@ -174,9 +185,24 @@ static void release_fn(size_t evhdlr_registration_id,
             lock->exit_code_given = true;
         }
     }
-    lock->lock.count--;
-    if (0 == lock->lock.count) {
-        DEBUG_WAKEUP_THREAD(&lock->lock);
+
+    /* A system PMIx daemon may have kept track of notifications for
+     * termination of previous application runs, and may send those
+     * notifications to this process, which has registered a callback for
+     * application terminations. Those notifcations need to be ignored.
+     *
+     * Therefore, in the co-spawn case, we expect one termination notification,
+     * which is for the combined application/daemon namespace when the daemon
+     * terminates.
+     *
+     * In the separate spawn case, we expect two terminations, the application
+     * and the daemon. */
+    if ((0 == strcmp(daemon_nspace, source->nspace)) ||
+        (0 == strcmp(client_nspace, source->nspace))) {
+        lock->lock.count--;
+        if (0 == lock->lock.count) {
+            DEBUG_WAKEUP_THREAD(&lock->lock);
+        }
     }
 
     /* tell the event handler state machine that we are the last step */
@@ -199,6 +225,7 @@ static void evhandler_reg_callbk(pmix_status_t status,
 {
     mylock_t *lock = (mylock_t*)cbdata;
 
+    printf("%s called to register callback\n", __FUNCTION__);
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
                    myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
@@ -207,62 +234,210 @@ static void evhandler_reg_callbk(pmix_status_t status,
     DEBUG_WAKEUP_THREAD(lock);
 }
 
+static int cospawn_launch(myrel_t *myrel) {
+    pmix_info_t *info;
+    pmix_app_t *app;
+    size_t ninfo;
+    int code = PMIX_ERR_JOB_TERMINATED;
+    pmix_status_t rc;
+    int n;
+    pmix_data_array_t data_array;
+    mylock_t mylock;
+    pmix_proc_t daemon_proc;
+    char cwd[_POSIX_PATH_MAX + 1];
+
+    printf("Calling %s to spawn application processes and debugger daemon\n",
+           __FUNCTION__);
+    /* Provide job-level directives so the apps do what the user requested.
+     * These attributes apply to both the application and daemon processes. */
+    ninfo = 4;
+    n = 0;
+    PMIX_INFO_CREATE(info, ninfo);
+    /* Forward stdout to this process */
+    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);
+    n++;
+    /* Forward stderr to this process */
+    PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDERR, NULL, PMIX_BOOL);
+    n++;
+    /* Process that is spawning processes is a tool process */
+    PMIX_INFO_LOAD(&info[n], PMIX_REQUESTOR_IS_TOOL, NULL, PMIX_BOOL);
+    n++;
+    /* Map spawned processes by slot */
+    PMIX_INFO_LOAD(&info[n], PMIX_MAPBY, "slot", PMIX_STRING);
+
+    /* The application and daemon processes are being spawned together
+     * so create 2 pmix_app_t structures. The first is parameters for
+     * the application and the second is parameters for the daemon. */
+    PMIX_APP_CREATE(app, 2);
+    /* setup the executable */
+    app[0].cmd = strdup("./hello");
+    /* Set up the executable command arguments, in this case just the
+     * application (argv[0]) */
+    PMIX_ARGV_APPEND(rc, app->argv, app[0].cmd);
+    app[0].env = NULL;
+    /* Set the working directory */
+    getcwd(cwd, _POSIX_PATH_MAX);
+    app[0].cwd = strdup(cwd);
+    /* Two application processes */
+    app[0].maxprocs = 2;
+
+    app[0].ninfo = 1;
+    PMIX_INFO_CREATE(app[0].info, app[0].ninfo);
+    n = 0;
+    if (stop_on_exec) {
+        /* Stop application at first instruction */
+        PMIX_INFO_LOAD(&app[n].info[0], PMIX_DEBUG_STOP_ON_EXEC, NULL,
+                       PMIX_BOOL);
+    } else {
+        /* Stop application in PMIx_Init */
+        PMIX_INFO_LOAD(&app[n].info[0], PMIX_DEBUG_STOP_IN_INIT, NULL,
+                       PMIX_BOOL);
+    }
+
+    /* Set up the daemon executable */
+    app[1].cmd = strdup("./daemon");
+    /* Set up daemon arguments, in this case just the executable (argv[0]) */
+    PMIX_ARGV_APPEND(rc, app[1].argv, app[1].cmd);
+    app[1].env = NULL;
+    /* Set the working directory */
+    app[1].cwd = strdup(cwd);
+    /* One daemon process */
+    app[1].maxprocs = 1;
+    /* Provide directives so the daemons go where we want, and
+     * let the RM know these are debugger daemons */
+    app[1].ninfo = 3;
+    n = 0;
+    PMIX_INFO_CREATE(app[1].info, app[1].ninfo);
+    /* This process is a debugger daemon */
+    PMIX_INFO_LOAD(&app[1].info[n], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL);
+    n++;
+    /* Notify this process when debugger job completes */
+    PMIX_INFO_LOAD(&app[1].info[n], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+    n++;
+    /* Tell daemon that application is waiting for daemon to relase it */
+    PMIX_INFO_LOAD(&app[1].info[n], PMIX_DEBUG_WAIT_FOR_NOTIFY, NULL,
+                   PMIX_BOOL); 
+    /* Spawn the job - the function will return when the app
+     * has been launched */
+    rc = PMIx_Spawn(info, ninfo, app, 2, client_nspace);
+    myrel->lock.count = 1; //app[0].maxprocs + app[1].maxprocs;
+    myrel->nspace = strdup(client_nspace);
+    PMIX_INFO_FREE(info, ninfo);
+    PMIX_APP_FREE(app, 2);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Application failed to launch with error: %s(%d)\n",
+                PMIx_Error_string(rc), rc);
+        return rc;
+    }
+    /* Daemon and application are in same namespace */
+    printf("Application namespace is %s\n", client_nspace);
+    /* Register the termination event handler here with the intent to
+     * filter out non-daemon notifcations .
+     * Since the daemon is in the same namespace as the application, it's
+     * rank is assigned one higher than the last application process. In 
+     * this example,the daemon's rank is 2.
+     */
+    strcpy(daemon_proc.nspace, client_nspace);
+    strcpy(daemon_nspace, client_nspace);
+    daemon_proc.rank = 2;
+    data_array.size = 1;
+    data_array.type = PMIX_PROC;
+    data_array.array = &daemon_proc;
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_CUSTOM_RANGE, &data_array,
+                   PMIX_DATA_ARRAY);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_RETURN_OBJECT, myrel, PMIX_POINTER);
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, info, 2, release_fn,
+                                evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 2);
+    return rc;
+}
+
 static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
 {
     pmix_status_t rc;
     pmix_info_t *dinfo;
     pmix_app_t *debugger;
     size_t dninfo;
-    char cwd[1024];
-    char dspace[PMIX_MAX_NSLEN+1];
+    int n;
+    char cwd[_POSIX_PATH_MAX];
     mylock_t mylock;
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     pmix_proc_t proc;
 
-    /* setup the debugger */
+    printf("Calling %s to spawn the debugger daemon\n", __FUNCTION__);
+    /* Setup the debugger  spawn parameters*/
     PMIX_APP_CREATE(debugger, 1);
     debugger[0].cmd = strdup("./daemon");
+    /* Set up debugger command arguments, in this example, just argv[0] */
     PMIX_ARGV_APPEND(rc, debugger[0].argv, "./daemon");
-    getcwd(cwd, 1024);  // point us to our current directory
+    /* No environment variables */
+    debugger[0].env = NULL;
+    /* Set the working directory to our current directory */
+    getcwd(cwd, _POSIX_PATH_MAX);
     debugger[0].cwd = strdup(cwd);
-    /* provide directives so the daemons go where we want, and
-     * let the RM know these are debugger daemons */
+    /* Spawn one daemon process */
+    debugger[0].maxprocs = 1;
+    /* No spawn attributes set here, all are set in dinfo array */
+    debugger[0].ninfo = 0;
+    debugger[0].info = NULL;
+    /* Set attributes for debugger daemon launch and let the RM know these are
+     * debugger daemons */
     dninfo = 7;
+    n = 0;
     PMIX_INFO_CREATE(dinfo, dninfo);
-    PMIX_INFO_LOAD(&dinfo[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
-    PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
-    PMIX_INFO_LOAD(&dinfo[2], PMIX_DEBUG_JOB, appspace, PMIX_STRING); // the nspace being debugged
-    PMIX_INFO_LOAD(&dinfo[3], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
-    PMIX_INFO_LOAD(&dinfo[4], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
-    PMIX_INFO_LOAD(&dinfo[5], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
-    PMIX_INFO_LOAD(&dinfo[6], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
-    /* spawn the daemons */
-    fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
-    if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
-        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
-        PMIX_INFO_FREE(dinfo, dninfo);
-        PMIX_APP_FREE(debugger, 1);
-        return rc;
-    }
-    /* cleanup */
+    /* Launch one daemon per node */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);
+    n++;
+    /* Indicate a debugger daemon is being spawned */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL);
+    n++;
+    /* Set the name of the namespace being debugged */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_DEBUG_JOB, appspace, PMIX_STRING);
+    n++;
+    /* Notify this process when the job completes */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+    n++;
+    /* Tell debugger daemon application processes are waiting to be released */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_DEBUG_WAIT_FOR_NOTIFY, NULL, PMIX_BOOL);
+    n++;
+    /* Forward stdout to this process */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);
+    n++;
+    /* Forward stderr to this process */
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_FWD_STDERR, NULL, PMIX_BOOL);
+    /* Spawn the daemons */
+    printf("Debugger: spawning %s\n", debugger[0].cmd);
+    rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, daemon_nspace);
     PMIX_INFO_FREE(dinfo, dninfo);
     PMIX_APP_FREE(debugger, 1);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
+        return rc;
+    }
+    /* Cleanup */
 
-    /* register callback for when this job terminates */
-    myrel->nspace = strdup(dspace);
-    PMIX_INFO_CREATE(dinfo, 2);
-    PMIX_INFO_LOAD(&dinfo[0], PMIX_EVENT_RETURN_OBJECT, myrel, PMIX_POINTER);
-    /* only call me back when this specific job terminates */
-    PMIX_LOAD_PROCID(&proc, dspace, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&dinfo[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
-    /* track that we need both jobs to terminate */
+    /* Register callback for when this job terminates */
+    myrel->nspace = strdup(daemon_nspace);
+    dninfo = 2;
+    n = 0;
+    PMIX_INFO_CREATE(dinfo, dninfo);
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_EVENT_RETURN_OBJECT, myrel, PMIX_POINTER);
+    n++;
+    /* Only call me back when this specific job terminates */
+    PMIX_LOAD_PROCID(&proc, daemon_nspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&dinfo[n], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
+    /* Track that we need both jobs to terminate */
     myrel->lock.count++;
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, dinfo, 2,
+    PMIx_Register_event_handler(&code, 1, dinfo, dninfo,
                                 release_fn, evhandler_reg_callbk, (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
-    fprintf(stderr, "Debugger: Registered for termination on nspace %s\n", dspace);
+    printf("Debugger: Registered for termination on nspace %s\n", daemon_nspace);
     rc = mylock.status;
     DEBUG_DESTRUCT_LOCK(&mylock);
     PMIX_INFO_FREE(dinfo, 2);
@@ -277,12 +452,11 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     size_t ninfo, napps;
     char *nspace = NULL;
-    int i;
+    int i, n;
     pmix_query_t *query;
-    size_t nq, n;
+    size_t nq;
     myquery_data_t myquery_data;
     bool cospawn = false, stop_on_exec = false, cospawn_reqd = false;
-    char cwd[1024];
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     mylock_t mylock;
     myrel_t myrel;
@@ -291,7 +465,7 @@ int main(int argc, char **argv)
     pmix_proc_t proc;
     pmix_data_array_t darray;
     char *tmp;
-    char clientspace[PMIX_MAX_NSLEN+1];
+    char cwd[_POSIX_PATH_MAX];
 
     pid = getpid();
 
@@ -309,34 +483,39 @@ int main(int argc, char **argv)
         }
     }
     info = NULL;
-    ninfo = 0;
+    ninfo = 2;
+    n = 0;
 
-    /* use the system connection first, if available */
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
-    /* init as a tool */
-    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
+    /* Use the system connection first, if available */
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[n], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    n++;
+    PMIX_INFO_LOAD(&info[n], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+    /* Init as a tool */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
         fprintf(stderr, "PMIx_tool_init failed: %s(%d)\n", PMIx_Error_string(rc), rc);
         exit(rc);
     }
-    PMIX_INFO_FREE(info, 1);
+    PMIX_INFO_FREE(info, ninfo);
 
-    fprintf(stderr, "Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    printf("Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
 
-    /* construct my own release first */
+    /* Construct my own release first */
     DEBUG_CONSTRUCT_LOCK(&myrel.lock);
 
-    /* register a default event handler */
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    /* Register a default event handler */
+    ninfo = 1;
+    n = 0;
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(NULL, 0, info, 1,
+    PMIx_Register_event_handler(NULL, 0, info, ninfo,
                                 notification_fn, evhandler_reg_callbk, (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 1);
+    PMIX_INFO_FREE(info, ninfo);
 
-    /* this is an initial launch - we need to launch the application
+    /* This is an initial launch - we need to launch the application
      * plus the debugger daemons, letting the RM know we are debugging
      * so that it will "pause" the app procs until we are ready. First
      * we need to know if this RM supports co-spawning of daemons with
@@ -360,7 +539,7 @@ int main(int argc, char **argv)
     DEBUG_WAIT_THREAD(&myquery_data.lock);
     DEBUG_DESTRUCT_LOCK(&myquery_data.lock);
 
-    /* we should have received back two info structs, one containing
+    /* We should have received back two info structs, one containing
      * a comma-delimited list of PMIx spawn attributes the RM supports,
      * and the other containing a comma-delimited list of PMIx debugger
      * attributes it supports */
@@ -371,7 +550,7 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    /* we would like to co-spawn the debugger daemons with the app, but
+    /* We would like to co-spawn the debugger daemons with the app, but
      * let's first check to see if this RM supports that operation by
      * looking for the PMIX_COSPAWN_APP attribute in the spawn support
      *
@@ -385,7 +564,7 @@ int main(int argc, char **argv)
      */
     for (n=0; n < myquery_data.ninfo; n++) {
         if (0 == strcmp(myquery_data.info[n].key, PMIX_QUERY_SPAWN_SUPPORT)) {
-            /* see if the cospawn attribute is included */
+            /* See if the cospawn attribute is included */
             if (NULL != strstr(myquery_data.info[n].value.data.string, PMIX_COSPAWN_APP)) {
                 cospawn = true;
             } else {
@@ -400,68 +579,76 @@ int main(int argc, char **argv)
         }
     }
 
-    /* if cospawn is available and they requested it, then we launch both
+    /* If cospawn is available and they requested it, then we launch both
      * the app and the debugger daemons at the same time */
     if (cospawn && cospawn_reqd) {
-
+        cospawn_launch(&myrel);
     } else {
-        /* we must do these as separate launches, so do the app first */
+        /* We must do these as separate launches, so do the app first */
         napps = 1;
         PMIX_APP_CREATE(app, napps);
-        /* setup the executable */
+        /* Setup the executable */
         app[0].cmd = strdup("hello");
         PMIX_ARGV_APPEND(rc, app[0].argv, "./hello");
-        getcwd(cwd, 1024);  // point us to our current directory
+        getcwd(cwd, _POSIX_PATH_MAX);  // point us to our current directory
         app[0].cwd = strdup(cwd);
         app[0].maxprocs = 2;
-        /* provide job-level directives so the apps do what the user requested */
-        ninfo = 6;
+        app[0].ninfo = 0;
+        /* Provide job-level directives so the apps do what the user requested */
+        ninfo = 5;
+        n = 0;
         PMIX_INFO_CREATE(info, ninfo);
-        PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
         if (stop_on_exec) {
-            PMIX_INFO_LOAD(&info[1], PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);  // procs are to stop on first instruction
+            PMIX_INFO_LOAD(&info[n], PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);  // procs are to stop on first instruction
         } else {
-            PMIX_INFO_LOAD(&info[1], PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // procs are to pause in PMIx_Init for debugger attach
+            PMIX_INFO_LOAD(&info[n], PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // procs are to pause in PMIx_Init for debugger attach
         }
-        PMIX_INFO_LOAD(&info[2], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
-        PMIX_INFO_LOAD(&info[3], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
-        PMIX_INFO_LOAD(&info[4], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the job completes
-        PMIX_INFO_LOAD(&info[5], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
+        n++;
+        PMIX_INFO_LOAD(&info[n], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
+        n++;
+        PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
+        n++;
+        PMIX_INFO_LOAD(&info[n], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+        n++;
+        PMIX_INFO_LOAD(&info[n], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the job completes
 
-        /* spawn the job - the function will return when the app
+        /* Spawn the job - the function will return when the app
          * has been launched */
-        fprintf(stderr, "Debugger: spawning %s\n", app[0].cmd);
-        if (PMIX_SUCCESS != (rc = PMIx_Spawn(info, ninfo, app, napps, clientspace))) {
+        printf("Debugger: spawning %s\n", app[0].cmd);
+        if (PMIX_SUCCESS != (rc = PMIx_Spawn(info, ninfo, app, napps, client_nspace))) {
             fprintf(stderr, "Application failed to launch with error: %s(%d)\n", PMIx_Error_string(rc), rc);
             goto done;
         }
         PMIX_INFO_FREE(info, ninfo);
         PMIX_APP_FREE(app, napps);
 
-        /* register callback for when the app terminates */
-        PMIX_INFO_CREATE(info, 2);
-        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
-        /* only call me back when this specific job terminates */
-        PMIX_LOAD_PROCID(&proc, clientspace, PMIX_RANK_WILDCARD);
-        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
+        /* Register callback for when the app terminates */
+        ninfo = 2;
+        n = 0;
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[n], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+        n++;
+        /* Only call me back when this specific job terminates */
+        PMIX_LOAD_PROCID(&proc, client_nspace, PMIX_RANK_WILDCARD);
+        PMIX_INFO_LOAD(&info[n], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
         /* track number of jobs to terminate */
         myrel.lock.count++;
 
         DEBUG_CONSTRUCT_LOCK(&mylock);
-        PMIx_Register_event_handler(&code, 1, info, 2,
+        PMIx_Register_event_handler(&code, 1, info, ninfo,
                                     release_fn, evhandler_reg_callbk, (void*)&mylock);
         DEBUG_WAIT_THREAD(&mylock);
-        fprintf(stderr, "Debugger: Registered for termination on nspace %s\n", clientspace);
+        printf("Debugger: Registered for termination on nspace %s\n", client_nspace);
         rc = mylock.status;
         DEBUG_DESTRUCT_LOCK(&mylock);
-        PMIX_INFO_FREE(info, 2);
+        PMIX_INFO_FREE(info, ninfo);
 
-        /* get the proctable for this nspace */
+        /* Get the proctable for this nspace */
         PMIX_QUERY_CREATE(query, 1);
         PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_PROC_TABLE);
         query[0].nqual = 1;
         PMIX_INFO_CREATE(query->qualifiers, query[0].nqual);
-        PMIX_INFO_LOAD(&query->qualifiers[0], PMIX_NSPACE, clientspace, PMIX_STRING);
+        PMIX_INFO_LOAD(&query->qualifiers[0], PMIX_NSPACE, client_nspace, PMIX_STRING);
 
         DEBUG_CONSTRUCT_LOCK(&myquery_data.lock);
         myquery_data.info = NULL;
@@ -471,7 +658,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "Debugger[%s:%d] Proctable query failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
-        /* wait to get a response */
+        /* Wait to get a response */
         DEBUG_WAIT_THREAD(&myquery_data.lock);
         DEBUG_DESTRUCT_LOCK(&myquery_data.lock);
         /* we should have gotten a response */
@@ -480,7 +667,7 @@ int main(int argc, char **argv)
                     myproc.nspace, myproc.rank, PMIx_Error_string(myquery_data.status));
             goto done;
         }
-        /* there should have been data */
+        /* There should have been data */
         if (NULL == myquery_data.info || 0 == myquery_data.ninfo) {
             fprintf(stderr, "Debugger[%s:%d] Proctable query return no results\n",
                     myproc.nspace, myproc.rank);
@@ -498,7 +685,7 @@ int main(int argc, char **argv)
             fprintf(stderr, "Debugger[%s:%d] Query returned no proctable info\n");
             goto done;
         }
-        /* the data array consists of a struct:
+        /* The data array consists of a struct:
          *     size_t size;
          *     void* array;
          *
@@ -510,16 +697,16 @@ int main(int argc, char **argv)
          *     int exit_code;
          *     pmix_proc_state_t state;
          */
-        fprintf(stderr, "Received proc table for %d procs\n", (int)myquery_data.info[0].value.data.darray->size);
+        printf("Received proc table for %d procs\n", (int)myquery_data.info[0].value.data.darray->size);
         /* now launch the debugger daemons */
-        if (PMIX_SUCCESS != (rc = spawn_debugger(clientspace, &myrel))) {
+        if (PMIX_SUCCESS != (rc = spawn_debugger(client_nspace, &myrel))) {
             fprintf(stderr, "Debugger daemons failed to spawn: %s\n", PMIx_Error_string(rc));
             goto done;
         }
     }
 
   rundebugger:
-    /* this is where a debugger tool would wait until the debug operation is complete */
+    /* This is where a debugger tool would wait until the debug operation is complete */
     DEBUG_WAIT_THREAD(&myrel.lock);
 
   done:

--- a/examples/debugger/hello.c
+++ b/examples/debugger/hello.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
     localrank = val->data.uint16;
     PMIX_VALUE_RELEASE(val);
 
-    fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
+    printf("Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
             myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
 
     if (0 < spin) {
@@ -78,12 +78,12 @@ int main(int argc, char **argv)
 
   done:
     /* finalize us */
-    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    printf("Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
                 myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+        printf("Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
     }
     fflush(stderr);
     return(0);


### PR DESCRIPTION
I have made some additions to the tools examples:

Implemented the direct co-spawn case which was not handled.
Completed the code for the attach example.

I am also working on some  CI testing framework using these examples as CI testcases so made additional changes:

Added printf statements at entry to each function. I think these are also useful to someone running the examples to understand how they work since they show more of the execution floow.

I changed the printfs so that only error message are written to stderr and anything else to stdout.

Note:  These examples currently work only as single-node tests. Co-launch support needs to be working before these test can run with multiple nodes. These examples will be updated after co-launch is working.
 
Finally, some minor comment cleanup and fixed a couple small potential problems.

Signed-off-by: David Wootton <dwootton@us.ibm.com>