### PR TITLE
Protect against symlinks

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1150,9 +1150,9 @@ static int detect_proxy(char *cmdpath)
 
 
     prte_output_verbose(2, prte_schizo_base_framework.framework_output,
-                        "%s[%s]: detect proxy with %s",
+                        "%s[%s]: detect proxy with %s (%s)",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        __FILE__, cmdpath);
+                        __FILE__, cmdpath, prte_tool_basename);
 
     if (NULL == cmdpath) {
         return 0;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -351,7 +351,6 @@ int prte(int argc, char *argv[])
             proxyrun = true;
         }
     }
-    prte_output(0, "PROXY[%s] IS %s", schizo->name, proxyrun ? "TRUE" : "FALSE");
 
     /* check if we are running as root - if we are, then only allow
      * us to proceed if the allow-run-as-root flag was given. Otherwise,


### PR DESCRIPTION
If the basename is in our install location but is a symlink
to the actual argv[0], then we need to ignore it so that the
correct proxy can be selected

Signed-off-by: Ralph Castain <rhc@pmix.org>