### PR TITLE
Revert 0288ebbc15

### DIFF
--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -186,7 +186,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char **custom_strings;
     int num_args, i;
     char *cur_prefix;
-    char *cpus_on_node;
     int proc_vpid_index;
     bool failed_launch = true;
     prte_job_t *daemons;
@@ -266,14 +265,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* start one orted on each node */
     prte_argv_append(&argc, &argv, "--ntasks-per-node=1");
-
-    /* add all CPUs to this task */
-    cpus_on_node = getenv("SLURM_CPUS_ON_NODE");
-    if (cpus_on_node) {
-        asprintf(&tmp, "--cpus-per-task=%s", cpus_on_node);
-        prte_argv_append(&argc, &argv, tmp);
-        free(tmp);
-    }
 
     if (!prte_enable_recovery) {
         /* kill the job if any orteds die */


### PR DESCRIPTION
It's similar to a518ea0c00. Per discussion with SchedMD this is not
needed.

Signed-off-by: Marcin Stolarek <cinek@schedmd.com>
(cherry picked from commit 71c4f1653ae27ca2c43db1aaf0176b9cfa8126fb)