### PR TITLE
Add prterun manpage, cleanup other manpages

### DIFF
--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -21,7 +21,10 @@
 
 include $(top_srcdir)/Makefile.prte-rules
 
-MD_FILES = prte.1.md
+MD_FILES = \
+	prte.1.md \
+	prte-map.1.md
+	prterun.1.md
 man_pages_from_md = $(MD_FILES:.1.md=.1)
 EXTRA_DIST = $(MD_FILES) $(man_pages_from_md)
 AM_LDFLAGS = $(PRTE_EXTRA_LIB_LDFLAGS) $(prte_hwloc_LDFLAGS) $(prte_libevent_LDFLAGS) $(prte_pmix_LDFLAGS)
@@ -59,6 +62,8 @@ prte_LDADD = \
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f prterun$(EXEEXT); $(LN_S) prte$(EXEEXT) prterun$(EXEEXT))
+	(cd $(DESTDIR)$(mandir)/man1; rm -f prte-rank.1 ; $(LN_S) prte-map.1 prte-rank.1)
+	(cd $(DESTDIR)$(mandir)/man1; rm -f prte-bind.1 ; $(LN_S) prte-map.1 prte-bind.1)
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/prterun$(EXEEXT)

--- a/src/tools/prte/prte-map.1.md
+++ b/src/tools/prte/prte-map.1.md
@@ -23,8 +23,8 @@ job. Most of the command line controls are targeted to `prun` since each job has
 its own unique requirements.
 
 `prterun` is just a wrapper around `prte` for a single job PRTE DVM. It is
-doing the job of both `prte` and `prun`, and, as such, accept the sum all of
-thier command line arguments. Any example that uses `prun` can substitue the
+doing the job of both `prte` and `prun`, and, as such, accepts the sum all of
+their command line arguments. Any example that uses `prun` can substitute the
 use of `prterun` except where otherwise noted.
 
 The `prte` process attempts to automatically discover the nodes in the

--- a/src/tools/prte/prte-map.1.md
+++ b/src/tools/prte/prte-map.1.md
@@ -433,16 +433,12 @@ example,
 :   launches 8 processes. Processes 0-1 on node `aa` since it has 2 slots and
     processes 2-7 on node `bb` since it has 6 slots.
 
-<!--
-// JJH TODO -- this does not work see https://github.com/openpmix/prrte/issues/771
-
 And here is a MIMD example:
 
 `prun --host aa --np 1 hostname : --host bb,cc --np 2 uptime`
 
 :   will launch process 0 running `hostname` on node `aa` and processes 1
     and 2 each running `uptime` on nodes `bb` and `cc`, respectively.
--->
 
 ## Mapping, Ranking, and Binding: Fundamentals
 

--- a/src/tools/prte/prte-map.1.md
+++ b/src/tools/prte/prte-map.1.md
@@ -1,0 +1,785 @@
+# NAME
+
+PRTE: Mapping, Ranking, and Binding
+
+# SYNOPSIS
+
+PRTE employs a three-phase procedure for assigning process locations and ranks:
+
+  1. **mapping**:   Assigns a default location to each process
+  2. **ranking**:   Assigns a unique rank value to each process
+  3. **binding**:   Constrains each process to run on specific processors
+
+This document describes these three phases with examples. Unless
+otherwise noted, this behavior is shared by `prun`, `prterun`, and `prte`.
+
+# QUICK SUMMARY
+
+The two binaries that most influence process layout are `prte` and `prun`.
+The `prte` process discovers the allocation, starts the daemons, and defines the
+default mapping/ranking/binding for all jobs.
+The `prun` process defines the specific mapping/ranking/binding for a specific
+job. Most of the command line controls are targeted to `prun` since each job has
+its own unique requirements.
+
+`prterun` is just a wrapper around `prte` for a single job PRTE DVM. It is
+doing the job of both `prte` and `prun`, and, as such, accept the sum all of
+thier command line arguments. Any example that uses `prun` can substitue the
+use of `prterun` except where otherwise noted.
+
+The `prte` process attempts to automatically discover the nodes in the
+allocation by querying supported resource managers. If a support resource
+manager is not present then `prte` relies on a hostfile provided by the user.
+In the absence of such a hostfile it will run all processes on the localhost.
+
+If running under a supported resource manager, the `prte` process will start the
+daemon processes (`prted`) on the remote nodes using the corresponding resource
+manager process starter. If no such starter is available then `rsh` or `ssh`
+is used.
+
+PRTE automatically maps processes in a round-robin fashion by CPU slot
+in one of two ways in the absence of any further directives:
+
+`Map by core:`
+
+:   when the number of total processes in the job is <= 2
+
+`Map by package:`
+
+:   when the number of total processes in the job is > 2
+
+PRTE automatically binds processes. Three binding patterns are used in the
+absence of any further directives:
+
+`Bind to core:`
+
+:   when the number of total processes in the job is <= 2
+
+`Bind to package:`
+
+:   when the number of total processes in the job is > 2
+
+`Bind to none:`
+
+:   when oversubscribed
+
+If your application uses threads, then you probably want to ensure that
+you are either not bound at all (by specifying `--bind-to none`), or
+bound to multiple cores using an appropriate binding level or specific
+number of processing elements per application process.
+
+PRTE automatically ranks processes starting from 0. Two ranking patterns are
+used in the absence of any further directives:
+
+`Rank by slot:`
+
+:   when the number of total processes in the job is <= 2
+
+`Rank by package:`
+
+:   when the number of total processes in the job is > 2
+
+# OPTIONS
+
+Listed here are the subset of command line options that will be used in the
+process mapping/ranking/binding discussion in this manual page.
+
+## Specifying Host Nodes
+
+Use one of the following options to specify which hosts (nodes) within
+the PRTE DVM environment to run on.
+
+`--host <host1,host2,...,hostN>` or `--host <host1:X,host2:Y,...,hostN:Z>`
+
+:   List of hosts on which to invoke processes. After each hostname a
+    colon (`:`) followed by a positive integer can be used to specify the
+    number of slots on that host (`:X`, `:Y`, and `:Z`). The default is `1`.
+
+`--hostfile <hostfile>`
+
+:   Provide a hostfile to use.
+
+`--machinefile <machinefile>`
+
+:   Synonym for `-hostfile`.
+
+`--default-hostfile <hostfile>`
+
+:   Provide a default hostfile to use.
+
+
+## Process Mapping / Ranking / Binding Options
+
+The following options specify the number of processes to launch. Note
+that none of the options imply a particular binding policy - e.g.,
+requesting `N` processes for each socket does not imply that the processes
+will be bound to the socket.
+
+`-c, -n, --n, --np <#>`
+
+:   Run this many copies of the program on the given nodes. This option
+    indicates that the specified file is an executable program and not
+    an application context. If no value is provided for the number of
+    copies to execute (i.e., neither the `-np` nor its synonyms are
+    provided on the command line), `prun` will automatically execute a
+    copy of the program on each process slot (see below for description
+    of a "process slot"). This feature, however, can only be used in
+    the SPMD model and will return an error (without beginning execution
+    of the application) otherwise.
+
+To map processes across sets of objects:
+
+`--map-by <object>`
+
+:   Map to the specified object. See defaults in Quick Summary. Supported
+    options include `slot`, `hwthread`, `core`, `l1cache`, `l2cache`, `l3cache`,
+    `package`, `node`, `seq`, `dist`, `ppr`, and `rankfile`. Any object can
+    include modifiers by adding a colon (`:`) and any combination of:
+    `PE=n` (bind n processing elements to each process), `SPAN` (load balance
+    the processes across the allocation), `OVERSUBSCRIBE` (allow more processes
+    on a node than processing elements), `NOOVERSUBSCRIBE` (`!OVERSUBSCRIBE`),
+    `NOLOCAL` (do not launch processes on the same node as `prun`), `HWTCPUS`
+    (use hardware threads as cpu slots), `CORECPUS` (use cores as cpu slots),
+    `DEVICE=dev` (for `dist` policy), `INHERIT`, `NOINHERIT` (`!INHERIT`),
+    `PE-LIST=a,b` (comma-delimited ranges of cpus to use for this job processed
+    as an unordered pool of CPUs),
+    `FILE=%s` (path to file containing sequential or rankfile entries).
+    `ppr` policy example: `--map-by ppr:N:<object>` will launch `N` times the
+    number of objects of the specified type on each node.
+
+To order processes' ranks:
+
+`--rank-by <object>`
+
+:   Rank in round-robin fashion according to the specified object. See defaults
+    in Quick Summary.
+    Supported options include `slot`, `hwthread`, `core`, `l1cache`, `l2cache`,
+    `l3cache`, `package`, and `node`. Any object can include modifiers
+    by adding a colon : and any combination of: `SPAN` or `FILL`.
+
+To bind processes to sets of objects:
+
+`--bind-to <object>`
+
+:   Bind processes to the specified object. See defaults in Quick Summary.
+    Supported options include `none`, `hwthread`, `core`, `l1cache`,
+    `l2cache`, `l3cache`, and `package`. Any object can include modifiers
+    by adding a colon : and any combination of: `overload-allowed` (if
+    overloading of this object is allowed), and `if-supported` (if that object
+    is supported on this system).
+
+## Diagnostics
+
+`--map-by :DISPLAY`
+
+:   Display a table showing the mapped location of each process prior to
+    launch.
+
+`--map-by :DISPLAYALLOC`
+
+:   Display the detected allocation of resources (e.g., nodes, slots)
+
+`--bind-to :REPORT`
+
+:   Report bindings for launched processes to `stderr`.
+
+# DESCRIPTION
+
+PRTE employs a three-phase procedure for assigning process locations and ranks:
+
+  1. **mapping**:   Assigns a default location to each process
+  2. **ranking**:   Assigns a unique rank value to each process
+  3. **binding**:   Constrains each process to run on specific processors
+
+The first phase of **mapping** is used to assign a default location to each
+process based on the mapper being employed. Mapping by slot, node, and
+sequentially results in the assignment of the processes to the node level. In
+contrast, mapping by object, allows the mapper to assign the process to an
+actual object on each node.
+
+*Note:* The location assigned to the process is independent of where it will be
+bound - the assignment is used solely as input to the binding algorithm.
+
+The second phase focuses on the **ranking** of the process within the job's
+namespace. PRTE separates this from the mapping procedure to allow more
+flexibility in the relative placement of processes.
+
+The third phase of **binding** actually binds each process to a given set of
+processors. This can improve performance if the operating system is placing
+processes suboptimally. For example, it might oversubscribe some multi-core
+processor sockets, leaving other sockets idle; this can lead processes to
+contend unnecessarily for common resources. Or, it might spread processes out
+too widely; this can be suboptimal if application performance is sensitive to
+interprocess communication costs. Binding can also keep the operating system
+from migrating processes excessively, regardless of how optimally those
+processes were placed to begin with.
+
+PRTE's support for process binding depends on the underlying operating system.
+Therefore, certain process binding options may not be available on every system.
+
+
+## Specifying Host Nodes
+
+Host nodes can be identified on the command line with the `--host` option or
+in a hostfile.
+
+For example, assuming no other resource manager or scheduler is involved,
+
+`prte --host aa,aa,bb ./a.out`
+
+:   launches two processes on node `aa` and one on `bb`.
+
+`prun --host aa ./a.out`
+
+:   launches one process on node `aa`.
+
+`prun --host aa:5 ./a.out`
+
+:   launches five processes on node `aa`.
+
+Or, consider the hostfile
+
+```
+$ cat myhostfile
+aa slots=2
+bb slots=2
+cc slots=2
+```
+
+Here, we list both the host names (`aa`, `bb`, and `cc`) but also how
+many "slots" there are for each. Slots indicate how many processes can
+potentially execute on a node. For best performance, the number of
+slots may be chosen to be the number of cores on the node or the
+number of processor sockets.
+
+If the hostfile does not provide slots information, the PRTE DVM will attempt
+to discover the number of cores (or hwthreads, if the `--use-hwthreads-as-cpus`
+option is set) and set the number of slots to that value.
+
+Examples using the hostfile above with and without the `--host` option
+
+`prun --hostfile myhostfile ./a.out`
+
+:   will launch two processes on each of the three nodes.
+
+`prun --hostfile myhostfile --host aa ./a.out`
+
+:   will launch two processes, both on node `aa`.
+
+`prun --hostfile myhostfile --host dd ./a.out`
+
+:   will find no hosts to run on and abort with an error. That is, the
+    specified host `dd` is not in the specified hostfile.
+
+When running under resource managers (e.g., SLURM, Torque, etc.), PRTE will
+obtain both the hostnames and the number of slots directly from the resource
+manger. The behavior of `--host` in that environment will behave the same as
+if a hostfile was provided (since it is provided by the resource manager).
+
+
+## Specifying Number of Processes
+
+As we have just seen, the number of processes to run can be set using
+the hostfile. Other mechanisms exist.
+
+The number of processes launched can be specified as a multiple of the
+number of nodes or processor sockets available. Consider the hostfile below for
+the examples that follow.
+
+```
+$ cat myhostfile
+aa
+bb
+```
+
+For example,
+
+`prun --hostfile myhostfile --map-by ppr:2:package ./a.out`
+
+:   launches processes 0-3 on node `aa` and process 4-7 on node `bb`, where
+    `aa` and `bb` are both dual-package nodes. The `--map-by ppr:2:package`
+    option also turns on the `--bind-to package` option, which is discussed
+    in a later section.
+
+`prun --hostfile myhostfile --map-by ppr:2:node ./a.out`
+
+:   launches processes 0-1 on node `aa` and processes 2-3 on node `bb`.
+
+`prun --hostfile myhostfile --map-by ppr:1:node ./a.out`
+
+:   launches one process per host node.
+
+Another alternative is to specify the number of processes with the `--np`
+option. Consider now the hostfile
+
+```
+$ cat myhostfile
+aa slots=4
+bb slots=4
+cc slots=4
+```
+
+Now,
+
+`prun --hostfile myhostfile --np 6 ./a.out`
+
+:   will launch processes 0-3 on node `aa` and processes 4-5 on node `bb`.
+    The remaining slots in the hostfile will not be used since the `-np`
+    option indicated that only 6 processes should be launched.
+
+## Mapping Processes to Nodes: Using Policies
+
+The examples above illustrate the default mapping of process processes
+to nodes. This mapping can also be controlled with various `prun`/`prterun`
+options that describe mapping policies.
+
+```
+$ cat myhostfile
+aa slots=4
+bb slots=4
+cc slots=4
+```
+
+Consider the hostfile above, with `--np 6`:
+
+```
+                              node aa      node bb      node cc
+prun                          0 1 2 3      4 5
+prun --map-by node            0 1          2 3          4 5
+prun --map-by node:NOLOCAL                 0 1 2        3 4 5
+```
+
+The `--map-by node` option will load balance the processes across the
+available nodes, numbering each process in a round-robin fashion.
+
+The `:NOLOCAL` qualifier to `--map-by` prevents any processes from being mapped
+onto the local host (in this case node `aa`). While `prun` typically consumes
+few system resources, the `:NOLOCAL` qualifier can be helpful for launching
+very large jobs where `prun` may actually need to use noticeable amounts of
+memory and/or processing time.
+
+Just as `--np` can specify fewer processes than there are slots, it can
+also oversubscribe the slots. For example, with the same hostfile:
+
+`prun --hostfile myhostfile --np 14 ./a.out`
+
+:   will produce an error since the default `:NOOVERSUBSCRIBE` qualifier to
+    `--map-by` prevents oversubscription.
+
+To oversubscribe the nodes you can use the `:OVERSUBSCRIBE` qualifier to
+`--map-by`:
+
+`prun --hostfile myhostfile --np 14 --map-by :OVERSUBSCRIBE ./a.out`
+
+:   will launch processes 0-5 on node `aa`, 6-9 on `bb`, and 10-13 on `cc`.
+
+Limits to oversubscription can also be specified in the hostfile itself:
+```
+% cat myhostfile
+aa slots=4 max_slots=4
+bb         max_slots=8
+cc slots=4
+```
+
+The `max_slots` field specifies such a limit. When it does, the `slots`
+value defaults to the limit. Now:
+
+// JJH TODO -- this does not work see https://github.com/openpmix/prrte/issues/770
+
+`prun --hostfile myhostfile --np 14 --map-by :OVERSUBSCRIBE ./a.out`
+
+:   causes the first 12 processes to be launched as before, but the
+    remaining two processes will be forced onto node cc. The other two
+    nodes are protected by the hostfile against oversubscription by this
+    job.
+
+Using the `:NOOVERSUBSCRIBE` qualifier to `--map-by` option can be helpful
+since the PRTE DVM currently does not get "max_slots" values from the
+resource manager.
+
+Of course, `--np` can also be used with the `--host` option. For
+example,
+
+`prun --host aa,bb --np 8 ./a.out`
+
+:   will produce an error since the default `:NOOVERSUBSCRIBE` qualifier to
+    `--map-by` prevents oversubscription.
+
+`prun --host aa,bb --np 8 --map-by :OVERSUBSCRIBE ./a.out`
+
+:   launches 8 processes. Since only two hosts are specified, after the
+    first two processes are mapped, one to `aa` and one to `bb`, the
+    remaining processes oversubscribe the specified hosts evenly.
+
+`prun --host aa:2,bb:6 --np 8 ./a.out`
+
+:   launches 8 processes. Processes 0-1 on node `aa` since it has 2 slots and
+    processes 2-7 on node `bb` since it has 6 slots.
+
+And here is a MIMD example:
+
+// JJH TODO -- this does not work see https://github.com/openpmix/prrte/issues/771
+
+`prun --host aa --np 1 hostname : --host bb,cc --np 2 uptime`
+
+:   will launch process 0 running `hostname` on node `aa` and processes 1
+    and 2 each running `uptime` on nodes `bb` and `cc`, respectively.
+
+
+## Mapping, Ranking, and Binding: Fundamentals
+
+The mapping of process processes to nodes can be defined not just with
+general policies but also, if necessary, using arbitrary mappings that
+cannot be described by a simple policy. One can use the "sequential
+mapper," which reads the hostfile line by line, assigning processes to
+nodes in whatever order the hostfile specifies. Use the
+`--prtemca rmaps seq` option.
+
+For example, using the hostfile below:
+```
+% cat myhostfile
+aa slots=4
+bb slots=4
+cc slots=4
+```
+
+The command below will launch three processes, one on each of nodes `aa`, `bb`,
+and `cc`, respectively. The slot counts don't matter; one process is launched
+per line on whatever node is listed on the line.
+```
+% prun --hostfile myhostfile --prtemca rmaps seq ./a.out
+```
+
+The *ranking* phase is best illustrated by considering the following hostfile
+and test cases we used the `--map-by ppr:2:package` option:
+
+```
+% cat myhostfile
+aa
+bb
+```
+
+```
+                         node aa       node bb
+--rank-by core           0 1 ! 2 3     4 5 ! 6 7
+--rank-by package        0 2 ! 1 3     4 6 ! 5 7
+--rank-by package:SPAN   0 4 ! 1 5     2 6 ! 3 7
+```
+
+Ranking by core and by slot provide the identical result - a simple
+progression of ranks across each node. Ranking by package does a
+round-robin ranking within each node until all processes have been
+assigned a rank, and then progresses to the next node. Adding the `:SPAN`
+modifier to the ranking directive causes the ranking algorithm to treat
+the entire allocation as a single entity - thus, the process ranks are
+assigned across all sockets before circling back around to the
+beginning.
+
+The *binding* phase restricts the process to a subset of the CPU resources
+on the node.
+
+The processors to be used for binding can be identified in terms of
+topological groupings - e.g., binding to an l3cache will bind each
+process to all processors within the scope of a single L3 cache within
+their assigned location. Thus, if a process is assigned by the mapper to
+a certain package, then a `--bind-to l3cache` directive will cause the
+process to be bound to the processors that share a single L3 cache
+within that package.
+
+To help balance loads, the binding directive uses a round-robin method
+when binding to levels lower than used in the mapper. For example,
+consider the case where a job is mapped to the package level, and then
+bound to core. Each package will have multiple cores, so if multiple
+processes are mapped to a given package, the binding algorithm will
+assign each process located to a package to a unique core in a
+round-robin manner.
+
+Alternatively, processes mapped by l2cache and then bound to package will
+simply be bound to all the processors in the package where they are
+located. In this manner, users can exert detailed control over relative
+process location and binding.
+
+Process mapping/ranking/binding can also be set with MCA parameters. Their
+usage is less convenient than that of the command line options. On the other
+hand, MCA parameters can be set not only on the `prun` command line, but
+alternatively in a system or user `mca-params.conf` file or as environment
+variables, as described in the MCA section below. Some examples include:
+
+```
+prun option          MCA parameter key           value
+--map-by core        rmaps_base_mapping_policy   core
+--map-by package     rmaps_base_mapping_policy   package
+--rank-by core       rmaps_base_ranking_policy   core
+--bind-to core       hwloc_base_binding_policy   core
+--bind-to socket     hwloc_base_binding_policy   socket
+--bind-to none       hwloc_base_binding_policy   none
+```
+
+## Diagnostics
+
+PRTE provides various diagnostic reports that aid the user in verifying and
+tuning the mapping/ranking/binding for a specific job.
+
+The `:REPORT` qualifier to `--bind-to` command line option can be used to
+report process bindings.
+
+As an example, consider a node with:
+ - Two processor packages,
+ - Four cores per package, and
+ - Eight hardware threads per core.
+
+In each of the examples below the binding is reported in a human readable
+format.
+
+```
+$ prun --np 4 --map-by core --bind-to core:REPORT ./a.out
+[node01:103137] MCW rank 0 bound to package[0][core:0]
+[node01:103137] MCW rank 1 bound to package[0][core:1]
+[node01:103137] MCW rank 2 bound to package[0][core:2]
+[node01:103137] MCW rank 3 bound to package[0][core:3]
+```
+
+The example above processes bind to successive cores on the first package.
+
+```
+$ prun --np 4 --map-by package --bind-to package:REPORT ./a.out
+[node01:103115] MCW rank 0 bound to package[0][core:0-9]
+[node01:103115] MCW rank 1 bound to package[1][core:10-19]
+[node01:103115] MCW rank 2 bound to package[0][core:0-9]
+[node01:103115] MCW rank 3 bound to package[1][core:10-19]
+```
+
+The example above processes bind to all cores on successive packages.
+The processes cycle though the packages in a round-robin fashion as many times
+as are needed.
+
+```
+$ prun --np 4 --map-by package:PE=2 --bind-to core:REPORT ./a.out
+[node01:103328] MCW rank 0 bound to package[0][core:0-1]
+[node01:103328] MCW rank 1 bound to package[1][core:10-11]
+[node01:103328] MCW rank 2 bound to package[0][core:2-3]
+[node01:103328] MCW rank 3 bound to package[1][core:12-13]
+```
+
+The example above shows us that 2 cores have been bound per process.
+The `:PE=2` qualifier states that 2 processing elements underneath the package
+(which would be cores in this case) are mapped to each process.
+The processes cycle though the packages in a round-robin fashion as many times
+as are needed.
+
+
+```
+$ prun --np 4 --map-by core:PE=2:HWTCPUS --bind-to :REPORT  hostname
+[node01:103506] MCW rank 0 bound to package[0][hwt:0-1]
+[node01:103506] MCW rank 1 bound to package[0][hwt:8-9]
+[node01:103506] MCW rank 2 bound to package[0][hwt:16-17]
+[node01:103506] MCW rank 3 bound to package[0][hwt:24-25]
+```
+
+The example above shows us that 2 hardware threads have been bound per process.
+In this case `prun` is mapping by hardware threads since we used the `:HWTCPUS`
+qualifier. Without that qualifier this command would return an error since
+by default `prun` will not map to resources smaller than a core.
+The `:PE=2` qualifier states that 2 processing elements underneath the core
+(which would be hardware threads in this case) are mapped to each process.
+The processes cycle though the cores in a round-robin fashion as many times
+as are needed.
+
+```
+$ prun --np 4 --bind-to none:REPORT  hostname
+[node01:107126] MCW rank 0 is not bound (or bound to all available processors)
+[node01:107126] MCW rank 1 is not bound (or bound to all available processors)
+[node01:107126] MCW rank 2 is not bound (or bound to all available processors)
+[node01:107126] MCW rank 3 is not bound (or bound to all available processors)
+```
+
+The example above binding is turned off.
+
+## Rankfiles
+
+Another way to specify arbitrary mappings is with a rankfile, which gives you
+detailed control over process binding as well.
+
+Rankfiles are text files that specify detailed information about how individual
+processes should be mapped to nodes, and to which processor(s) they should be
+bound. Each line of a rankfile specifies the location of one process. The
+general form of each line in the rankfile is:
+
+```
+rank <N>=<hostname> slot=<slot list>
+```
+
+// JJH TODO this does not work see https://github.com/openpmix/prrte/issues/772
+
+For example:
+```
+$ cat myrankfile
+rank 0=aa slot=1:0-2
+rank 1=bb slot=0:0,1
+rank 2=cc slot=1-2
+$ prun --host aa,bb,cc,dd --map-by rankfile:FILE=myrankfile ./a.out
+```
+
+Means that
+
+```
+Rank 0 runs on node aa, bound to logical package 1, cores 0-2.
+Rank 1 runs on node bb, bound to logical package 0, cores 0 and 1.
+Rank 2 runs on node cc, bound to logical cores 1 and 2.
+```
+
+Rankfiles can alternatively be used to specify *physical* processor locations.
+In this case, the syntax is somewhat different. Packages are no longer
+recognized, and the slot number given must be the number of the physical PU as
+most OS's do not assign a unique physical identifier to each core in the node.
+Thus, a proper physical rankfile looks something like the following:
+
+```
+$ cat myphysicalrankfile
+rank 0=aa slot=1
+rank 1=bb slot=8
+rank 2=cc slot=6
+$ prun --host aa,bb,cc,dd --map-by rankfile:FILE=myrankfile ./a.out
+```
+
+This means that
+
+```
+Rank 0 will run on node aa, bound to the core that contains physical PU 1
+Rank 1 will run on node bb, bound to the core that contains physical PU 8
+Rank 2 will run on node cc, bound to the core that contains physical PU 6
+```
+
+The hostnames listed above are "absolute," meaning that actual resolvable
+hostnames are specified. However, hostnames can also be specified as
+"relative," meaning that they are specified in relation to an
+externally-specified list of hostnames (e.g., by `prun`'s `--host` argument,
+a hostfile, or a job scheduler).
+
+The "relative" specification is of the form "`+n<X>`", where `X` is an integer
+specifying the Xth hostname in the set of all available hostnames, indexed
+from 0. For example:
+
+```
+$ cat myrankfile
+rank 0=+n0 slot=1:0-2
+rank 1=+n1 slot=0:0,1
+rank 2=+n2 slot=1-2
+$ prun --host aa,bb,cc,dd --map-by rankfile:FILE=myrankfile ./a.out
+```
+
+All package/core slot locations are be specified as *logical* indexes. You can
+use tools such as HWLOC's "lstopo" to find the logical indexes of packages and
+cores.
+
+## Deprecated Options
+
+These deprecated options will be removed in a future release.
+
+`--bind-to-core`
+
+:   **(Deprecated: Use `--bind-to core`)**
+    Bind processes to cores
+
+`-bind-to-socket, --bind-to-socket`
+
+:   **(Deprecated: Use `--bind-to package`)**
+    Bind processes to processor sockets
+
+`--bycore`
+
+:   **(Deprecated: Use `--map-by core`)**
+    Map processes by core
+
+`-bynode, --bynode`
+
+:   **(Deprecated: Use `--map-by node`)**
+    Launch processes one per node, cycling by node in a round-robin
+    fashion. This spreads processes evenly among nodes and assigns ranks
+    in a round-robin, "by node" manner.
+
+`--byslot`
+
+:   **(Deprecated: Use `--map-by slot`)**
+    Map and rank processes round-robin by slot.
+
+`--cpus-per-proc <#perproc>`
+
+:   **(Deprecated: Use `--map-by <obj>:PE=<#perproc>`)**
+    Bind each process to the specified number of cpus.
+
+`--cpus-per-rank <#perrank>`
+
+:   **(Deprecated: Use `--map-by <obj>:PE=<#perrank>`)**
+    Alias for `--cpus-per-proc`.
+
+`--display-allocation`
+
+:   **(Deprecated: Use `--map-by :DISPLAYALLOC`)**
+    Display the detected resource allocation.
+
+`--display-map`
+
+:   **(Deprecated: Use `--map-by :DISPLAY`)**
+    Display a table showing the mapped location of each process prior to
+    launch.
+
+`--nolocal`
+
+:   **(Deprecated: Use `--map-by :NOLOCAL`)**
+    Do not run any copies of the launched application on the same node
+    as `prun` is running. This option will override listing the `localhost`
+    with `--host` or any other host-specifying mechanism.
+
+`--nooversubscribe`
+
+:   **(Deprecated: Use `--map-by :NOOVERSUBSCRIBE`)**
+    Do not oversubscribe any nodes; error (without starting any
+    processes) if the requested number of processes would cause
+    oversubscription. This option implicitly sets "max_slots" equal
+    to the "slots" value for each node. (Enabled by default).
+
+`--npernode <#pernode>`
+
+:   **(Deprecated: Use `--map-by ppr:<#pernode>:node`)**
+    On each node, launch this many processes.
+
+`--npersocket <#persocket>`
+
+:   **(Deprecated: Use `--map-by ppr:<#perpackage>:package`)**
+    On each node, launch this many processes times the number of
+    processor sockets on the node. The `--npersocket` option also turns
+    on the `--bind-to socket` option. The term `socket` has been globally
+    replaced with `package`.
+
+`--oversubscribe`
+
+:   **(Deprecated: Use `--map-by :OVERSUBSCRIBE`)**
+    Nodes are allowed to be oversubscribed, even on a managed system,
+    and overloading of processing elements.
+
+`--pernode`
+
+:   **(Deprecated: Use `--map-by ppr:1:node`)**
+    On each node, launch one process.
+
+`--ppr`
+
+:   **(Deprecated: Use `--map-by ppr:<list>`)**
+    Comma-separated list of number of processes on a given resource type
+    [default: none].
+
+`--rankfile <FILENAME>`
+
+:   **(Deprecated: Use `--map-by rankfile:FILE=<FILENAME>`)**
+    Use a rankfile for mapping/ranking/binding
+
+`--report-bindings`
+
+:   **(Deprecated: Use `--bind-to :REPORT`)**
+    Report any bindings for launched processes.
+
+`--use-hwthread-cpus`
+
+:   **(Deprecated: Use `--map-by :HWTCPUS`)**
+    Use hardware threads as independent cpus.

--- a/src/tools/prte/prte.1.md
+++ b/src/tools/prte/prte.1.md
@@ -99,8 +99,8 @@ Setting MCA parameters:
 
 `--gpmixmca <key> <value>`
 
-:   Pass global PMIx MCA parameters that are applicable to all contexts.
-    `<key>` is the parameter name; `<value>` is the parameter value.
+:   Pass global PMIx MCA parameters that are applicable to all application
+    contexts. `<key>` is the parameter name; `<value>` is the parameter value.
 
 `--mca <key> <value>`
 
@@ -117,9 +117,11 @@ Setting MCA parameters:
 :   Send arguments to various PRTE MCA modules. See the "MCA" section,
     below.
 
-`-pmixam <arg0>`
+`--pmixam <arg0>`
 
-:   Aggregate PMIx MCA parameter set file list.
+:   Aggregate PMIx MCA parameter set file list. The `arg0` argument is a
+    comma-separated list of tuning files. Each file containing MCA parameter
+    sets for this application context.
 
 The following options are useful for developers; they are not generally
 useful to most PRTE users:

--- a/src/tools/prte/prte.1.md
+++ b/src/tools/prte/prte.1.md
@@ -20,21 +20,24 @@ $ /usr/local/bin/prte ...
 is equivalent to
 
 ```
-$ prte --prefix /usr/local
+$ prte --prefix /usr/local ...
 ```
 
 # QUICK SUMMARY
 
 `prte` will establish a DVM that can be used to execute subsequent
 applications. Use of `prte` can be advantageous, for example, when
-you want to execute a number of short-lived tasks. In such cases, the
-time required to start the PRTE DVM can be a significant fraction of
-the time to execute the overall application. Thus, creating a persistent
-DVM can speed the overall execution. In addition, a persistent DVM will
-support executing multiple parallel applications while maintaining
-separation between their respective cores.
+you want to execute a number of short-lived tasks (e.g., in a workflow
+scenario). In such cases, the time required to start the PRTE DVM can be a
+significant fraction of the time to execute the overall application. Thus,
+creating a persistent PRTE DVM can speed the overall execution. In addition, a
+persistent PRTE DVM will support executing multiple parallel applications while
+maintaining separation between their respective cores.
 
 # OPTIONS
+
+This section includes many commonly used options. There may be other options
+listed with `prte --help`.
 
 `-h, --help`
 
@@ -43,10 +46,42 @@ separation between their respective cores.
 `-V, --version`
 
 :   Print version number. If no other arguments are given, this will
-    also cause prte to exit.
+    also cause `prte` to exit.
+
+`--daemonize`
+
+:   Daemonize the DVM daemons into the background
+
+`--no-ready-msg`
+
+:   Do not print a DVM ready message
+
+`--report-pid <arg0>`
+
+:   Print out `prte`'s PID during startup. The `<arg0>` must be a `-` to
+    indicate that the PID is to be output to `stdout`, a `+` to indicate that
+    the PID is to be output to `stderr`, or a filename to which the PID is to
+    be written.
+
+`--report-uri <arg0>`
+
+:   Print out `prte`'s URI during startup. The `<arg0>` must be a `-` to
+    indicate that the URI is to be output to `stdout`, a `+` to indicate that
+    the URI is to be output to `stderr`, or a filename to which the URI is to
+    be written.
+
+`--system-server`
+
+:   Start the DVM as the system server
+
+`--prefix <dir>`
+
+:   Prefix directory that will be used to set the `PATH` and
+    `LD_LIBRARY_PATH` on the remote node before invoking the PRTE
+    daemon.
 
 Use one of the following options to specify which hosts (nodes) of the
-cluster to use for the DVM.
+cluster to use for the DVM. See prte-map(1) for more details.
 
 `-H, --host <host1,host2,...,hostN>`
 
@@ -60,17 +95,11 @@ cluster to use for the DVM.
 
 :   Synonym for `-hostfile`.
 
-`--prefix <dir>`
-
-:   Prefix directory that will be used to set the `PATH` and
-    `LD_LIBRARY_PATH` on the remote node before invoking the PRTE
-    daemon.
-
 Setting MCA parameters:
 
-`--gmca <key> <value>`
+`--gpmixmca <key> <value>`
 
-:   Pass global MCA parameters that are applicable to all contexts.
+:   Pass global PMIx MCA parameters that are applicable to all contexts.
     `<key>` is the parameter name; `<value>` is the parameter value.
 
 `--mca <key> <value>`
@@ -78,12 +107,19 @@ Setting MCA parameters:
 :   Send arguments to various MCA modules. See the "MCA" section,
     below.
 
-`--report-uri <channel>`
+`--pmixmca <key> <value>`
 
-:   Print out prte's URI during startup. The channel must be
-    either a '-' to indicate that the URI is to be output to stdout, a
-    '+' to indicate that the URI is to be output to stderr, or a
-    filename to which the URI is to be written.
+:   Send arguments to various PMIx MCA modules. See the "MCA" section,
+    below.
+
+`--prtemca <key> <value>`
+
+:   Send arguments to various PRTE MCA modules. See the "MCA" section,
+    below.
+
+`-pmixam <arg0>`
+
+:   Aggregate PMIx MCA parameter set file list.
 
 The following options are useful for developers; they are not generally
 useful to most PRTE users:
@@ -97,38 +133,23 @@ useful to most PRTE users:
 :   Enable debugging of the PRTE daemons in the DVM, storing output in
     files.
 
-There may be other options listed with `prte --help`.
 
 # DESCRIPTION
 
 `prte` starts a Distributed Virtual Machine (DVM) by launching a
 daemon on each node of the allocation, as modified or specified by the
-`--host` and `--hostfile` options. Applications can subsequently be
-executed using the `prun` command. The DVM remains in operation until
-receiving the `pterm` command.
+`--host` and `--hostfile` options (See prte-map(1) for more details).
+Applications can subsequently be executed using the `prun` command. The DVM
+remains in operation until receiving the `pterm` command.
 
-## Specifying Host Nodes
+When starting the Distributed Virtual Machine (DVM), `prte` will prefer to use
+the process starter provided by a supported resource manager to start the
+`prted` daemons on the allocated compute nodes. If a supported resource manager
+or process starter is not available then `rsh` or `ssh` are used with a
+corresponding hostfile, or if no hostfile is provided then all `X` copies are
+run on the `localhost`.
 
-Host nodes can be identified on the `prte` command line with the
-`--host` option or in a hostfile.
+# RETURN VALUE
 
-For example,
-
-`prte -H aa,aa,bb ./a.out`
-
-:   launches two processes on node aa and one on bb.
-
-Or, consider the hostfile
-
-```
-$ cat myhostfile aa slots=2 bb slots=2 cc slots=2
-```
-
-Here, we list both the host names (`aa`, `bb`, and `cc`) but also how
-many "slots" there are for each. Slots indicate how many processes can
-potentially execute on a node. For best performance, the number of
-slots may be chosen to be the number of cores on the node or the
-number of processor sockets. If the hostfile does not provide slots
-information, a default of 1 is assumed. When running under resource
-managers (e.g., SLURM, Torque, etc.), PRTE will obtain both the
-hostnames and the number of slots directly from the resource manger.
+`prte` returns `0` if no abnormal daemon failure occurs during the life of the
+DVM, and non-zero otherwise.

--- a/src/tools/prte/prterun.1.md
+++ b/src/tools/prte/prterun.1.md
@@ -1,0 +1,117 @@
+# NAME
+
+prterun - Execute serial and parallel jobs with the PMIx Reference Runtime (PRTE).
+
+# SYNOPSIS
+
+`prterun` does **not** require a running `prte` Distributed Virtual Machine
+(DVM). It will start the `prte` DVM, run a single job, and shutdown the DVM.
+
+Single Process Multiple Data (SPMD) Model:
+
+```
+prterun [ options ] <program> [ <args> ]
+```
+
+Multiple Instruction Multiple Data (MIMD) Model:
+
+```
+prterun [ global_options ] \
+        [ local_options1 ] <program1> [ <args1> ] : \
+        [ local_options2 ] <program2> [ <args2> ] : \
+        ... : \
+        [ local_optionsN ] <programN> [ <argsN> ]
+```
+
+Note that in both models, invoking `prterun` via an absolute path name is
+equivalent to specifying the `--prefix` option with a `<dir>` value
+equivalent to the directory where `prterun` resides, minus its last
+subdirectory. For example:
+
+```
+$ /usr/local/bin/prterun ...
+```
+
+is equivalent to
+
+```
+$ prterun --prefix /usr/local
+```
+
+# QUICK SUMMARY
+
+If you are simply looking for how to run an application, you probably
+want to use a command line of the following form:
+
+```
+$ prterun [ -np X ] [ --hostfile <filename> ] <program>
+```
+
+This will run `X` copies of `<program>` in your current run-time environment
+over the set of hosts specified by `<filename>`, scheduling (by default)
+in a round-robin fashion by CPU slot. If running under a supported resource
+manager a hostfile is usually not required unless the caller wishes to further
+restrict the set of resources used for that job.
+
+# OPTIONS
+
+This section includes many commonly used options. There may be other options
+listed with `prterun --help`.
+
+`prterun` will send the name of the directory where it was invoked on the
+local node to each of the remote nodes, and attempt to change to that
+directory. See the "Current Working Directory" section below for
+further details.
+
+`<program>`
+
+:   The program executable. This is identified as the first
+    non-recognized argument to `prterun`.
+
+`<args>`
+
+:   Pass these run-time arguments to every new process. These must
+    always be the last arguments to `prterun` after the `<program>`.
+    If an app context file is used, `<args>` will be ignored.
+
+`-h, --help`
+
+:   Display help for this command
+
+`-V, --version`
+
+:   Print version number. If no other arguments are given, this will
+    also cause `prterun` to exit.
+
+Since `prterun` combines both `prte` and `prun` it accepts all of the command
+line arguments from both of these tools. See prte(1) and prun(1) for details
+on the command line options. See prte-map(1) for more details on mapping,
+ranking, and binding options.
+
+# DESCRIPTION
+
+One invocation of `prterun` starts the PRTE DVM (i.e., `prte`), runs a single
+job (similar to `prun`), then terminates the DVM (similar to `pterm`). If
+the application is single process multiple data (SPMD), the application
+can be specified on the `prterun` command line.
+
+If the application is multiple instruction multiple data (MIMD),
+comprising of multiple programs, the set of programs and argument can be
+specified in one of two ways: Extended Command Line Arguments, and
+Application Context.
+
+An application context describes the MIMD program set including all
+arguments in a separate file. This file essentially contains multiple
+`prterun` command lines, less the command name itself. The ability to
+specify different options for different instantiations of a program is
+another reason to use an application context.
+
+Extended command line arguments allow for the description of the
+application layout on the command line using colons (`:`) to separate
+the specification of programs and arguments. Some options are globally
+set across all specified programs (e.g. `--hostfile`), while others are
+specific to a single program (e.g. `--np`).
+
+# RETURN VALUE
+
+See prun(1) for details.

--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -27,7 +27,7 @@ attempting to %s.  Returned value %d instead of PRTE_SUCCESS.
 [prun:usage]
 %s (%s) %s
 
-Usage: %s [OPTION]...
+Usage: %s [ options ] <program> [ <args> ]
 Submit job to the PMIx Reference RTE
 
 %s

--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -1,8 +1,11 @@
 # NAME
 
-prun - Execute serial and parallel jobs with the PMIx Reference Server.
+prun - Execute serial and parallel jobs with the PMIx Reference Runtime (PRTE).
 
 # SYNOPSIS
+
+`prun` requires a running `prte` Distributed Virtual Machine (DVM) to be running
+at the time of the call. See prte(1) for more information.
 
 Single Process Multiple Data (SPMD) Model:
 
@@ -14,10 +17,10 @@ Multiple Instruction Multiple Data (MIMD) Model:
 
 ```
 prun [ global_options ] \
-    [ local_options1 ] <program1> [ <args1> ] : \
-    [ local_options2 ] <program2> [ <args2> ] : \
-    ... : \
-    [ local_optionsN ] <programN> [ <argsN> ]
+     [ local_options1 ] <program1> [ <args1> ] : \
+     [ local_options2 ] <program2> [ <args2> ] : \
+     ... : \
+     [ local_optionsN ] <programN> [ <argsN> ]
 ```
 
 Note that in both models, invoking `prun` via an absolute path name is
@@ -44,22 +47,20 @@ want to use a command line of the following form:
 $ prun [ -np X ] [ --hostfile <filename> ] <program>
 ```
 
-This will run X copies of `<program>` in your current run-time
-environment (if running under a supported resource manager, PSRVR's
-`prun` will usually automatically use the corresponding resource manager
-process starter, as opposed to, for example, `rsh or `ssh`, which
-require the use of a hostfile, or will default to running all X copies
-on the localhost), scheduling (by default) in a round-robin fashion by
-CPU slot. See the rest of this page for more details.
+This will run `X` copies of `<program>` in your current run-time environment
+over the set of hosts specified by `<filename>`, scheduling (by default)
+in a round-robin fashion by CPU slot. If running under a supported resource
+manager a hostfile is usually not required unless the caller wishes to further
+restrict the set of resources used for that job.
 
-Please note that prun automatically binds processes. Three binding
+Please note that PRTE automatically binds processes. Three binding
 patterns are used in the absence of any further directives:
 
 `Bind to core:`
 
 :   when the number of processes is <= 2
 
-`Bind to socket:`
+`Bind to package:`
 
 :   when the number of processes is > 2
 
@@ -72,7 +73,16 @@ you are either not bound at all (by specifying `--bind-to none`), or
 bound to multiple cores using an appropriate binding level or specific
 number of processing elements per application process.
 
+Default ranking is by `slot` if number of processes <= 2, otherwise default to
+ranking by `package` (formally known as "socket").
+
+See prte-map(1) for more details on mapping, ranking, and binding options.
+
+
 # OPTIONS
+
+This section includes many commonly used options. There may be other options
+listed with `prun --help`.
 
 `prun` will send the name of the directory where it was invoked on the
 local node to each of the remote nodes, and attempt to change to that
@@ -82,13 +92,13 @@ further details.
 `<program>`
 
 :   The program executable. This is identified as the first
-    non-recognized argument to prun.
+    non-recognized argument to `prun`.
 
 `<args>`
 
 :   Pass these run-time arguments to every new process. These must
-    always be the last arguments to `prun`. If an app context file is
-    used, `<args>` will be ignored.
+    always be the last arguments to `prun` after the `<program>`.
+    If an app context file is used, `<args>` will be ignored.
 
 `-h, --help`
 
@@ -96,7 +106,7 @@ further details.
 
 `-q, --quiet`
 
-:   Suppress informative messages from prun during application
+:   Suppress informative messages from `prun` during application
     execution.
 
 `-v, --verbose`
@@ -106,289 +116,122 @@ further details.
 `-V, --version`
 
 :   Print version number. If no other arguments are given, this will
-    also cause prun to exit.
+    also cause `prun` to exit.
 
-`-N <num>`
 
-:   Launch num processes per node on all allocated nodes (synonym for
-    npernode).
-
-`-display-map, --display-map`
-
-:   Display a table showing the mapped location of each process prior to
-    launch.
-
-`-display-allocation, --display-allocation`
-
-:   Display the detected resource allocation.
-
-`-output-proctable, --output-proctable`
-
-:   Output the debugger proctable after launch.
-
-`-max-vm-size, --max-vm-size <size>`
-
-:   Number of processes to run.
-
-`-novm, --novm`
-
-:   Execute without creating an allocation-spanning virtual machine
-    (only start daemons on nodes hosting application procs).
-
-`-hnp, --hnp <arg0>`
-
-:   Specify the URI of the psrvr process, or the name of the file
-    (specified as file:filename) that contains that info.
-
-Use one of the following options to specify which hosts (nodes) within
-the psrvr to run on.
-
-`-H, -host, --host <host1,host2,...,hostN>`
-
-:   List of hosts on which to invoke processes. Pass +e to allocate only
-    onto empty nodes or +e:N to allocate onto nodes at least N of which
-    are empty (i.e. exclusive to this prun instance).
-
-`-hostfile, --hostfile <hostfile>`
-
-:   Provide a hostfile to use.
-
-`-default-hostfile, --default-hostfile <hostfile>`
-
-:   Provide a default hostfile.
-
-`-machinefile, --machinefile <machinefile>`
-
-:   Synonym for `-hostfile`.
-
-`-cpu-set, --cpu-set <list>`
-
-:   Restrict launched processes to the specified logical cpus on each
-    node (comma-separated list). Note that the binding options will
-    still apply within the specified envelope - e.g., you can elect to
-    bind each process to only one cpu within the specified cpu set.
+## Specifying Number of Processes
 
 The following options specify the number of processes to launch. Note
 that none of the options imply a particular binding policy - e.g.,
 requesting N processes for each socket does not imply that the processes
-will be bound to the socket.
+will be bound to the package.
 
-`-c, -n, --n, -np <#>`
+Additional options and details are presented in prte-map(1). Below are a few
+of the commonly used options.
+
+`-c, -n, --n, --np <#>`
 
 :   Run this many copies of the program on the given nodes. This option
     indicates that the specified file is an executable program and not
     an application context. If no value is provided for the number of
-    copies to execute (i.e., neither the "-np" nor its synonyms are
-    provided on the command line), prun will automatically execute a
+    copies to execute (i.e., neither the `--np` nor its synonyms are
+    provided on the command line), `prun` will automatically execute a
     copy of the program on each process slot (see below for description
     of a "process slot"). This feature, however, can only be used in
     the SPMD model and will return an error (without beginning execution
     of the application) otherwise.
 
-`-map-by,----map-by ppr:N:<object>`
+`-N <num>`
 
-:   Launch N times the number of objects of the specified type on each
-    node.
+:   Launch `num` processes per node on all allocated nodes (synonym for
+    `--map-by prr:<num>:node`).
 
-`-npersocket, --npersocket <#persocket>`
-
-:   On each node, launch this many processes times the number of
-    processor sockets on the node. The `-npersocket` option also turns
-    on the `-bind-to-socket` option. (deprecated in favor of --map-by
-    ppr:n:socket)
-
-`-npernode, --npernode <#pernode>`
-
-:   On each node, launch this many processes. (deprecated in favor of
-    --map-by ppr:n:node)
-
-`-pernode, --pernode`
-
-:   On each node, launch one process -- equivalent to `-npernode` 1.
-    (deprecated in favor of --map-by ppr:1:node)
-
-To map processes:
-
-`-map-by,--map-by <foo>`
-
-:   Map to the specified object, defaults to `socket`. Supported options
-    include `slot`, `hwthread`, `core`, `L1cache`, `L2cache`, `L3cache`,
-    `socket`, `numa`, `board`, `node`, `sequential`, `distance`, and
-    `ppr`. Any object can include modifiers by adding a : and any
-    combination of PE=n (bind n processing elements to each proc), SPAN
-    (load balance the processes across the allocation), OVERSUBSCRIBE
-    (allow more processes on a node than processing elements), and
-    NOOVERSUBSCRIBE. This includes PPR, where the pattern would be
-    terminated by another colon to separate it from the modifiers.
-
-`-bycore, --bycore`
-
-:   Map processes by core (deprecated in favor of --map-by core)
-
-`-byslot, --byslot`
-
-:   Map and rank processes round-robin by slot.
-
-`-nolocal, --nolocal`
-
-:   Do not run any copies of the launched application on the same node
-    as prun is running. This option will override listing the localhost
-    with `--host` or any other host-specifying mechanism.
-
-`-nooversubscribe, --nooversubscribe`
-
-:   Do not oversubscribe any nodes; error (without starting any
-    processes) if the requested number of processes would cause
-    oversubscription. This option implicitly sets "max_slots" equal
-    to the "slots" value for each node. (Enabled by default).
-
-`-oversubscribe, --oversubscribe`
-
-:   Nodes are allowed to be oversubscribed, even on a managed system,
-    and overloading of processing elements.
-
-`-bynode, --bynode`
-
-:   Launch processes one per node, cycling by node in a round-robin
-    fashion. This spreads processes evenly among nodes and assigns ranks
-    in a round-robin, "by node" manner.
-
-`-cpu-list, --cpu-list <cpus>`
-
-:   List of processor IDs to bind processes to [default=NULL].
-
-To order processes' ranks:
-
-`--rank-by <foo>`
-
-:   Rank in round-robin fashion according to the specified object,
-    defaults to `slot`. Supported options include slot, hwthread, core,
-    L1cache, L2cache, L3cache, socket, numa, board, and node.
-
-For process binding:
-
-`--bind-to <foo>`
-
-:   Bind processes to the specified object, defaults to `core`.
-    Supported options include slot, hwthread, core, l1cache, l2cache,
-    l3cache, socket, numa, board, and none.
-
-`-cpus-per-proc, --cpus-per-proc <#perproc>`
-
-:   Bind each process to the specified number of cpus. (deprecated in
-    favor of --map-by <obj>:PE=n)
-
-`-cpus-per-rank, --cpus-per-rank <#perrank>`
-
-:   Alias for `-cpus-per-proc`. (deprecated in favor of --map-by
-    <obj>:PE=n)
-
-`-bind-to-core, --bind-to-core`
-
-:   Bind processes to cores (deprecated in favor of --bind-to core)
-
-`-bind-to-socket, --bind-to-socket`
-
-:   Bind processes to processor sockets (deprecated in favor of
-    --bind-to socket)
-
-`-report-bindings, --report-bindings`
-
-:   Report any bindings for launched processes.
-
-For rankfiles:
-
-`-rf, --rankfile <rankfile>`
-
-:   Provide a rankfile file.
+## I/O Management
 
 To manage standard I/O:
 
-`-output-filename, --output-filename <filename>`
+`--output-filename <filename>`
 
-:   Redirect the stdout, stderr, and stddiag of all processes to a
-    process-unique version of the specified filename. Any directories in
-    the filename will automatically be created. Each output file will
-    consist of filename.id, where the id will be the processes' rank,
-    left-filled with zero's for correct ordering in listings.B oth
-    stdout and stderr will be redirected to the file. A relative path
-    value will be converted to an absolute path based on the cwd where
-    prun is executed. Note that this *will not* work on environments
-    where the file system on compute nodes differs from that where prun
-    is executed. This option accepts one case-insensitive directive,
-    specified after a colon: NOCOPY indicates that the output is not to
+:   Redirect the `stdout`, `stderr`, and `stddiag` of all processes to a
+    process-unique version of the specified filename ("filename.id"). Any
+    directories in the filename will automatically be created. Each output file
+    will consist of "filename.id", where the `id` will be the processes' rank,
+    left-filled with zero's for correct ordering in listings. Both
+    `stdout` and `stderr` will be redirected to the file. A relative path
+    value will be converted to an absolute path based on the current working
+    directory where `prun` is executed. Note that this *will not* work in
+    environments where the file system on compute nodes differs from that where
+    `prun` is executed. This option accepts one case-insensitive directive,
+    specified after a colon (`:`): `NOCOPY` indicates that the output is not to
     be echoed to the terminal.
 
-`-output-directory, --output-directory <path>`
+`--output-directory <path>`
 
-:   Redirect the stdout, stderr, and stddiag of all processes to a
+:   Redirect the `stdout`, `stderr`, and `stddiag` of all processes to a
     process-unique location consisting of
-    "<path>/<jobid>/rank.id/stdout[err]", where the id will be
+    "<path>/<jobid>/rank.id/std[out,err,diag]", where the `id` will be
     the processes' rank, left-filled with zero's for correct ordering
     in listings. Any directories in the filename will automatically be
     created. A relative path value will be converted to an absolute path
-    based on the cwd where prun is executed. Note that this *will not*
-    work on environments where the file system on compute nodes differs
-    from that where prun is executed. This option also supports two
+    based on the current working directory where `prun` is executed. Note that
+    this *will not* work on environments where the file system on compute nodes
+    differs from that where `prun` is executed. This option also supports two
     case-insensitive directives, specified in comma-delimited form after
-    a colon: NOJOBID (omits the jobid directory layer) and NOCOPY (do
+    a colon (`:`): `NOJOBID` (omits the jobid directory layer) and `NOCOPY` (do
     not copy the output to the terminal).
 
-`-stdin, --stdin <rank> `
+`--stdin <rank>`
 
-:   The rank of the process that is to receive stdin. The default is to
-    forward stdin to rank 0, but this option can be used to forward
-    stdin to any process. It is also acceptable to specify `none`,
-    indicating that no processes are to receive stdin.
+:   The rank of the process that is to receive `stdin`. The default is to
+    forward `stdin` to rank 0, but this option can be used to forward
+    `stdin` to any process. It is also acceptable to specify `none`,
+    indicating that no processes are to receive `stdin`.
 
-`-merge-stderr-to-stdout, --merge-stderr-to-stdout`
+`--merge-stderr-to-stdout`
 
-:   Merge stderr to stdout for each process.
+:   Merge `stderr` to `stdout` for each process.
 
-`-tag-output, --tag-output`
+`--tag-output`
 
-:   Tag each line of output to stdout, stderr, and stddiag with
-    `[jobid, MCW_rank]<stdxxx>` indicating the process jobid and
-    rank of the process that generated the output, and the channel which
-    generated it.
+:   Tag each line of output to `stdout`, `stderr`, and `stddiag` with
+    `[jobid, MCW_rank]<stdxxx>` indicating the jobid and rank of the process
+    that generated the output, and the channel which generated it.
 
-`-timestamp-output, --timestamp-output`
+`--timestamp-output`
 
-:   Timestamp each line of output to stdout, stderr, and stddiag.
+:   Timestamp each line of output to `stdout`, `stderr`, and `stddiag`.
 
-`-xml, --xml`
+`--xml`
 
-:   Provide all output to stdout, stderr, and stddiag in an xml format.
+:   Provide all output to `stdout`, `stderr`, and `stddiag` in an xml format.
 
-`-xml-file, --xml-file <filename>`
-
-:   Provide all output in XML format to the specified file.
-
-`-xterm, --xterm <ranks>`
+`--xterm <ranks>`
 
 :   Display the output from the processes identified by their ranks in
-    separate xterm windows. The ranks are specified as a comma-separated
-    list of ranges, with a -1 indicating all. A separate window will be
-    created for each specified process. **Note:** xterm will normally
+    separate `xterm` windows. The ranks are specified as a comma-separated
+    list of ranges, with a `-1` indicating all. A separate window will be
+    created for each specified process. **Note:** `xterm` will normally
     terminate the window upon termination of the process running within
     it. However, by adding a "!" to the end of the list of specified
-    ranks, the proper options will be provided to ensure that xterm
+    ranks, the proper options will be provided to ensure that `xterm`
     keeps the window open *after* the process terminates, thus allowing
-    you to see the process' output. Each xterm window will subsequently
-    need to be manually closed. **Note:** In some environments, xterm
+    you to see the process' output. Each `xterm` window will subsequently
+    need to be manually closed. **Note:** In some environments, `xterm`
     may require that the executable be in the user's path, or be
     specified in absolute or relative terms. Thus, it may be necessary
     to specify a local executable as "./foo" instead of just "foo".
-    If xterm fails to find the executable, prun will hang, but still
+    If `xterm` fails to find the executable, `prun` will hang, but still
     respond correctly to a ctrl-c. If this happens, please check that
     the executable is being specified correctly and try again.
 
+## File and Environment Management
+
 To manage files and runtime environment:
 
-`-path, --path <path>`
+`--path <path>`
 
-:   <path> that will be used when attempting to locate the requested
-    executables. This is used prior to using the local PATH setting.
+:   `<path>` that will be used when attempting to locate the requested
+    executables. This is used prior to using the local `PATH` setting.
 
 `--prefix <dir>`
 
@@ -398,9 +241,9 @@ To manage files and runtime environment:
 
 `--noprefix`
 
-:   Disable the automatic --prefix behavior
+:   Disable the automatic `--prefix` behavior
 
-`-s, --preload-binary`
+`-s | --preload-binary`
 
 :   Copy the specified executable(s) to remote machines prior to
     starting remote processes. The executables will be copied to the
@@ -412,24 +255,24 @@ To manage files and runtime environment:
     directory of the remote machines where processes will be launched
     prior to starting those processes.
 
-`-set-cwd-to-session-dir, --set-cwd-to-session-dir`
+`--set-cwd-to-session-dir`
 
 :   Set the working directory of the started processes to their session
     directory.
 
-`-wd <dir>`
+`--wdir <dir>`
 
-:   Synonym for `-wdir`.
-
-`-wdir <dir>`
-
-:   Change to the directory <dir> before the user's program executes.
+:   Change to the directory `<dir>` before the user's program executes.
     See the "Current Working Directory" section for notes on relative
-    paths. **Note:** If the `-wdir` option appears both on the command
+    paths. **Note:** If the `--wdir` option appears both on the command
     line and in an application context, the context will take precedence
-    over the command line. Thus, if the path to the desired wdir is
+    over the command line. Thus, if the path to the desired working directory is
     different on the backend nodes, then it must be specified as an
     absolute path that is correct for the backend node.
+
+`--wd <dir>`
+
+:   Synonym for `--wdir`.
 
 `-x <env>`
 
@@ -443,34 +286,39 @@ The parser for the `-x` option is not very sophisticated; it does not
 even understand quoted values. Users are advised to set variables in the
 environment, and then use `-x` to export (not define) them.
 
-Setting MCA parameters:
+## MCA Parameters
 
-`-gpmca, --gpmca <key> <value>`
+Setting MCA parameters take a few different forms depending the target
+project for the parameter. For example, MCA parameters targeting OpenPMIx
+will contain the string `pmix` in their name, and MCA parameters targeting
+PRTE will contain the string `prte` in their name. See the "MCA" section,
+below, for finer details on the MCA.
 
-:   Pass global MCA parameters that are applicable to all contexts.
+`--gpmixmca <key> <value>`
+
+:   Pass global PMIx MCA parameters that are applicable to all contexts.
     `<key>` is the parameter name; `<value>` is the parameter value.
 
-`-pmca, --pmca <key> <value>`
+`--mca <key> <value>`
 
 :   Send arguments to various MCA modules. See the "MCA" section,
     below.
 
-`-am <arg0>`
+`--pmixmca <key> <value>`
 
-:   Aggregate MCA parameter set file list.
+:   Send arguments to various PMIx MCA modules. See the "MCA" section,
+    below.
 
-`-tune, --tune <tune_file>`
+`--prtemca <key> <value>`
 
-:   Specify a tune file to set arguments for various MCA modules and
-    environment variables. See the "Setting MCA parameters and
-    environment variables from file" section, below.
+:   Send arguments to various PRTE MCA modules. See the "MCA" section,
+    below.
 
-For debugging:
+`-pmixam <arg0>`
 
-`-debug, --debug`
+:   Aggregate PMIx MCA parameter set file list.
 
-:   Invoke the user-level debugger indicated by the
-    `prte_base_user_debugger` MCA parameter.
+## Debugging Options
 
 `--get-stack-traces`
 
@@ -480,11 +328,6 @@ For debugging:
     take a little time and produce a lot of output, especially for large
     process-count jobs.
 
-`-debugger, --debugger <args>`
-
-:   Sequence of debuggers to search for when `--debug` is used (i.e. a
-    synonym for `prte_base_user_debugger` MCA parameter).
-
 `--timeout <seconds>`
 
 :   The maximum number of seconds that `prun` will run. After this many
@@ -492,10 +335,8 @@ For debugging:
     exit status. Using `--timeout` can be also useful when combined
     with the `--get-stack-traces` option.
 
-`-tv, --tv`
 
-:   Launch processes under the TotalView debugger. Deprecated backwards
-    compatibility flag. Synonym for `--debug`.
+## Other Options
 
 There are also other options:
 
@@ -506,105 +347,66 @@ There are also other options:
 
 `--app <appfile>`
 
-:   Provide an appfile, ignoring all other command line options.
+:   Provide an `appfile`, ignoring all other command line options.
 
-`-cf, --cartofile <cartofile>`
-
-:   Provide a cartography file.
-
-`-continuous, --continuous`
+`--continuous`
 
 :   Job is to run until explicitly terminated.
 
-`-disable-recovery, --disable-recovery`
+`--enable-recovery`
+
+:   Enable recovery from process failure [Default = disabled].
+
+`--disable-recovery`
 
 :   Disable recovery (resets all recovery options to off).
 
-`-do-not-launch, --do-not-launch`
+`--do-not-launch`
 
 :   Perform all necessary operations to prepare to launch the
     application, but do not actually launch it.
 
-`-do-not-resolve, --do-not-resolve`
+`--do-not-resolve`
 
 :   Do not attempt to resolve interfaces.
 
-`-enable-recovery, --enable-recovery`
+`--index-argv-by-rank`
 
-:   Enable recovery from process failure [Default = disabled].
+:   Uniquely index `argv[0]` for each process using its rank.
 
-`-index-argv-by-rank, --index-argv-by-rank`
-
-:   Uniquely index argv[0] for each process using its rank.
-
-`-max-restarts, --max-restarts <num>`
+`--max-restarts <num>`
 
 :   Max number of times to restart a failed process.
 
-`--ppr <list>`
-
-:   Comma-separated list of number of processes on a given resource type
-    [default: none]. (deprecated in favor of --map-by ppr:<list>)
-
-`-report-child-jobs-separately, --report-child-jobs-separately`
+`--report-child-jobs-separately`
 
 :   Return the exit status of the primary job only.
 
-`-report-events, --report-events <URI>`
-
-:   Report events to a tool listening at the specified URI.
-
-`-report-pid, --report-pid <channel>`
-
-:   Print out prun's PID during startup. The channel must be either a
-    '-' to indicate that the pid is to be output to stdout, a '+' to
-    indicate that the pid is to be output to stderr, or a filename to
-    which the pid is to be written.
-
-`-report-uri, --report-uri <channel>`
-
-:   Print out prun's URI during startup. The channel must be either a
-    '-' to indicate that the URI is to be output to stdout, a '+' to
-    indicate that the URI is to be output to stderr, or a filename to
-    which the URI is to be written.
-
-`-show-progress, --show-progress`
+`--show-progress`
 
 :   Output a brief periodic report on launch progress.
 
-`-terminate, --terminate`
+`--terminate`
 
 :   Terminate the DVM.
-
-`-use-hwthread-cpus, --use-hwthread-cpus`
-
-:   Use hardware threads as independent cpus.
-
-`-use-regexp, --use-regexp`
-
-:   Use regular expressions for launch.
 
 The following options are useful for developers; they are not generally
 useful to most users:
 
-`-d, --debug-devel`
-
-:   Enable debugging. This is not generally useful for most users.
-
-`-display-devel-allocation, --display-devel-allocation`
+`--display-devel-allocation`
 
 :   Display a detailed list of the allocation being used by this job.
 
-`-display-devel-map, --display-devel-map`
+`--display-devel-map`
 
 :   Display a more detailed table showing the mapped location of each
     process prior to launch.
 
-`-display-diffable-map, --display-diffable-map`
+`--display-diffable-map`
 
 :   Display a diffable process map just before launch.
 
-`-display-topo, --display-topo`
+`--display-topo`
 
 :   Display the topology as part of the process map just before launch.
 
@@ -613,11 +415,9 @@ useful to most users:
 :   When paired with the `--timeout` command line option, report the
     run-time subsystem state of each process when the timeout expires.
 
-There may be other options listed with `prun --help`.
-
 # DESCRIPTION
 
-One invocation of `prun` starts an application running under PSRVR. If
+One invocation of `prun` starts an application running under the PRTE DVM. If
 the application is single process multiple data (SPMD), the application
 can be specified on the `prun` command line.
 
@@ -635,390 +435,14 @@ another reason to use an application context.
 Extended command line arguments allow for the description of the
 application layout on the command line using colons (`:`) to separate
 the specification of programs and arguments. Some options are globally
-set across all specified programs (e.g. --hostfile), while others are
-specific to a single program (e.g. -np).
+set across all specified programs (e.g. `--hostfile`), while others are
+specific to a single program (e.g. `--np`).
 
 ## Specifying Host Nodes
 
-Host nodes can be identified on the `prun` command line with the `-host`
-option or in a hostfile.
+Host nodes can be identified on the `prun` command line with the `--host`
+option or in a hostfile. See prte-map(1) for more details.
 
-For example,
-
-prun -H aa,aa,bb ./a.out
-
-:   launches two processes on node aa and one on bb.
-
-Or, consider the hostfile
-
-```
-$ cat myhostfile aa slots=2 bb slots=2 cc slots=2
-```
-
-Here, we list both the host names (aa, bb, and cc) but also how many
-"slots" there are for each. Slots indicate how many processes can
-potentially execute on a node. For best performance, the number of slots
-may be chosen to be the number of cores on the node or the number of
-processor sockets. If the hostfile does not provide slots information,
-PSRVR will attempt to discover the number of cores (or hwthreads, if the
-use-hwthreads-as-cpus option is set) and set the number of slots to that
-value. This default behavior also occurs when specifying the `-host`
-option with a single hostname. Thus, the command
-
-prun -H aa ./a.out
-
-:   launches a number of processes equal to the number of cores on node
-    aa.
-
-prun -hostfile myhostfile ./a.out
-
-:   will launch two processes on each of the three nodes.
-
-prun -hostfile myhostfile -host aa ./a.out
-
-:   will launch two processes, both on node aa.
-
-prun -hostfile myhostfile -host dd ./a.out
-
-:   will find no hosts to run on and abort with an error. That is, the
-    specified host dd is not in the specified hostfile.
-
-When running under resource managers (e.g., SLURM, Torque, etc.), PSRVR
-will obtain both the hostnames and the number of slots directly from the
-resource manger.
-
-## Specifying Number of Processes
-
-As we have just seen, the number of processes to run can be set using
-the hostfile. Other mechanisms exist.
-
-The number of processes launched can be specified as a multiple of the
-number of nodes or processor sockets available. For example,
-
-prun -H aa,bb -npersocket 2 ./a.out
-
-:   launches processes 0-3 on node aa and process 4-7 on node bb, where
-    aa and bb are both dual-socket nodes. The `-npersocket` option also
-    turns on the `-bind-to-socket` option, which is discussed in a later
-    section.
-
-prun -H aa,bb -npernode 2 ./a.out
-
-:   launches processes 0-1 on node aa and processes 2-3 on node bb.
-
-prun -H aa,bb -npernode 1 ./a.out
-
-:   launches one process per host node.
-
-prun -H aa,bb -pernode ./a.out
-
-:   is the same as `-npernode` 1.
-
-Another alternative is to specify the number of processes with the `-np`
-option. Consider now the hostfile
-
-```
-$ cat myhostfile aa slots=4 bb slots=4 cc slots=4
-```
-
-Now,
-
-`prun -hostfile myhostfile -np 6 ./a.out`
-
-:   will launch processes 0-3 on node aa and processes 4-5 on node bb.
-    The remaining slots in the hostfile will not be used since the `-np`
-    option indicated that only 6 processes should be launched.
-
-## Mapping Processes to Nodes: Using Policies
-
-The examples above illustrate the default mapping of process processes
-to nodes. This mapping can also be controlled with various `prun`
-options that describe mapping policies.
-
-Consider the same hostfile as above, again with `-np` 6:
-
-node aa node bb node cc
-
-prun 0 1 2 3 4 5
-
-prun --map-by node 0 3 1 4 2 5
-
-prun -nolocal 0 1 2 3 4 5
-
-The `--map-by node` option will load balance the processes across the
-available nodes, numbering each process in a round-robin fashion.
-
-The `-nolocal` option prevents any processes from being mapped onto the
-local host (in this case node aa). While `prun` typically consumes few
-system resources, `-nolocal` can be helpful for launching very large
-jobs where `prun` may actually need to use noticeable amounts of memory
-and/or processing time.
-
-Just as `-np` can specify fewer processes than there are slots, it can
-also oversubscribe the slots. For example, with the same hostfile:
-
-prun -hostfile myhostfile -np 14 ./a.out
-
-:   will launch processes 0-3 on node aa, 4-7 on bb, and 8-11 on cc. It
-    will then add the remaining two processes to whichever nodes it
-    chooses.
-
-One can also specify limits to oversubscription. For example, with the
-same hostfile:
-
-prun -hostfile myhostfile -np 14 -nooversubscribe ./a.out
-
-:   will produce an error since `-nooversubscribe` prevents
-    oversubscription.
-
-Limits to oversubscription can also be specified in the hostfile itself:
-% cat myhostfile aa slots=4 max_slots=4 bb max_slots=4 cc slots=4
-
-The `max_slots` field specifies such a limit. When it does, the `slots`
-value defaults to the limit. Now:
-
-prun -hostfile myhostfile -np 14 ./a.out
-
-:   causes the first 12 processes to be launched as before, but the
-    remaining two processes will be forced onto node cc. The other two
-    nodes are protected by the hostfile against oversubscription by this
-    job.
-
-Using the `--nooversubscribe` option can be helpful since PSRVR
-currently does not get "max_slots" values from the resource manager.
-
-Of course, `-np` can also be used with the `-H` or `-host` option. For
-example,
-
-prun -H aa,bb -np 8 ./a.out
-
-:   launches 8 processes. Since only two hosts are specified, after the
-    first two processes are mapped, one to aa and one to bb, the
-    remaining processes oversubscribe the specified hosts.
-
-And here is a MIMD example:
-
-prun -H aa -np 1 hostname : -H bb,cc -np 2 uptime
-
-:   will launch process 0 running `hostname` on node aa and processes 1
-    and 2 each running `uptime` on nodes bb and cc, respectively.
-
-## Mapping, Ranking, and Binding: Oh My!
-
-PSRVR employs a three-phase procedure for assigning process locations
-and ranks:
-
-**Mapping**
-
-:   Assigns a default location to each process
-
-**Ranking**
-
-:   Assigns a rank value to each process
-
-**Binding**
-
-:   Constrains each process to run on specific processors
-
-The *mapping* step is used to assign a default location to each process
-based on the mapper being employed. Mapping by slot, node, and
-sequentially results in the assignment of the processes to the node
-level. In contrast, mapping by object, allows the mapper to assign the
-process to an actual object on each node.
-
-**Note:** the location assigned to the process is independent of where
-it will be bound - the assignment is used solely as input to the binding
-algorithm.
-
-The mapping of process processes to nodes can be defined not just with
-general policies but also, if necessary, using arbitrary mappings that
-cannot be described by a simple policy. One can use the "sequential
-mapper," which reads the hostfile line by line, assigning processes to
-nodes in whatever order the hostfile specifies. Use the `-pmca rmaps
-seq` option. For example, using the same hostfile as before:
-
-prun -hostfile myhostfile -pmca rmaps seq ./a.out
-
-will launch three processes, one on each of nodes aa, bb, and cc,
-respectively. The slot counts don't matter; one process is launched per
-line on whatever node is listed on the line.
-
-Another way to specify arbitrary mappings is with a rankfile, which
-gives you detailed control over process binding as well. Rankfiles are
-discussed below.
-
-The second phase focuses on the *ranking* of the process within the job.
-PSRVR separates this from the mapping procedure to allow more
-flexibility in the relative placement of processes. This is best
-illustrated by considering the following two cases where we used the
----map-by ppr:2:socket option:
-
-node aa node bb
-
-rank-by core 0 1 ! 2 3 4 5 ! 6 7
-
-rank-by socket 0 2 ! 1 3 4 6 ! 5 7
-
-rank-by socket:span 0 4 ! 1 5 2 6 ! 3 7
-
-Ranking by core and by slot provide the identical result - a simple
-progression of ranks across each node. Ranking by socket does a
-round-robin ranking within each node until all processes have been
-assigned a rank, and then progresses to the next node. Adding the `span`
-modifier to the ranking directive causes the ranking algorithm to treat
-the entire allocation as a single entity - thus, the MCW ranks are
-assigned across all sockets before circling back around to the
-beginning.
-
-The *binding* phase actually binds each process to a given set of
-processors. This can improve performance if the operating system is
-placing processes suboptimally. For example, it might oversubscribe some
-multi-core processor sockets, leaving other sockets idle; this can lead
-processes to contend unnecessarily for common resources. Or, it might
-spread processes out too widely; this can be suboptimal if application
-performance is sensitive to interprocess communication costs. Binding
-can also keep the operating system from migrating processes excessively,
-regardless of how optimally those processes were placed to begin with.
-
-The processors to be used for binding can be identified in terms of
-topological groupings - e.g., binding to an l3cache will bind each
-process to all processors within the scope of a single L3 cache within
-their assigned location. Thus, if a process is assigned by the mapper to
-a certain socket, then a `---bind-to l3cache` directive will cause the
-process to be bound to the processors that share a single L3 cache
-within that socket.
-
-To help balance loads, the binding directive uses a round-robin method
-when binding to levels lower than used in the mapper. For example,
-consider the case where a job is mapped to the socket level, and then
-bound to core. Each socket will have multiple cores, so if multiple
-processes are mapped to a given socket, the binding algorithm will
-assign each process located to a socket to a unique core in a
-round-robin manner.
-
-Alternatively, processes mapped by l2cache and then bound to socket will
-simply be bound to all the processors in the socket where they are
-located. In this manner, users can exert detailed control over relative
-MCW rank location and binding.
-
-Finally, `--report-bindings` can be used to report bindings.
-
-As an example, consider a node with two processor sockets, each
-comprising four cores. We run `prun` with `-np 4 --report-bindings` and
-the following additional options:
-
-```
-% prun ... --map-by core --bind-to core [...] ... binding child
-[...,0] to cpus 0001 [...] ... binding child [...,1] to cpus
-0002 [...] ... binding child [...,2] to cpus 0004 [...] ...
-binding child [...,3] to cpus 0008
-```
-
-```
-% prun ... --map-by socket --bind-to socket [...] ... binding
-child [...,0] to socket 0 cpus 000f [...] ... binding child
-[...,1] to socket 1 cpus 00f0 [...] ... binding child [...,2]
-to socket 0 cpus 000f [...] ... binding child [...,3] to socket 1
-cpus 00f0
-```
-
-```
-% prun ... --map-by core:PE=2 --bind-to core [...] ... binding
-child [...,0] to cpus 0003 [...] ... binding child [...,1] to
-cpus 000c [...] ... binding child [...,2] to cpus 0030 [...]
-... binding child [...,3] to cpus 00c0
-```
-
-```
-% prun ... --bind-to none
-```
-
-Here, `--report-bindings` shows the binding of each process as a mask.
-In the first case, the processes bind to successive cores as indicated
-by the masks 0001, 0002, 0004, and 0008. In the second case, processes
-bind to all cores on successive sockets as indicated by the masks 000f
-and 00f0. The processes cycle through the processor sockets in a
-round-robin fashion as many times as are needed. In the third case, the
-masks show us that 2 cores have been bound per process. In the fourth
-case, binding is turned off and no bindings are reported.
-
-PSRVR's support for process binding depends on the underlying operating
-system. Therefore, certain process binding options may not be available
-on every system.
-
-Process binding can also be set with MCA parameters. Their usage is less
-convenient than that of `prun` options. On the other hand, MCA
-parameters can be set not only on the `prun` command line, but
-alternatively in a system or user mca-params.conf file or as environment
-variables, as described in the MCA section below. Some examples include:
-
-prun option MCA parameter key value
-
---map-by core rmaps_base_mapping_policy core --map-by socket
-rmaps_base_mapping_policy socket --rank-by core
-rmaps_base_ranking_policy core --bind-to core
-hwloc_base_binding_policy core --bind-to socket
-hwloc_base_binding_policy socket --bind-to none
-hwloc_base_binding_policy none
-
-## Rankfiles
-
-Rankfiles are text files that specify detailed information about how
-individual processes should be mapped to nodes, and to which
-processor(s) they should be bound. Each line of a rankfile specifies the
-location of one process. The general form of each line in the rankfile
-is:
-
-rank <N>=<hostname> slot=<slot list>
-
-For example:
-
-$ cat myrankfile rank 0=aa slot=1:0-2 rank 1=bb slot=0:0,1 rank 2=cc
-slot=1-2 $ prun -H aa,bb,cc,dd -rf myrankfile ./a.out
-
-Means that
-
-Rank 0 runs on node aa, bound to logical socket 1, cores 0-2. Rank 1
-runs on node bb, bound to logical socket 0, cores 0 and 1. Rank 2 runs
-on node cc, bound to logical cores 1 and 2.
-
-Rankfiles can alternatively be used to specify *physical* processor
-locations. In this case, the syntax is somewhat different. Sockets are
-no longer recognized, and the slot number given must be the number of
-the physical PU as most OS's do not assign a unique physical identifier
-to each core in the node. Thus, a proper physical rankfile looks
-something like the following:
-
-$ cat myphysicalrankfile rank 0=aa slot=1 rank 1=bb slot=8 rank 2=cc
-slot=6
-
-This means that
-
-Rank 0 will run on node aa, bound to the core that contains physical PU
-1 Rank 1 will run on node bb, bound to the core that contains physical
-PU 8 Rank 2 will run on node cc, bound to the core that contains
-physical PU 6
-
-Rankfiles are treated as *logical* by default, and the MCA parameter
-rmaps_rank_file_physical must be set to 1 to indicate that the
-rankfile is to be considered as *physical*.
-
-The hostnames listed above are "absolute," meaning that actual
-resolveable hostnames are specified. However, hostnames can also be
-specified as "relative," meaning that they are specified in relation
-to an externally-specified list of hostnames (e.g., by prun's --host
-argument, a hostfile, or a job scheduler).
-
-The "relative" specification is of the form "+n<X>", where X is an
-integer specifying the Xth hostname in the set of all available
-hostnames, indexed from 0. For example:
-
-$ cat myrankfile rank 0=+n0 slot=1:0-2 rank 1=+n1 slot=0:0,1 rank 2=+n2
-slot=1-2 $ prun -H aa,bb,cc,dd -rf myrankfile ./a.out
-
-All socket/core slot locations are be specified as *logical* indexes.
-You can use tools such as HWLOC's "lstopo" to find the logical
-indexes of socket and cores.
 
 ## Application Context or Executable Program?
 
@@ -1029,49 +453,49 @@ specified, then the file is assumed to be an executable program.
 
 ## Locating Files
 
-If no relative or absolute path is specified for a file, prun will first
+If no relative or absolute path is specified for a file, `prun` will first
 look for files by searching the directories specified by the `--path`
 option. If there is no `--path` option set or if the file is not found
-at the `--path` location, then prun will search the user's PATH
+at the `--path` location, then `prun` will search the user's PATH
 environment variable as defined on the source node(s).
 
 If a relative directory is specified, it must be relative to the initial
 working directory determined by the specific starter used. For example
-when using the rsh or ssh starters, the initial directory is $HOME by
+when using the rsh or ssh starters, the initial directory is `$HOME` by
 default. Other starters may set the initial directory to the current
 working directory from the invocation of `prun`.
 
 ## Current Working Directory
 
-The `-wdir` prun option (and its synonym, `-wd`) allows the user to
+The `--wdir` prun option (and its synonym, `--wd`) allows the user to
 change to an arbitrary directory before the program is invoked. It can
 also be used in application context files to specify working directories
 on specific nodes and/or for specific applications.
 
-If the `-wdir` option appears both in a context file and on the command
+If the `--wdir` option appears both in a context file and on the command
 line, the context file directory will override the command line value.
 
-If the `-wdir` option is specified, prun will attempt to change to the
+If the `--wdir` option is specified, `prun` will attempt to change to the
 specified directory on all of the remote nodes. If this fails, `prun`
 will abort.
 
-If the `-wdir` option is **not** specified, prun will send the directory
+If the `--wdir` option is **not** specified, `prun` will send the directory
 name where `prun` was invoked to each of the remote nodes. The remote
 nodes will try to change to that directory. If they are unable (e.g., if
-the directory does not exist on that node), then prun will use the
+the directory does not exist on that node), then `prun` will use the
 default directory determined by the starter.
 
 All directory changing occurs before the user's program is invoked.
 
 ## Standard I/O
 
-PSRVR directs UNIX standard input to /dev/null on all processes except
+The PRTE DVM directs UNIX standard input to `/dev/null` on all processes except
 the rank 0 process. The rank 0 process inherits standard input from
 `prun`. **Note:** The node that invoked `prun` need not be the same as
-the node where the rank 0 process resides. PSRVR handles the redirection
+the node where the rank 0 process resides. PRTE DVM handles the redirection
 of `prun`'s standard input to the rank 0 process.
 
-PSRVR directs UNIX standard output and error from remote nodes to the
+The PRTE DVM directs UNIX standard output and error from remote nodes to the
 node that invoked `prun` and prints it on the standard output/error of
 `prun`. Local processes inherit the standard output/error of `prun` and
 transfer to it directly.
@@ -1080,29 +504,29 @@ Thus it is possible to redirect standard I/O for applications by using
 the typical shell redirection procedure on `prun`.
 
 ```
-$ prun -np 2 my_app < my_input > my_output
+$ prun --np 2 my_app < my_input > my_output
 ```
 
 Note that in this example *only* the rank 0 process will receive the
 stream from `my_input` on stdin. The stdin on all the other nodes will
-be tied to /dev/null. However, the stdout from all nodes will be
+be tied to `/dev/null`. However, the stdout from all nodes will be
 collected into the `my_output` file.
 
 ## Signal Propagation
 
-When prun receives a SIGTERM and SIGINT, it will attempt to kill the
-entire job by sending all processes in the job a SIGTERM, waiting a
+When `prun` receives a `SIGTERM` and `SIGINT`, it will attempt to kill the
+entire job by sending all processes in the job a `SIGTERM`, waiting a
 small number of seconds, then sending all processes in the job a
-SIGKILL.
+`SIGKILL`.
 
-SIGUSR1 and SIGUSR2 signals received by prun are propagated to all
+`SIGUSR1` and `SIGUSR2` signals received by `prun` are propagated to all
 processes in the job.
 
-A SIGTSTOP signal to prun will cause a SIGSTOP signal to be sent to all
-of the programs started by prun and likewise a SIGCONT signal to prun
-will cause a SIGCONT sent.
+A `SIGTSTOP` signal to `prun` will cause a `SIGSTOP` signal to be sent to all
+of the programs started by `prun` and likewise a `SIGCONT` signal to `prun`
+will cause a `SIGCONT` sent.
 
-Other signals are not currently propagated by prun.
+Other signals are not currently propagated by `prun`.
 
 ## Process Termination / Signal Handling
 
@@ -1113,27 +537,27 @@ application.
 
 ## Process Environment
 
-Processes in the application inherit their environment from the PSRVR
+Processes in the application inherit their environment from the PRTE DVM
 daemon upon the node on which they are running. The environment is
 typically inherited from the user's shell. On remote nodes, the exact
 environment is determined by the boot MCA module used. The `rsh` launch
-module, for example, uses either `rsh`/`ssh` to launch the PSRVR daemon
+module, for example, uses either `rsh`/`ssh` to launch the PRTE DVM daemon
 on remote nodes, and typically executes one or more of the user's
 shell-setup files before launching the daemon. When running dynamically
 linked applications which require the `LD_LIBRARY_PATH` environment
 variable to be set, care must be taken to ensure that it is correctly
-set when booting PSRVR.
+set when booting PRTE DVM.
 
 See the "Remote Execution" section for more details.
 
 ## Remote Execution
 
-PSRVR requires that the `PATH` environment variable be set to find
-executables on remote nodes (this is typically only necessary in `rsh`-
-or `ssh`-based environments -- batch/scheduled environments typically
+The PRTE DVM requires that the `PATH` environment variable be set to find
+executables on remote nodes. This is typically only necessary in `rsh`-
+or `ssh`-based environments. Batch and scheduled environments typically
 copy the current environment to the execution of remote jobs, so if the
 current environment has `PATH` and/or `LD_LIBRARY_PATH` set properly,
-the remote nodes will also have it set properly). If PSRVR was compiled
+the remote nodes will also have it set properly. If the PRTE DVM was compiled
 with shared library support, it may also be necessary to have the
 `LD_LIBRARY_PATH` environment variable set on remote nodes as well
 (especially to find the shared libraries required to run user
@@ -1144,15 +568,15 @@ files to set `PATH` and/or `LD_LIBRARY_PATH`. The `--prefix` option
 is provided for some simple configurations where this is not possible.
 
 The `--prefix` option takes a single argument: the base directory on
-the remote node where PSRVR is installed. PSRVR will use this directory
+the remote node where PRTE DVM is installed. The PRTE DVM will use this directory
 to set the remote `PATH` and `LD_LIBRARY_PATH` before executing any
 user applications. This allows running jobs without having
 pre-configured the `PATH` and `LD_LIBRARY_PATH` on the remote nodes.
 
-PSRVR adds the basename of the current node's "bindir" (the directory
-where PSRVR's executables are installed) to the prefix and uses that to
-set the `PATH` on the remote node. Similarly, PSRVR adds the basename of
-the current node's "libdir" (the directory where PSRVR's libraries
+The PRTE DVM adds the basename of the current node's "bindir" (the directory
+where the PRTE DVM's executables are installed) to the prefix and uses that to
+set the `PATH` on the remote node. Similarly, PRTE DVM adds the basename of
+the current node's "libdir" (the directory where the PRTE DVM's libraries
 are installed) to the prefix and uses that to set the
 `LD_LIBRARY_PATH` on the remote node. For example:
 
@@ -1170,8 +594,8 @@ If the following command line is used:
 $ prun --prefix /remote/node/directory
 ```
 
-PSRVR will add "/remote/node/directory/bin" to the `PATH` and
-"/remote/node/directory/lib64" to the D_LIBRARY_PATH on the remote
+The PRTE DVM will add "/remote/node/directory/bin" to the `PATH` and
+"/remote/node/directory/lib64" to the `LD_LIBRARY_PATH` on the remote
 node before attempting to execute anything.
 
 The `--prefix` option is not sufficient if the installation paths on
@@ -1182,7 +606,9 @@ a common prefix.
 
 Note that executing `prun` via an absolute pathname is equivalent to
 specifying `--prefix` without the last subdirectory in the absolute
-pathname to `prun`. For example:
+pathname to `prun`.
+
+For example:
 
 ```
 $ /usr/local/bin/prun ...
@@ -1191,12 +617,12 @@ $ /usr/local/bin/prun ...
 is equivalent to
 
 ```
-$ prun --prefix /usr/local
+$ prun --prefix /usr/local ...
 ```
 
 ## Exported Environment Variables
 
-All environment variables that are named in the form PMIX_\* will
+All environment variables that are named in the form `PMIX_\*` will
 automatically be exported to new processes on the local and remote
 nodes. Environmental parameters can also be set/forwarded to the new
 processes using the MCA parameter `mca_base_env_list`. While the
@@ -1208,46 +634,49 @@ them; not to define them.
 
 ## Setting MCA Parameters
 
-The `-pmca` switch allows the passing of parameters to various MCA
-(Modular Component Architecture) modules. MCA modules have direct impact
-on programs because they allow tunable parameters to be set at run time
-(such as which BTL communication device driver to use, what parameters
-to pass to that BTL, etc.).
+The `--mca` / `--pmixmca` / `--prtemca` switches (referenced here as
+"`--mca` switches" for brevity) allow the passing of parameters
+to various MCA (Modular Component Architecture) modules. MCA modules have
+direct impact on programs because they allow tunable parameters to be set at
+run time.
 
-The `-pmca` switch takes two arguments: `<key>` and `<value>`. The
+The `-mca` switch takes two arguments: `<key>` and `<value>`. The
 `<key>` argument generally specifies which MCA module will receive the
-value. For example, the `<key>` "btl" is used to select which BTL to
-be used for transporting messages. The `<value>` argument is the value
+value. For example, the `<key>` "rmaps" is used to select which RMAPS to
+be used for mapping processes to nodes. The `<value>` argument is the value
 that is passed. For example:
 
-prun -pmca btl tcp,self -np 1 foo
+`prun -prtemca rmaps seq -np 1 foo`
 
-:   Tells PSRVR to use the "tcp" and "self" BTLs, and to run a
-    single copy of "foo" on an allocated node.
+:   Tells PRTE to use the "seq" RMAPS component, and to run a
+    single copy of "a.out" on an allocated node.
 
-prun -pmca btl self -np 1 foo
-
-:   Tells PSRVR to use the "self" BTL, and to run a single copy of
-    "foo" on an allocated node.
-
-The `-pmca` switch can be used multiple times to specify different
+The `-mca` switch can be used multiple times to specify different
 `<key>` and/or `<value>` arguments. If the same `<key>` is
 specified more than once, the `<value>`s are concatenated with a comma
 (",") separating them.
 
-Note that the `-pmca` switch is simply a shortcut for setting
+Note that the `-mca` switch is simply a shortcut for setting
 environment variables. The same effect may be accomplished by setting
 corresponding environment variables before running `prun`. The form of
-the environment variables that PSRVR sets is:
+the environment variables depends on the type of the `--mca` switch.
 
-```
-PMIX_MCA_<key>=<value>
-```
+`--mca`
 
-Thus, the `-pmca` switch overrides any previously set environment
-variables. The `-pmca` settings similarly override MCA parameters set in
-the $PRTE_PREFIX/etc/psrvr-mca-params.conf or
-$HOME/.psrvr/mca-params.conf file.
+:    `PRTE_MCA_<key>=<value>`
+
+`--pmixmca`
+
+:    `PMIX_MCA_<key>=<value>`
+
+`--prtemca`
+
+:    `PRTE_MCA_<key>=<value>``
+
+Thus, the `-mca` switch overrides any previously set environment
+variables. The `-mca` settings similarly override MCA parameters set in
+the `$PRTE_PREFIX/etc/prte-mca-params.conf` or
+`$HOME/.prte/mca-params.conf` file.
 
 Unknown `<key>` arguments are still set as environment variable --
 they are not checked (by `prun`) for correctness. Illegal or incorrect
@@ -1259,27 +688,12 @@ find the available parameters for a specific component, use the `pinfo`
 command. See the *pinfo(1)* man page for detailed information on the
 command.
 
-## Setting MCA parameters and environment variables from file.
-
-The `-tune` command line option and its synonym `-pmca
-mca_base_envar_file_prefix` allows a user to set mca parameters and
-environment variables with the syntax described below. This option
-requires a single file or list of files separated by "," to follow.
-
-A valid line in the file may contain zero or many "-x", "-pmca", or
-"--pmca" arguments. The following patterns are supported: -pmca var val
--pmca var "val" -x var=val -x var. If any argument is duplicated in
-the file, the last value read will be used.
-
-MCA parameters and environment specified on the command line have higher
-precedence than variables specified in the file.
-
 ## Running as root
 
-The PSRVR team strongly advises against executing `prun` as the root
+The PRTE team strongly advises against executing `prun` as the root
 user. Applications should be run as regular (non-root) users.
 
-Reflecting this advice, prun will refuse to run as root by default. To
+Reflecting this advice, `prun` will refuse to run as root by default. To
 override this default, you can add the `--allow-run-as-root` option to
 the `prun` command line.
 
@@ -1289,7 +703,7 @@ There is no standard definition for what `prun` should return as an exit
 status. After considerable discussion, we settled on the following
 method for assigning the `prun` exit status (note: in the following
 description, the "primary" job is the initial application started by
-prun - all jobs that are spawned by that job are designated
+`prun` - all jobs that are spawned by that job are designated
 "secondary" jobs):
 
 -   if all processes in the primary job normally terminate with exit
@@ -1306,14 +720,14 @@ prun - all jobs that are spawned by that job are designated
     non-zero status, and (b) output a message summarizing the exit
     status of the primary and all secondary jobs.
 
--   if the cmd line option --report-child-jobs-separately is set, we
+-   if the cmd line option `--report-child-jobs-separately` is set, we
     will return -only- the exit status of the primary job. Any non-zero
     exit status in secondary jobs will be reported solely in a summary
     print statement.
 
-By default, PSRVR records and notes that processes exited with non-zero
+By default, PRTE DVM records and notes that processes exited with non-zero
 termination status. This is generally not considered an "abnormal
-termination" - i.e., PSRVR will not abort a job if one or more
+termination" - i.e., the PRTE DVM will not abort a job if one or more
 processes return a non-zero status. Instead, the default behavior simply
 reports the number of processes terminating with non-zero status upon
 completion of the job.
@@ -1322,15 +736,15 @@ However, in some cases it can be desirable to have the job abort when
 any process terminates with non-zero status. For example, a non-PMIx job
 might detect a bad result from a calculation and want to abort, but
 doesn't want to generate a core file. Or a PMIx job might continue past
-a call to PMIx_Finalize, but indicate that all processes should abort
+a call to `PMIx_Finalize`, but indicate that all processes should abort
 due to some post-PMIx result.
 
 It is not anticipated that this situation will occur frequently.
-However, in the interest of serving the broader community, PSRVR now has
+However, in the interest of serving the broader community, the PRTE DVM now has
 a means for allowing users to direct that jobs be aborted upon any
 process exiting with non-zero status. Setting the MCA parameter
-"prte_abort_on_non_zero_status" to 1 will cause PSRVR to abort
-all processes once any process exits with non-zero status.
+"prte_abort_on_non_zero_status" to 1 will cause the PRTE DVM to abort
+all processes once any process exits with non-zero status in that job.
 
 Terminations caused in this manner will be reported on the console as an
 "abnormal termination", with the first process to so exit identified
@@ -1339,12 +753,12 @@ along with its exit status.
 # RETURN VALUE
 
 `prun` returns 0 if all processes started by `prun` exit after calling
-PMIx_Finalize. A non-zero value is returned if an internal error
-occurred in prun, or one or more processes exited before calling
-PMIx_Finalize. If an internal error occurred in prun, the corresponding
+`PMIx_Finalize`. A non-zero value is returned if an internal error
+occurred in `prun`, or one or more processes exited before calling
+`PMIx_Finalize`. If an internal error occurred in `prun`, the corresponding
 error code is returned. In the event that one or more processes exit
-before calling PMIx_Finalize, the return value of the rank of the
-process that `prun` first notices died before calling PMIx_Finalize
+before calling `PMIx_Finalize`, the return value of the rank of the
+process that `prun` first notices died before calling `PMIx_Finalize`
 will be returned. Note that, in general, this will be the first process
 that died but is not guaranteed to be so.
 

--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -141,11 +141,6 @@ of the commonly used options.
     the SPMD model and will return an error (without beginning execution
     of the application) otherwise.
 
-`-N <num>`
-
-:   Launch `num` processes per node on all allocated nodes (synonym for
-    `--map-by prr:<num>:node`).
-
 ## I/O Management
 
 To manage standard I/O:
@@ -191,17 +186,17 @@ To manage standard I/O:
 
 :   Merge `stderr` to `stdout` for each process.
 
-`--tag-output`
+`--map-by :TAGOUTPUT`
 
 :   Tag each line of output to `stdout`, `stderr`, and `stddiag` with
     `[jobid, MCW_rank]<stdxxx>` indicating the jobid and rank of the process
     that generated the output, and the channel which generated it.
 
-`--timestamp-output`
+`--map-by :TIMESTAMPOUTPUT`
 
 :   Timestamp each line of output to `stdout`, `stderr`, and `stddiag`.
 
-`--xml`
+`--map-by :XMLOUTPUT`
 
 :   Provide all output to `stdout`, `stderr`, and `stddiag` in an xml format.
 
@@ -361,14 +356,10 @@ There are also other options:
 
 :   Disable recovery (resets all recovery options to off).
 
-`--do-not-launch`
+`--map-by :DONOTLAUNCH`
 
 :   Perform all necessary operations to prepare to launch the
     application, but do not actually launch it.
-
-`--do-not-resolve`
-
-:   Do not attempt to resolve interfaces.
 
 `--index-argv-by-rank`
 
@@ -393,20 +384,21 @@ There are also other options:
 The following options are useful for developers; they are not generally
 useful to most users:
 
-`--display-devel-allocation`
+`--map-by :DISPLAYALLOC`
 
 :   Display a detailed list of the allocation being used by this job.
 
-`--display-devel-map`
+`--map-by :DISPLAYDEVEL`
 
 :   Display a more detailed table showing the mapped location of each
     process prior to launch.
 
-`--display-diffable-map`
+`--map-by :DISPLAYDIFF`
 
-:   Display a diffable process map just before launch.
+:   Display a diffable process map (mostly intended for developers) just
+    before launch.
 
-`--display-topo`
+`--map-by :DISPLAYTOPO`
 
 :   Display the topology as part of the process map just before launch.
 

--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -53,20 +53,8 @@ in a round-robin fashion by CPU slot. If running under a supported resource
 manager a hostfile is usually not required unless the caller wishes to further
 restrict the set of resources used for that job.
 
-Please note that PRTE automatically binds processes. Three binding
-patterns are used in the absence of any further directives:
-
-`Bind to core:`
-
-:   when the number of processes is <= 2
-
-`Bind to package:`
-
-:   when the number of processes is > 2
-
-`Bind to none:`
-
-:   when oversubscribed
+Please note that PRTE automatically binds processes. See prte-map(1) for
+defaults for the mapping, ranking, and binding of processes.
 
 If your application uses threads, then you probably want to ensure that
 you are either not bound at all (by specifying `--bind-to none`), or
@@ -291,8 +279,8 @@ below, for finer details on the MCA.
 
 `--gpmixmca <key> <value>`
 
-:   Pass global PMIx MCA parameters that are applicable to all contexts.
-    `<key>` is the parameter name; `<value>` is the parameter value.
+:   Pass global PMIx MCA parameters that are applicable to all application
+    contexts. `<key>` is the parameter name; `<value>` is the parameter value.
 
 `--mca <key> <value>`
 
@@ -309,9 +297,11 @@ below, for finer details on the MCA.
 :   Send arguments to various PRTE MCA modules. See the "MCA" section,
     below.
 
-`-pmixam <arg0>`
+`--pmixam <arg0>`
 
-:   Aggregate PMIx MCA parameter set file list.
+:   Aggregate PMIx MCA parameter set file list. The `arg0` argument is a
+    comma-separated list of tuning files. Each file containing MCA parameter
+    sets for this application context.
 
 ## Debugging Options
 

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -350,7 +350,7 @@ static prte_cmd_line_init_t cmd_line_init[] = {
     { '\0', "bind-to", 1, PRTE_CMD_LINE_TYPE_STRING,
       "Binding policy for job. Allowed values: none, hwthread, core, l1cache, l2cache, "
       "l3cache, package, (\"none\" is the default when oversubscribed, \"core\" is "
-      "the default when np<=2, and \"socket\" is the default when np>2). Allowed colon-delimited qualifiers: "
+      "the default when np<=2, and \"package\" is the default when np>2). Allowed colon-delimited qualifiers: "
       "overload-allowed, if-supported",
       PRTE_CMD_LINE_OTYPE_BINDING },
 


### PR DESCRIPTION
 * Add a `prterun.1` manpage that mostly references other pages to
   avoid too much redundancy.
 * Split out the map/rank/bind discussion to a stand alone man
   page since it is shared by `prun` and `prterun` (and, one could
   argue `PMIx_Spawn` in the context of PRTE). Additionally, it
   is quite expansive so this provides a single place to provide
   additional examples and notes on the interplay of these three
   operations.
   - Add a soft link for `prte-rank.1` and `prte-bind.1` which
     link to `prte-map.1` for ease of use.
 * Closes #450
