### PR TITLE
Fix computation of num_contributors

### DIFF
--- a/src/mca/routed/direct/routed_direct.c
+++ b/src/mca/routed/direct/routed_direct.c
@@ -265,5 +265,20 @@ static size_t num_routes(void)
 
 static int get_num_contributors(pmix_rank_t *dmns, size_t ndmns)
 {
-    return ndmns;
+    size_t nsize = ndmns;
+    size_t n;
+
+    if (PRTE_PROC_IS_MASTER) {
+        /* if I am one of the daemons, leave me out - I'll
+         * be accounted for separately */
+        for (n=0; n < ndmns; n++) {
+            if (dmns[n] == PRTE_PROC_MY_NAME->rank) {
+                nsize -= 1;
+                break;
+            }
+        }
+        return nsize;
+    } else {
+        return 0;
+    }
 }

--- a/src/mca/routed/radix/routed_radix.c
+++ b/src/mca/routed/radix/routed_radix.c
@@ -446,6 +446,11 @@ static int get_num_contributors(pmix_rank_t *dmns, size_t ndmns)
     n = 0;
     PRTE_LIST_FOREACH(child, &my_children, prte_routed_tree_t) {
         for (j = 0; j < (int) ndmns; j++) {
+            /* if the child is one of the daemons, then take it */
+            if (dmns[j] == child->rank) {
+                n++;
+                break;
+            }
             if (prte_bitmap_is_set_bit(&child->relatives, dmns[j])) {
                 n++;
                 break;

--- a/test/double-get.c
+++ b/test/double-get.c
@@ -8,15 +8,6 @@ static bool mywait = false;
 static bool refresh = false;
 static bool timeout = false;
 
-#define ERR(msg, ...)                                                                          \
-    do {                                                                                       \
-        time_t tm = time(NULL);                                                                \
-        char *stm = ctime(&tm);                                                                \
-        stm[strlen(stm) - 1] = 0;                                                              \
-        fprintf(stderr, "%s ERROR: %s:%d  " msg "\n", stm, __FILE__, __LINE__, ##__VA_ARGS__); \
-        exit(1);                                                                               \
-    } while (0);
-
 int pmi_set_string(const char *key, void *data, size_t size)
 {
     int rc;
@@ -27,12 +18,12 @@ int pmi_set_string(const char *key, void *data, size_t size)
     value.data.bo.bytes = data;
     value.data.bo.size = size;
     if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
-        ERR("Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Put failed: %s\n", myproc.nspace, myproc.rank,
             PMIx_Error_string(rc));
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        ERR("Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace, myproc.rank,
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Commit failed: %s\n", myproc.nspace, myproc.rank,
             PMIx_Error_string(rc));
     }
 
@@ -66,11 +57,11 @@ int pmi_get_string(uint32_t peer_rank, const char *key, void **data_out, size_t 
         rc = PMIx_Get(&proc, key, NULL, 0, &pvalue);
     }
     if (PMIX_SUCCESS != rc) {
-        ERR("Client ns %s rank %d: PMIx_Get on rank %u %s: %s\n", myproc.nspace, myproc.rank,
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Get on rank %u %s: %s\n", myproc.nspace, myproc.rank,
             peer_rank, key, PMIx_Error_string(rc));
     }
     if (pvalue->type != PMIX_BYTE_OBJECT) {
-        ERR("Client ns %s rank %d: PMIx_Get %s: got wrong data type\n", myproc.nspace, myproc.rank,
+        fprintf(stderr, "ERROR: Client ns %s rank %d: PMIx_Get %s: got wrong data type\n", myproc.nspace, myproc.rank,
             key);
     }
     *data_out = pvalue->data.bo.bytes;
@@ -141,7 +132,7 @@ int main(int argc, char *argv[])
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-        ERR("PMIx_Init failed");
+        fprintf(stderr, "ERROR: PMIx_Init failed");
         exit(1);
     }
     if (myproc.rank == 0) {
@@ -190,7 +181,7 @@ int main(int argc, char *argv[])
     printf("%d: obtained data \"%s\"\n", myproc.rank, data_out);
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        ERR("Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "ERROR: Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
     }
     if (myproc.rank == 0)
         printf("PMIx finalized\n");


### PR DESCRIPTION
Be a little more careful when computing the number of
expected contributors to a grpcomm collective operation.
Also cleanup a couple of tests

Fixes #950 

Signed-off-by: Ralph Castain <rhc@pmix.org>