### PR TITLE
config: alps: add transitive dep of libalpsii: libugni

### DIFF
--- a/config/prte_check_alps.m4
+++ b/config/prte_check_alps.m4
@@ -147,6 +147,18 @@ AC_DEFUN([PRTE_CHECK_ALPS],[
                                                        AC_MSG_WARN([on the configure line using --with-alps option.])
                                                        AC_MSG_ERROR([Aborting])],[])]
                                                        )
+                               PKG_CHECK_MODULES_STATIC([CRAY_UGNI], [cray-ugni],
+                                               [prte_check_cray_alps_happy="yes"
+                                                AC_DEFINE_UNQUOTED([CRAY_UGNI],[1],
+                                                                   [defined to 1 if cray uGNI available, 0 otherwise])
+                                               ],
+                                               [prte_check_cray_alps_happy="no"]
+                                               [AS_IF([test "$with_alps" = "yes"],
+                                                      [AC_MSG_WARN([ALPS support requested but pkg-config failed.])
+                                                       AC_MSG_WARN([Need to explicitly indicate ALPS directory])
+                                                       AC_MSG_WARN([on the configure line using --with-alps option.])
+                                                       AC_MSG_ERROR([Aborting])],[])]
+                                                       )
                             ],
                             [AC_MSG_WARN([See ./configure --help for how to control Open MPI])
                              AC_MSG_WARN([configuration for ALPS on CLE 5 and higher systems])
@@ -175,9 +187,9 @@ AC_DEFUN([PRTE_CHECK_ALPS],[
     AS_IF([test "$prte_check_cray_alps_happy" = "yes"],
           [$1_LDFLAGS="[$]$1_LDFLAGS $CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS"
            $1_CPPFLAGS="[$]$1_CPPFLAGS $CRAY_ALPSLLI_CFLAGS $CRAY_ALPSUTIL_CFLAGS $CRAY_ALPS_CFLAGS $CRAY_WLM_DETECT_CFLAGS"
-           $1_LIBS="[$]$1_LIBS $CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"
-           $1_WRAPPER_EXTRA_LDFLAGS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"
-           $1_WRAPPER_EXTRA_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS"
+           $1_LIBS="[$]$1_LIBS $CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS $CRAY_UGNI_LIBS"
+           $1_WRAPPER_EXTRA_LDFLAGS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS $CRAY_UGNI_LIBS"
+           $1_WRAPPER_EXTRA_LIBS="$CRAY_ALPSLLI_LIBS $CRAY_ALPSUTIL_LIBS $CRAY_WLM_DETECT_LIBS $CRAY_UGNI_LIBS"
 	   $2],
 	  [$3])
 ])


### PR DESCRIPTION
This is a fix/workaround for a (new) linking failure when building prrte `--with-alps`:

	libtool: link: x86_64-pc-linux-gnu-gcc ... -pthread -Wl,-O1
	-Wl,--as-needed -o .libs/prted prted.o
	-L/lus/theta-fs0/projects/CASPER/acolin/gpref/gp-knl-2/usr/lib64
	../../../src/.libs/libprrte.so -L=/usr/lib
	-L/opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64
	-L/opt/cray/wlm_detect/1.3.3-7.0.2.1_2.18__g7109084.ari/lib64 -lalpslli
	-lalpsutil -lwlm_detect /lus/theta-fs0/projects/CASPER/acolin/gpref/gp-knl-2/usr/lib64/libpmix.so -lz
	-lmunge -lm -lutil -ldl -levent_core -levent_pthreads -lhwloc -pthread
	-Wl,-rpath -Wl,/lus/theta-fs0/projects/CASPER/acolin/gpref/gp-knl-2/usr/lib64
	/lus/theta-fs0/projects/CASPER/acolin/gpref/gp-knl-2/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld:

	warning: libugni.so.0, needed by /opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64/libalpslli.so, not
	found (try using -rpath or -rpath-link)
	/lus/theta-fs0/projects/CASPER/acolin/gpref/gp-knl-2/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld:
	/opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64/libalpslli.so:
	undefined reference to `GNI_GetLocalDeviceIds'
	...
	collect2: error: ld returned 1 exit status

This didn't happen before, so perhaps Cray libs were updated, not sure.

In any case, it appears that we need to explicitly handle transitive dependencies. There's already code in prrte that handles the `libwlm_detect` transitive dependency. Now, there's one more transitive dependency: `libugni`:

	$ readelf -d /opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64/libalpslli.so | grep NEEDED
	 0x0000000000000001 (NEEDED)             Shared library: [libwlm_detect.so.0]
	 0x0000000000000001 (NEEDED)             Shared library: [libugni.so.0]
	 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

Perhaps the underlying problem is that the pkg-config file installed by Cray lists the dependencies as private instead of public:

	$ export PKG_CONFIG_PATH=/opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64/pkgconfig

	$ grep Requires ${PKG_CONFIG_PATH}/cray-alpslli.pc
	Requires:
	Requires.private: cray-wlm_detect cray-ugni

	$ pkg-config  --libs cray-alpslli
	-L/opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64 -lalpslli
	$ pkg-config  --print-requires cray-alpslli
	$ pkg-config  --print-requires-private cray-alpslli
	cray-wlm_detect
	cray-ugni

If the Cray .pc file would be fixed, then PRRTE would not need to handle
transitive dependencies at all, and just ask for `cray-alpslli`:

	$ grep Requires /tmp/acolin-pc/cray-alpslli.pc
	Requires: cray-wlm_detect cray-ugni

	$ export PKG_CONFIG_PATH=/tmp/acolin-pc:${PKG_CONFIG_PATH}
	$ pkg-config  --print-requires cray-alpslli
	cray-wlm_detect
	cray-ugni
	$  pkg-config  --libs cray-alpslli
	-L/opt/cray/alps/6.6.59-7.0.2.1_3.65__g872a8d62.ari/lib64 \
	-L/opt/cray/wlm_detect/1.3.3-7.0.2.1_2.18__g7109084.ari/lib64 \
	-L/opt/cray/ugni/6.0.14.0-7.0.2.1_3.60__ge78e5b0.ari/lib64 \
	-lalpslli -lwlm_detect -lugni

Signed-off-by: Alexei Colin <acolin@isi.edu>