### PR TITLE
Continue work on tool support

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +31,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <pthread.h>
+#include <libgen.h>
 
 #include <pmix_tool.h>
 #include "debugger.h"
@@ -415,7 +417,7 @@ int main(int argc, char **argv)
     /* Display the process table */
     printf("[%s:%d:%lu] Local proctable received for nspace '%s' has %d entries\n",
             myproc.nspace, myproc.rank, (unsigned long)pid, target_namespace,
-            myquery_data.info[0].value.data.darray->size);
+            (int)myquery_data.info[0].value.data.darray->size);
 
     proctable = myquery_data.info[0].value.data.darray->array;
     for (i = 0; i < myquery_data.info[0].value.data.darray->size; i++) {
@@ -453,7 +455,7 @@ int main(int argc, char **argv)
                            info, ninfo, NULL, NULL);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr,
-                "%s[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                "[%s:%u:%lu] Sending release failed with error %s(%d)\n",
                 myproc.nspace, myproc.rank, (unsigned long)pid,
                 PMIx_Error_string(rc), rc);
         goto done;

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -300,7 +301,6 @@ static int rte_init(int argc, char **argv)
         error = "pmix_server_init";
         goto error;
     }
-
     /* Setup the communication infrastructure */
     /*
      * Routed system

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,6 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -17,6 +17,7 @@
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/runtime/prte_locks.c
+++ b/src/runtime/prte_locks.c
@@ -13,6 +13,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,6 +34,7 @@ prte_atomic_lock_t prte_finalize_lock = PRTE_ATOMIC_LOCK_INIT;
 prte_atomic_lock_t prte_abort_inprogress_lock = PRTE_ATOMIC_LOCK_INIT;
 prte_atomic_lock_t prte_jobs_complete_lock = PRTE_ATOMIC_LOCK_INIT;
 prte_atomic_lock_t prte_quit_lock = PRTE_ATOMIC_LOCK_INIT;
+prte_lock_t prte_init_lock = PRTE_LOCK_STATIC_INIT;
 
 int prte_locks_init(void)
 {

--- a/src/runtime/prte_locks.h
+++ b/src/runtime/prte_locks.h
@@ -11,6 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +30,7 @@
 #include "prte_config.h"
 
 #include "src/sys/atomic.h"
+#include "src/threads/threads.h"
 
 BEGIN_C_DECLS
 
@@ -39,6 +41,7 @@ PRTE_EXPORT extern prte_atomic_lock_t prte_finalize_lock;
 PRTE_EXPORT extern prte_atomic_lock_t prte_abort_inprogress_lock;
 PRTE_EXPORT extern prte_atomic_lock_t prte_jobs_complete_lock;
 PRTE_EXPORT extern prte_atomic_lock_t prte_quit_lock;
+PRTE_EXPORT extern prte_lock_t prte_init_lock;
 
 /**
  * Initialize the locks

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -12,6 +12,7 @@
  * Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +44,7 @@ PRTE_EXPORT extern const char prte_version_string[];
 /**
  * Whether PRTE is initialized or we are in prte_finalize
  */
-PRTE_EXPORT extern int prte_initialized;
+PRTE_EXPORT extern bool prte_initialized;
 PRTE_EXPORT extern bool prte_finalizing;
 PRTE_EXPORT extern int prte_debug_output;
 PRTE_EXPORT extern bool prte_debug_flag;

--- a/src/threads/threads.h
+++ b/src/threads/threads.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,6 +81,14 @@ typedef struct {
     prte_condition_t cond;
     volatile bool active;
 } prte_lock_t;
+
+#define PRTE_LOCK_STATIC_INIT               \
+    {                                       \
+        .status = 0,                        \
+        .mutex = PRTE_MUTEX_STATIC_INIT,    \
+        .cond = PRTE_CONDITION_STATIC_INIT, \
+        .active = false                     \
+    }
 
 #define PRTE_CONSTRUCT_LOCK(l)                          \
     do {                                                \

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,6 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow


### PR DESCRIPTION
Protect the daemons from attempting to process local events prior to actually being ready to do so. For example, a debugger could spawn "prterun", which causes PMIx_server_init to pause until the debugger has connected to it. The debugger then releases prterun to continue launching the application. However, that release event gets cached, and so prterun gets hit with it before it can complete prte_init. This leads to a segfault as prte isn't ready yet to process anything.

So protect all that by simply adding a check for "initialized" and ignoring any events until that has been set.

Signed-off-by: Ralph Castain <rhc@pmix.org>