### PR TITLE
Enable merge-stderr-to-stdout

### DIFF
--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -133,6 +133,7 @@ typedef struct {
     prte_iof_read_event_t *revstderr;
     prte_list_t *subscribers;
     bool copy;
+    bool merge;
 } prte_iof_proc_t;
 PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_iof_proc_t);
 
@@ -156,7 +157,6 @@ struct prte_iof_base_t {
     size_t output_limit;
     prte_iof_sink_t *iof_write_stdout;
     prte_iof_sink_t *iof_write_stderr;
-    bool redirect_app_stderr_to_stdout;
     prte_list_t requests;
 };
 typedef struct prte_iof_base_t prte_iof_base_t;

--- a/src/mca/iof/base/iof_base_frame.c
+++ b/src/mca/iof/base/iof_base_frame.c
@@ -71,14 +71,6 @@ static int prte_iof_base_register(prte_mca_base_register_flag_t flags)
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                       &prte_iof_base.output_limit);
 
-    /* Redirect application stderr to stdout (at source) */
-    prte_iof_base.redirect_app_stderr_to_stdout = false;
-    (void) prte_mca_base_var_register(
-        "prte", "iof", "base", "redirect_app_stderr_to_stdout",
-        "Redirect application stderr to stdout at source (default: false)",
-        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_iof_base.redirect_app_stderr_to_stdout);
-
     return PRTE_SUCCESS;
 }
 
@@ -160,6 +152,7 @@ static void prte_iof_base_proc_construct(prte_iof_proc_t *ptr)
     ptr->revstderr = NULL;
     ptr->subscribers = NULL;
     ptr->copy = true;
+    ptr->merge = false;
 }
 static void prte_iof_base_proc_destruct(prte_iof_proc_t *ptr)
 {

--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -138,7 +138,7 @@ int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
     if (prte_xml_output) {
         if (prte_tag_output) {
             snprintf(begintag, PRTE_IOF_BASE_TAG_MAX,
-                     "<%s nspace=\"%s\" rank=\"%s\"", suffix,
+                     "<%s localjobid=\"%s\" rank=\"%s\"", suffix,
                      PRTE_LOCAL_JOBID_PRINT(name->nspace),
                      PRTE_VPID_PRINT(name->rank));
         } else if (prte_timestamp_output) {

--- a/src/mca/iof/base/iof_base_setup.h
+++ b/src/mca/iof/base/iof_base_setup.h
@@ -31,6 +31,7 @@
 struct prte_iof_base_io_conf_t {
     int usepty;
     bool connect_stdin;
+    bool merge;
 
     /* private - callers should not modify these fields */
     int p_stdin[2];

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -168,6 +168,9 @@ SETUP:
         PRTE_IOF_READ_EVENT(&proct->revstderr, proct, fd, PRTE_IOF_STDERR,
                             prte_iof_hnp_read_local_handler, false);
     }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+        proct->merge = true;
+    }
     /* setup any requested output files */
     if (PRTE_SUCCESS != (rc = prte_iof_base_setup_output_files(dst_name, jdata, proct))) {
         PRTE_ERROR_LOG(rc);
@@ -180,13 +183,13 @@ SETUP:
      * been defined!
      */
     if (NULL != proct->revstdout
-        && (prte_iof_base.redirect_app_stderr_to_stdout || NULL != proct->revstderr)) {
+        && (proct->merge || NULL != proct->revstderr)) {
         prte_iof_base_check_target(proct);
         if (!proct->revstdout->activated) {
             PRTE_IOF_READ_ACTIVATE(proct->revstdout);
             proct->revstdout->activated = true;
         }
-        if (!prte_iof_base.redirect_app_stderr_to_stdout && !proct->revstderr->activated) {
+        if (!proct->merge && !proct->revstderr->activated) {
             PRTE_IOF_READ_ACTIVATE(proct->revstderr);
             proct->revstderr->activated = true;
         }

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -162,6 +162,9 @@ SETUP:
         PRTE_IOF_READ_EVENT(&proct->revstderr, proct, fd, PRTE_IOF_STDERR,
                             prte_iof_prted_read_handler, false);
     }
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+        proct->merge = true;
+    }
     /* setup any requested output files */
     if (PRTE_SUCCESS != (rc = prte_iof_base_setup_output_files(dst_name, jobdat, proct))) {
         PRTE_ERROR_LOG(rc);
@@ -174,9 +177,9 @@ SETUP:
      * been defined!
      */
     if (NULL != proct->revstdout
-        && (prte_iof_base.redirect_app_stderr_to_stdout || NULL != proct->revstderr)) {
+        && (proct->merge || NULL != proct->revstderr)) {
         PRTE_IOF_READ_ACTIVATE(proct->revstdout);
-        if (!prte_iof_base.redirect_app_stderr_to_stdout) {
+        if (!proct->merge) {
             PRTE_IOF_READ_ACTIVATE(proct->revstderr);
         }
     }

--- a/src/mca/odls/alps/odls_alps_module.c
+++ b/src/mca/odls/alps/odls_alps_module.c
@@ -456,7 +456,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    if (!prte_iof_base.redirect_app_stderr_to_stdout) {
+    if (!cd->opts.merge) {
         close(cd->opts.p_stderr[1]);
     }
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1438,6 +1438,9 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             cd->index_argv = index_argv;
             /* setup any IOF */
             cd->opts.usepty = PRTE_ENABLE_PTY_SUPPORT;
+            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+                cd->opts.merge = true;
+            }
 
             /* do we want to setup stdin? */
             if (jobdat->stdin_target == PMIX_RANK_WILDCARD
@@ -2087,6 +2090,9 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
     cd->fork_local = fork_local;
     /* setup any IOF */
     cd->opts.usepty = PRTE_ENABLE_PTY_SUPPORT;
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+        cd->opts.merge = true;
+    }
 
     /* do we want to setup stdin? */
     if (jobdat->stdin_target == PMIX_RANK_WILDCARD || child->name.rank == jobdat->stdin_target) {

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -429,7 +429,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    if (!prte_iof_base.redirect_app_stderr_to_stdout) {
+    if (!cd->opts.merge) {
         close(cd->opts.p_stderr[1]);
     }
 


### PR DESCRIPTION
Update handling to be per-job so it can support DVM operations.
Correctly pass the option to the DVM for handling.

Fixes #916 

Signed-off-by: Ralph Castain <rhc@pmix.org>