### PR TITLE
Continue work on node resolution

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -111,7 +111,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
     char *tmp = NULL, *tmp2, *tmp3;
     int i, istart;
     prte_node_t *alloc;
-    char *flgs;
+    char *flgs, *aliases;
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
         prte_asprintf(&tmp, "<allocation>\n");
@@ -137,11 +137,21 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
         } else {
             /* build the flags string */
             flgs = prte_ras_base_flag_string(alloc);
-            prte_asprintf(&tmp2, "\t%s: slots=%d max_slots=%d slots_inuse=%d state=%s\n\t%s\n",
+            /* build the aliases string */
+            if (NULL != alloc->aliases) {
+                aliases = prte_argv_join(alloc->aliases, ',');
+            } else {
+                aliases = NULL;
+            }
+            prte_asprintf(&tmp2, "    %s: slots=%d max_slots=%d slots_inuse=%d state=%s\n\t%s\n\taliases: %s\n",
                           (NULL == alloc->name) ? "UNKNOWN" : alloc->name, (int) alloc->slots,
                           (int) alloc->slots_max, (int) alloc->slots_inuse,
-                          prte_node_state_to_str(alloc->state), flgs);
+                          prte_node_state_to_str(alloc->state), flgs,
+                          (NULL == aliases) ? "NONE" : aliases);
             free(flgs);
+            if (NULL != aliases) {
+                free(aliases);
+            }
         }
         if (NULL == tmp) {
             tmp = tmp2;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -523,8 +523,7 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < prte_output_get_verbosity(prte_ras_base_framework.framework_output) ||
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
+    if (4 < prte_output_get_verbosity(prte_ras_base_framework.framework_output)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -418,8 +418,7 @@ complete:
      * we do so - can ignore this if we are mapping debugger
      * daemons as they do not count against the allocation */
     if (PRTE_MAPPING_DEBUGGER & PRTE_GET_MAPPING_DIRECTIVE(policy)) {
-        num_slots = prte_list_get_size(
-            allocated_nodes); // tell the mapper there is one slot/node for debuggers
+        num_slots = prte_list_get_size(allocated_nodes); // tell the mapper there is one slot/node for debuggers
     } else {
         PRTE_LIST_FOREACH_SAFE(node, next, allocated_nodes, prte_node_t)
         {

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -309,11 +309,11 @@ process:
              */
             match = false;
             for (j = 0; j < prte_node_pool->size; j++) {
-                if (NULL
-                    == (node = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool, j))) {
+                node = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool, j);
+                if (NULL == node) {
                     continue;
                 }
-                if (prte_node_match(node, sq->hostname)) {
+                if (0 == strcmp(node->name, sq->hostname)) {
                     match = true;
                     break;
                 }

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -483,7 +483,7 @@ PRTE_EXPORT char *prte_get_proc_hostname(const pmix_proc_t *proc);
 PRTE_EXPORT prte_node_rank_t prte_get_proc_node_rank(const pmix_proc_t *proc);
 
 /* check to see if two nodes match */
-PRTE_EXPORT bool prte_node_match(prte_node_t *n1, const char *name);
+PRTE_EXPORT prte_node_t* prte_node_match(prte_list_t *nodes, const char *name);
 PRTE_EXPORT bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2);
 
 /* global variables used by RTE - instanced in prte_globals.c */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -454,11 +454,10 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_show_resolved_nodenames);
 
-    prte_do_not_resolve = false;
+    prte_do_not_resolve = true;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "do_not_resolve",
                                       "Do not attempt to resolve hostnames "
-                                      "[always true for managed allocations, "
-                                      "defaults to false otherwise]",
+                                      "[defaults to true]",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                       PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_do_not_resolve);

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -102,18 +102,6 @@ static char *hostfile_parse_string(void)
     return strdup(prte_util_hostfile_value.sval);
 }
 
-static prte_node_t *hostfile_lookup(prte_list_t *nodes, const char *name)
-{
-    prte_node_t *node;
-
-    PRTE_LIST_FOREACH(node, nodes, prte_node_t) {
-        if (prte_node_match(node, name)) {
-            return node;
-        }
-    }
-    return NULL;
-}
-
 static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exclude, bool keep_all)
 {
     int rc;
@@ -185,7 +173,8 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
 
             /* Do we need to make a new node object?  First check to see
                if it's already in the exclude list */
-            if (NULL == (node = hostfile_lookup(exclude, node_name))) {
+            node = prte_node_match(exclude, node_name);
+            if (NULL == node) {
                 node = PRTE_NEW(prte_node_t);
                 if (prte_keep_fqdn_hostnames || NULL == alias) {
                     node->name = strdup(node_name);
@@ -228,7 +217,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
                              keep_all ? "TRUE" : "FALSE"));
 
         /* Do we need to make a new node object? */
-        if (keep_all || NULL == (node = hostfile_lookup(updates, node_name))) {
+        if (keep_all || NULL == (node = prte_node_match(updates, node_name))) {
             node = PRTE_NEW(prte_node_t);
             if (prte_keep_fqdn_hostnames || NULL == alias) {
                 node->name = strdup(node_name);
@@ -328,7 +317,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
         }
 
         /* Do we need to make a new node object? */
-        if (NULL == (node = hostfile_lookup(updates, node_name))) {
+        if (NULL == (node = prte_node_match(updates, node_name))) {
             node = PRTE_NEW(prte_node_t);
             node->name = node_name;
             node->slots = 1;

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -97,8 +97,6 @@ void prte_setup_hostname(void)
 
     /* get the nodename */
     gethostname(hostname, sizeof(hostname));
-    /* add the raw name to our list of aliases */
-    prte_argv_append_nosize(&prte_process_info.aliases, hostname);
 
     prte_strip_prefix = NULL;
     (void) prte_mca_base_var_register(


### PR DESCRIPTION
Streamline the resolve check by first considering the primary
node names. Then check aliases as a second pass, thus only
impacting those who utilize multiple names for a node.

Signed-off-by: Ralph Castain <rhc@pmix.org>