### PR TITLE
Centralize the interface include/exclude logic

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -375,6 +375,15 @@ static int rte_init(int argc, char **argv)
     /* obviously, we have "reported" */
     jdata->num_reported = 1;
 
+    if (0 < prte_output_get_verbosity(prte_ess_base_framework.framework_output)) {
+        prte_output(0, "ALIASES FOR %s", node->name);
+        if (NULL != node->aliases) {
+            for (idx=0; NULL != node->aliases[idx]; idx++) {
+                prte_output(0, "\tALIAS: %s", node->aliases[idx]);
+            }
+        }
+    }
+
     /* Now provide a chance for the PLM
      * to perform any module-specific init functions. This
      * needs to occur AFTER the communications are setup

--- a/src/mca/oob/tcp/oob_tcp_component.h
+++ b/src/mca/oob/tcp/oob_tcp_component.h
@@ -55,8 +55,6 @@ typedef struct {
     prte_list_t peers;               // connection addresses for peers
 
     /* Port specifications */
-    char *if_include; /**< list of ip interfaces to include */
-    char *if_exclude; /**< list of ip interfaces to exclude */
     int tcp_sndbuf;   /**< socket send buffer size */
     int tcp_rcvbuf;   /**< socket recv buffer size */
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1422,6 +1422,15 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             free(alias);
         }
 
+        if (0 < prte_output_get_verbosity(prte_plm_base_framework.framework_output)) {
+            prte_output(0, "ALIASES FOR NODE %s (%s)", daemon->node->name, nodename);
+            if (NULL != daemon->node->aliases) {
+                for (ni=0; NULL != daemon->node->aliases[ni]; ni++) {
+                    prte_output(0, "\tALIAS: %s", daemon->node->aliases[ni]);
+                }
+            }
+        }
+
         /* unpack the topology signature for that node */
         idx = 1;
         ret = PMIx_Data_unpack(NULL, buffer, &sig, &idx, PMIX_STRING);

--- a/src/mca/prteif/posix_ipv4/if_posix.c
+++ b/src/mca/prteif/posix_ipv4/if_posix.c
@@ -196,12 +196,6 @@ static int if_posix_open(void)
             continue;
         }
 #endif
-#if 0
-        if (!prte_if_retain_loopback && (ifr->ifr_flags & IFF_LOOPBACK) != 0) {
-            continue;
-        }
-#endif
-
         intf = PRTE_NEW(prte_if_t);
         if (NULL == intf) {
             prte_output(0, "prte_ifinit: unable to allocated %lu bytes\n",

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1069,7 +1069,6 @@ static int parse_cli(int argc, int start, char **argv, char ***target)
 {
     char *p1, *p2;
     int i;
-    pmix_status_t rc;
     bool takeus;
     char *param = NULL;
 
@@ -1188,14 +1187,7 @@ static int parse_cli(int argc, int start, char **argv, char ***target)
 #endif
     }
 
-    rc = prte_schizo_base_parse_prte(argc, start, argv, target);
-    if (PRTE_SUCCESS != rc) {
-        return rc;
-    }
-
-    rc = prte_schizo_base_parse_pmix(argc, start, argv, target);
-
-    return rc;
+    return PRTE_SUCCESS;
 }
 
 static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, bool cmdline)

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -411,19 +411,11 @@ static int define_cli(prte_cmd_line_t *cli)
 
 static int parse_cli(int argc, int start, char **argv, char ***target)
 {
-    pmix_status_t rc;
-
     prte_output_verbose(1, prte_schizo_base_framework.framework_output, "%s schizo:prte: parse_cli",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
-    rc = prte_schizo_base_parse_prte(argc, start, argv, target);
-    if (PRTE_SUCCESS != rc) {
-        return rc;
-    }
-
-    rc = prte_schizo_base_parse_pmix(argc, start, argv, target);
-
-    return rc;
+    /* we already did this in the tool */
+    return PRTE_SUCCESS;
 }
 
 static int convert_deprecated_cli(char *option, char ***argv, int i)

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -258,30 +258,26 @@ int prte(int argc, char *argv[])
 
     /* init the globals */
     PRTE_CONSTRUCT(&apps, prte_list_t);
-
-    /* because we have to use the schizo framework and init our hostname
-     * prior to parsing the incoming argv for cmd line options, do a hacky
-     * search to support passing of impacted options (e.g., verbosity for schizo) */
-    for (i = 1; NULL != argv[i]; i++) {
-        if (0 == strcmp(argv[i], "--prtemca") || 0 == strcmp(argv[i], "--mca")) {
-            if (0 == strncmp(argv[i + 1], "schizo", 6) ||
-                0 == strcmp(argv[i + 1], "prte_keep_fqdn_hostnames") ||
-                0 == strcmp(argv[i + 1], "prte_strip_prefix")) {
-                prte_asprintf(&param, "PRTE_MCA_%s", argv[i + 1]);
-                prte_setenv(param, argv[i + 2], true, &environ);
-                free(param);
-                i += 2;
-            }
-        }
-    }
-
-    /* init the tiny part of PRTE we use */
-    prte_init_util(PRTE_PROC_MASTER);
-
     fullpath = prte_find_absolute_path(argv[0]);
     prte_tool_basename = prte_basename(argv[0]);
     pargc = argc;
     pargv = prte_argv_copy(argv);
+
+    /* because we have to use the schizo framework and init our hostname
+     * prior to parsing the incoming argv for cmd line options, do a hacky
+     * search to support passing of impacted options (e.g., verbosity for schizo) */
+    rc = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    rc = prte_schizo_base_parse_pmix(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* init the tiny part of PRTE we use */
+    prte_init_util(PRTE_PROC_MASTER);
 
     /** setup callbacks for abort signals - from this point
      * forward, we need to abort in a manner that allows us

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -609,6 +609,8 @@ extern char *prte_signal_string;
 extern char *prte_stacktrace_output_filename;
 extern char *prte_net_private_ipv4;
 extern char *prte_set_max_sys_limits;
+extern char *prte_if_include;
+extern char *prte_if_exclude;
 
 /* Enable/disable ft */
 PRTE_EXPORT extern bool prte_enable_ft;

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -193,10 +193,16 @@ int prte_init_util(prte_proc_type_t flags)
         goto error;
     }
 
+    /* Register all MCA Params */
+    if (PRTE_SUCCESS != (ret = prte_register_params())) {
+        error = "prte_register_params";
+        goto error;
+    }
+
     /* initialize if framework */
-    if (PRTE_SUCCESS
-        != (ret = prte_mca_base_framework_open(&prte_prteif_base_framework,
-                                               PRTE_MCA_BASE_OPEN_DEFAULT))) {
+    ret = prte_mca_base_framework_open(&prte_prteif_base_framework,
+                                       PRTE_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != ret) {
         fprintf(stderr,
                 "prte_prteif_base_open() failed -- process will likely abort (%s:%d, returned %d "
                 "instead of PRTE_SUCCESS)\n",
@@ -270,12 +276,6 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
         goto error;
     }
     prte_process_info.proc_type = flags;
-
-    /* Register all MCA Params */
-    if (PRTE_SUCCESS != (ret = prte_register_params())) {
-        error = "prte_register_params";
-        goto error;
-    }
 
     if (PRTE_SUCCESS != (ret = prte_hwloc_base_register())) {
         error = "prte_hwloc_base_register";

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -40,10 +40,10 @@
 #include "src/util/argv.h"
 #include "src/util/output.h"
 #include "src/util/printf.h"
-#include "src/util/prte_environ.h"
-
-#include "src/mca/errmgr/errmgr.h"
 #include "src/util/proc_info.h"
+#include "src/util/prte_environ.h"
+#include "src/util/show_help.h"
+#include "src/mca/errmgr/errmgr.h"
 
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
@@ -60,6 +60,8 @@ static char *prte_jobfam_session_dir = NULL;
 char *prte_signal_string = NULL;
 char *prte_stacktrace_output_filename = NULL;
 char *prte_net_private_ipv4 = NULL;
+char *prte_if_include = NULL;
+char *prte_if_exclude = NULL;
 char *prte_set_max_sys_limits = NULL;
 int prte_pmix_verbose_output = 0;
 
@@ -165,6 +167,44 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_net_private_ipv4);
     if (0 > ret) {
         return ret;
+    }
+
+    prte_if_include = NULL;
+    ret = prte_mca_base_var_register("prte", "prte", NULL, "if_include",
+                                     "Comma-delimited list of devices and/or CIDR notation of TCP networks to use for PRTE "
+                                    "bootstrap communication (e.g., \"eth0,192.168.0.0/16\").  Mutually exclusive with "
+                                     "prte_if_exclude.",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_2,
+                                     PRTE_MCA_BASE_VAR_SCOPE_LOCAL, &prte_if_include);
+    (void) prte_mca_base_var_register_synonym(ret, "prte", "oob", "tcp", "include",
+                                              PRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED
+                                              | PRTE_MCA_BASE_VAR_SYN_FLAG_INTERNAL);
+    (void) prte_mca_base_var_register_synonym(ret, "prte", "oob", "tcp", "if_include",
+                                              PRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED
+                                              | PRTE_MCA_BASE_VAR_SYN_FLAG_INTERNAL);
+
+    prte_if_exclude = NULL;
+    ret = prte_mca_base_var_register("prte", "prte", NULL, "if_exclude",
+                                     "Comma-delimited list of devices and/or CIDR notation of TCP networks to NOT use for PRTE "
+                                     "bootstrap communication -- all devices not matching these specifications will be used "
+                                     "(e.g., \"eth0,192.168.0.0/16\").  If set to a non-default value, it is mutually exclusive "
+                                        "with prte_if_include.",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_2,
+                                     PRTE_MCA_BASE_VAR_SCOPE_LOCAL, &prte_if_exclude);
+    (void) prte_mca_base_var_register_synonym(ret, "prte", "oob", "tcp", "exclude",
+                                              PRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED
+                                              | PRTE_MCA_BASE_VAR_SYN_FLAG_INTERNAL);
+    (void) prte_mca_base_var_register_synonym(ret, "prte", "oob", "tcp", "if_exclude",
+                                              PRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED
+                                              | PRTE_MCA_BASE_VAR_SYN_FLAG_INTERNAL);
+
+    /* if_include and if_exclude need to be mutually exclusive */
+    if (NULL != prte_if_include && NULL != prte_if_exclude) {
+        /* Return ERR_NOT_AVAILABLE so that a warning message about
+         "open" failing is not printed */
+        prte_show_help("help-oob-tcp.txt", "include-exclude", true,
+                       prte_if_include, prte_if_exclude);
+        return PRTE_ERR_NOT_AVAILABLE;
     }
 
     prte_set_max_sys_limits = NULL;

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -266,12 +266,23 @@ int main(int argc, char *argv[])
 
     /* initialize the globals */
     PMIX_DATA_BUFFER_CREATE(bucket);
-
-    /* init the tiny part of PRTE we use */
-    prte_init_util(PRTE_PROC_DAEMON);
     prte_tool_basename = prte_basename(argv[0]);
     pargc = argc;
     pargv = prte_argv_copy(argv);
+
+    /* we always need the prrte and pmix params */
+    ret = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = prte_schizo_base_parse_pmix(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
+
+    /* init the tiny part of PRTE we use */
+    prte_init_util(PRTE_PROC_DAEMON);
 
     /* setup the cmd line - this is specific to the proxy */
     prte_cmd_line = PRTE_NEW(prte_cmd_line_t);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -365,14 +365,25 @@ int prun(int argc, char *argv[])
         }
     }
 
-    /* init the tiny part of PRTE we use */
-    prte_init_util(PRTE_PROC_TOOL); // just so we pickup any PRTE params from sys/user files
-
     fullpath = prte_find_absolute_path(argv[0]);
     prte_tool_basename = prte_basename(argv[0]);
     pargc = argc;
     pargv = prte_argv_copy(argv);
     gethostname(hostname, sizeof(hostname));
+
+    /* we always need the prrte and pmix params */
+    rc = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    rc = prte_schizo_base_parse_pmix(pargc, 0, pargv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    /* init the tiny part of PRTE we use */
+    prte_init_util(PRTE_PROC_TOOL); // just so we pickup any PRTE params from sys/user files
 
     /** setup callbacks for abort signals - from this point
      * forward, we need to abort in a manner that allows us

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -247,6 +247,17 @@ int main(int argc, char *argv[])
     /* init the globals */
     PRTE_CONSTRUCT(&job_info, prte_list_t);
 
+    /* we always need the prrte and pmix params */
+    rc = prte_schizo_base_parse_prte(argc, 0, argv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    rc = prte_schizo_base_parse_pmix(argc, 0, argv, NULL);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
     /* init the tiny part of PRTE we use */
     prte_init_util(PRTE_PROC_MASTER);
 

--- a/src/util/if.c
+++ b/src/util/if.c
@@ -65,6 +65,7 @@
 
 #include "constants.h"
 #include "src/class/prte_list.h"
+#include "src/runtime/prte_globals.h"
 #include "src/util/argv.h"
 #include "src/util/if.h"
 #include "src/util/net.h"

--- a/src/util/net.c
+++ b/src/util/net.c
@@ -369,8 +369,7 @@ char *prte_net_get_hostname(const struct sockaddr *addr)
 #        if defined(__NetBSD__)
         /* hotfix for netbsd: on my netbsd machine, getnameinfo
            returns an unkown error code. */
-        if (NULL
-            == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
+        if (NULL == inet_ntop(AF_INET6, &((struct sockaddr_in6 *) addr)->sin6_addr, name, NI_MAXHOST)) {
             prte_output(0, "prte_sockaddr2str failed with error code %d", errno);
             return NULL;
         }


### PR DESCRIPTION
The logic that defined interface aliases for the host name
was separate from that used to define interfaces for the
inter-daemon communication system (oob). Combine the two
and update the interface include/exclude parameters (leaving
deprecated synonyms for the prior forms).

Signed-off-by: Ralph Castain <rhc@pmix.org>