### PR TITLE
Ensure that common local interface names are not included in aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ test/attachtest/tool
 test/get-immediate
 test/abort
 test/simple_spawn
+test/hello

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -703,12 +703,18 @@ static void doit(char *tgt,
         prte_output_verbose(1, prte_schizo_base_framework.framework_output,
                             "%s schizo:prte:parse_env adding %s %s to cmd line",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), p1, value);
-        prte_argv_append_nosize(dstenv, "--prtemca");
+        if (0 == strcmp(tgt, "PMIX_MCA_")) {
+            prte_argv_append_nosize(dstenv, "--pmixmca");
+        } else {
+            prte_argv_append_nosize(dstenv, "--prtemca");
+        }
         prte_argv_append_nosize(dstenv, p1);
         prte_argv_append_nosize(dstenv, value);
     } else {
         /* push it into our environment with a PRTE_MCA_ prefix*/
-        if (0 != strcmp(tgt, "PRTE_MCA_")) {
+        if (0 == strcmp(tgt, "PMIX_MCA_")) {
+            prte_asprintf(&tmp, "PMIX_MCA_%s", p1);
+        }else if (0 != strcmp(tgt, "PRTE_MCA_")) {
             prte_asprintf(&tmp, "PRTE_MCA_%s", p1);
         } else {
             tmp = strdup(param);
@@ -775,6 +781,8 @@ static int parse_env(prte_cmd_line_t *cmd_line,
                     break;
                 }
             }
+        } else if (0 == strncmp("PMIX_MCA_", srcenv[i], strlen("PMIX_MCA_"))) {
+            doit("PMIX_MCA_", srcenv[i], srcenv, dstenv, cmdline);
         }
     }
 

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -160,6 +160,9 @@ prte_cmd_line_init_t prted_cmd_line_opts[] = {
     { '\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
         "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
         PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "pmixmca", 2, PRTE_CMD_LINE_TYPE_STRING,
+        "Pass context-specific PMIx MCA parameters; they are considered global if --gmca is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+        PRTE_CMD_LINE_OTYPE_LAUNCH },
 
     /* Debug options */
     { '\0', "debug", 0, PRTE_CMD_LINE_TYPE_BOOL,
@@ -672,6 +675,7 @@ int main(int argc, char *argv[])
     /* include any non-loopback aliases for this node */
     for (n=0; NULL != prte_process_info.aliases[n]; n++) {
         if (0 != strcmp(prte_process_info.aliases[n], "localhost") &&
+            0 != strcmp(prte_process_info.aliases[n], "127.0.0.1") &&
             0 != strcmp(prte_process_info.aliases[n], prte_process_info.nodename)) {
             prte_argv_append_nosize(&nonlocal, prte_process_info.aliases[n]);
         }

--- a/src/util/if.c
+++ b/src/util/if.c
@@ -327,8 +327,11 @@ prte_ifislocal(const char *hostname)
      * function will not attempt to resolve the address if
      * told not to do so */
     if (PRTE_SUCCESS == prte_ifaddrtoname(hostname, addrname, ADDRLEN)) {
-        /* add this to our known aliases */
-        prte_argv_append_nosize(&prte_process_info.aliases, hostname);
+        if (0 != strcmp(hostname, "localhost") &&
+            0 != strcmp(hostname, "127.0.0.1")) {
+            /* add this to our known aliases */
+            prte_argv_append_nosize(&prte_process_info.aliases, hostname);
+        }
         return true;
     }
 
@@ -514,8 +517,13 @@ void prte_ifgetaliases(char ***aliases)
         if ((intf->if_flags & IFF_LOOPBACK) != 0) {
             continue;
         }
+        /* ignore the obvious */
         if (addr->sin_family == AF_INET) {
             inet_ntop(AF_INET, &(addr->sin_addr.s_addr), ipv4, INET_ADDRSTRLEN);
+            if (0 == strcmp(ipv4, "localhost") ||
+                0 == strcmp(ipv4, "127.0.0.1")) {
+                continue;
+            }
             prte_argv_append_nosize(aliases, ipv4);
         }
 #if PRTE_ENABLE_IPV6

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -150,11 +150,6 @@ void prte_setup_hostname(void)
     } else {
         prte_process_info.nodename = strdup(hostname);
     }
-
-    /* add "localhost" to our list of aliases */
-    prte_argv_append_nosize(&prte_process_info.aliases, "localhost");
-    prte_argv_append_nosize(&prte_process_info.aliases, "127.0.0.1");
-
 }
 
 bool prte_check_host_is_local(char *name)
@@ -162,7 +157,9 @@ bool prte_check_host_is_local(char *name)
     int i;
 
     for (i=0; NULL != prte_process_info.aliases[i]; i++) {
-        if (0 == strcmp(name, prte_process_info.aliases[i])) {
+        if (0 == strcmp(name, prte_process_info.aliases[i])
+            || 0 == strcmp(name, "localhost")
+            || 0 == strcmp(name, "127.0.0.1")) {
             return true;
         }
     }

--- a/test/Makefile
+++ b/test/Makefile
@@ -40,7 +40,8 @@ TESTS = \
 	attachtest/app.c \
 	attachtest/tool.c \
 	abort \
-	simple_spawn
+	simple_spawn \
+	hello
 
 all: $(TESTS)
 

--- a/test/hello.c
+++ b/test/hello.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pid_t pid;
+    char hostname[1024];
+    pmix_value_t *val;
+    uint16_t localrank;
+    size_t n;
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    /* get our local rank */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    localrank = val->data.uint16;
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
+            myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
+
+    pmix_proc_t wild;
+    PMIX_LOAD_PROCID(&wild, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&wild, PMIX_LOCAL_PEERS, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Unable to get local peers\n");
+    } else {
+        fprintf(stderr, "%s:%u - local peers %s\n", myproc.nspace, myproc.rank, val->data.string);
+    }
+
+  done:
+    /* finalize us */
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    }
+    fflush(stderr);
+    return(0);
+}


### PR DESCRIPTION
Inclusion of "localhost" and "127.0.0.1" in hostname aliases causes
every node to think it matches with every other node, leading to
some rather interesting misidentifications. Ensure we forward PMIx
MCA params on the cmd line to launched prteds. Add another test

Fixes https://github.com/openpmix/prrte/issues/863

Signed-off-by: Ralph Castain <rhc@pmix.org>