### PR TITLE
Extend sanity check to display/output directives

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -127,11 +127,11 @@ mapping operation. This can happen if you request a map type
 
 #
 [unrecognized-policy]
-The specified %s policy is not recognized:
+The specified %s directive is not recognized:
 
-  Policy: %s
+  Directive: %s
 
-Please check for a typo or ensure that the option is a supported
+Please check for a typo or ensure that the directive is a supported
 one.
 #
 [oversubscribe-conflict]
@@ -524,3 +524,19 @@ hardware thread in that core.
 In contrast, a case such as "--map-by package:hwtcpus --bind-to hwthread"
 would result in each process being bound to successive hardware threads
 on each package.
+#
+[unrecognized-qualifier]
+The %s directive contains an unrecognized qualifier:
+
+  Qualifier: %s
+  Valid qualifiers: %s
+
+Please check for a typo or ensure that the qualifier is a supported one.
+#
+[unrecognized-directive]
+The specified %s directive is not recognized:
+
+  Directive: %s
+  Valid directives: %s
+
+Please check for a typo or ensure that the directive is a supported one.

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -92,6 +92,7 @@ PRTE_EXPORT int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline
                                                         prte_schizo_convertor_fn_t convert);
 PRTE_EXPORT int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target);
 PRTE_EXPORT int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target);
+PRTE_EXPORT int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line);
 
 END_C_DECLS
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -362,4 +362,205 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete, char *option,
     return PRTE_SUCCESS;
 }
 
+static bool check_qualifiers(char *directive,
+                             char **valid,
+                             char *qual)
+{
+    size_t n, len, l1, l2;
+    char *v;
+
+    l1 = strlen(qual);
+    for (n=0; NULL != valid[n]; n++) {
+        l2 = strlen(valid[n]);
+        len = (l1 < l2) ? l1 : l2;
+        if (0 == strncasecmp(valid[n], qual, len)) {
+            return true;
+        }
+    }
+    v = prte_argv_join(valid, ',');
+    prte_show_help("help-prte-rmaps-base.txt",
+                   "unrecognized-qualifier", true,
+                   directive, qual, v);
+    free(v);
+    return false;
+}
+
+static bool check_directives(char *directive,
+                             char **valid,
+                             char **quals,
+                             char *dir)
+{
+    size_t n, m, len, l1, l2;
+    char **args, **qls, *v, *q;
+    char *pproptions[] = {"slot", "hwthread", "core", "l1cache",
+                          "l2cache",  "l3cache", "package", "node",
+                          NULL};
+    bool found;
+
+    /* if it starts with a ':', then these are just modifiers */
+    if (':' == dir[0]) {
+        return check_qualifiers(directive, quals, &dir[1]);
+    }
+
+    args = prte_argv_split(dir, ':');
+    for (n = 0; NULL != valid[n]; n++) {
+        l1 = strlen(args[0]);
+        l2 = strlen(valid[n]);
+        len = (l1 < l2) ? l1 : l2;
+        if (0 == strncasecmp(args[0], valid[n], len)) {
+            /* valid directive - check any qualifiers */
+            if (NULL != args[1] && NULL != quals) {
+                if (0 == strcmp(directive, "map-by") &&
+                    0 == strcmp(args[0], "ppr")) {
+                    /* unfortunately, this is a special case that
+                     * must be checked separately due to the format
+                     * of the qualifier */
+                    v = NULL;
+                    m = strtoul(args[1], &v, 10);
+                    if (NULL != v && 0 < strlen(v)) {
+                        /* the first entry had to be a pure number */
+                        prte_asprintf(&v, "ppr:[Number of procs/object]:%s", args[2]);
+                        prte_show_help("help-prte-rmaps-base.txt",
+                                       "unrecognized-qualifier", true,
+                                       directive, dir, v);
+                        free(v);
+                        prte_argv_free(args);
+                        return false;
+                    }
+                    found = false;
+                    for (m=0; NULL != pproptions[m]; m++) {
+                        if (0 == strcasecmp(args[2], pproptions[m])) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        v = prte_argv_join(pproptions, ',');
+                        prte_asprintf(&q, "ppr:%s:[%s]", args[1], v);
+                        free(v);
+                        prte_show_help("help-prte-rmaps-base.txt",
+                                       "unrecognized-qualifier", true,
+                                       directive, dir, q);
+                        free(q);
+                        prte_argv_free(args);
+                        return false;
+                    }
+                    if (NULL != args[3]) {
+                        qls = prte_argv_split(args[3], ',');
+                    } else {
+                        prte_argv_free(args);
+                        return true;
+                    }
+                } else {
+                    qls = prte_argv_split(args[1], ',');
+                }
+               for (m=0; NULL != qls[m]; m++) {
+                    if (!check_qualifiers(directive, quals, qls[m])) {
+                        prte_argv_free(qls);
+                        prte_argv_free(args);
+                        return false;
+                    }
+                }
+                prte_argv_free(qls);
+                prte_argv_free(args);
+                return true;
+            }
+            prte_argv_free(args);
+            return true;
+        }
+    }
+    v = prte_argv_join(valid, ',');
+    prte_show_help("help-prte-rmaps-base.txt",
+                   "unrecognized-directive", true,
+                   directive, dir, v);
+    prte_argv_free(args);
+    return false;
+}
+
+int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
+{
+    prte_value_t *pval;
+    char *mappers[] = {"slot", "hwthread", "core", "l1cache", "l2cache",  "l3cache", "package",
+                       "node", "seq",      "dist", "ppr",     "rankfile", NULL};
+    char *mapquals[] = {"pe=", "span", "oversubscribe", "nooversubscribe", "nolocal",
+                        "hwtcpus", "corecpus", "device=", "inherit", "noinherit", "pe-list=",
+                        "file=", "donotlaunch", NULL};
+
+    char *rankers[] = {"slot",    "hwthread", "core", "l1cache", "l2cache",
+                       "l3cache", "package",  "node", NULL};
+    char *rkquals[] = {"span", "fill", NULL};
+
+    char *binders[] = {"none",    "hwthread", "core",    "l1cache",
+                       "l2cache", "l3cache",  "package", NULL};
+    char *bndquals[] = {"overload-allowed", "if-supported", "ordered", "report", NULL};
+
+    char *outputs[] = {"tag", "timestamp", "xml", "merge-stderr-to-stdout", NULL};
+    char *displays[] = {"allocation", "map", "bind", "map-devel", "topo", NULL};
+
+    bool hwtcpus = false;
+
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "map-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "map-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "rank-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "rank-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "bind-to")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "bind-to");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "output")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "output");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "display")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "display");
+        return PRTE_ERR_SILENT;
+    }
+
+    /* quick check that we have valid directives */
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "map-by", 0, 0))) {
+        if (NULL != strcasestr(pval->value.data.string, "HWTCPUS")) {
+            hwtcpus = true;
+        }
+        if (!check_directives("map-by", mappers, mapquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rank-by", 0, 0))) {
+        if (!check_directives("rank-by", rankers, rkquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "bind-to", 0, 0))) {
+        if (!check_directives("bind-to", binders, bndquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+        if (0 == strncasecmp(pval->value.data.string, "HWTHREAD", strlen("HWTHREAD")) && !hwtcpus) {
+            /* if we are told to bind-to hwt, then we have to be treating
+             * hwt's as the allocatable unit */
+            prte_show_help("help-prte-rmaps-base.txt", "invalid-combination", true);
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "output", 0, 0))) {
+        if (!check_directives("output", outputs, NULL, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "display", 0, 0))) {
+        if (!check_directives("display", displays, NULL, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
 PRTE_CLASS_INSTANCE(prte_schizo_base_active_module_t, prte_list_item_t, NULL, NULL);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -65,7 +65,6 @@ static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, b
 static int detect_proxy(char *argv);
 static void allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
-static int check_sanity(prte_cmd_line_t *cmd_line);
 
 prte_schizo_base_module_t prte_schizo_ompi_module = {.name = "ompi",
                                                      .define_cli = define_cli,
@@ -75,7 +74,7 @@ prte_schizo_base_module_t prte_schizo_ompi_module = {.name = "ompi",
                                                      .detect_proxy = detect_proxy,
                                                      .allow_run_as_root = allow_run_as_root,
                                                      .job_info = job_info,
-                                                     .check_sanity = check_sanity};
+                                                     .check_sanity = prte_schizo_base_sanity};
 
 static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     /* basic options */
@@ -1585,9 +1584,4 @@ static void job_info(prte_cmd_line_t *cmdline, void *jobinfo)
             PMIX_ERROR_LOG(rc);
         }
     }
-}
-
-static int check_sanity(prte_cmd_line_t *cmd_line)
-{
-    return PRTE_SUCCESS;
 }

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -62,7 +62,6 @@ static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, b
 static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
 static int detect_proxy(char *argv);
 static void allow_run_as_root(prte_cmd_line_t *cmd_line);
-static int check_sanity(prte_cmd_line_t *cmd_line);
 static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 
 prte_schizo_base_module_t prte_schizo_prte_module = {.name = "prte",
@@ -73,7 +72,7 @@ prte_schizo_base_module_t prte_schizo_prte_module = {.name = "prte",
                                                      .setup_fork = setup_fork,
                                                      .detect_proxy = detect_proxy,
                                                      .allow_run_as_root = allow_run_as_root,
-                                                     .check_sanity = check_sanity,
+                                                     .check_sanity = prte_schizo_base_sanity,
                                                      .job_info = job_info};
 
 static prte_cmd_line_init_t prte_cmd_line_init[] = {
@@ -995,113 +994,4 @@ static void allow_run_as_root(prte_cmd_line_t *cmd_line)
 static void job_info(prte_cmd_line_t *cmdline, void *jobinfo)
 {
     return;
-}
-
-static int check_sanity(prte_cmd_line_t *cmd_line)
-{
-    prte_value_t *pval;
-    int n;
-    char **args;
-    char *mappers[] = {"slot", "hwthread", "core", "l1cache", "l2cache",  "l3cache", "package",
-                       "node", "seq",      "dist", "ppr",     "rankfile", NULL};
-    char *rankers[] = {"slot",    "hwthread", "core", "l1cache", "l2cache",
-                       "l3cache", "package",  "node", NULL};
-    char *binders[] = {"none",    "hwthread", "core",    "l1cache",
-                       "l2cache", "l3cache",  "package", NULL};
-    bool good = false;
-    bool hwtcpus = false;
-
-    if (1 < prte_cmd_line_get_ninsts(cmd_line, "map-by")) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, "map-by");
-        return PRTE_ERR_SILENT;
-    }
-    if (1 < prte_cmd_line_get_ninsts(cmd_line, "rank-by")) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, "rank-by");
-        return PRTE_ERR_SILENT;
-    }
-    if (1 < prte_cmd_line_get_ninsts(cmd_line, "bind-to")) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, "bind-to");
-        return PRTE_ERR_SILENT;
-    }
-
-    /* quick check that we have valid directives */
-    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "map-by", 0, 0))) {
-        if (NULL != strcasestr(pval->value.data.string, "HWTCPUS")) {
-            hwtcpus = true;
-        }
-        /* if it starts with a ':', then these are just modifiers */
-        if (':' == pval->value.data.string[0]) {
-            goto rnk;
-        }
-        args = prte_argv_split(pval->value.data.string, ':');
-        good = false;
-        for (n = 0; NULL != mappers[n]; n++) {
-            if (0 == strcasecmp(args[0], mappers[n])) {
-                good = true;
-                break;
-            }
-        }
-        if (!good) {
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "mapping",
-                           args[0]);
-            prte_argv_free(args);
-            return PRTE_ERR_SILENT;
-        }
-        prte_argv_free(args);
-    }
-
-rnk:
-    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rank-by", 0, 0))) {
-        /* if it starts with a ':', then these are just modifiers */
-        if (':' == pval->value.data.string[0]) {
-            goto bnd;
-        }
-        args = prte_argv_split(pval->value.data.string, ':');
-        good = false;
-        for (n = 0; NULL != rankers[n]; n++) {
-            if (0 == strcasecmp(args[0], rankers[n])) {
-                good = true;
-                break;
-            }
-        }
-        if (!good) {
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "ranking",
-                           args[0]);
-            prte_argv_free(args);
-            return PRTE_ERR_SILENT;
-        }
-        prte_argv_free(args);
-    }
-
-bnd:
-    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "bind-to", 0, 0))) {
-        /* if it starts with a ':', then these are just modifiers */
-        if (':' == pval->value.data.string[0]) {
-            return PRTE_SUCCESS;
-        }
-        args = prte_argv_split(pval->value.data.string, ':');
-        good = false;
-        for (n = 0; NULL != binders[n]; n++) {
-            if (0 == strcasecmp(args[0], binders[n])) {
-                good = true;
-                break;
-            }
-        }
-        if (!good) {
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "binding",
-                           args[0]);
-            prte_argv_free(args);
-            return PRTE_ERR_SILENT;
-        }
-        if (0 == strcasecmp(args[0], "HWTHREAD") && !hwtcpus) {
-            /* if we are told to bind-to hwt, then we have to be treating
-             * hwt's as the allocatable unit */
-            prte_show_help("help-prte-rmaps-base.txt", "invalid-combination", true);
-            prte_argv_free(args);
-            return PRTE_ERR_SILENT;
-        }
-        prte_argv_free(args);
-    }
-
-    return PRTE_SUCCESS;
 }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -430,10 +430,10 @@ int prte(int argc, char *argv[])
     if (PRTE_SUCCESS != rc) {
         if (PRTE_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
+            param = prte_argv_join(pargv, ' ');
+            fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
+            free(param);
         }
-        param = prte_argv_join(pargv, ' ');
-        fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
-        free(param);
         return rc;
     }
 
@@ -888,19 +888,19 @@ int prte(int argc, char *argv[])
         targv = prte_argv_split(pval->value.data.string, ',');
 
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
-            if (0 == strcmp(targv[idx], "allocation")) {
+            if (0 == strncasecmp(targv[idx], "allocation", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map")) {
+            if (0 == strcasecmp(targv[idx], "map")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "bind")) {
+            if (0 == strncasecmp(targv[idx], "bind", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-devel")) {
+            if (0 == strcasecmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "topo")) {
+            if (0 == strncasecmp(targv[idx], "topo", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);
             }
         }
@@ -913,16 +913,16 @@ int prte(int argc, char *argv[])
         targv = prte_argv_split(pval->value.data.string, ',');
 
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
-            if (0 == strcmp(targv[idx], "tag")) {
+            if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
             }
-            if (0 == strcmp(targv[idx], "timestamp")) {
+            if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
             }
-            if (0 == strcmp(targv[idx], "xml")) {
+            if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":XMLOUTPUT", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "merge-stderr-to-stdout")) {
+            if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
             }
             if (NULL != (ptr = strchr(targv[idx], ':'))) {
@@ -976,6 +976,7 @@ int prte(int argc, char *argv[])
         }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
         free(param);
+        free(ptr);
     }
 
     /* check what user wants us to do with stdin */

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -501,10 +501,10 @@ int prun(int argc, char *argv[])
     if (PRTE_SUCCESS != rc) {
         if (PRTE_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
+            param = prte_argv_join(pargv, ' ');
+            fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
+            free(param);
         }
-        param = prte_argv_join(pargv, ' ');
-        fprintf(stderr, "\n******* Cmd line: %s\n\n\n", param);
-        free(param);
         return rc;
     }
 
@@ -721,19 +721,19 @@ int prun(int argc, char *argv[])
         targv = prte_argv_split(pval->value.data.string, ',');
 
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
-            if (0 == strcmp(targv[idx], "allocation")) {
+            if (0 == strncasecmp(targv[idx], "allocation", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map")) {
+            if (0 == strcasecmp(targv[idx], "map")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "bind")) {
+            if (0 == strncasecmp(targv[idx], "bind", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "map-devel")) {
+            if (0 == strcasecmp(targv[idx], "map-devel")) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "topo")) {
+            if (0 == strncasecmp(targv[idx], "topo", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);
             }
         }
@@ -746,16 +746,16 @@ int prun(int argc, char *argv[])
         targv = prte_argv_split(pval->value.data.string, ',');
 
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
-            if (0 == strcmp(targv[idx], "tag")) {
+            if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
             }
-            if (0 == strcmp(targv[idx], "timestamp")) {
+            if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
             }
-            if (0 == strcmp(targv[idx], "xml")) {
+            if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":XMLOUTPUT", PMIX_STRING);
             }
-            if (0 == strcmp(targv[idx], "merge-stderr-to-stdout")) {
+            if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
             }
             if (NULL != (ptr = strchr(targv[idx], ':'))) {
@@ -806,6 +806,7 @@ int prun(int argc, char *argv[])
         }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
         free(param);
+        free(ptr);
     }
 
     /* check what user wants us to do with stdin */


### PR DESCRIPTION
Check the display and output directives for validity. Extend
checks to include qualifiers. Accept both lower and upper
case versions, and allow user to abbreviate.

Fixes #919 

Signed-off-by: Ralph Castain <rhc@pmix.org>