### PR TITLE
Cleanup topology sharing

### DIFF
--- a/src/mca/routed/radix/routed_radix.c
+++ b/src/mca/routed/radix/routed_radix.c
@@ -384,6 +384,8 @@ static void update_routing_plan(void)
     prte_list_item_t *item;
     int Level,Sum,NInLevel,Ii;
     int NInPrevLevel;
+    prte_job_t *dmns;
+    prte_proc_t *d;
 
     /* clear the list of children if any are already present */
     while (NULL != (item = prte_list_remove_first(&my_children))) {
@@ -420,11 +422,13 @@ static void update_routing_plan(void)
 
     if (0 < prte_output_get_verbosity(prte_routed_base_framework.framework_output)) {
         prte_output(0, "%s: parent %d num_children %d", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_PROC_MY_PARENT->rank, num_children);
+        dmns = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
         for (item = prte_list_get_first(&my_children);
              item != prte_list_get_end(&my_children);
              item = prte_list_get_next(item)) {
             child = (prte_routed_tree_t*)item;
-            prte_output(0, "%s: \tchild %d", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), child->rank);
+            d = (prte_proc_t*)prte_pointer_array_get_item(dmns->procs, child->rank);
+            prte_output(0, "%s: \tchild %d node %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), child->rank, d->node->name);
             for (j=0; j < (int)prte_process_info.num_daemons; j++) {
                 if (prte_bitmap_is_set_bit(&child->relatives, j)) {
                     prte_output(0, "%s: \t\trelation %d", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), j);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -123,6 +123,8 @@ prte_pointer_array_t *prte_node_pool = NULL;
 prte_pointer_array_t *prte_node_topologies = NULL;
 prte_pointer_array_t *prte_local_children = NULL;
 pmix_rank_t prte_total_procs = 0;
+char *prte_base_compute_node_sig = NULL;
+bool prte_hetero_nodes = false;
 
 /* IOF controls */
 /* generate new xterm windows to display output from specified ranks */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -579,6 +579,8 @@ PRTE_EXPORT extern prte_pointer_array_t *prte_node_pool;
 PRTE_EXPORT extern prte_pointer_array_t *prte_node_topologies;
 PRTE_EXPORT extern prte_pointer_array_t *prte_local_children;
 PRTE_EXPORT extern pmix_rank_t prte_total_procs;
+PRTE_EXPORT extern char *prte_base_compute_node_sig;
+PRTE_EXPORT extern bool prte_hetero_nodes;
 
 /* IOF controls */
 /* generate new xterm windows to display output from specified ranks */


### PR DESCRIPTION
We only want to communicate topologies to compute node daemons
if we are operating in a heterogeneous situation - i.e., where
nodes that might house application procs differ in some way
from each other. We weren't doing a very good job of inferring
whether or not we were in that situation, so instead just
directly detect in when we get the topology signature back from
each compute node.

Thanks to @acolinisi for the initial report and patch
Refs #792 and replaces it
Refs #793 and replaces it

Signed-off-by: Ralph Castain <rhc@pmix.org>