### PR TITLE
Avoid zero-byte malloc in argv_join_range

### DIFF
--- a/src/util/argv.c
+++ b/src/util/argv.c
@@ -16,6 +16,7 @@
  *
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -347,7 +348,7 @@ char *prte_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
 
     /* Bozo case */
 
-    if (NULL == argv || NULL == argv[0] || (int)start > prte_argv_count(argv)) {
+    if (NULL == argv || NULL == argv[0] || (int)start >= prte_argv_count(argv)) {
         return strdup("");
     }
 
@@ -358,10 +359,15 @@ char *prte_argv_join_range(char **argv, size_t start, size_t end, int delimiter)
         str_len += strlen(*p) + 1;
     }
 
+    if (0 == str_len) {
+        return strdup("");
+    }
+
     /* Allocate the string. */
 
-    if (NULL == (str = (char*) malloc(str_len)))
+    if (NULL == (str = (char*) malloc(str_len))) {
         return NULL;
+    }
 
     /* Loop filling in the string. */
 


### PR DESCRIPTION
Tracks https://github.com/open-mpi/ompi/pull/8581

Signed-off-by: Ralph Castain <rhc@pmix.org>