### PR TITLE
pmix_server_iof_pull_fn needs to call passed callback function

### DIFF
--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1306,6 +1306,7 @@ pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
     for (i = 0; i < nprocs; i++) {
         PRTE_PMIX_CONVERT_PROCT(rc, &name, &procs[i]);
         if (PRTE_SUCCESS != rc) {
+            cbfunc(PMIX_ERR_BAD_PARAM, cbdata);
             return PMIX_ERR_BAD_PARAM;
         }
         if (channels & PMIX_FWD_STDOUT_CHANNEL) {
@@ -1319,6 +1320,7 @@ pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
             PRTE_IOF_SINK_ACTIVATE(sink->wev);
         }
     }
+    cbfunc(PMIX_SUCCESS, cbdata);
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
The pmix_server_iof_pull_fn function needs to call the callback passed to it before returning. 
Ref: openpmix/openpmix#2010

Prior to this fix, the callback registration function specified in the call to PMIx_IOF_pull was not being called. 

The debug output generated by setting pmix_client_iof_verbose to 99 contained a message **pmix:iof_register/deregister returned status UNPACK-PAST-END** because the expected response packet had not been generated.

Once I added code to invoke the callback, the error message was not generated and the registration callback ran as expected.

Signed-off-by: David Wootton <dwootton@us.ibm.com>