### PR TITLE
Solve the race condition on fast-loop calls to spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ test/abort
 test/simple_spawn
 test/hello
 test/connect
+test/loop_child
+test/loop_spawn

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -43,7 +43,7 @@
 #include "src/mca/odls/base/base.h"
 #include "src/mca/odls/base/odls_private.h"
 #include "src/mca/odls/odls.h"
-#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/base/base.h"
 #include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/mca/rml/rml.h"
@@ -333,7 +333,7 @@ static void job_errors(int fd, short args, void *cbdata)
      * has been notified that the spawn completed - otherwise, a quick-failing
      * job might not generate a spawn response */
     rc = prte_pmix_convert_job_state_to_error(jobstate);
-    rc = prte_plm_base_spawn_reponse(rc, jdata);
+    rc = prte_plm_base_spawn_response(rc, jdata);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
@@ -522,7 +522,7 @@ keep_going:
     /* all jobs were spawned by a requestor, so ensure that requestor
      * has been notified that the spawn completed - otherwise, a quick-failing
      * job might not generate a spawn response */
-    rc = prte_plm_base_spawn_reponse(PRTE_SUCCESS, jdata);
+    rc = prte_plm_base_spawn_response(PRTE_SUCCESS, jdata);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
@@ -753,7 +753,7 @@ keep_going:
 
 cleanup:
     rc = prte_pmix_convert_proc_state_to_error(state);
-    rc = prte_plm_base_spawn_reponse(rc, jdata);
+    rc = prte_plm_base_spawn_response(rc, jdata);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }

--- a/src/mca/plm/base/base.h
+++ b/src/mca/plm/base/base.h
@@ -70,6 +70,7 @@ PRTE_EXPORT void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
 PRTE_EXPORT void prte_plm_base_post_launch(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_registered(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_wrap_args(char **args);
+PRTE_EXPORT int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata);
 
 END_C_DECLS
 

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -94,7 +94,6 @@ PRTE_EXPORT void prte_plm_base_reset_job(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_setup_prted_cmd(int *argc, char ***argv);
 PRTE_EXPORT void prte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
-PRTE_EXPORT int prte_plm_base_spawn_reponse(int32_t status, prte_job_t *jdata);
 
 /**
  * Utilities for plm components that use proxy daemons

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -424,7 +424,8 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
     for (n = 0; n < prte_pmix_server_globals.reqs.num_rooms; n++) {
         prte_hotel_knock(&prte_pmix_server_globals.reqs, n, (void **) &req);
         if (NULL != req) {
-            if (PMIX_CHECK_PROCID(&req->tproc, pname)) {
+            if (0 == strncmp(req->tproc.nspace, pname->nspace, PMIX_MAX_NSLEN) &&
+                PMIX_CHECK_RANK(req->tproc.rank, pname->rank)) {
                 prte_hotel_checkout(&prte_pmix_server_globals.reqs, n);
                 PRTE_RELEASE(req);
             }

--- a/src/prted/pmix/pmix_server.h
+++ b/src/prted/pmix/pmix_server.h
@@ -40,6 +40,8 @@ PRTE_EXPORT int prte_pmix_server_register_nspace(prte_job_t *jdata);
 
 PRTE_EXPORT void prte_pmix_server_clear(pmix_proc_t *pname);
 
+PRTE_EXPORT void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret);
+
 END_C_DECLS
 
 #endif /* PMIX_SERVER_H_ */

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -67,7 +67,7 @@
 #include "src/mca/odls/base/base.h"
 #include "src/mca/odls/odls.h"
 #include "src/mca/oob/base/base.h"
-#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/base/base.h"
 #include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/mca/rml/rml.h"
@@ -478,6 +478,12 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
             /* we can safely ignore this request as the job
              * was already cleaned up, or it was a tool */
             goto CLEANUP;
+        }
+        /* if would be rare, but a very fast terminating job could conceivably
+         * reach here prior to the spawn requestor being notified of spawn */
+        ret = prte_plm_base_spawn_response(PMIX_SUCCESS, jdata);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
         }
 
         /* release all resources (even those on other nodes) that we

--- a/test/Makefile
+++ b/test/Makefile
@@ -42,7 +42,9 @@ TESTS = \
 	abort \
 	simple_spawn \
 	hello \
-	connect
+	connect \
+	loop_child \
+	loop_spawn
 
 all: $(TESTS)
 

--- a/test/loop_child.c
+++ b/test/loop_child.c
@@ -1,0 +1,62 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <getopt.h>
+
+#include <pmix.h>
+
+static bool verbose = false;
+
+int main( int argc, char **argv )
+{
+    pmix_status_t rc;
+    pmix_proc_t myproc;
+    pmix_proc_t procs[2];
+    pmix_value_t *returnval;
+    pmix_info_t info;
+    static struct option myoptions[] = {{"verbose", no_argument, NULL, 'v'},
+                                        {0, 0, 0, 0}};
+    int option_index;
+    int opt;
+
+    while ((opt = getopt_long(argc, argv, "v", myoptions, &option_index)) != -1) {
+        switch (opt) {
+            case 'v':
+                verbose = true;
+                break;
+        }
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to init\n");
+        exit(1);
+    }
+    PMIX_INFO_LOAD(&info, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, &info, 1, &returnval);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s.%u]: Unable to retrieve parent\n", myproc.nspace, myproc.rank);
+        goto done;
+    }
+    PMIX_XFER_PROCID(&procs[0], returnval->data.proc);
+    PMIX_VALUE_RELEASE(returnval);
+
+    PMIX_XFER_PROCID(&procs[1], &myproc);
+    rc = PMIx_Connect(procs, 2, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s.%u]: Failed to connect\n", myproc.nspace, myproc.rank);
+        exit(1);
+    }
+
+    PMIx_Disconnect(procs, 2, NULL, 0);
+
+done:
+    PMIx_Finalize(NULL, 0);
+    if (verbose) {
+        printf("[%s.%u]: exiting\n", myproc.nspace, myproc.rank);
+    }
+    return 0;
+}

--- a/test/loop_spawn.c
+++ b/test/loop_spawn.c
@@ -1,0 +1,193 @@
+/*file .c : spawned  the file Exe*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <getopt.h>
+
+#include <pmix.h>
+
+#include "test.h"
+
+#define     EXE_TEST             "./loop_child"
+
+static bool verbose = false;
+
+static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
+                      const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                      pmix_info_t *results, size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    mylock_t *lock = NULL;
+    pmix_status_t jobstatus = 0;
+    pmix_nspace_t jobid = {0};
+    size_t n;
+    char *msg = NULL;
+
+    /* we should always have info returned to us - if not, there is
+     * nothing we can do */
+    if (NULL != info) {
+        for (n = 0; n < ninfo; n++) {
+            if (0 == strncmp(info[n].key, PMIX_JOB_TERM_STATUS, PMIX_MAX_KEYLEN)) {
+                jobstatus = info[n].value.data.status;
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                PMIX_LOAD_NSPACE(jobid, info[n].value.data.proc->nspace);
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+                lock = (mylock_t *) info[n].value.data.ptr;
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN)) {
+                msg = info[n].value.data.string;
+            }
+        }
+        if (verbose) {
+            fprintf(stdout, "JOB %s COMPLETED WITH STATUS %d MSG %s\n",
+                    jobid, jobstatus,  (NULL == msg) ? "NONE" : msg);
+        }
+    }
+    if (NULL != lock) {
+        /* save the status */
+        lock->status = jobstatus;
+        if (NULL != msg) {
+            lock->msg = strdup(msg);
+        }
+        /* release the lock */
+        DEBUG_WAKEUP_THREAD(lock);
+    }
+
+    /* we _always_ have to execute the evhandler callback or
+     * else the event progress engine will hang */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int iter, itermax = 100;
+    bool sync = false;
+    pmix_status_t rc;
+    pmix_proc_t myproc;
+    pmix_proc_t procs[2];
+    pmix_app_t app;
+    pmix_nspace_t nspace;
+    pmix_proc_t pname;
+    mylock_t lock, rellock;
+    pmix_info_t iptr[3];
+    static struct option myoptions[] = {{"iters", required_argument, NULL, 'i'},
+                                        {"sync", no_argument, NULL, 's'},
+                                        {"verbose", no_argument, NULL, 'v'},
+                                        {"help", no_argument, NULL, 'h'},
+                                        {0, 0, 0, 0}};
+    int option_index;
+    int opt;
+
+    while ((opt = getopt_long(argc, argv, "hsvi:", myoptions, &option_index)) != -1) {
+        switch (opt) {
+            case 'i':
+                itermax = strtol(optarg, NULL, 10);
+                break;
+            case 's':
+                sync = true;
+                break;
+            case 'v':
+                verbose = true;
+                break;
+            case 'h':
+                fprintf(stderr,
+                        "Usage: %s\n    Options:\n"
+                        "        [-i N] [number of iterations]\n"
+                        "        [-s] [Sync mode - wait for termination before spawning next child]\n"
+                        "        [-v] [Verbose]\n",
+                        argv[0]);
+                exit(1);
+            default:
+                fprintf(stderr,
+                        "Usage: %s\n    Options:\n"
+                        "        [-i N] [number of iterations]\n"
+                        "        [-s] [Sync mode - wait for termination before spawning next child]\n"
+                        "        [-v] [Verbose]\n",
+                        argv[0]);
+                exit(1);
+        }
+    }
+
+    if (verbose) {
+        printf("parent*******************************\n");
+        printf("parent: Launching Child*\n");
+    }
+
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Failed to init\n");
+        exit(1);
+    }
+
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup(EXE_TEST);
+    PMIX_ARGV_APPEND(rc, app.argv, EXE_TEST);
+    if (verbose) {
+        PMIX_ARGV_APPEND(rc, app.argv, "--verbose");
+    }
+    app.maxprocs = 1;
+
+    PMIX_XFER_PROCID(&procs[0], &myproc);
+
+    for (iter = 0; iter < itermax; ++iter) {
+        rc = PMIx_Spawn(NULL, 0, &app, 1, nspace);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Failed to spawn iteration %d: %s\n", iter, PMIx_Error_string(rc));
+            goto done;
+        }
+        if (sync) {
+            DEBUG_CONSTRUCT_LOCK(&rellock);
+            rc = PMIX_ERR_JOB_TERMINATED;
+            /* give the handler a name */
+            PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "JOB_TERMINATION_EVENT", PMIX_STRING);
+            /* specify we only want to be notified when our
+             * child job terminates */
+            PMIX_LOAD_PROCID(&pname, nspace, PMIX_RANK_WILDCARD);
+            PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
+            /* request that they return our lock object */
+            PMIX_INFO_LOAD(&iptr[2], PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
+            /* do the registration */
+            DEBUG_CONSTRUCT_LOCK(&lock);
+            PMIx_Register_event_handler(&rc, 1, iptr, 3, evhandler, regcbfunc, &lock);
+            DEBUG_WAIT_THREAD(&lock);
+            DEBUG_DESTRUCT_LOCK(&lock);
+            PMIX_INFO_DESTRUCT(&iptr[0]);
+            PMIX_INFO_DESTRUCT(&iptr[1]);
+            PMIX_INFO_DESTRUCT(&iptr[2]);
+        }
+
+        PMIX_LOAD_PROCID(&procs[1], nspace, 0);
+        rc = PMIx_Connect(procs, 2, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "[%s.%u]: Failed to connect\n", myproc.nspace, myproc.rank);
+            exit(1);
+        }
+
+        PMIx_Disconnect(procs, 2, NULL, 0);
+
+        if (sync) {
+            DEBUG_WAIT_THREAD(&rellock);
+            DEBUG_DESTRUCT_LOCK(&rellock);
+        }
+    }
+
+done:
+    PMIx_Finalize(NULL, 0);
+    if (verbose) {
+        printf("parent: End .\n" );
+    }
+    return 0;
+}

--- a/test/test.h
+++ b/test/test.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix_common.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+    int count;
+    char *msg;
+    size_t evhandler_ref;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                \
+    do {                                       \
+        pthread_mutex_init(&(l)->mutex, NULL); \
+        pthread_cond_init(&(l)->cond, NULL);   \
+        (l)->active = true;                    \
+        (l)->status = PMIX_SUCCESS;            \
+        (l)->count = 0;                        \
+        (l)->evhandler_ref = 0;                \
+    } while (0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while (0)
+
+#define DEBUG_WAIT_THREAD(lck)                              \
+    do {                                                    \
+        pthread_mutex_lock(&(lck)->mutex);                  \
+        while ((lck)->active) {                             \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex); \
+        }                                                   \
+        pthread_mutex_unlock(&(lck)->mutex);                \
+    } while (0)
+
+#define DEBUG_WAKEUP_THREAD(lck)              \
+    do {                                      \
+        pthread_mutex_lock(&(lck)->mutex);    \
+        (lck)->active = false;                \
+        pthread_cond_broadcast(&(lck)->cond); \
+        pthread_mutex_unlock(&(lck)->mutex);  \
+    } while (0)
+
+/* define a structure for collecting returned
+ * info from a query */
+typedef struct {
+    mylock_t lock;
+    pmix_info_t *info;
+    size_t ninfo;
+} myquery_data_t;
+
+#define DEBUG_CONSTRUCT_MYQUERY(q)          \
+    do {                                    \
+        DEBUG_CONSTRUCT_LOCK(&((q)->lock)); \
+        (q)->info = NULL;                   \
+        (q)->ninfo = 0;                     \
+    } while (0)
+
+#define DEBUG_DESTRUCT_MYQUERY(q)                  \
+    do {                                           \
+        DEBUG_DESTRUCT_LOCK(&((q)->lock));         \
+        if (NULL != (q)->info) {                   \
+            PMIX_INFO_FREE((q)->info, (q)->ninfo); \
+        }                                          \
+    } while (0)
+
+/* define a structure for releasing when a given
+ * nspace terminates */
+typedef struct {
+    mylock_t lock;
+    char *nspace;
+    int exit_code;
+    bool exit_code_given;
+} myrel_t;
+
+#define DEBUG_CONSTRUCT_MYREL(r)            \
+    do {                                    \
+        DEBUG_CONSTRUCT_LOCK(&((r)->lock)); \
+        (r)->nspace = NULL;                 \
+        (r)->exit_code = 0;                 \
+        (r)->exit_code_given = false;       \
+    } while (0)
+
+#define DEBUG_DESTRUCT_MYREL(r)            \
+    do {                                   \
+        DEBUG_DESTRUCT_LOCK(&((r)->lock)); \
+        if (NULL != (r)->nspace) {         \
+            free((r)->nspace);             \
+        }                                  \
+    } while (0)


### PR DESCRIPTION
Port the "loop_spawn" test to PRRTE by converting all calls
to PMIx. This allows guaranteed reproduction of the reported
hangs in tight-loop calls to "spawn". Ensure that the spawn
notification is always sent prior to sending job termination
event. Don't allow check for wildcard nspace when clearing
the request hotel as spawn requests that have not yet been
assigned a job nspace will inadvertently be caught.

Refs https://github.com/openpmix/pmix-tests/pull/74

Signed-off-by: Ralph Castain <rhc@pmix.org>