### PR TITLE
FINALLY squash the "unable to retrieve spawn req" error

### DIFF
--- a/src/class/prte_hotel.h
+++ b/src/class/prte_hotel.h
@@ -221,6 +221,21 @@ static inline int prte_hotel_checkin(prte_hotel_t *hotel, void *occupant, int *r
     return PRTE_SUCCESS;
 }
 
+static inline int prte_hotel_recheck(prte_hotel_t *hotel, void *occupant, int room_num)
+{
+    prte_hotel_room_t *room;
+
+    room = &(hotel->rooms[room_num]);
+    if (PRTE_UNLIKELY(NULL != room->occupant)) {
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+    room->occupant = occupant;
+    /* Assign the event and make it pending */
+    if (NULL != hotel->evbase) {
+        prte_event_add(&(room->eviction_timer_event), &(hotel->eviction_timeout));
+    }
+    return PRTE_SUCCESS;
+}
 /**
  * Check the specified occupant out of the hotel.
  *

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -365,7 +365,7 @@ static void proc_errors(int fd, short args, void *cbdata)
     prte_proc_t *pptr, *proct;
     pmix_proc_t *proc = &caddy->name;
     prte_proc_state_t state = caddy->proc_state;
-    int i, rc;
+    int i;
     int32_t i32, *i32ptr;
 
     PRTE_ACQUIRE_OBJECT(caddy);
@@ -745,10 +745,5 @@ keep_going:
     }
 
 cleanup:
-    rc = prte_pmix_convert_proc_state_to_error(state);
-    rc = prte_plm_base_spawn_response(rc, jdata);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-    }
     PRTE_RELEASE(caddy);
 }

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -178,6 +178,7 @@ void prte_odls_base_start_threads(prte_job_t *jdata)
             }
         }
     }
+startup:
     if (0 == prte_odls_globals.num_threads) {
         if (NULL == prte_event_base_ptr) {
             prte_event_base_ptr = (prte_event_base_t **) malloc(sizeof(prte_event_base_t *));
@@ -186,7 +187,6 @@ void prte_odls_base_start_threads(prte_job_t *jdata)
         }
         prte_odls_globals.ev_bases = prte_event_base_ptr;
     } else {
-    startup:
         prte_odls_globals.ev_bases = (prte_event_base_t **) malloc(prte_odls_globals.num_threads
                                                                    * sizeof(prte_event_base_t *));
         for (i = 0; i < prte_odls_globals.num_threads; i++) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -595,9 +595,8 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
         /* dvm job => launch was requested by a TOOL, so we notify the launch proxy
          * and NOT the originator (as that would be us) */
         nptr = NULL;
-        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr,
-                                PMIX_PROC)
-            || NULL == nptr) {
+        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC) ||
+            NULL == nptr) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
             return PRTE_ERR_NOT_FOUND;
         }

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -222,10 +222,12 @@ typedef int8_t prte_node_state_t;
  * PLM commands
  */
 typedef uint8_t prte_plm_cmd_flag_t;
-#define PRTE_PLM_LAUNCH_JOB_CMD    1
-#define PRTE_PLM_UPDATE_PROC_STATE 2
-#define PRTE_PLM_REGISTERED_CMD    3
-#define PRTE_PLM_ALLOC_JOBID_CMD   4
+#define PRTE_PLM_LAUNCH_JOB_CMD         1
+#define PRTE_PLM_UPDATE_PROC_STATE      2
+#define PRTE_PLM_REGISTERED_CMD         3
+#define PRTE_PLM_ALLOC_JOBID_CMD        4
+#define PRTE_PLM_READY_FOR_DEBUG_CMD    5
+#define PRTE_PLM_LOCAL_LAUNCH_COMP_CMD  6
 
 END_C_DECLS
 

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -160,7 +160,6 @@ static void track_jobs(int fd, short argc, void *cbdata)
     int rc, i;
     prte_proc_state_t running = PRTE_PROC_STATE_RUNNING;
     prte_proc_t *child;
-    pmix_rank_t null = PMIX_RANK_INVALID;
 
     PRTE_ACQUIRE_OBJECT(caddy);
 
@@ -173,7 +172,7 @@ static void track_jobs(int fd, short argc, void *cbdata)
         /* update the HNP with all proc states for this job */
         PMIX_DATA_BUFFER_CREATE(alert);
         /* pack update state command */
-        cmd = PRTE_PLM_UPDATE_PROC_STATE;
+        cmd = PRTE_PLM_LOCAL_LAUNCH_COMP_CMD;
         rc = PMIx_Data_pack(NULL, alert, &cmd, 1, PMIX_UINT8);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -188,21 +187,14 @@ static void track_jobs(int fd, short argc, void *cbdata)
             goto cleanup;
         }
         for (i = 0; i < prte_local_children->size; i++) {
-            if (NULL
-                == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i))) {
+            child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+            if (NULL == child) {
                 continue;
             }
             /* if this child is part of the job... */
             if (PMIX_CHECK_NSPACE(child->name.nspace, caddy->jdata->nspace)) {
                 /* pack the child's vpid */
                 rc = PMIx_Data_pack(NULL, alert, &child->name.rank, 1, PMIX_PROC_RANK);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(alert);
-                    goto cleanup;
-                }
-                /* pack the pid */
-                rc = PMIx_Data_pack(NULL, alert, &child->pid, 1, PMIX_PID);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(alert);
@@ -221,6 +213,13 @@ static void track_jobs(int fd, short argc, void *cbdata)
                         PMIX_DATA_BUFFER_RELEASE(alert);
                         goto cleanup;
                     }
+                    /* pack its exit code */
+                    rc = PMIx_Data_pack(NULL, alert, &child->exit_code, 1, PMIX_INT32);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_DATA_BUFFER_RELEASE(alert);
+                        goto cleanup;
+                    }
                 } else {
                     /* pack the RUNNING state to avoid any race conditions */
                     rc = PMIx_Data_pack(NULL, alert, &running, 1, PMIX_UINT32);
@@ -230,22 +229,7 @@ static void track_jobs(int fd, short argc, void *cbdata)
                         goto cleanup;
                     }
                 }
-                /* pack its exit code */
-                rc = PMIx_Data_pack(NULL, alert, &child->exit_code, 1, PMIX_INT32);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(alert);
-                    goto cleanup;
-                }
             }
-        }
-
-        /* flag that this job is complete so the receiver can know */
-        rc = PMIx_Data_pack(NULL, alert, &null, 1, PMIX_PROC_RANK);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(alert);
-            goto cleanup;
         }
         break;
 
@@ -258,7 +242,7 @@ static void track_jobs(int fd, short argc, void *cbdata)
         PMIX_DATA_BUFFER_CREATE(alert);
         running = PRTE_PROC_STATE_READY_FOR_DEBUG;
         /* pack update state command */
-        cmd = PRTE_PLM_UPDATE_PROC_STATE;
+        cmd = PRTE_PLM_READY_FOR_DEBUG_CMD;
         rc = PMIx_Data_pack(NULL, alert, &cmd, 1, PMIX_UINT8);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -273,35 +257,14 @@ static void track_jobs(int fd, short argc, void *cbdata)
             goto cleanup;
         }
         for (i = 0; i < prte_local_children->size; i++) {
-            if (NULL
-                == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i))) {
+            child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+            if (NULL == child) {
                 continue;
             }
             /* if this child is part of the job... */
             if (PMIX_CHECK_NSPACE(child->name.nspace, caddy->jdata->nspace)) {
                 /* pack the child's vpid */
                 rc = PMIx_Data_pack(NULL, alert, &child->name.rank, 1, PMIX_PROC_RANK);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(alert);
-                    goto cleanup;
-                }
-                /* pack the pid */
-                rc = PMIx_Data_pack(NULL, alert, &child->pid, 1, PMIX_PID);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(alert);
-                    goto cleanup;
-                }
-                /* pack the READY-FOR-DEBUG state to avoid any race conditions */
-                rc = PMIx_Data_pack(NULL, alert, &running, 1, PMIX_UINT32);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(alert);
-                    goto cleanup;
-                }
-                /* pack its exit code */
-                rc = PMIx_Data_pack(NULL, alert, &child->exit_code, 1, PMIX_INT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(alert);
@@ -441,9 +404,8 @@ static void track_procs(int fd, short argc, void *cbdata)
 
             /* pack all the local child vpids */
             for (i = 0; i < prte_local_children->size; i++) {
-                if (NULL
-                    == (pptr = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                           i))) {
+                pptr = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+                if (NULL == pptr) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(pptr->name.nspace, proc->nspace)) {

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -388,8 +388,8 @@ static void eviction_cbfunc(struct prte_hotel_t *hotel, int room_num, void *occu
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
         }
         /* not done yet - check us back in */
-        if (PRTE_SUCCESS
-            == (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
+        rc = prte_hotel_recheck(&prte_pmix_server_globals.reqs, req, req->room_num);
+        if (PRTE_SUCCESS == rc) {
             prte_output_verbose(2, prte_pmix_server_globals.output,
                                 "%s server:evict checked back in to room %d",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->room_num);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -59,8 +59,8 @@ void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret)
     prte_job_t *jdata;
 
     jdata = prte_get_job_data_object(jobid);
-    if (NULL != jdata
-        && prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_NOTIFIED, NULL, PMIX_BOOL)) {
+    if (NULL != jdata &&
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_NOTIFIED, NULL, PMIX_BOOL)) {
         /* already done */
         return;
     }


### PR DESCRIPTION
Checking the request back into the hotel changes the room number!
So add a prte_hotel_recheck function that just puts the occupant
back into their prior room and reactivates the timer event.

Signed-off-by: Ralph Castain <rhc@pmix.org>