### PR TITLE
Silence warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1156,6 +1156,8 @@ LIBS="$LIBS $PRTE_FINAL_LIBS"
 AC_MSG_CHECKING([need zlib support])
 if test "$prte_zlib_support" == "1" && test "$prte_external_pmix_version_need_zlib" == "yes"; then
     AC_MSG_RESULT([yes])
+    prte_add_zlib=yes
+    PRTE_SUMMARY_ADD([[Optional Packages]],[[zlib]], [prte_zlib], [$prte_add_zlib])
 elif test "$prte_zlib_support" != "1"; then
     AC_MSG_RESULT([yes])
     AC_MSG_WARN([*************************************************])
@@ -1167,9 +1169,13 @@ elif test "$prte_zlib_support" != "1"; then
     AC_MSG_WARN([* continue, but strongly recommend installing   *])
     AC_MSG_WARN([* zlib for better user experience.              *])
     AC_MSG_WARN([*************************************************])
+    prte_add_zlib=no
+    PRTE_SUMMARY_ADD([[Optional Packages]],[[zlib]], [prte_zlib], [$prte_add_zlib])
 else
     AC_MSG_RESULT([no])
+    prte_add_zlib=no
 fi
+AM_CONDITIONAL([PRTE_ADD_ZLIB], [test "$prte_add_zlib" = "yes"])
 
 # restore any user-provided Werror flags
 AS_IF([test ! -z "$PRTE_CFLAGS_cache"], [CFLAGS="$CFLAGS $PRTE_CFLAGS_cache"])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,8 +23,6 @@
 # $HEADER$
 #
 
-AM_CPPFLAGS = $(prte_zlib_CPPFLAGS)
-
 SUBDIRS = \
 	include \
 	etc \
@@ -47,15 +45,23 @@ DIST_SUBDIRS = \
 
 lib_LTLIBRARIES = libprrte.la
 libprrte_la_SOURCES =
+
 libprrte_la_LIBADD = \
         mca/base/libprrte_mca_base.la \
 		util/libprrteutil.la \
 		$(MCA_prte_FRAMEWORK_LIBS) \
-        $(prte_zlib_LIBS) \
 		$(PRTE_EXTRA_LIB)
-libprrte_la_DEPENDENCIES = $(libprrte_la_LIBADD)
-libprrte_la_LDFLAGS = -version-info $(libprrte_so_version) $(prte_zlib_LDFLAGS)
-libprrte_la_CPPFLAGS = $(prte_zlib_CPPFLAGS)
+libprrte_la_DEPENDENCIES =
+libprrte_la_LDFLAGS = -version-info $(libprrte_so_version)
+libprrte_la_CPPFLAGS =
+
+if PRTE_ADD_ZLIB
+libprrte_la_LIBADD += $(prte_zlib_LIBS)
+libprrte_la_DEPENDENCIES += $(libprrte_la_LIBADD)
+libprrte_la_LDFLAGS += $(prte_zlib_LDFLAGS)
+libprrte_la_CPPFLAGS += $(prte_zlib_CPPFLAGS)
+endif
+
 
 # included subdirectory Makefile.am's and appended-to variables
 headers =

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -417,6 +417,11 @@ static void hnp_complete(const prte_job_t *jdata)
             PRTE_RELEASE(proct);
         }
     }
+    /* although there may be output from other jobs in these sinks,
+     * be sure to flush it all out to ensure we get anything from
+     * this job */
+    prte_iof_base_write_handler(0, 0, prte_iof_base.iof_write_stdout);
+    prte_iof_base_write_handler(0, 0, prte_iof_base.iof_write_stderr);
 }
 
 static int finalize(void)

--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -114,7 +114,6 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
     int32_t numbytes;
     prte_iof_proc_t *proct = (prte_iof_proc_t*)rev->proc;
     int rc;
-    prte_ns_cmp_bitmask_t mask=PRTE_NS_CMP_ALL;
     bool exclusive;
     prte_iof_sink_t *sink;
 
@@ -173,7 +172,7 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
             return;
         }
         /* if the daemon is me, then this is a local sink */
-        if (PRTE_EQUAL == prte_util_compare_name_fields(mask, PRTE_PROC_MY_NAME, &proct->stdinev->daemon)) {
+        if (PMIX_CHECK_PROCID(PRTE_PROC_MY_NAME, &proct->stdinev->daemon)) {
             PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                                  "%s read %d bytes from stdin - writing to %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,


### PR DESCRIPTION
Properly handle zlib support when zlib is present. Silence
warnings about duplicate AM_CFLAGS setting

Signed-off-by: Ralph Castain <rhc@pmix.org>