### PR TITLE
Fix preload-binary

### DIFF
--- a/src/mca/filem/raw/filem_raw.h
+++ b/src/mca/filem/raw/filem_raw.h
@@ -45,9 +45,10 @@ PRTE_CLASS_DECLARATION(prte_filem_raw_outbound_t);
 
 typedef struct {
     prte_list_item_t super;
+    prte_event_t ev;
+    int fd;
     prte_filem_raw_outbound_t *outbound;
     prte_app_idx_t app_idx;
-    prte_event_t ev;
     bool pending;
     char *src;
     char *file;

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -224,7 +224,7 @@ static int create_app(prte_cmd_line_t *prte_cmd_line, int argc, char *argv[], pr
      * preload their binary via the preload_files option
      */
     if (NULL == strstr(app->app.argv[0], "java")) {
-        if (prte_cmd_line_is_taken(prte_cmd_line, "preload-binaries")) {
+        if (prte_cmd_line_is_taken(prte_cmd_line, "preload-binary")) {
             PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_SESSION_CWD, NULL, PMIX_BOOL);
             PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PRELOAD_BIN, NULL, PMIX_BOOL);
         }


### PR DESCRIPTION
Fix use of the event library in the filem/raw component. Set
the attribute indicating that the executable has been placed
into the session directory. Ensure the odls utilizes that
location if the attribute is set.

Fixes #942 

Signed-off-by: Ralph Castain <rhc@pmix.org>