### PR TITLE
Update status code and ensure job-end event propagation

### DIFF
--- a/examples/fault.c
+++ b/examples/fault.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
     pmix_info_t *info;
     mylock_t mylock;
     myrel_t myrel;
-    pmix_status_t code[2] = {PMIX_ERR_PROC_ABORTED, PMIX_ERR_JOB_TERMINATED};
+    pmix_status_t code[2] = {PMIX_ERR_PROC_ABORTED, PMIX_EVENT_JOB_END};
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {

--- a/examples/launcher.c
+++ b/examples/launcher.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     pmix_status_t code[6] = {PMIX_ERR_PROC_ABORTING,
                              PMIX_ERR_PROC_ABORTED,
                              PMIX_ERR_PROC_REQUESTED_ABORT,
-                             PMIX_ERR_JOB_TERMINATED,
+                             PMIX_EVENT_JOB_END,
                              PMIX_ERR_UNREACH,
                              PMIX_ERR_LOST_CONNECTION};
     pmix_nspace_t appspace;

--- a/src/mca/propagate/prperror/propagate_prperror.c
+++ b/src/mca/propagate/prperror/propagate_prperror.c
@@ -100,7 +100,7 @@ static void flush_error_list(size_t evhdlr_registration_id, pmix_status_t status
 static int init(void)
 {
     PRTE_CONSTRUCT(&prte_error_procs, prte_list_t);
-    pmix_status_t pcode1 = PMIX_ERR_JOB_TERMINATED;
+    pmix_status_t pcode1 = PMIX_EVENT_JOB_END;
     PMIx_Register_event_handler(&pcode1, 1, NULL, 0, flush_error_list, NULL, NULL);
     return PRTE_SUCCESS;
 }

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -78,7 +78,7 @@ pmix_status_t prte_pmix_convert_rc(int rc)
         return PMIX_ERR_NODE_OFFLINE;
 
     case PRTE_ERR_JOB_TERMINATED:
-        return PMIX_ERR_JOB_TERMINATED;
+        return PMIX_EVENT_JOB_END;
 
     case PRTE_ERR_PROC_RESTART:
         return PMIX_ERR_PROC_RESTART;
@@ -162,7 +162,7 @@ int prte_pmix_convert_status(pmix_status_t status)
     case PMIX_ERR_NODE_OFFLINE:
         return PRTE_ERR_NODE_OFFLINE;
 
-    case PMIX_ERR_JOB_TERMINATED:
+    case PMIX_EVENT_JOB_END:
         return PRTE_ERR_JOB_TERMINATED;
 
     case PMIX_ERR_PROC_RESTART:
@@ -352,7 +352,7 @@ pmix_status_t prte_pmix_convert_job_state_to_error(int state)
         return PMIX_ERR_JOB_TERM_WO_SYNC;
 
     case PRTE_JOB_STATE_TERMINATED:
-        return PMIX_ERR_JOB_TERMINATED;
+        return PMIX_EVENT_JOB_END;
 
     default:
         return PMIX_ERROR;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -413,7 +413,7 @@ void pmix_server_notify(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
         PRTE_RELEASE(cd);
     }
 
-    if (PMIX_ERR_JOB_TERMINATED == code) {
+    if (PMIX_EVENT_JOB_END == code) {
         jdata = prte_get_job_data_object(source.nspace);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
     }

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -415,7 +415,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                 pmix_info_t info[3];
                 bool flag;
                 prte_job_t *jd;
-                pmix_status_t xrc = PMIX_ERR_JOB_TERMINATED;
+                pmix_status_t xrc = PMIX_EVENT_JOB_END;
                 /* we need to notify this job that its CHILD job terminated
                  * as that is the job it is looking for */
                 jd = (prte_job_t *) prte_list_get_first(&jdata->children);
@@ -431,7 +431,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                 PMIX_LOAD_PROCID(&pname, jd->nspace, PMIX_RANK_WILDCARD);
                 PMIX_INFO_LOAD(&info[2], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
                 PRTE_PMIX_CONSTRUCT_LOCK(&lk);
-                PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED, &pname, PMIX_RANGE_SESSION, info, 3,
+                PMIx_Notify_event(PMIX_EVENT_JOB_END, &pname, PMIX_RANGE_SESSION, info, 3,
                                   _notify_release, &lk);
                 PRTE_PMIX_WAIT_THREAD(&lk);
                 PRTE_PMIX_DESTRUCT_LOCK(&lk);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -1011,7 +1011,7 @@ int prun(int argc, char *argv[])
 
     /* register to be notified when
      * our job completes */
-    ret = PMIX_ERR_JOB_TERMINATED;
+    ret = PMIX_EVENT_JOB_END;
     /* setup the info */
     ninfo = 3;
     PMIX_INFO_CREATE(iptr, ninfo);

--- a/test/loop_spawn.c
+++ b/test/loop_spawn.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         }
         if (sync) {
             DEBUG_CONSTRUCT_LOCK(&rellock);
-            rc = PMIX_ERR_JOB_TERMINATED;
+            rc = PMIX_EVENT_JOB_END;
             /* give the handler a name */
             PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "JOB_TERMINATION_EVENT", PMIX_STRING);
             /* specify we only want to be notified when our


### PR DESCRIPTION
Update the "err_job_terminated" status to "event_job_end" to
track changes in PMIx. Give the DVM a chance to get the "job-end"
event out before shutting down. 

Fixes https://github.com/openpmix/prrte/issues/953

Signed-off-by: Ralph Castain <rhc@pmix.org>