### PR TITLE
prun: man: document options for selecting DVM

### DIFF
--- a/src/tools/prun/prun.1.md
+++ b/src/tools/prun/prun.1.md
@@ -343,6 +343,11 @@ There are also other options:
 
 :   Job is to run until explicitly terminated.
 
+`--dvm-uri`
+
+:   Specify the URI of the DVM master, or the name of the file (specified as
+    file:filename) that contains that info.
+
 `--enable-recovery`
 
 :   Enable recovery from process failure [Default = disabled].
@@ -363,6 +368,10 @@ There are also other options:
 `--max-restarts <num>`
 
 :   Max number of times to restart a failed process.
+
+`--pid`
+
+:   PID of the daemon to which we should connect.
 
 `--report-child-jobs-separately`
 


### PR DESCRIPTION
These options were documented in the help, but not in the man page.
They are important enough to mention in the man page, so that a
search for "DVM" or "dvm" matches something.

Helps with Issue #864.

Signed-off-by: Alexei Colin <acolin@isi.edu>