### PR TITLE
Correctly account for user slot directives under DVM

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -462,6 +462,7 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *tota
                 } else {
                     s = node->slots - node->slots_inuse;
                 }
+                node->slots_available = s;
                 /* add the available slots */
                 PRTE_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
                                      "%s node %s has %d slots available",
@@ -510,8 +511,9 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *tota
              item != prte_list_get_end(allocated_nodes);
              item = prte_list_get_next(item)) {
             node = (prte_node_t*)item;
-            prte_output(0, "    node: %s daemon: %s", node->name,
-                        (NULL == node->daemon) ? "NULL" : PRTE_VPID_PRINT(node->daemon->name.rank));
+            prte_output(0, "    node: %s daemon: %s slots_available: %d", node->name,
+                        (NULL == node->daemon) ? "NULL" : PRTE_VPID_PRINT(node->daemon->name.rank),
+                        node->slots_available);
         }
     }
 

--- a/src/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/src/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -333,8 +333,8 @@ static int mindist_map(prte_job_t *jdata)
                             }
                         }
                         /* if slots < avg + extra (adjusted for cpus/proc), then try to take all */
-                        if ((node->slots - node->slots_inuse) < (navg + extra_procs_to_assign)) {
-                            num_procs_to_assign = node->slots - node->slots_inuse;
+                        if (node->slots_available < (navg + extra_procs_to_assign)) {
+                            num_procs_to_assign = node->slots_available;
                             /* if we can't take any proc, skip following steps */
                             if (num_procs_to_assign == 0) {
                                 continue;
@@ -349,8 +349,8 @@ static int mindist_map(prte_job_t *jdata)
                                             navg, num_procs_to_assign, extra_procs_to_assign);
                     }
                 } else {
-                    num_procs_to_assign = ((int)app->num_procs - nprocs_mapped) > node->slots ?
-                            node->slots : ((int)app->num_procs - nprocs_mapped);
+                    num_procs_to_assign = ((int)app->num_procs - nprocs_mapped) > node->slots_available ?
+                            node->slots_available : ((int)app->num_procs - nprocs_mapped);
                 }
 
                 if (bynode) {

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -286,6 +286,14 @@ static int ppr_mapper(prte_job_t *jdata)
              * that many procs on this node
              */
             if (PRTE_HWLOC_NODE_LEVEL == start) {
+                if (ppr[start] > node->slots_available) {
+                    /* not enough slots available for this request */
+                    prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error",
+                                   true, ppr[start], app->app);
+                    PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
+                    rc = PRTE_ERR_SILENT;
+                    goto error;
+                }
                 obj = hwloc_get_root_obj(node->topology->topo);
                 for (j=0; j < ppr[start] && nprocs_mapped < total_procs; j++) {
                     if (NULL == (proc = prte_rmaps_base_setup_proc(jdata, node, idx))) {
@@ -299,10 +307,10 @@ static int ppr_mapper(prte_job_t *jdata)
                 /* get the number of lowest resources on this node */
                 nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
                                                            lowest, cache_level);
-                /* Map up to number of slots on node or number of specified resource on node
+                /* Map up to number of slots_available on node or number of specified resource on node
                  * whichever is less. */
-                if (node->slots < (int)nobjs) {
-                    num_available = node->slots;
+                if (node->slots_available < (int)nobjs) {
+                    num_available = node->slots_available;
                 }
                 else {
                     num_available = nobjs;


### PR DESCRIPTION
We don't want to change the overall allocation on a per-job
basis as that would mess everything up for subsequent jobs.
So track the available slots per-job and have the mappers
use that value instead of allocated slots.

Fixes https://github.com/openpmix/prrte/issues/719

Signed-off-by: Ralph Castain <rhc@pmix.org>