### PR TITLE
build: Explicitly list libprrte dependencies

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,8 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -26,18 +28,18 @@
 SUBDIRS = \
 	include \
 	etc \
-    util \
-    mca/base \
+	util \
+	mca/base \
 	$(MCA_prte_FRAMEWORKS_SUBDIRS) \
 	$(MCA_prte_FRAMEWORK_COMPONENT_STATIC_SUBDIRS) \
-    . \
+	. \
 	$(MCA_prte_FRAMEWORK_COMPONENT_DSO_SUBDIRS)
 
 DIST_SUBDIRS = \
 	include \
 	etc \
-    util \
-    mca/base \
+	util \
+	mca/base \
 	$(MCA_prte_FRAMEWORKS_SUBDIRS) \
 	$(MCA_prte_FRAMEWORK_COMPONENT_ALL_SUBDIRS)
 
@@ -47,11 +49,14 @@ lib_LTLIBRARIES = libprrte.la
 libprrte_la_SOURCES =
 
 libprrte_la_LIBADD = \
-        mca/base/libprrte_mca_base.la \
-		util/libprrteutil.la \
-		$(MCA_prte_FRAMEWORK_LIBS) \
-		$(PRTE_EXTRA_LIB)
-libprrte_la_DEPENDENCIES =
+	mca/base/libprrte_mca_base.la \
+	util/libprrteutil.la \
+	$(MCA_prte_FRAMEWORK_LIBS) \
+	$(PRTE_EXTRA_LIB)
+libprrte_la_DEPENDENCIES = \
+	mca/base/libprrte_mca_base.la \
+	util/libprrteutil.la \
+	$(MCA_prte_FRAMEWORK_LIBS)
 libprrte_la_LDFLAGS = -version-info $(libprrte_so_version)
 libprrte_la_CPPFLAGS =
 


### PR DESCRIPTION
Change libprrte_la_DEPENDENCIES to explicitly list the internal
build artifacts that are included in libprrte_la_LIBADD, so that
Automake doesn't just ignore the indirection from
MCA_prrte_FRAMEWORK_LIBS.  This fixes an issue where changes in
a framework base or component were not causing a relink of
libprrte.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

Fixes the PRRTE part of openpmix/prrte#897.