### PR TITLE
Have OMPI check default AMCA param file directory

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -13,6 +13,12 @@
 [missing-param-file]
 Unable to locate the variable file:
    %s
+[missing-param-file-def]
+Unable to locate the variable file:
+   %s
+either relative to the current working directory
+or in the default location:
+   %s
 #
 [bad-param-line]
 Parsing error in variable file:

--- a/src/mca/schizo/ompi/Makefile.am
+++ b/src/mca/schizo/ompi/Makefile.am
@@ -2,12 +2,16 @@
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+
+AM_CFLAGS = \
+            -DDEFAULT_PARAM_FILE_PATH="\"@AMCA_PARAM_SETS_DIR@\""
 
 sources = \
           schizo_ompi_component.c \


### PR DESCRIPTION
If the specified tune file is not an absolute path and
it isn't found, then try looking in the default location.

Fixes https://github.com/openpmix/prrte/issues/559

Signed-off-by: Ralph Castain <rhc@pmix.org>