### PR TITLE
Make '-x' a PRTE personality CLI option

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -96,8 +96,11 @@ An incorrect value for the "--stream-buffering" option was given:
 Valid values are limited to 0, 1, or 2. Your application will continue, but
 please correct your command line in the future.
 #
-[duplicate-value]
-WARNING: an MCA parameter was listed more than once on the command line, or
+[missing-envar-param]
+Warning: Could not find the environment variable: %s
+#
+[duplicate-mca-value]
+Error: an MCA parameter was listed more than once on the command line, or
 multiple times in one or more files, but with conflicting values:
 
   Param:  %s

--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -263,6 +263,11 @@ To manage files and runtime environment:
     before executing the program. Only one environment variable can be
     specified per `-x` option. Existing environment variables can be
     specified or new variable names specified with corresponding values.
+    If multiple `-x` options with the same variable name (regardless of value)
+    are provided then the last one listed on the command line will take
+    precedence, and the others will be ignored. The exception to this
+    is for PRTE_MCA_ prefixed environment variables which will report
+    an error in that scenario if any of the values differ.
     For example: `$ prun -x DISPLAY -x OFILE=/tmp/out ...`
 
 The parser for the `-x` option is not very sophisticated; it does not


### PR DESCRIPTION
 * Fixes #801
 * Move the `-x` handling from the `ompi` personality to the `prte` personality
