### PR TITLE
Correctly retrieve the launch proxy

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1223,8 +1223,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         /* if this app isn't being used on our node, skip it */
         if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_USED_ON_NODE)) {
             prte_output_verbose(5, prte_odls_base_framework.framework_output,
-                                "%s app %d not used on node", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                j);
+                                "%s app %d not used on node",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), j);
             continue;
         }
 
@@ -1244,9 +1244,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
              */
             /* cycle through children to find those for this jobid */
             for (idx = 0; idx < prte_local_children->size; idx++) {
-                if (NULL
-                    == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                            idx))) {
+                child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+                if (NULL == child) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
@@ -1273,9 +1272,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
              */
             /* cycle through children to find those for this jobid */
             for (idx = 0; idx < prte_local_children->size; idx++) {
-                if (NULL
-                    == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                            idx))) {
+                child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+                if (NULL == child) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
@@ -1290,9 +1288,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_filem.link_local_files(jobdat, app))) {
             /* cycle through children to find those for this jobid */
             for (idx = 0; idx < prte_local_children->size; idx++) {
-                if (NULL
-                    == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                            idx))) {
+                child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+                if (NULL == child) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
@@ -1339,9 +1336,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         if (PRTE_SUCCESS != rc) {
             /* cycle through children to find those for this jobid */
             for (idx = 0; idx < prte_local_children->size; idx++) {
-                if (NULL
-                    == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                            idx))) {
+                child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+                if (NULL == child) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
@@ -1358,9 +1354,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                            prte_process_info.nodename, app, __FILE__, __LINE__, msg);
             /* cycle through children to find those for this jobid */
             for (idx = 0; idx < prte_local_children->size; idx++) {
-                if (NULL
-                    == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                            idx))) {
+                child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+                if (NULL == child) {
                     continue;
                 }
                 if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
@@ -1386,9 +1381,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         /* okay, now let's launch all the local procs for this app using the provided fork_local fn
          */
         for (idx = 0; idx < prte_local_children->size; idx++) {
-            if (NULL
-                == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                        idx))) {
+            child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, idx);
+            if (NULL == child) {
                 continue;
             }
             /* does this child belong to this app? */
@@ -1523,8 +1517,8 @@ int prte_odls_base_default_signal_local_procs(const pmix_proc_t *proc, int32_t s
     if (NULL == proc) {
         rc = PRTE_SUCCESS; /* pre-set this as an empty list causes us to drop to bottom */
         for (i = 0; i < prte_local_children->size; i++) {
-            if (NULL
-                == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i))) {
+            child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+            if (NULL == child) {
                 continue;
             }
             if (0 == child->pid || !PRTE_FLAG_TEST(child, PRTE_PROC_FLAG_ALIVE)) {
@@ -1540,7 +1534,8 @@ int prte_odls_base_default_signal_local_procs(const pmix_proc_t *proc, int32_t s
 
     /* we want it sent to some specified process, so find it */
     for (i = 0; i < prte_local_children->size; i++) {
-        if (NULL == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i))) {
+        child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+        if (NULL == child) {
             continue;
         }
         if (PMIX_CHECK_PROCID(&child->name, proc)) {
@@ -1687,9 +1682,8 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         } else {
             /* has any child in this job already registered? */
             for (i = 0; i < prte_local_children->size; i++) {
-                if (NULL
-                    == (cptr = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children,
-                                                                           i))) {
+                cptr = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, i);
+                if (NULL == cptr) {
                     continue;
                 }
                 if (!PMIX_CHECK_NSPACE(cptr->name.nspace, proc->name.nspace)) {
@@ -1846,8 +1840,8 @@ int prte_odls_base_default_kill_local_procs(prte_pointer_array_t *procs,
             continue;
         }
         for (j = 0; j < prte_local_children->size; j++) {
-            if (NULL
-                == (child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, j))) {
+            child = (prte_proc_t *) prte_pointer_array_get_item(prte_local_children, j);
+            if (NULL == child) {
                 continue;
             }
 

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -385,8 +385,7 @@ static void job_started(int fd, short args, void *cbdata)
         /* dvm job => launch was requested by a TOOL, so we notify the launch proxy
          * and NOT the originator (as that would be us) */
         nptr = NULL;
-        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr,
-                                PMIX_PROC)
+        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC)
             || NULL == nptr) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
             return;
@@ -426,8 +425,7 @@ static void ready_for_debug(int fd, short args, void *cbdata)
     /* launch was requested by a TOOL, so we notify the launch proxy
      * and NOT the originator (as that would be us) */
     nptr = NULL;
-    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr,
-                            PMIX_PROC)
+    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC)
         || NULL == nptr) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         goto DONE;
@@ -827,6 +825,7 @@ static void dvm_notify(int sd, short args, void *cbdata)
         if (PMIX_CHECK_NSPACE(proc->nspace, jdata->nspace)) {
             notify = false;
         }
+        PMIX_PROC_RELEASE(proc);
     }
 
     if (notify) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -70,7 +70,6 @@ void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret)
     if (NULL == req) {
         /* we are hosed */
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        prte_output(0, "UNABLE TO RETRIEVE SPWN_REQ FOR JOB %s [room=%d]", jobid, room);
         return;
     }
 
@@ -219,7 +218,7 @@ static void interim(int sd, short args, void *cbdata)
     /* create the job object */
     jdata = PRTE_NEW(prte_job_t);
     jdata->map = PRTE_NEW(prte_job_map_t);
-    PMIX_XFER_PROCID(&jdata->originator, requestor);
+    PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
 
     /* transfer the apps across */
     for (n = 0; n < cd->napps; n++) {
@@ -678,8 +677,8 @@ static void interim(int sd, short args, void *cbdata)
     }
 
     /* indicate the requestor so bookmarks can be correctly set */
-    prte_set_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, PRTE_ATTR_GLOBAL, requestor,
-                       PMIX_PROC);
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, PRTE_ATTR_GLOBAL,
+                       &jdata->originator, PMIX_PROC);
 
     /* indicate that IO is to be forwarded */
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_FORWARD_OUTPUT);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -444,8 +444,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     }
 
     /* get the parent job that spawned this one */
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &parentproc,
-                           PMIX_PROC)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &parentproc, PMIX_PROC)) {
         parent = prte_get_job_data_object(parentproc->nspace);
         if (NULL != parent
             && (PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -672,8 +672,14 @@ int prte_attr_unload(prte_attribute_t *kv, void **data, pmix_data_type_t type)
 {
     pmix_byte_object_t *boptr;
     pmix_envar_t *envar;
-    pmix_data_type_t pointers[] = {PMIX_STRING, PMIX_BYTE_OBJECT, PMIX_POINTER, PMIX_PROC_NSPACE,
-                                   PMIX_PROC,   PMIX_ENVAR,       PMIX_UNDEF};
+    pmix_data_type_t pointers[] = {
+        PMIX_STRING,
+        PMIX_BYTE_OBJECT,
+        PMIX_POINTER,
+        PMIX_PROC_NSPACE,
+        PMIX_PROC,
+        PMIX_ENVAR,
+        PMIX_UNDEF};
     int n;
     bool found = false;
 


### PR DESCRIPTION
The get_attribute function returns a malloc'd pointer to
the process ID. This fixes the "manystress" test as memory
corruption was leading to incorrect termination of processes.

Signed-off-by: Ralph Castain <rhc@pmix.org>