### PR TITLE
Fix the MPMD case

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -310,11 +310,6 @@ int prte_hwloc_base_get_topology(void)
             PRTE_ERROR_LOG(PRTE_ERR_NOT_SUPPORTED);
             return PRTE_ERR_NOT_SUPPORTED;
         }
-        /* filter the cpus thru any default cpu set */
-        if (PRTE_SUCCESS != (rc = prte_hwloc_base_filter_cpus(prte_hwloc_topology))) {
-            hwloc_topology_destroy(prte_hwloc_topology);
-            return rc;
-        }
     } else {
         prte_output_verbose(1, prte_hwloc_base_output,
                             "hwloc:base loading topology from file %s",
@@ -322,6 +317,12 @@ int prte_hwloc_base_get_topology(void)
         if (PRTE_SUCCESS != (rc = prte_hwloc_base_set_topology(prte_hwloc_base_topo_file))) {
             return rc;
         }
+    }
+
+    /* filter the cpus thru any default cpu set */
+    if (PRTE_SUCCESS != (rc = prte_hwloc_base_filter_cpus(prte_hwloc_topology))) {
+        hwloc_topology_destroy(prte_hwloc_topology);
+        return rc;
     }
 
     /* fill prte_cache_line_size global with the smallest L1 cache

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -256,9 +256,6 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
     if (!prte_list_is_empty(&nodes)) {
         /* flag that the allocation is managed */
         prte_managed_allocation = true;
-        /* since it is managed, we do not attempt to resolve
-         * the nodenames */
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_RESOLVE, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
         /* store the results in the global resource pool - this removes the
          * list items
          */

--- a/src/mca/ras/simulator/ras_sim_component.c
+++ b/src/mca/ras/simulator/ras_sim_component.c
@@ -134,7 +134,6 @@ static int ras_sim_component_query(prte_mca_base_module_t **module, int *priorit
         /* cannot launch simulated nodes or resolve their names to addresses */
         jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
         prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_RESOLVE, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
         return PRTE_SUCCESS;
     }
 

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -578,7 +578,6 @@ static int bind_in_place(prte_job_t *jdata,
             hwloc_bitmap_and(available, mycpus, available);
             hwloc_bitmap_free(mycpus);
         }
-
         /* cycle thru the procs */
         for (j=0; j < node->procs->size; j++) {
             if (NULL == (proc = (prte_proc_t*)prte_pointer_array_get_item(node->procs, j))) {

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -268,22 +268,6 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
                                     NULL, PMIX_BOOL);
             }
 
-        } else if (0 == strcasecmp(ck2[i], "DONOTRESOLVE")) {
-            if (NULL == jdata) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "mapping policy", ck2[i]);
-                return PRTE_ERR_SILENT;
-            }
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_RESOLVE, PRTE_ATTR_GLOBAL,
-                               NULL, PMIX_BOOL);
-            /* if we are not in a persistent DVM, then make sure we don't try to launch
-             * the daemons either */
-            if (!prte_persistent) {
-                djob = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-                prte_set_attribute(&djob->attributes, PRTE_JOB_DO_NOT_RESOLVE, PRTE_ATTR_GLOBAL,
-                                   NULL, PMIX_BOOL);
-            }
-            
         } else if (0 == strcasecmp(ck2[i], "NOLOCAL")) {
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_USE_LOCAL);
 

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -644,9 +644,9 @@ int pmix_server_spawn_fn(const pmix_proc_t *proc,
     prte_pmix_server_op_caddy_t *cd;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s spawn upcalled on behalf of proc %s:%u",
+                        "%s spawn upcalled on behalf of proc %s:%u with %"PRIsize_t" job infos",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        proc->nspace, proc->rank);
+                        proc->nspace, proc->rank, ninfo);
 
     cd = PRTE_NEW(prte_pmix_server_op_caddy_t);
     PMIX_LOAD_PROCID(&cd->proc, proc->nspace, proc->rank);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -982,9 +982,6 @@ int prun(int argc, char *argv[])
         if (NULL != strcasestr(pval->value.data.string, "DONOTLAUNCH")) {
             PMIX_INFO_LIST_ADD(ret, jinfo, "PRTE_JOB_DO_NOT_LAUNCH", NULL, PMIX_BOOL);
         }
-        if (NULL != strcasestr(pval->value.data.string, "DONOTRESOLVE")) {
-            PMIX_INFO_LIST_ADD(ret, jinfo, "PRTE_JOB_DO_NOT_RESOLVE", NULL, PMIX_BOOL);
-        }
     }
 
     /* if the user specified a ranking policy, then set it */

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -449,8 +449,6 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_NOINHERIT";
         case PRTE_JOB_FILE:
             return "JOB-FILE";
-        case PRTE_JOB_DO_NOT_RESOLVE:
-            return "DO-NOT-RESOLVE";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -188,7 +188,6 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_PPR                    (PRTE_JOB_START_KEY + 81)    // char* - string specifying the procs-per-resource pattern
 #define PRTE_JOB_NOINHERIT              (PRTE_JOB_START_KEY + 82)    // bool do NOT inherit parent's mapping/ranking/binding policies
 #define PRTE_JOB_FILE                   (PRTE_JOB_START_KEY + 83)    // char* - file to use for sequential or rankfile mapping
-#define PRTE_JOB_DO_NOT_RESOLVE         (PRTE_JOB_START_KEY + 84)    // bool - do not resolve nodes
 
 #define PRTE_JOB_MAX_KEY   300
 

--- a/src/util/if.h
+++ b/src/util/if.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,27 +62,6 @@ BEGIN_C_DECLS
     ( (n4)        & 0x000000FF)
 
 /**
- *  Lookup an interface by name and return its primary address.
- *
- *  @param if_name (IN)   Interface name
- *  @param if_addr (OUT)  Interface address buffer
- *  @param size    (IN)   Interface address buffer size
- */
-PRTE_EXPORT int prte_ifnametoaddr(const char* if_name,
-                                    struct sockaddr* if_addr,
-                                    int size);
-
-/**
- *  Lookup an interface by address and return its name.
- *
- *  @param if_addr (IN)   Interface address (hostname or dotted-quad)
- *  @param if_name (OUT)  Interface name buffer
- *  @param size    (IN)   Interface name buffer size
- */
-PRTE_EXPORT int prte_ifaddrtoname(const char* if_addr,
-                                    char* if_name, int size);
-
-/**
  *  Lookup an interface by name and return its prte_list index.
  *
  *  @param if_name (IN)  Interface name
@@ -96,21 +76,6 @@ PRTE_EXPORT int prte_ifnametoindex(const char* if_name);
  *  @return              Interface kernel index
  */
 PRTE_EXPORT int prte_ifnametokindex(const char* if_name);
-
-/*
- *  Attempt to resolve an address (given as either IPv4/IPv6 string
- *  or hostname) and return the kernel index of the interface
- *  that is on the same network as the specified address
- */
-PRTE_EXPORT int prte_ifaddrtokindex(const char* if_addr);
-
-/**
- *  Lookup an interface by prte_list index and return its kernel index.
- *
- *  @param if_name (IN)  Interface prte_list index
- *  @return              Interface kernel index
- */
-PRTE_EXPORT int prte_ifindextokindex(int if_index);
 
 /**
  *  Returns the number of available interfaces.
@@ -141,15 +106,6 @@ PRTE_EXPORT int prte_ifnext(int if_index);
 PRTE_EXPORT int prte_ifindextoname(int if_index, char* if_name, int);
 
 /**
- *  Lookup an interface by kernel index and return its name.
- *
- *  @param if_index (IN)  Interface kernel index
- *  @param if_name (OUT)  Interface name buffer
- *  @param size (IN)      Interface name buffer size
- */
-PRTE_EXPORT int prte_ifkindextoname(int if_kindex, char* if_name, int);
-
-/**
  *  Lookup an interface by index and return its primary address.
  *
  *  @param if_index (IN)  Interface index
@@ -161,32 +117,6 @@ PRTE_EXPORT int prte_ifindextoaddr(int if_index, struct sockaddr*,
 PRTE_EXPORT int prte_ifkindextoaddr(int if_kindex,
                                       struct sockaddr* if_addr,
                                       unsigned int length);
-
-/**
- *  Lookup an interface by index and return its network mask (in CIDR
- *  notation -- NOT the actual netmask itself!).
- *
- *  @param if_index (IN)  Interface index
- *  @param if_name (OUT)  Interface address buffer
- *  @param size (IN)      Interface address buffer size
- */
-PRTE_EXPORT int prte_ifindextomask(int if_index, uint32_t*, int);
-
-/**
- *  Lookup an interface by index and return its MAC address.
- *
- *  @param if_index (IN)  Interface index
- *  @param if_mac (OUT)   Interface's MAC address
- */
-PRTE_EXPORT int prte_ifindextomac(int if_index, uint8_t if_mac[6]);
-
-/**
- *  Lookup an interface by index and return its MTU.
- *
- *  @param if_index (IN)  Interface index
- *  @param if_mtu (OUT)   Interface's MTU
- */
-PRTE_EXPORT int prte_ifindextomtu(int if_index, int *mtu);
 
 /**
  *  Lookup an interface by index and return its flags.


### PR DESCRIPTION
The cmd line parsing results get reset every time we create an app-context,
so pickup all the job-level info before we parse for local options.

Fixes https://github.com/openpmix/prrte/issues/771

Signed-off-by: Ralph Castain <rhc@pmix.org>