### PR TITLE
Remove stale code that was moved elsewhere in the function

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -169,20 +169,6 @@ int prte_ess_base_prted_setup(void)
             break;
         }
     }
-    if (15 < prte_output_get_verbosity(prte_ess_base_framework.framework_output)) {
-        char *output = NULL;
-        pmix_topology_t topo;
-        prte_output(0, "%s Topology Info:", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        topo.source = "hwloc";
-        topo.topology = prte_hwloc_topology;
-        ret = PMIx_Data_print(&output, NULL, &topo, PMIX_TOPO);
-        if (PMIX_SUCCESS == ret) {
-            fprintf(stderr, "%s\n", output);
-            free(output);
-        } else {
-            PMIX_ERROR_LOG(ret);
-        }
-    }
 
     /* define the HNP name */
     PMIX_LOAD_PROCID(PRTE_PROC_MY_HNP, PRTE_PROC_MY_NAME->nspace, 0);


### PR DESCRIPTION
Must come after pmix has been initialized.

Fixes #1022 

Signed-off-by: Ralph Castain <rhc@pmix.org>