### PR TITLE
autoconf/prte_check_lsf: check for librt for liblsf

### DIFF
--- a/config/prte_check_lsf.m4
+++ b/config/prte_check_lsf.m4
@@ -86,12 +86,21 @@ AC_DEFUN([PRTE_CHECK_LSF],[
                     [prte_check_lsf_happy="no"],
                     [prte_check_lsf_happy="yes"])
 
+          # liblsf requires shm_open, shm_unlink, which are in librt
+          PRTE_SEARCH_LIBS_COMPONENT([shm_open_rt], [shm_open], [rt],
+                        [shm_open_rt_happy="yes"],
+                        [shm_open_rt_happy="no"])
+
+          AS_IF([test "$shm_open_rt_happy" = "no"],
+                    [prte_check_lsf_happy="no"],
+                    [prte_check_lsf_happy="yes"])
+
           # liblsb requires liblsf - using ls_info as a test for liblsf presence
           PRTE_CHECK_PACKAGE([ls_info_lsf],
                      [lsf/lsf.h],
                      [lsf],
                      [ls_info],
-                     [$yp_all_nsl_LIBS],
+                     [$yp_all_nsl_LIBS $shm_open_rt_LIBS],
                      [$prte_check_lsf_dir],
                      [$prte_check_lsf_libdir],
                      [ls_info_lsf_happy="yes"],
@@ -115,7 +124,7 @@ AC_DEFUN([PRTE_CHECK_LSF],[
                         [lsf/lsbatch.h],
                         [bat],
                         [lsb_launch],
-                        [$ls_info_lsf_LIBS $yp_all_nsl_LIBS],
+                        [$ls_info_lsf_LIBS $yp_all_nsl_LIBS $shm_open_rt_LIBS],
                         [$prte_check_lsf_dir],
                         [$prte_check_lsf_libdir],
                         [prte_check_lsf_happy="yes"],


### PR DESCRIPTION
This fixes failure to find/use liblsf by configure on:

	$ cat /etc/system-release
	Red Hat Enterprise Linux Server release 7.6 (Maipo)

	$ ./configure ... \
		--with-lsf=/opt/ibm/spectrumcomputing/lsf/10.1.0.9 \
		--with-lsf-libdir=/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib
	checking for MCA component ess:lsf compile mode... dso
	checking --with-lsf value... sanity check ok (/opt/ibm/spectrumcomputing/lsf/10.1.0.9)
	checking --with-lsf-libdir value... sanity check ok (/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib)
	checking for library containing yp_all... -lnsl
	checking lsf/lsf.h usability... yes
	checking lsf/lsf.h presence... yes
	checking for lsf/lsf.h... yes
	checking for library containing ls_info... no
	checking for libevent conflict... No. -levent is not being explicitly
	used.
	configure: WARNING: LSF support requested (via --with-lsf) but not
	found.
	configure: error: Aborting.

In config.log, there is the failure to link against -llsf:

	configure:45517: checking for library containing ls_info
	...
	configure:45548: powerpc64le-unknown-linux-gnu-gcc -o conftest -g -Wundef -Wno-long-long -Wsign-compare -Wmissing-prototypes
	-Wstrict-prototypes -Wcomment -Werro r-implicit-function-declaration -fno-strict-aliasing -pedantic -Wall -finline-functions -pthread
	-I/opt/ibm/spectrumcomputing/lsf/10.1.0.9/include   -L/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib
	conftest.c -llsf -lnsl -lnsl -lm -lutil   >&5
	...
	/<custom_prefix>/usr/lib/gcc/powerpc64le-unknown-linux-gnu/10.2.0/../../../../powerpc64le-unknown-linux-gnu/bin/ld:
	/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so:
	undefined reference to `shm_open'
	/<custom_prefix>/usr/lib/gcc/powerpc64le-unknown-linux-gnu/10.2.0/../../../../powerpc64le-unknown-linux-gnu/bin/ld:
	/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so:
	undefined reference to `shm_unlink'
	collect2: error: ld returned 1 exit status

Configure fails because of failure to link anything with -llsf:

	$ echo 'int main() { return 0; }' > main.c
	$ gcc -o main main.c -L /opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib -llsf -lnsl
	/<custom_prefix>/usr/lib/gcc/powerpc64le-unknown-linux-gnu/10.2.0/../../../../powerpc64le-unknown-linux-gnu/bin/ld:
	/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so:
	undefined reference to `shm_open'
	/<custom_prefix>/usr/lib/gcc/powerpc64le-unknown-linux-gnu/10.2.0/../../../../powerpc64le-unknown-linux-gnu/bin/ld:
	/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so:
	undefined reference to `shm_unlink'
	collect2: error: ld returned 1 exit status

liblsf shipped on the system does indeed need shm_open, shm_unlink:

	$ nm /opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so | grep shm_open
	00000000000c2370 t 00000653.plt_call.shm_open
			 U shm_open

In case this is relevant, liblsf does not contain the reference to librt:

	$ readelf -d /opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib/liblsf.so | grep NEEDED
	0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
	0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
	0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
	0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
	0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

A workaround is:

	LDFLAGS="-lrt" ./configure ...

Or, alternatively, this commit fixes plain `./configure`, by adding a
check that is very similar to an existing check for yp_all symbol. With
this patch, the `./configure` successfully detects liblsf:

	--- MCA component ess:lsf (m4 configuration macro)
	checking for MCA component ess:lsf compile mode... dso
	checking --with-lsf value... sanity check ok (/opt/ibm/spectrumcomputing/lsf/10.1.0.9)
	checking --with-lsf-libdir value... sanity check ok (/opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib)
	checking for library containing yp_all... -lnsl
	checking for library containing shm_open... -lrt
	checking lsf/lsf.h usability... yes
	checking lsf/lsf.h presence... yes
	checking for lsf/lsf.h... yes
	checking for library containing ls_info... -llsf
	checking if liblsf requires libnl v1 or v3...
	checking for LSF dir... /opt/ibm/spectrumcomputing/lsf/10.1.0.9 (from --with-lsf)
	checking for LSF library dir...  /opt/ibm/spectrumcomputing/lsf/10.1.0.9/linux3.10-glibc2.17-ppc64le-csm/lib (from --with-lsf-libdir)
	checking for liblsf function... yes
	checking for liblsf yp requirements... yes
	checking lsf/lsbatch.h usability... yes
	checking lsf/lsbatch.h presence... yes
	checking for lsf/lsbatch.h... yes
	checking for library containing lsb_launch... -lbat
	checking if libbat requires libnl v1 or v3... configure: WARNING: Could not link a simple program with lib bat
	checking for libevent conflict... No. LSF checks passed.
	checking if MCA component ess:lsf can compile... yes

Signed-off-by: Alexei Colin <acolin@isi.edu>