### PR TITLE
Extend support for PMIx_Connect and fix Fence problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ test/get-immediate
 test/abort
 test/simple_spawn
 test/hello
+test/connect

--- a/src/mca/grpcomm/base/base.h
+++ b/src/mca/grpcomm/base/base.h
@@ -73,7 +73,7 @@ typedef struct {
     prte_list_t ongoing;
     prte_hash_table_t sig_table;
     char *transports;
-    size_t context_id;
+    uint32_t context_id;
 } prte_grpcomm_base_t;
 
 PRTE_EXPORT extern prte_grpcomm_base_t prte_grpcomm_base;

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -105,6 +105,7 @@ static int prte_grpcomm_base_open(prte_mca_base_open_flag_t flags)
     PRTE_CONSTRUCT(&prte_grpcomm_base.ongoing, prte_list_t);
     PRTE_CONSTRUCT(&prte_grpcomm_base.sig_table, prte_hash_table_t);
     prte_hash_table_init(&prte_grpcomm_base.sig_table, 128);
+    prte_grpcomm_base.context_id = UINT32_MAX;
 
     return prte_mca_base_framework_components_open(&prte_grpcomm_base_framework, flags);
 }

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -260,8 +260,8 @@ static void allgather_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *
             if (1 == mode) {
                 size_t sz;
                 sz = prte_grpcomm_base.context_id;
-                ++prte_grpcomm_base.context_id;
-                rc = PMIx_Data_pack(NULL, reply, &sz, 1, PMIX_SIZE);
+                --prte_grpcomm_base.context_id;
+                rc = PMIx_Data_pack(NULL, reply, &sz, 1, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1041,7 +1041,8 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
     int32_t cnt;
     int rc = PRTE_SUCCESS;
     pmix_status_t ret;
-    size_t cid, n;
+    uint32_t cid;
+    size_t n;
     pmix_byte_object_t bo;
     int32_t byused;
 
@@ -1055,7 +1056,7 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
     if (1 == cd->mode) {
         /* a context id was requested, get it */
         cnt = 1;
-        rc = PMIx_Data_unpack(NULL, buf, &cid, &cnt, PMIX_SIZE);
+        rc = PMIx_Data_unpack(NULL, buf, &cid, &cnt, PMIX_UINT32);
         /* error if they didn't return it */
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -1079,7 +1080,7 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
         n = 0;
         if (1 == cd->mode) {
-            PMIX_INFO_LOAD(&cd->info[n], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_SIZE);
+            PMIX_INFO_LOAD(&cd->info[n], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_UINT32);
             ++n;
         }
         if (NULL != bo.bytes && 0 < bo.size) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -151,6 +151,7 @@ typedef struct {
     pmix_data_buffer_t *buf;
     pmix_modex_cbfunc_t cbfunc;
     pmix_info_cbfunc_t infocbfunc;
+    pmix_op_cbfunc_t opcbfunc;
     int mode;
     pmix_info_t *info;
     size_t ninfo;

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,7 +41,8 @@ TESTS = \
 	attachtest/tool.c \
 	abort \
 	simple_spawn \
-	hello
+	hello \
+	connect
 
 all: $(TESTS)
 

--- a/test/connect.c
+++ b/test/connect.c
@@ -1,0 +1,102 @@
+/* -*- C -*-
+ *
+ * $HEADER$
+ *
+ * Test of connect
+ */
+
+#include <stdio.h>
+#include "pmix.h"
+
+int main(int argc, char* argv[])
+{
+    pmix_status_t rc;
+    pmix_proc_t myproc;
+    pmix_proc_t wildcard;
+    pmix_proc_t remote;
+    pmix_value_t value;
+    pmix_value_t *returnval;
+    pmix_info_t info;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to init\n");
+        exit(1);
+    }
+
+    printf("Hello from rank %u\n", myproc.rank);
+
+    /* put some remote values */
+    PMIX_VALUE_CONSTRUCT(&value);
+    value.type = PMIX_STRING;
+    value.data.string="12345";
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, "spastic-global", &value))) {
+        fprintf(stderr, "%u: Global put failed\n", myproc.rank);
+        exit(1);
+    }
+    value.data.string = "67890";
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, "spastic-remote", &value))) {
+        fprintf(stderr, "%u: Remote put failed\n", myproc.rank);
+        exit(1);
+    }
+    value.data.string = "abcdef";
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, "spastic-local", &value))) {
+        fprintf(stderr, "%u: Local put failed\n", myproc.rank);
+        exit(1);
+    }
+
+    /* commit them */
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%u: Failed to commit\n", myproc.rank);
+        exit(1);
+    }
+
+    printf("%u: Connecting\n", myproc.rank);
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Connect(&wildcard, 1, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to connect\n");
+        exit(1);
+    }
+    printf("%u: Connect succeeded!\n", myproc.rank);
+    if (0 != myproc.rank && 1 != myproc.rank) {
+        goto done;
+    }
+
+    /* try to get a remote value */
+    PMIX_LOAD_NSPACE(&remote, myproc.nspace);
+    if (0 == myproc.rank) {
+        remote.rank = 1;
+    } else {
+        remote.rank = 0;
+    }
+    printf("%u: Attempt to get global value\n", myproc.rank);
+    PMIX_INFO_LOAD(&info, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
+    rc = PMIx_Get(&remote, "spastic-global", &info, 1, &returnval);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%u: Unable to retrieve global data from %u\n", myproc.rank, remote.rank);
+        goto done;
+    }
+    printf("%u: Global value for rank %u obtained\n", myproc.rank, remote.rank);
+
+    printf("%u: Attempt to get remote value\n", myproc.rank);
+    rc = PMIx_Get(&remote, "spastic-remote", &info, 1, &returnval);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%u: Unable to retrieve remote data from %u\n", myproc.rank, remote.rank);
+        goto done;
+    }
+    printf("%u: Remote value for rank %u obtained\n", myproc.rank, remote.rank);
+
+    remote.rank = 0;
+    rc = PMIx_Get(&remote, PMIX_GROUP_CONTEXT_ID, &info, 1, &returnval);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%u: Unable to retrieve context ID from %u\n", myproc.rank, remote.rank);
+        goto done;
+    }
+    printf("%u: Context ID %lu obtained\n", myproc.rank, (unsigned long)returnval->data.uint32);
+
+done:
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/test/hello.c
+++ b/test/hello.c
@@ -53,21 +53,21 @@ int main(int argc, char **argv)
      * the "debugger release" notification arrives */
     rc = PMIx_Init(&myproc, NULL, 0);
     if (PMIX_SUCCESS != rc && PMIX_ERR_UNREACH != rc) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank,
-                PMIx_Error_string(rc));
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         exit(0);
     }
     /* get our local rank */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
         goto done;
     }
     localrank = val->data.uint16;
     PMIX_VALUE_RELEASE(val);
 
     fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
-            myproc.nspace, myproc.rank, (unsigned long) pid, hostname, (int) localrank);
+            myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
 
     pmix_proc_t wild;
     PMIX_LOAD_PROCID(&wild, myproc.nspace, PMIX_RANK_WILDCARD);
@@ -78,13 +78,13 @@ int main(int argc, char **argv)
         fprintf(stderr, "%s:%u - local peers %s\n", myproc.nspace, myproc.rank, val->data.string);
     }
 
-done:
+  done:
     /* finalize us */
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace,
-                myproc.rank, PMIx_Error_string(rc));
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
     }
     fflush(stderr);
-    return (0);
+    return(0);
 }

--- a/test/simple_spawn.c
+++ b/test/simple_spawn.c
@@ -77,12 +77,11 @@ int main(int argc, char *argv[])
         if (PMIX_SUCCESS != rc) {
             printf("Disonnect from children failed!\n");
         }
-        printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
-    }
+        printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);    }
     /* Otherwise, we're the child */
     else {
-        printf("Hello from the child %s.%u of %d on host %s pid %ld\n", myproc.nspace, myproc.rank,
-               size, hostname, (long) pid);
+        printf("Hello from the child %s.%u of %d on host %s pid %ld\n",
+               myproc.nspace, myproc.rank, size, hostname, (long)pid);
         PMIX_LOAD_PROCID(&peers[0], val->data.proc->nspace, PMIX_RANK_WILDCARD);
         PMIX_LOAD_PROCID(&peers[1], myproc.nspace, PMIX_RANK_WILDCARD);
         PMIX_VALUE_RELEASE(val);


### PR DESCRIPTION
PMIx_Connect requires that we perform a "fence" across all
the participants. At the conclusion of the "fence", all participants
are supposed to have access to not only the job-level info
from all participating nspace's, but also the endpoint info "put"
by all participants. Add the fence and seed it with any "put"
info.

In addition, add the generation of a context ID on behalf of
the participants so they can use it (if they choose) as, for
example, a new communicator ID and avoid multiple collective
operations. Number the assigned values from the max ID down
so we only hit a conflict if someone tries to create a massive
number of new communicators...which they shouldn't do.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 34e525cea6cfd2cefaeea4bbee90be6096c3ba62)