### PR TITLE
util: hostfile: fix segfault in nodes list iteration

### DIFF
--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -747,7 +747,7 @@ int prte_util_filter_hostfile_nodes(prte_list_t *nodes,
                 /* search the list of nodes provided to us and find it */
                 for (item1 = prte_list_get_first(nodes);
                      item1 != prte_list_get_end(nodes);
-                     item1 = prte_list_get_next(nodes)) {
+                     item1 = prte_list_get_next(item1)) {
                     node_from_list = (prte_node_t*)item1;
                     if (prte_node_match(node_from_pool, node_from_list->name)) {
                         if (remove) {


### PR DESCRIPTION
hostfile contents:

        +n0 slots=1
        +n1 slots=1

Command:

        prte &
        prun -n 2 --hostfile hostfile --bind-to none --map-by :OVERSUBSCRIBE:DISPLAY ./mpitest


        [thetamom3:64300] mca:rmaps:rr: mapping job [11893,2]

        Thread 1 "prte" received signal SIGSEGV, Segmentation fault.
        0x00007ffff7be80ce in ?? ()
           from /lib64/libc.so.6
        (gdb) bt
        #0  0x00007ffff7be80ce in ?? ()
           from /lib64/libc.so.6
        #1  0x00007ffff7eace18 in prte_node_match (n1=0x555555718df0,
            name=0x686e692073252073 <error: Cannot access memory at address 0x686e692073252073>)
            at /var/tmp/portage/sys-cluster/openmpi-5.0.0_pre20201202/work/openmpi-5.0.0_pre20201202/3rd-party/prrte/src/runtime/prte_globals.c:483

