### PR TITLE
Provide more details in the show_help message

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -14,6 +14,7 @@
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -408,16 +409,6 @@ directive.
 Please specify a mapping level that has more than one cpu, or
 else let us define a default mapping that will allow multiple
 cpus-per-proc.
-#
-[seq:not-enough-resources]
-A sequential map was requested, but not enough node entries
-were given to support the requested number of processes:
-
-  Num procs:  %d
-  Num nodes:  %d
-
-We cannot continue - please adjust either the number of processes
-or provide more node locations in the file.
 #
 [device-not-specified]
 The request to map processes by distance could not be completed

--- a/src/mca/rmaps/seq/help-prte-rmaps-seq.txt
+++ b/src/mca/rmaps/seq/help-prte-rmaps-seq.txt
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,7 +22,26 @@
 # This is the US/English general help file for PRTE's prun.
 #
 [prte-rmaps-seq:resource-not-found]
-The specified hostfile contained a node (%s) that is not in your
+The specified sequence file contained a node (%s) that is not in your
 allocation. We therefore cannot map a process rank to it. Please
-check your allocation and hostfile to ensure the hostfile only
+check your allocation and sequence file to ensure the latter only
 contains allocated nodes.
+#
+[seq:not-enough-resources]
+A sequential map was requested, but not enough node entries
+were given to support the requested number of processes:
+
+  Num procs:  %d
+  Num nodes:  %d
+
+The sequential mapper requires that there be a node entry for
+every process in the job, and it processes the provided file
+using each node entry to identify the node where that numbered
+rank is to be placed.
+
+Note that you can provide a separate sequence file (different
+from a hostfile that specifies the number of slots on each node)
+for use by the sequential mapper in its assignments by using the
+appropriate modifier:
+
+  Example: --map-by seq:file=myseqfile

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -295,7 +295,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata)
                                 "mca:rmaps:seq: setting num procs to %s for app %s",
                                 PRTE_VPID_PRINT(app->num_procs), app->app);
         } else if (num_nodes < app->num_procs) {
-            prte_show_help("help-prte-rmaps-base.txt", "seq:not-enough-resources", true,
+            prte_show_help("help-prte-rmaps-seq.txt", "seq:not-enough-resources", true,
                            app->num_procs, num_nodes);
             return PRTE_ERR_SILENT;
         }


### PR DESCRIPTION
When the sequential mapper doesn't have enough entries
to cover the number of procs to be launched, give a
more detailed explanation and include solutions

Fixes https://github.com/openpmix/prrte/issues/670

Signed-off-by: Ralph Castain <rhc@pmix.org>