### PR TITLE
Provide show_help if libz is missing on backend node

### DIFF
--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -33,6 +33,7 @@
 #include "src/util/name_fns.h"
 #include "src/util/nidmap.h"
 #include "src/util/proc_info.h"
+#include "src/util/show_help.h"
 
 #include "grpcomm_direct.h"
 #include "src/mca/grpcomm/base/base.h"
@@ -396,7 +397,8 @@ static void xcast_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
                 return;
             }
         } else {
-            PMIX_ERROR_LOG(PMIX_ERROR);
+            prte_show_help("help-prte-runtime.txt", "failed-to-uncompress",
+                           true, prte_process_info.nodename);
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
             PMIX_DATA_BUFFER_DESTRUCT(&datbuf);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1079,7 +1079,8 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender, pmix_data_bu
             rc = PMIx_Data_load(&datbuf, &bo);
             PMIX_BYTE_OBJECT_DESTRUCT(&bo);
         } else {
-            PMIX_ERROR_LOG(PMIX_ERROR);
+            prte_show_help("help-prte-runtime.txt", "failed-to-uncompress",
+                           true, prte_process_info.nodename);
             prted_failed_launch = true;
             PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
             goto CLEANUP;
@@ -1492,7 +1493,8 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                             goto CLEANUP;
                         }
                     } else {
-                        PMIX_ERROR_LOG(PMIX_ERROR);
+                        prte_show_help("help-prte-runtime.txt", "failed-to-uncompress",
+                                       true, prte_process_info.nodename);
                         prted_failed_launch = true;
                         PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
                         PMIX_BYTE_OBJECT_DESTRUCT(&bo);

--- a/src/runtime/help-prte-runtime.txt
+++ b/src/runtime/help-prte-runtime.txt
@@ -64,3 +64,13 @@ as the mapping.
 PRTE was unable to determine the number of nodes in your allocation. We
 are therefore assuming a very large number to ensure you receive proper error
 messages.
+#
+[failed-to-uncompress]
+A compressed message was received that could not be
+decompressed. This is most likely due to a missing
+libz library on the receiving node:
+
+  node:  %s
+
+Please ensure that the libz library is present on all
+compute nodes.


### PR DESCRIPTION
If libz is present on the frontend, then messages sent to the
backend nodes will be compressed. If the messages are flagged
as having been compressed and we cannot decompress them (e.g.,
if libz isn't present on the backend), then output a help
message and abort. Otherwise, we'll try to unpack the compressed
message and just report an unpack error, which isn't very helpful.

Signed-off-by: Ralph Castain <rhc@pmix.org>