### PR TITLE
Revert "Update fix to Slurm launcher"

### DIFF
--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -187,6 +187,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char **custom_strings;
     int num_args, i;
     char *cur_prefix;
+    char *cpus_on_node;
     int proc_vpid_index;
     bool failed_launch=true;
     prte_job_t *daemons;
@@ -270,8 +271,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     prte_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    /* tell Slurm to add all CPUs to this task */
-    putenv("SLURM_WHOLE=1");
+    /* add all CPUs to this task */
+    cpus_on_node = getenv("SLURM_CPUS_ON_NODE");
+    if(cpus_on_node) {
+	    asprintf(&tmp, "--cpus-per-task=%s", cpus_on_node);
+	    prte_argv_append(&argc, &argv, tmp);
+	    free(tmp);
+    }
 
     if (!prte_enable_recovery) {
         /* kill the job if any orteds die */


### PR DESCRIPTION
Per discussion with SchedMD:
This reverts commit ba4084a3ce6358c08d972ee248eee30a9c6fd730.

Signed-off-by: Ralph Castain <rhc@pmix.org>