### PR TITLE
Silence -qinline xlc compiler warning.

### DIFF
--- a/config/prte_setup_cc.m4
+++ b/config/prte_setup_cc.m4
@@ -362,11 +362,14 @@ AC_DEFUN([PRTE_SETUP_CC],[
         CFLAGS_orig="$CFLAGS"
 
         # Note: Some versions of clang (at least >= 3.5 -- perhaps
-        # older versions, too?) will *warn* about -finline-functions,
-        # but still allow it.  This is very annoying, so check for
-        # that warning, too.  The clang warning looks like this:
+        # older versions, too?) and xlc with -g (v16.1, perhaps older)
+        # will *warn* about -finline-functions, but still allow it.
+        # This is very annoying, so check for that warning, too.
+        # The clang warning looks like this:
         # clang: warning: optimization flag '-finline-functions' is not supported
         # clang: warning: argument unused during compilation: '-finline-functions'
+        # the xlc warning looks like this:
+        # warning: "-qinline" is not compatible with "-g". "-qnoinline" is being set.
         CFLAGS="$CFLAGS_orig -finline-functions"
         add=
         AC_CACHE_CHECK([if $CC supports -finline-functions],
@@ -374,7 +377,7 @@ AC_DEFUN([PRTE_SETUP_CC],[
                    [AC_TRY_COMPILE([], [],
                                    [prte_cv_cc_finline_functions="yes"
                                     if test -s conftest.err ; then
-                                        for i in unused 'not supported' ; do
+                                        for i in unused 'not supported\|not compatible' ; do
                                             if $GREP -iq "$i" conftest.err; then
                                                 prte_cv_cc_finline_functions="no"
                                                 break;


### PR DESCRIPTION
With '-g' and '-finline-functions' xlc will throw:
'warning: "-qinline" is not compatible with "-g". "-qnoinline" is being set.'

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>