### PR TITLE
util/nidmap: pass pre-allocated topology object

### DIFF
--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -676,7 +676,7 @@ int prte_util_parse_node_info(pmix_data_buffer_t *buf)
     uint8_t *flags = NULL;
     uint8_t *bytes = NULL;
     prte_topology_t *t2, *t3;
-    pmix_topology_t *ptopo;
+    pmix_topology_t ptopo;
     hwloc_topology_t topo;
     char *sig;
     pmix_data_buffer_t bucket;
@@ -753,9 +753,8 @@ int prte_util_parse_node_info(pmix_data_buffer_t *buf)
                 PMIX_ERROR_LOG(rc);
                 goto cleanup;
             }
-            topo = ptopo->topology;
-            ptopo->topology = NULL;
-            PMIX_TOPOLOGY_FREE(ptopo, 1);
+            topo = ptopo.topology;
+            ptopo.topology = NULL;
             /* record it */
             t2 = PRTE_NEW(prte_topology_t);
             t2->index = index;


### PR DESCRIPTION
This fixes a segfault that occurs in prted in nidmap.c at

	PMIX_TOPOLOGY_FREE(ptopo, 1);

due to this cast in pmix_bfrops_base_unpack_topology
(pmix/src/mca/bfrops/base/bfrop_base_unpack.c:1915):

	ptr = (pmix_topology_t *) dest;

actually casing a (pmix_topology_t **) to a (pmix_topology_t *).

The code in nidmap.c appears to assume that the unpack code allocates
the object, like it does in pmix_bfrops_base_unpack_val:

	case PMIX_TOPO:
            PMIX_TOPOLOGY_CREATE(val->data.topo, 1);

but the above code path is not the one that runs, the one that actually
runs is this (and this one does not allocate):

	pmix_bfrops_base_unpack_topology
	pmix_bfrops_base_unpack_buffer
	pmix_bfrops_base_unpack
	pmix41_unpack
	PMIx_Data_unpack

Note: I also tried instead changing the code in PMIX in pmix_bfprops_base_unpack_topology to allocate, but that resulted in master openmpi process segfaulting -- I didn't bother investigating.

Note: this fixes the segfault, but launch of prted daemons is still not working for me, due to error about unpacking that topology info buffer:

    [b08n18:46344] [/.../openmpi-5.9999/3rd-party/prrte/src/util/nidmap.c:788] PMIx Error: UNPACK-PAST-END
    
Everything used to work on an identical system with ompi+pmix master at 2020-12-02. Maybe some issue (other than the one patched by this PR) introduced by

commit 8b8dc8e4ce4a7a4471f5682e37cdf0baf7968325
Date:   Mon Feb 15 11:55:37 2021 -0800
Replace PRRTE compression support with PMIx

Do prted launch ok for you? Thanks in advance.