### PR TITLE
Set the default for enable-mca-dso

### DIFF
--- a/config/prte_mca.m4
+++ b/config/prte_mca.m4
@@ -62,7 +62,8 @@ AC_DEFUN([PRTE_MCA],[
                         type-component pairs that will be built as
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
-                        platform.]))
+                        platform.]),
+                        [], [enable_mca_dso=ess-alps,plm-alps,plm-lsf,plm-tm,ras-alps,ras-lsf])
     AC_ARG_ENABLE(mca-static,
         AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or

--- a/src/mca/ess/lsf/Makefile.am
+++ b/src/mca/ess/lsf/Makefile.am
@@ -12,14 +12,15 @@
 # Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
-
-AM_CPPFLAGS = $(ess_lsf_CPPFLAGS)
+# The LSF plugin does not call any LSF library functions - it
+# therefore does NOT need to link against LSF libraries
 
 sources = \
         ess_lsf.h \
@@ -41,11 +42,9 @@ endif
 mcacomponentdir = $(prtelibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_ess_lsf_la_SOURCES = $(sources)
-mca_ess_lsf_la_LDFLAGS = -module -avoid-version $(ess_lsf_LDFLAGS)
-mca_ess_lsf_la_LIBADD = $(ess_lsf_LIBS) \
-                        $(top_builddir)/src/libprrte.la
+mca_ess_lsf_la_LDFLAGS = -module -avoid-version
+mca_ess_lsf_la_LIBADD = $(top_builddir)/src/libprrte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_ess_lsf_la_SOURCES =$(sources)
-libmca_ess_lsf_la_LDFLAGS = -module -avoid-version $(ess_lsf_LDFLAGS)
-libmca_ess_lsf_la_LIBADD = $(ess_lsf_LIBS)
+libmca_ess_lsf_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ras/slurm/Makefile.am
+++ b/src/mca/ras/slurm/Makefile.am
@@ -12,14 +12,15 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
-
-AM_CPPFLAGS = $(ras_slurm_CPPFLAGS)
+# The Slurm plugin does not call any Slurm functions - it therefore
+# does NOT need to link against any Slurm libraries
 
 dist_prtedata_DATA = help-ras-slurm.txt
 
@@ -48,11 +49,9 @@ endif
 mcacomponentdir = $(prtelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_slurm_la_SOURCES = $(component_sources)
-mca_ras_slurm_la_LDFLAGS = -module -avoid-version $(ras_slurm_LDFLAGS)
-mca_ras_slurm_la_LIBADD = $(ras_slurm_LIBS) \
-                          $(top_builddir)/src/libprrte.la
+mca_ras_slurm_la_LDFLAGS = -module -avoid-version
+mca_ras_slurm_la_LIBADD = $(top_builddir)/src/libprrte.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_slurm_la_SOURCES = $(lib_sources)
-libmca_ras_slurm_la_LDFLAGS = -module -avoid-version $(ras_slurm_LDFLAGS)
-libmca_ras_slurm_la_LIBADD = $(ras_slurm_LIBS)
+libmca_ras_slurm_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ras/tm/Makefile.am
+++ b/src/mca/ras/tm/Makefile.am
@@ -12,19 +12,20 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
 #
+# The TM plugin does not call any Torque/PBS functions - it therefore
+# does NOT need to link against any Torque/PBS libraries
 
 # Use the top-level Makefile.options
 
 dist_prtedata_DATA = help-ras-tm.txt
 
-
-AM_CPPFLAGS = $(ras_tm_CPPFLAGS)
 
 sources = \
         ras_tm.h \
@@ -51,11 +52,9 @@ endif
 mcacomponentdir = $(prtelibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ras_tm_la_SOURCES = $(component_sources)
-mca_ras_tm_la_LDFLAGS = -module -avoid-version $(ras_tm_LDFLAGS)
-mca_ras_tm_la_LIBADD = $(ras_tm_LIBS)  \
-                       $(top_builddir)/src/libprrte.la
+mca_ras_tm_la_LDFLAGS = -module -avoid-version
+mca_ras_tm_la_LIBADD = $(top_builddir)/src/libprrte.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ras_tm_la_SOURCES = $(lib_sources)
-libmca_ras_tm_la_LDFLAGS = -module -avoid-version $(ras_tm_LDFLAGS)
-libmca_ras_tm_la_LIBADD = $(ras_tm_LIBS)
+libmca_ras_tm_la_LDFLAGS = -module -avoid-version


### PR DESCRIPTION
Some components should always be built as dso's to allow
for situations where the libs aren't present on the backend.
Default to supporting that situation, allowing a user to
override it if they want everything static.

Remove some unnecessary library linkages on components that
don't actually call any functions from such libraries.

Signed-off-by: Ralph Castain <rhc@pmix.org>