### PR TITLE
Refactor IOF to shift output responsibilities to PMIx

### DIFF
--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -52,6 +52,7 @@
 #include "src/class/prte_list.h"
 #include "src/event/event-internal.h"
 #include "src/mca/mca.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/util/fd.h"
 
 #include "src/mca/errmgr/errmgr.h"
@@ -70,14 +71,6 @@ PRTE_EXPORT extern prte_mca_base_framework_t prte_iof_base_framework;
  * Select an available component.
  */
 PRTE_EXPORT int prte_iof_base_select(void);
-
-/* track xon/xoff of processes */
-typedef struct {
-    prte_object_t super;
-    prte_job_t *jdata;
-    prte_bitmap_t xoff;
-} prte_iof_job_t;
-PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_iof_job_t);
 
 /*
  * Maximum size of single msg
@@ -131,19 +124,8 @@ typedef struct {
     prte_iof_sink_t *stdinev;
     prte_iof_read_event_t *revstdout;
     prte_iof_read_event_t *revstderr;
-    prte_list_t *subscribers;
-    bool copy;
-    bool merge;
 } prte_iof_proc_t;
 PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_iof_proc_t);
-
-typedef struct {
-    prte_list_item_t super;
-    pmix_proc_t requestor;
-    pmix_proc_t target;
-    uint16_t stream;
-} prte_iof_request_t;
-PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_iof_request_t);
 
 typedef struct {
     prte_list_item_t super;
@@ -151,15 +133,6 @@ typedef struct {
     int numbytes;
 } prte_iof_write_output_t;
 PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_iof_write_output_t);
-
-/* the iof globals struct */
-struct prte_iof_base_t {
-    size_t output_limit;
-    prte_iof_sink_t *iof_write_stdout;
-    prte_iof_sink_t *iof_write_stderr;
-    prte_list_t requests;
-};
-typedef struct prte_iof_base_t prte_iof_base_t;
 
 /* Write event macro's */
 
@@ -262,16 +235,13 @@ static inline bool prte_iof_base_fd_always_ready(int fd)
 
 PRTE_EXPORT int prte_iof_base_flush(void);
 
-PRTE_EXPORT extern prte_iof_base_t prte_iof_base;
+PRTE_EXPORT extern int prte_iof_base_output_limit;
 
 /* base functions */
 PRTE_EXPORT int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
                                            const unsigned char *data, int numbytes,
                                            prte_iof_write_event_t *channel);
-PRTE_EXPORT void prte_iof_base_static_dump_output(prte_iof_read_event_t *rev);
 PRTE_EXPORT void prte_iof_base_write_handler(int fd, short event, void *cbdata);
-
-PRTE_EXPORT void prte_iof_base_check_target(prte_iof_proc_t *proct);
 
 END_C_DECLS
 

--- a/src/mca/iof/base/iof_base_setup.h
+++ b/src/mca/iof/base/iof_base_setup.h
@@ -31,7 +31,6 @@
 struct prte_iof_base_io_conf_t {
     int usepty;
     bool connect_stdin;
-    bool merge;
 
     /* private - callers should not modify these fields */
     int p_stdin[2];
@@ -51,9 +50,5 @@ PRTE_EXPORT int prte_iof_base_setup_prefork(prte_iof_base_io_conf_t *opts);
 PRTE_EXPORT int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts, char ***env);
 
 PRTE_EXPORT int prte_iof_base_setup_parent(const pmix_proc_t *name, prte_iof_base_io_conf_t *opts);
-
-/* setup output files */
-PRTE_EXPORT int prte_iof_base_setup_output_files(const pmix_proc_t *dst_name, prte_job_t *jobdat,
-                                                 prte_iof_proc_t *proct);
 
 #endif

--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -49,51 +49,6 @@
 
 #include "iof_hnp.h"
 
-static void restart_stdin(int fd, short event, void *cbdata)
-{
-    prte_timer_t *tm = (prte_timer_t *) cbdata;
-
-    PRTE_ACQUIRE_OBJECT(tm);
-
-    if (NULL != prte_iof_hnp_component.stdinev && !prte_job_term_ordered
-        && !prte_iof_hnp_component.stdinev->active) {
-        PRTE_IOF_READ_ACTIVATE(prte_iof_hnp_component.stdinev);
-    }
-
-    /* if this was a timer callback, then release the timer */
-    if (NULL != tm) {
-        PRTE_RELEASE(tm);
-    }
-}
-
-/* return true if we should read stdin from fd, false otherwise */
-bool prte_iof_hnp_stdin_check(int fd)
-{
-#if defined(HAVE_TCGETPGRP)
-    if (isatty(fd) && (getpgrp() != tcgetpgrp(fd))) {
-        return false;
-    }
-#endif
-    return true;
-}
-
-void prte_iof_hnp_stdin_cb(int fd, short event, void *cbdata)
-{
-    bool should_process;
-
-    PRTE_ACQUIRE_OBJECT(prte_iof_hnp_component.stdinev);
-
-    should_process = prte_iof_hnp_stdin_check(0);
-
-    if (should_process) {
-        PRTE_IOF_READ_ACTIVATE(prte_iof_hnp_component.stdinev);
-    } else {
-
-        prte_event_del(prte_iof_hnp_component.stdinev->ev);
-        prte_iof_hnp_component.stdinev->active = false;
-    }
-}
-
 static void lkcbfunc(pmix_status_t status, void *cbdata)
 {
     prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
@@ -112,9 +67,10 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
     unsigned char data[PRTE_IOF_BASE_MSG_MAX];
     int32_t numbytes;
     prte_iof_proc_t *proct = (prte_iof_proc_t *) rev->proc;
-    int rc;
-    bool exclusive;
-    prte_iof_sink_t *sink;
+    pmix_byte_object_t bo;
+    pmix_iof_channel_t pchan;
+    prte_pmix_lock_t lock;
+    pmix_status_t prc;
 
     PRTE_ACQUIRE_OBJECT(rev);
 
@@ -153,159 +109,31 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         numbytes = 0;
     }
 
-    /* is this read from our stdin? */
-    if (PRTE_IOF_STDIN & rev->tag) {
-        /* The event has fired, so it's no longer active until we
-           re-add it */
-        rev->active = false;
-        if (NULL == proct->stdinev) {
-            /* nothing further to do */
-            return;
-        }
-
-        /* if job termination has been ordered, just ignore the
-         * data and delete the read event
-         */
-        if (prte_job_term_ordered) {
-            PRTE_RELEASE(rev);
-            return;
-        }
-        /* if the daemon is me, then this is a local sink */
-        if (PMIX_CHECK_PROCID(PRTE_PROC_MY_NAME, &proct->stdinev->daemon)) {
-            PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                 "%s read %d bytes from stdin - writing to %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
-                                 PRTE_NAME_PRINT(&proct->name)));
-            /* send the bytes down the pipe - we even send 0 byte events
-             * down the pipe so it forces out any preceding data before
-             * closing the output stream
-             */
-            if (NULL != proct->stdinev->wev) {
-                if (PRTE_IOF_MAX_INPUT_BUFFERS < prte_iof_base_write_output(&proct->name, rev->tag,
-                                                                            data, numbytes,
-                                                                            proct->stdinev->wev)) {
-                    /* getting too backed up - stop the read event for now if it is still active */
-
-                    PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                         "buffer backed up - holding"));
-                    return;
-                }
-            }
-        } else {
-            PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                 "%s sending %d bytes from stdinev to daemon %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
-                                 PRTE_NAME_PRINT(&proct->stdinev->daemon)));
-
-            /* send the data to the daemon so it can
-             * write it to the proc's fd - in this case,
-             * we pass sink->name to indicate who is to
-             * receive the data. If the connection closed,
-             * numbytes will be zero so zero bytes will be
-             * sent - this will tell the daemon to close
-             * the fd for stdin to that proc
-             */
-            if (PRTE_SUCCESS
-                != (rc = prte_iof_hnp_send_data_to_endpoint(&proct->stdinev->daemon,
-                                                            &proct->stdinev->name, PRTE_IOF_STDIN,
-                                                            data, numbytes))) {
-                /* if the addressee is unknown, remove the sink from the list */
-                if (PRTE_ERR_ADDRESSEE_UNKNOWN == rc) {
-                    PRTE_RELEASE(rev->sink);
-                }
-            }
-        }
-
-        /* if num_bytes was zero, or we read the last piece of the file, then we need to terminate
-         * the event */
-        if (0 == numbytes) {
-            if (0 != prte_list_get_size(&proct->stdinev->wev->outputs)) {
-                /* some stuff has yet to be written, so delay the release of proct->stdinev */
-                proct->stdinev->closed = true;
-            } else {
-                /* this will also close our stdin file descriptor */
-                PRTE_RELEASE(proct->stdinev);
-            }
-        } else {
-            /* if we are looking at a tty, then we just go ahead and restart the
-             * read event assuming we are not backgrounded
-             */
-            if (prte_iof_hnp_stdin_check(fd)) {
-                restart_stdin(fd, 0, NULL);
-            } else {
-                /* delay for awhile and then restart */
-                PRTE_TIMER_EVENT(0, 10000, restart_stdin, PRTE_INFO_PRI);
-            }
-        }
-        /* nothing more to do */
-        return;
+   /* this must be output from one of my local procs */
+    pchan = 0;
+    if (PRTE_IOF_STDOUT & rev->tag) {
+        pchan |= PMIX_FWD_STDOUT_CHANNEL;
     }
-
-    /* this must be output from one of my local procs - see
-     * if anyone else has requested a copy of this info. If
-     * we were directed to put it into a file, then
-     */
-    exclusive = false;
-    if (NULL != proct->subscribers) {
-        PRTE_LIST_FOREACH(sink, proct->subscribers, prte_iof_sink_t)
-        {
-            /* if the target isn't set, then this sink is for another purpose - ignore it */
-            if (PMIX_NSPACE_INVALID(sink->daemon.nspace)) {
-                continue;
-            }
-            if ((sink->tag & rev->tag) && PMIX_CHECK_NSPACE(sink->name.nspace, proct->name.nspace)
-                && PMIX_CHECK_RANK(sink->name.rank, proct->name.rank)) {
-                /* need to send the data to the remote endpoint - if
-                 * the connection closed, numbytes will be zero, so
-                 * the remote endpoint will know to close its local fd.
-                 * In this case, we pass rev->name to indicate who the
-                 * data came from.
-                 */
-                PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                     "%s sending data from proc %s of size %d via PMIx to tool %s",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                     PRTE_NAME_PRINT(&proct->name), (int) numbytes,
-                                     PRTE_NAME_PRINT(&sink->daemon)));
-                /* don't pass down zero byte blobs */
-                if (0 < numbytes) {
-                    pmix_byte_object_t bo;
-                    pmix_iof_channel_t pchan;
-                    prte_pmix_lock_t lock;
-                    pmix_status_t prc;
-                    pchan = 0;
-                    if (PRTE_IOF_STDIN & rev->tag) {
-                        pchan |= PMIX_FWD_STDIN_CHANNEL;
-                    }
-                    if (PRTE_IOF_STDOUT & rev->tag) {
-                        pchan |= PMIX_FWD_STDOUT_CHANNEL;
-                    }
-                    if (PRTE_IOF_STDERR & rev->tag) {
-                        pchan |= PMIX_FWD_STDERR_CHANNEL;
-                    }
-                    if (PRTE_IOF_STDDIAG & rev->tag) {
-                        pchan |= PMIX_FWD_STDDIAG_CHANNEL;
-                    }
-                    /* setup the byte object */
-                    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
-                    bo.bytes = (char *) data;
-                    bo.size = numbytes;
-                    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-                    prc = PMIx_server_IOF_deliver(&proct->name, pchan, &bo, NULL, 0, lkcbfunc,
-                                                  (void *) &lock);
-                    if (PMIX_SUCCESS != prc) {
-                        PMIX_ERROR_LOG(prc);
-                    } else {
-                        /* wait for completion */
-                        PRTE_PMIX_WAIT_THREAD(&lock);
-                    }
-                    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-                }
-                if (sink->exclusive) {
-                    exclusive = true;
-                }
-            }
-        }
+    if (PRTE_IOF_STDERR & rev->tag) {
+        pchan |= PMIX_FWD_STDERR_CHANNEL;
     }
+    if (PRTE_IOF_STDDIAG & rev->tag) {
+        pchan |= PMIX_FWD_STDDIAG_CHANNEL;
+    }
+    /* setup the byte object */
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+    bo.bytes = (char *) data;
+    bo.size = numbytes;
+    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+    prc = PMIx_server_IOF_deliver(&proct->name, pchan, &bo, NULL, 0, lkcbfunc,
+                                  (void *) &lock);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+    } else {
+        /* wait for completion */
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
+    PRTE_PMIX_DESTRUCT_LOCK(&lock);
 
     PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output, "%s read %d bytes from %s of %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
@@ -320,11 +148,9 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         /* make sure we don't do recursive delete on the proct */
         PRTE_RETAIN(proct);
         if (rev->tag & PRTE_IOF_STDOUT) {
-            prte_iof_base_static_dump_output(proct->revstdout);
             PRTE_RELEASE(proct->revstdout);
             proct->revstdout = NULL;
         } else if (rev->tag & PRTE_IOF_STDERR) {
-            prte_iof_base_static_dump_output(proct->revstderr);
             PRTE_RELEASE(proct->revstderr);
             proct->revstderr = NULL;
         }
@@ -335,34 +161,6 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         }
         PRTE_RELEASE(proct);
         return;
-    }
-    if (proct->copy) {
-        if (NULL != proct->subscribers) {
-            if (!exclusive) {
-                /* output this to our local output */
-                if (PRTE_IOF_STDOUT & rev->tag) {
-                    prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes,
-                                               prte_iof_base.iof_write_stdout->wev);
-                } else {
-                    prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes,
-                                               prte_iof_base.iof_write_stderr->wev);
-                }
-            }
-        } else {
-            /* output this to our local output */
-            if (PRTE_IOF_STDOUT & rev->tag) {
-                prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes,
-                                           prte_iof_base.iof_write_stdout->wev);
-            } else {
-                prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes,
-                                           prte_iof_base.iof_write_stderr->wev);
-            }
-        }
-    }
-    /* see if the user wanted the output directed to files */
-    if (NULL != rev->sink && !(PRTE_IOF_STDIN & rev->sink->tag)) {
-        /* output to the corresponding file */
-        prte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, rev->sink->wev);
     }
 
     /* re-add the event */

--- a/src/mca/iof/iof.h
+++ b/src/mca/iof/iof.h
@@ -127,32 +127,6 @@
 
 BEGIN_C_DECLS
 
-/* define a macro for requesting a proxy PULL of IO on
- * behalf of a tool that had the HNP spawn a job. First
- * argument is the prte_job_t of the spawned job, second
- * is a pointer to the name of the requesting tool */
-#define PRTE_IOF_PROXY_PULL(a, b)                                            \
-    do {                                                                     \
-        pmix_data_buffer_t *buf;                                             \
-        prte_iof_tag_t tag;                                                  \
-        pmix_proc_t nm;                                                      \
-                                                                             \
-        PMIX_DATA_BUFFER_CREATE(buf);                                        \
-                                                                             \
-        /* setup the tag to pull from HNP */                                 \
-        tag = PRTE_IOF_STDOUTALL | PRTE_IOF_PULL | PRTE_IOF_EXCLUSIVE;       \
-        PMIx_Data_pack(NULL, buf, &tag, 1, PMIX_UINT16);                     \
-        /* pack the name of the source we want to pull */                    \
-        PMIX_LOAD_PROCID(&nm, (a)->nspace, PMIX_RANK_WILDCARD);              \
-        PMIx_Data_pack(NULL, buf, &nm, 1, PMIX_PROC);                        \
-        /* pack the name of the tool */                                      \
-        PMIx_Data_pack(NULL, buf, (b), 1, PMIX_PROC);                        \
-                                                                             \
-        /* send the buffer to the HNP */                                     \
-        prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, buf, PRTE_RML_TAG_IOF_HNP, \
-                                prte_rml_send_callback, NULL);               \
-    } while (0);
-
 /* Initialize the selected module */
 typedef int (*prte_iof_base_init_fn_t)(void);
 

--- a/src/mca/odls/alps/odls_alps_module.c
+++ b/src/mca/odls/alps/odls_alps_module.c
@@ -456,9 +456,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    if (!cd->opts.merge) {
-        close(cd->opts.p_stderr[1]);
-    }
+    close(cd->opts.p_stderr[1]);
 
     /* Block reading a message from the pipe */
     while (1) {

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1457,9 +1457,6 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             cd->index_argv = index_argv;
             /* setup any IOF */
             cd->opts.usepty = PRTE_ENABLE_PTY_SUPPORT;
-            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
-                cd->opts.merge = true;
-            }
 
             /* do we want to setup stdin? */
             if (jobdat->stdin_target == PMIX_RANK_WILDCARD
@@ -2109,9 +2106,6 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
     cd->fork_local = fork_local;
     /* setup any IOF */
     cd->opts.usepty = PRTE_ENABLE_PTY_SUPPORT;
-    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
-        cd->opts.merge = true;
-    }
 
     /* do we want to setup stdin? */
     if (jobdat->stdin_target == PMIX_RANK_WILDCARD || child->name.rank == jobdat->stdin_target) {

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -429,9 +429,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
         close(cd->opts.p_stdin[0]);
     }
     close(cd->opts.p_stdout[1]);
-    if (!cd->opts.merge) {
-        close(cd->opts.p_stderr[1]);
-    }
+    close(cd->opts.p_stderr[1]);
 
 #if PRTE_HAVE_STOP_ON_EXEC
     if (NULL != cd->child) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -346,7 +346,6 @@ void prte_plm_base_complete_setup(int fd, short args, void *cbdata)
     pmix_rank_t *vptr;
     int i, rc;
     char *serial_number;
-    pmix_proc_t requestor, *rptr;
 
     PRTE_ACQUIRE_OBJECT(caddy);
 
@@ -364,27 +363,6 @@ void prte_plm_base_complete_setup(int fd, short args, void *cbdata)
 
     /* convenience */
     jdata = caddy->jdata;
-
-    /* If this job is being started by me, then there is nothing
-     * further we need to do as any user directives (e.g., to tie
-     * off IO to /dev/null) will have been included in the launch
-     * message and the IOF knows how to handle any default situation.
-     * However, if this is a proxy spawn request, then the spawner
-     * might be a tool that wants IO forwarded to it. If that's the
-     * situation, then the job object will contain an attribute
-     * indicating that request */
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_FWDIO_TO_TOOL, NULL, PMIX_BOOL)) {
-        /* send a message to our IOF containing the requested pull */
-        rptr = &requestor;
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &rptr,
-                               PMIX_PROC)) {
-            PRTE_IOF_PROXY_PULL(jdata, rptr);
-        } else {
-            PRTE_IOF_PROXY_PULL(jdata, &jdata->originator);
-        }
-        /* the tool will PUSH its stdin, so nothing we need to do here
-         * about stdin */
-    }
 
     /* if coprocessors were detected, now is the time to
      * identify who is attached to what host - this info

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -355,6 +355,55 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     free(tmp);
     prte_list_append(info, &kv->super);
 
+    /* check for output directives */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
+       kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    tmp = NULL;
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_FILE, (void **) &tmp, PMIX_STRING)
+        && NULL != tmp) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_OUTPUT_TO_FILE, tmp, PMIX_STRING);
+        prte_list_append(info, &kv->super);
+        free(tmp);
+    }
+    tmp = NULL;
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY, (void **) &tmp, PMIX_STRING)
+        && NULL != tmp) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_OUTPUT_TO_DIRECTORY, tmp, PMIX_STRING);
+        prte_list_append(info, &kv->super);
+        free(tmp);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, NULL, PMIX_BOOL)) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    /* if we are a non-persistent HNP, then write the output locally */
+    if (PRTE_PROC_IS_MASTER && !prte_persistent) {
+       kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+
     /* for each app in the job, create an app-array */
     for (n = 0; n < jdata->apps->size; n++) {
         if (NULL == (app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps, n))) {

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -944,7 +944,7 @@ int prte(int argc, char *argv[])
                 if (NULL != (cptr = strchr(ptr, ':'))) {
                     *cptr = '\0';
                     ++cptr;
-                    if (0 != strcasecmp(cptr, "nocopy")) {
+                    if (0 == strcasecmp(cptr, "nocopy")) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
                     }
                 }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -680,6 +680,9 @@ int prun(int argc, char *argv[])
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_SERVER_URI, pval->value.data.string, PMIX_STRING);
     }
 
+    /* output all IOF */
+    PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_IOF_LOCAL_OUTPUT, NULL, PMIX_BOOL);
+
     /* convert to array of info */
     PMIX_INFO_LIST_CONVERT(ret, tinfo, &darray);
     iptr = (pmix_info_t *) darray.array;
@@ -792,7 +795,7 @@ int prun(int argc, char *argv[])
                 if (NULL != (cptr = strchr(ptr, ':'))) {
                     *cptr = '\0';
                     ++cptr;
-                    if (0 != strcasecmp(cptr, "nocopy")) {
+                    if (0 == strcasecmp(cptr, "nocopy")) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
                     }
                 }
@@ -828,7 +831,7 @@ int prun(int argc, char *argv[])
                 if (NULL != (cptr = strchr(ptr, ':'))) {
                     *cptr = '\0';
                     ++cptr;
-                    if (0 != strcasecmp(cptr, "nocopy")) {
+                    if (0 == strcasecmp(cptr, "nocopy")) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
                     }
                 }


### PR DESCRIPTION
Let the PMIx library do the final output of stdout/stderr,
including formatting and redirecting to files, so that tools
see the same behavior as prterun.

Signed-off-by: Ralph Castain <rhc@pmix.org>