### PR TITLE
tools/prte: fix help for rankfile to show FILE=

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -348,8 +348,8 @@ static prte_cmd_line_init_t cmd_line_init[] = {
     /* Mapping options */
     { '\0', "map-by", 1, PRTE_CMD_LINE_TYPE_STRING,
       "Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache | "
-      "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |,"
-      "rankfile:<rankfile_path>]"
+      "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr | "
+      "rankfile:FILE=<rankfile_path>]"
       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
       "DEVICE(for dist policy), INHERIT, NOINHERIT, PE-LIST=a,b (comma-delimited "


### PR DESCRIPTION
The syntax that works is this:

	--map-by rankfile:FILE=arankfile:NOLOCAL:DISPLAY

Also, remove stray comma.

Help text before this commit:
```
   --map-by <arg0>                   Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache
                                     | l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr
                                     |,rankfile:<rankfile_path>] with supported colon-delimited modifiers:
                                     PE=y (for multiple cpus/proc), SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE,
                                     NOLOCAL, HWTCPUS, CORECPUS, DEVICE(for dist policy), INHERIT, NOINHERIT,
                                     PE-LIST=a,b (comma-delimited ranges of cpus to use for this job)
```

Fixed after this commit:
```
   --map-by <arg0>                   Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache
                                     | l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |
                                     rankfile:FILE=<rankfile_path>] with supported colon-delimited modifiers:
                                     PE=y (for multiple cpus/proc), SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE,
                                     NOLOCAL, HWTCPUS, CORECPUS, DEVICE(for dist policy), INHERIT, NOINHERIT,
                                     PE-LIST=a,b (comma-delimited ranges of cpus to use for this job)
```

Mention: PR #732 