### PR TITLE
Do better on zlib dependency

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -17,6 +17,7 @@
 # Copyright (c) 2014-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -108,6 +109,7 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
         prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
         prte_external_pmix_save_LDFLAGS=$LDFLAGS
         prte_external_pmix_save_LIBS=$LIBS
+        prte_external_pmix_version_need_zlib=no
 
         # if the pmix_version.h file does not exist, then
         # this must be from a pre-1.1.5 version
@@ -136,6 +138,19 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                                    prte_external_pmix_version=4x
                                    prte_external_pmix_version_found=4],
                                   [AC_MSG_RESULT([not found])])])
+
+        AS_IF([test "$prte_external_pmix_version_found" = "4"],
+              [AC_MSG_CHECKING([version 4.1])
+                AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                    #include <pmix_version.h>
+                                                    #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+                                                    #error "not version 4.1 or above"
+                                                    #endif
+                                                   ], [])],
+                                  [AC_MSG_RESULT([found])
+                                   prte_external_pmix_version_need_zlib=no],
+                                  [AC_MSG_RESULT([not found])
+                                   prte_external_pmix_version_need_zlib=yes])])
 
         AS_IF([test "$prte_external_pmix_version_found" = "0"],
               [AC_MSG_CHECKING([version 3x])

--- a/config/prte_setup_zlib.m4
+++ b/config/prte_setup_zlib.m4
@@ -78,8 +78,6 @@ AC_DEFUN([PRTE_ZLIB_CONFIG],[
 
     AC_DEFINE_UNQUOTED([PRTE_HAVE_ZLIB], [$prte_zlib_support],
                        [Whether or not we have zlib support])
-    AM_CONDITIONAL([PRTE_HAVE_ZLIB], [test $prte_lib_support -eq 1])
-    AC_SUBST(prte_zlib_CPPFLAGS)
-    AC_SUBST(prte_zlib_LDFLAGS)
+
     PRTE_VAR_SCOPE_POP
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1130,17 +1130,22 @@ CPPFLAGS="$CPP_INCLUDES $CPPFLAGS $PRTE_FINAL_CPPFLAGS"
 LDFLAGS="$LDFLAGS $PRTE_FINAL_LDFLAGS"
 LIBS="$LIBS $PRTE_FINAL_LIBS"
 
+AC_MSG_CHECKING([need zlib support])
+if test "$prte_zlib_support" == "1" && test "$prte_external_pmix_version_need_zlib" == "yes"; then
+    AC_MSG_RESULT([yes])
+    CPPFLAGS="$CPPFLAGS $prte_zlib_CPPFLAGS"
+    LDFLAGS="$LDFLAGS $prte_zlib_LDFLAGS"
+    LIBS="$LIBS -lz"
+else
+    AC_MSG_RESULT([no])
+fi
+
 #
 # Delayed the substitution of CFLAGS and CXXFLAGS until now because
 # they may have been modified throughout the course of this script.
 #
 
 AC_SUBST(CFLAGS)
-
-#
-# Aggregate MCA parameters directory
-#
-AC_SUBST([AMCA_PARAM_SETS_DIR], ['$(prtedatadir)/amca-param-sets'])
 
 ############################################################################
 # final wrapper compiler config

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,12 +54,6 @@ libprrte_la_DEPENDENCIES = $(libprrte_la_LIBADD)
 libprrte_la_LDFLAGS = -version-info $(libprrte_so_version)
 libprrte_la_CPPFLAGS =
 
-if PRTE_HAVE_ZLIB
-libprrte_la_LIBADD += -lzlib
-libprrte_la_CPPFLAGS += $(prte_zlib_CPPFLAGS)
-libprrte_la_LDFLAGS += $(prte_zlib_LDFLAGS)
-endif
-
 # included subdirectory Makefile.am's and appended-to variables
 headers =
 noinst_LTLIBRARIES =


### PR DESCRIPTION
We only need zlib if PMIx is < v4.1, so constrain addition
of libs and flags to that case

Signed-off-by: Ralph Castain <rhc@pmix.org>