### PR TITLE
Enable output to a directory

### DIFF
--- a/src/mca/iof/base/iof_base_setup.c
+++ b/src/mca/iof/base/iof_base_setup.c
@@ -254,8 +254,8 @@ int prte_iof_base_setup_output_files(const pmix_proc_t *dst_name, prte_job_t *jo
 
     /* see if we are to output to a directory */
     dirname = NULL;
-    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY, (void **) &dirname,
-                           PMIX_STRING)
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY,
+                           (void **) &dirname, PMIX_STRING)
         && NULL != dirname) {
         np = jobdat->num_procs / 10;
         /* determine the number of digits required for max vpid */

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -540,3 +540,11 @@ The specified %s directive is not recognized:
   Valid directives: %s
 
 Please check for a typo or ensure that the directive is a supported one.
+#
+[missing-qualifier]
+The %s option contains a directive that is missing a value:
+
+  Directive: %s
+  Valid directive: "%s=<value>"
+
+Please check for a typo or ensure that the value is provided.

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -403,6 +403,10 @@ static bool check_directives(char *directive,
     }
 
     args = prte_argv_split(dir, ':');
+    /* remove any '=' in the directive */
+    if (NULL != (v = strchr(args[0], '='))) {
+        *v = '\0';
+    }
     for (n = 0; NULL != valid[n]; n++) {
         l1 = strlen(args[0]);
         l2 = strlen(valid[n]);
@@ -494,7 +498,8 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
                        "l2cache", "l3cache",  "package", NULL};
     char *bndquals[] = {"overload-allowed", "if-supported", "ordered", "report", NULL};
 
-    char *outputs[] = {"tag", "timestamp", "xml", "merge-stderr-to-stdout", NULL};
+    char *outputs[] = {"tag", "timestamp", "xml", "merge-stderr-to-stdout", "directory", "filename", NULL};
+
     char *displays[] = {"allocation", "map", "bind", "map-devel", "topo", NULL};
 
     bool hwtcpus = false;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -567,6 +567,10 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_FILE, PRTE_ATTR_GLOBAL,
                                info->value.data.string, PMIX_STRING);
 
+        } else if (PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY, PRTE_ATTR_GLOBAL,
+                               info->value.data.string, PMIX_STRING);
+
             /***   MERGE STDERR TO STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MERGE_STDERR_STDOUT)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -253,6 +253,8 @@ int prte(int argc, char *argv[])
     prte_schizo_base_module_t *schizo;
     prte_ess_base_signal_t *sig;
     char **targv;
+    char *outdir = NULL;
+    char *outfile = NULL;
 
     /* init the globals */
     PRTE_CONSTRUCT(&apps, prte_list_t);
@@ -908,11 +910,16 @@ int prte(int argc, char *argv[])
     }
 
     /* cannot have both files and directory set for output */
-    ptr = NULL;
+    outdir = NULL;
+    outfile = NULL;
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output", 0, 0))) {
         targv = prte_argv_split(pval->value.data.string, ',');
 
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
+            /* remove any '=' sign in the directive */
+            if (NULL != (ptr = strchr(targv[idx], '='))) {
+                *ptr = '\0';
+            }
             if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
             }
@@ -925,58 +932,70 @@ int prte(int argc, char *argv[])
             if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
             }
-            if (NULL != (ptr = strchr(targv[idx], ':'))) {
+            if (0 == strncasecmp(targv[idx], "directory", strlen(targv[idx]))) {
+                if (NULL != outfile) {
+                    prte_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
+                    return PRTE_ERR_FATAL;
+                }
+                if (NULL == ptr) {
+                    prte_show_help("help-prte-rmaps-base.txt",
+                                   "missing-qualifier", true,
+                                   "output", "directory", "directory");
+                    return PRTE_ERR_FATAL;
+                }
                 ++ptr;
-                ptr = strdup(ptr);
+                /* If the given filename isn't an absolute path, then
+                 * convert it to one so the name will be relative to
+                 * the directory where prun was given as that is what
+                 * the user will have seen */
+                if (!prte_path_is_absolute(ptr)) {
+                    char cwd[PRTE_PATH_MAX];
+                    if (NULL == getcwd(cwd, sizeof(cwd))) {
+                        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+                        goto DONE;
+                    }
+                    outdir = prte_os_path(false, cwd, ptr, NULL);
+                } else {
+                    outdir = strdup(ptr);
+                }
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
+            }
+            if (0 == strncasecmp(targv[idx], "file", strlen(targv[idx]))) {
+                if (NULL != outdir) {
+                    prte_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
+                    return PRTE_ERR_FATAL;
+                }
+                if (NULL == ptr) {
+                    prte_show_help("help-prte-rmaps-base.txt",
+                                   "missing-qualifier", true,
+                                   "output", "filename", "filename");
+                    return PRTE_ERR_FATAL;
+                }
+                ++ptr;
+                /* If the given filename isn't an absolute path, then
+                 * convert it to one so the name will be relative to
+                 * the directory where prun was given as that is what
+                 * the user will have seen */
+                if (!prte_path_is_absolute(ptr)) {
+                    char cwd[PRTE_PATH_MAX];
+                    if (NULL == getcwd(cwd, sizeof(cwd))) {
+                        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+                        goto DONE;
+                    }
+                    outfile = prte_os_path(false, cwd, ptr, NULL);
+                } else {
+                    outfile = strdup(ptr);
+                }
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_FILE, outfile, PMIX_STRING);
             }
         }
         prte_argv_free(targv);
     }
-
-    param = NULL;
-    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output-filename", 0, 0))) {
-        param = pval->value.data.string;
+    if (NULL != outdir) {
+        free(outdir);
     }
-    if (NULL != param && NULL != ptr) {
-        prte_show_help("help-prted.txt", "both-file-and-dir-set", true, param, ptr);
-        return PRTE_ERR_FATAL;
-    } else if (NULL != param) {
-        /* if we were asked to output to files, pass it along. */
-        /* if the given filename isn't an absolute path, then
-         * convert it to one so the name will be relative to
-         * the directory where prun was given as that is what
-         * the user will have seen */
-        if (!prte_path_is_absolute(param)) {
-            char cwd[PRTE_PATH_MAX];
-            if (NULL == getcwd(cwd, sizeof(cwd))) {
-                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                goto DONE;
-            }
-            ptr = prte_os_path(false, cwd, param, NULL);
-        } else {
-            ptr = strdup(param);
-        }
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_FILE, ptr, PMIX_STRING);
-        free(ptr);
-    } else if (NULL != ptr) {
-        /* if we were asked to output to a directory, pass it along. */
-        /* If the given filename isn't an absolute path, then
-         * convert it to one so the name will be relative to
-         * the directory where prun was given as that is what
-         * the user will have seen */
-        if (!prte_path_is_absolute(ptr)) {
-            char cwd[PRTE_PATH_MAX];
-            if (NULL == getcwd(cwd, sizeof(cwd))) {
-                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                goto DONE;
-            }
-            param = prte_os_path(false, cwd, ptr, NULL);
-        } else {
-            param = strdup(ptr);
-        }
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, param, PMIX_STRING);
-        free(param);
-        free(ptr);
+    if (NULL != outfile) {
+        free(outfile);
     }
 
     /* check what user wants us to do with stdin */


### PR DESCRIPTION
Cleanup the output to file and directory support. Change the
directives to be more "check-friendly" by using equal signs
instead of qualifiers - i.e., "output file=foo.txt". Add these
to sanity check and properly parse to pass the option along
to the RTE.

Fixes #917 

Signed-off-by: Ralph Castain <rhc@pmix.org>