### PR TITLE
Re-enable prterun --rankfile option

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -318,6 +318,9 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
             PRTE_RELEASE(caddy);
             return;
         }
+        /* Record that the rankfile mapping policy has been selected */
+        PRTE_SET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping, PRTE_MAPPING_GIVEN);
+        PRTE_SET_MAPPING_POLICY(prte_rmaps_base.mapping, PRTE_MAPPING_BYUSER);
         /* rankfile is considered equivalent to an RM allocation */
         if (!(PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping))) {
             PRTE_SET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -508,3 +508,13 @@ A %s was given that requires a value, but the provided value is invalid:
   Given:   %s
 
 Please provide a valid value for this policy, or remove it.
+#
+[rankfile-no-filename]
+The request to map processes using a rankfile could not be completed
+because the filename of the rankfile was not specified. Please 
+specify the name of the rankfile.
+#
+[missing-modifier]
+A ':' was found in a modifier specification but there is no modifier
+following the ':'. Please specify a modifier.
+#

--- a/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -86,7 +86,6 @@ static int prte_rmaps_rank_file_register(void)
                                            PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE,
                                            PRTE_INFO_LVL_9,
                                            PRTE_MCA_BASE_VAR_SCOPE_READONLY, &my_priority);
-    prte_rankfile = NULL;
     tmp = prte_mca_base_component_var_register(c, "path",
                                           "Name of the rankfile to be used for mapping processes (relative or absolute path)",
                                           PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE,

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -149,6 +149,9 @@ static prte_cmd_line_init_t cmd_line_init[] = {
       "Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]",
       PRTE_CMD_LINE_OTYPE_LAUNCH },
 
+    { '\0', "rankfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+      "Name of file to specify explicit task mapping",
+      PRTE_CMD_LINE_OTYPE_LAUNCH },
 
     /* mpiexec mandated form launch key parameters */
     { '\0', "initial-errhandler", 1, PRTE_CMD_LINE_TYPE_STRING,
@@ -940,6 +943,11 @@ static int parse_env(prte_cmd_line_t *cmd_line,
         xparams = NULL;
         prte_argv_free(xvals);
         xvals = NULL;
+    }
+
+    /* Check for rankfile option */
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rankfile", 0, 0))) {
+        prte_rankfile = strdup(pval->data.string);
     }
 
     /* now process any tune file specification - the tune file processor

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -347,20 +347,19 @@ static prte_cmd_line_init_t cmd_line_init[] = {
     /* Mapping options */
     { '\0', "map-by", 1, PRTE_CMD_LINE_TYPE_STRING,
       "Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache | "
-      "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr],"
+      "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |,"
+      "rankfile:<rankfile_path>]"
       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
       "DEVICE(for dist policy), INHERIT, NOINHERIT, PE-LIST=a,b (comma-delimited "
       "ranges of cpus to use for this job)",
       PRTE_CMD_LINE_OTYPE_MAPPING },
 
-
       /* Ranking options */
     { '\0', "rank-by", 1, PRTE_CMD_LINE_TYPE_STRING,
       "Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache "
       "| l2cache | l3cache | package (default:np>2) | node], with modifier :SPAN or :FILL",
       PRTE_CMD_LINE_OTYPE_RANKING },
-
 
       /* Binding options */
     { '\0', "bind-to", 1, PRTE_CMD_LINE_TYPE_STRING,


### PR DESCRIPTION
This fixes issue #680.

This pull reqest re-enables the --map-by rankfile:filename option for prterun and for OMPI. It also flags the --rankfile option as deprecated and converts it to the --map-by rankfile option.

Enablement is done by setting the prte_rankfile global variable to the pathname of the rankfile and letting the rankfile processing code that was not disabled deal with the specified rankfile.

This change does not work for prun, or on a per-DVM basis since it looks like the existing code is dependent on the use of the prte_rankfile variable, and where some thought needs to be given about how to restructure to not use the global.

Signed-off-by: David Wootton <dwootton@us.ibm.com>