### PR TITLE
Ensure the wireup info is properly stored

### DIFF
--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -45,6 +45,7 @@ int prte_plm_base_set_hnp_name(void)
     /* we may have been passed a PMIx nspace to use */
     if (NULL != (evar = getenv("PMIX_SERVER_NSPACE"))) {
         PMIX_LOAD_PROCID(&prte_process_info.myproc, evar, 0);
+        prte_plm_globals.base_nspace = strdup(evar);
 
         if (NULL != (evar = getenv("PMIX_SERVER_RANK"))) {
             PRTE_PROC_MY_NAME->rank = strtoul(evar, NULL, 10);

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -155,6 +155,8 @@ int prte_init_util(prte_proc_type_t flags)
      * must come AFTER we initialize the installdirs as it
      * causes the MCA var system to initialize */
     prte_setup_hostname();
+    /* load the output verbose stream */
+    prte_output_setup_stream_prefix();
 
     if (PRTE_SUCCESS != (ret = prte_net_init())) {
         error = "prte_net_init";

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -21,6 +21,7 @@
  * Copyright (c) 2018      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -194,7 +195,6 @@ bool prte_output_init(void)
             verbose.lds_want_stderr = true;
         }
     }
-    prte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", prte_process_info.nodename, getpid());
 
     for (i = 0; i < PRTE_OUTPUT_MAX_STREAMS; ++i) {
         info[i].ldi_used = false;
@@ -224,6 +224,10 @@ bool prte_output_init(void)
     return true;
 }
 
+void prte_output_setup_stream_prefix(void)
+{
+    prte_asprintf(&verbose.lds_prefix, "[%s:%05d] ", prte_process_info.nodename, getpid());
+}
 
 /*
  * Open a stream

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -17,6 +17,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -507,6 +508,8 @@ struct prte_output_stream_t {
                                                         const char *prefix,
                                                         char **olddir,
                                                         char **oldprefix);
+
+PRTE_EXPORT void prte_output_setup_stream_prefix(void);
 
 #if PRTE_ENABLE_DEBUG
     /**


### PR DESCRIPTION
It was incorrectly being stored under the daemon's
own name instead of the daemon whose URI it was. Also,
simplify the pack/unpack procedure.

Signed-off-by: Ralph Castain <rhc@pmix.org>