### PR TITLE
build: Fix handling of prte_get_version.sh

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -26,6 +26,7 @@
 EXTRA_DIST = \
         distscript.sh \
         prte_get_version.m4sh \
+        prte_get_version.sh \
         ltmain_nag_pthread.diff \
         ltmain_pgi_tp.diff \
         prte_mca_priority_sort.pl \
@@ -35,6 +36,3 @@ EXTRA_DIST = \
         md2nroff.pl \
         from-savannah/upstream-config.guess \
         from-savannah/upstream-config.sub
-
-maintainer-clean-local:
-	rm -f prte_get_version.sh


### PR DESCRIPTION
Two semi-related fixes for prte_get_version.sh.  First,
prte_get_version.sh is committed to Git, so it should not be
removed as part of maintainer-clean.  Second, because autogen.pl
is no longer generated from prte_get_version.m4sh, it needs to
be included in the dist tarball so that autogen.pl can be run
on a dist tarball.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>