### PR TITLE
Inform procs that node is oversubscribed

### DIFF
--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -218,6 +218,13 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                 prte_list_append(&iarray->infolist, &kv->super);
                 free(tmp);
             }
+            /* if oversubscribed, mark it */
+            if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
+                prte_output(0, "NODE %s IS OVERSUB", node->name);
+                kv = PRTE_NEW(prte_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_NODE_OVERSUBSCRIBED, NULL, PMIX_BOOL);
+                prte_list_append(&iarray->infolist, &kv->super);
+            }
             /* add to the overall payload */
             prte_list_append(&nodeinfo, &iarray->super);
         }

--- a/test/hello.c
+++ b/test/hello.c
@@ -42,6 +42,7 @@ int main(int argc, char **argv)
     pmix_value_t *val;
     uint16_t localrank;
     size_t n;
+    pmix_info_t optional;
 
     pid = getpid();
     gethostname(hostname, 1024);
@@ -76,6 +77,15 @@ int main(int argc, char **argv)
         fprintf(stderr, "Unable to get local peers\n");
     } else {
         fprintf(stderr, "%s:%u - local peers %s\n", myproc.nspace, myproc.rank, val->data.string);
+    }
+
+    PMIX_LOAD_PROCID(&wild, myproc.nspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&optional, PMIX_OPTIONAL, NULL, PMIX_BOOL);
+    rc = PMIx_Get(&wild, PMIX_NODE_OVERSUBSCRIBED, &optional, 1, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Not oversubscribed\n");
+    } else {
+        fprintf(stderr, "%s:%u - oversubscribed\n", myproc.nspace, myproc.rank);
     }
 
   done:


### PR DESCRIPTION
Use new attribute to indicate that the node is oversubscribed

Signed-off-by: Ralph Castain <rhc@pmix.org>