### PR TITLE
Assign ranks when computing job placement

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -274,13 +274,6 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
         }
     }
 
-    /* compute the ranks and add the proc objects
-     * to the jdata->procs array */
-    if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_vpids(jdata))) {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
-
     /* assemble the node and proc map info */
     list = NULL;
     procs = NULL;

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -538,18 +538,19 @@ compute:
         }
     }
 
+    /* compute the ranks and add the proc objects
+     * to the jdata->procs array */
+    if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_vpids(jdata))) {
+        PRTE_ERROR_LOG(rc);
+        jdata->exit_code = rc;
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+        goto cleanup;
+    }
+
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) ||
         prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL) ||
         prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL) ||
         prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
-        /* compute the ranks and add the proc objects
-         * to the jdata->procs array */
-        if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_vpids(jdata))) {
-            PRTE_ERROR_LOG(rc);
-            jdata->exit_code = rc;
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-            goto cleanup;
-        }
         /* compute and save local ranks */
         if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_local_ranks(jdata))) {
             PRTE_ERROR_LOG(rc);


### PR DESCRIPTION
Ranks need to be assigned when mapping is done so that
all participants correctly know rank-to-node assignments

Refs https://github.com/openpmix/prrte/issues/696#issuecomment-747760303

Signed-off-by: Ralph Castain <rhc@pmix.org>