### PR TITLE
Aggregate "ready for debug" events

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
      * directive is provided so that something like an MPI implementation
      * can do some initial setup in MPI_Init prior to pausing for the
      * debugger */
-    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_WAIT_FOR_NOTIFY, NULL, 0, &val))) {
+    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_STOP_IN_APP, NULL, 0, &val))) {
         /* register for debugger release */
         DEBUG_CONSTRUCT_LOCK(&mylock);
         PMIX_INFO_CREATE(info, 1);

--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -25,6 +25,7 @@
  */
 
 #define _GNU_SOURCE
+#include <ctype.h>
 #include <limits.h>
 #include <pthread.h>
 #include <stdio.h>

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -206,6 +206,7 @@ int main(int argc, char **argv)
     char *myuri = NULL;
     void *jinfo, *linfo, *dirs;
     myquery_data_t *mydata = NULL;
+    pmix_rank_t rank;
 
     /* need to provide args */
     if (2 > argc) {
@@ -321,7 +322,8 @@ int main(int argc, char **argv)
     /* create the launch directives to tell the launcher what
      * to do with the app it is going to spawn for us */
     PMIX_INFO_LIST_START(linfo);
-    PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);
+    rank = PMIX_RANK_WILDCARD;
+    PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, &rank, PMIX_PROC_RANK);  // stop all procs in init
     PMIX_INFO_LIST_CONVERT(rc, linfo, &darray);
     PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_LAUNCH_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
     PMIX_INFO_LIST_RELEASE(linfo);
@@ -370,12 +372,12 @@ int main(int argc, char **argv)
      * nspace of the child job and alerting us that things are ready
      * for us to spawn the debugger daemons - this will be registered
      * with the IL we started */
-    printf("REGISTERING LAUNCH_COMPLETE HANDLER\n");
+    printf("REGISTERING READY-FOR-DEBUG HANDLER\n");
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    code = PMIX_LAUNCH_COMPLETE;
+    code = PMIX_READY_FOR_DEBUG;
     n = 0;
     PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_HDLR_NAME, "LAUNCH-COMPLETE", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_HDLR_NAME, "READY-FOR-DEBUG", PMIX_STRING);
     PMIx_Register_event_handler(&code, 1, info, 1, spawn_cbfunc, evhandler_reg_callbk,
                                 (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -465,18 +465,25 @@ static void interim(int sd, short args, void *cbdata)
             /***   STOP ON EXEC FOR DEBUGGER   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_ON_EXEC)) {
 #if PRTE_HAVE_STOP_ON_EXEC
-            flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, PRTE_ATTR_GLOBAL, &flag,
-                               PMIX_BOOL);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, PRTE_ATTR_GLOBAL,
+                               &info->value.data.rank, PMIX_PROC_RANK);
 #else
             /* we cannot support the request */
             rc = PRTE_ERR_NOT_SUPPORTED;
             goto complete;
 #endif
 
-            /***   STOP IN INIT AND WAIT AT SOME PROGRAMMATIC POINT FOR DEBUGGER    ***/
-            /***   ALLOW TO FALL INTO THE JOB-LEVEL CACHE AS THEY ARE INCLUDED IN   ***/
-            /***   THE INITIAL JOB-INFO DELIVERED TO PROCS                          ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_INIT)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, PRTE_ATTR_GLOBAL,
+                               &info->value.data.rank, PMIX_PROC_RANK);
+            /* also must add to job-level cache */
+            pmix_server_cache_job_info(jdata, info);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_APP)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
+                               &info->value.data.rank, PMIX_PROC_RANK);
+            /* also must add to job-level cache */
+            pmix_server_cache_job_info(jdata, info);
 
             /***   TAG STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_TAG_OUTPUT)

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -428,11 +428,10 @@ pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *so
     pmix_data_buffer_t pbkt;
     pmix_status_t ret;
     size_t n;
-    prte_job_t *jdata;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s local process %s:%d generated event code %s range %s",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), source->nspace, source->rank,
+                        "%s local process %s generated event code %s range %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(source),
                         PMIx_Error_string(code), PMIx_Data_range_string(range));
 
     /* we can get events prior to completing prte_init as we have
@@ -454,9 +453,8 @@ pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *so
 
     /* if this is notification of procs being ready for debug, then
      * we treat this as a state change */
-    if (PMIX_DEBUG_WAITING_FOR_NOTIFY == code) {
-        jdata = prte_get_job_data_object(source->nspace);
-        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_READY_FOR_DEBUG);
+    if (PMIX_READY_FOR_DEBUG == code) {
+        PRTE_ACTIVATE_PROC_STATE((pmix_proc_t*)source, PRTE_PROC_STATE_READY_FOR_DEBUG);
         goto done;
     }
 

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -247,8 +247,11 @@ static void _query(int sd, short args, void *cbdata)
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_DEBUG_SUPPORT)) {
                 ans = NULL;
                 prte_argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_INIT);
+                prte_argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_APP);
+#if PRTE_HAVE_STOP_ON_EXEC
+                prte_argv_append_nosize(&ans, PMIX_DEBUG_STOP_ON_EXEC);
+#endif
                 prte_argv_append_nosize(&ans, PMIX_DEBUG_TARGET);
-                prte_argv_append_nosize(&ans, PMIX_DEBUG_WAIT_FOR_NOTIFY);
                 /* create the return kv */
                 kv = PRTE_NEW(prte_info_item_t);
                 tmp = prte_argv_join(ans, ',');

--- a/src/threads/threads.h
+++ b/src/threads/threads.h
@@ -74,6 +74,7 @@ typedef pthread_cond_t prte_condition_t;
     } while (0)
 
 typedef struct {
+    size_t hdlr_id;
     int status;
     prte_mutex_t mutex;
     prte_condition_t cond;
@@ -82,8 +83,8 @@ typedef struct {
 
 #define PRTE_LOCK_STATIC_INIT                                                             \
     {                                                                                     \
-        .status = 0, .mutex = PRTE_MUTEX_STATIC_INIT, .cond = PRTE_CONDITION_STATIC_INIT, \
-        .active = false                                                                   \
+        .hdlr_id = 0, .status = 0, .mutex = PRTE_MUTEX_STATIC_INIT,                       \
+        .cond = PRTE_CONDITION_STATIC_INIT, .active = false                               \
     }
 
 #define PRTE_CONSTRUCT_LOCK(l)                     \

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -212,7 +212,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_OUTPUT_TO_DIRECTORY \
     (PRTE_JOB_START_KEY + 61) // string - path of directory to which stdout/err is to be directed
 #define PRTE_JOB_STOP_ON_EXEC \
-    (PRTE_JOB_START_KEY + 62) // bool - stop procs on first instruction for debugger attach
+    (PRTE_JOB_START_KEY + 62) // pmix_rank_t of procs to stop on first instruction for debugger attach
 #define PRTE_JOB_SPAWN_NOTIFIED \
     (PRTE_JOB_START_KEY         \
      + 63) // bool - process requesting a spawn operation has been notified of result
@@ -254,6 +254,8 @@ typedef uint16_t prte_job_flags_t;
     (PRTE_JOB_START_KEY + 86) // uint16_t - Number of debug daemons per node
 #define PRTE_JOB_DEBUG_DAEMONS_PER_PROC \
     (PRTE_JOB_START_KEY + 87) // uint16_t - Number of debug daemons per application proc
+#define PRTE_JOB_STOP_IN_INIT      (PRTE_JOB_START_KEY + 88) // pmix_rank_t of procs to stop
+#define PRTE_JOB_STOP_IN_APP       (PRTE_JOB_START_KEY + 89) // pmix_rank_t of procs to stop
 
 #define PRTE_JOB_MAX_KEY 300
 

--- a/src/util/name_fns.c
+++ b/src/util/name_fns.c
@@ -269,6 +269,12 @@ char *prte_util_print_vpids(const pmix_rank_t vpid)
         snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%s", "INVALID");
     } else if (PMIX_RANK_WILDCARD == vpid) {
         snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%s", "WILDCARD");
+    } else if (PMIX_RANK_LOCAL_NODE == vpid) {
+        snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%s", "LOCALNODE");
+    } else if (PMIX_RANK_LOCAL_PEERS == vpid) {
+        snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%s", "LOCALPEERS");
+    } else if (PMIX_RANK_UNDEF == vpid) {
+        snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%s", "UNDEFINED");
     } else {
         snprintf(ptr->buffers[ptr->cntr++], PRTE_PRINT_NAME_ARGS_MAX_SIZE, "%u", vpid);
     }
@@ -281,20 +287,20 @@ int prte_util_convert_vpid_to_string(char **vpid_string, const pmix_rank_t vpid)
     /* check for wildcard value - handle appropriately */
     if (PMIX_RANK_WILDCARD == vpid) {
         *vpid_string = strdup("WILDCARD");
-        return PRTE_SUCCESS;
-    }
-
-    /* check for invalid value - handle appropriately */
-    if (PMIX_RANK_INVALID == vpid) {
+    } else if (PMIX_RANK_INVALID == vpid) {
         *vpid_string = strdup("INVALID");
-        return PRTE_SUCCESS;
+    } else if (PMIX_RANK_LOCAL_NODE == vpid) {
+        *vpid_string = strdup("LOCALNODE");
+    } else if (PMIX_RANK_LOCAL_PEERS == vpid) {
+        *vpid_string = strdup("LOCALPEERS");
+    } else if (PMIX_RANK_UNDEF == vpid) {
+        *vpid_string = strdup("UNDEFINED");
+    } else {
+        if (0 > prte_asprintf(vpid_string, "%u", vpid)) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
     }
-
-    if (0 > prte_asprintf(vpid_string, "%u", vpid)) {
-        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-
     return PRTE_SUCCESS;
 }
 


### PR DESCRIPTION
Update debugger-related events to track PMIx. Aggregate
events across the job depending upon number of procs
being debugged. Deal with the "localpeers" rank when
the PMIx server aggregates for us.

Fixes #885 

Signed-off-by: Ralph Castain <rhc@pmix.org>