### PR TITLE
Temporary fix for prun delay

### DIFF
--- a/examples/client2.c
+++ b/examples/client2.c
@@ -165,10 +165,12 @@ int main(int argc, char **argv)
     }
     PMIX_INFO_FREE(info, 1);
 
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(info, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
     /* check the returned data */
     for (n = 0; n < nprocs; n++) {
         proc.rank = n;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "test-key", NULL, 0, &val))) {
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "test-key", info, 1, &val))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get on rank %u failed: %d\n", myproc.nspace,
                     myproc.rank, proc.rank, rc);
             goto done;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -591,6 +591,7 @@ static void check_complete(int fd, short args, void *cbdata)
             /* if this is a tool it might be interested in the terminated event */
             if (PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_TOOL)) {
                 ++num_tools_attached;
+                continue;
             }
             /* if the job is flagged to not be monitored, skip it */
             if (PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_DO_NOT_MONITOR)) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -287,10 +287,10 @@ static prte_cmd_line_init_t prte_tool_options[] = {
     {'\0', "do-not-connect", 0, PRTE_CMD_LINE_TYPE_BOOL, "Do not connect to a server",
      PRTE_CMD_LINE_OTYPE_DVM},
     /* wait to connect */
-    {'\0', "wait-to-connect", 0, PRTE_CMD_LINE_TYPE_INT,
+    {'\0', "wait-to-connect", 1, PRTE_CMD_LINE_TYPE_INT,
      "Delay specified number of seconds before trying to connect", PRTE_CMD_LINE_OTYPE_DVM},
     /* number of times to try to connect */
-    {'\0', "num-connect-retries", 0, PRTE_CMD_LINE_TYPE_INT,
+    {'\0', "num-connect-retries", 1, PRTE_CMD_LINE_TYPE_INT,
      "Max number of times to try to connect", PRTE_CMD_LINE_OTYPE_DVM},
     /* provide a connection PID */
     {'\0', "pid", 1, PRTE_CMD_LINE_TYPE_STRING,
@@ -589,6 +589,7 @@ int prun(int argc, char *argv[])
 
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "wait-to-connect", 0, 0))
         && 0 < pval->value.data.integer) {
+        sleep(pval->value.data.integer);
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
     }
 


### PR DESCRIPTION
When given a dvm-uri option, prun is not correctly executing
the delay-and-retry procedure to find the file. Passing the
wait-for-connect option also has no impact.

Fix temporarily by doing the pause in prun itself.

Also noted that fence doesn't seem to be circulating info
as it should. Cleaned up a minor potential issue.

Signed-off-by: Ralph Castain <rhc@pmix.org>