### PR TITLE
Fix nodename alias problem and mapping inheritance

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -633,7 +633,9 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
     if (NULL != spec) {
         free(spec);
     }
-    if (NULL != jdata) {
+    if (NULL == jdata) {
+        prte_rmaps_base.mapping = tmp;
+    } else {
         if (NULL == jdata->map) {
             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
             return PRTE_ERR_BAD_PARAM;

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1112,6 +1112,26 @@ static int parse_cli(int argc, int start,
                 continue;
             }
         }
+        if (0 == strcmp("--map-by", argv[i])) {
+            /* if they set "inherit", then make this the default for prte */
+            if (NULL != strcasestr(argv[i+1], "inherit") &&
+                NULL == strcasestr(argv[i+1], "noinherit")) {
+                if (NULL == target) {
+                    /* push it into our environment */
+                    prte_setenv("PRTE_MCA_rmaps_default_inherit", "1", true, &environ);
+                    prte_setenv("PRTE_MCA_rmaps_default_mapping_policy", argv[i+1], true, &environ);
+                } else {
+                    prte_argv_append_nosize(target, "--prtemca");
+                    prte_argv_append_nosize(target, "rmaps_default_inherit");
+                    prte_argv_append_nosize(target, "1");
+                    prte_argv_append_nosize(target, "--prtemca");
+                    prte_argv_append_nosize(target, "rmaps_default_mapping_policy");
+                    prte_argv_append_nosize(target, argv[i+1]);
+                }
+            }
+        }
+
+#if PRTE_ENABLE_FT
         if (0 == strcmp("--with-ft", argv[i]) ||
             0 == strcmp("-with-ft", argv[i])) {
             if (NULL == argv[i+1]) {
@@ -1149,6 +1169,7 @@ static int parse_cli(int argc, int start,
             }
            free(p1);
         }
+#endif
     }
 
     rc = prte_schizo_base_parse_prte(argc, start,

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -333,6 +333,12 @@ bool prte_node_match(prte_node_t *n1, char *name)
         return true;
     }
 
+    /* do the node and the name both refer to me? */
+    if (prte_check_host_is_local(n1->name) &&
+        prte_check_host_is_local(name)) {
+        return true;
+    }
+
     /* get the aliases for n1 and check those against "name" */
     if (prte_get_attribute(&n1->attributes, PRTE_NODE_ALIAS, (void**)&n1alias, PMIX_STRING)) {
         n1names = prte_argv_split(n1alias, ',');


### PR DESCRIPTION
Correctly check node names for local aliases 

---------------------

Properly handle the "inherit" directive
When used with "mpirun", users expect the initial mapping
policy to be the default and for that to be inherited by
any child jobs unless told otherwise. Push the directives
into the environment to make that happen. Fix a bug in
rmaps base where it didn't save the default policy.

------------------------

Signed-off-by: Ralph Castain <rhc@pmix.org>