### PR TITLE
First pass: remove PRRTE "tools"

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -223,6 +223,7 @@ int main(int argc, char **argv)
 
     /* Initialize this daemon - since we were launched by the RM, our
      * connection info * will have been provided at startup. */
+    printf("INIT TOOL\n");
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
         fprintf(stderr, "Debugger daemon: PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
         exit(0);
@@ -232,9 +233,12 @@ int main(int argc, char **argv)
 
     /* Register our default event handler */
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(NULL, 0, NULL, 0, notification_fn, evhandler_reg_callbk,
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "DEFAULT", PMIX_STRING);
+    PMIx_Register_event_handler(NULL, 0, info, 1, notification_fn, evhandler_reg_callbk,
                                 (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
+    PMIX_INFO_FREE(info, 1);
     if (PMIX_SUCCESS != mylock.status) {
         rc = mylock.status;
         DEBUG_DESTRUCT_LOCK(&mylock);
@@ -323,6 +327,7 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc, target_namespace, PMIX_RANK_WILDCARD);
 
     PMIX_INFO_LIST_START(dirs);
+    PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_HDLR_NAME, "APP-TERMINATION", PMIX_STRING);
     /* Pass the lock we will use to wait for notification of the
      * PMIX_EVENT_JOB_END event */
     PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -621,6 +621,7 @@ static int rte_finalize(void)
 
 static void rte_abort(int status, bool report)
 {
+    prte_output(0, "ABORT");
     /* do NOT do a normal finalize as this will very likely
      * hang the process. We are aborting due to an abnormal condition
      * that precludes normal cleanup

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -188,16 +188,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     PRTE_ACQUIRE_OBJECT(state);
 
-    /* if we are launching debugger daemons, then just go
-     * do it - no new daemons will be launched
-     */
-    if (PRTE_FLAG_TEST(state->jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
-        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-        PRTE_RELEASE(state);
-        return;
-    }
-
     /* start by setting up the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     if (PRTE_SUCCESS != (rc = prte_plm_base_setup_virtual_machine(state->jdata))) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -604,7 +604,7 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
 
         /* direct an event back to our controller */
         timestamp = time(NULL);
-        PMIX_INFO_CREATE(iptr, 4);
+        PMIX_INFO_CREATE(iptr, 5);
         /* target this notification solely to that one tool */
         PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_CUSTOM_RANGE, nptr, PMIX_PROC);
         PMIX_PROC_RELEASE(nptr);
@@ -614,8 +614,10 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
         PMIX_INFO_LOAD(&iptr[2], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
         /* provide the timestamp */
         PMIX_INFO_LOAD(&iptr[3], PMIX_EVENT_TIMESTAMP, &timestamp, PMIX_TIME);
-        PMIx_Notify_event(PMIX_LAUNCH_COMPLETE, &prte_process_info.myproc, PMIX_RANGE_CUSTOM, iptr,
-                          4, NULL, NULL);
+        /* protect against loops */
+        PMIX_INFO_LOAD(&iptr[4], "prte.notify.donotloop", NULL, PMIX_BOOL);
+        PMIx_Notify_event(PMIX_LAUNCH_COMPLETE, &prte_process_info.myproc, PMIX_RANGE_CUSTOM,
+                          iptr, 5, NULL, NULL);
         PMIX_INFO_FREE(iptr, 4);
     }
 

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -197,16 +197,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
                          "%s plm:slurm: LAUNCH DAEMONS CALLED",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
-    /* if we are launching debugger daemons, then just go
-     * do it - no new daemons will be launched
-     */
-    if (PRTE_FLAG_TEST(state->jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
-        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-        PRTE_RELEASE(state);
-        return;
-    }
-
     /* start by setting up the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     if (PRTE_SUCCESS != (rc = prte_plm_base_setup_virtual_machine(state->jdata))) {

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -1006,16 +1006,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     PRTE_ACQUIRE_OBJECT(state);
 
-    /* if we are launching debugger daemons, then just go
-     * do it - no new daemons will be launched
-     */
-    if (PRTE_FLAG_TEST(state->jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
-        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-        PRTE_RELEASE(state);
-        return;
-    }
-
     /* setup the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     if (PRTE_SUCCESS != (rc = prte_plm_base_setup_virtual_machine(state->jdata))) {

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -191,16 +191,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     jdata = state->jdata;
 
-    /* if we are launching debugger daemons, then just go
-     * do it - no new daemons will be launched
-     */
-    if (PRTE_FLAG_TEST(state->jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)) {
-        jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
-        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-        PRTE_RELEASE(state);
-        return;
-    }
-
     /* setup the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     if (PRTE_SUCCESS != (rc = prte_plm_base_setup_virtual_machine(jdata))) {

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -540,13 +540,17 @@ DISPLAY:
 next_state:
     /* are we to report this event? */
     if (prte_report_events) {
-        if (PMIX_SUCCESS
-            != (ret = PMIx_Notify_event(PMIX_NOTIFY_ALLOC_COMPLETE, NULL, PMIX_GLOBAL, NULL, 0,
-                                        NULL, NULL))) {
+        pmix_info_t info;
+        PMIX_INFO_LOAD(&info, "prte.notify.donotloop", NULL, PMIX_BOOL);
+
+        ret = PMIx_Notify_event(PMIX_NOTIFY_ALLOC_COMPLETE, NULL, PMIX_GLOBAL,
+                                &info, 1, NULL, NULL);
+        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
             PMIX_ERROR_LOG(ret);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PRTE_RELEASE(caddy);
         }
+        PMIX_INFO_DESTRUCT(&info);
     }
 
     /* set total slots alloc */

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -412,14 +412,23 @@ addknown:
                          (int) prte_list_get_size(allocated_nodes)));
 
 complete:
-    num_slots = 0;
-    /* remove all nodes that are already at max usage, and
-     * compute the total number of allocated slots while
-     * we do so - can ignore this if we are mapping debugger
-     * daemons as they do not count against the allocation */
-    if (PRTE_MAPPING_DEBUGGER & PRTE_GET_MAPPING_DIRECTIVE(policy)) {
-        num_slots = prte_list_get_size(allocated_nodes); // tell the mapper there is one slot/node for debuggers
+    /* if we are mapping debuggers, then they don't count against
+     * the allocation */
+    if (PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
+        num_slots = INT32_MAX;
+        if (!prte_hnp_is_allocated
+            || (PRTE_GET_MAPPING_DIRECTIVE(policy) & PRTE_MAPPING_NO_USE_LOCAL)) {
+            PRTE_LIST_FOREACH_SAFE(node, next, allocated_nodes, prte_node_t)
+            {
+                if (0 == node->index) {
+                    prte_list_remove_item(allocated_nodes, &node->super);
+                    PRTE_RELEASE(node); /* "un-retain" it */
+                    break;
+                }
+            }
+        }
     } else {
+        num_slots = 0;
         PRTE_LIST_FOREACH_SAFE(node, next, allocated_nodes, prte_node_t)
         {
             /* if the hnp was not allocated, or flagged not to be used,
@@ -521,6 +530,7 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata, prte_node_t *node, pr
 {
     prte_proc_t *proc;
     int rc;
+    prte_app_context_t *app;
 
     proc = PRTE_NEW(prte_proc_t);
     /* set the jobid */
@@ -529,6 +539,7 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata, prte_node_t *node, pr
     /* flag the proc as ready for launch */
     proc->state = PRTE_PROC_STATE_INIT;
     proc->app_idx = idx;
+    app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, idx);
     /* mark the proc as UPDATED so it will be included in the launch */
     PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_UPDATED);
     if (NULL == node->daemon) {
@@ -541,8 +552,7 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata, prte_node_t *node, pr
     proc->node = node;
     /* if this is a debugger job, then it doesn't count against
      * available slots - otherwise, it does */
-    if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)
-        && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+    if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
         node->num_procs++;
         ++node->slots_inuse;
     }

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -336,7 +336,7 @@ static int ppr_mapper(prte_job_t *jdata)
                 }
             }
 
-            if (!(PRTE_MAPPING_DEBUGGER & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping))) {
+            if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
                 /* set the total slots used */
                 if ((int) node->num_procs <= node->slots) {
                     node->slots_inuse = (int) node->num_procs;

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -89,8 +89,7 @@ PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_job_map_t);
 /* directives given */
 #define PRTE_MAPPING_LOCAL_GIVEN 0x2000
 #define PRTE_MAPPING_GIVEN       0x4000
-/* mapping a debugger job */
-#define PRTE_MAPPING_DEBUGGER                     0x8000
+/* macros to set/get/unset mapping directive */
 #define PRTE_SET_MAPPING_DIRECTIVE(target, pol)   (target) |= (pol)
 #define PRTE_UNSET_MAPPING_DIRECTIVE(target, pol) (target) &= ~(pol)
 #define PRTE_GET_MAPPING_DIRECTIVE(pol)           ((pol) &0xff00)

--- a/src/mca/rml/rml_types.h
+++ b/src/mca/rml/rml_types.h
@@ -87,9 +87,7 @@ BEGIN_C_DECLS
 /* For FileM RSH Component */
 #define PRTE_RML_TAG_FILEM_RSH 23
 
-/* For SnapC Framework */
-#define PRTE_RML_TAG_SNAPC      24
-#define PRTE_RML_TAG_SNAPC_FULL 25
+#define PRTE_RML_TAG_JOBID_RESP      24
 
 /* For tools */
 #define PRTE_RML_TAG_TOOL 26

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -392,7 +392,7 @@ static void job_started(int fd, short args, void *cbdata)
             return;
         }
         timestamp = time(NULL);
-        PMIX_INFO_CREATE(iptr, 4);
+        PMIX_INFO_CREATE(iptr, 5);
         /* target this notification solely to that one tool */
         PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_CUSTOM_RANGE, nptr, PMIX_PROC);
         PMIX_PROC_RELEASE(nptr);
@@ -402,9 +402,10 @@ static void job_started(int fd, short args, void *cbdata)
         PMIX_INFO_LOAD(&iptr[2], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
         /* provide the timestamp */
         PMIX_INFO_LOAD(&iptr[3], PMIX_EVENT_TIMESTAMP, &timestamp, PMIX_TIME);
+        PMIX_INFO_LOAD(&iptr[4], "prte.notify.donotloop", NULL, PMIX_BOOL);
         PMIx_Notify_event(PMIX_EVENT_JOB_START, &prte_process_info.myproc, PMIX_RANGE_CUSTOM, iptr,
-                          4, NULL, NULL);
-        PMIX_INFO_FREE(iptr, 4);
+                          5, NULL, NULL);
+        PMIX_INFO_FREE(iptr, 5);
     }
 
     PRTE_RELEASE(caddy);
@@ -442,6 +443,7 @@ static void ready_for_debug(int fd, short args, void *cbdata)
     PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
     /* provide the timestamp */
     PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_EVENT_TIMESTAMP, &timestamp, PMIX_TIME);
+    PMIX_INFO_LIST_ADD(rc, tinfo, "prte.notify.donotloop", NULL, PMIX_BOOL);
     PMIX_INFO_LIST_CONVERT(rc, tinfo, &darray);
     if (PMIX_ERR_EMPTY == rc) {
         iptr = NULL;
@@ -491,6 +493,7 @@ static void check_complete(int fd, short args, void *cbdata)
     char *tmp;
     prte_timer_t *timer;
     int num_tools_attached = 0;
+    prte_app_context_t *app;
 
     PRTE_ACQUIRE_OBJECT(caddy);
     jdata = caddy->jdata;
@@ -693,8 +696,9 @@ release:
                     /* skip procs from another job */
                     continue;
                 }
-                if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)
-                    && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+                app = (prte_app_context_t*) prte_pointer_array_get_item(jdata->apps, proc->app_idx);
+                if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON) &&
+                    !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
                     node->slots_inuse--;
                     node->num_procs--;
                     node->next_node_rank--;
@@ -800,7 +804,8 @@ static void dvm_notify(int sd, short args, void *cbdata)
     char *errmsg = NULL;
 
     PRTE_OUTPUT_VERBOSE((2, prte_state_base_framework.framework_output,
-                         "%s state:dvm:dvm_notify called", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+                         "%s state:dvm:dvm_notify called",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
     /* see if there was any problem */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_ABORTED_PROC, (void **) &pptr, PMIX_POINTER)

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -324,8 +324,6 @@ PRTE_EXPORT extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op,
                                                       const pmix_info_t directives[], size_t ndirs,
                                                       pmix_info_cbfunc_t cbfunc, void *cbdata);
 
-PRTE_EXPORT void prte_pmix_server_tool_conn_complete(prte_job_t *jdata, pmix_server_req_t *req);
-
 /* declare the RML recv functions for responses */
 PRTE_EXPORT extern void pmix_server_launch_resp(int status, pmix_proc_t *sender,
                                                 pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
@@ -336,6 +334,10 @@ PRTE_EXPORT extern void pmix_server_keyval_client(int status, pmix_proc_t *sende
                                                   void *cbdata);
 
 PRTE_EXPORT extern void pmix_server_notify(int status, pmix_proc_t *sender,
+                                           pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                           void *cbdata);
+
+PRTE_EXPORT extern void pmix_server_jobid_return(int status, pmix_proc_t *sender,
                                            pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                            void *cbdata);
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -166,8 +166,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                             /* go ahead and register this client - since we are going to wait
                              * for register_nspace to complete and the PMIx library serializes
                              * the registration requests, we don't need to wait here */
-                            ret = PMIx_server_register_client(&pptr->name, uid, gid, (void *) pptr,
-                                                              NULL, NULL);
+                            ret = PMIx_server_register_client(&pptr->name, uid, gid,
+                                                              (void*)pptr, NULL, NULL);
                             if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
                                 PMIX_ERROR_LOG(ret);
                             }
@@ -397,12 +397,6 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         PMIX_INFO_LOAD(&kv->info, PMIX_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
         prte_list_append(info, &kv->super);
     }
-    /* if we are a non-persistent HNP, then write the output locally */
-    if (PRTE_PROC_IS_MASTER && !prte_persistent) {
-       kv = PRTE_NEW(prte_info_item_t);
-        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, NULL, PMIX_BOOL);
-        prte_list_append(info, &kv->super);
-    }
 
     /* for each app in the job, create an app-array */
     for (n = 0; n < jdata->apps->size; n++) {
@@ -524,24 +518,20 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                     PMIX_INFO_LOAD(&kv->info, PMIX_LOCALITY_STRING, NULL, PMIX_STRING);
                     prte_list_append(pmap, &kv->super);
                 }
-                /* debugger daemons and tools don't get session directories */
-                if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_DEBUGGER_DAEMON)
-                    && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
-                    /* create and pass a proc-level session directory */
-                    if (0 > prte_asprintf(&tmp, "%s/%u/%u", prte_process_info.jobfam_session_dir,
-                                          PRTE_LOCAL_JOBID(jdata->nspace), pptr->name.rank)) {
-                        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-                        return PRTE_ERR_OUT_OF_RESOURCE;
-                    }
-                    if (PRTE_SUCCESS != (rc = prte_os_dirpath_create(tmp, S_IRWXU))) {
-                        PRTE_ERROR_LOG(rc);
-                        return rc;
-                    }
-                    kv = PRTE_NEW(prte_info_item_t);
-                    PMIX_INFO_LOAD(&kv->info, PMIX_PROCDIR, tmp, PMIX_STRING);
-                    free(tmp);
-                    prte_list_append(pmap, &kv->super);
+                /* create and pass a proc-level session directory */
+                if (0 > prte_asprintf(&tmp, "%s/%u/%u", prte_process_info.jobfam_session_dir,
+                                      PRTE_LOCAL_JOBID(jdata->nspace), pptr->name.rank)) {
+                    PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                    return PRTE_ERR_OUT_OF_RESOURCE;
                 }
+                if (PRTE_SUCCESS != (rc = prte_os_dirpath_create(tmp, S_IRWXU))) {
+                    PRTE_ERROR_LOG(rc);
+                    return rc;
+                }
+                kv = PRTE_NEW(prte_info_item_t);
+                PMIX_INFO_LOAD(&kv->info, PMIX_PROCDIR, tmp, PMIX_STRING);
+                free(tmp);
+                prte_list_append(pmap, &kv->super);
             }
 
             /* global/univ rank */

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -115,7 +115,6 @@ static pmix_proc_t myproc;
 static bool signals_set = false;
 static bool forcibly_die = false;
 static prte_event_t term_handler;
-static prte_event_t die_handler;
 static prte_event_t epipe_handler;
 static int term_pipe[2];
 static prte_mutex_t prun_abort_inprogress_lock = PRTE_MUTEX_STATIC_INIT;
@@ -184,6 +183,24 @@ static void spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
     PRTE_PMIX_WAKEUP_THREAD(lock);
 }
 
+static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    clean_abort(0, 0, NULL);
+    cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+}
+
+static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
+{
+    mylock_t *lock = (mylock_t *) cbdata;
+
+    lock->status = status;
+    PRTE_PMIX_WAKEUP_THREAD(&lock->lock);
+}
+
+
 static int wait_pipe[2];
 
 static int wait_dvm(pid_t pid)
@@ -225,7 +242,7 @@ static prte_cmd_line_init_t cmd_line_init[] = {
 int prte(int argc, char *argv[])
 {
     int rc = 1, i, j;
-    char *param, *ptr, *tpath, *fullpath, *cptr;
+    char *param, *ptr, *tpath, *cptr;
     prte_pmix_lock_t lock;
     prte_list_t apps;
     prte_pmix_app_t *app;
@@ -255,10 +272,10 @@ int prte(int argc, char *argv[])
     char **targv;
     char *outdir = NULL;
     char *outfile = NULL;
+    pmix_status_t code;
 
     /* init the globals */
     PRTE_CONSTRUCT(&apps, prte_list_t);
-    fullpath = prte_find_absolute_path(argv[0]);
     prte_tool_basename = prte_basename(argv[0]);
     pargc = argc;
     pargv = prte_argv_copy(argv);
@@ -405,10 +422,9 @@ int prte(int argc, char *argv[])
 
     /* if we were given a keepalive pipe, set up to monitor it now */
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "keepalive", 0, 0))) {
-        prte_event_set(prte_event_base, &die_handler, pval->value.data.integer, PRTE_EV_READ,
-                       clean_abort, NULL);
-        prte_event_add(&die_handler, NULL);
-        prte_fd_set_cloexec(pval->value.data.integer); // don't let children inherit this
+        prte_asprintf(&param, "%d", pval->value.data.integer);
+        prte_setenv("PMIX_KEEPALIVE_PIPE", param, true, &environ);
+        free(param);
     }
 
     /* let the schizo components take a pass at it to get the MCA params */
@@ -535,6 +551,38 @@ int prte(int argc, char *argv[])
      */
     prte_launch_environ = prte_argv_copy(environ);
 
+    /* default to a persistent DVM */
+    prte_persistent = true;
+
+    /* if we are told to daemonize, then we cannot have apps */
+    if (!prte_cmd_line_is_taken(prte_cmd_line, "daemonize")) {
+        /* see if they want to run an application - let's parse
+         * the cmd line to get it */
+        rc = prte_parse_locals(prte_cmd_line, &apps, pargc, pargv, &hostfiles, &hosts);
+
+        /* did they provide an app? */
+        if (PMIX_SUCCESS != rc || 0 == prte_list_get_size(&apps)) {
+            if (proxyrun) {
+                prte_show_help("help-prun.txt", "prun:executable-not-specified", true,
+                               prte_tool_basename, prte_tool_basename);
+                PRTE_UPDATE_EXIT_STATUS(rc);
+                goto DONE;
+            }
+            /* nope - just need to wait for instructions */
+        } else {
+            /* they did provide an app - this is only allowed
+             * when running as a proxy! */
+            if (!proxyrun) {
+                prte_show_help("help-prun.txt", "prun:executable-incorrectly-given", true,
+                               prte_tool_basename, prte_tool_basename);
+                PRTE_UPDATE_EXIT_STATUS(rc);
+                goto DONE;
+            }
+            /* mark that we are not a persistent DVM */
+            prte_persistent = false;
+        }
+    }
+
     /* setup PRTE infrastructure */
     if (PRTE_SUCCESS != (ret = prte_init(&pargc, &pargv, PRTE_PROC_MASTER))) {
         PRTE_ERROR_LOG(ret);
@@ -584,6 +632,16 @@ int prte(int argc, char *argv[])
             goto DONE;
         }
     }
+
+    /* setup the keepalive event registration */
+    PRTE_PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    code = PMIX_ERR_JOB_TERMINATED;
+    PMIX_LOAD_PROCID(&pname, "PMIX_KEEPALIVE_PIPE", PMIX_RANK_UNDEF);
+    PMIX_INFO_LOAD(&info, PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
+    PMIx_Register_event_handler(&code, 1, &info, 1, parent_died_fn, evhandler_reg_callbk,
+                                (void *) &mylock);
+    PRTE_PMIX_WAIT_THREAD(&mylock.lock);
+    PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
 
     /* check for launch directives in case we were launched by a
      * tool wanting to direct our operation - this needs to be
@@ -709,38 +767,6 @@ int prte(int argc, char *argv[])
         PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
     } else {
         PMIX_LOAD_PROCID(&parent, prte_process_info.myproc.nspace, prte_process_info.myproc.rank);
-    }
-
-    /* default to a persistent DVM */
-    prte_persistent = true;
-
-    /* if we are told to daemonize, then we cannot have apps */
-    if (!prte_cmd_line_is_taken(prte_cmd_line, "daemonize")) {
-        /* see if they want to run an application - let's parse
-         * the cmd line to get it */
-        rc = prte_parse_locals(prte_cmd_line, &apps, pargc, pargv, &hostfiles, &hosts);
-
-        /* did they provide an app? */
-        if (PMIX_SUCCESS != rc || 0 == prte_list_get_size(&apps)) {
-            if (proxyrun) {
-                prte_show_help("help-prun.txt", "prun:executable-not-specified", true,
-                               prte_tool_basename, prte_tool_basename);
-                PRTE_UPDATE_EXIT_STATUS(rc);
-                goto DONE;
-            }
-            /* nope - just need to wait for instructions */
-        } else {
-            /* they did provide an app - this is only allowed
-             * when running as a proxy! */
-            if (!proxyrun) {
-                prte_show_help("help-prun.txt", "prun:executable-incorrectly-given", true,
-                               prte_tool_basename, prte_tool_basename);
-                PRTE_UPDATE_EXIT_STATUS(rc);
-                goto DONE;
-            }
-            /* mark that we are not a persistent DVM */
-            prte_persistent = false;
-        }
     }
 
     /* add any hostfile directives to the daemon job */
@@ -1244,6 +1270,7 @@ proceed:
     while (prte_event_base_active) {
         prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
     }
+
     PRTE_ACQUIRE_OBJECT(prte_event_base_active);
 
     /* close the push of our stdin */
@@ -1349,8 +1376,7 @@ static void surekill(void)
 static void abort_signal_callback(int fd)
 {
     uint8_t foo = 1;
-    char *msg
-        = "Abort is in progress...hit ctrl-c again to forcibly terminate\n\n";
+    char *msg = "Abort is in progress...hit ctrl-c again to forcibly terminate\n\n";
 
     /* if this is the first time thru, just get
      * the current time

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -130,6 +130,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
     pmix_byte_object_t pbo;
     pmix_topology_t ptopo;
     char *tmp;
+    pmix_info_t info[4];
 
     /* unpack the command */
     n = 1;
@@ -402,41 +403,17 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
         }
         /* kill the local procs */
         prte_odls.kill_local_procs(NULL);
-        /* cycle thru our known jobs to find any that are tools - these
-         * may not have been killed if, for example, we didn't start
-         * them */
-        for (i = 0; i < prte_job_data->size; i++) {
-            jdata = (prte_job_t *) prte_pointer_array_get_item(prte_job_data, i);
-            if (NULL == jdata) {
-                continue;
-            }
-            if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)
-                && 0 < prte_list_get_size(&jdata->children)) {
-                pmix_info_t info[3];
-                bool flag;
-                prte_job_t *jd;
-                pmix_status_t xrc = PMIX_EVENT_JOB_END;
-                /* we need to notify this job that its CHILD job terminated
-                 * as that is the job it is looking for */
-                jd = (prte_job_t *) prte_list_get_first(&jdata->children);
-                /* must notify this tool of termination so it can
-                 * cleanly exit - otherwise, it may hang waiting for
-                 * some kind of notification */
-                /* ensure this only goes to the job terminated event handler */
-                flag = true;
-                PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, &flag, PMIX_BOOL);
-                /* provide the status */
-                PMIX_INFO_LOAD(&info[1], PMIX_JOB_TERM_STATUS, &xrc, PMIX_STATUS);
-                /* tell the requestor which job */
-                PMIX_LOAD_PROCID(&pname, jd->nspace, PMIX_RANK_WILDCARD);
-                PMIX_INFO_LOAD(&info[2], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
-                PRTE_PMIX_CONSTRUCT_LOCK(&lk);
-                PMIx_Notify_event(PMIX_EVENT_JOB_END, &pname, PMIX_RANGE_SESSION, info, 3,
-                                  _notify_release, &lk);
-                PRTE_PMIX_WAIT_THREAD(&lk);
-                PRTE_PMIX_DESTRUCT_LOCK(&lk);
-            }
-        }
+        /* any tools attached to us will have done so via PMIx, so
+         * let's provide them with a friendly "job end" notification */
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &prte_process_info.myproc, PMIX_PROC);
+        PMIX_INFO_LOAD(&info[2], "prte.notify.donotloop", NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[3], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
+        PRTE_PMIX_CONSTRUCT_LOCK(&lk);
+        ret = PMIx_Notify_event(PMIX_EVENT_JOB_END, &prte_process_info.myproc,
+                                PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
+        PRTE_PMIX_WAIT_THREAD(&lk);
+        PRTE_PMIX_DESTRUCT_LOCK(&lk);
         /* flag that prteds were ordered to terminate */
         prte_prteds_term_ordered = true;
         if (PRTE_PROC_IS_MASTER) {
@@ -495,15 +472,15 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                     continue;
                 }
                 for (i = 0; i < node->procs->size; i++) {
-                    if (NULL
-                        == (proct = (prte_proc_t *) prte_pointer_array_get_item(node->procs, i))) {
+                    proct = (prte_proc_t *) prte_pointer_array_get_item(node->procs, i);
+                    if (NULL == proct) {
                         continue;
                     }
                     if (!PMIX_CHECK_NSPACE(proct->name.nspace, job)) {
                         /* skip procs from another job */
                         continue;
                     }
-                    if (!PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_TOOL)) {
+                    if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
                         node->slots_inuse--;
                         node->num_procs--;
                     }

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -270,8 +270,6 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_APPEND_ENVAR";
         case PRTE_APP_ADD_ENVAR:
             return "PRTE_APP_ADD_ENVAR";
-        case PRTE_APP_DEBUGGER_DAEMON:
-            return "PRTE_APP_DEBUGGER_DAEMON";
         case PRTE_APP_PSET_NAME:
             return "PRTE_APP_PSET_NAME";
 

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -32,7 +32,10 @@
 
 /*** ATTRIBUTE FLAGS - never sent anywwhere ***/
 typedef uint8_t prte_app_context_flags_t;
-#define PRTE_APP_FLAG_USED_ON_NODE 0x01 // is being used on the local node
+#define PRTE_APP_FLAG_USED_ON_NODE  0x01    // is being used on the local node
+#define PRTE_APP_DEBUGGER_DAEMON    0x02    // this app describes daemons to be co-launched
+                                            //    with the application procs in the other apps
+                                            //    and does not count against allocation
 
 /* APP_CONTEXT ATTRIBUTE KEYS */
 #define PRTE_APP_HOSTFILE            1  // string  - hostfile
@@ -56,8 +59,6 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_PREPEND_ENVAR      19 // prte_envar_t - prepend the specified value to the given envar
 #define PRTE_APP_APPEND_ENVAR       20 // prte_envar_t - append the specified value to the given envar
 #define PRTE_APP_ADD_ENVAR          21 // prte_envar_t - add envar, do not override pre-existing one
-#define PRTE_APP_DEBUGGER_DAEMON    22 // bool - flag that this app describes daemons to be co-launched
-                                       //        with the application procs in the other apps
 #define PRTE_APP_PSET_NAME          23 // string - user-assigned name for the process
                                        //          set containing the given process
 
@@ -91,7 +92,6 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_FLAG_UPDATED           0x0001 // job has been updated and needs to be included in the pidmap message
 #define PRTE_JOB_FLAG_RESTARTED         0x0004 // some procs in this job are being restarted
 #define PRTE_JOB_FLAG_ABORTED           0x0008 // did this job abort?
-#define PRTE_JOB_FLAG_DEBUGGER_DAEMON   0x0010 // job is launching debugger daemons
 #define PRTE_JOB_FLAG_FORWARD_OUTPUT    0x0020 // forward output from the apps
 #define PRTE_JOB_FLAG_DO_NOT_MONITOR    0x0040 // do not monitor apps for termination
 #define PRTE_JOB_FLAG_FORWARD_COMM      0x0080 //
@@ -99,7 +99,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_FLAG_RESTART           0x0200 //
 #define PRTE_JOB_FLAG_PROCS_MIGRATING   0x0400 // some procs in job are migrating from one node to another
 #define PRTE_JOB_FLAG_OVERSUBSCRIBED    0x0800 // at least one node in the job is oversubscribed
-#define PRTE_JOB_FLAG_TOOL              0x1000 // job is a tool
+#define PRTE_JOB_FLAG_TOOL              0x1000 // job is a tool and doesn't count against allocations
 #define PRTE_JOB_FLAG_LAUNCHER          0x2000 // job is also a launcher
 #define PRTE_JOB_FLAG_ERR_REPORTED      0x4000 // error report for job has been output
 
@@ -215,7 +215,6 @@ typedef uint16_t prte_proc_flags_t;
 #define PRTE_PROC_FLAG_DATA_IN_SM   0x0800 // modex data has been stored in the local shared memory region
 #define PRTE_PROC_FLAG_DATA_RECVD   0x1000 // modex data for this proc has been received
 #define PRTE_PROC_FLAG_SM_ACCESS    0x2000 // indicate if process can read modex data from shared memory region
-#define PRTE_PROC_FLAG_TOOL         0x4000 // proc is a tool and doesn't count against allocations
 
 /***   PROCESS ATTRIBUTE KEYS   ***/
 #define PRTE_PROC_START_KEY PRTE_JOB_MAX_KEY


### PR DESCRIPTION
Tools are restricted to being PMIx-based tools. Any app
started by PRRTE is to be treated just as a "client" - i.e.,
PRRTE shouldn't/doesn't care what that app does. Only distinction
we retain is that declared "debugger daemons" are not counted
against the allocation.

Signed-off-by: Ralph Castain <rhc@pmix.org>