### PR TITLE
Check the datatype on debug "stop" attributes

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -196,6 +196,7 @@ static void interim(int sd, short args, void *cbdata)
     bool flag;
     size_t m, n;
     uint16_t u16;
+    pmix_rank_t rank;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
                         "%s spawn called from proc %s with %d apps",
@@ -465,8 +466,21 @@ static void interim(int sd, short args, void *cbdata)
             /***   STOP ON EXEC FOR DEBUGGER   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_ON_EXEC)) {
 #if PRTE_HAVE_STOP_ON_EXEC
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, PRTE_ATTR_GLOBAL,
-                               &info->value.data.rank, PMIX_PROC_RANK);
+            if (PMIX_PROC_RANK == info->value.type) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, PRTE_ATTR_GLOBAL,
+                                   &info->value.data.rank, PMIX_PROC_RANK);
+            } else if (PMIX_BOOL == info->value.type) {
+                flag = PMIX_INFO_TRUE(info);
+                if (flag) {
+                    rank = PMIX_RANK_WILDCARD;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, PRTE_ATTR_GLOBAL,
+                                       &rank, PMIX_PROC_RANK);
+                }
+            } else {
+                /* we cannot support the request at this time */
+                rc = PRTE_ERR_NOT_SUPPORTED;
+                goto complete;
+            }
 #else
             /* we cannot support the request */
             rc = PRTE_ERR_NOT_SUPPORTED;
@@ -474,14 +488,40 @@ static void interim(int sd, short args, void *cbdata)
 #endif
 
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_INIT)) {
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, PRTE_ATTR_GLOBAL,
-                               &info->value.data.rank, PMIX_PROC_RANK);
+            if (PMIX_PROC_RANK == info->value.type) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, PRTE_ATTR_GLOBAL,
+                                   &info->value.data.rank, PMIX_PROC_RANK);
+            } else if (PMIX_BOOL == info->value.type) {
+                flag = PMIX_INFO_TRUE(info);
+                if (flag) {
+                    rank = PMIX_RANK_WILDCARD;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, PRTE_ATTR_GLOBAL,
+                                       &rank, PMIX_PROC_RANK);
+                }
+            } else {
+                /* we cannot support the request at this time */
+                rc = PRTE_ERR_NOT_SUPPORTED;
+                goto complete;
+            }
             /* also must add to job-level cache */
             pmix_server_cache_job_info(jdata, info);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_APP)) {
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
-                               &info->value.data.rank, PMIX_PROC_RANK);
+            if (PMIX_PROC_RANK == info->value.type) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
+                                   &info->value.data.rank, PMIX_PROC_RANK);
+            } else if (PMIX_BOOL == info->value.type) {
+                flag = PMIX_INFO_TRUE(info);
+                if (flag) {
+                    rank = PMIX_RANK_WILDCARD;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
+                                       &rank, PMIX_PROC_RANK);
+                }
+            } else {
+                /* we cannot support the request at this time */
+                rc = PRTE_ERR_NOT_SUPPORTED;
+                goto complete;
+            }
             /* also must add to job-level cache */
             pmix_server_cache_job_info(jdata, info);
 


### PR DESCRIPTION
Currently support "bool" by equating it to a rank of
WILDCARD and pmix_rank_t for either a specific rank
or "all" (a.k.a., WILDCARD). Return a not-supported
error for a pmix_data_array_t or any other type - we
may eventually support the array, but not now.

Signed-off-by: Ralph Castain <rhc@pmix.org>