### PR TITLE
Begin populating PRRTE tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ test/get-nofence
 test/attachtest/app
 test/attachtest/tool
 test/get-immediate
+test/abort
+test/simple_spawn

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,7 +38,9 @@ TESTS = \
 	get-nofence \
 	get-immediate \
 	attachtest/app.c \
-	attachtest/tool.c
+	attachtest/tool.c \
+	abort \
+	simple_spawn
 
 all: $(TESTS)
 

--- a/test/abort.c
+++ b/test/abort.c
@@ -1,0 +1,64 @@
+/* -*- C -*-
+ *
+ * $HEADER$
+ *
+ * The most basic of applications
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "pmix.h"
+
+int main(int argc, char* argv[])
+{
+    int size;
+    int errcode;
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    pmix_proc_t proc;
+    pmix_value_t *val = NULL;
+
+    if (1 < argc) {
+        errcode = strtol(argv[1], NULL, 10);
+    } else {
+        errcode = 2;
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(errcode);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIX_VALUE_GET_NUMBER(rc, val, size, int);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: get size number failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIX_VALUE_RELEASE(val);
+
+    printf("Hello, World, I am %d of %d\n", myproc.rank, size);
+
+    if (1 == size) {
+            PMIx_Abort(errcode, "Aborting", NULL, 0);
+    } else {
+        if (1 == myproc.rank) {
+            PMIx_Abort(errcode, "Aborting", NULL, 0);
+        } else {
+            errcode = 0;
+            sleep(99999999);
+        }
+    }
+
+done:
+    PMIx_Finalize(NULL, 0);
+    return errcode;
+}

--- a/test/simple_spawn.c
+++ b/test/simple_spawn.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/param.h>
+
+
+#include <pmix.h>
+
+int main(int argc, char* argv[])
+{
+    pmix_status_t rc;
+    int size;
+    pid_t pid;
+    pmix_proc_t myproc;
+    pmix_proc_t proc;
+    pmix_app_t app;
+    pmix_proc_t peers[2];
+    char hostname[1024];
+    pmix_value_t *val = NULL;
+    pmix_nspace_t nspace;
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client: PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        exit(1);
+    }
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIX_VALUE_GET_NUMBER(rc, val, size, int);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: get size number failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIX_VALUE_RELEASE(val);
+
+    printf("[%s:%u pid %ld] of %d starting up on node %s!\n",
+           myproc.nspace, myproc.rank, (long)pid, size, hostname);
+
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, NULL, 0, &val);
+    /* If we don't find it, then we're the parent */
+    if (PMIX_SUCCESS != rc) {
+        pid = getpid();
+        printf("Parent [pid %ld] about to spawn!\n", (long)pid);
+        PMIX_APP_CONSTRUCT(&app);
+        app.cmd = strdup(argv[0]);
+        PMIX_ARGV_APPEND(rc, app.argv, argv[0]);
+        app.maxprocs = 3;
+        rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+        if (PMIX_SUCCESS != rc) {
+            printf("Child failed to spawn\n");
+            return rc;
+        }
+        printf("Parent done with spawn\n");
+        /* connect to the children */
+    }
+    /* Otherwise, we're the child */
+    else {
+        printf("Hello from the child %s.%u of %d on host %s pid %ld\n",
+               myproc.nspace, myproc.rank, size, hostname, (long)pid);
+    }
+
+done:
+    PMIx_Finalize(NULL, 0);
+    fprintf(stderr, "%d: exiting\n", pid);
+    return 0;
+}


### PR DESCRIPTION
Port tests from the old ORTE test/simple directory to PRRTE,
stripping away the MPI dependencies and replacing them with
direct PMIx calls. Fix missing PMIX_PARENT_ID key in job
registration.

Signed-off-by: Ralph Castain <rhc@pmix.org>