### PR TITLE
Count contributors instead of children

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -829,15 +829,6 @@ void prte_rmaps_base_display_map(prte_job_t *jdata)
 {
     /* ignore daemon job */
     char *output = NULL;
-    int i, j, cnt;
-    prte_node_t *node;
-    prte_proc_t *proc;
-    char *tmp1;
-    hwloc_obj_t bd = NULL;
-    ;
-    prte_hwloc_locality_t locality;
-    prte_proc_t *p0;
-    char *p0bitmap, *procbitmap;
 
     /* only have rank=0 output this */
     if (0 != PRTE_PROC_MY_NAME->rank) {

--- a/src/mca/routed/binomial/routed_binomial.c
+++ b/src/mca/routed/binomial/routed_binomial.c
@@ -49,6 +49,7 @@ static void update_routing_plan(void);
 static void get_routing_list(prte_list_t *coll);
 static int set_lifeline(pmix_proc_t *proc);
 static size_t num_routes(void);
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns);
 
 prte_routed_module_t prte_routed_binomial_module = {
     .initialize = init,
@@ -62,6 +63,7 @@ prte_routed_module_t prte_routed_binomial_module = {
     .update_routing_plan = update_routing_plan,
     .get_routing_list = get_routing_list,
     .num_routes = num_routes,
+    .get_num_contributors = get_num_contributors
 };
 
 /* local globals */
@@ -429,4 +431,21 @@ static size_t num_routes(void)
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (int) prte_list_get_size(&my_children)));
     return prte_list_get_size(&my_children);
+}
+
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns)
+{
+    int j, n;
+    prte_routed_tree_t *child;
+
+    n = 0;
+    PRTE_LIST_FOREACH(child, &my_children, prte_routed_tree_t) {
+        for (j = 0; j < (int) ndmns; j++) {
+            if (prte_bitmap_is_set_bit(&child->relatives, dmns[j].rank)) {
+                n++;
+                break;
+            }
+        }
+    }
+    return n;
 }

--- a/src/mca/routed/direct/routed_direct.c
+++ b/src/mca/routed/direct/routed_direct.c
@@ -42,6 +42,7 @@ static void update_routing_plan(void);
 static void get_routing_list(prte_list_t *coll);
 static int set_lifeline(pmix_proc_t *proc);
 static size_t num_routes(void);
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns);
 
 prte_routed_module_t prte_routed_direct_module = {
     .initialize = init,
@@ -55,6 +56,7 @@ prte_routed_module_t prte_routed_direct_module = {
     .update_routing_plan = update_routing_plan,
     .get_routing_list = get_routing_list,
     .num_routes = num_routes,
+    .get_num_contributors = get_num_contributors
 };
 
 static pmix_proc_t mylifeline;
@@ -259,4 +261,9 @@ static size_t num_routes(void)
         return 0;
     }
     return prte_list_get_size(&my_children);
+}
+
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns)
+{
+    return ndmns;
 }

--- a/src/mca/routed/radix/routed_radix.c
+++ b/src/mca/routed/radix/routed_radix.c
@@ -52,6 +52,7 @@ static void update_routing_plan(void);
 static void get_routing_list(prte_list_t *coll);
 static int set_lifeline(pmix_proc_t *proc);
 static size_t num_routes(void);
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns);
 
 prte_routed_module_t prte_routed_radix_module = {
     .initialize = init,
@@ -65,6 +66,7 @@ prte_routed_module_t prte_routed_radix_module = {
     .update_routing_plan = update_routing_plan,
     .get_routing_list = get_routing_list,
     .num_routes = num_routes,
+    .get_num_contributors = get_num_contributors
 };
 
 /* local globals */
@@ -430,4 +432,21 @@ static void get_routing_list(prte_list_t *coll)
 static size_t num_routes(void)
 {
     return prte_list_get_size(&my_children);
+}
+
+static int get_num_contributors(pmix_proc_t *dmns, size_t ndmns)
+{
+    int j, n;
+    prte_routed_tree_t *child;
+
+    n = 0;
+    PRTE_LIST_FOREACH(child, &my_children, prte_routed_tree_t) {
+        for (j = 0; j < (int) ndmns; j++) {
+            if (prte_bitmap_is_set_bit(&child->relatives, dmns[j].rank)) {
+                n++;
+                break;
+            }
+        }
+    }
+    return n;
 }

--- a/src/mca/routed/routed.h
+++ b/src/mca/routed/routed.h
@@ -175,6 +175,7 @@ typedef int (*prte_routed_module_set_lifeline_fn_t)(pmix_proc_t *proc);
  */
 typedef size_t (*prte_routed_module_num_routes_fn_t)(void);
 
+typedef int (*prte_routed_module_get_num_contributors_fn_t)(pmix_proc_t *dmns, size_t ndmns);
 /* ******************************************************************** */
 
 /**
@@ -199,6 +200,7 @@ typedef struct {
     prte_routed_module_update_routing_plan_fn_t update_routing_plan;
     prte_routed_module_get_routing_list_fn_t get_routing_list;
     prte_routed_module_num_routes_fn_t num_routes;
+    prte_routed_module_get_num_contributors_fn_t get_num_contributors;
 } prte_routed_module_t;
 
 /* provide an interface to the routed framework stub functions */

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -570,7 +570,7 @@ void prte_data_server(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                         rinfo->persistence = data->persistence;
                         prte_list_append(&answers, &rinfo->super);
                         prte_output_verbose(1, prte_data_server_output,
-                                            "%s data server: adding %s to data from %s:%d",
+                                            "%s data server: adding %s to data from %s",
                                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), data->info[n].key,
                                             PRTE_NAME_PRINT(&data->owner));
                     }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -568,7 +568,7 @@ int prun(int argc, char *argv[])
     if (NULL != (param = getenv("PMIX_NAMESPACE"))) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_NSPACE, param, PMIX_STRING);
     } else {
-        prte_asprintf(&param, "%s.%s.%lu", prte_tool_basename, hostname, getpid());
+        prte_asprintf(&param, "%s.%s.%lu", prte_tool_basename, hostname, (unsigned long)getpid());
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_NSPACE, param, PMIX_STRING);
         free(param);
     }

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
     PMIX_INFO_LIST_START(tinfo);
 
     /* tell PMIx what our name should be */
-    prte_asprintf(&param, "%s.%s.%lu", prte_tool_basename, hostname, getpid());
+    prte_asprintf(&param, "%s.%s.%lu", prte_tool_basename, hostname, (unsigned long)getpid());
     PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_TOOL_NSPACE, param, PMIX_STRING);
     free(param);
     rank = 0;


### PR DESCRIPTION
When computing the number of contributions a daemon should
expect to receive for a given collective operation (e.g.,
fence), calculate the number of children that have a
participating daemon underneath them. This extends the search
to the bottom of the routing tree instead of just to the
child itself.

Also silence a couple of warnings.

Fixes https://github.com/open-mpi/ompi/issues/4718

Signed-off-by: Ralph Castain <rhc@pmix.org>