### PR TITLE
Constrain parse_env when looking for cmd line adds

### DIFF
--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -786,6 +786,11 @@ static int parse_env(prte_cmd_line_t *cmd_line,
         }
     }
 
+    if (cmdline) {
+        /* if we are looking at the cmd line, then we are done */
+        return PRTE_SUCCESS;
+    }
+
     env = *dstenv;
 
     /* now look for -x options - not allowed to conflict with a -mca option */


### PR DESCRIPTION
When looking for MCA params to add to the cmd line, ensure
we don't inadvertently step into other options

Fixes https://github.com/openpmix/prrte/issues/870

Signed-off-by: Ralph Castain <rhc@pmix.org>