### PR TITLE
Rename/report display

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -448,7 +448,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                                    "binding policy", quals[i]);
                     return PRTE_ERR_SILENT;
                 }
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BINDINGS, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BIND, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
             } else {
                 /* unknown option */

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -448,7 +448,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                                    "binding policy", quals[i]);
                     return PRTE_ERR_SILENT;
                 }
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_REPORT_BINDINGS, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BINDINGS, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
             } else {
                 /* unknown option */

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -168,7 +168,7 @@ static int bind_generic(prte_job_t *jdata, prte_node_t *node, int target_depth)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         dobind = true;
     }
     /* reset usage */
@@ -473,7 +473,7 @@ static int bind_in_place(prte_job_t *jdata, hwloc_obj_type_t target, unsigned ca
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 
@@ -803,7 +803,7 @@ static int bind_to_cpuset(prte_job_t *jdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 
@@ -1058,7 +1058,7 @@ execute:
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -167,8 +167,8 @@ static int bind_generic(prte_job_t *jdata, prte_node_t *node, int target_depth)
     dobind = false;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         dobind = true;
     }
     /* reset usage */
@@ -472,8 +472,8 @@ static int bind_in_place(prte_job_t *jdata, hwloc_obj_type_t target, unsigned ca
     dobind = false;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 
@@ -802,8 +802,8 @@ static int bind_to_cpuset(prte_job_t *jdata)
     dobind = false;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 
@@ -1057,8 +1057,8 @@ execute:
     dobind = false;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         dobind = true;
     }
 

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -237,7 +237,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                                "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, PRTE_ATTR_GLOBAL, NULL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, PRTE_ATTR_GLOBAL, NULL,
                                PMIX_BOOL);
 
         } else if (0 == strcasecmp(ck2[i], "DISPLAYALLOC")) {

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -219,7 +219,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                                "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, PRTE_ATTR_GLOBAL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, PRTE_ATTR_GLOBAL,
                                NULL, PMIX_BOOL);
 
         } else if (0 == strcasecmp(ck2[i], "DISPLAYTOPO")) {
@@ -237,7 +237,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                                "mapping policy", ck2[i]);
                 return PRTE_ERR_SILENT;
             }
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, PRTE_ATTR_GLOBAL, NULL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, PRTE_ATTR_GLOBAL, NULL,
                                PMIX_BOOL);
 
         } else if (0 == strcasecmp(ck2[i], "DISPLAYALLOC")) {

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -757,8 +757,8 @@ ranking:
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         /* compute and save local ranks */
         if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_local_ranks(jdata))) {
             PRTE_ERROR_LOG(rc);
@@ -806,8 +806,8 @@ ranking:
     }
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         /* display the map */
         prte_rmaps_base_display_map(jdata);
     }
@@ -846,7 +846,7 @@ void prte_rmaps_base_display_map(prte_job_t *jdata)
         return;
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DIFF, NULL, PMIX_BOOL)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
         /* intended solely to test mapping methods, this output
          * can become quite long when testing at scale. Rather
          * than enduring all the malloc/free's required to

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -758,7 +758,7 @@ ranking:
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         /* compute and save local ranks */
         if (PRTE_SUCCESS != (rc = prte_rmaps_base_compute_local_ranks(jdata))) {
             PRTE_ERROR_LOG(rc);
@@ -807,7 +807,7 @@ ranking:
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL)
         || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)
-        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+        || prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         /* display the map */
         prte_rmaps_base_display_map(jdata);
     }
@@ -846,7 +846,7 @@ void prte_rmaps_base_display_map(prte_job_t *jdata)
         return;
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_XML, NULL, PMIX_BOOL)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DIFF, NULL, PMIX_BOOL)) {
         /* intended solely to test mapping methods, this output
          * can become quite long when testing at scale. Rather
          * than enduring all the malloc/free's required to

--- a/src/mca/rtc/hwloc/rtc_hwloc.c
+++ b/src/mca/rtc/hwloc/rtc_hwloc.c
@@ -149,7 +149,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
                     return;
                 }
             }
-            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL,
+            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BIND, NULL,
                                    PMIX_BOOL)) {
                 if (0 == rc) {
                     report_binding(jobdat, child->name.rank);
@@ -159,7 +159,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
                                 child->name.rank);
                 }
             }
-        } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL,
+        } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BIND, NULL,
                                       PMIX_BOOL)) {
             prte_output(0, "MCW rank %d is not bound (or bound to all available processors)",
                         child->name.rank);
@@ -229,7 +229,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
         }
 
         if (0 == rc
-            && prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL, PMIX_BOOL)) {
+            && prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BIND, NULL, PMIX_BOOL)) {
             report_binding(jobdat, child->name.rank);
         }
 

--- a/src/mca/rtc/hwloc/rtc_hwloc.c
+++ b/src/mca/rtc/hwloc/rtc_hwloc.c
@@ -149,7 +149,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
                     return;
                 }
             }
-            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL,
+            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL,
                                    PMIX_BOOL)) {
                 if (0 == rc) {
                     report_binding(jobdat, child->name.rank);
@@ -159,7 +159,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
                                 child->name.rank);
                 }
             }
-        } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL,
+        } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL,
                                       PMIX_BOOL)) {
             prte_output(0, "MCW rank %d is not bound (or bound to all available processors)",
                         child->name.rank);
@@ -229,7 +229,7 @@ static void set(prte_job_t *jobdat, prte_proc_t *child, char ***environ_copy, in
         }
 
         if (0 == rc
-            && prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL)) {
+            && prte_get_attribute(&jobdat->attributes, PRTE_JOB_DISPLAY_BINDINGS, NULL, PMIX_BOOL)) {
             report_binding(jobdat, child->name.rank);
         }
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -310,7 +310,7 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, bind, map, map-devel, map-xml, proctable, topo",
+     "Allowed values: allocation, bind, map, map-devel, map-diffable, proctable, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
@@ -531,9 +531,9 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--display-topo")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "topo", true);
     }
-    /* --display-diffable-map  ->  --display map-xml */
+    /* --display-diffable-map  ->  --display map-diffable */
     else if (0 == strcmp(option, "--display-diff")) {
-        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-xml", true);
+        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-diffable", true);
     }
     /* --report-bindings  ->  --display bind */
     else if (0 == strcmp(option, "--report-bindings")) {

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -531,9 +531,9 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--display-topo")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "topo", true);
     }
-    /* --display-diffable-map  ->  --display map-diffable */
+    /* --display-diffable-map  ->  --display map-xml */
     else if (0 == strcmp(option, "--display-diff")) {
-        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-diffable", true);
+        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-xml", true);
     }
     /* --report-bindings  ->  --display bind */
     else if (0 == strcmp(option, "--report-bindings")) {

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -310,7 +310,7 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, map, bind, proctable, map-xml, map-devel, topo",
+     "Allowed values: allocation, bind, map, map-devel, map-xml, proctable, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -310,7 +310,7 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, map, bind, proctable, allocation, map-diffable, topo",
+     "Allowed values: allocation, map, bind, proctable, map-xml, map-devel, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -296,7 +296,7 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, map, bind, proctable, allocation, map-xml, topo",
+     "Allowed values: allocation, bind, map, map-devel, map-xml, proctable, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -296,7 +296,7 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, map, bind, proctable, allocation, map-diffable, topo",
+     "Allowed values: allocation, map, bind, proctable, allocation, map-xml, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
@@ -446,9 +446,9 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--display-topo")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "topo", true);
     }
-    /* --display-diffable-map  ->  --display map-diffable */
+    /* --display-diffable-map  ->  --display map-xml */
     else if (0 == strcmp(option, "--display-diff")) {
-        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-diffable", true);
+        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-xml", true);
     }
     /* --report-bindings  ->  --display bind */
     else if (0 == strcmp(option, "--report-bindings")) {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -296,7 +296,7 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
     /* display options */
     {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
      "Comma-delimited list of options for displaying information about the allocation and job."
-     "Allowed values: allocation, bind, map, map-devel, map-xml, proctable, topo",
+     "Allowed values: allocation, bind, map, map-devel, map-diffable, proctable, topo",
      PRTE_CMD_LINE_OTYPE_DEBUG},
     /* developer options */
     {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
@@ -446,9 +446,9 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--display-topo")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "topo", true);
     }
-    /* --display-diffable-map  ->  --display map-xml */
+    /* --display-diffable-map  ->  --display map-diffable */
     else if (0 == strcmp(option, "--display-diff")) {
-        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-xml", true);
+        rc = prte_schizo_base_convert(argv, i, 1, "--display", NULL, "map-diffable", true);
     }
     /* --report-bindings  ->  --display bind */
     else if (0 == strcmp(option, "--report-bindings")) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -421,9 +421,9 @@ static void interim(int sd, short args, void *cbdata)
             PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
 
             /***   REPORT BINDINGS  ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_BINDINGS)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_REPORT_BINDINGS)) {
             flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BINDINGS, PRTE_ATTR_GLOBAL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BIND, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
             /***   CPU LIST  ***/

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -421,9 +421,9 @@ static void interim(int sd, short args, void *cbdata)
             PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
 
             /***   REPORT BINDINGS  ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_REPORT_BINDINGS)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_BINDINGS)) {
             flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_REPORT_BINDINGS, PRTE_ATTR_GLOBAL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_BINDINGS, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
             /***   CPU LIST  ***/

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -150,7 +150,7 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
         return;
     }
 
-    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
+    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)) {
         /* just provide a simple output for users */
         prte_asprintf(&tmp, "\nData for node: %s\tNum slots: %ld\tMax slots: %ld\tNum procs: %ld",
                       (NULL == src->name) ? "UNKNOWN" : src->name, (long) src->slots,
@@ -281,7 +281,7 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
         return;
     }
 
-    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
+    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)) {
         if (prte_get_attribute(&src->attributes, PRTE_PROC_CPU_BITMAP, (void **) &cpu_bitmap,
                                PMIX_STRING)
             && NULL != cpu_bitmap && NULL != src->node->topology
@@ -488,7 +488,7 @@ void prte_map_print(char **output, prte_job_t *jdata)
         }
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_MAP_DEVEL, NULL, PMIX_BOOL)) {
         prte_asprintf(
             &tmp,
             "\n=================================   JOB MAP   =================================\n"

--- a/src/tools/prte/prte-map.1.md
+++ b/src/tools/prte/prte-map.1.md
@@ -194,7 +194,7 @@ of one or more of the following to the `--bind-to` option:
 
 :   Display the detected allocation of resources (e.g., nodes, slots)
 
-`--bind-to :REPORT`
+`--bind-to :DISPLAY`
 
 :   Report bindings for launched processes to `stderr`.
 
@@ -644,7 +644,7 @@ The lowest level CPUs are 'cores' and we have 20 total (10 per package).
 
 If we run:
 ```
-prun --np 20 --hostfile myhostfile --map-by package --bind-to package:REPORT hostname
+prun --np 20 --hostfile myhostfile --map-by package --bind-to package:DISPLAY hostname
 ```
 
 Then 10 processes are mapped to each package, and bound at the package level.
@@ -653,7 +653,7 @@ at the hardware level.
 
 However, if we run:
 ```
-prun --np 21 --hostfile myhostfile --map-by package --bind-to package:REPORT hostname
+prun --np 21 --hostfile myhostfile --map-by package --bind-to package:DISPLAY hostname
 ```
 
 Then 11 processes are mapped to the first package and 10 to the second package.
@@ -677,7 +677,7 @@ The lowest level CPUs are 'hwthreads' (because we are going to use the
 
 If we re-run (from the package example) and add the `:HWTCPUS` qualifier:
 ```
-prun --np 21 --hostfile myhostfile --map-by package:HWTCPUS --bind-to package:REPORT hostname
+prun --np 21 --hostfile myhostfile --map-by package:HWTCPUS --bind-to package:DISPLAY hostname
 ```
 
 Without the `:HWTCPUS` qualifier this would be overloading (as we saw
@@ -688,7 +688,7 @@ with the `:HWTCPUS` qualifier, it is not overloading since we have
 
 Alternatively, if we run:
 ```
-prun --np 161 --hostfile myhostfile --map-by package:HWTCPUS --bind-to package:REPORT hostname
+prun --np 161 --hostfile myhostfile --map-by package:HWTCPUS --bind-to package:DISPLAY hostname
 ```
 
 Then 81 processes are mapped to the first package and 80 to the second package.
@@ -702,7 +702,7 @@ So the first package is overloaded.
 PRTE provides various diagnostic reports that aid the user in verifying and
 tuning the mapping/ranking/binding for a specific job.
 
-The `:REPORT` qualifier to `--bind-to` command line option can be used to
+The `:DISPLAY` qualifier to `--bind-to` command line option can be used to
 report process bindings.
 
 As an example, consider a node with:
@@ -714,7 +714,7 @@ In each of the examples below the binding is reported in a human readable
 format.
 
 ```
-$ prun --np 4 --map-by core --bind-to core:REPORT ./a.out
+$ prun --np 4 --map-by core --bind-to core:DISPLAY ./a.out
 [node01:103137] MCW rank 0 bound to package[0][core:0]
 [node01:103137] MCW rank 1 bound to package[0][core:1]
 [node01:103137] MCW rank 2 bound to package[0][core:2]
@@ -724,7 +724,7 @@ $ prun --np 4 --map-by core --bind-to core:REPORT ./a.out
 The example above processes bind to successive cores on the first package.
 
 ```
-$ prun --np 4 --map-by package --bind-to package:REPORT ./a.out
+$ prun --np 4 --map-by package --bind-to package:DISPLAY ./a.out
 [node01:103115] MCW rank 0 bound to package[0][core:0-9]
 [node01:103115] MCW rank 1 bound to package[1][core:10-19]
 [node01:103115] MCW rank 2 bound to package[0][core:0-9]
@@ -736,7 +736,7 @@ The processes cycle though the packages in a round-robin fashion as many times
 as are needed.
 
 ```
-$ prun --np 4 --map-by package:PE=2 --bind-to core:REPORT ./a.out
+$ prun --np 4 --map-by package:PE=2 --bind-to core:DISPLAY ./a.out
 [node01:103328] MCW rank 0 bound to package[0][core:0-1]
 [node01:103328] MCW rank 1 bound to package[1][core:10-11]
 [node01:103328] MCW rank 2 bound to package[0][core:2-3]
@@ -751,7 +751,7 @@ as are needed.
 
 
 ```
-$ prun --np 4 --map-by core:PE=2:HWTCPUS --bind-to :REPORT  hostname
+$ prun --np 4 --map-by core:PE=2:HWTCPUS --bind-to :DISPLAY  hostname
 [node01:103506] MCW rank 0 bound to package[0][hwt:0-1]
 [node01:103506] MCW rank 1 bound to package[0][hwt:8-9]
 [node01:103506] MCW rank 2 bound to package[0][hwt:16-17]
@@ -768,7 +768,7 @@ The processes cycle though the cores in a round-robin fashion as many times
 as are needed.
 
 ```
-$ prun --np 4 --bind-to none:REPORT  hostname
+$ prun --np 4 --bind-to none:DISPLAY  hostname
 [node01:107126] MCW rank 0 is not bound (or bound to all available processors)
 [node01:107126] MCW rank 1 is not bound (or bound to all available processors)
 [node01:107126] MCW rank 2 is not bound (or bound to all available processors)
@@ -991,7 +991,7 @@ These deprecated options will be removed in a future release.
 
 `--report-bindings`
 
-:   **(Deprecated: Use `--bind-to :REPORT`)**
+:   **(Deprecated: Use `--bind-to :DISPLAY`)**
     Report any bindings for launched processes.
 
 `--tag-output`

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -895,8 +895,8 @@ int prte(int argc, char *argv[])
             if (0 == strcmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-xml")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYXML", PMIX_STRING);
+            if (0 == strcmp(targv[idx], "map-diffable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDIFF", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "proctable")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -890,7 +890,7 @@ int prte(int argc, char *argv[])
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "bind")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "proctable")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -886,20 +886,20 @@ int prte(int argc, char *argv[])
             if (0 == strcmp(targv[idx], "allocation")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
-            }
             if (0 == strcmp(targv[idx], "bind")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":DISPLAY", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "proctable")) {
+            if (0 == strcmp(targv[idx], "map")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-diffable")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDIFF", PMIX_STRING);
+            if (0 == strcmp(targv[idx], "map-xml")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYXML", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "proctable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "topo")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -724,7 +724,7 @@ int prun(int argc, char *argv[])
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "bind")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "proctable")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -720,20 +720,20 @@ int prun(int argc, char *argv[])
             if (0 == strcmp(targv[idx], "allocation")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
-            }
             if (0 == strcmp(targv[idx], "bind")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":DISPLAY", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "proctable")) {
+            if (0 == strcmp(targv[idx], "map")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-diffable")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDIFF", PMIX_STRING);
+            if (0 == strcmp(targv[idx], "map-xml")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYXML", PMIX_STRING);
+            }
+            if (0 == strcmp(targv[idx], "proctable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "topo")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -729,8 +729,8 @@ int prun(int argc, char *argv[])
             if (0 == strcmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-xml")) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYXML", PMIX_STRING);
+            if (0 == strcmp(targv[idx], "map-diffable")) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDIFF", PMIX_STRING);
             }
             if (0 == strcmp(targv[idx], "proctable")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -349,7 +349,7 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB-FWD-IO-TO-TOOL";
         case PRTE_JOB_LAUNCHED_DAEMONS:
             return "JOB-LAUNCHED-DAEMONS";
-        case PRTE_JOB_REPORT_BINDINGS:
+        case PRTE_JOB_DISPLAY_BINDINGS:
             return "JOB-REPORT-BINDINGS";
         case PRTE_JOB_CPUSET:
             return "JOB-CPUSET";
@@ -407,12 +407,12 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_SPAWN_NOTIFIED";
         case PRTE_JOB_DISPLAY_MAP:
             return "DISPLAY_JOB_MAP";
-        case PRTE_JOB_DISPLAY_DEVEL_MAP:
-            return "DISPLAY_DEVEL_JOB_MAP";
+        case PRTE_JOB_DISPLAY_MAP_DEVEL:
+            return "DISPLAY_JOB_MAP_DEVEL";
         case PRTE_JOB_DISPLAY_TOPO:
             return "DISPLAY_TOPOLOGY";
-        case PRTE_JOB_DISPLAY_DIFF:
-            return "DISPLAY_DIFFABLE";
+        case PRTE_JOB_DISPLAY_MAP_XML:
+            return "DISPLAY_JOB_MAP_XML";
         case PRTE_JOB_DISPLAY_ALLOC:
             return "DISPLAY_ALLOCATION";
         case PRTE_JOB_DO_NOT_LAUNCH:

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -349,7 +349,7 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB-FWD-IO-TO-TOOL";
         case PRTE_JOB_LAUNCHED_DAEMONS:
             return "JOB-LAUNCHED-DAEMONS";
-        case PRTE_JOB_DISPLAY_BINDINGS:
+        case PRTE_JOB_DISPLAY_BIND:
             return "JOB-REPORT-BINDINGS";
         case PRTE_JOB_CPUSET:
             return "JOB-CPUSET";

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -411,8 +411,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "DISPLAY_JOB_MAP_DEVEL";
         case PRTE_JOB_DISPLAY_TOPO:
             return "DISPLAY_TOPOLOGY";
-        case PRTE_JOB_DISPLAY_MAP_XML:
-            return "DISPLAY_JOB_MAP_XML";
+        case PRTE_JOB_DISPLAY_MAP_DIFF:
+            return "DISPLAY_JOB_MAP_DIFF";
         case PRTE_JOB_DISPLAY_ALLOC:
             return "DISPLAY_ALLOCATION";
         case PRTE_JOB_DO_NOT_LAUNCH:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -165,7 +165,7 @@ typedef uint16_t prte_job_flags_t;
     (PRTE_JOB_START_KEY + 33) // Forward IO for this job to the tool requesting its spawn
 #define PRTE_JOB_LAUNCHED_DAEMONS \
     (PRTE_JOB_START_KEY + 35) // bool - Job caused new daemons to be spawned
-#define PRTE_JOB_REPORT_BINDINGS (PRTE_JOB_START_KEY + 36) // bool - Report process bindings
+#define PRTE_JOB_DISPLAY_BINDINGS (PRTE_JOB_START_KEY + 36) // bool - Report process bindings
 #define PRTE_JOB_CPUSET          (PRTE_JOB_START_KEY + 37) // string - "soft" cgroup envelope for the job
 #define PRTE_JOB_NOTIFICATIONS \
     (PRTE_JOB_START_KEY + 38) // string - comma-separated list of desired notifications+methods
@@ -217,9 +217,9 @@ typedef uint16_t prte_job_flags_t;
     (PRTE_JOB_START_KEY         \
      + 63) // bool - process requesting a spawn operation has been notified of result
 #define PRTE_JOB_DISPLAY_MAP       (PRTE_JOB_START_KEY + 64) // bool - display job map
-#define PRTE_JOB_DISPLAY_DEVEL_MAP (PRTE_JOB_START_KEY + 65) // bool - display devel level job map
+#define PRTE_JOB_DISPLAY_MAP_DEVEL (PRTE_JOB_START_KEY + 65) // bool - display devel level job map
 #define PRTE_JOB_DISPLAY_TOPO      (PRTE_JOB_START_KEY + 66) // bool - display topology with job map
-#define PRTE_JOB_DISPLAY_DIFF      (PRTE_JOB_START_KEY + 67) // bool - display diffable job map
+#define PRTE_JOB_DISPLAY_MAP_XML   (PRTE_JOB_START_KEY + 67) // bool - display diffable XML job map
 #define PRTE_JOB_DISPLAY_ALLOC     (PRTE_JOB_START_KEY + 68) // bool - display allocation
 #define PRTE_JOB_DO_NOT_LAUNCH     (PRTE_JOB_START_KEY + 69) // bool - do not launch job
 #define PRTE_JOB_XML_OUTPUT        (PRTE_JOB_START_KEY + 70) // bool - print in xml format

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -219,7 +219,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_DISPLAY_MAP       (PRTE_JOB_START_KEY + 64) // bool - display job map
 #define PRTE_JOB_DISPLAY_MAP_DEVEL (PRTE_JOB_START_KEY + 65) // bool - display devel level job map
 #define PRTE_JOB_DISPLAY_TOPO      (PRTE_JOB_START_KEY + 66) // bool - display topology with job map
-#define PRTE_JOB_DISPLAY_MAP_XML   (PRTE_JOB_START_KEY + 67) // bool - display diffable XML job map
+#define PRTE_JOB_DISPLAY_MAP_DIFF  (PRTE_JOB_START_KEY + 67) // bool - display diffable XML job map
 #define PRTE_JOB_DISPLAY_ALLOC     (PRTE_JOB_START_KEY + 68) // bool - display allocation
 #define PRTE_JOB_DO_NOT_LAUNCH     (PRTE_JOB_START_KEY + 69) // bool - do not launch job
 #define PRTE_JOB_XML_OUTPUT        (PRTE_JOB_START_KEY + 70) // bool - print in xml format

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -165,7 +165,7 @@ typedef uint16_t prte_job_flags_t;
     (PRTE_JOB_START_KEY + 33) // Forward IO for this job to the tool requesting its spawn
 #define PRTE_JOB_LAUNCHED_DAEMONS \
     (PRTE_JOB_START_KEY + 35) // bool - Job caused new daemons to be spawned
-#define PRTE_JOB_DISPLAY_BINDINGS (PRTE_JOB_START_KEY + 36) // bool - Report process bindings
+#define PRTE_JOB_DISPLAY_BIND    (PRTE_JOB_START_KEY + 36) // bool - Report process bindings
 #define PRTE_JOB_CPUSET          (PRTE_JOB_START_KEY + 37) // string - "soft" cgroup envelope for the job
 #define PRTE_JOB_NOTIFICATIONS \
     (PRTE_JOB_START_KEY + 38) // string - comma-separated list of desired notifications+methods


### PR DESCRIPTION
This PR is testing the water about renaming / rationalizing some of the display options

Changes
1. `--bind-to :REPORT` to `--bind-to :DISPLAY`
2. Internal constant PRTE_JOB_REPORT_BINDINGS -> PRTE_JOB_DISPLAY_BINDINGS (note there is a similarly named PMIX attribute, that is not consistent, but being a PMIX standardized attribute makes it more difficult to change)
3. Internal constant PRTE_DISPLAY_XYZ -> PRTE_DISPLAY_MAP_XYZ when relevant
4. reorder the options for --display in Alph order.
