### PR TITLE
Remove stale PMIx version constraints

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -268,13 +268,7 @@ int main(int argc, char **argv)
      * the applicaton processes and the debugger daemons have the same
      * namespace, so this module uses the debugger namespace, which it knows.
      */
-#ifdef PMIX_LOAD_PROCID
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
-#else
-    PMIX_PROC_CONSTRUCT(&proc);
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_KEYLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
-#endif
     rc = PMIx_Get(&proc, PMIX_DEBUG_JOB, NULL, 0, &val);
     if (PMIX_ERR_NOT_FOUND == rc) {
         /* Save the application namespace for later */

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -171,18 +171,7 @@ static void prted_abort(int error_code, char *fmt, ...)
         goto cleanup;
     }
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(PRTE_PROC_MY_NAME->nspace)) {
-        tmp = strdup(PRTE_PROC_MY_NAME->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, alert, &PRTE_PROC_MY_NAME->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(alert);
@@ -510,18 +499,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             /* pack only the data for this proc - have to start with the jobid
              * so the receiver can unpack it correctly
              */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            char *tmp = NULL;
-            if (0 < strlen(proc->nspace)) {
-                tmp = strdup(proc->nspace);
-            }
-            rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-            if (NULL != tmp) {
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_pack(NULL, alert, &proc->nspace, 1, PMIX_PROC_NSPACE);
-#endif
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
@@ -633,18 +611,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             /* pack only the data for this proc - have to start with the jobid
              * so the receiver can unpack it correctly
              */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            char *tmp = NULL;
-            if (0 < strlen(proc->nspace)) {
-                tmp = strdup(proc->nspace);
-            }
-            rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-            if (NULL != tmp) {
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_pack(NULL, alert, &proc->nspace, 1, PMIX_PROC_NSPACE);
-#endif
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
@@ -796,18 +763,8 @@ static int pack_state_update(pmix_data_buffer_t *alert, prte_job_t *jobdat)
     pmix_rank_t null=PMIX_RANK_INVALID;
 
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(jobdat->nspace)) {
-        tmp = strdup(jobdat->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
+
     rc = PMIx_Data_pack(NULL, alert, &jobdat->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -654,12 +654,7 @@ static void signal_forward_callback(int fd, short event, void *arg)
     }
 
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    rc = PMIx_Data_pack(NULL, cmd, (void*)&tmp, 1, PMIX_STRING);
-#else
     rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, cmd, &PRTE_JOBID_WILDCARD, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(cmd);

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -232,14 +232,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
                     }
                 }
                 /* pack the jobdata buffer */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-                pmix_byte_object_t pbo;
-                pbo.bytes = (char*)priorjob.base_ptr;
-                pbo.size = priorjob.bytes_used;
-                rc = PMIx_Data_pack(NULL, &jobdata, &pbo, 1, PMIX_BYTE_OBJECT);
-#else
                 rc = PMIx_Data_pack(NULL, &jobdata, &priorjob, 1, PMIX_DATA_BUFFER);
-#endif
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_DESTRUCT(&jobdata);
@@ -250,14 +243,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
             }
         }
         /* pack the jobdata buffer */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        pmix_byte_object_t pbo;
-        pbo.bytes = (char*)jobdata.base_ptr;
-        pbo.size = jobdata.bytes_used;
-        rc = PMIx_Data_pack(NULL, buffer, &pbo, 1, PMIX_BYTE_OBJECT);
-#else
         rc = PMIx_Data_pack(NULL, buffer, &jobdata, 1, PMIX_DATA_BUFFER);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_DESTRUCT(&jobdata);
@@ -327,11 +313,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
             return prte_pmix_convert_status(ret);
         }
         free(tmp);
-#ifdef PMIX_REGEX
         PMIX_INFO_LOAD(&cd.info[0], PMIX_NODE_MAP, regex, PMIX_REGEX);
-#else
-        PMIX_INFO_LOAD(&cd.info[0], PMIX_NODE_MAP, regex, PMIX_STRING);
-#endif
         free(regex);
     }
 
@@ -347,11 +329,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
             return prte_pmix_convert_status(ret);
         }
         free(tmp);
-#ifdef PMIX_REGEX
         PMIX_INFO_LOAD(&cd.info[1], PMIX_PROC_MAP, regex, PMIX_REGEX);
-#else
-        PMIX_INFO_LOAD(&cd.info[1], PMIX_PROC_MAP, regex, PMIX_STRING);
-#endif
         free(regex);
     }
 
@@ -360,15 +338,8 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer,
      * the ability for transport specifications */
     (void)strncpy(cd.info[2].key, PMIX_ALLOC_NETWORK, PMIX_MAX_KEYLEN);
     cd.info[2].value.type = PMIX_DATA_ARRAY;
-#if PMIX_NUMERIC_VERSION < 0x00020203
-    PMIX_INFO_CREATE(info, 3);
-    cd.info[2].value.data.darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
-    cd.info[2].value.data.darray->array = info;
-    cd.info[2].value.data.darray->size = 3;
-#else
     PMIX_DATA_ARRAY_CREATE(cd.info[2].value.data.darray, 3, PMIX_INFO);
     info = (pmix_info_t*)cd.info[2].value.data.darray->array;
-#endif
     asprintf(&tmp, "%s.net", jdata->nspace);
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NETWORK_ID, tmp, PMIX_STRING);
     free(tmp);
@@ -447,27 +418,13 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer,
     if (0 != flag) {
         /* unpack the buffer containing the info */
         cnt=1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        rc = PMIx_Data_unpack(NULL, buffer, &bo, &cnt, PMIX_BYTE_OBJECT);
-        PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
-        dbuf.base_ptr = bo.bytes;
-        dbuf.bytes_used = bo.size;
-#else
         rc = PMIx_Data_unpack(NULL, buffer, &dbuf, &cnt, PMIX_DATA_BUFFER);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto REPORT_ERROR;
         }
         cnt=1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        rc = PMIx_Data_unpack(NULL, buffer, &bo, &cnt, PMIX_BYTE_OBJECT);
-        PMIX_DATA_BUFFER_CONSTRUCT(&jdbuf);
-        jdbuf.base_ptr = bo.bytes;
-        jdbuf.bytes_used = bo.size;
-#else
         rc = PMIx_Data_unpack(NULL, &dbuf, &jdbuf, &cnt, PMIX_DATA_BUFFER);
-#endif
         while (PMIX_SUCCESS == rc) {
             /* unpack each job and add it to the local prte_job_data array */
             cnt=1;
@@ -522,14 +479,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer,
             cnt = 1;
         }
         PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        rc = PMIx_Data_unpack(NULL, buffer, &bo, &cnt, PMIX_BYTE_OBJECT);
-        PMIX_DATA_BUFFER_CONSTRUCT(&jdbuf);
-        jdbuf.base_ptr = bo.bytes;
-        jdbuf.bytes_used = bo.size;
-#else
         rc = PMIx_Data_unpack(NULL, &dbuf, &jdbuf, &cnt, PMIX_DATA_BUFFER);
-#endif
     }
 
     /* unpack the job we are to launch */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -649,18 +649,7 @@ int prte_plm_base_spawn_reponse(int32_t status, prte_job_t *jdata)
         return prte_pmix_convert_status(rc);
     }
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(jdata->nspace)) {
-        tmp = strdup(jdata->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, answer, &tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, answer, &jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(answer);
@@ -881,18 +870,7 @@ static void timeout_cb(int fd, short event, void *cbdata)
             goto giveup;
         }
         /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        char *tmp = NULL;
-        if (0 < strlen(jdata->nspace)) {
-            tmp = strdup(jdata->nspace);
-        }
-        rc = PMIx_Data_pack(NULL, &buffer, &tmp, 1, PMIX_STRING);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         rc = PMIx_Data_pack(NULL, &buffer, &jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_DESTRUCT(&buffer);

--- a/src/mca/plm/base/plm_base_prted_cmds.c
+++ b/src/mca/plm/base/plm_base_prted_cmds.c
@@ -225,18 +225,7 @@ int prte_plm_base_prted_signal_local_procs(pmix_nspace_t job, int32_t signal)
     }
 
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(job)) {
-        tmp = strdup(job);
-    }
-    rc = PMIx_Data_pack(NULL, &cmd, &tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, &cmd, &job, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_DESTRUCT(&cmd);

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -188,18 +188,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
         }
 
         /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        char *tmp = NULL;
-        if (0 < strlen(job)) {
-            tmp = strdup(job);
-        }
-        rc = PMIx_Data_pack(NULL, answer, &tmp, 1, PMIX_STRING);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         rc = PMIx_Data_pack(NULL, answer, &job, 1, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }
@@ -353,13 +342,8 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
         }
 
         /* pack an invalid jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        tmp = NULL;
-        rc = PMIx_Data_pack(NULL, answer, &tmp, 1, PMIX_STRING);
-#else
         PMIX_LOAD_NSPACE(job, NULL);
         rc = PMIx_Data_pack(NULL, answer, &job, 1, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }
@@ -386,16 +370,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                             PRTE_NAME_PRINT(sender));
         count = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        tmp = NULL;
-        rc = PMIx_Data_unpack(NULL, buffer, &tmp, &count, PMIX_STRING);
-        if (NULL != tmp) {
-            PMIX_LOAD_NSPACE(job, tmp);
-            free(tmp);
-        }
-#else
         rc = PMIx_Data_unpack(NULL, buffer, &job, &count, PMIX_PROC_NSPACE);
-#endif
         while (PMIX_SUCCESS == rc) {
             prte_output_verbose(5, prte_plm_base_framework.framework_output,
                                 "%s plm:base:receive got update_proc_state for job %s",
@@ -470,16 +445,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
             }
             /* prepare for next job */
             count = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            tmp = NULL;
-            rc = PMIx_Data_unpack(NULL, buffer, &tmp, &count, PMIX_STRING);
-            if (NULL != tmp) {
-                PMIX_LOAD_NSPACE(job, tmp);
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_unpack(NULL, buffer, &job, &count, PMIX_PROC_NSPACE);
-#endif
         }
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
             PMIX_ERROR_LOG(rc);
@@ -491,15 +457,7 @@ void prte_plm_base_recv(int status, pmix_proc_t* sender,
 
     case PRTE_PLM_REGISTERED_CMD:
         count=1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        rc = PMIx_Data_unpack(NULL, buffer, &tmp, &count, PMIX_STRING);
-        PMIX_LOAD_NSPACE(job, tmp);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         rc = PMIx_Data_unpack(NULL, buffer, &job, &count, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto CLEANUP;

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -182,14 +182,12 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     { '\0', "timeout", 1, PRTE_CMD_LINE_TYPE_INT,
         "Timeout the job after the specified number of seconds",
         PRTE_CMD_LINE_OTYPE_DEBUG },
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     { '\0', "report-state-on-timeout", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Report all job and process states upon timeout",
         PRTE_CMD_LINE_OTYPE_DEBUG },
     { '\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Get stack traces of all application procs on timeout",
         PRTE_CMD_LINE_OTYPE_DEBUG },
-#endif
 
 
     { '\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -169,14 +169,12 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
     { '\0', "timeout", 1, PRTE_CMD_LINE_TYPE_INT,
         "Timeout the job after the specified number of seconds",
         PRTE_CMD_LINE_OTYPE_DEBUG },
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     { '\0', "report-state-on-timeout", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Report all job and process states upon timeout",
         PRTE_CMD_LINE_OTYPE_DEBUG },
     { '\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Get stack traces of all application procs on timeout",
         PRTE_CMD_LINE_OTYPE_DEBUG },
-#endif
 
 
     { '\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -768,15 +768,11 @@ static void dvm_notify(int sd, short args, void *cbdata)
         PRTE_OUTPUT_VERBOSE((2, prte_state_base_framework.framework_output,
                              "%s state:dvm:dvm_notify notification requested",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-    #ifdef PMIX_EVENT_TEXT_MESSAGE
         /* if it was an abnormal termination, then construct an appropriate
          * error message */
         if (PRTE_SUCCESS != rc) {
             errmsg = prte_dump_aborted_procs(jdata);
         }
-    #else
-        errmsg = NULL;
-    #endif
         /* construct the info to be provided */
         if (NULL == errmsg) {
             ninfo = 3;
@@ -797,12 +793,10 @@ static void dvm_notify(int sd, short args, void *cbdata)
             pname.rank = PMIX_RANK_WILDCARD;
         }
         PMIX_INFO_LOAD(&info[2], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
-    #ifdef PMIX_EVENT_TEXT_MESSAGE
         if (NULL != errmsg) {
             PMIX_INFO_LOAD(&info[3], PMIX_EVENT_TEXT_MESSAGE, errmsg, PMIX_STRING);
             free(errmsg);
         }
-    #endif
 
         /* pack the info for sending */
         PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
@@ -900,18 +894,7 @@ static void dvm_notify(int sd, short args, void *cbdata)
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(jdata->nspace)) {
-        tmp = strdup(jdata->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, reply, (void*)&tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, reply, &jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -190,18 +190,7 @@ static void track_jobs(int fd, short argc, void *cbdata)
                 goto cleanup;
             }
             /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            char *tmp = NULL;
-            if (0 < strlen(caddy->jdata->nspace)) {
-                tmp = strdup(caddy->jdata->nspace);
-            }
-            rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-            if (NULL != tmp) {
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_pack(NULL, alert, &caddy->jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
@@ -285,18 +274,7 @@ static void track_jobs(int fd, short argc, void *cbdata)
                 goto cleanup;
             }
             /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            tmp = NULL;
-            if (0 < strlen(caddy->jdata->nspace)) {
-                tmp = strdup(caddy->jdata->nspace);
-            }
-            rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-            if (NULL != tmp) {
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_pack(NULL, alert, &caddy->jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
@@ -436,18 +414,7 @@ static void track_procs(int fd, short argc, void *cbdata)
                 goto cleanup;
             }
             /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-            char *tmp = NULL;
-            if (0 < strlen(proc->nspace)) {
-                tmp = strdup(proc->nspace);
-            }
-            rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-            if (NULL != tmp) {
-                free(tmp);
-            }
-#else
             rc = PMIx_Data_pack(NULL, alert, &proc->nspace, 1, PMIX_PROC_NSPACE);
-#endif
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
@@ -708,18 +675,7 @@ static int pack_state_update(pmix_data_buffer_t *alert, prte_job_t *jdata)
     pmix_rank_t null=PMIX_RANK_INVALID;
 
     /* pack the jobid */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(jdata->nspace)) {
-        tmp = strdup(jdata->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, alert, (void*)&tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, alert, &jdata->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -41,7 +41,6 @@ pmix_status_t prte_pmix_convert_rc(int rc)
 {
     switch (rc) {
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     case PRTE_ERR_HEARTBEAT_ALERT:
     case PRTE_ERR_FILE_ALERT:
     case PRTE_ERR_HEARTBEAT_LOST:
@@ -57,7 +56,6 @@ pmix_status_t prte_pmix_convert_rc(int rc)
 
     case PRTE_ERR_JOB_CANCELLED:
         return PMIX_ERR_JOB_CANCELED;
-#endif
 
     case PRTE_ERR_DEBUGGER_RELEASE:
         return PMIX_ERR_DEBUGGER_RELEASE;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -73,16 +73,7 @@ void pmix_server_launch_resp(int status, pmix_proc_t* sender,
 
     /* unpack the jobid */
     cnt = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    rc = PMIx_Data_unpack(NULL, buffer, &tmp, &cnt, PMIX_STRING);
-    PMIX_LOAD_NSPACE(jobid, tmp);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_unpack(NULL, buffer, &jobid, &cnt, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         ret = prte_pmix_convert_rc(rc);
@@ -316,11 +307,9 @@ static void interim(int sd, short args, void *cbdata)
                     prte_add_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
                                        PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
                 } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_PSET_NAME,
                                        PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
-#endif
                 } else {
                     /* unrecognized key */
                     if (9 < prte_output_get_verbosity(prte_pmix_server_globals.output)) {
@@ -578,7 +567,6 @@ static void interim(int sd, short args, void *cbdata)
             envar.separator = info->value.data.envar.separator;
             prte_add_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
                                PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
-#if PMIX_NUMERIC_VERSION >= 0x00040000
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
 
@@ -599,7 +587,6 @@ static void interim(int sd, short args, void *cbdata)
                 prte_add_attribute(&jdata->attributes, PRTE_JOB_REPORT_STATE,
                                    PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
             }
-#endif
         /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {
             /* cache for inclusion with job info at registration */

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -193,7 +193,6 @@ static void dmodex_req(int sd, short args, void *cbdata)
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          req->tproc.nspace, req->tproc.rank);
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     /* check if they want us to refresh the cache */
     if (NULL != req->info) {
         size_t n;
@@ -205,7 +204,6 @@ static void dmodex_req(int sd, short args, void *cbdata)
             }
         }
     }
-#endif
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
                          "%s DMODX REQ REFRESH %s REQUIRED KEY %s",

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -321,12 +321,10 @@ PRTE_EXPORT extern pmix_status_t pmix_server_stdin_fn(const pmix_proc_t *source,
                                                        const pmix_byte_object_t *bo,
                                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
 PRTE_EXPORT extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
                                                        const pmix_proc_t procs[], size_t nprocs,
                                                        const pmix_info_t directives[], size_t ndirs,
                                                        pmix_info_cbfunc_t cbfunc, void *cbdata);
-#endif
 
 PRTE_EXPORT void prte_pmix_server_tool_conn_complete(prte_job_t *jdata,
                                                        pmix_server_req_t *req);

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -78,9 +78,7 @@ static void _query(int sd, short args, void *cbdata)
     size_t m, n, p;
     uint32_t key, nodeid;
     char **nspaces, *hostname, *uri;
-#ifdef PMIX_QUERY_NAMESPACE_INFO
     char *cmdline;
-#endif
     char **ans, *tmp;
     prte_app_context_t *app;
     int matched;
@@ -88,9 +86,7 @@ static void _query(int sd, short args, void *cbdata)
     pmix_info_t *info;
     pmix_data_array_t *darray;
     prte_proc_t *proct;
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     size_t sz;
-#endif
 
     PRTE_ACQUIRE_OBJECT(cd);
 
@@ -179,7 +175,6 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_NAMESPACES, tmp, PMIX_STRING);
                 free(tmp);
                 prte_list_append(&results, &kv->super);
-#ifdef PMIX_QUERY_NAMESPACE_INFO
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_NAMESPACE_INFO)) {
                 /* get the current jobids */
                 PRTE_CONSTRUCT(&stack, prte_list_t);
@@ -227,7 +222,6 @@ static void _query(int sd, short args, void *cbdata)
                     ++p;
                 }
                 PRTE_LIST_DESTRUCT(&stack);
-#endif
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_SPAWN_SUPPORT)) {
                 ans = NULL;
                 prte_argv_append_nosize(&ans, PMIX_HOST);
@@ -362,7 +356,6 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_INFO_LOAD(&kv->info, PMIX_SERVER_URI, uri, PMIX_STRING);
                 free(uri);
                 prte_list_append(&results, &kv->super);
-    #ifdef PMIX_QUERY_PROC_TABLE
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_PROC_TABLE)) {
                 /* construct a list of values with prte_proc_info_t
                  * entries for each proc in the indicated job */
@@ -384,9 +377,6 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_DATA_ARRAY_CREATE(darray, jdata->num_procs, PMIX_PROC_INFO);
                 kv->info.value.type = PMIX_DATA_ARRAY;
                 kv->info.value.data.darray = darray;
-        #if PMIX_NUMERIC_VERSION < 0x00030100
-                PMIX_PROC_INFO_CREATE(darray->array, jdata->num_local_procs);
-        #endif
                 procinfo = (pmix_proc_info_t*)darray->array;
                 p = 0;
                 for (k=0; k < jdata->procs->size; k++) {
@@ -427,9 +417,6 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_DATA_ARRAY_CREATE(darray, jdata->num_local_procs, PMIX_PROC_INFO);
                 kv->info.value.type = PMIX_DATA_ARRAY;
                 kv->info.value.data.darray = darray;
-        #if PMIX_NUMERIC_VERSION < 0x00030100
-                PMIX_PROC_INFO_CREATE(darray->array, jdata->num_local_procs);
-        #endif
                 procinfo = (pmix_proc_info_t*)darray->array;
                 p = 0;
                 for (k=0; k < jdata->procs->size; k++) {
@@ -451,8 +438,6 @@ static void _query(int sd, short args, void *cbdata)
                         ++p;
                     }
                 }
-    #endif
-    #ifdef PMIX_QUERY_NUM_PSETS
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_NUM_PSETS)) {
                 kv = PRTE_NEW(prte_info_item_t);
                 sz = prte_list_get_size(&prte_pmix_server_globals.psets);
@@ -471,7 +456,6 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
                 prte_list_append(&results, &kv->super);
                 free(tmp);
-    #endif
             } else if (0 == strcmp(q->keys[n], PMIX_JOB_SIZE)) {
                 jdata = prte_get_job_data_object(jobid);
                 if (NULL == jdata) {

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -155,12 +155,10 @@ static int create_app(prte_cmd_line_t *prte_cmd_line,
         app->app.cwd = strdup(cwd);
     }
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     /* if they specified a process set name, then pass it along */
     if (NULL != (pvalue = prte_cmd_line_get_param(prte_cmd_line, "pset", 0, 0))) {
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PSET_NAME, pvalue->value.data.string, PMIX_STRING);
     }
-#endif
 
     /* Did the user specify a hostfile. Need to check for both
      * hostfile and machine file.

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -204,16 +204,7 @@ void prte_daemon_recv(int status, pmix_proc_t* sender,
     case PRTE_DAEMON_SIGNAL_LOCAL_PROCS:
         /* unpack the jobid */
         n = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        tmp = NULL;
-        ret = PMIx_Data_unpack(NULL, buffer, &tmp, &n, PMIX_STRING);
-        PMIX_LOAD_NSPACE(job, tmp);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         ret = PMIx_Data_unpack(NULL, buffer, &job, &n, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             goto CLEANUP;
@@ -475,16 +466,7 @@ void prte_daemon_recv(int status, pmix_proc_t* sender,
     case PRTE_DAEMON_DVM_CLEANUP_JOB_CMD:
         /* unpack the jobid */
         n = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        tmp = NULL;
-        ret = PMIx_Data_unpack(NULL, buffer, &tmp, &n, PMIX_STRING);
-        PMIX_LOAD_NSPACE(job, tmp);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         ret = PMIx_Data_unpack(NULL, buffer, &job, &n, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             goto CLEANUP;
@@ -640,16 +622,7 @@ void prte_daemon_recv(int status, pmix_proc_t* sender,
 
         /* unpack the jobid */
         n = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-        tmp = NULL;
-        ret = PMIx_Data_unpack(NULL, buffer, &tmp, &n, PMIX_STRING);
-        PMIX_LOAD_NSPACE(job, tmp);
-        if (NULL != tmp) {
-            free(tmp);
-        }
-#else
         ret = PMIx_Data_unpack(NULL, buffer, &job, &n, PMIX_PROC_NSPACE);
-#endif
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             goto CLEANUP;

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -54,16 +54,7 @@ int prte_job_pack(pmix_data_buffer_t *bkt,
     prte_info_item_t *val;
 
     /* pack the nspace */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    char *tmp = NULL;
-    if (0 < strlen(job->nspace)) {
-        tmp = strdup(job->nspace);
-    }
-    rc = PMIx_Data_pack(NULL, bkt, (void*)&tmp, 1, PMIX_STRING);
-    free(tmp);
-#else
     rc = PMIx_Data_pack(NULL, bkt, (void*)&job->nspace, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return prte_pmix_convert_status(rc);
@@ -261,18 +252,7 @@ int prte_job_pack(pmix_data_buffer_t *bkt,
     }
 
     /* pack the launcher ID */
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    tmp = NULL;
-    if (0 < strlen(job->launcher)) {
-        tmp = strdup(job->launcher);
-    }
-    rc = PMIx_Data_pack(NULL, bkt, (void*)&tmp, 1, PMIX_STRING);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_pack(NULL, bkt, (void*)&job->launcher, 1, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return prte_pmix_convert_status(rc);

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -64,16 +64,7 @@ int prte_job_unpack(pmix_data_buffer_t *bkt,
 
     /* unpack the nspace */
     n = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    tmp = NULL;
-    rc = PMIx_Data_unpack(NULL, bkt, &tmp, &n, PMIX_STRING);
-    PMIX_LOAD_NSPACE(jptr->nspace, tmp);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_unpack(NULL, bkt, &jptr->nspace, &n, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PRTE_RELEASE(jptr);
@@ -283,16 +274,7 @@ int prte_job_unpack(pmix_data_buffer_t *bkt,
 
     /* unpack the launcher ID */
     n = 1;
-#if PMIX_NUMERIC_VERSION < 0x00040100
-    tmp = NULL;
-    rc = PMIx_Data_unpack(NULL, bkt, &tmp, &n, PMIX_STRING);
-    PMIX_LOAD_NSPACE(jptr->launcher, tmp);
-    if (NULL != tmp) {
-        free(tmp);
-    }
-#else
     rc = PMIx_Data_unpack(NULL, bkt, &jptr->launcher, &n, PMIX_PROC_NSPACE);
-#endif
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PRTE_RELEASE(jptr);

--- a/src/runtime/help-prte-runtime.txt
+++ b/src/runtime/help-prte-runtime.txt
@@ -64,11 +64,3 @@ as the mapping.
 PRTE was unable to determine the number of nodes in your allocation. We
 are therefore assuming a very large number to ensure you receive proper error
 messages.
-#
-[compress-unavailable]
-PRRTE was unable to find a usable compression library
-on the system. We will therefore be unable to compress
-large data streams. This may result in longer-than-normal
-startup times and larger memory footprints. We will
-continue, but strongly recommend installing zlib or
-a comparable compression library for better user experience.

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -187,14 +187,6 @@ char *prte_daemon_cores = NULL;
 /* enable/disable ft */
 bool prte_enable_ft = false;
 
-#if PMIX_NUMERIC_VERSION < 0x00040100
-#if PRTE_HAVE_ZLIB
-size_t prte_base_compress_limit;
-#else
-bool prte_base_silence_compress_warn;
-#endif
-#endif
-
 int prte_dt_init(void)
 {
     /* set default output */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -641,14 +641,6 @@ extern char *prte_set_max_sys_limits;
 /* Enable/disable ft */
 PRTE_EXPORT extern bool prte_enable_ft;
 
-#if PMIX_NUMERIC_VERSION < 0x00040100
-#if PRTE_HAVE_ZLIB
-PRTE_EXPORT extern size_t prte_base_compress_limit;
-#else
-PRTE_EXPORT extern bool prte_base_silence_compress_warn;
-#endif
-#endif
-
 END_C_DECLS
 
 #endif /* PRTE_RUNTIME_PRTE_GLOBALS_H */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -650,25 +650,5 @@ int prte_register_params(void)
                         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_enable_ft);
 #endif
 
-#if PMIX_NUMERIC_VERSION < 0x00040100
-#if PRTE_HAVE_ZLIB
-    prte_base_compress_limit = 4096;
-    prte_mca_base_var_register("prte", "prte", NULL, "compress_limit",
-                               "Threshold beyond which data will be compressed",
-                               PRTE_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0,
-                               PRTE_MCA_BASE_VAR_FLAG_NONE,
-                               PRTE_INFO_LVL_3,
-                               PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_base_compress_limit);
-#else
-    prte_base_silence_compress_warn = false;
-    prte_mca_base_var_register("prte", "prte", NULL, "silence_compression_warning",
-                               "Do not warn if compression unavailable",
-                               PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
-                               PRTE_MCA_BASE_VAR_FLAG_NONE,
-                               PRTE_INFO_LVL_3,
-                               PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_base_silence_compress_warn);
-#endif
-#endif
-
     return PRTE_SUCCESS;
 }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -749,7 +749,6 @@ int prte(int argc, char *argv[])
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_FILE, ptr, PMIX_STRING);
         free(ptr);
     } else if (NULL != ptr) {
-#if PMIX_NUMERIC_VERSION >= 0x00040000
         /* if we were asked to output to a directory, pass it along. */
         /* If the given filename isn't an absolute path, then
          * convert it to one so the name will be relative to
@@ -767,7 +766,6 @@ int prte(int argc, char *argv[])
         }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
         free(param);
-#endif
     }
     /* if we were asked to merge stderr to stdout, mark it so */
     if (prte_cmd_line_is_taken(prte_cmd_line, "merge-stderr-to-stdout")) {
@@ -843,14 +841,12 @@ int prte(int argc, char *argv[])
         }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT, &i, PMIX_INT);
     }
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     if (prte_cmd_line_is_taken(prte_cmd_line, "get-stack-traces")) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_STACKTRACES, NULL, PMIX_BOOL);
     }
     if (prte_cmd_line_is_taken(prte_cmd_line, "report-state-on-timeout")) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_REPORT_STATE, NULL, PMIX_BOOL);
     }
-#endif
 
     /* give the schizo components a chance to add to the job info */
     prte_schizo.job_info(prte_cmd_line, jinfo);
@@ -1101,7 +1097,6 @@ int prte(int argc, char *argv[])
     }
 
   proceed:
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     /* push our stdin to the apps */
     PMIX_LOAD_PROCID(&pname, spawnednspace, 0);  // forward stdin to rank=0
     PMIX_INFO_CREATE(iptr, 1);
@@ -1115,7 +1110,6 @@ int prte(int argc, char *argv[])
     }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(iptr, 1);
-#endif
 
     /* loop the event lib until an exit event is detected */
     while (prte_event_base_active) {
@@ -1123,7 +1117,6 @@ int prte(int argc, char *argv[])
     }
     PRTE_ACQUIRE_OBJECT(prte_event_base_active);
 
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     /* close the push of our stdin */
     PMIX_INFO_LOAD(&info, PMIX_IOF_COMPLETE, NULL, PMIX_BOOL);
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
@@ -1135,7 +1128,6 @@ int prte(int argc, char *argv[])
     }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_DESTRUCT(&info);
-#endif
 
   DONE:
     /* cleanup and leave */
@@ -1301,11 +1293,7 @@ static void signal_forward_callback(int signum, short args, void *cbdata)
     /* send the signal out to the processes */
     PMIX_LOAD_PROCID(&proc, spawnednspace, PMIX_RANK_WILDCARD);
     PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_SIGNAL, &signum, PMIX_INT);
-#if PMIX_NUMERIC_VERSION >= 0x00040000
     rc = PMIx_Job_control(&proc, 1, &info, 1, NULL, NULL);
-#else
-    rc = PMIx_Job_control(&proc, 1, &info, 1);
-#endif
     if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
         fprintf(stderr, "Signal %d could not be sent to job %s (returned %s)",
                 signum, spawnednspace, PMIx_Error_string(rc));

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -384,6 +384,8 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    /* ensure we silence any compression warnings */
+    prte_setenv("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
 
     if (PRTE_SUCCESS != (ret = prte_init(&argc, &argv, PRTE_PROC_DAEMON))) {
         PRTE_ERROR_LOG(ret);

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -212,10 +212,8 @@ static void evhandler(size_t evhdlr_registration_id,
                 PMIX_LOAD_NSPACE(jobid, info[n].value.data.proc->nspace);
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
                 lock = (prte_pmix_lock_t*)info[n].value.data.ptr;
-        #ifdef PMIX_EVENT_TEXT_MESSAGE
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN)) {
                 msg = info[n].value.data.string;
-        #endif
             }
         }
         if (verbose && PMIX_CHECK_NSPACE(jobid, myjobid)) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -633,12 +633,10 @@ int prte_attr_load(prte_attribute_t *kv,
         kv->data.data.rank = *(pmix_rank_t *)data;
         break;
 
-#if PMIX_NUMERIC_VERSION >= 0x00040100
     case PMIX_PROC_NSPACE:
         PMIX_PROC_CREATE(kv->data.data.proc, 1);
         PMIX_LOAD_NSPACE(kv->data.data.proc->nspace, (char*)data);
         break;
-#endif
 
     case PMIX_PROC:
         PMIX_PROC_CREATE(kv->data.data.proc, 1);
@@ -673,9 +671,7 @@ int prte_attr_unload(prte_attribute_t *kv,
         PMIX_STRING,
         PMIX_BYTE_OBJECT,
         PMIX_POINTER,
-#if PMIX_NUMERIC_VERSION >= 0x00040100
         PMIX_PROC_NSPACE,
-#endif
         PMIX_PROC,
         PMIX_ENVAR,
         PMIX_UNDEF
@@ -786,12 +782,10 @@ int prte_attr_unload(prte_attribute_t *kv,
         memcpy(*data, &kv->data.data.rank, sizeof(pmix_rank_t));
         break;
 
-#if PMIX_NUMERIC_VERSION >= 0x00040100
     case PMIX_PROC_NSPACE:
         PMIX_PROC_CREATE(*data, 1);
         memcpy(*data, kv->data.data.proc->nspace, sizeof(pmix_nspace_t));
         break;
-#endif
 
     case PMIX_PROC:
         PMIX_PROC_CREATE(*data, 1);


### PR DESCRIPTION
We now require v4.0.1 and above, so no longer need to check against lower versions

Signed-off-by: Ralph Castain <rhc@pmix.org>