### PR TITLE
Replace PRTE_FORCED_TERMINATE macro

### DIFF
--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -288,13 +288,10 @@ static void job_errors(int fd, short args, void *cbdata)
         return;
     }
 
-    /* if the jdata is NULL, then we ignore it as this
-     * is reporting an unrecoverable error
-     */
+    /* if the jdata is NULL, then it is referencing the daemon job */
     if (NULL == caddy->jdata) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        PRTE_RELEASE(caddy);
-        return;
+        caddy->jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+        PRTE_RETAIN(caddy->jdata);
     }
 
     /* update the state */

--- a/src/mca/filem/base/filem_base_receive.c
+++ b/src/mca/filem/base/filem_base_receive.c
@@ -179,7 +179,7 @@ static void filem_base_process_get_proc_node_name_cmd(pmix_proc_t* sender,
     rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &name, &count, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         return;
     }
 
@@ -189,14 +189,14 @@ static void filem_base_process_get_proc_node_name_cmd(pmix_proc_t* sender,
     /* get the job data object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(name.nspace))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         return;
     }
     /* get the proc object for it */
     proc = (prte_proc_t*)prte_pointer_array_get_item(jdata->procs, name.rank);
     if (NULL == proc || NULL == proc->node) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         return;
     }
 
@@ -207,7 +207,7 @@ static void filem_base_process_get_proc_node_name_cmd(pmix_proc_t* sender,
     rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, answer, &(proc->node->name), 1, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(answer);
         return;
     }
@@ -216,7 +216,7 @@ static void filem_base_process_get_proc_node_name_cmd(pmix_proc_t* sender,
                                           PRTE_RML_TAG_FILEM_BASE_RESP,
                                           prte_rml_send_callback, NULL))) {
         PRTE_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(answer);
         return;
     }
@@ -244,7 +244,7 @@ static void filem_base_process_get_remote_path_cmd(pmix_proc_t* sender,
     rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &filename, &count, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         goto CLEANUP;
     }
 
@@ -295,14 +295,14 @@ static void filem_base_process_get_remote_path_cmd(pmix_proc_t* sender,
     rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, answer, &tmp_name, 1, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(answer);
         goto CLEANUP;
     }
     rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, answer, &file_type, 1, PMIX_INT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(answer);
         goto CLEANUP;
     }
@@ -311,7 +311,7 @@ static void filem_base_process_get_remote_path_cmd(pmix_proc_t* sender,
                                           PRTE_RML_TAG_FILEM_BASE_RESP,
                                           prte_rml_send_callback, NULL))) {
         PRTE_ERROR_LOG(rc);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(answer);
     }
 

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -196,7 +196,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(rly);
         PMIX_DATA_BUFFER_RELEASE(relay);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         return;
      }
@@ -205,7 +205,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, buffer, &pbo, &cnt, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(rly);
         return;
     }
@@ -217,7 +217,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
             ret = PMIx_Data_load(&datbuf, &bo);
             if (PMIX_SUCCESS != ret) {
                 PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-                PRTE_FORCED_TERMINATE(ret);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
                 PMIX_DATA_BUFFER_RELEASE(rly);
                 return;
@@ -225,7 +225,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
         } else {
             PMIX_ERROR_LOG(PMIX_ERROR);
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-            PRTE_FORCED_TERMINATE(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
             PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
             PMIX_DATA_BUFFER_RELEASE(rly);
             return;
@@ -234,7 +234,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
         ret = PMIx_Data_load(&datbuf, &pbo);
         if (PMIX_SUCCESS != ret) {
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-            PRTE_FORCED_TERMINATE(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
             PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
             PMIX_DATA_BUFFER_RELEASE(rly);
             return;
@@ -249,6 +249,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         goto CLEANUP;
     }
     PMIX_PROC_CREATE(sig.signature, sig.sz);
@@ -257,7 +258,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_PROC_FREE(sig.signature, sig.sz);
         goto CLEANUP;
     }
@@ -270,7 +271,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         goto CLEANUP;
     }
 
@@ -279,7 +280,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         goto CLEANUP;
     }
 
@@ -289,7 +290,7 @@ static void rbcast_recv(int status, pmix_proc_t* sender,
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         goto CLEANUP;
     }
     if( prte_grpcomm_rbcast_cb[cbtype](relay) ) {

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -389,7 +389,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, buffer, &compressed, &cnt, PMIX_BOOL);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
@@ -400,7 +400,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, buffer, &pbo, &cnt, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
         return;
@@ -413,7 +413,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
             ret = PMIx_Data_load(&datbuf, &bo);
             if (PMIX_SUCCESS != ret) {
                 PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-                PRTE_FORCED_TERMINATE(ret);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
                 PRTE_DESTRUCT(&coll);
                 PMIX_DATA_BUFFER_RELEASE(rly);
@@ -422,7 +422,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
         } else {
             PMIX_ERROR_LOG(PMIX_ERROR);
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-            PRTE_FORCED_TERMINATE(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
             PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
             PRTE_DESTRUCT(&coll);
             PMIX_DATA_BUFFER_RELEASE(rly);
@@ -432,7 +432,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
         ret = PMIx_Data_load(&datbuf, &pbo);
         if (PMIX_SUCCESS != ret) {
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-            PRTE_FORCED_TERMINATE(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
             PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
             PRTE_DESTRUCT(&coll);
             PMIX_DATA_BUFFER_RELEASE(rly);
@@ -447,7 +447,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, data, &sig.sz, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
@@ -458,7 +458,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, data, sig.signature, &cnt, PMIX_PROC);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
@@ -472,7 +472,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_unpack(NULL, data, &tag, &cnt, PMIX_UINT32);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
@@ -484,7 +484,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
     ret = PMIx_Data_copy_payload(relay, data);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_FORCED_TERMINATE(ret);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_DESTRUCT(&datbuf);
         PRTE_DESTRUCT(&coll);
         PMIX_DATA_BUFFER_RELEASE(rly);
@@ -522,7 +522,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&nm->name));
                 }
                 PRTE_RELEASE(item);
-                PRTE_FORCED_TERMINATE(PRTE_ERR_UNREACH);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 continue;
             }
             if ((PRTE_PROC_STATE_RUNNING < rec->state &&
@@ -534,7 +534,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
                                 PRTE_FLAG_TEST(rec, PRTE_PROC_FLAG_ALIVE) ? prte_proc_state_to_str(rec->state) : "NOT ALIVE");
                 }
                 PRTE_RELEASE(item);
-                PRTE_FORCED_TERMINATE(PRTE_ERR_UNREACH);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 continue;
             }
             /* copy the buffer for send */
@@ -544,7 +544,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
                 PRTE_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_RELEASE(rlycopy);
                 PRTE_RELEASE(item);
-                PRTE_FORCED_TERMINATE(PRTE_ERR_UNREACH);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 continue;
             }
             if (PRTE_SUCCESS != (ret = prte_rml.send_buffer_nb(&nm->name, rlycopy, PRTE_RML_TAG_XCAST,
@@ -552,7 +552,7 @@ static void xcast_recv(int status, pmix_proc_t* sender,
                 PRTE_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_RELEASE(rlycopy);
                 PRTE_RELEASE(item);
-                PRTE_FORCED_TERMINATE(PRTE_ERR_UNREACH);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 continue;
             }
             PRTE_RELEASE(item);

--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -337,7 +337,7 @@ void prte_iof_base_write_handler(int _fd, short event, void *cbdata)
                 /* if the list is getting too large, abort */
                 if (prte_iof_base.output_limit < prte_list_get_size(&wev->outputs)) {
                     prte_output(0, "IO Forwarding is running too far behind - something is blocking us from writing");
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     goto ABORT;
                 }
                 /* leave the write event running so it will call us again
@@ -360,7 +360,7 @@ void prte_iof_base_write_handler(int _fd, short event, void *cbdata)
             /* if the list is getting too large, abort */
             if (prte_iof_base.output_limit < prte_list_get_size(&wev->outputs)) {
                 prte_output(0, "IO Forwarding is running too far behind - something is blocking us from writing");
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 goto ABORT;
             }
             /* leave the write event running so it will call us again

--- a/src/mca/oob/tcp/oob_tcp_connection.c
+++ b/src/mca/oob/tcp/oob_tcp_connection.c
@@ -176,7 +176,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
     remote_list = PRTE_NEW(prte_list_t);
     if (NULL == remote_list) {
         prte_output(0, "%s CANNOT CREATE SOCKET, OUT OF MEMORY", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        PRTE_FORCED_TERMINATE(1);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
         return;
     }
 
@@ -188,7 +188,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         interface = PRTE_NEW(prte_if_t);
         if (NULL == interface) {
             prte_output(0, "%s CANNOT CREATE SOCKET, OUT OF MEMORY", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-            PRTE_FORCED_TERMINATE(1);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
         interface->af_family = addr->addr.ss_family;
@@ -308,7 +308,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
              * and return them as "unreachable"
              */
             prte_output(0, "%s CANNOT CREATE SOCKET", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-            PRTE_FORCED_TERMINATE(1);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
 
@@ -333,7 +333,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
                          prte_socket_errno );
 
             CLOSE_THE_SOCKET(peer->sd);
-            PRTE_FORCED_TERMINATE(1);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
 
@@ -492,7 +492,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
                     rc);
         /* close the socket */
         CLOSE_THE_SOCKET(peer->sd);
-        PRTE_FORCED_TERMINATE(1);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
     }
 
 cleanup:

--- a/src/mca/oob/tcp/oob_tcp_sendrecv.c
+++ b/src/mca/oob/tcp/oob_tcp_sendrecv.c
@@ -272,7 +272,7 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
                 PRTE_RML_SEND_COMPLETE(msg->msg);
                 PRTE_RELEASE(msg);
                 peer->send_msg = NULL;
-                PRTE_FORCED_TERMINATE(1);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
                 return;
             }
 
@@ -438,7 +438,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                 PRTE_NAME_PRINT(&peer->name));
             prte_event_del(&peer->recv_event);
-            PRTE_FORCED_TERMINATE(1);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             return;
         }
         break;
@@ -572,7 +572,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                             PRTE_NAME_PRINT(&(peer->name)));
                 /* turn off the recv event */
                 prte_event_del(&peer->recv_event);
-                PRTE_FORCED_TERMINATE(1);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
                 return;
             }
         }

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -444,13 +444,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
         prte_argv_free(env);
     }
 
-    /* cleanup the caddy */
-    PRTE_RELEASE(state);
-
     /* check for failed launch - if so, force terminate */
     if (failed_launch) {
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_START);
     }
+
+    /* cleanup the caddy */
+    PRTE_RELEASE(state);
 }
 
 

--- a/src/mca/plm/base/plm_base_prted_cmds.c
+++ b/src/mca/plm/base/plm_base_prted_cmds.c
@@ -64,9 +64,7 @@ static void failed_cmd(int fd, short event, void *cbdata)
                          "%s plm:base:orted_cmd command timed out",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
     PRTE_RELEASE(tm);
-/*
-    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
-*/
+    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
 }
 #endif
 

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -421,7 +421,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
                     /* get the proc data object */
                     if (NULL == (proc = (prte_proc_t*)prte_pointer_array_get_item(jdata->procs, vpid))) {
                         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-                        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FORCED_EXIT);
                         goto CLEANUP;
                     }
                     /* NEVER update the proc state before activating the state machine - let
@@ -485,7 +485,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
     /* see if an error occurred - if so, wakeup the HNP so we can exit */
     if (PRTE_PROC_IS_MASTER && PRTE_SUCCESS != rc) {
         jdata = NULL;
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
     }
 
     PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -384,13 +384,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
         prte_argv_free(env);
     }
 
-    /* cleanup the caddy */
-    PRTE_RELEASE(state);
-
     /* check for failed launch - if so, force terminate */
     if (failed_launch) {
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(state->jata, PRTE_JOB_STATE_FAILED_TO_START);
     }
+
+    /* cleanup the caddy */
+    PRTE_RELEASE(state);
 }
 
 

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -176,11 +176,13 @@ typedef int32_t prte_job_state_t;
 #define PRTE_JOB_STATE_ALLOC_FAILED            (PRTE_JOB_STATE_ERROR + 18)  /* job failed to obtain an allocation */
 #define PRTE_JOB_STATE_MAP_FAILED              (PRTE_JOB_STATE_ERROR + 19)  /* job failed to map */
 #define PRTE_JOB_STATE_CANNOT_LAUNCH           (PRTE_JOB_STATE_ERROR + 20)  /* resources were busy and so the job cannot be launched */
+#define PRTE_JOB_STATE_FILES_POSN_FAILED       (PRTE_JOB_STATE_ERROR + 21)
 
+#define PRTE_JOB_STATE_FT                      200
 /* define an FT event */
-#define PRTE_JOB_STATE_FT_CHECKPOINT           (PRTE_JOB_STATE_ERROR + 21)
-#define PRTE_JOB_STATE_FT_CONTINUE             (PRTE_JOB_STATE_ERROR + 22)
-#define PRTE_JOB_STATE_FT_RESTART              (PRTE_JOB_STATE_ERROR + 23)
+#define PRTE_JOB_STATE_FT_CHECKPOINT           (PRTE_JOB_STATE_FT + 1)
+#define PRTE_JOB_STATE_FT_CONTINUE             (PRTE_JOB_STATE_FT + 2)
+#define PRTE_JOB_STATE_FT_RESTART              (PRTE_JOB_STATE_FT + 3)
 
 
 /* Define a boundary so that external developers

--- a/src/mca/plm/rsh/plm_rsh_component.c
+++ b/src/mca/plm/rsh/plm_rsh_component.c
@@ -20,6 +20,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -349,7 +350,7 @@ static int rsh_component_query(prte_mca_base_module_t **module, int *priority)
         if (NULL != prte_plm_rsh_component.agent) {
             prte_show_help("help-plm-rsh.txt", "agent-not-found", true,
                            prte_plm_rsh_component.agent);
-            PRTE_FORCED_TERMINATE(PRTE_ERR_NOT_FOUND);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_NEVER_LAUNCHED);
             return PRTE_ERR_FATAL;
         }
         /* this isn't an error - we just cannot be selected */

--- a/src/mca/plm/rsh/plm_rsh_module.c
+++ b/src/mca/plm/rsh/plm_rsh_module.c
@@ -1290,8 +1290,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
     return;
 
  cleanup:
+    PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_START);
     PRTE_RELEASE(state);
-    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
 }
 
 /**

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -479,13 +479,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
         prte_argv_free(env);
     }
 
-    /* cleanup the caddy */
-    PRTE_RELEASE(state);
-
     /* check for failed launch - if so, force terminate */
     if (failed_launch) {
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
     }
+
+    /* cleanup the caddy */
+    PRTE_RELEASE(state);
 }
 
 

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -235,7 +235,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                     /* an allocation is required, so this is fatal */
                     PRTE_DESTRUCT(&nodes);
                     prte_show_help("help-ras-base.txt", "ras-base:no-allocation", true);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
                     PRTE_RELEASE(caddy);
                     return;
                 } else {
@@ -247,7 +247,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
             }
             PRTE_ERROR_LOG(rc);
             PRTE_DESTRUCT(&nodes);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -265,7 +265,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
             PRTE_ERROR_LOG(rc);
             PRTE_DESTRUCT(&nodes);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -277,7 +277,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
          */
         PRTE_DESTRUCT(&nodes);
         prte_show_help("help-ras-base.txt", "ras-base:no-allocation", true);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
         PRTE_RELEASE(caddy);
         return;
     }
@@ -298,7 +298,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         /* a rank/seqfile was provided - parse it */
         if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&nodes, hosts))) {
             PRTE_DESTRUCT(&nodes);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             free(hosts);
             return;
@@ -315,7 +315,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
          */
         if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
             PRTE_ERROR_LOG(rc);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -345,7 +345,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
             if (PRTE_SUCCESS != (rc = prte_util_add_dash_host_nodes(&nodes, hosts, true))) {
                 free(hosts);
                 PRTE_DESTRUCT(&nodes);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
                 PRTE_RELEASE(caddy);
                 return;
             }
@@ -362,7 +362,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
          */
         if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
             PRTE_ERROR_LOG(rc);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -400,7 +400,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                 free(hosts);
                 PRTE_DESTRUCT(&nodes);
                 /* set an error event */
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
                 PRTE_RELEASE(caddy);
                 return;
             }
@@ -417,7 +417,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
          */
         if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
             PRTE_ERROR_LOG(rc);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -437,7 +437,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&nodes,
                                                                prte_default_hostfile))) {
             PRTE_DESTRUCT(&nodes);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -452,7 +452,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
          */
         if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
             PRTE_ERROR_LOG(rc);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
             return;
         }
@@ -473,7 +473,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
     if (NULL == node) {
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         PRTE_DESTRUCT(&nodes);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
         PRTE_RELEASE(caddy);
         return;
     }
@@ -495,7 +495,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
     if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
         PRTE_ERROR_LOG(rc);
         PRTE_DESTRUCT(&nodes);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
         PRTE_RELEASE(caddy);
         return;
     }
@@ -514,7 +514,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                                                      NULL, PMIX_GLOBAL, NULL, 0,
                                                      NULL, NULL))) {
             PMIX_ERROR_LOG(ret);
-            PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
         }
     }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -958,14 +958,14 @@ static void recv_data(int fd, short args, void *cbdata)
          */
         PRTE_DESTRUCT(&nds);
         prte_show_help("help-ras-base.txt", "ras-base:no-allocation", true);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_ALLOC_FAILED);
     }
 
     /* store the found nodes */
     if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nds, jdata))) {
         PRTE_ERROR_LOG(rc);
         PRTE_DESTRUCT(&nds);
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_ALLOC_FAILED);
         return;
     }
     PRTE_DESTRUCT(&nds);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -233,8 +233,7 @@ static void files_ready(int status, void *cbdata)
     prte_job_t *jdata = (prte_job_t*)cbdata;
 
     if (PRTE_SUCCESS != status) {
-        PRTE_FORCED_TERMINATE(status);
-        return;
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
     } else {
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP);
     }
@@ -293,21 +292,21 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             rc = prte_util_nidmap_create(prte_node_pool, buf);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             /* provide the info on the capabilities of each node */
             if (PRTE_SUCCESS != (rc = prte_util_pass_node_info(buf))) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             /* get wireup info for daemons */
@@ -322,7 +321,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
                     PMIX_DATA_BUFFER_RELEASE(buf);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
                 /* use the PMIx data support to pack it */
@@ -334,7 +333,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     PMIX_INFO_DESTRUCT(&info);
                     PMIX_DATA_BUFFER_RELEASE(buf);
                     return;
@@ -343,7 +342,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     PMIX_INFO_DESTRUCT(&info);
                     PMIX_DATA_BUFFER_RELEASE(buf);
                     return;
@@ -354,7 +353,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     PMIX_INFO_DESTRUCT(&info);
                     PMIX_DATA_BUFFER_RELEASE(buf);
                 }
@@ -363,7 +362,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     PMIX_INFO_DESTRUCT(&info);
                     PMIX_DATA_BUFFER_RELEASE(buf);
                 }
@@ -372,7 +371,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
                     PMIX_DATA_BUFFER_RELEASE(wireup);
-                    PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     PMIX_INFO_DESTRUCT(&info);
                     PMIX_DATA_BUFFER_RELEASE(buf);
                 }
@@ -385,7 +384,7 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             /* release the data since it has now been copied into our buffer */
@@ -399,7 +398,7 @@ static void vm_ready(int fd, short args, void *cbdata)
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);
                 PMIX_PROC_FREE(sig.signature, 1);
-                PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             PMIX_DATA_BUFFER_RELEASE(buf);
@@ -433,7 +432,7 @@ static void vm_ready(int fd, short args, void *cbdata)
 
     /* position any required files */
     if (PRTE_SUCCESS != prte_filem.preposition_files(caddy->jdata, files_ready, caddy->jdata)) {
-        PRTE_FORCED_TERMINATE(PRTE_ERROR_DEFAULT_EXIT_CODE);
+        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
     }
     PRTE_RELEASE(caddy);
 }

--- a/src/mca/state/state.h
+++ b/src/mca/state/state.h
@@ -73,13 +73,6 @@ PRTE_EXPORT extern prte_mca_base_framework_t prte_state_base_framework;
 /* For ease in debugging the state machine, it is STRONGLY recommended
  * that the functions be accessed using the following macros
  */
-#define PRTE_FORCED_TERMINATE(x)                                                    \
-    do {                                                                            \
-        if (!prte_abnormal_term_ordered) {                                          \
-            prte_output(0, "FORCE TERMINATE ORDERED AT %s:%d - error %s(%d)",       \
-                        __FILE__, __LINE__, PRTE_ERROR_NAME((x)), (x));             \
-        } \
-    } while(0);
 
 /* Timestamp for state printouts */
 #define PRTE_STATE_GET_TIMESTAMP(t)                                         \

--- a/src/util/error_strings.c
+++ b/src/util/error_strings.c
@@ -132,6 +132,8 @@ const char *prte_job_state_to_str(prte_job_state_t state)
         return "MAP FAILED";
     case PRTE_JOB_STATE_CANNOT_LAUNCH:
         return "CANNOT LAUNCH";
+    case PRTE_JOB_STATE_FILES_POSN_FAILED:
+        return "FILE PREPOSITION FAILED";
     case PRTE_JOB_STATE_FT_CHECKPOINT:
         return "FAULT TOLERANCE CHECKPOINT";
     case PRTE_JOB_STATE_FT_CONTINUE:


### PR DESCRIPTION
Activate the correct job state instead of just outputting that a
problem occurred. In most cases, we will abort the DVM because
we don't have any other recovery mode available to us. However,
there are some places where the error only impacts the application
being launched - in those cases, we can leave the DVM "up" and
simply report the job error.

Fixes #487 

Signed-off-by: Ralph Castain <rhc@pmix.org>