### PR TITLE
Correctly handle dynamic extensions of the DVM

### DIFF
--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -226,6 +226,9 @@ int prte_pmix_convert_status(pmix_status_t status)
     case PMIX_SUCCESS:
     case PMIX_OPERATION_SUCCEEDED:
         return PRTE_SUCCESS;
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+
     default:
         return status;
     }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -958,13 +958,14 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t* sender,
     pmix_status_t prc, pret;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s dmdx:recv response from proc %s",
+                        "%s dmdx:recv response from proc %s with %d bytes",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        PRTE_NAME_PRINT(sender));
+                        PRTE_NAME_PRINT(sender), (int)buffer->bytes_used);
 
     d = PRTE_NEW(datacaddy_t);
 
     /* unpack the status */
+    cnt = 1;
     if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &pret, &cnt, PMIX_STATUS))) {
         PMIX_ERROR_LOG(prc);
         PRTE_RELEASE(d);


### PR DESCRIPTION
The DVM can be extended in response to add_host and add_hostfile
directives. In such cases, we need to provide the new daemons
with a complete picture of the currently executing jobs so they
can properly map the new one.

Signed-off-by: Ralph Castain <rhc@pmix.org>