### PR TITLE
util/nidmap: revert typo in source buffer pointer

### DIFF
--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -781,14 +781,14 @@ int prte_util_parse_node_info(pmix_data_buffer_t *buf)
         /* now get the array of assigned topologies */
         /* unpack the compression flag */
         cnt = 1;
-        rc = PMIx_Data_unpack(NULL, &bucket, &compressed, &cnt, PMIX_BOOL);
+        rc = PMIx_Data_unpack(NULL, buf, &compressed, &cnt, PMIX_BOOL);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
         /* unpack the topologies object */
         cnt = 1;
-        rc = PMIx_Data_unpack(NULL, &bucket, &pbo, &cnt, PMIX_BYTE_OBJECT);
+        rc = PMIx_Data_unpack(NULL, buf, &pbo, &cnt, PMIX_BYTE_OBJECT);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto cleanup;


### PR DESCRIPTION
This fixes an error in decoding topology info:
    
            [b08n18:46344]
            [/.../openmpi-5.9999/3rd-party/prrte/src/util/nidmap.c:788] PMIx Error:
            UNPACK-PAST-END
    
The reason is that bucket is used after destruction.

The issue appears to have been introduced in:
    
            commit 2a9fbab1ff97b77cd03c40cca6224df0eb699c4a
            Date:   Fri Jan 15 08:28:27 2021 -0800
    
                Convert PRRTE process names to PMIx process names
    
            @@ -858,71 +927,75 @@ int prte_util_parse_node_info(prte_buffer_t *buf)
                         sum->available = prte_hwloc_base_setup_summary(topo);
                         prte_pointer_array_set_item(prte_node_topologies, index,
            t2);
                     }
            -        PRTE_DESTRUCT(&bucket);
            +        PMIX_DATA_BUFFER_DESTRUCT(&bucket);
    
                     /* now get the array of assigned topologies */
                     /* unpack the compression flag */
                     cnt = 1;
            -        if (PRTE_SUCCESS != (rc = prte_dss.unpack(buf, &compressed,
                     &cnt, PRTE_BOOL))) {
            -            PRTE_ERROR_LOG(rc);
            +        rc = PMIx_Data_unpack(NULL, &bucket, &compressed, &cnt,
            PMIX_BOOL);
            +        if (PMIX_SUCCESS != rc) {
            +            PMIX_ERROR_LOG(rc);
                         goto cleanup;
                     }

Note: this PR with PR #792 fixes the segfault, then the above error, but prterun still fails with yet another issues with topology info:

```
prterun -n 1 bash ...
batch5:
--------------------------------------------------------------------------
A ppr pattern was specified, but the topology information
for the following node is missing:

  Node:  batch5
--------------------------------------------------------------------------
```
A workaround is to use `--map-by :NOLOCAL`.