### PR TITLE
Move singleton and keepalive cmd line options to PRRTE

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -105,12 +105,6 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
         PRTE_CMD_LINE_OTYPE_GENERAL },
 
     /* mpirun options */
-    { '\0', "singleton", 1, PRTE_CMD_LINE_TYPE_STRING,
-        "ID of the singleton process that started us",
-        PRTE_CMD_LINE_OTYPE_DVM },
-    { '\0', "keepalive", 1, PRTE_CMD_LINE_TYPE_INT,
-        "Pipe to monitor - DVM will terminate upon closure",
-        PRTE_CMD_LINE_OTYPE_DVM },
     /* Specify the launch agent to be used */
     { '\0', "launch-agent", 1, PRTE_CMD_LINE_TYPE_STRING,
         "Name of daemon executable used to start processes on remote nodes (default: prted)",

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -415,6 +415,12 @@ static prte_cmd_line_init_t prte_dvm_cmd_line_init[] = {
     { '\0', "default-hostfile", 1, PRTE_CMD_LINE_TYPE_STRING,
         "Provide a default hostfile",
         PRTE_CMD_LINE_OTYPE_LAUNCH },
+    { '\0', "singleton", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "ID of the singleton process that started us",
+        PRTE_CMD_LINE_OTYPE_DVM },
+    { '\0', "keepalive", 1, PRTE_CMD_LINE_TYPE_INT,
+        "Pipe to monitor - DVM will terminate upon closure",
+        PRTE_CMD_LINE_OTYPE_DVM },
 
     /* End of list */
     { '\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL }


### PR DESCRIPTION
If a singleton MPI proc wants to spawn, it needs to start
prte to support it. In that instance, it needs prte to
act as a DVM and therefore requires the prte personality.

Signed-off-by: Ralph Castain <rhc@pmix.org>