### PR TITLE
Simplify the schizo framework

### DIFF
--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -223,6 +224,8 @@ static struct known_signal known_signals[] = {
         prte_list_append(&prte_ess_base_signals, &_sig->super);           \
     } while(0)
 
+static bool signals_added = false;
+
 int prte_ess_base_setup_signals(char *mysignals)
 {
     int i, sval, nsigs;
@@ -236,13 +239,16 @@ int prte_ess_base_setup_signals(char *mysignals)
         return PRTE_SUCCESS;
     }
 
-    /* we know that some signals are (nearly) always defined, regardless
-     * of environment, so add them here */
-    nsigs = sizeof(known_signals) / sizeof(struct known_signal);
-    for (i=0; i < nsigs; i++) {
-        if (known_signals[i].can_forward) {
-            ESS_ADDSIGNAL(known_signals[i].signal, known_signals[i].signame);
+    if (!signals_added) {
+        /* we know that some signals are (nearly) always defined, regardless
+         * of environment, so add them here */
+        nsigs = sizeof(known_signals) / sizeof(struct known_signal);
+        for (i=0; i < nsigs; i++) {
+            if (known_signals[i].can_forward) {
+                ESS_ADDSIGNAL(known_signals[i].signal, known_signals[i].signame);
+            }
         }
+        signals_added = true;  // only do this once
     }
 
     /* see if they asked for anything beyond those - note that they may

--- a/src/mca/schizo/base/Makefile.am
+++ b/src/mca/schizo/base/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -47,7 +47,6 @@ PRTE_EXPORT    int prte_schizo_base_select(void);
 typedef struct {
     /* list of active modules */
     prte_list_t active_modules;
-    char **personalities;
     bool test_proxy_launch;
 } prte_schizo_base_t;
 
@@ -73,22 +72,15 @@ PRTE_EXPORT int prte_schizo_base_convert(char ***argv, int idx, int ntodelete,
                                          char *modifier, bool report);
 
 /* the base stub functions */
-PRTE_EXPORT int prte_schizo_base_define_cli(prte_cmd_line_t *cli);
 PRTE_EXPORT int prte_schizo_base_parse_cli(int argc, int start, char **argv,
                                              char *personality, char ***target);
-PRTE_EXPORT int prte_schizo_base_parse_deprecated_cli(prte_cmd_line_t *cmdline,
-                                                        int *argc, char ***argv);
 
-PRTE_EXPORT void prte_schizo_base_parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                                                    char ***argv);
 PRTE_EXPORT int prte_schizo_base_parse_env(prte_cmd_line_t *cmd_line,
                                              char **srcenv,
                                              char ***dstenv,
                                              bool cmdline);
-PRTE_EXPORT int prte_schizo_base_detect_proxy(char **argv);
-PRTE_EXPORT int prte_schizo_base_define_session_dir(char **tmpdir);
+PRTE_EXPORT prte_schizo_base_module_t* prte_schizo_base_detect_proxy(char *cmdpath);
 
-PRTE_EXPORT int prte_schizo_base_allow_run_as_root(prte_cmd_line_t *cmd_line);
 PRTE_EXPORT void prte_schizo_base_wrap_args(char **args);
 PRTE_EXPORT int prte_schizo_base_setup_app(prte_app_context_t *app);
 PRTE_EXPORT int prte_schizo_base_setup_fork(prte_job_t *jdata,
@@ -101,6 +93,14 @@ PRTE_EXPORT void prte_schizo_base_job_info(prte_cmd_line_t *cmdline, void *jobin
 PRTE_EXPORT int prte_schizo_base_get_remaining_time(uint32_t *timeleft);
 PRTE_EXPORT int prte_schizo_base_check_sanity(prte_cmd_line_t *cmdline);
 PRTE_EXPORT void prte_schizo_base_finalize(void);
+PRTE_EXPORT void prte_schizo_base_root_error_msg(void);
+PRTE_EXPORT char *prte_schizo_base_getline(FILE *fp);
+PRTE_EXPORT bool prte_schizo_base_check_ini(char *cmdpath, char *file);
+PRTE_EXPORT char* prte_schizo_base_strip_quotes(char *p);
+PRTE_EXPORT int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline,
+                                                        int *argc, char ***argv,
+                                                        char **options,
+                                                        prte_schizo_convertor_fn_t convert);
 
 END_C_DECLS
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -39,14 +39,9 @@
  */
 prte_schizo_base_t prte_schizo_base = {{{0}}};
 prte_schizo_API_module_t prte_schizo = {
-    .define_cli = prte_schizo_base_define_cli,
     .parse_cli = prte_schizo_base_parse_cli,
-    .parse_deprecated_cli = prte_schizo_base_parse_deprecated_cli,
-    .parse_proxy_cli = prte_schizo_base_parse_proxy_cli,
     .parse_env = prte_schizo_base_parse_env,
     .detect_proxy = prte_schizo_base_detect_proxy,
-    .define_session_dir = prte_schizo_base_define_session_dir,
-    .allow_run_as_root = prte_schizo_base_allow_run_as_root,
     .wrap_args = prte_schizo_base_wrap_args,
     .setup_app = prte_schizo_base_setup_app,
     .setup_fork = prte_schizo_base_setup_fork,
@@ -57,19 +52,8 @@ prte_schizo_API_module_t prte_schizo = {
     .finalize = prte_schizo_base_finalize
 };
 
-static char *personalities = "prte";
-
 static int prte_schizo_base_register(prte_mca_base_register_flag_t flags)
 {
-    /* pickup any defined personalities */
-    prte_mca_base_var_register("prte", "schizo", "base", "personalities",
-                                "Comma-separated list of personalities",
-                                PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                PRTE_MCA_BASE_VAR_FLAG_NONE,
-                                PRTE_INFO_LVL_9,
-                                PRTE_MCA_BASE_VAR_SCOPE_READONLY,
-                                &personalities);
-
     /* test proxy launch */
     prte_schizo_base.test_proxy_launch = false;
     prte_mca_base_var_register("prte", "schizo", "base", "test_proxy_launch",
@@ -86,9 +70,6 @@ static int prte_schizo_base_close(void)
 {
     /* cleanup globals */
     PRTE_LIST_DESTRUCT(&prte_schizo_base.active_modules);
-    if (NULL != prte_schizo_base.personalities) {
-        prte_argv_free(prte_schizo_base.personalities);
-    }
 
     return prte_mca_base_framework_components_close(&prte_schizo_base_framework, NULL);
 }
@@ -103,10 +84,6 @@ static int prte_schizo_base_open(prte_mca_base_open_flag_t flags)
 
     /* init the globals */
     PRTE_CONSTRUCT(&prte_schizo_base.active_modules, prte_list_t);
-    prte_schizo_base.personalities = NULL;
-    if (NULL != personalities) {
-        prte_schizo_base.personalities = prte_argv_split(personalities, ',');
-    }
 
     /* Open up all available components */
     rc = prte_mca_base_framework_components_open(&prte_schizo_base_framework, flags);
@@ -119,20 +96,6 @@ PRTE_MCA_BASE_FRAMEWORK_DECLARE(prte, schizo, "PRTE Schizo Subsystem",
                                  prte_schizo_base_register,
                                  prte_schizo_base_open, prte_schizo_base_close,
                                  prte_schizo_base_static_components, PRTE_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
-
-static void cvcon(prte_convertor_t *p)
-{
-    p->options = NULL;
-}
-static void cvdes(prte_convertor_t *p)
-{
-    if (NULL != p->options) {
-        prte_argv_free(p->options);
-    }
-}
-PRTE_CLASS_INSTANCE(prte_convertor_t,
-                     prte_list_item_t,
-                     cvcon, cvdes);
 
 typedef struct {
     char *name;

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -15,6 +15,8 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#include <ctype.h>
+
 #include "src/class/prte_list.h"
 
 #include "src/mca/errmgr/errmgr.h"
@@ -23,27 +25,6 @@
 #include "src/util/name_fns.h"
 #include "src/util/show_help.h"
 #include "src/mca/schizo/base/base.h"
-
-static int process_deprecated_cli(prte_cmd_line_t *cmdline,
-                                  int *argc, char ***argv,
-                                  prte_list_t *convertors);
-
- int prte_schizo_base_define_cli(prte_cmd_line_t *cli)
-{
-    int rc;
-    prte_schizo_base_active_module_t *mod;
-
-    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
-        if (NULL != mod->module->define_cli) {
-            rc = mod->module->define_cli(cli);
-            if (PRTE_SUCCESS != rc && PRTE_ERR_TAKE_NEXT_OPTION != rc) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
-            }
-        }
-    }
-    return PRTE_SUCCESS;
-}
 
 int prte_schizo_base_parse_cli(int argc, int start, char **argv,
                                 char *personality, char ***target)
@@ -61,39 +42,6 @@ int prte_schizo_base_parse_cli(int argc, int start, char **argv,
         }
     }
     return PRTE_SUCCESS;
-}
-
-int prte_schizo_base_parse_deprecated_cli(prte_cmd_line_t *cmdline,
-                                           int *argc, char ***argv)
-{
-    int rc;
-    prte_schizo_base_active_module_t *mod;
-    prte_list_t convertors;
-
-    PRTE_CONSTRUCT(&convertors, prte_list_t);
-
-    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
-        if (NULL != mod->module->register_deprecated_cli) {
-            mod->module->register_deprecated_cli(&convertors);
-        }
-    }
-
-    rc = process_deprecated_cli(cmdline, argc, argv, &convertors);
-    PRTE_LIST_DESTRUCT(&convertors);
-
-    return rc;
-}
-
-void prte_schizo_base_parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                                       char ***argv)
-{
-    prte_schizo_base_active_module_t *mod;
-
-    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
-        if (NULL != mod->module->parse_proxy_cli) {
-            mod->module->parse_proxy_cli(cmd_line, argv);
-        }
-    }
 }
 
 int prte_schizo_base_parse_env(prte_cmd_line_t *cmd_line,
@@ -115,68 +63,27 @@ int prte_schizo_base_parse_env(prte_cmd_line_t *cmd_line,
     return PRTE_SUCCESS;
 }
 
-int prte_schizo_base_detect_proxy(char **argv)
+prte_schizo_base_module_t* prte_schizo_base_detect_proxy(char *cmdpath)
 {
-    int rc, ret = PRTE_ERR_TAKE_NEXT_OPTION;
     prte_schizo_base_active_module_t *mod;
+    prte_schizo_base_module_t *md = NULL;
+    int pri = -1, p;
 
     PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
         if (NULL != mod->module->detect_proxy) {
-            rc = mod->module->detect_proxy(argv);
-            if (PRTE_SUCCESS == rc) {
-                ret = PRTE_SUCCESS;  // indicate we are running as a proxy
-            } else if (PRTE_ERR_TAKE_NEXT_OPTION != rc) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
+            p = mod->module->detect_proxy(cmdpath);
+            if (pri < p) {
+                pri = p;
+                md = mod->module;
             }
         }
     }
-    return ret;
+    return md;
 }
 
-int prte_schizo_base_define_session_dir(char **tmpdir)
+PRTE_EXPORT void prte_schizo_base_root_error_msg(void)
 {
-    int rc;
-    prte_schizo_base_active_module_t *mod;
-
-    *tmpdir = NULL;
-    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
-        if (NULL != mod->module->define_session_dir) {
-            rc = mod->module->define_session_dir(tmpdir);
-            if (PRTE_SUCCESS == rc) {
-                return rc;
-            }
-            if (PRTE_ERR_TAKE_NEXT_OPTION != rc) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
-            }
-        }
-    }
-    return PRTE_SUCCESS;
-}
-
-int prte_schizo_base_allow_run_as_root(prte_cmd_line_t *cmd_line)
-{
-    int rc;
-    prte_schizo_base_active_module_t *mod;
-
-    PRTE_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t) {
-        if (NULL != mod->module->allow_run_as_root) {
-            rc = mod->module->allow_run_as_root(cmd_line);
-            if (PRTE_SUCCESS == rc) {
-                return rc;
-            }
-        }
-    }
-
-    /* show_help is not yet available, so print an error manually */
-    fprintf(stderr, "--------------------------------------------------------------------------\n");
-    if (prte_cmd_line_is_taken(cmd_line, "help")) {
-        fprintf(stderr, "%s cannot provide the help message when run as root.\n\n", prte_tool_basename);
-    } else {
-        fprintf(stderr, "%s has detected an attempt to run as root.\n\n", prte_tool_basename);
-    }
-
+    fprintf(stderr, "%s has detected an attempt to run as root.\n\n", prte_tool_basename);
     fprintf(stderr, "Running as root is *strongly* discouraged as any mistake (e.g., in\n");
     fprintf(stderr, "defining TMPDIR) or bug can result in catastrophic damage to the OS\n");
     fprintf(stderr, "file system, leaving your system in an unusable state.\n\n");
@@ -311,9 +218,10 @@ void prte_schizo_base_finalize(void)
 }
 
 
-static int process_deprecated_cli(prte_cmd_line_t *cmdline,
-                                  int *argc, char ***argv,
-                                  prte_list_t *convertors)
+int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline,
+                                            int *argc, char ***argv,
+                                            char **options,
+                                            prte_schizo_convertor_fn_t convert)
 {
     int pargc;
     char **pargs, *p2;
@@ -321,7 +229,6 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
     prte_cmd_line_init_t e;
     prte_cmd_line_option_t *option;
     bool found;
-    prte_convertor_t *cv;
 
     pargs = *argv;
     pargc = *argc;
@@ -353,7 +260,7 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
                 free(p2);
             } else {
                 prte_show_help("help-schizo-base.txt", "single-dash-error", true,
-                                p2, pargs[i]);
+                               p2, pargs[i]);
                 free(p2);
                 ret = PRTE_OPERATION_SUCCEEDED;
             }
@@ -361,42 +268,37 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
 
         /* is this an argument someone needs to convert? */
         found = false;
-        PRTE_LIST_FOREACH(cv, convertors, prte_convertor_t) {
-            for (n=0; NULL != cv->options[n]; n++) {
-                if (0 == strcmp(pargs[i], cv->options[n])) {
-                    rc = cv->convert(cv->options[n], argv, i);
-                    if (PRTE_SUCCESS != rc &&
-                        PRTE_ERR_SILENT != rc &&
-                        PRTE_ERR_TAKE_NEXT_OPTION != rc &&
-                        PRTE_OPERATION_SUCCEEDED != rc) {
-                        return rc;
-                    }
-                    if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
-                        /* we did the conversion but don't want
-                         * to deprecate i */
-                        rc = PRTE_SUCCESS;
-                    } else if (PRTE_OPERATION_SUCCEEDED == rc) {
-                        /* Advance past any command line option
-                         * parameters */
-                        memset(&e, 0, sizeof(prte_cmd_line_init_t));
-                        e.ocl_cmd_long_name = &pargs[i][2];
-                        option = prte_cmd_line_find_option(cmdline, &e);
-                        i += option->clo_num_params;
-                        rc = PRTE_ERR_SILENT;
-                    } else {
-                        --i;
-                    }
-                    found = true;
-                    if (PRTE_ERR_SILENT != rc) {
-                        ret = PRTE_OPERATION_SUCCEEDED;
-                    }
-                    pargs = *argv;
-                    pargc = prte_argv_count(pargs);
-                    break;  // for loop
+        for (n=0; NULL != options[n]; n++) {
+            if (0 == strcmp(pargs[i], options[n])) {
+                rc = convert(options[n], argv, i);
+                if (PRTE_SUCCESS != rc &&
+                    PRTE_ERR_SILENT != rc &&
+                    PRTE_ERR_TAKE_NEXT_OPTION != rc &&
+                    PRTE_OPERATION_SUCCEEDED != rc) {
+                    return rc;
                 }
-            }
-            if (found) {
-                break;  // foreach loop
+                if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
+                    /* we did the conversion but don't want
+                     * to deprecate i */
+                    rc = PRTE_SUCCESS;
+                } else if (PRTE_OPERATION_SUCCEEDED == rc) {
+                    /* Advance past any command line option
+                     * parameters */
+                    memset(&e, 0, sizeof(prte_cmd_line_init_t));
+                    e.ocl_cmd_long_name = &pargs[i][2];
+                    option = prte_cmd_line_find_option(cmdline, &e);
+                    i += option->clo_num_params;
+                    rc = PRTE_ERR_SILENT;
+                } else {
+                    --i;
+                }
+                found = true;
+                if (PRTE_ERR_SILENT != rc) {
+                    ret = PRTE_OPERATION_SUCCEEDED;
+                }
+                pargs = *argv;
+                pargc = prte_argv_count(pargs);
+                break;  // for loop
             }
         }
 
@@ -437,3 +339,77 @@ static int process_deprecated_cli(prte_cmd_line_t *cmdline,
 
     return ret;
 }
+
+char *prte_schizo_base_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[2048];
+
+    memset(input, 0, 2048);
+    ret = fgets(input, 2048, fp);
+    if (NULL != ret) {
+        input[strlen(input)-1] = '\0';  /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
+}
+
+
+bool prte_schizo_base_check_ini(char *cmdpath, char *file)
+{
+    FILE *fp;
+    char *line;
+    size_t n;
+
+    if (NULL == cmdpath || NULL == file) {
+        return false;
+    }
+
+    /* look for an open-mpi.ini or ompi.ini file */
+    fp = fopen(file, "r");
+    if (NULL == fp) {
+        return false;
+    }
+    /* read the file to find the proxy defnitions */
+    while (NULL != (line = prte_schizo_base_getline(fp))) {
+        if('\0' == line[0]) {
+            continue; /* skip empty lines */
+        }
+        /* find the start of text in the line */
+        n = 0;
+        while ('\0' != line[n] && isspace(line[n])) {
+            ++n;
+        }
+        /* if the text starts with a '#' or the line
+         * is empty, then ignore it */
+        if ('\0' == line[n] || '#' == line[n]) {
+            /* empty line or comment */
+            continue;
+        }
+        if (0 == strcmp(cmdpath, &line[n])) {
+            /* this is us! */
+            return true;
+        }
+    }
+    return false;
+}
+
+char* prte_schizo_base_strip_quotes(char *p)
+{
+    char *pout;
+
+    /* strip any quotes around the args */
+    if ('\"' == p[0]) {
+        pout = strdup(&p[1]);
+    } else {
+        pout = strdup(p);
+    }
+    if ('\"' == pout[strlen(pout)- 1]) {
+        pout[strlen(pout)-1] = '\0';
+    }
+    return pout;
+
+}
+

--- a/src/mca/schizo/ompi/schizo_ompi.h
+++ b/src/mca/schizo/ompi/schizo_ompi.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,8 +24,337 @@
 
 BEGIN_C_DECLS
 
-PRTE_MODULE_EXPORT extern prte_schizo_base_component_t prte_schizo_ompi_component;
+typedef struct {
+    prte_schizo_base_component_t super;
+    int priority;
+} prte_schizo_ompi_component_t;
+
+PRTE_MODULE_EXPORT extern prte_schizo_ompi_component_t prte_schizo_ompi_component;
 extern prte_schizo_base_module_t prte_schizo_ompi_module;
+
+static prte_cmd_line_init_t ompi_cmd_line_init[] = {
+    /* basic options */
+    { 'h', "help", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "This help message",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'V', "version", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Print version and exit",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'v', "verbose", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Be verbose", PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'q', "quiet", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Suppress helpful messages", PRTE_CMD_LINE_OTYPE_GENERAL },
+    { '\0', "parsable", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "When used in conjunction with other parameters, the output is displayed in a machine-parsable format",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { '\0', "parseable", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Synonym for --parsable",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* mpirun options */
+    { '\0', "singleton", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "ID of the singleton process that started us",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "keepalive", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Pipe to monitor - DVM will terminate upon closure",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    /* Specify the launch agent to be used */
+    { '\0', "launch-agent", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Name of daemon executable used to start processes on remote nodes (default: prted)",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    /* maximum size of VM - typically used to subdivide an allocation */
+    { '\0', "max-vm-size", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of daemons to start",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "debug-daemons", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Debug daemons",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "debug-daemons-file", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable debugging of any PRTE daemons used by this application, storing output in files",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "leave-session-attached", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Do not discard stdout/stderr of remote PRTE daemons",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "tmpdir", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Set the root for the session directory tree",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "prefix", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Prefix to be used to look for RTE executables",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "noprefix", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Disable automatic --prefix behavior",
+        PRTE_CMD_LINE_OTYPE_DVM },
+
+    /* setup MCA parameters */
+    { '\0', "omca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific OMPI MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "gomca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass global OMPI MCA parameters that are applicable to all contexts (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "mca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* setup MCA parameters */
+    { '\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "tune", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "File(s) containing MCA params for tuning DVM operations",
+        PRTE_CMD_LINE_OTYPE_DVM },
+
+    /* forward signals */
+    { '\0', "forward-signals", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-delimited list of additional signals (names or integers) to forward to "
+        "application processes [\"none\" => forward nothing]. Signals provided by "
+        "default include SIGTSTP, SIGUSR1, SIGUSR2, SIGABRT, SIGALRM, and SIGCONT",
+        PRTE_CMD_LINE_OTYPE_DVM},
+
+    { '\0', "debug", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Top-level PRTE debug switch (default: false)",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "debug-verbose", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Verbosity level for PRTE debug messages (default: 1)",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { 'd', "debug-devel", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable debugging of PRTE",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+    { '\0', "timeout", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Timeout the job after the specified number of seconds",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+    { '\0', "report-state-on-timeout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Report all job and process states upon timeout",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Get stack traces of all application procs on timeout",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+#endif
+
+
+    { '\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Allow execution as root (STRONGLY DISCOURAGED)",
+        PRTE_CMD_LINE_OTYPE_DVM },    /* End of list */
+    /* fwd mpirun port */
+    { '\0', "fwd-mpirun-port", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Forward mpirun port to compute node daemons so all will use it",
+        PRTE_CMD_LINE_OTYPE_DVM },
+
+    /* Conventional options - for historical compatibility, support
+     * both single and multi dash versions */
+    /* Number of processes; -c, -n, --n, -np, and --np are all
+     synonyms */
+    { 'c', "np", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'n', "n", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'N', NULL, 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run per node",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    /* Use an appfile */
+    { '\0',  "app", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide an appfile; ignore all other command line options",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* output options */
+    /* exit status reporting */
+    { '\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Return the exit status of the primary job only",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* select XML output */
+    { '\0', "xml", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Provide all output in XML format",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* tag output */
+    { '\0', "tag-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Tag all output with [job,rank]",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "timestamp-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Timestamp all application process output",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-directory", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOJOBID (do not include a job-id directory level) and NOCOPY (do not copy the output to the stdout/err streams)",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-filename", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Redirect output from application processes into filename.rank. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOCOPY (do not copy the output to the stdout/err streams)",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "merge-stderr-to-stdout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Merge stderr to stdout for each process",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "xterm", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Create a new xterm window and display output from the specified ranks there",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "stream-buffering", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* input options */
+    /* select stdin option */
+    { '\0', "stdin", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify procs to receive stdin [rank, all, none] (default: 0, indicating rank 0)",
+        PRTE_CMD_LINE_OTYPE_INPUT },
+
+    /* debugger options */
+    { '\0', "output-proctable", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Print the complete proctable to stdout [-], stderr [+], or a file [anything else] after launch",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "stop-on-exec", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "If supported, stop each process at start of execution",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+    /* launch options */
+    /* request that argv[0] be indexed */
+    { '\0', "index-argv-by-rank", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Uniquely index argv[0] for each process using its rank",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload the binary on the remote machine */
+    { 's', "preload-binary", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Preload the binary on the remote machine before starting the remote process.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload files on the remote machine */
+    { '\0', "preload-files", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Preload the comma separated list of files to the remote machines current working directory before starting the remote process.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Export environment variables; potentially used multiple times,
+     so it does not make sense to set into a variable */
+    { 'x', NULL, 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes; \"-x foo*\" exports all current environmental variables starting with \"foo\")",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wdir", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Set the working directory of the started processes",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wd", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Synonym for --wdir",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "set-cwd-to-session-dir", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Set the working directory of the started processes to their session directory",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "path", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "PATH to be used to look for executables to start processes",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "show-progress", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Output a brief periodic report on launch progress",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "pset", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "User-specified name assigned to the processes in their given application",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Set a hostfile */
+    { '\0', "hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "machinefile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "default-hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a default hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { 'H', "host", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "List of hosts to invoke processes on",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* placement options */
+    /* Mapping options */
+    { '\0', "map-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache | "
+        "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |,"
+        "rankfile]"
+        " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
+        "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
+        "DEVICE(for dist policy), INHERIT, NOINHERIT, PE-LIST=a,b (comma-delimited "
+        "ranges of cpus to use for this job), FILE=<path> for seq and rankfile options",
+        PRTE_CMD_LINE_OTYPE_MAPPING },
+
+    /* Ranking options */
+    { '\0', "rank-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache "
+        "| l2cache | l3cache | package (default:np>2) | node], with modifier :SPAN or :FILL",
+        PRTE_CMD_LINE_OTYPE_RANKING },
+
+    /* Binding options */
+    { '\0', "bind-to", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Binding policy for job. Allowed values: none, hwthread, core, l1cache, l2cache, "
+        "l3cache, package, (\"none\" is the default when oversubscribed, \"core\" is "
+        "the default when np<=2, and \"package\" is the default when np>2). Allowed colon-delimited qualifiers: "
+        "overload-allowed, if-supported",
+        PRTE_CMD_LINE_OTYPE_BINDING },
+
+    /* rankfile */
+    { '\0', "rankfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Name of file to specify explicit task mapping",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+
+    /* developer options */
+    { '\0', "do-not-resolve", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Do not attempt to resolve interfaces - usually used to determine proposed process placement/binding prior to obtaining an allocation",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Perform all necessary operations to prepare to launch the application, but do not actually launch it (usually used to test mapping patterns)",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a detailed process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-topo", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the topology as part of the process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-diffable-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a diffable process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "report-bindings", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Whether to report process bindings to stderr",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a detailed list (mostly intended for developers) of the allocation being used by this job",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the process map just before launch",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "display-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the allocation being used by this job",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+#if PRTE_ENABLE_FT
+    { '\0', "enable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable recovery from process failure [Default = disabled]",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "max-restarts", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Max number of times to restart a failed process",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "disable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Disable recovery (resets all recovery options to off)",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "continuous", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Job is to run until explicitly terminated",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "with-ft", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the type(s) of error handling that the application will use.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+#endif
+
+    /* mpiexec mandated form launch key parameters */
+    { '\0', "initial-errhandler", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the initial error handler that is attached to predefined communicators during the first MPI call.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "with-ft", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the type(s) of error handling that the application will use.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Display Commumication Protocol : MPI_Init */
+    { '\0', "display-comm", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display table of communication methods between ranks during MPI_Init",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* Display Commumication Protocol : MPI_Finalize */
+    { '\0', "display-comm-finalize", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display table of communication methods between ranks during MPI_Finalize",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* End of list */
+    { '\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL }
+};
 
 END_C_DECLS
 

--- a/src/mca/schizo/ompi/schizo_ompi_component.c
+++ b/src/mca/schizo/ompi/schizo_ompi_component.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,24 +30,27 @@ static int component_query(prte_mca_base_module_t **module, int *priority);
 /*
  * Struct of function pointers and all that to let us be initialized
  */
-prte_schizo_base_component_t prte_schizo_ompi_component = {
-    .base_version = {
-        PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
-        .mca_component_name = "ompi",
-        PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
-                                    PRTE_RELEASE_VERSION),
-        .mca_query_component = component_query,
+prte_schizo_ompi_component_t prte_schizo_ompi_component = {
+    .super = {
+        .base_version = {
+            PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+            .mca_component_name = "ompi",
+            PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
+                                        PRTE_RELEASE_VERSION),
+            .mca_query_component = component_query,
+        },
+        .base_data = {
+            /* The component is checkpoint ready */
+            PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
     },
-    .base_data = {
-        /* The component is checkpoint ready */
-        PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
-    },
+    .priority = 50
 };
 
 static int component_query(prte_mca_base_module_t **module, int *priority)
 {
     *module = (prte_mca_base_module_t*)&prte_schizo_ompi_module;
-    *priority = 40;
+    *priority = prte_schizo_ompi_component.priority;
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/schizo/pmix/schizo_pmix.c
+++ b/src/mca/schizo/pmix/schizo_pmix.c
@@ -18,6 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,8 +54,6 @@
 static int define_cli(prte_cmd_line_t *cli);
 static int parse_cli(int argc, int start, char **argv,
                      char *personality, char ***target);
-static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                            char ***argv);
 static int parse_env(prte_cmd_line_t *cmd_line,
                      char **srcenv,
                      char ***dstenv,
@@ -62,9 +61,9 @@ static int parse_env(prte_cmd_line_t *cmd_line,
 static void wrap_args(char **args);
 
 prte_schizo_base_module_t prte_schizo_pmix_module = {
+    .name = "pmix",
     .define_cli = define_cli,
     .parse_cli = parse_cli,
-    .parse_proxy_cli = parse_proxy_cli,
     .parse_env = parse_env,
     .wrap_args = wrap_args
 };
@@ -321,40 +320,6 @@ static void wrap_args(char **args)
             prte_asprintf(&tstr, "\"%s\"", args[i]);
             free(args[i]);
             args[i] = tstr;
-        }
-    }
-}
-
-static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                            char ***argv)
-{
-    int i;
-    char *ptr;
-    char *param, *value;
-
-    /* harvest all the MCA params in the environ */
-    for (i = 0; NULL != environ[i]; ++i) {
-        if (0 == strncmp("PMIX_MCA", environ[i], strlen("PMIX_MCA"))) {
-            /* check for duplicate in app->env - this
-             * would have been placed there by the
-             * cmd line processor. By convention, we
-             * always let the cmd line override the
-             * environment
-             */
-            param = strdup(environ[i]);
-            ptr = &param[strlen("PMIX_MCA_")];
-            value = strchr(param, '=');
-            if (NULL == value) {
-                /* should never happen */
-                free(param);
-                continue;
-            }
-            *value = '\0';
-            value++;
-            prte_argv_append_nosize(argv, "--pmixmca");
-            prte_argv_append_nosize(argv, ptr);
-            prte_argv_append_nosize(argv, value);
-            free(param);
         }
     }
 }

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -38,10 +38,13 @@
 #include "src/util/argv.h"
 #include "src/util/prte_environ.h"
 #include "src/util/os_dirpath.h"
+#include "src/util/os_path.h"
+#include "src/util/path.h"
 #include "src/util/show_help.h"
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/base/base.h"
+#include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/util/name_fns.h"
 #include "src/util/session_dir.h"
@@ -52,100 +55,34 @@
 #include "schizo_prte.h"
 
 static int define_cli(prte_cmd_line_t *cli);
-static void register_deprecated_cli(prte_list_t *convertors);
 static int parse_cli(int argc, int start, char **argv,
                      char *personality, char ***target);
-static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                            char ***argv);
+static int parse_deprecated_cli(prte_cmd_line_t *cmdline,
+                                int *argc, char ***argv);
 static int parse_env(prte_cmd_line_t *cmd_line,
                      char **srcenv,
                      char ***dstenv,
                      bool cmdline);
 static int setup_fork(prte_job_t *jdata,
                       prte_app_context_t *context);
-static int define_session_dir(char **tmpdir);
-static int detect_proxy(char **argv);
-static int allow_run_as_root(prte_cmd_line_t *cmd_line);
+static int detect_proxy(char *argv);
+static void allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void wrap_args(char **args);
 static int check_sanity(prte_cmd_line_t *cmd_line);
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 
 prte_schizo_base_module_t prte_schizo_prte_module = {
+    .name = "prte",
     .define_cli = define_cli,
-    .register_deprecated_cli = register_deprecated_cli,
     .parse_cli = parse_cli,
-    .parse_proxy_cli = parse_proxy_cli,
+    .parse_deprecated_cli = parse_deprecated_cli,
     .parse_env = parse_env,
     .setup_fork = setup_fork,
-    .define_session_dir = define_session_dir,
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
     .wrap_args = wrap_args,
-    .check_sanity = check_sanity
-};
-
-
-/* Cmd-line options common to PRTE master/daemons/tools */
-static prte_cmd_line_init_t cmd_line_init[] = {
-    /* Various "obvious" generalized options */
-    { 'h', "help", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "This help message", PRTE_CMD_LINE_OTYPE_GENERAL },
-    { 'V', "version", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Print version and exit", PRTE_CMD_LINE_OTYPE_GENERAL },
-    { 'v', "verbose", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Be verbose", PRTE_CMD_LINE_OTYPE_GENERAL },
-    { 'q', "quiet", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Suppress helpful messages", PRTE_CMD_LINE_OTYPE_GENERAL },
-
-      /* DVM-related options */
-    { '\0', "tmpdir", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Set the root for the session directory tree",
-      PRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Allow execution as root (STRONGLY DISCOURAGED)",
-      PRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "personality", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Comma-separated list of programming model, languages, and containers being used (default=\"prte\")",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-    { '\0', "prefix", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Prefix to be used to look for PRTE executables",
-      PRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "noprefix", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Disable automatic --prefix behavior",
-      PRTE_CMD_LINE_OTYPE_DVM },
-
-
-    /* setup MCA parameters */
-    { '\0', "mca", 2, PRTE_CMD_LINE_TYPE_STRING,
-      "Pass context-specific MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-    { '\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
-      "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-
-    /* Request parseable help output */
-    { '\0', "prte_info_pretty", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "When used in conjunction with other parameters, the output is displayed in 'prte_info_prettyprint' format (default)",
-      PRTE_CMD_LINE_OTYPE_GENERAL },
-    { '\0', "parsable", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "When used in conjunction with other parameters, the output is displayed in a machine-parsable format",
-       PRTE_CMD_LINE_OTYPE_GENERAL },
-    { '\0', "parseable", 0, PRTE_CMD_LINE_TYPE_BOOL,
-      "Synonym for --parsable",
-      PRTE_CMD_LINE_OTYPE_GENERAL },
-
-    /* Set a hostfile */
-    { '\0', "hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Provide a hostfile",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-    { '\0', "machinefile", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "Provide a hostfile",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-    { 'H', "host", 1, PRTE_CMD_LINE_TYPE_STRING,
-      "List of hosts to invoke processes on",
-      PRTE_CMD_LINE_OTYPE_LAUNCH },
-
-    /* End of list */
-    { '\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL }
+    .check_sanity = check_sanity,
+    .job_info = job_info
 };
 
 static char *frameworks[] = {
@@ -173,6 +110,36 @@ static char *frameworks[] = {
     NULL,
 };
 
+static prte_cmd_line_init_t prte_dvm_cmd_line_init[] = {
+    /* do not print a "ready" message */
+    { '\0', "no-ready-msg", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Do not print a DVM ready message",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "daemonize", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Daemonize the DVM daemons into the background",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "system-server", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Start the DVM as the system server",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "set-sid", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Direct the DVM daemons to separate from the current session",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "report-pid", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Printout pid on stdout [-], stderr [+], or a file [anything else]",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "report-uri", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Printout URI on stdout [-], stderr [+], or a file [anything else]",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0',  "test-suicide", 1, PRTE_CMD_LINE_TYPE_BOOL,
+        "Suicide instead of clean abort after delay",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "personality", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-separated list of programming model, languages, and containers being used (default=\"prte\")",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* End of list */
+    { '\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL }
+};
 
 static int define_cli(prte_cmd_line_t *cli)
 {
@@ -187,30 +154,19 @@ static int define_cli(prte_cmd_line_t *cli)
         return PRTE_ERR_BAD_PARAM;
     }
 
-    /* we always are used, so just add ours to the end */
-    rc = prte_cmd_line_add(cli, cmd_line_init);
+    rc = prte_cmd_line_add(cli, prte_cmd_line_init);
     if (PRTE_SUCCESS != rc){
         return rc;
     }
 
+    if (PRTE_PROC_IS_MASTER) {
+        rc = prte_cmd_line_add(cli, prte_dvm_cmd_line_init);
+        if (PRTE_SUCCESS != rc){
+            return rc;
+        }
+    }
+
     return PRTE_SUCCESS;
-}
-
-static char *strip_quotes(char *p)
-{
-    char *pout;
-
-    /* strip any quotes around the args */
-    if ('\"' == p[0]) {
-        pout = strdup(&p[1]);
-    } else {
-        pout = strdup(p);
-    }
-    if ('\"' == pout[strlen(pout)- 1]) {
-        pout[strlen(pout)-1] = '\0';
-    }
-    return pout;
-
 }
 
 static int parse_cli(int argc, int start, char **argv,
@@ -236,8 +192,8 @@ static int parse_cli(int argc, int start, char **argv,
                 /* this is an error */
                 return PRTE_ERR_FATAL;
             }
-            p1 = strip_quotes(argv[i+1]);
-            p2 = strip_quotes(argv[i+2]);
+            p1 = prte_schizo_base_strip_quotes(argv[i+1]);
+            p2 = prte_schizo_base_strip_quotes(argv[i+2]);
             if (NULL == target) {
                 /* push it into our environment */
                 asprintf(&param, "PRTE_MCA_%s", p1);
@@ -257,8 +213,8 @@ static int parse_cli(int argc, int start, char **argv,
                 /* this is an error */
                 return PRTE_ERR_FATAL;
             }
-            p1 = strip_quotes(argv[i+1]);
-            p2 = strip_quotes(argv[i+2]);
+            p1 = prte_schizo_base_strip_quotes(argv[i+1]);
+            p2 = prte_schizo_base_strip_quotes(argv[i+2]);
 
             /* this is a generic MCA designation, so see if the parameter it
              * refers to belongs to one of our frameworks */
@@ -294,7 +250,7 @@ static int parse_cli(int argc, int start, char **argv,
     return PRTE_SUCCESS;
 }
 
-static int parse_deprecated_cli(char *option, char ***argv, int i)
+static int convert_deprecated_cli(char *option, char ***argv, int i)
 {
     int rc = PRTE_ERR_NOT_FOUND;
     char **pargs = *argv;
@@ -452,9 +408,11 @@ static int parse_deprecated_cli(char *option, char ***argv, int i)
     return rc;
 }
 
-static void register_deprecated_cli(prte_list_t *convertors)
+static int parse_deprecated_cli(prte_cmd_line_t *cmdline,
+                                int *argc, char ***argv)
 {
-    prte_convertor_t *cv;
+    pmix_status_t rc;
+
     char *options[] = {
         "--display-devel-map",
         "--display-map",
@@ -473,10 +431,10 @@ static void register_deprecated_cli(prte_list_t *convertors)
         NULL
     };
 
-    cv = PRTE_NEW(prte_convertor_t);
-    cv->options = prte_argv_copy(options);
-    cv->convert = parse_deprecated_cli;
-    prte_list_append(convertors, &cv->super);
+    rc = prte_schizo_base_process_deprecated_cli(cmdline, argc, argv,
+                                                 options, convert_deprecated_cli);
+
+    return rc;
 }
 
 static void doit(char *tgt,
@@ -575,7 +533,7 @@ static int parse_env(prte_cmd_line_t *cmd_line,
         for (i = 0; i < j; ++i) {
             /* the value is the envar */
             pval = prte_cmd_line_get_param(cmd_line, "x", i, 0);
-            p1 = strip_quotes(pval->value.data.string);
+            p1 = prte_schizo_base_strip_quotes(pval->value.data.string);
             /* if there is an '=' in it, then they are setting a value */
             if (NULL != (p2 = strchr(p1, '='))) {
                 *p2 = '\0';
@@ -784,54 +742,59 @@ static int setup_fork(prte_job_t *jdata,
     return PRTE_SUCCESS;
 }
 
-static int define_session_dir(char **tmpdir)
+static int detect_proxy(char *cmdpath)
 {
-    int uid;
-    pid_t mypid;
+    prte_output_verbose(2, prte_schizo_base_framework.framework_output,
+                        "%s[%s]: detect proxy with %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        __FILE__, cmdpath);
 
-    /* setup a session directory based on our userid and pid */
-    uid = geteuid();
-    mypid = getpid();
-
-    prte_asprintf(tmpdir, "%s/%s.session.%lu.%lu",
-                   prte_tmp_directory(), prte_tool_basename,
-                   (unsigned long)uid,
-                   (unsigned long)mypid);
-
-    return PRTE_SUCCESS;
-}
-
-static int detect_proxy(char **argv)
-{
-    /* if the basename of the cmd was "mpirun" or "mpiexec",
-     * we default to us */
-    if (prte_schizo_base.test_proxy_launch ||
-        0 == strcmp(prte_tool_basename, "prterun")) {
-        /* add us to the personalities */
-        prte_argv_append_unique_nosize(&prte_schizo_base.personalities, "prte");
-        return PRTE_SUCCESS;
+    /* we are lowest priority, so we will be checked last */
+    if (NULL == cmdpath) {
+        /* must use us */
+        return 100;
     }
 
-    return PRTE_ERR_TAKE_NEXT_OPTION;
+    /* if this isn't a full path, then it is a list
+     * of personalities we need to check */
+    if (!prte_path_is_absolute(cmdpath)) {
+        /* if it contains "prte", then we are available */
+        if (NULL != strstr(cmdpath, "prte") ||
+            NULL != strstr(cmdpath, "prrte")) {
+            return 100;
+        }
+    }
+
+    /* if it is in our install path, then it belongs to us */
+    if (NULL != strstr(cmdpath, prte_install_dirs.prefix)) {
+        return 100;
+    }
+
+    /* we are always the lowest priority */
+    return prte_schizo_prte_component.priority;
 }
 
-static int allow_run_as_root(prte_cmd_line_t *cmd_line)
+static void allow_run_as_root(prte_cmd_line_t *cmd_line)
 {
-    /* we always run last */
     char *r1, *r2;
 
     if (prte_cmd_line_is_taken(cmd_line, "allow-run-as-root")) {
-        return PRTE_SUCCESS;
+        return;
     }
 
     if (NULL != (r1 = getenv("PRTE_ALLOW_RUN_AS_ROOT")) &&
         NULL != (r2 = getenv("PRTE_ALLOW_RUN_AS_ROOT_CONFIRM"))) {
         if (0 == strcmp(r1, "1") && 0 == strcmp(r2, "1")) {
-            return PRTE_SUCCESS;
+            return;
         }
     }
 
-    return PRTE_ERR_TAKE_NEXT_OPTION;
+    prte_schizo_base_root_error_msg();
+}
+
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo)
+{
+    return;
 }
 
 static void wrap_args(char **args)
@@ -855,89 +818,6 @@ static void wrap_args(char **args)
             prte_asprintf(&tstr, "\"%s\"", args[i]);
             free(args[i]);
             args[i] = tstr;
-        }
-    }
-}
-
-static void parse_proxy_cli(prte_cmd_line_t *cmd_line,
-                            char ***argv)
-{
-    int i, j;
-    prte_value_t *pval;
-    char **hostfiles = NULL;
-    char **hosts = NULL;
-    char *ptr;
-    char *param, *value;
-
-    /* check for hostfile and/or dash-host options */
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "hostfile"))) {
-        prte_argv_append_nosize(argv, "--hostfile");
-        for (j=0; j < i; j++) {
-            pval = prte_cmd_line_get_param(cmd_line, "hostfile", j, 0);
-            if (NULL == pval) {
-                break;
-            }
-            prte_argv_append_nosize(&hostfiles, pval->value.data.string);
-        }
-        ptr = prte_argv_join(hostfiles, ',');
-        prte_argv_free(hostfiles);
-        prte_argv_append_nosize(argv, ptr);
-        free(ptr);
-    }
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "host"))) {
-        prte_argv_append_nosize(argv, "--host");
-        for (j=0; j < i; j++) {
-            pval = prte_cmd_line_get_param(cmd_line, "host", j, 0);
-            if (NULL == pval) {
-                break;
-            }
-            prte_argv_append_nosize(&hosts, pval->value.data.string);
-        }
-        ptr = prte_argv_join(hosts, ',');
-        prte_argv_append_nosize(argv, ptr);
-        free(ptr);
-    }
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "daemonize"))) {
-        prte_argv_append_nosize(argv, "--daemonize");
-    }
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "set-sid"))) {
-        prte_argv_append_nosize(argv, "--set-sid");
-    }
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "launch-agent"))) {
-        prte_argv_append_nosize(argv, "--launch-agent");
-        pval = prte_cmd_line_get_param(cmd_line, "launch-agent", 0, 0);
-        prte_argv_append_nosize(argv, pval->value.data.string);
-    }
-    if (0 < (i = prte_cmd_line_get_ninsts(cmd_line, "max-vm-size"))) {
-        prte_argv_append_nosize(argv, "--max-vm-size");
-        pval = prte_cmd_line_get_param(cmd_line, "max-vm-size", 0, 0);
-        prte_asprintf(&value, "%d", pval->value.data.integer);
-        prte_argv_append_nosize(argv, value);
-        free(value);
-    }
-    /* harvest all the MCA params in the environ */
-    for (i = 0; NULL != environ[i]; ++i) {
-        if (0 == strncmp("PRTE_MCA", environ[i], strlen("PRTE_MCA"))) {
-            /* check for duplicate in app->env - this
-             * would have been placed there by the
-             * cmd line processor. By convention, we
-             * always let the cmd line override the
-             * environment
-             */
-            param = strdup(environ[i]);
-            ptr = &param[strlen("PRTE_MCA_")];
-            value = strchr(param, '=');
-            if (NULL == value) {
-                /* should never happen */
-                free(param);
-                continue;
-            }
-            *value = '\0';
-            value++;
-            prte_argv_append_nosize(argv, "--prtemca");
-            prte_argv_append_nosize(argv, ptr);
-            prte_argv_append_nosize(argv, value);
-            free(param);
         }
     }
 }

--- a/src/mca/schizo/prte/schizo_prte.h
+++ b/src/mca/schizo/prte/schizo_prte.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -23,9 +24,321 @@
 
 BEGIN_C_DECLS
 
-PRTE_MODULE_EXPORT extern prte_schizo_base_component_t prte_schizo_prte_component;
+typedef struct {
+    prte_schizo_base_component_t super;
+    int priority;
+} prte_schizo_prte_component_t;
+
+PRTE_MODULE_EXPORT extern prte_schizo_prte_component_t prte_schizo_prte_component;
 extern prte_schizo_base_module_t prte_schizo_prte_module;
 
+static prte_cmd_line_init_t prte_cmd_line_init[] = {
+    /* basic options */
+    { 'h', "help", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "This help message",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'V', "version", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Print version and exit",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'v', "verbose", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Be verbose", PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'q', "quiet", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Suppress helpful messages", PRTE_CMD_LINE_OTYPE_GENERAL },
+    { '\0', "parsable", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "When used in conjunction with other parameters, the output is displayed in a machine-parsable format",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { '\0', "parseable", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Synonym for --parsable",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* prterun options */
+   /* Specify the launch agent to be used */
+    { '\0', "launch-agent", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Name of daemon executable used to start processes on remote nodes (default: prted)",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    /* maximum size of VM - typically used to subdivide an allocation */
+    { '\0', "max-vm-size", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of daemons to start",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "debug-daemons", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Debug daemons",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "debug-daemons-file", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable debugging of any PRTE daemons used by this application, storing output in files",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "leave-session-attached", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Do not discard stdout/stderr of remote PRTE daemons",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "tmpdir", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Set the root for the session directory tree",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "prefix", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Prefix to be used to look for RTE executables",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "noprefix", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Disable automatic --prefix behavior",
+        PRTE_CMD_LINE_OTYPE_DVM },
+
+    /* setup MCA parameters */
+    { '\0', "mca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* setup MCA parameters */
+    { '\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "tune", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "File(s) containing MCA params for tuning DVM operations",
+        PRTE_CMD_LINE_OTYPE_DVM },
+
+    /* forward signals */
+    { '\0', "forward-signals", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-delimited list of additional signals (names or integers) to forward to "
+        "application processes [\"none\" => forward nothing]. Signals provided by "
+        "default include SIGTSTP, SIGUSR1, SIGUSR2, SIGABRT, SIGALRM, and SIGCONT",
+        PRTE_CMD_LINE_OTYPE_DVM},
+
+    { '\0', "debug", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Top-level PRTE debug switch (default: false)",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "debug-verbose", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Verbosity level for PRTE debug messages (default: 1)",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { 'd', "debug-devel", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable debugging of PRTE",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+    { '\0', "timeout", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Timeout the job after the specified number of seconds",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+#if PMIX_NUMERIC_VERSION >= 0x00040000
+    { '\0', "report-state-on-timeout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Report all job and process states upon timeout",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Get stack traces of all application procs on timeout",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+#endif
+
+
+    { '\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Allow execution as root (STRONGLY DISCOURAGED)",
+        PRTE_CMD_LINE_OTYPE_DVM },    /* End of list */
+
+    /* Conventional options - for historical compatibility, support
+     * both single and multi dash versions */
+    /* Number of processes; -c, -n, --n, -np, and --np are all
+     synonyms */
+    { 'c', "np", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'n', "n", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    { 'N', NULL, 1, PRTE_CMD_LINE_TYPE_INT,
+        "Number of processes to run per node",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+    /* Use an appfile */
+    { '\0',  "app", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide an appfile; ignore all other command line options",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* output options */
+    /* exit status reporting */
+    { '\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Return the exit status of the primary job only",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* select XML output */
+    { '\0', "xml", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Provide all output in XML format",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    /* tag output */
+    { '\0', "tag-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Tag all output with [job,rank]",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "timestamp-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Timestamp all application process output",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-directory", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOJOBID (do not include a job-id directory level) and NOCOPY (do not copy the output to the stdout/err streams)",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "output-filename", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Redirect output from application processes into filename.rank. A relative path value will be converted to an absolute path. The directory name may include a colon followed by a comma-delimited list of optional case-insensitive directives. Supported directives currently include NOCOPY (do not copy the output to the stdout/err streams)",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "merge-stderr-to-stdout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Merge stderr to stdout for each process",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "xterm", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Create a new xterm window and display output from the specified ranks there",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
+    { '\0', "stream-buffering", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* input options */
+    /* select stdin option */
+    { '\0', "stdin", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify procs to receive stdin [rank, all, none] (default: 0, indicating rank 0)",
+        PRTE_CMD_LINE_OTYPE_INPUT },
+
+    /* debugger options */
+    { '\0', "output-proctable", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Print the complete proctable to stdout [-], stderr [+], or a file [anything else] after launch",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "stop-on-exec", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "If supported, stop each process at start of execution",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+    /* launch options */
+    /* request that argv[0] be indexed */
+    { '\0', "index-argv-by-rank", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Uniquely index argv[0] for each process using its rank",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload the binary on the remote machine */
+    { 's', "preload-binary", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Preload the binary on the remote machine before starting the remote process.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Preload files on the remote machine */
+    { '\0', "preload-files", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Preload the comma separated list of files to the remote machines current working directory before starting the remote process.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Export environment variables; potentially used multiple times,
+     so it does not make sense to set into a variable */
+    { 'x', NULL, 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the environment variable foo and takes its value from the current environment; \"-x foo=bar\" exports the environment variable name foo and sets its value to \"bar\" in the started processes; \"-x foo*\" exports all current environmental variables starting with \"foo\")",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wdir", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Set the working directory of the started processes",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "wd", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Synonym for --wdir",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "set-cwd-to-session-dir", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Set the working directory of the started processes to their session directory",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "path", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "PATH to be used to look for executables to start processes",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "show-progress", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Output a brief periodic report on launch progress",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "pset", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "User-specified name assigned to the processes in their given application",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    /* Set a hostfile */
+    { '\0', "hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "machinefile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "default-hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Provide a default hostfile",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { 'H', "host", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "List of hosts to invoke processes on",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* placement options */
+    /* Mapping options */
+    { '\0', "map-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache | "
+        "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |,"
+        "rankfile]"
+        " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
+        "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
+        "DEVICE(for dist policy), INHERIT, NOINHERIT, PE-LIST=a,b (comma-delimited "
+        "ranges of cpus to use for this job), FILE=<path> for seq and rankfile options",
+        PRTE_CMD_LINE_OTYPE_MAPPING },
+
+    /* Ranking options */
+    { '\0', "rank-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache "
+        "| l2cache | l3cache | package (default:np>2) | node], with modifier :SPAN or :FILL",
+        PRTE_CMD_LINE_OTYPE_RANKING },
+
+    /* Binding options */
+    { '\0', "bind-to", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Binding policy for job. Allowed values: none, hwthread, core, l1cache, l2cache, "
+        "l3cache, package, (\"none\" is the default when oversubscribed, \"core\" is "
+        "the default when np<=2, and \"package\" is the default when np>2). Allowed colon-delimited qualifiers: "
+        "overload-allowed, if-supported",
+        PRTE_CMD_LINE_OTYPE_BINDING },
+
+    /* rankfile */
+    { '\0', "rankfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Name of file to specify explicit task mapping",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+
+    /* developer options */
+    { '\0', "do-not-resolve", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Do not attempt to resolve interfaces - usually used to determine proposed process placement/binding prior to obtaining an allocation",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Perform all necessary operations to prepare to launch the application, but do not actually launch it (usually used to test mapping patterns)",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a detailed process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-topo", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the topology as part of the process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-diffable-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a diffable process map (mostly intended for developers) just before launch",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "report-bindings", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Whether to report process bindings to stderr",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-devel-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display a detailed list (mostly intended for developers) of the allocation being used by this job",
+        PRTE_CMD_LINE_OTYPE_DEVEL },
+    { '\0', "display-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the process map just before launch",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+    { '\0', "display-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display the allocation being used by this job",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
+
+#if PRTE_ENABLE_FT
+    { '\0', "enable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Enable recovery from process failure [Default = disabled]",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "max-restarts", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Max number of times to restart a failed process",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "disable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Disable recovery (resets all recovery options to off)",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "continuous", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Job is to run until explicitly terminated",
+        PRTE_CMD_LINE_OTYPE_FT },
+    { '\0', "with-ft", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the type(s) of error handling that the application will use.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+#endif
+
+    /* mpiexec mandated form launch key parameters */
+    { '\0', "initial-errhandler", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the initial error handler that is attached to predefined communicators during the first MPI call.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "with-ft", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Specify the type(s) of error handling that the application will use.",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
+
+    /* Display Commumication Protocol : MPI_Init */
+    { '\0', "display-comm", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display table of communication methods between ranks during MPI_Init",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* Display Commumication Protocol : MPI_Finalize */
+    { '\0', "display-comm-finalize", 0, PRTE_CMD_LINE_TYPE_BOOL,
+        "Display table of communication methods between ranks during MPI_Finalize",
+        PRTE_CMD_LINE_OTYPE_GENERAL },
+
+    /* End of list */
+    { '\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL }
+};
 END_C_DECLS
 
 #endif /* MCA_SCHIZO_OMPI_H_ */

--- a/src/mca/schizo/prte/schizo_prte_component.c
+++ b/src/mca/schizo/prte/schizo_prte_component.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,23 +30,26 @@ static int component_query(prte_mca_base_module_t **module, int *priority);
 /*
  * Struct of function pointers and all that to let us be initialized
  */
-prte_schizo_base_component_t prte_schizo_prte_component = {
-    .base_version = {
-        PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
-        .mca_component_name = "prte",
-        PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
-                                    PRTE_RELEASE_VERSION),
-        .mca_query_component = component_query,
+prte_schizo_prte_component_t prte_schizo_prte_component = {
+    .super = {
+        .base_version = {
+            PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+            .mca_component_name = "prte",
+            PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
+                                        PRTE_RELEASE_VERSION),
+            .mca_query_component = component_query,
+        },
+        .base_data = {
+            /* The component is checkpoint ready */
+            PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
     },
-    .base_data = {
-        /* The component is checkpoint ready */
-        PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
-    },
+    .priority = 5
 };
 
 static int component_query(prte_mca_base_module_t **module, int *priority)
 {
     *module = (prte_mca_base_module_t*)&prte_schizo_prte_module;
-    *priority = 5;
+    *priority = prte_schizo_prte_component.priority;
     return PRTE_SUCCESS;
 }

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -39,13 +39,6 @@ BEGIN_C_DECLS
 
 typedef int (*prte_schizo_convertor_fn_t)(char *option, char ***argv, int idx);
 
-typedef struct {
-    prte_list_item_t super;
-    char **options;
-    prte_schizo_convertor_fn_t convert;
-} prte_convertor_t;
-PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_convertor_t);
-
 /*
  * schizo module functions
  */
@@ -80,21 +73,18 @@ typedef int (*prte_schizo_base_module_parse_cli_fn_t)(int argc, int start,
                                                       char *personality,
                                                       char ***target);
 
-typedef void (*prte_schizo_base_module_register_deprecated_cli_fn_t)(prte_list_t *convertors);
+typedef int (*prte_schizo_base_parse_deprecated_cli_fn_t)(prte_cmd_line_t *cmdline,
+                                                          int *argc, char ***argv);
 
 /* detect if we are running as a proxy
  * Check the environment to determine what, if any, host we are running
  * under. Check the argv to see if we are running as a proxy for some
- * other command and to see which environment we are proxying.
+ * other command and to see which environment we are proxying. Return
+ * a priority indicating the level of confidence this component has
+ * that it is the proxy, with 100 being a definitive "yes". Highest
+ * confidence wins.
  */
-typedef int (*prte_schizo_base_detect_proxy_fn_t)(char **argv);
-
-/* define a (hopefully) unique session directory we can use */
-typedef int (*prte_schizo_base_define_session_dir_fn_t)(char **tmpdir);
-
-/* parse the environment for proxy cmd line entries */
-typedef void (*prte_schizo_base_module_parse_proxy_cli_fn_t)(prte_cmd_line_t *cmd_line,
-                                                              char ***argv);
+typedef int (*prte_schizo_base_detect_proxy_fn_t)(char *cmdpath);
 
 /* parse the environment of the
  * tool to extract any personality-specific envars that need to be
@@ -105,7 +95,7 @@ typedef int (*prte_schizo_base_module_parse_env_fn_t)(prte_cmd_line_t *cmd_line,
                                                        bool cmdline);
 
 /* check if running as root is allowed in this environment */
-typedef int (*prte_schizo_base_module_allow_run_as_root_fn_t)(prte_cmd_line_t *cmd_line);
+typedef void (*prte_schizo_base_module_allow_run_as_root_fn_t)(prte_cmd_line_t *cmd_line);
 
 /* wrap cmd line args */
 typedef void (*prte_schizo_base_module_wrap_args_fn_t)(char **args);
@@ -149,18 +139,21 @@ typedef void (*prte_schizo_base_module_job_info_fn_t)(prte_cmd_line_t *cmdline, 
 /* give the components a chance to check sanity */
 typedef int (*prte_schizo_base_module_check_sanity_fn_t)(prte_cmd_line_t *cmdline);
 
+typedef void (*prte_schizo_base_module_output_version_fn_t)(void);
+
+typedef char* (*prte_schizo_base_module_print_help_fn_t)(char *args);
+
 /*
  * schizo module version 1.3.0
  */
 typedef struct {
+    char *name;
     prte_schizo_base_module_init_fn_t                      init;
     prte_schizo_base_module_define_cli_fn_t                define_cli;
     prte_schizo_base_module_parse_cli_fn_t                 parse_cli;
-    prte_schizo_base_module_register_deprecated_cli_fn_t   register_deprecated_cli;
-    prte_schizo_base_module_parse_proxy_cli_fn_t           parse_proxy_cli;
+    prte_schizo_base_parse_deprecated_cli_fn_t             parse_deprecated_cli;
     prte_schizo_base_module_parse_env_fn_t                 parse_env;
     prte_schizo_base_detect_proxy_fn_t                     detect_proxy;
-    prte_schizo_base_define_session_dir_fn_t               define_session_dir;
     prte_schizo_base_module_allow_run_as_root_fn_t         allow_run_as_root;
     prte_schizo_base_module_wrap_args_fn_t                 wrap_args;
     prte_schizo_base_module_setup_app_fn_t                 setup_app;
@@ -169,23 +162,19 @@ typedef struct {
     prte_schizo_base_module_get_rem_time_fn_t              get_remaining_time;
     prte_schizo_base_module_job_info_fn_t                  job_info;
     prte_schizo_base_module_check_sanity_fn_t              check_sanity;
+    prte_schizo_base_module_output_version_fn_t            output_version;
+    prte_schizo_base_module_print_help_fn_t                print_help;
     prte_schizo_base_module_finalize_fn_t                  finalize;
 } prte_schizo_base_module_t;
 
 
-typedef int (*prte_schizo_base_API_parse_deprecated_cli_fn_t)(prte_cmd_line_t *cmdline,
-                                                               int *argc, char ***argv);
+typedef prte_schizo_base_module_t* (*prte_schizo_API_detect_proxy_fn_t)(char *cmdpath);
 
 typedef struct {
     prte_schizo_base_module_init_fn_t                      init;
-    prte_schizo_base_module_define_cli_fn_t                define_cli;
     prte_schizo_base_module_parse_cli_fn_t                 parse_cli;
-    prte_schizo_base_API_parse_deprecated_cli_fn_t         parse_deprecated_cli;
-    prte_schizo_base_module_parse_proxy_cli_fn_t           parse_proxy_cli;
     prte_schizo_base_module_parse_env_fn_t                 parse_env;
-    prte_schizo_base_detect_proxy_fn_t                     detect_proxy;
-    prte_schizo_base_define_session_dir_fn_t               define_session_dir;
-    prte_schizo_base_module_allow_run_as_root_fn_t         allow_run_as_root;
+    prte_schizo_API_detect_proxy_fn_t                      detect_proxy;
     prte_schizo_base_module_wrap_args_fn_t                 wrap_args;
     prte_schizo_base_module_setup_app_fn_t                 setup_app;
     prte_schizo_base_module_setup_fork_fn_t                setup_fork;

--- a/src/mca/schizo/singularity/schizo_singularity.c
+++ b/src/mca/schizo/singularity/schizo_singularity.c
@@ -35,41 +35,26 @@ static const char *singularity_exec_argc_env_var_name = "SY_EXEC_ARGS";
 static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
 
 prte_schizo_base_module_t prte_schizo_singularity_module = {
+    .name = "singularity",
     .setup_fork = setup_fork
 };
 
 static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
 {
     int i;
-    bool takeus = false;
     char *pth = NULL; // Path to the directory where the Singularity binary is
     char *exec_args = NULL;
     pmix_envar_t envar;
     char **cmd_args = NULL;
 
-    if (NULL != prte_schizo_base.personalities &&
-        NULL != jdata->personality) {
-        /* see if we are included */
-        for (i=0; NULL != jdata->personality[i]; i++) {
-            if (0 == strcmp(jdata->personality[i], "singularity")) {
-                takeus = true;
-                break;
-            }
-        }
+     /* even if they didn't specify, check to see if
+     * this involves a singularity container */
+    if (0 == strcmp(app->argv[0],"singularity") ||
+        NULL != strstr(app->argv[0], ".sif")) {
+        goto process;
     }
-    /* If we did not find the singularity binary in the environment of the
-     * application, we check if the arguments include the singularity
-     * command itself (assuming full path) or a Singularity image. */
-    if (!takeus) {
-        /* even if they didn't specify, check to see if
-         * this involves a singularity container */
-        if (0 == strcmp(app->argv[0],"singularity") ||
-            NULL != strstr(app->argv[0], ".sif")) {
-            goto process;
-        }
-        /* guess not */
-        return PRTE_ERR_TAKE_NEXT_OPTION;
-    }
+    /* guess not */
+    return PRTE_ERR_TAKE_NEXT_OPTION;
 
   process:
     prte_output_verbose(1, prte_schizo_base_framework.framework_output,

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies Ltd.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,23 +30,12 @@
 #include "schizo_slurm.h"
 
 static int get_remaining_time(uint32_t *timeleft);
-static int define_session_dir(char **tmpdir);
 
 prte_schizo_base_module_t prte_schizo_slurm_module = {
-    .define_session_dir = define_session_dir,
+    .name = "slurm",
     .get_remaining_time = get_remaining_time
 };
 
-static int define_session_dir(char **tmpdir)
-{
-    char *jid;
-
-    /* setup a session dir based on our slurm jobid */
-    jid = getenv("SLURM_JOBID");
-    prte_asprintf(tmpdir, "%s.session.%s", prte_tool_basename, jid);
-
-    return PRTE_SUCCESS;
-}
 static int get_remaining_time(uint32_t *timeleft)
 {
     char output[256], *cmd, *jobid, **res;

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -12,6 +12,7 @@
 # Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -51,7 +52,9 @@ man_MANS = $(man_pages_from_md)
 endif
 
 prte_SOURCES = \
-        prte.c
+        main.c \
+        prte.c \
+        prte.h
 
 prte_LDADD = \
     $(PRTE_EXTRA_LTLIB) \

--- a/src/tools/prte/main.c
+++ b/src/tools/prte/main.c
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *                                                                         *
+ *          PRTE: PMIx Reference RunTime Environment (PRTE)              *
+ *                                                                         *
+ *                   https://github.com/openpmix/prte                     *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "prte.h"
+
+int main(int argc, char *argv[])
+{
+    return prte(argc, argv);
+}
+
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */

--- a/src/tools/prte/prte.h
+++ b/src/tools/prte/prte.h
@@ -21,18 +21,18 @@
  * $HEADER$
  */
 
-#ifndef PRUN_H
-#define PRUN_H
+#ifndef PRTE_H
+#define PRTE_H
 
 #include "prte_config.h"
 
 BEGIN_C_DECLS
 
 /**
- * Main body of prun functionality
+ * Main body of prte functionality
  */
-int prun(int argc, char *argv[]);
+int prte(int argc, char *argv[]);
 
 END_C_DECLS
 
-#endif /* PRTERUN_PRTERUN_H */
+#endif /* PRTE_H */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -134,9 +134,9 @@ static char *prte_parent_uri = NULL;
 static prte_cmd_line_t *prte_cmd_line = NULL;
 
 /*
- * define the orted context table for obtaining parameters
+ * define the prted context table for obtaining parameters
  */
-prte_cmd_line_init_t prte_cmd_line_opts[] = {
+prte_cmd_line_init_t prted_cmd_line_opts[] = {
     /* DVM-specific options */
     /* uri of PMIx publish/lookup server, or at least where to get it */
     { '\0', "prte-server", 1, PRTE_CMD_LINE_TYPE_STRING,
@@ -157,6 +157,9 @@ prte_cmd_line_init_t prte_cmd_line_opts[] = {
     { '\0', "set-sid", 0, PRTE_CMD_LINE_TYPE_BOOL,
       "Direct the DVM daemons to separate from the current session",
       PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
 
     /* Debug options */
     { '\0', "debug", 0, PRTE_CMD_LINE_TYPE_BOOL,
@@ -260,6 +263,9 @@ int main(int argc, char *argv[])
     size_t z1=1;
     pmix_value_t *vptr;
     int32_t one=1;
+    char **pargv;
+    int pargc;
+    prte_schizo_base_module_t *schizo;
 
     char *umask_str = getenv("PRTE_DAEMON_UMASK_VALUE");
     if (NULL != umask_str) {
@@ -277,48 +283,13 @@ int main(int argc, char *argv[])
     /* init the tiny part of PRTE we use */
     prte_init_util(PRTE_PROC_DAEMON);
     prte_tool_basename = prte_basename(argv[0]);
+    pargc = argc;
+    pargv = prte_argv_copy(argv);
 
-    /* because we have to use the schizo framework prior to parsing the
-     * incoming argv for cmd line options, do a hacky search to support
-     * passing of verbosity option for schizo debugging */
-    for (i=1; NULL != argv[i]; i++) {
-        if (0 == strcmp(argv[i], "schizo_base_verbose")) {
-            /* the next option is the verbosity level */
-            prte_setenv("PRTE_MCA_schizo_base_verbose", argv[i+1], true, &environ);
-            break;
-        }
-    }
-
-    /* setup our cmd line */
+    /* setup the cmd line - this is specific to the proxy */
     prte_cmd_line = PRTE_NEW(prte_cmd_line_t);
-    if (PRTE_SUCCESS != (ret = prte_cmd_line_add(prte_cmd_line, prte_cmd_line_opts))) {
-        PRTE_ERROR_LOG(ret);
-        return ret;
-    }
-
-    /* open the SCHIZO framework */
-    if (PRTE_SUCCESS != (ret = prte_mca_base_framework_open(&prte_schizo_base_framework,
-                                                     PRTE_MCA_BASE_OPEN_DEFAULT))) {
-        PRTE_ERROR_LOG(ret);
-        return ret;
-    }
-
-    if (PRTE_SUCCESS != (ret = prte_schizo_base_select())) {
-        PRTE_ERROR_LOG(ret);
-        return ret;
-    }
-    /* scan for personalities */
-    prte_argv_append_unique_nosize(&prte_schizo_base.personalities, "prte");
-    prte_argv_append_unique_nosize(&prte_schizo_base.personalities, "pmix");
-    for (i=0; NULL != argv[i]; i++) {
-        if (0 == strcmp(argv[i], "--personality")) {
-            prte_argv_append_unique_nosize(&prte_schizo_base.personalities, argv[i+1]);
-        }
-    }
-
-    /* setup the rest of the cmd line only once */
-    if (PRTE_SUCCESS != (ret = prte_schizo.define_cli(prte_cmd_line))) {
-        PRTE_ERROR_LOG(ret);
+    ret = prte_cmd_line_add(prte_cmd_line, prted_cmd_line_opts);
+    if (PRTE_SUCCESS != ret){
         return ret;
     }
 
@@ -332,51 +303,6 @@ int main(int argc, char *argv[])
        return ret;
     }
 
-    /* now let the schizo components take a pass at it to get the MCA params */
-    if (PRTE_SUCCESS != (ret = prte_schizo.parse_cli(argc, 0, argv, NULL, NULL))) {
-        if (PRTE_ERR_SILENT != ret) {
-            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
-                    prte_strerror(ret));
-        }
-       return ret;
-    }
-
-    /* see if print version is requested. Do this before
-     * check for help so that --version --help works as
-     * one might expect. */
-     if (prte_cmd_line_is_taken(prte_cmd_line, "version")) {
-        fprintf(stdout, "%s (%s) %s\n\nReport bugs to %s\n",
-                prte_tool_basename, "PMIx Reference RunTime Environment",
-                PRTE_VERSION, PACKAGE_BUGREPORT);
-        exit(0);
-    }
-
-    /* Check for help request */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "help")) {
-        char *str, *args = NULL;
-        args = prte_cmd_line_get_usage_msg(prte_cmd_line, false);
-        str = prte_show_help_string("help-prun.txt", "prun:usage", false,
-                                    prte_tool_basename, "PRTE", PRTE_VERSION,
-                                    prte_tool_basename, args,
-                                    PACKAGE_BUGREPORT);
-        if (NULL != str) {
-            printf("%s", str);
-            free(str);
-        }
-        free(args);
-
-        /* If someone asks for help, that should be all we do */
-        exit(0);
-    }
-
-    /* check if we are running as root - if we are, then only allow
-     * us to proceed if the allow-run-as-root flag was given. Otherwise,
-     * exit with a giant warning flag
-     */
-    if (0 == geteuid()) {
-        prte_schizo.allow_run_as_root(prte_cmd_line);  // will exit us if not allowed
-    }
-
     /* save the environment for launch purposes. This MUST be
      * done so that we can pass it to any local procs we
      * spawn - otherwise, those local procs won't see any
@@ -384,6 +310,36 @@ int main(int argc, char *argv[])
      * orted was executed - e.g., by .csh
      */
     prte_launch_environ = prte_argv_copy(environ);
+
+    /* open the SCHIZO framework */
+    if (PRTE_SUCCESS != (ret = prte_mca_base_framework_open(&prte_schizo_base_framework,
+                                                            PRTE_MCA_BASE_OPEN_DEFAULT))) {
+        PRTE_ERROR_LOG(ret);
+        return ret;
+    }
+
+    if (PRTE_SUCCESS != (ret = prte_schizo_base_select())) {
+        PRTE_ERROR_LOG(ret);
+        return ret;
+    }
+
+    /* get our schizo module */
+    schizo = prte_schizo.detect_proxy(NULL);
+    if (NULL == schizo || 0 != strcmp(schizo->name, "prte")) {
+        prte_show_help("help-schizo-base.txt", "no-proxy", true,
+                       prte_tool_basename, "NONE");
+        return 1;
+    }
+
+    /* parse the CLI to load the MCA params */
+    if (PRTE_SUCCESS != (ret = schizo->parse_cli(pargc, 0, pargv, NULL, NULL))) {
+        if (PRTE_ERR_SILENT != ret) {
+            fprintf(stderr, "%s: command line error (%s)\n",
+                    prte_tool_basename,
+                    prte_strerror(ret));
+        }
+        return ret;
+    }
 
     /* purge any ess/prte flags set in the environ when we were launched */
     prte_unsetenv("PRTE_MCA_ess", &prte_launch_environ);

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -410,8 +410,7 @@ int main(int argc, char *argv[])
     signal(SIGINT, abort_signal_callback);
     signal(SIGHUP, abort_signal_callback);
 
-    /* now initialize PMIx - we have to indicate we are a launcher so that we
-     * will provide rendezvous points for tools to connect to us */
+    /* now initialize PMIx */
     if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
         fprintf(stderr, "%s failed to initialize, likely due to no DVM being available\n", prte_tool_basename);
         exit(1);

--- a/src/util/bipartite_graph.c
+++ b/src/util/bipartite_graph.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,6 +73,7 @@ PRTE_CLASS_DECLARATION(prte_bp_graph_edge_t);
 PRTE_CLASS_INSTANCE(prte_bp_graph_edge_t, prte_object_t,
                    edge_constructor, edge_destructor);
 
+#if GRAPH_DEBUG
 static void dump_vec(const char *name, int *vec, int n)
     __prte_attribute_unused__;
 
@@ -116,7 +118,7 @@ static void dump_flow(int *flow, int n)
     }
     fprintf(stderr, "}\n");
 }
-
+#endif
 
 static int get_capacity(prte_bp_graph_t *g, int source, int target)
 {

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -53,10 +53,11 @@ typedef uint8_t prte_proc_type_t;
 #define PRTE_PROC_TYPE_NONE     0x0000
 #define PRTE_PROC_DAEMON        0x0002
 #define PRTE_PROC_MASTER        0x0004
+#define PRTE_PROC_TOOL          0x0008
 
 #define PRTE_PROC_IS_DAEMON         (PRTE_PROC_DAEMON & prte_process_info.proc_type)
 #define PRTE_PROC_IS_MASTER         (PRTE_PROC_MASTER & prte_process_info.proc_type)
-
+#define PRTE_PROC_IS_TOOL           (PRTE_PROC_TOOL & prte_process_info.proc_type)
 
 /**
  * Process information structure

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -153,8 +153,9 @@ int prte_setup_top_session_dir(void)
         }
 
         if (0 > prte_asprintf(&prte_process_info.top_session_dir,
-                         "%s/prte.%s.%lu", prte_process_info.tmpdir_base,
-                         prte_process_info.nodename, (unsigned long)uid)) {
+                              "%s/prte.session.%lu",
+                              prte_process_info.tmpdir_base,
+                              (unsigned long)uid)) {
             prte_process_info.top_session_dir = NULL;
             rc = PRTE_ERR_OUT_OF_RESOURCE;
             goto exit;
@@ -179,8 +180,11 @@ static int _setup_jobfam_session_dir(pmix_proc_t *proc)
         }
 
         if (0 > prte_asprintf(&prte_process_info.jobfam_session_dir,
-                         "%s/dvm.%lu", prte_process_info.top_session_dir,
-                         (unsigned long)prte_process_info.pid)) {
+                              "%s/%s/%s.%lu",
+                              prte_process_info.top_session_dir,
+                              prte_process_info.nodename,
+                              prte_tool_basename,
+                              (unsigned long)prte_process_info.pid)) {
             rc = PRTE_ERR_OUT_OF_RESOURCE;
         }
     }
@@ -203,8 +207,9 @@ _setup_job_session_dir(pmix_proc_t *proc)
         }
         if (!PMIX_NSPACE_INVALID(proc->nspace)) {
             if (0 > prte_asprintf(&prte_process_info.job_session_dir,
-                             "%s/%s", prte_process_info.jobfam_session_dir,
-                             PRTE_LOCAL_JOBID_PRINT(proc->nspace))) {
+                                  "%s/%s",
+                                  prte_process_info.jobfam_session_dir,
+                                  PRTE_LOCAL_JOBID_PRINT(proc->nspace))) {
                 prte_process_info.job_session_dir = NULL;
                 rc = PRTE_ERR_OUT_OF_RESOURCE;
                 goto exit;


### PR DESCRIPTION
Only allow one personality per submitted job, picking the one
that either correlates to the proxy cmd being used, or where
the PRRTE tool is in the install prefix location of that proxy,
or based on component priority where no other options are available.

Make every component provide a full set of options so they can fully
configure the cmd line.

Signed-off-by: Ralph Castain <rhc@pmix.org>