### PR TITLE
Avoid threadlock scenario

### DIFF
--- a/src/mca/odls/alps/odls_alps_module.c
+++ b/src/mca/odls/alps/odls_alps_module.c
@@ -370,7 +370,7 @@ static int do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
         }
 
         /* now set any child-level controls such as binding */
-        prte_rtc.set(cd->jdata, cd->child, &cd->env, write_fd);
+        prte_rtc.set(cd, write_fd);
 
     } else if (!PRTE_FLAG_TEST(cd->jdata, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
         /* tie stdin/out/err/internal to /dev/null */

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -81,7 +81,7 @@ static int prte_odls_base_register(prte_mca_base_register_flag_t flags)
         PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_odls_globals.timeout_before_sigkill);
 
-    prte_odls_globals.max_threads = 32;
+    prte_odls_globals.max_threads = 16;
     (void) prte_mca_base_var_register("prte", "odls", "base", "max_threads",
                                       "Maximum number of threads to use for spawning local procs",
                                       PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0,

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -285,7 +285,7 @@ static void send_error_show_help(int fd, int exit_status, const char *file, cons
     write_help_msg(fd, &msg, file, topic, ap);
     va_end(ap);
 
-    exit(exit_status);
+    _exit(exit_status);
 }
 
 static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
@@ -327,7 +327,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
         }
 
         /* now set any child-level controls such as binding */
-        prte_rtc.set(cd->jdata, cd->child, &cd->env, write_fd);
+        prte_rtc.set(cd, write_fd);
 
     } else if (!PRTE_FLAG_TEST(cd->jdata, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
         /* tie stdin/out/err/internal to /dev/null */
@@ -416,7 +416,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     }
     send_error_show_help(write_fd, 1, "help-prte-odls-default.txt", "execve error",
                          prte_process_info.nodename, dir, cd->app->app, msg);
-    free(msg);
+    // does not return
 }
 
 static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)

--- a/src/mca/rtc/base/base.h
+++ b/src/mca/rtc/base/base.h
@@ -23,6 +23,7 @@
 
 #include "src/class/prte_list.h"
 #include "src/mca/mca.h"
+#include "src/mca/odls/base/odls_private.h"
 #include "src/util/printf.h"
 
 #include "src/mca/rtc/rtc.h"
@@ -65,7 +66,7 @@ typedef struct {
 PRTE_CLASS_DECLARATION(prte_rtc_base_selected_module_t);
 
 PRTE_EXPORT void prte_rtc_base_assign(prte_job_t *jdata);
-PRTE_EXPORT void prte_rtc_base_set(prte_job_t *jdata, prte_proc_t *proc, char ***env, int error_fd);
+PRTE_EXPORT void prte_rtc_base_set(prte_odls_spawn_caddy_t *cd, int error_fd);
 PRTE_EXPORT void prte_rtc_base_get_avail_vals(prte_list_t *vals);
 
 /* Called from the child to send a warning show_help message up the

--- a/src/mca/rtc/base/rtc_base_stubs.c
+++ b/src/mca/rtc/base/rtc_base_stubs.c
@@ -32,7 +32,7 @@ void prte_rtc_base_assign(prte_job_t *jdata)
     }
 }
 
-void prte_rtc_base_set(prte_job_t *jdata, prte_proc_t *proc, char ***environ_copy, int error_fd)
+void prte_rtc_base_set(prte_odls_spawn_caddy_t *cd, int error_fd)
 {
     prte_rtc_base_selected_module_t *active;
 
@@ -40,7 +40,7 @@ void prte_rtc_base_set(prte_job_t *jdata, prte_proc_t *proc, char ***environ_cop
     {
         if (NULL != active->module->set) {
             /* give this module a chance to operate on it */
-            active->module->set(jdata, proc, environ_copy, error_fd);
+            active->module->set(cd, error_fd);
         }
     }
 }

--- a/src/mca/rtc/rtc.h
+++ b/src/mca/rtc/rtc.h
@@ -25,7 +25,7 @@
 
 #include "src/class/prte_list.h"
 #include "src/mca/mca.h"
-
+#include "src/mca/odls/base/odls_private.h"
 #include "src/runtime/prte_globals.h"
 
 BEGIN_C_DECLS
@@ -56,7 +56,7 @@ typedef void (*prte_rtc_base_module_assign_fn_t)(prte_job_t *jdata);
  * Each module is responsible for reporting errors via the state machine. Thus,
  * no error code is returned. However, warnings and error messages for the user
  * can be output via the provided error_fd */
-typedef void (*prte_rtc_base_module_set_fn_t)(prte_job_t *jdata, prte_proc_t *proc, char ***env,
+typedef void (*prte_rtc_base_module_set_fn_t)(prte_odls_spawn_caddy_t *cd,
                                               int error_fd);
 
 /* Return a list of valid controls values for this component.


### PR DESCRIPTION
Lookup the app context for a child prior to dispatching
local launch to a launch thread. Avoids having multiple
threads attempting to access the pointer array and
deadlocking. Reduce default number of threads to something
more reasonable.

Signed-off-by: Ralph Castain <rhc@pmix.org>