### PR TITLE
Resolve -N and --map-by conflict

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -99,6 +99,7 @@ PRTE_EXPORT int prte_schizo_base_setup_child(prte_job_t *jobdat,
                                                char ***env);
 PRTE_EXPORT void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 PRTE_EXPORT int prte_schizo_base_get_remaining_time(uint32_t *timeleft);
+PRTE_EXPORT int prte_schizo_base_check_sanity(prte_cmd_line_t *cmdline);
 PRTE_EXPORT void prte_schizo_base_finalize(void);
 
 END_C_DECLS

--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -98,4 +99,9 @@ multiple times in one or more files, but with conflicting values:
   Value:  %s
 
 We cannot determine which value was intended, and therefore are unable to proceed.
+Please correct your command line.
+#
+[multi-instances]
+ERROR: The "%s" command line option was listed more than once on the command line.
+Only one instance of this option is permitted.
 Please correct your command line.

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -280,6 +281,22 @@ int prte_schizo_base_get_remaining_time(uint32_t *timeleft)
         }
     }
     return PRTE_ERR_NOT_SUPPORTED;
+}
+
+int prte_schizo_base_check_sanity(prte_cmd_line_t *cmdline)
+{
+    int rc;
+    prte_schizo_base_active_module_t *mod;
+
+    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
+        if (NULL != mod->module->check_sanity) {
+            rc = mod->module->check_sanity(cmdline);
+            if (PRTE_SUCCESS != rc && PRTE_ERR_TAKE_NEXT_OPTION != rc) {
+                return rc;
+            }
+        }
+    }
+    return PRTE_SUCCESS;
 }
 
 void prte_schizo_base_finalize(void)

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -67,6 +67,7 @@ static int define_session_dir(char **tmpdir);
 static int detect_proxy(char **argv);
 static int allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void wrap_args(char **args);
+static int check_sanity(prte_cmd_line_t *cmd_line);
 
 prte_schizo_base_module_t prte_schizo_prte_module = {
     .define_cli = define_cli,
@@ -78,7 +79,8 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .define_session_dir = define_session_dir,
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
-    .wrap_args = wrap_args
+    .wrap_args = wrap_args,
+    .check_sanity = check_sanity
 };
 
 
@@ -827,4 +829,24 @@ static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
             free(param);
         }
     }
+}
+
+static int check_sanity(prte_cmd_line_t *cmd_line)
+{
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "map-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances",
+                       true, "map-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "rank-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances",
+                       true, "rank-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "bind-to")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances",
+                       true, "bind-to");
+        return PRTE_ERR_SILENT;
+    }
+    return PRTE_SUCCESS;
 }

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -5,6 +5,7 @@
  *                         reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -145,6 +146,9 @@ typedef int (*prte_schizo_base_module_get_rem_time_fn_t)(uint32_t *timeleft);
 /* give the components a chance to add job info */
 typedef void (*prte_schizo_base_module_job_info_fn_t)(prte_cmd_line_t *cmdline, void *jobinfo);
 
+/* give the components a chance to check sanity */
+typedef int (*prte_schizo_base_module_check_sanity_fn_t)(prte_cmd_line_t *cmdline);
+
 /*
  * schizo module version 1.3.0
  */
@@ -164,6 +168,7 @@ typedef struct {
     prte_schizo_base_module_setup_child_fn_t               setup_child;
     prte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
     prte_schizo_base_module_job_info_fn_t                  job_info;
+    prte_schizo_base_module_check_sanity_fn_t              check_sanity;
     prte_schizo_base_module_finalize_fn_t                  finalize;
 } prte_schizo_base_module_t;
 
@@ -187,6 +192,7 @@ typedef struct {
     prte_schizo_base_module_setup_child_fn_t               setup_child;
     prte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
     prte_schizo_base_module_job_info_fn_t                  job_info;
+    prte_schizo_base_module_check_sanity_fn_t              check_sanity;
     prte_schizo_base_module_finalize_fn_t                  finalize;
 } prte_schizo_API_module_t;
 

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -601,6 +601,21 @@ int main(int argc, char *argv[])
         return rc;
     }
 
+    /* check command line sanity - ensure there aren't multiple instances of
+     * options where there should be only one */
+    rc = prte_schizo.check_sanity(prte_cmd_line);
+    if (PRTE_SUCCESS != rc) {
+        if (PRTE_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n",
+                    prte_tool_basename,
+                    prte_strerror(rc));
+        }
+        param = prte_argv_join(pargv, ' ');
+        fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
+        free(param);
+        return rc;
+    }
+
     if (prte_cmd_line_is_taken(prte_cmd_line, "verbose")) {
         verbose = true;
     }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -716,6 +716,21 @@ int prun(int argc, char *argv[])
         return rc;
     }
 
+    /* check command line sanity - ensure there aren't multiple instances of
+     * options where there should be only one */
+    rc = prte_schizo.check_sanity(prte_cmd_line);
+    if (PRTE_SUCCESS != rc) {
+        if (PRTE_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n",
+                    prte_tool_basename,
+                    prte_strerror(rc));
+        }
+        param = prte_argv_join(pargv, ' ');
+        fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
+        free(param);
+        return rc;
+    }
+
     if (prte_cmd_line_is_taken(prte_cmd_line, "verbose")) {
         verbose = true;
     }


### PR DESCRIPTION
Correctly assemble the resulting --map-by option. Add
cmd line sanity check for cases where --map-by, --rank-by,
or --bind-to get multiplied invoked on the cmd line.

Fixes https://github.com/openpmix/prrte/issues/707

Signed-off-by: Ralph Castain <rhc@pmix.org>