### PR TITLE
Fix indirect debugger operation

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -213,6 +213,7 @@ static void interim(int sd, short args, void *cbdata)
     /* create the job object */
     jdata = PRTE_NEW(prte_job_t);
     jdata->map = PRTE_NEW(prte_job_map_t);
+    PMIX_XFER_PROCID(&jdata->originator, requestor);
 
     /* transfer the apps across */
     for (n=0; n < cd->napps; n++) {


### PR DESCRIPTION
Minor cleanups of the indirect example. Target the tool for the launch
complete event. Properly track the originator of the job

Combined with https://github.com/openpmix/openpmix/pull/2109
Fixes #797 

Signed-off-by: Ralph Castain <rhc@pmix.org>