### PR TITLE
Adding --output and --display options

### DIFF
--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -112,6 +112,14 @@ static prte_schizo_conflicts_t bindto_modifiers[] = {
     {.name = ""}
 };
 
+static prte_schizo_conflicts_t output_modifiers[] = {
+    {.name = ""}
+};
+
+static prte_schizo_conflicts_t display_modifiers[] = {
+    {.name = ""}
+};
+
 static int check_modifiers(char *modifier, char **checks, prte_schizo_conflicts_t *conflicts)
 {
     int n, m, k;
@@ -153,6 +161,10 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete,
             modifiers = rankby_modifiers;
         } else if (0 == strcmp(option, "--bind-to")) {
             modifiers = bindto_modifiers;
+        } else if (0 == strcmp(option, "--output")) {
+            modifiers = output_modifiers;
+        } else if (0 == strcmp(option, "--display")) {
+            modifiers = display_modifiers;
         } else  {
             prte_output(0, "UNRECOGNIZED OPTION: %s", option);
             return PRTE_ERR_BAD_PARAM;
@@ -164,9 +176,9 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete,
     for (j=0; NULL != pargs[j]; j++) {
         if (0 == strcmp(pargs[j], option)) {
             found = true;
-            /* if it is a --tune option, then we need to simply append the
-             * comma-delimited list of files they gave to the existing one */
-            if (0 == strcasecmp(option, "--tune")) {
+            /* if it is a --tune, --output, or --display option, then we need to simply
+             * append the comma-delimited list of files they gave to the existing one */
+            if (0 == strcasecmp(option, "--tune") || 0 == strcasecmp(option, "--output") || 0 == strcasecmp(option, "--display")) {
                 /* it is possible someone gave this option more than once - avoid that here
                  * while preserving ordering of files */
                 if (j < idx) {
@@ -184,7 +196,7 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete,
                 prte_argv_free(tmp);
                 free(pargs[j+1]);
                 pargs[j+1] = p2;
-                if (0 != strcmp(pargs[j], "--tune")) {
+                if (0 != strcmp(pargs[j], "--tune") || 0 != strcmp(pargs[j], "--output") || 0 != strcmp(pargs[j], "--display")) {
                     prte_asprintf(&help_str, "%s %s", option, p2);
                     /* can't just call show_help as we want every instance to be reported */
                     output = prte_show_help_string("help-schizo-base.txt", "deprecated-converted", true,
@@ -324,6 +336,12 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete,
         if (0 == strcasecmp(option, "--tune")) {
             p2 = NULL;
             prte_asprintf(&help_str, "%s %s", pargs[idx], pargs[idx+1]);
+        } else if (0 == strcasecmp(option, "--output") || 0 == strcasecmp(option, "--display")) {
+            if (NULL != directive) {
+                prte_asprintf(&p2, "%s:%s", directive, modifier);
+            } else {
+                p2 = strdup(modifier);
+            }
         } else if (NULL == directive) {
             prte_asprintf(&p2, ":%s", modifier);
         } else if (NULL == modifier) {

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -217,6 +217,10 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
         PRTE_CMD_LINE_OTYPE_GENERAL },
 
     /* output options */
+    { '\0', "output", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-delimited list of options that control the output generated."
+        "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir:DIRNAME",
+        PRTE_CMD_LINE_OTYPE_OUTPUT },
     /* exit status reporting */
     { '\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Return the exit status of the primary job only",
@@ -340,6 +344,11 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
         PRTE_CMD_LINE_OTYPE_LAUNCH },
 
 
+    /* display options */
+    { '\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-delimited list of options for displaying information about the allocation and job."
+        "Allowed values: allocation, map, bind, proctable, allocation, map-diffable, topo",
+        PRTE_CMD_LINE_OTYPE_DEBUG },
     /* developer options */
     { '\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
         "Perform all necessary operations to prepare to launch the application, but do not actually launch it (usually used to test mapping patterns)",

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -241,7 +241,7 @@ int prte(int argc, char *argv[])
     mylock_t mylock;
     prte_value_t *pval;
     uint32_t ui32;
-    char **pargv;
+    char **pargv, **targv;
     int pargc;
     prte_job_t *jdata;
     prte_app_context_t *dapp;
@@ -498,7 +498,6 @@ int prte(int argc, char *argv[])
     if (prte_debug_flag || prte_debug_daemons_flag || prte_leave_session_attached) {
         prte_devel_level_output = true;
     }
-    
     /* detach from controlling terminal
      * otherwise, remain attached so output can get to us
      */
@@ -718,14 +717,65 @@ int prte(int argc, char *argv[])
     /* pass the personality */
     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, schizo->name, PMIX_STRING);
 
+    /* get display options */
+    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "display", 0, 0))) {
+        targv = prte_argv_split(pval->value.data.string, ',');
+
+        for (int idx = 0; idx < prte_argv_count(targv); idx++) {
+            if (0 == strcmp(targv[idx], "allocation")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "map")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "bind")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "proctable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "allocation-devel")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "map-diffable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDIFF", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "topo")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);
+            }
+        }
+        prte_argv_free(targv);
+    }
+
     /* cannot have both files and directory set for output */
-    param = NULL;
     ptr = NULL;
+    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output", 0, 0))) {
+        targv = prte_argv_split(pval->value.data.string, ',');
+
+        for (int idx = 0; idx < prte_argv_count(targv); idx++) {
+            if (0 == strcmp(targv[idx], "tag")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
+            }
+            if (0 == strcmp(targv[idx], "timestamp")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
+            }
+            if (0 == strcmp(targv[idx], "xml")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":XMLOUTPUT", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "merge-stderr-to-stdout")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
+            }
+            if (NULL != (ptr = strchr(targv[idx], ':'))) {
+                ++ptr;
+                ptr = strdup(ptr);
+            }
+        }
+        prte_argv_free(targv);
+    }
+
+    param = NULL;
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output-filename", 0, 0))) {
         param = pval->value.data.string;
-    }
-    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output-directory", 0, 0))) {
-        ptr = pval->value.data.string;
     }
     if (NULL != param && NULL != ptr) {
         prte_show_help("help-prted.txt", "both-file-and-dir-set", true,
@@ -767,10 +817,6 @@ int prte(int argc, char *argv[])
         }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
         free(param);
-    }
-    /* if we were asked to merge stderr to stdout, mark it so */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "merge-stderr-to-stdout")) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
     }
 
     /* check what user wants us to do with stdin */
@@ -893,7 +939,6 @@ int prte(int argc, char *argv[])
         }
         PMIX_INFO_FREE(mylock.info, mylock.ninfo);
     }
-    
     /* see if we ourselves were spawned by someone */
     ret = PMIx_Get(&prte_process_info.myproc, PMIX_PARENT_ID, NULL, 0, &val);
     if (PMIX_SUCCESS == ret) {
@@ -974,7 +1019,6 @@ int prte(int argc, char *argv[])
                 prte_set_attribute(&dapp->attributes, PRTE_APP_HOSTFILE, PRTE_ATTR_GLOBAL, pval->value.data.string, PMIX_STRING);
             }
         }
-        
         /* Did the user specify any hosts? */
         if (0 < (j = prte_cmd_line_get_ninsts(prte_cmd_line, "host"))) {
             char **targ=NULL, *tval;
@@ -1004,7 +1048,6 @@ int prte(int argc, char *argv[])
             prte_argv_free(hosts);
         }
     }
-    
     /* spawn the DVM - we skip the initial steps as this
      * isn't a user-level application */
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOCATE);


### PR DESCRIPTION
added --output <arg0> and --display <arg0> options which allow the user to
specify what prrte reports with a comma separated list.

--output options tag, timestamp, xml, merge-stderr-to-stdout, dir:DIRNAME
replace --tag-output, --timestamp-output, --xml, --merge-stderr-to-stdout, and
--output-directory DIRNAME respectively.

--display options allocation, map, bind, proctable, allocation-devel,
map-diffable, and topo replace --display-allocation, --display-map,
--report-bindings, --output-proctable, --display-devel-allocation,
--display-diffable-map, and --display-topo respectively

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>