### PR TITLE
Fix issues in grpcomm/bmg and errmgr/detector from NSPACE changes

### DIFF
--- a/src/mca/errmgr/detector/errmgr_detector.c
+++ b/src/mca/errmgr/detector/errmgr_detector.c
@@ -239,7 +239,7 @@ static void error_notify_cbfunc(size_t evhdlr_registration_id, pmix_status_t sta
 
 static int init(void)
 {
-    fd_event_base = prte_sync_event_base;
+    fd_event_base = prte_event_base;
 
     if (PRTE_PROC_IS_DAEMON) {
         prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_HEARTBEAT_REQUEST,
@@ -265,10 +265,10 @@ int finalize(void)
         prte_event_del(&prte_errmgr_world_detector.fd_event);
         prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_HEARTBEAT_REQUEST);
         prte_rml.recv_cancel(PRTE_NAME_WILDCARD, PRTE_RML_TAG_HEARTBEAT);
-        if (prte_sync_event_base != fd_event_base) {
+        if (prte_event_base != fd_event_base) {
             prte_event_base_free(fd_event_base);
         }
-        /* set heartbeat peroid to infinity and observer to invalid */
+        /* set heartbeat period to infinity and observer to invalid */
         prte_errmgr_world_detector.hb_period = INFINITY;
         prte_errmgr_world_detector.hb_observer = PMIX_RANK_INVALID;
     }
@@ -556,7 +556,8 @@ static void fd_heartbeat_recv_cb(int status, pmix_proc_t *sender, pmix_data_buff
     prte_errmgr_detector_t *detector = &prte_errmgr_world_detector;
     int rc;
     int32_t cnt;
-    uint32_t vpid, jobid;
+    pmix_rank_t vpid;
+    pmix_nspace_t jobid;
 
     if (sender->rank == prte_process_info.myproc.rank) {
         /* this is a quit msg from observed process, stop detector */

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
@@ -583,8 +583,6 @@ int prte_ess_base_prted_finalize(void)
     if (NULL != log_path) {
         unlink(log_path);
     }
-    /* shutdown the pmix server */
-    pmix_server_finalize();
 
 #if PRTE_ENABLE_FT
     if (NULL != prte_propagate.finalize) {
@@ -596,6 +594,9 @@ int prte_ess_base_prted_finalize(void)
     if (NULL != prte_errmgr.finalize) {
         prte_errmgr.finalize();
     }
+
+    /* shutdown the pmix server */
+    pmix_server_finalize();
 
     /* close frameworks */
     (void) prte_mca_base_framework_close(&prte_filem_base_framework);

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2016-2020 The University of Tennessee and The University
+ * Copyright (c) 2016-2021 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  *
@@ -132,7 +132,6 @@ static int rbcast(pmix_data_buffer_t *buf)
     }
     for (i = start_i; i <= log2no + 1 && i > 0; i = i + increase_val) {
         for (d = 1; d >= -1; d -= 2) {
-            // for(i=1; i <= nprocs/2; i*=2) for(d=1; d >= -1; d-=2) {
             int idx = (nprocs + vpid + d * ((int) pow(2, i) - 1)) % nprocs;
 
             /* daemon.vpid cannot be 0, because daemond id ranges 1-nprocs, thus if idx==0, change
@@ -141,12 +140,20 @@ static int rbcast(pmix_data_buffer_t *buf)
                 idx = nprocs;
             }*/
             PMIX_LOAD_PROCID(&daemon, prte_process_info.myproc.nspace, idx);
-            PRTE_RETAIN(buf);
 
             PRTE_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                                  "%s grpcomm:bmg: broadcast message in %d daemons to %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), nprocs,
                                  PRTE_NAME_PRINT(&daemon)));
+
+            pmix_data_buffer_t* sndbuf;
+            PMIX_DATA_BUFFER_CREATE(sndbuf);
+            rc = PMIx_Data_copy_payload(sndbuf, buf);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DATA_BUFFER_RELEASE(sndbuf);
+                PRTE_ERROR_LOG(rc);
+                return rc;
+            }
             if (0 > (rc = prte_rml.send_buffer_nb(&daemon, buf, PRTE_RML_TAG_RBCAST,
                                                   prte_rml_send_callback, NULL))) {
                 PRTE_ERROR_LOG(rc);
@@ -154,6 +161,7 @@ static int rbcast(pmix_data_buffer_t *buf)
         }
     }
 
+//    PMIX_DATA_BUFFER_RELEASE(buf);
     return rc;
 }
 

--- a/src/mca/propagate/prperror/propagate_prperror.c
+++ b/src/mca/propagate/prperror/propagate_prperror.c
@@ -369,6 +369,7 @@ static int prte_propagate_prperror(const pmix_nspace_t job, const pmix_proc_t *s
     /* goes to all daemons */
     sig = PRTE_NEW(prte_grpcomm_signature_t);
     sig->signature = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
+    sig->sz = 1;
     PMIX_LOAD_PROCID(&sig->signature[0], PRTE_PROC_MY_NAME->nspace, PMIX_RANK_WILDCARD);
     if (PRTE_SUCCESS != (rc = prte_grpcomm_API_rbcast(sig, PRTE_RML_TAG_PROPAGATE, &prperror_buffer))) {
         PRTE_ERROR_LOG(rc);
@@ -381,7 +382,7 @@ static int prte_propagate_prperror(const pmix_nspace_t job, const pmix_proc_t *s
             PMIX_INFO_FREE(pinfo, pcnt);
         }
     }
-    // PRTE_DESTRUCT(&prperror_buffer);
+    PMIX_DATA_BUFFER_DESTRUCT(&prperror_buffer);
     PMIX_INFO_FREE(pinfo, pcnt);
     PRTE_RELEASE(sig);
     /* we're done! */


### PR DESCRIPTION
In recent weeks
1. some changes have been made to the prte_data_buffer_t (non-refcountable anymore), that broke grpcomm/bmg
2. some changes have been made to the jobid/namespaces; that broke errmgr/detector

Test using OMPI master, PRTE master and testings from the ompi-tests-public repository

```
git submodule && autogen, etc. 
cd ompi-builddir
${ompi_srcdir}/configure && make install
git clone openmpi/ompi-tests-public
cd ompi-tests-public 
git submodule update --recursive 
cd ulfm-testing/api
ULFM_PREFIX=${ompi_builddir} runtest.sh
```
