### PR TITLE
Complete update of indirect example use-case

### DIFF
--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -368,26 +368,6 @@ int main(int argc, char **argv)
     }
     PMIX_INFO_FREE(info, ninfo);
 
-    /* register to receive the launch complete event telling us the
-     * nspace of the child job and alerting us that things are ready
-     * for us to spawn the debugger daemons - this will be registered
-     * with the IL we started */
-    printf("REGISTERING READY-FOR-DEBUG HANDLER\n");
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    code = PMIX_READY_FOR_DEBUG;
-    n = 0;
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(&info[n], PMIX_EVENT_HDLR_NAME, "READY-FOR-DEBUG", PMIX_STRING);
-    PMIx_Register_event_handler(&code, 1, info, 1, spawn_cbfunc, evhandler_reg_callbk,
-                                (void *) &mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    DEBUG_DESTRUCT_LOCK(&mylock);
-    PMIX_INFO_FREE(info, 1);
-    if (!ilactive) {
-        fprintf(stderr, "Error: Launcher not active\n");
-        goto done;
-    }
-
     printf("RELEASING %s [%s:%d]\n", argv[1], proc.nspace, proc.rank);
     /* release the IL to spawn its job */
     PMIX_INFO_CREATE(info, 2);
@@ -420,6 +400,26 @@ int main(int argc, char **argv)
         goto done;
     }
     printf("APPLICATION HAS LAUNCHED: %s\n", (char *) appnspace);
+
+    /* register to receive the ready-for-debug event alerting us that things are ready
+     * for us to spawn the debugger daemons - this will be registered
+     * with the IL we started */
+    printf("REGISTERING READY-FOR-DEBUG HANDLER\n");
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    code = PMIX_READY_FOR_DEBUG;
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "READY-FOR-DEBUG", PMIX_STRING);
+    PMIX_LOAD_PROCID(&proc, appnspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
+    PMIx_Register_event_handler(&code, 1, info, 2, spawn_cbfunc, evhandler_reg_callbk,
+                                (void *) &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 2);
+    if (!ilactive) {
+        fprintf(stderr, "Error: Launcher not active\n");
+        goto done;
+    }
 
     /* setup the debugger */
     mydata = (myquery_data_t *) malloc(sizeof(myquery_data_t));

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -445,6 +445,18 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_NOINHERIT";
         case PRTE_JOB_FILE:
             return "JOB-FILE";
+        case PRTE_JOB_DO_NOT_RESOLVE:
+            return "DO-NOT-RESOLVE";
+        case PRTE_JOB_DEBUG_TARGET:
+            return "DEBUG-TARGET";
+        case PRTE_JOB_DEBUG_DAEMONS_PER_NODE:
+            return "DEBUG-DAEMONS-PER-NODE";
+        case PRTE_JOB_DEBUG_DAEMONS_PER_PROC:
+            return "DEBUG-DAEMONS-PER-PROC";
+        case PRTE_JOB_STOP_IN_INIT:
+            return "STOP-IN-INIT";
+        case PRTE_JOB_STOP_IN_APP:
+            return "STOP-IN-APP";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";


### PR DESCRIPTION
Indirect should limit its registration of READY_FOR_DEBUG
to just the job in which it is interested as there could
be multiple jobs in PRRTE. `prun` needs to register for
the READY_FOR_DEBUG event on the app it launches so that
the event can be relayed to the debugger. Since the debugger
is fork/exec'ing the `prun` tool, enable `prun` to get its
process ID from the environment so that it and the debugger
agree on `prun`'s name.

Signed-off-by: Ralph Castain <rhc@pmix.org>