### PR TITLE
Provide runtime warning if unable to compress

### DIFF
--- a/src/pmix/Makefile.am
+++ b/src/pmix/Makefile.am
@@ -14,6 +14,7 @@
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -22,6 +23,8 @@
 #
 
 # This makefile.am does not stand on its own - it is included from src/Makefile.am
+
+AM_CPPFLAGS = $(prte_zlib_CPPFLAGS)
 
 # Source code files
 headers += \

--- a/src/runtime/help-prte-runtime.txt
+++ b/src/runtime/help-prte-runtime.txt
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -63,3 +64,11 @@ as the mapping.
 PRTE was unable to determine the number of nodes in your allocation. We
 are therefore assuming a very large number to ensure you receive proper error
 messages.
+#
+[compress-unavailable]
+PRRTE was unable to find a usable compression library
+on the system. We will therefore be unable to compress
+large data streams. This may result in longer-than-normal
+startup times and larger memory footprints. We will
+continue, but strongly recommend installing zlib or
+a comparable compression library for better user experience.

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -187,6 +187,14 @@ char *prte_daemon_cores = NULL;
 /* enable/disable ft */
 bool prte_enable_ft = false;
 
+#if PMIX_NUMERIC_VERSION < 0x00040100
+#if PRTE_HAVE_ZLIB
+size_t prte_base_compress_limit;
+#else
+bool prte_base_silence_compress_warn;
+#endif
+#endif
+
 int prte_dt_init(void)
 {
     /* set default output */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -641,6 +641,14 @@ extern char *prte_set_max_sys_limits;
 /* Enable/disable ft */
 PRTE_EXPORT extern bool prte_enable_ft;
 
+#if PMIX_NUMERIC_VERSION < 0x00040100
+#if PRTE_HAVE_ZLIB
+PRTE_EXPORT extern size_t prte_base_compress_limit;
+#else
+PRTE_EXPORT extern bool prte_base_silence_compress_warn;
+#endif
+#endif
+
 END_C_DECLS
 
 #endif /* PRTE_RUNTIME_PRTE_GLOBALS_H */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -650,5 +650,25 @@ int prte_register_params(void)
                         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_enable_ft);
 #endif
 
+#if PMIX_NUMERIC_VERSION < 0x00040100
+#if PRTE_HAVE_ZLIB
+    prte_base_compress_limit = 4096;
+    prte_mca_base_var_register("prte", "prte", NULL, "compress_limit",
+                               "Threshold beyond which data will be compressed",
+                               PRTE_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
+                               PRTE_MCA_BASE_VAR_FLAG_NONE,
+                               PRTE_INFO_LVL_3,
+                               PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_base_compress_limit);
+#else
+    prte_base_silence_compress_warn = false;
+    prte_mca_base_var_register("prte", "prte", NULL, "silence_compression_warning",
+                               "Do not warn if compression unavailable",
+                               PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
+                               PRTE_MCA_BASE_VAR_FLAG_NONE,
+                               PRTE_INFO_LVL_3,
+                               PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_base_silence_compress_warn);
+#endif
+#endif
+
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
If PRRTE is built against an early version of PMIx that does
not provide compression support, and if PRRTE itself is unable
to find an adequate compression library, then provide a one-time
warning. Toggle it off with an MCA param.

If PRRTE is able to find adequate compression support, provide
an MCA param to control the minimum message size before we
start to compress.

Signed-off-by: Ralph Castain <rhc@pmix.org>