### PR TITLE
Check the node name before checking aliases

### DIFF
--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -165,6 +165,10 @@ bool prte_check_host_is_local(const char *name)
 {
     int i;
 
+    if (0 == strcmp(name, prte_process_info.nodename)) {
+        return true;
+    }
+
     for (i = 0; NULL != prte_process_info.aliases[i]; i++) {
         if (0 == strcmp(name, prte_process_info.aliases[i]) ||
             0 == strcmp(name, "localhost") ||

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -165,14 +165,14 @@ bool prte_check_host_is_local(const char *name)
 {
     int i;
 
-    if (0 == strcmp(name, prte_process_info.nodename)) {
+    if (0 == strcmp(name, prte_process_info.nodename) ||
+        0 == strcmp(name, "localhost") ||
+        0 == strcmp(name, "127.0.0.1")) {
         return true;
     }
 
     for (i = 0; NULL != prte_process_info.aliases[i]; i++) {
-        if (0 == strcmp(name, prte_process_info.aliases[i]) ||
-            0 == strcmp(name, "localhost") ||
-            0 == strcmp(name, "127.0.0.1")) {
+        if (0 == strcmp(name, prte_process_info.aliases[i])) {
             return true;
         }
     }


### PR DESCRIPTION
When checking for local node, always check the node name
itself first.

Signed-off-by: Ralph Castain <rhc@pmix.org>