### PR TITLE
Ensure proper teardown when job cannot be launched

### DIFF
--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -833,6 +833,47 @@ static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
 
 static int check_sanity(prte_cmd_line_t *cmd_line)
 {
+    prte_value_t *pval;
+    int n;
+    char **args;
+    char *mappers[] = {
+        "slot",
+        "hwthread",
+        "core",
+        "l1cache",
+        "l2cache",
+        "l3cache",
+        "package",
+        "node",
+        "seq",
+        "dist",
+        "ppr",
+        "rankfile",
+        NULL
+    };
+    char *rankers[] = {
+        "slot",
+        "hwthread",
+        "core",
+        "l1cache",
+        "l2cache",
+        "l3cache",
+        "package",
+        "node",
+        NULL
+    };
+    char *binders[] = {
+        "none",
+        "hwthread",
+        "core",
+        "l1cache",
+        "l2cache",
+        "l3cache",
+        "package",
+        NULL
+    };
+    bool good;
+
     if (1 < prte_cmd_line_get_ninsts(cmd_line, "map-by")) {
         prte_show_help("help-schizo-base.txt", "multi-instances",
                        true, "map-by");
@@ -848,5 +889,64 @@ static int check_sanity(prte_cmd_line_t *cmd_line)
                        true, "bind-to");
         return PRTE_ERR_SILENT;
     }
+
+    /* quick check that we have valid directives */
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "map-by", 0, 0))) {
+        args = prte_argv_split(pval->value.data.string, ':');
+        good = false;
+        for (n=0; NULL != mappers[n]; n++) {
+            if (0 == strcasecmp(args[0], mappers[n])) {
+                good = true;
+                break;
+            }
+        }
+        if (!good) {
+            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "mapping", args[0]);
+        }
+        prte_argv_free(args);
+        if (good) {
+            return PRTE_SUCCESS;
+        }
+        return PRTE_ERR_SILENT;
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rank-by", 0, 0))) {
+        args = prte_argv_split(pval->value.data.string, ':');
+        good = false;
+        for (n=0; NULL != rankers[n]; n++) {
+            if (0 == strcasecmp(args[0], rankers[n])) {
+                good = true;
+                break;
+            }
+        }
+        if (!good) {
+            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "ranking", args[0]);
+        }
+        prte_argv_free(args);
+        if (good) {
+            return PRTE_SUCCESS;
+        }
+        return PRTE_ERR_SILENT;
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "bind-to", 0, 0))) {
+        args = prte_argv_split(pval->value.data.string, ':');
+        good = false;
+        for (n=0; NULL != binders[n]; n++) {
+            if (0 == strcasecmp(args[0], binders[n])) {
+                good = true;
+                break;
+            }
+        }
+        if (!good) {
+            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "binding", args[0]);
+        }
+        prte_argv_free(args);
+        if (good) {
+            return PRTE_SUCCESS;
+        }
+        return PRTE_ERR_SILENT;
+    }
+
     return PRTE_SUCCESS;
 }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -538,6 +538,7 @@ static void check_complete(int fd, short args, void *cbdata)
             }
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
             PRTE_RELEASE(caddy);
+            prte_dvm_ready = false;
             return;
         }
         PRTE_RELEASE(caddy);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -630,6 +630,8 @@ static void interim(int sd, short args, void *cbdata)
         PMIX_LOAD_NSPACE(nspace, NULL);
         prc = prte_pmix_convert_rc(rc);
         cd->spcbfunc(prc, nspace, cd->cbdata);
+        /* this isn't going to launch, so indicate that */
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
     }
     PRTE_RELEASE(cd);
 }

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -191,7 +191,6 @@ void prte_data_server(int status, pmix_proc_t* sender,
     uint8_t command;
     int32_t count;
     prte_data_object_t *data;
-    pmix_byte_object_t bo;
     pmix_data_buffer_t *answer, *reply;
     int rc, k;
     uint32_t ninfo, i;
@@ -671,7 +670,6 @@ void prte_data_server(int status, pmix_proc_t* sender,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(answer);
-            free(bo.bytes);
             goto SEND_ERROR;
         }
 


### PR DESCRIPTION
Do a sanity check on map/rank/bind policies before bothering
to start the DVM on a proxy run. Ensure the DVM actually is
built and ready before trying to spawn a job so the HNP doesn't
vacate the premises and leave the prted's stranded.

Fixes https://github.com/openpmix/prrte/issues/679

Signed-off-by: Ralph Castain <rhc@pmix.org>