### PR TITLE
Protect against invalid nspaces and generate tool names

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -214,6 +214,10 @@ prte_job_t *prte_get_job_data_object(const pmix_nspace_t job)
     if (NULL == prte_job_data) {
         return NULL;
     }
+    /* if the nspace is invalid, then reject it */
+    if (PMIX_NSPACE_INVALID(job)) {
+        return NULL;
+    }
     for (i = 0; i < prte_job_data->size; i++) {
         if (NULL == (jptr = (prte_job_t *) prte_pointer_array_get_item(prte_job_data, i))) {
             continue;
@@ -234,7 +238,10 @@ int prte_set_job_data_object(prte_job_t *jdata)
     if (NULL == prte_job_data) {
         return PRTE_ERROR;
     }
-
+    /* if the nspace is invalid, then that's an error */
+    if (PMIX_NSPACE_INVALID(jdata->nspace)) {
+        return PRTE_ERROR;
+    }
     /* verify that we don't already have this object */
     for (i = 0; i < prte_job_data->size; i++) {
         if (NULL == (jptr = (prte_job_t *) prte_pointer_array_get_item(prte_job_data, i))) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -325,6 +325,8 @@ int prun(int argc, char *argv[])
     pmix_value_t *val;
     pmix_data_array_t darray;
     prte_schizo_base_module_t *schizo;
+    char hostname[PRTE_PATH_MAX];
+    pmix_rank_t rank;
 
     /* init the globals */
     PRTE_CONSTRUCT(&apps, prte_list_t);
@@ -338,6 +340,7 @@ int prun(int argc, char *argv[])
     prte_tool_basename = prte_basename(argv[0]);
     pargc = argc;
     pargv = prte_argv_copy(argv);
+    gethostname(hostname, sizeof(hostname));
 
     /** setup callbacks for abort signals - from this point
      * forward, we need to abort in a manner that allows us
@@ -546,6 +549,13 @@ int prun(int argc, char *argv[])
 
     /* setup options */
     PMIX_INFO_LIST_START(tinfo);
+
+    /* tell PMIx what our name should be */
+    prte_asprintf(&param, "%s.%s.%lu", prte_tool_basename, hostname, getpid());
+    PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_NSPACE, param, PMIX_STRING);
+    free(param);
+    rank = 0;
+    PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_RANK, &rank, PMIX_PROC_RANK);
 
     if (prte_cmd_line_is_taken(prte_cmd_line, "do-not-connect")) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);


### PR DESCRIPTION
Protect the accessor functions for prte_job_t objects against
invalid namespaces. Have prun and pterm generate their own
names so they don't burden prte with having to do it for them.

Signed-off-by: Ralph Castain <rhc@pmix.org>