### PR TITLE
Update the routing plan and wireup info prior to relay

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -223,7 +223,9 @@ int prte_ess_base_prted_setup(void)
      * a specific module to use
      */
     (void) prte_mca_base_var_env_name("plm", &param);
-    plm_in_use = !!(getenv(param));
+    if (NULL != getenv(param)) {
+        plm_in_use = true;
+    }
     free (param);
     if (plm_in_use)  {
         if (PRTE_SUCCESS != (ret = prte_mca_base_framework_open(&prte_plm_base_framework,

--- a/src/mca/odls/odls_types.h
+++ b/src/mca/odls/odls_types.h
@@ -77,8 +77,6 @@ typedef uint8_t prte_daemon_cmd_flag_t;
 /* process called "errmgr.abort_procs" */
 #define PRTE_DAEMON_ABORT_PROCS_CALLED      (prte_daemon_cmd_flag_t) 28
 
-/* nidmap for the DVM */
-#define PRTE_DAEMON_DVM_NIDMAP_CMD          (prte_daemon_cmd_flag_t) 29
 /* add procs for the DVM */
 #define PRTE_DAEMON_DVM_ADD_PROCS           (prte_daemon_cmd_flag_t) 30
 
@@ -93,9 +91,6 @@ typedef uint8_t prte_daemon_cmd_flag_t;
 
 /* tell DVM daemons to cleanup resources from job */
 #define PRTE_DAEMON_DVM_CLEANUP_JOB_CMD     (prte_daemon_cmd_flag_t) 34
-
-/* pass node info */
-#define PRTE_DAEMON_PASS_NODE_INFO_CMD      (prte_daemon_cmd_flag_t) 35
 
 /*
  * Struct written up the pipe from the child to the parent.


### PR DESCRIPTION
We need to ensure that the xcast updates its wiring plan
prior to attempting to relay the message down the routing
tree.

Signed-off-by: Ralph Castain <rhc@pmix.org>