### PR TITLE
PRRTE debugger examples changes required for debug tools CI framework

### DIFF
--- a/examples/debugger/attach.c
+++ b/examples/debugger/attach.c
@@ -232,7 +232,7 @@ static void iof_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbd
     int i;
     mylock_t *lock = (mylock_t *) cbdata;
 
-    printf("%s called to register/de-register IOF handler refid=%ld\n", __FUNCTION__,
+    printf("%s called to register IOF handler refid=%ld\n", __FUNCTION__,
            evhandler_ref);
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
@@ -257,7 +257,8 @@ static void iof_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbd
 
 static void iof_dereg_callbk(pmix_status_t status, void *cbdata)
 {
-    printf("%s called as reult of de-registering I/O forwarding\n", __FUNCTION__);
+    printf("%s called as reult of de-registering I/O forwarding, status %s\n",
+           __FUNCTION__, PMIx_Error_string(status));
 }
 
 int main(int argc, char **argv)

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
 
     /* spawn the launcher - the function will return when the launcher
      * has been started. */
-    fprintf(stderr, "SPAWNING LAUNCHER\n");
+    printf("SPAWNING LAUNCHER\n");
     rc = PMIx_Spawn(info, ninfo, app, napps, clientspace);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_APP_FREE(app, napps);


### PR DESCRIPTION
These are updates to the attach and indirect debug examples required to match the CI test framework with the pmix-tests pull request ref: pmix-tests/#84

Signed-off-by: David Wootton <dwootton@us.ibm.com>