### PR TITLE
Improve node name matching

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -110,7 +110,6 @@ static int rte_init(int argc, char **argv)
     prte_node_t *node;
     prte_proc_t *proc;
     prte_app_context_t *app;
-    char *aptr;
     char *coprocessors, **sns;
     uint32_t h;
     int idx;
@@ -369,9 +368,7 @@ static int rte_init(int argc, char **argv)
     PRTE_FLAG_SET(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
     node->state = PRTE_NODE_STATE_UP;
     /* get our aliases - will include all the interface aliases captured in prte_init */
-    aptr = prte_argv_join(prte_process_info.aliases, ',');
-    prte_set_attribute(&node->attributes, PRTE_NODE_ALIAS, PRTE_ATTR_LOCAL, aptr, PMIX_STRING);
-    free(aptr);
+    node->aliases = prte_argv_copy(prte_process_info.aliases);
     /* record that the daemon job is running */
     jdata->num_procs = 1;
     jdata->state = PRTE_JOB_STATE_RUNNING;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -501,7 +501,8 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < prte_output_get_verbosity(prte_ras_base_framework.framework_output)) {
+    if (4 < prte_output_get_verbosity(prte_ras_base_framework.framework_output) ||
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -188,9 +188,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             PMIX_INFO_LOAD(&kv->info, PMIX_HOSTNAME, node->name, PMIX_STRING);
             prte_list_append(&iarray->infolist, &kv->super);
             /* add any aliases */
-            if (prte_get_attribute(&node->attributes, PRTE_NODE_ALIAS, (void **) &regex,
-                                   PMIX_STRING)
-                && NULL != regex) {
+            if (NULL != node->aliases) {
+                regex = pmix_argv_join(node->aliases, ',');
                 kv = PRTE_NEW(prte_info_item_t);
                 PMIX_INFO_LOAD(&kv->info, PMIX_HOSTNAME_ALIASES, regex, PMIX_STRING);
                 prte_list_append(&iarray->infolist, &kv->super);

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -122,7 +122,6 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
     char *tmp, *tmp2, *tmp3;
     int32_t i;
     prte_proc_t *proc;
-    char **alias;
 
     /* set default result */
     *output = NULL;
@@ -134,14 +133,12 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
                       (int) src->slots_max);
         /* does this node have any aliases? */
         tmp3 = NULL;
-        if (prte_get_attribute(&src->attributes, PRTE_NODE_ALIAS, (void **) &tmp3, PMIX_STRING)) {
-            alias = prte_argv_split(tmp3, ',');
-            for (i = 0; NULL != alias[i]; i++) {
-                prte_asprintf(&tmp2, "%s\t<noderesolve resolved=\"%s\"/>\n", tmp, alias[i]);
+        if (NULL != src->aliases) {
+            for (i = 0; NULL != src->aliases[i]; i++) {
+                prte_asprintf(&tmp2, "%s\t<noderesolve resolved=\"%s\"/>\n", tmp, src->aliases[i]);
                 free(tmp);
                 tmp = tmp2;
             }
-            prte_argv_free(alias);
         }
         if (NULL != tmp3) {
             free(tmp3);
@@ -168,14 +165,12 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
     free(tmp3);
     /* does this node have any aliases? */
     tmp3 = NULL;
-    if (prte_get_attribute(&src->attributes, PRTE_NODE_ALIAS, (void **) &tmp3, PMIX_STRING)) {
-        alias = prte_argv_split(tmp3, ',');
-        for (i = 0; NULL != alias[i]; i++) {
-            prte_asprintf(&tmp2, "%s\n                resolved from %s", tmp, alias[i]);
+    if (NULL != src->aliases) {
+        for (i = 0; NULL != src->aliases[i]; i++) {
+            prte_asprintf(&tmp2, "%s\n                resolved from %s", tmp, src->aliases[i]);
             free(tmp);
             tmp = tmp2;
         }
-        prte_argv_free(alias);
     }
     if (NULL != tmp3) {
         free(tmp3);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -256,6 +256,8 @@ typedef struct {
     int32_t index;
     /** String node name */
     char *name;
+    /** aliases */
+    char **aliases;
     /* daemon on this node */
     struct prte_proc_t *daemon;
     /** number of procs on this node */
@@ -481,7 +483,7 @@ PRTE_EXPORT char *prte_get_proc_hostname(const pmix_proc_t *proc);
 PRTE_EXPORT prte_node_rank_t prte_get_proc_node_rank(const pmix_proc_t *proc);
 
 /* check to see if two nodes match */
-PRTE_EXPORT bool prte_node_match(prte_node_t *n1, char *name);
+PRTE_EXPORT bool prte_node_match(prte_node_t *n1, const char *name);
 
 /* global variables used by RTE - instanced in prte_globals.c */
 PRTE_EXPORT extern bool prte_debug_daemons_flag;
@@ -503,8 +505,8 @@ PRTE_EXPORT extern char *prte_oob_static_ports;
 PRTE_EXPORT extern bool prte_keep_fqdn_hostnames;
 PRTE_EXPORT extern bool prte_have_fqdn_allocation;
 PRTE_EXPORT extern bool prte_show_resolved_nodenames;
-PRTE_EXPORT extern int prte_use_hostname_alias;
 PRTE_EXPORT extern int prte_hostname_cutoff;
+PRTE_EXPORT extern bool prte_do_not_resolve;
 
 /* debug flags */
 PRTE_EXPORT extern int prted_debug_failure;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -441,20 +441,19 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_3,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_hostname_cutoff);
 
-    /* which alias to use in MPIR_proctab */
-    prte_use_hostname_alias = 1;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "hostname_alias_index",
-        "Which alias to use for the debugger proc table [default: 1st alias]",
-        PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_use_hostname_alias);
-
     prte_show_resolved_nodenames = false;
     (void) prte_mca_base_var_register(
         "prte", "prte", NULL, "show_resolved_nodenames",
         "Display any node names that are resolved to a different name (default: false)",
         PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_show_resolved_nodenames);
+
+    prte_do_not_resolve = false;
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "do_not_resolve",
+                                      "Do not attempt to resolve hostnames)",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
+                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_do_not_resolve);
 
     /* allow specification of the launch agent */
     prte_launch_agent = "prted";

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -347,6 +347,22 @@ int prun(int argc, char *argv[])
     PRTE_CONSTRUCT(&apps, prte_list_t);
     PRTE_CONSTRUCT(&forwarded_signals, prte_list_t);
 
+    /* because we have to use the schizo framework and init our hostname
+     * prior to parsing the incoming argv for cmd line options, do a hacky
+     * search to support passing of impacted options (e.g., verbosity for schizo) */
+    for (i = 1; NULL != argv[i]; i++) {
+        if (0 == strcmp(argv[i], "--prtemca") || 0 == strcmp(argv[i], "--mca")) {
+            if (0 == strncmp(argv[i + 1], "schizo", 6) ||
+                0 == strcmp(argv[i + 1], "prte_keep_fqdn_hostnames") ||
+                0 == strcmp(argv[i + 1], "prte_strip_prefix")) {
+                prte_asprintf(&param, "PRTE_MCA_%s", argv[i + 1]);
+                prte_setenv(param, argv[i + 2], true, &environ);
+                free(param);
+                i += 2;
+            }
+        }
+    }
+
     /* init the tiny part of PRTE we use */
     prte_init_util(PRTE_PROC_TOOL); // just so we pickup any PRTE params from sys/user files
 
@@ -395,20 +411,6 @@ int prun(int argc, char *argv[])
 
     /* setup callback for SIGPIPE */
     signal(SIGPIPE, epipe_signal_callback);
-
-    /* because we have to use the schizo framework prior to parsing the
-     * incoming argv for cmd line options, do a hacky search to support
-     * passing of options (e.g., verbosity) for schizo */
-    for (i = 1; NULL != argv[i]; i++) {
-        if (0 == strcmp(argv[i], "--prtemca") || 0 == strcmp(argv[i], "--mca")) {
-            if (0 == strncmp(argv[i + 1], "schizo", 6)) {
-                prte_asprintf(&param, "PRTE_MCA_%s", argv[i + 1]);
-                prte_setenv(param, argv[i + 2], true, &environ);
-                free(param);
-                i += 2;
-            }
-        }
-    }
 
     /* open the SCHIZO framework */
     if (PRTE_SUCCESS

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -283,8 +283,6 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "NODE-LAUNCHID";
         case PRTE_NODE_HOSTID:
             return "NODE-HOSTID";
-        case PRTE_NODE_ALIAS:
-            return "NODE-ALIAS";
         case PRTE_NODE_SERIAL_NUMBER:
             return "NODE-SERIAL-NUM";
 

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -80,7 +80,6 @@ typedef uint8_t prte_node_flags_t;
 #define PRTE_NODE_LAUNCH_ID     (PRTE_NODE_START_KEY + 2) // int32 - Launch id needed by some systems to launch a proc on this node
 #define PRTE_NODE_HOSTID        (PRTE_NODE_START_KEY + 3) // pmix_rank_t - if this "node" is a coprocessor being hosted on a different node, then
                                                           // we need to know the id of our "host" to help any procs on us to determine locality
-#define PRTE_NODE_ALIAS         (PRTE_NODE_START_KEY + 4) // comma-separate list of alternate names for the node
 #define PRTE_NODE_SERIAL_NUMBER (PRTE_NODE_START_KEY + 5) // string - serial number: used if node is a coprocessor
 #define PRTE_NODE_PORT          (PRTE_NODE_START_KEY + 6) // int32 - Alternate port to be passed to plm
 

--- a/src/util/if.c
+++ b/src/util/if.c
@@ -311,25 +311,9 @@ bool prte_ifislocal(const char *hostname)
 #    else
     char addrname[ADDRLEN + 1];
 #    endif
-    int i;
 
-    /* see if it matches any of our known aliases */
-    if (NULL != prte_process_info.aliases) {
-        for (i = 0; NULL != prte_process_info.aliases[i]; i++) {
-            if (0 == strcmp(hostname, prte_process_info.aliases[i])) {
-                return true;
-            }
-        }
-    }
-
-    /* okay, have to resolve the address - the prte_ifislocal
-     * function will not attempt to resolve the address if
-     * told not to do so */
+    /* resolve the address */
     if (PRTE_SUCCESS == prte_ifaddrtoname(hostname, addrname, ADDRLEN)) {
-        if (0 != strcmp(hostname, "localhost") && 0 != strcmp(hostname, "127.0.0.1")) {
-            /* add this to our known aliases */
-            prte_argv_append_nosize(&prte_process_info.aliases, hostname);
-        }
         return true;
     }
 

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -296,11 +296,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         prte_pointer_array_set_item(prte_node_pool, n, nd);
         /* see if this is our node */
         if (prte_check_host_is_local(names[n])) {
-            /* add our aliases as an attribute - will include all the interface aliases captured in
+            /* add our aliases - will include all the interface aliases captured in
              * prte_init */
-            raw = prte_argv_join(prte_process_info.aliases, ',');
-            prte_set_attribute(&nd->attributes, PRTE_NODE_ALIAS, PRTE_ATTR_LOCAL, raw, PMIX_STRING);
-            free(raw);
+            nd->aliases = prte_argv_copy(prte_process_info.aliases);
         }
         /* set the topology - always default to homogeneous
          * as that is the most common scenario */

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -39,8 +39,10 @@
 #include "src/mca/base/base.h"
 #include "src/mca/base/prte_mca_base_var.h"
 #include "src/pmix/pmix-internal.h"
+#include "src/runtime/prte_globals.h"
 #include "src/util/argv.h"
 #include "src/util/attr.h"
+#include "src/util/if.h"
 #include "src/util/net.h"
 #include "src/util/output.h"
 #include "src/util/proc_info.h"
@@ -50,28 +52,29 @@
 /* provide a connection to a reqd variable */
 extern bool prte_keep_fqdn_hostnames;
 
-PRTE_EXPORT prte_process_info_t prte_process_info = {.myproc = {{0}, 0},
-                                                     .my_hnp = {{0}, 0},
-                                                     .my_hnp_uri = NULL,
-                                                     .my_parent = {{0}, 0},
-                                                     .hnp_pid = 0,
-                                                     .num_daemons = 1,
-                                                     .num_nodes = 1,
-                                                     .nodename = NULL,
-                                                     .aliases = NULL,
-                                                     .pid = 0,
-                                                     .proc_type = PRTE_PROC_TYPE_NONE,
-                                                     .my_port = 0,
-                                                     .num_restarts = 0,
-                                                     .tmpdir_base = NULL,
-                                                     .top_session_dir = NULL,
-                                                     .jobfam_session_dir = NULL,
-                                                     .job_session_dir = NULL,
-                                                     .proc_session_dir = NULL,
-                                                     .sock_stdin = NULL,
-                                                     .sock_stdout = NULL,
-                                                     .sock_stderr = NULL,
-                                                     .cpuset = NULL};
+PRTE_EXPORT prte_process_info_t prte_process_info = {
+    .myproc = {{0}, 0},
+    .my_hnp = {{0}, 0},
+    .my_hnp_uri = NULL,
+    .my_parent = {{0}, 0},
+    .hnp_pid = 0,
+    .num_daemons = 1,
+    .num_nodes = 1,
+    .nodename = NULL,
+    .aliases = NULL,
+    .pid = 0,
+    .proc_type = PRTE_PROC_TYPE_NONE,
+    .my_port = 0,
+    .num_restarts = 0,
+    .tmpdir_base = NULL,
+    .top_session_dir = NULL,
+    .jobfam_session_dir = NULL,
+    .job_session_dir = NULL,
+    .proc_session_dir = NULL,
+    .sock_stdin = NULL,
+    .sock_stdout = NULL,
+    .sock_stderr = NULL,
+    .cpuset = NULL};
 
 static bool init = false;
 static char *prte_strip_prefix;
@@ -96,15 +99,6 @@ void prte_setup_hostname(void)
     gethostname(hostname, sizeof(hostname));
     /* add this to our list of aliases */
     prte_argv_append_nosize(&prte_process_info.aliases, hostname);
-
-    // Strip off the FQDN if present, ignore IP addresses
-    if (!prte_keep_fqdn_hostnames && !prte_net_isaddr(hostname)) {
-        if (NULL != (ptr = strchr(hostname, '.'))) {
-            *ptr = '\0';
-            /* add this to our list of aliases */
-            prte_argv_append_nosize(&prte_process_info.aliases, hostname);
-        }
-    }
 
     prte_strip_prefix = NULL;
     (void) prte_mca_base_var_register(
@@ -135,7 +129,7 @@ void prte_setup_hostname(void)
                     prte_process_info.nodename = strdup(&hostname[idx]);
                 }
                 /* add this to our list of aliases */
-                prte_argv_append_nosize(&prte_process_info.aliases, prte_process_info.nodename);
+                prte_argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
                 match = true;
                 break;
             }
@@ -148,16 +142,37 @@ void prte_setup_hostname(void)
     } else {
         prte_process_info.nodename = strdup(hostname);
     }
+    prte_argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
+
+    // if we are not keeping FQDN, then strip it off if not an IP address
+    if (!prte_keep_fqdn_hostnames && !prte_net_isaddr(hostname)) {
+        if (NULL != (ptr = strchr(hostname, '.'))) {
+            *ptr = '\0';
+            /* add this to our list of aliases */
+            prte_argv_append_unique_nosize(&prte_process_info.aliases, hostname);
+        }
+    }
+
 }
 
-bool prte_check_host_is_local(char *name)
+bool prte_check_host_is_local(const char *name)
 {
     int i;
 
     for (i = 0; NULL != prte_process_info.aliases[i]; i++) {
-        if (0 == strcmp(name, prte_process_info.aliases[i]) || 0 == strcmp(name, "localhost")
-            || 0 == strcmp(name, "127.0.0.1")) {
+        if (0 == strcmp(name, prte_process_info.aliases[i]) ||
+            0 == strcmp(name, "localhost") ||
+            0 == strcmp(name, "127.0.0.1")) {
             return true;
+        }
+        /* if it wasn't one of those and we are allowed
+         * to resolve addresses, then try that too */
+        if (!prte_do_not_resolve) {
+            if (prte_ifislocal(name)) {
+                /* add to our aliases */
+                prte_argv_append_nosize(&prte_process_info.aliases, name);
+                return true;
+            }
         }
     }
     return false;

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -135,7 +135,7 @@ PRTE_EXPORT int prte_proc_info_finalize(void);
 
 PRTE_EXPORT void prte_setup_hostname(void);
 
-PRTE_EXPORT bool prte_check_host_is_local(char *name);
+PRTE_EXPORT bool prte_check_host_is_local(const char *name);
 
 END_C_DECLS
 


### PR DESCRIPTION
Keep aliases handy for use instead of in an attribute. Use a more thorough algorithm
for checking for matches, and ensure that -host and -hostfile processing always
uses it.

Signed-off-by: Ralph Castain <rhc@pmix.org>