### PR TITLE
Create and install a prte_version.h header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ config/ext_no_configure_components.m4
 config/ext_m4_config_include.m4
 config/mca_library_paths.txt
 
+include/prte_version.h
 contrib/docker/tmp
 
 examples/alloc

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,7 +22,7 @@
 # $HEADER$
 #
 
-SUBDIRS = config contrib src
+SUBDIRS = config contrib src include
 DIST_SUBDIRS = config contrib src
 EXTRA_DIST = README INSTALL VERSION Doxyfile LICENSE autogen.pl
 

--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -18,6 +18,7 @@ dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl
 dnl Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2021      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -232,6 +233,19 @@ else
 fi
 AC_DEFINE_UNQUOTED(PRTE_PROXY_VERSION_STRING, "$PRTE_PROXY_VERSION_STRING",
                    [Version string to be returned by prte when in proxy mode])
+
+#
+# Save the actual version in an external header file so that
+# packages that use us can know what version we are
+#
+prtemajor=${PRTE_MAJOR_VERSION}L
+prteminor=${PRTE_MINOR_VERSION}L
+prterelease=${PRTE_RELEASE_VERSION}L
+prtenumeric=$(printf 0x%4.4x%2.2x%2.2x $PRTE_MAJOR_VERSION $PRTE_MINOR_VERSION $PRTE_RELEASE_VERSION)
+AC_SUBST(prtemajor)
+AC_SUBST(prteminor)
+AC_SUBST(prterelease)
+AC_SUBST(prtenumeric)
 
 AC_MSG_CHECKING([if a proxy package name for prte is required])
 AC_ARG_WITH(proxy-package-name,

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -1197,6 +1198,8 @@ AC_CONFIG_FILES([
     Makefile
     config/Makefile
     contrib/Makefile
+    include/Makefile
+    include/prte_version.h
 ])
 
 PRTE_CONFIG_FILES

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+#
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+include_HEADERS = \
+        prte.h
+
+nodist_include_HEADERS = \
+    prte_version.h

--- a/include/prte.h
+++ b/include/prte.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#ifndef PRTE_H
+#define PRTE_H
+
+#include "prte_version.h"
+
+#endif

--- a/include/prte_version.h.in
+++ b/include/prte_version.h.in
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#ifndef PRTE_VERSION_H
+#define PRTE_VERSION_H
+
+/* define PRTE version */
+#define PRTE_VERSION_MAJOR @prtemajor@
+#define PRTE_VERSION_MINOR @prteminor@
+#define PRTE_VERSION_RELEASE @prterelease@
+
+#define PRTE_NUMERIC_VERSION @prtenumeric@
+#endif


### PR DESCRIPTION
Allow external packages to detect what version of PRRTE
this is - if the header is not found, then they can safely
assume it is version 1.0.

Signed-off-by: Ralph Castain <rhc@pmix.org>