### PR TITLE
Correctly specify the "ssh" plm backend for Torque

### DIFF
--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -305,7 +305,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* enable local launch by the orteds */
     (void) prte_mca_base_var_env_name ("plm", &var);
-    prte_setenv(var, "rsh", true, &env);
+    prte_setenv(var, "ssh", true, &env);
     free(var);
 
     /* add our umask -- see big note in orted.c */


### PR DESCRIPTION
The rsh component was renamed to ssh by another commit

Signed-off-by: Ralph Castain <rhc@pmix.org>