### PR TITLE
Take another pass at hostname aliasing

### DIFF
--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -65,11 +65,10 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, prte_list_t *nodelist
 {
     char *pe_hostfile = getenv("PE_HOSTFILE");
     char *job_id = getenv("JOB_ID");
-    char buf[1024], *tok, *num, *queue, *arch, *ptr, *tmp;
+    char buf[1024], *tok, *num, *queue, *arch, *ptr;
     int rc;
     FILE *fp;
     prte_node_t *node;
-    prte_list_item_t *item;
     bool found;
 
     /* show the Grid Engine's JOB_ID */
@@ -98,17 +97,9 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, prte_list_t *nodelist
         queue = strtok_r(NULL, " \n", &tok);
         arch = strtok_r(NULL, " \n", &tok);
 
-        if (!prte_keep_fqdn_hostnames && !prte_net_isaddr(ptr)) {
-            if (NULL != (tmp = strchr(ptr, '.'))) {
-                *tmp = '\0';
-            }
-        }
-
         /* see if we already have this node */
         found = false;
-        for (item = prte_list_get_first(nodelist); item != prte_list_get_end(nodelist);
-             item = prte_list_get_next(item)) {
-            node = (prte_node_t *) item;
+        PRTE_LIST_FOREACH(node, nodelist, prte_node_t) {
             if (0 == strcmp(ptr, node->name)) {
                 /* just add the slots */
                 node->slots += (int) strtol(num, (char **) NULL, 10);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -390,7 +390,6 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, prte_list
     int *slots;
     bool found_range = false;
     bool more_to_come = false;
-    char *ptr;
 
     orig = base = strdup(regexp);
     if (NULL == base) {
@@ -551,12 +550,6 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, prte_list
 
     for (i = 0; NULL != names && NULL != names[i]; ++i) {
         prte_node_t *node;
-
-        if (!prte_keep_fqdn_hostnames && !prte_net_isaddr(names[i])) {
-            if (NULL != (ptr = strchr(names[i], '.'))) {
-                *ptr = '\0';
-            }
-        }
 
         PRTE_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                              "%s ras:slurm:allocate:discover: adding node %s (%d slot%s)",

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -258,7 +258,7 @@ int prte_rmaps_base_get_target_nodes(prte_list_t *allocated_nodes, int32_t *tota
                                          "NODE %s HAS NO DAEMON", node->name));
                     continue;
                 }
-                if (!prte_node_match(node, nptr->name)) {
+                if (!prte_nptr_match(node, nptr)) {
                     PRTE_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
                                          "NODE %s DOESNT MATCH NODE %s", node->name, nptr->name));
                     continue;

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -489,7 +489,6 @@ static int process_file(char *path, prte_list_t *list)
     FILE *fp;
     seq_node_t *sq;
     char *sep, *eptr;
-    char *ptr;
 
     /* open the file */
     fp = fopen(path, "r");
@@ -519,13 +518,6 @@ static int process_file(char *path, prte_list_t *list)
             }
             *(eptr + 1) = 0;
             sq->cpuset = strdup(sep);
-        }
-
-        // Strip off the FQDN if present, ignore IP addresses
-        if (!prte_keep_fqdn_hostnames && !prte_net_isaddr(hstname)) {
-            if (NULL != (ptr = strchr(hstname, '.'))) {
-                *ptr = '\0';
-            }
         }
 
         sq->hostname = hstname;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -484,6 +484,7 @@ PRTE_EXPORT prte_node_rank_t prte_get_proc_node_rank(const pmix_proc_t *proc);
 
 /* check to see if two nodes match */
 PRTE_EXPORT bool prte_node_match(prte_node_t *n1, const char *name);
+PRTE_EXPORT bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2);
 
 /* global variables used by RTE - instanced in prte_globals.c */
 PRTE_EXPORT extern bool prte_debug_daemons_flag;

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -165,14 +165,14 @@ bool prte_check_host_is_local(const char *name)
             0 == strcmp(name, "127.0.0.1")) {
             return true;
         }
-        /* if it wasn't one of those and we are allowed
-         * to resolve addresses, then try that too */
-        if (!prte_do_not_resolve) {
-            if (prte_ifislocal(name)) {
-                /* add to our aliases */
-                prte_argv_append_nosize(&prte_process_info.aliases, name);
-                return true;
-            }
+    }
+    /* if it wasn't one of those and we are allowed
+     * to resolve addresses, then try that too */
+    if (!prte_do_not_resolve) {
+        if (prte_ifislocal(name)) {
+            /* add to our aliases */
+            prte_argv_append_nosize(&prte_process_info.aliases, name);
+            return true;
         }
     }
     return false;


### PR DESCRIPTION
Remove an incorrect check against hostname lengths. Try to do a better job
of capturing aliases, including those for managed allocations.

Signed-off-by: Ralph Castain <rhc@pmix.org>