### PR TITLE
Cleanup some warnings/format and fix simple_spawn test

### DIFF
--- a/src/mca/grpcomm/base/grpcomm_base_stubs.c
+++ b/src/mca/grpcomm/base/grpcomm_base_stubs.c
@@ -284,8 +284,7 @@ prte_grpcomm_coll_t *prte_grpcomm_base_get_tracker(prte_grpcomm_signature_t *sig
     size_t n;
 
     /* search the existing tracker list to see if this already exists */
-    PRTE_LIST_FOREACH(coll, &prte_grpcomm_base.ongoing, prte_grpcomm_coll_t)
-    {
+    PRTE_LIST_FOREACH(coll, &prte_grpcomm_base.ongoing, prte_grpcomm_coll_t) {
         if (NULL == sig->signature) {
             if (NULL == coll->sig->signature) {
                 /* only one collective can operate at a time
@@ -295,8 +294,8 @@ prte_grpcomm_coll_t *prte_grpcomm_base_get_tracker(prte_grpcomm_signature_t *sig
             /* if only one is NULL, then we can't possibly match */
             break;
         }
-        if (sig->sz == coll->sig->sz
-            && 0 == memcmp(sig->signature, coll->sig->signature, sig->sz * sizeof(pmix_proc_t))) {
+        if (sig->sz == coll->sig->sz &&
+            0 == memcmp(sig->signature, coll->sig->signature, sig->sz * sizeof(pmix_proc_t))) {
             PRTE_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                                  "%s grpcomm:base:returning existing collective",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -50,7 +50,7 @@ int prte_ras_base_node_insert(prte_list_t *nodes, prte_job_t *jdata)
     int32_t num_nodes;
     int rc, i;
     prte_node_t *node, *hnp_node, *nptr;
-    bool hnp_alone = true, skiphnp = false;
+    bool skiphnp = false;
     prte_attribute_t *kv;
     prte_proc_t *daemon;
     prte_job_t *djob;
@@ -198,8 +198,7 @@ int prte_ras_base_node_insert(prte_list_t *nodes, prte_job_t *jdata)
             if (!prte_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
                 prte_have_fqdn_allocation = true;
             }
-            /* indicate the HNP is not alone */
-            hnp_alone = false;
+            /* duplicate the node if requested */
             for (i = 1; i < prte_ras_base.multiplier; i++) {
                 rc = prte_node_copy(&nptr, node);
                 if (PRTE_SUCCESS != rc) {

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -54,7 +54,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     prte_node_t *node;
     prte_job_map_t *app_map, *daemon_map;
     prte_proc_t *proc;
-    int rc;
+    int rc = PRTE_SUCCESS;
     bool did_map, pernode = false, perpackage = false;
     prte_rmaps_base_selected_module_t *mod;
     prte_job_t *parent = NULL, *target_jdata;
@@ -234,6 +234,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 PRTE_SET_MAPPING_DIRECTIVE(daemon_map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
             }
         }
+        nprocs = jdata->num_procs;
         goto ranking;
     }
 


### PR DESCRIPTION
The simple_spawn test was incorrectly having every initial
job process call "spawn" instead of just rank=0. This created
a confusion of new child processes. In addition, each process
that did call "spawn" was the only one who knew the nspace
of the child job - yet a "connect" was called across all members
of the parent job. This caused "connect" to hang.

Signed-off-by: Ralph Castain <rhc@pmix.org>