### PR TITLE
Fix a segfault when retrieving stacktraces after job timeout

### DIFF
--- a/src/mca/plm/base/help-plm-base.txt
+++ b/src/mca/plm/base/help-plm-base.txt
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -182,4 +183,4 @@ The user-provided time limit for job execution has been reached:
 
 The job will now be aborted.  Please check your code and/or
 adjust/remove the job execution time limit (as specified by --timeout
-command line option oror MPIEXEC_TIMEOUT environment variable).
+command line option or MPIEXEC_TIMEOUT environment variable).


### PR DESCRIPTION
Ensure use of proper macro for object release. Don't transmit
PMIX_BUFFER objects - use PMIX_BYTE_OBJECT instead. Ensure we
always know what job is being traced as some daemons may not
have any local procs, and thus will return an empty buffer
(which we need so we know when all daemons have reported)

Fixes https://github.com/openpmix/prrte/issues/828

Signed-off-by: Ralph Castain <rhc@pmix.org>