### PR TITLE
Fix attach example to wait for daemon process, not prterun to complete, use PMIx_IOF_pull

### DIFF
--- a/examples/debugger/attach.c
+++ b/examples/debugger/attach.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,6 +41,10 @@ static int query_application_namespace(char *nspace);
 
 static pmix_proc_t myproc;
 static char application_namespace[PMIX_MAX_NSLEN + 1];
+static char *iof_data;
+static int iof_size;
+static int iof_registered;
+static size_t iof_handler_id;
 
 /* This is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
@@ -103,6 +108,41 @@ static void notification_fn(size_t evhdlr_registration_id,
     /* This example doesn't do anything with default events */
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* This is the handler function to capture stdio data from the daemon process.
+ * It accumulates stdio data in a buffer. That buffer is displayed at the end
+ * of this program's execution, instead of as it is received, so the output
+ * does not get randomly interspersed with other output. */
+static void stdio_callback(size_t iofhdlr, pmix_iof_channel_t channel, 
+                           pmix_proc_t *source, pmix_byte_object_t *payload,
+                           pmix_info_t info[], size_t ninfo) {
+    if (NULL == iof_data) {
+        /* Allocate initial string plus trailing '\0' that is not in
+         * payload->bytes then copy data and append '\0' */
+        iof_size = payload->size;
+        /* iof_size counts number of bytes sent, need one more for trailing 
+         * '\0' */
+        iof_data = malloc(iof_size + 1);
+        if (NULL == iof_data) {
+            fprintf(stderr, "Unable to allocate I/O buffer, terminating\n");
+            exit(1);
+        }
+        memcpy(iof_data, payload->bytes, payload->size);
+        iof_data[payload->size] = '\0';
+    }
+    else {
+        /* Reallocate buffer to hold additional data, copy data and append
+         * '\0' at end of buffer. */
+        iof_data = realloc(iof_data, iof_size + payload->size + 1);
+        if (NULL == iof_data) {
+            fprintf(stderr, "Unable to allocate I/O buffer, terminating\n");
+            exit(1);
+        }
+        memcpy(&iof_data[iof_size], payload->bytes, payload->size);
+        iof_size = iof_size + payload->size;
+        iof_data[iof_size] = '\0';
     }
 }
 
@@ -185,16 +225,57 @@ static void evhandler_reg_callbk(pmix_status_t status,
                                  size_t evhandler_ref,
                                  void *cbdata)
 {
+    int i;
     mylock_t *lock = (mylock_t*)cbdata;
 
-    printf("%s called to register callback\n", __FUNCTION__);
+    printf("%s called to register callback refid=%d\n", __FUNCTION__,
+           evhandler_ref);
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
                 myproc.nspace, myproc.rank, status,
                 (unsigned long)evhandler_ref);
     }
+    if (NULL == lock) {
+        return;
+    }
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
+}
+
+/* Registration callback for IOF handler. This funcion gets called both when
+ * the IOF handler is registered, and when it gets de-registered.
+ */
+static void iof_reg_callbk(pmix_status_t status, size_t evhandler_ref,
+                           void *cbdata)
+{
+    int i;
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    printf("%s called to register/de-register IOF handler refid=%d\n",
+           __FUNCTION__, evhandler_ref);
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                myproc.nspace, myproc.rank, status,
+                (unsigned long)evhandler_ref);
+    }
+    iof_handler_id = evhandler_ref;
+    if (NULL == lock) {
+        return;
+    }
+    /* Only post the lock when handler is being registered */
+    if (iof_registered) {
+        printf("IOF registration handler called for de-registration\n");
+        return;
+    }
+    iof_registered = 1;
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void iof_dereg_callbk(pmix_status_t status, void *cbdata)
+{
+    printf("%s called with status %s\n", __FUNCTION__,
+           PMIx_Error_string(status));
 }
 
 int main(int argc, char **argv)
@@ -205,7 +286,7 @@ int main(int argc, char **argv)
     char *nspace = NULL;
     mylock_t mylock;
     pid_t pid;
-    int n;
+    int i, n;
 
     pid = getpid();
 
@@ -243,15 +324,22 @@ int main(int argc, char **argv)
         fprintf(stderr, "Failed to attach to nspace %s: error code %d\n",
                 nspace, rc);
     }
+    rc = PMIx_IOF_deregister(iof_handler_id, NULL, 0, iof_dereg_callbk, NULL);
+    printf("PMIx_IOF_deregister completed with status %s\n",
+           PMIx_Error_string(rc));
     PMIx_tool_finalize();
-
+    n = 0;
+    if (NULL != iof_data) {
+        printf("Forwarded stdio data:\n%s", iof_data);
+        printf("End forwarded stdio\n");
+    }
     return(rc);
 }
 
 static int attach_to_running_job(char *nspace)
 {
     pmix_status_t rc;
-    pmix_proc_t myproc;
+    pmix_proc_t daemon_proc;
     pmix_query_t *query;
     pmix_info_t *info;
     pmix_app_t *app;
@@ -260,12 +348,13 @@ static int attach_to_running_job(char *nspace)
     size_t nq;
     int n;
     myquery_data_t *q;
-    mylock_t mylock;
+    mylock_t mylock, iof_lock;
     myrel_t myrel;
     char cwd[_POSIX_PATH_MAX];
     char dspace[PMIX_MAX_NSLEN + 1];
+    char localhost[] = "c685f8n0x";
 
-    printf("%s called to attach to application with namespace %s\n",
+    printf("%s called to attach to application with namespace=%s\n",
            __FUNCTION__, nspace);
     /* This is where a debugger tool would process the proctable to
      * create whatever blob it needs to provide to its daemons */
@@ -298,9 +387,11 @@ static int attach_to_running_job(char *nspace)
     app->maxprocs = 1;
     /* Provide directives so the daemon goes where we want, and
      * let the RM know this is a debugger daemon */
-    ninfo = 6;
+    ninfo = 7; //6;
     n = 0;
     PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[n], PMIX_HOST, localhost, PMIX_STRING);
+    n++;
     /* Map debugger daemon processes by node */
     PMIX_INFO_LOAD(&info[n], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);
     n++;
@@ -329,6 +420,21 @@ static int attach_to_running_job(char *nspace)
                 PMIx_Error_string(rc));
         return -1;
     }
+    PMIX_PROC_LOAD(&daemon_proc, dspace, PMIX_RANK_WILDCARD);
+    DEBUG_CONSTRUCT_LOCK(&iof_lock);
+    /* Register a handler to handle daemon's stdout and stderr */
+    ninfo = 1;
+    n = 0;
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[n], PMIX_IOF_REDIRECT, NULL, PMIX_BOOL);
+    rc = PMIx_IOF_pull(&daemon_proc, 1, info, ninfo,
+                       PMIX_FWD_STDOUT_CHANNEL | PMIX_FWD_STDERR_CHANNEL,
+                       stdio_callback, iof_reg_callbk, &iof_lock);
+    PMIX_INFO_FREE(info, ninfo);
+    DEBUG_WAIT_THREAD(&iof_lock);
+    rc = iof_lock.status;
+    /* Don't destroy the iof_lock since evhandler_reg_callback gets called
+     * multiple times */
     /* This is where a debugger tool would wait until the debug operation is
      * complete */
     /* Register callback for when the debugger daemon terminates */
@@ -337,7 +443,7 @@ static int attach_to_running_job(char *nspace)
     PMIX_INFO_CREATE(info, 2);
     PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
     /* Only call me back when this specific job terminates */
-    PMIX_INFO_LOAD(&info[1], PMIX_NSPACE, dspace, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &daemon_proc, PMIX_PROC);
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(&code, 1, info, 2, release_fn,


### PR DESCRIPTION
Fix the attach example to wait for the daemon process to complete, not prterun process.

The sequence for execution is

prterun -n 2 --report-uri + hello 30 is manually started
attach &LT;prterun-uri&GT;
attach spawns the daemon process
attach waits for the daemon process to terminate
daemon process is waiting for prterun to terminate
prterun is waiting for hello to terminate
When hello terminates, terminates ripple back until attach is notified that the daemon is terminated
attach wraps up its processing

Previous to this change, attach was being notified that the prterun process was terminated, and started wrapup processing prematurely before the daemon terminated, resulting in random lost output.

Also changed the attach example to use PMIx_IOF_pull to get stdio output from the daemon process.

Signed-off-by: David Wootton <dwootton@us.ibm.com>