### PR TITLE
Support the "nocopy" feature when outputting to files

### DIFF
--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -171,6 +171,9 @@ SETUP:
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
         proct->merge = true;
     }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, NULL, PMIX_BOOL)) {
+        proct->copy = false;
+    }
     /* setup any requested output files */
     if (PRTE_SUCCESS != (rc = prte_iof_base_setup_output_files(dst_name, jdata, proct))) {
         PRTE_ERROR_LOG(rc);

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -165,6 +165,9 @@ SETUP:
     if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
         proct->merge = true;
     }
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_OUTPUT_NOCOPY, NULL, PMIX_BOOL)) {
+        proct->copy = false;
+    }
     /* setup any requested output files */
     if (PRTE_SUCCESS != (rc = prte_iof_base_setup_output_files(dst_name, jobdat, proct))) {
         PRTE_ERROR_LOG(rc);

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -499,6 +499,7 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
     char *bndquals[] = {"overload-allowed", "if-supported", "ordered", "report", NULL};
 
     char *outputs[] = {"tag", "timestamp", "xml", "merge-stderr-to-stdout", "directory", "filename", NULL};
+    char *outquals[] = {"nocopy", NULL};
 
     char *displays[] = {"allocation", "map", "bind", "map-devel", "topo", NULL};
 
@@ -554,7 +555,7 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
     }
 
     if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "output", 0, 0))) {
-        if (!check_directives("output", outputs, NULL, pval->value.data.string)) {
+        if (!check_directives("output", outputs, outquals, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
     }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -186,9 +186,13 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
 
     /* output options */
     {'\0', "output", 1, PRTE_CMD_LINE_TYPE_STRING,
-     "Comma-delimited list of options that control the output generated."
-     "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir:DIRNAME",
-     PRTE_CMD_LINE_OTYPE_OUTPUT},
+        "Comma-delimited list of options that control how output is generated."
+        "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir=DIRNAME, file=filename."
+        " The dir option redirects output from application processes into DIRNAME/job/rank/std[out,err,diag]."
+        " The file option redirects output from application processes into filename.rank. In both cases, "
+        "the provided name will be converted to an absolute path. Supported qualifiers include NOCOPY"
+        " (do not copy the output to the stdout/err streams).",
+        PRTE_CMD_LINE_OTYPE_OUTPUT},
     /* exit status reporting */
     {'\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,
      "Return the exit status of the primary job only", PRTE_CMD_LINE_OTYPE_OUTPUT},

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -174,8 +174,12 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
 
     /* output options */
     {'\0', "output", 1, PRTE_CMD_LINE_TYPE_STRING,
-     "Comma-delimited list of options that control the output generated."
-     "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir:DIRNAME",
+     "Comma-delimited list of options that control how output is generated."
+     "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir=DIRNAME, file=filename."
+     " The dir option redirects output from application processes into DIRNAME/job/rank/std[out,err,diag]."
+     " The file option redirects output from application processes into filename.rank. In both cases, "
+     "the provided name will be converted to an absolute path. Supported qualifiers include NOCOPY"
+     " (do not copy the output to the stdout/err streams).",
      PRTE_CMD_LINE_OTYPE_OUTPUT},
     /* exit status reporting */
     {'\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -571,6 +571,11 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY, PRTE_ATTR_GLOBAL,
                                info->value.data.string, PMIX_STRING);
 
+        } else if (PMIX_CHECK_KEY(info, PMIX_OUTPUT_NOCOPY)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+
             /***   MERGE STDERR TO STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MERGE_STDERR_STDOUT)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -225,7 +225,7 @@ static prte_cmd_line_init_t cmd_line_init[] = {
 int prte(int argc, char *argv[])
 {
     int rc = 1, i, j;
-    char *param, *ptr, *tpath, *fullpath;
+    char *param, *ptr, *tpath, *fullpath, *cptr;
     prte_pmix_lock_t lock;
     prte_list_t apps;
     prte_pmix_app_t *app;
@@ -944,6 +944,14 @@ int prte(int argc, char *argv[])
                     return PRTE_ERR_FATAL;
                 }
                 ++ptr;
+                /* check for qualifiers */
+                if (NULL != (cptr = strchr(ptr, ':'))) {
+                    *cptr = '\0';
+                    ++cptr;
+                    if (0 != strcasecmp(cptr, "nocopy")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                    }
+                }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
                  * the directory where prun was given as that is what
@@ -972,6 +980,14 @@ int prte(int argc, char *argv[])
                     return PRTE_ERR_FATAL;
                 }
                 ++ptr;
+                /* check for qualifiers */
+                if (NULL != (cptr = strchr(ptr, ':'))) {
+                    *cptr = '\0';
+                    ++cptr;
+                    if (0 != strcasecmp(cptr, "nocopy")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                    }
+                }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
                  * the directory where prun was given as that is what

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -315,7 +315,7 @@ static prte_cmd_line_init_t prte_tool_options[] = {
 int prun(int argc, char *argv[])
 {
     int rc = 1, i;
-    char *param, *ptr;
+    char *param, *ptr, *cptr;
     prte_pmix_lock_t lock, rellock;
     prte_list_t apps;
     prte_pmix_app_t *app;
@@ -777,6 +777,14 @@ int prun(int argc, char *argv[])
                     return PRTE_ERR_FATAL;
                 }
                 ++ptr;
+                /* check for qualifiers */
+                if (NULL != (cptr = strchr(ptr, ':'))) {
+                    *cptr = '\0';
+                    ++cptr;
+                    if (0 != strcasecmp(cptr, "nocopy")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                    }
+                }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
                  * the directory where prun was given as that is what
@@ -805,6 +813,14 @@ int prun(int argc, char *argv[])
                     return PRTE_ERR_FATAL;
                 }
                 ++ptr;
+                /* check for qualifiers */
+                if (NULL != (cptr = strchr(ptr, ':'))) {
+                    *cptr = '\0';
+                    ++cptr;
+                    if (0 != strcasecmp(cptr, "nocopy")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                    }
+                }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
                  * the directory where prun was given as that is what

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -458,6 +458,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "STOP-IN-APP";
         case PRTE_JOB_ENVARS_HARVESTED:
             return "ENVARS-HARVESTED";
+        case PRTE_JOB_OUTPUT_NOCOPY:
+            return "DO-NOT-COPY-OUTPUT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -195,6 +195,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_STOP_IN_INIT               (PRTE_JOB_START_KEY + 88) // pmix_rank_t of procs to stop
 #define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY + 89) // pmix_rank_t of procs to stop
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY + 90) // envars have already been harvested
+#define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY + 91) // bool - do not copy output to stdout/err
 
 #define PRTE_JOB_MAX_KEY 300
 


### PR DESCRIPTION
Add a "nocopy" directive to the output directive. Include it in
sanity checks. Ensure we set the copy flag correctly in the IOF.

Signed-off-by: Ralph Castain <rhc@pmix.org>