### PR TITLE
Fix cmdline parser and enable singleton "comm_spawn"

### DIFF
--- a/src/event/event-internal.h
+++ b/src/event/event-internal.h
@@ -8,6 +8,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,6 +60,7 @@ typedef struct event_base prte_event_base_t;
 typedef struct event prte_event_t;
 
 PRTE_EXPORT extern prte_event_base_t *prte_sync_event_base;
+PRTE_EXPORT extern prte_event_base_t *prte_event_base;
 
 PRTE_EXPORT int prte_event_base_open(void);
 PRTE_EXPORT int prte_event_base_close(void);

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -36,6 +37,9 @@ int prte_event_base_open(void)
     if (NULL == (prte_sync_event_base = event_base_new())) {
         return PRTE_ERROR;
     }
+    /* PRTE tools "block" in their own loop over the event
+     * base, so no progress thread is required */
+    prte_event_base = prte_sync_event_base;
 
     /* set the number of priorities */
     if (0 < PRTE_EVENT_NUM_PRI) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -838,6 +838,7 @@ static void _cnct(int sd, short args, void *cbdata)
     }
 
   release:
+    rc = prte_pmix_convert_rc(rc);
     if (NULL != cd->cbfunc) {
         cd->cbfunc(rc, cd->cbdata);
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -184,6 +184,7 @@ static void _client_abort(int sd, short args, void *cbdata)
     prte_job_t *jdata;
     prte_proc_t *p, *ptr;
     int i;
+    int rc = PRTE_SUCCESS;
 
     PRTE_ACQUIRE_OBJECT(cd);
 
@@ -193,7 +194,8 @@ static void _client_abort(int sd, short args, void *cbdata)
         /* find the named process */
         p = NULL;
         if (NULL == (jdata = prte_get_job_data_object(cd->proc.nspace))) {
-            return;
+            rc = PRTE_ERR_NOT_FOUND;
+            goto release;
         }
         for (i=0; i < jdata->procs->size; i++) {
             if (NULL == (ptr = (prte_proc_t*)prte_pointer_array_get_item(jdata->procs, i))) {
@@ -213,9 +215,10 @@ static void _client_abort(int sd, short args, void *cbdata)
         PRTE_ACTIVATE_PROC_STATE(&p->name, PRTE_PROC_STATE_CALLED_ABORT);
     }
 
+release:
     /* release the caller */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(PRTE_SUCCESS, cd->cbdata);
+        cd->cbfunc(rc, cd->cbdata);
     }
     PRTE_RELEASE(cd);
 }

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -67,7 +67,6 @@ PRTE_EXPORT extern char *prte_job_ident;  /* instantiated in src/runtime/prte_gl
 PRTE_EXPORT extern bool prte_create_session_dirs;  /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern bool prte_execute_quiet;  /* instantiated in src/runtime/prte_globals.c */
 PRTE_EXPORT extern bool prte_report_silent_errors;  /* instantiated in src/runtime/prte_globals.c */
-PRTE_EXPORT extern prte_event_base_t *prte_event_base;  /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern bool prte_event_base_active; /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern bool prte_proc_is_bound;  /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern int prte_progress_thread_debug;  /* instantiated in src/runtime/prte_init.c */

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -241,7 +241,6 @@ int prte_init(int* pargc, char*** pargv, prte_proc_type_t flags)
         error = "prte_event_base_open";
         goto error;
     }
-    prte_event_use_threads();
 
     /* ensure we know the type of proc for when we finalize */
     prte_process_info.proc_type = flags;
@@ -335,10 +334,6 @@ int prte_init(int* pargc, char*** pargv, prte_proc_type_t flags)
         error = "prte_ess_base_select";
         goto error;
     }
-
-    /* PRTE tools "block" in their own loop over the event
-     * base, so no progress thread is required */
-    prte_event_base = prte_sync_event_base;
 
     /* initialize the RTE for this environment */
     if (PRTE_SUCCESS != (ret = prte_ess.init(*pargc, *pargv))) {

--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -250,12 +250,26 @@ int prte_cmd_line_parse(prte_cmd_line_t *cmd, bool ignore_unknown,
         if (0 == strcmp(cmd->lcl_argv[i], "--")) {
             ++i;
             while (i < cmd->lcl_argc) {
-                prte_argv_append(&cmd->lcl_tail_argc, &cmd->lcl_tail_argv,
-                                 cmd->lcl_argv[i]);
+                if (0 != strcmp(cmd->lcl_argv[i], "&") ||
+                    '>' != cmd->lcl_argv[i][0] ||
+                    '<' != cmd->lcl_argv[i][0]) {
+                    prte_argv_append(&cmd->lcl_tail_argc, &cmd->lcl_tail_argv,
+                                     cmd->lcl_argv[i]);
+                }
                 ++i;
             }
 
             break;
+        }
+
+        /* is it the ampersand or an output redirection? if so,
+         * then that should be at the end of the cmd line - either
+         * way, we ignore it */
+        else if (0 == strcmp(cmd->lcl_argv[i], "&") ||
+                 '>' == cmd->lcl_argv[i][0] ||
+                 '<' == cmd->lcl_argv[i][0]) {
+            ++i;
+            continue;
         }
 
         /* If it's not an option, then this is an error.  Note that


### PR DESCRIPTION
Fix cmd line parser
Needs to ignore IO redirection and background directives - they
are not applications!

--------------------------------------------

Enable singleton "comm spawn" operations
Detect that we have been started by a singleton and
self-register the job. Provide a keepalive pipe
option so we can suicide if the singleton dies.
Return a PMIx error constant when something goes
wrong in spawn. Ensure we don't leave the client
hanging if there is an error in connect.

---------------------------------------------

Signed-off-by: Ralph Castain <rhc@pmix.org>