### PR TITLE
schizo/ompi: add ompi5 personality to prterun

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1228,6 +1228,7 @@ static int detect_proxy(char **argv)
     /* if the basename of the cmd was "mpirun" or "mpiexec",
      * we default to us */
     if (prte_schizo_base.test_proxy_launch ||
+        0 == strcmp(prte_tool_basename, "prterun") ||
         0 == strcmp(prte_tool_basename, "mpirun") ||
         0 == strcmp(prte_tool_basename, "mpiexec") ||
         0 == strcmp(prte_tool_basename, "oshrun")) {


### PR DESCRIPTION
Fixes propagation of environment variables with `prterun -x`.

Note that propagation already works for `mpirun -x` without this commit,
and does NOT work for `prun -x` without or with this commit.

	$ cat echo-FOO.sh
	echo $(hostname): $FOO

	$ env FOO=bar mpirun -x FOO -n 1 --map-by ppr:1:node:NOLOCAL bash echo-FOO.sh
	e25n15: bar

Before this commit:

	$ env FOO=bar prterun -x FOO -n 1 --map-by ppr:1:node:NOLOCAL bash echo-FOO.sh
	e25n15:

	$ env FOO=bar prterun --mca schizo_base_personalities prte,ompi5 \
		-x FOO -n 1 --map-by ppr:1:node:NOLOCAL bash echo-FOO.sh
	e25n15: bar

After this commit:

	$ env FOO=bar prterun -x FOO -n 1 --map-by ppr:1:node:NOLOCAL bash echo-FOO.sh
	e25n15: bar

Note: the only known workaround for `prun -x` is to explicitly add the
personality via an MCA parameter:

	$ prte --daemonize
	$ env FOO=bar prun  --mca schizo_base_personalities prte,ompi5 \
		-x FOO -n 1 --map-by ppr:1:node:NOLOCAL bash echo-FOO.sh
	e25n15: bar
	$ pterm

Sidenote: without :NOLOCAL, we see env var propagate to the HNP (batch5)
node, but not to the worker compute nodes. Not attaching output without
:NOLOCAL because at the time of this commit it is broken for an
unrelated reason (see note in PR #793), but the behavior without :NOLOCAL has been observed on
an earlier version of master (2020-12-02). In short, env var propagation
on HNP is different because it doesn't involve the whole path through
ssh launcher, followed by prted daemon, followed by launch.

Signed-off-by: Alexei Colin <acolin@isi.edu>