### PR TITLE
build: support cobuild in Open MPI

### DIFF
--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -4,6 +4,8 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -11,10 +13,33 @@
 # $HEADER$
 #
 
-# MCA_hwloc_CONFIG([action-if-found], [action-if-not-found])
+#
+# We have three modes for building hwloc.
+#
+# First is an embedded hwloc, where PRTE is being built into
+# another library and assumes that hwloc is available, that there
+# is a single header (pointed to by --with-hwloc-header) which
+# includes all the Hwloc bits, and that the right hwloc
+# configuration is used.  This mode is used when --enable-embeded-mode
+# is specified to configure.
+#
+# Second is as a co-built hwloc.  In this case, PRTE's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# hwloc headers and LIBS will point to where the .la file for
+# hwloc will exist.  When co-building, hwloc's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-hwloc=cobuild option is specified.
+#
+# Third is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# hwloc.  This mode is used whenever the other modes are not used.
+#
+# PRTE_HWLOC_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PRTE_HWLOC_CONFIG],[
-    PRTE_VAR_SCOPE_PUSH([prte_hwloc_dir prte_hwloc_libdir prte_hwloc_standard_lib_location prte_hwloc_standard_header_location prte_check_hwloc_save_CPPFLAGS prte_check_hwloc_save_LDFLAGS prte_check_hwloc_save_LIBS])
+    PRTE_VAR_SCOPE_PUSH([hwloc_build_mode prte_hwloc_header_given prte_have_topology_dup])
 
     AC_ARG_WITH([hwloc],
                 [AS_HELP_STRING([--with-hwloc=DIR],
@@ -26,30 +51,99 @@ AC_DEFUN([PRTE_HWLOC_CONFIG],[
 
     AC_ARG_WITH([hwloc-header],
                 [AS_HELP_STRING([--with-hwloc-header=HEADER],
-                                [The value that should be included in C files to include hwloc.h])])
+                                [The value that should be included in C files to include hwloc.h.  This option only has meaning if --enable-embedded-mode is enabled.])])
 
     prte_hwloc_support=0
+    prte_hwloc_source=""
+    prte_hwloc_support_will_build=no
+
     prte_hwloc_header_given=0
+    prte_hwloc_have_topology_dup=0
+    PRTE_HWLOC_HEADER="<hwloc.h>"
+
+    # figure out our mode...
+    AS_IF([test "$prte_mode" = "embedded"],
+          [_PRTE_HWLOC_EMBEDDED_MODE(embedded)],
+          [test "$with_hwloc" = "cobuild"],
+          [_PRTE_HWLOC_EMBEDDED_MODE(cobuild)],
+          [_PRTE_HWLOC_EXTERNAL])
+
+    AS_IF([test $prte_hwloc_support -eq 1],
+          [AC_MSG_CHECKING([hwloc header])
+           AC_MSG_RESULT([$PRTE_HWLOC_HEADER])])
+
+    AC_DEFINE_UNQUOTED([PRTE_HWLOC_HEADER], [$PRTE_HWLOC_HEADER],
+                   [Location of hwloc.h])
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC], [$prte_hwloc_support],
+                   [Whether or not we have hwloc support])
+    AC_DEFINE_UNQUOTED([PRTE_HWLOC_HEADER_GIVEN], [$prte_hwloc_header_given],
+                       [Whether or not the hwloc header was given to us])
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC_TOPOLOGY_DUP], [$prte_have_topology_dup],
+                       [Whether or not hwloc_topology_dup is available])
+
+    PRTE_SUMMARY_ADD([[Required Packages]], [[HWLOC]], [prte_hwloc], [$prte_hwloc_support_will_build ($prte_hwloc_source)])
+
+    PRTE_VAR_SCOPE_POP
+])
+
+AC_DEFUN([_PRTE_HWLOC_EMBEDDED_MODE],[
+    AC_MSG_CHECKING([for hwloc])
+    AC_MSG_RESULT([$1])
+
+    AS_IF([test "$1" == "embedded"], [
+        AS_IF([test -n "$with_hwloc_header" && test "$with_hwloc_header" != "yes"],
+              [PRTE_HWLOC_HEADER="$with_hwloc_header"])
+	# in emedded mode, assume we have topology_dup
+        prte_hwloc_have_topology_dup=1
+	prte_hwloc_header_given=1])
+
+    AS_IF([test "$1" == "cobuild"],
+           [AC_MSG_CHECKING([if cobuild hwloc version is 1.5 or greater])
+            AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+              [[
+    #if HWLOC_API_VERSION < 0x00010500
+    #error "hwloc API version is less than 0x00010500"
+    #endif
+              ]])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+               AC_MSG_ERROR([Cannot continue])])
+
+            AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
+            AC_COMPILE_IFELSE(
+                  [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+                  [[
+            #if HWLOC_API_VERSION < 0x00010800
+            #error "hwloc API version is less than 0x00010800"
+            #endif
+                  ]])],
+                  [AC_MSG_RESULT([yes])
+                   prte_have_topology_dup=1],
+                  [AC_MSG_RESULT([no])])])
+
+    prte_hwloc_support=1
+    prte_hwloc_source=$1
+    prte_hwloc_support_will_build=yes
+ ])
+
+AC_DEFUN([_PRTE_HWLOC_EXTERNAL],[
+    PRTE_VAR_SCOPE_PUSH([prte_hwloc_dir prte_hwloc_libdir prte_hwloc_standard_lib_location prte_hwloc_standard_header_location prte_check_hwloc_save_CPPFLAGS prte_check_hwloc_save_LDFLAGS prte_check_hwloc_save_LIBS])
+
+    prte_hwloc_support=0
     prte_check_hwloc_save_CPPFLAGS="$CPPFLAGS"
     prte_check_hwloc_save_LDFLAGS="$LDFLAGS"
     prte_check_hwloc_save_LIBS="$LIBS"
     prte_hwloc_standard_header_location=yes
     prte_hwloc_standard_lib_location=yes
-    prte_have_topology_dup=0
 
-    if test "x$with_hwloc_header" != "x"; then
-        AS_IF([test "$with_hwloc_header" = "yes"],
-              [PRTE_HWLOC_HEADER="<hwloc.h>"],
-              [PRTE_HWLOC_HEADER="\"$with_hwloc_header\""
-               prte_hwloc_header_given=1])
-        prte_hwloc_support=1
-        prte_hwloc_source="external header"
-        prte_have_topology_dup=1
+    AS_IF([test "$with_hwloc" = "internal" || test "$with_hwloc" = "external"],
+          [with_hwloc=])
 
-    elif test "$with_hwloc" != "no"; then
+    if test "$with_hwloc" != "no"; then
         AC_MSG_CHECKING([for hwloc in])
         if test ! -z "$with_hwloc" && test "$with_hwloc" != "yes"; then
-            prte_hwloc_dir=$with_hwloc
+            prte_hwloc_dir=$with_hwloc/include
             prte_hwloc_standard_header_location=no
             prte_hwloc_standard_lib_location=no
             AS_IF([test -z "$with_hwloc_libdir" || test "$with_hwloc_libdir" = "yes"],
@@ -64,7 +158,7 @@ AC_DEFUN([PRTE_HWLOC_CONFIG],[
                    AC_MSG_RESULT([$prte_hwloc_dir and $prte_hwloc_libdir])],
                   [AC_MSG_RESULT([$with_hwloc_libdir])])
         else
-            prte_hwloc_dir=/usr
+            prte_hwloc_dir=/usr/include
             if test -d /usr/lib; then
                 prte_hwloc_libdir=/usr/lib
             elif test -d /usr/lib64; then
@@ -93,53 +187,58 @@ AC_DEFUN([PRTE_HWLOC_CONFIG],[
                            [prte_hwloc_support=1],
                            [prte_hwloc_support=0])
 
-        if test ! -z "$with_hwloc" && test "$with_hwloc" != "no" && test "$prte_hwloc_support" != "1"; then
-            AC_MSG_WARN([HWLOC SUPPORT REQUESTED AND NOT FOUND])
-            AC_MSG_ERROR([CANNOT CONTINUE])
-        fi
-
-        # update global flags to test for HWLOC version
         AS_IF([test "$prte_hwloc_standard_header_location" != "yes"],
               [PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_hwloc_CPPFLAGS)])
+
         AS_IF([test "$prte_hwloc_standard_lib_location" != "yes"],
               [PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_hwloc_LDFLAGS)])
         PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_hwloc_LIBS)
+    fi
 
-        if test $prte_hwloc_support = "1"; then
-            AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
-            AC_COMPILE_IFELSE(
-                  [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-                  [[
-            #if HWLOC_API_VERSION < 0x00010500
-            #error "hwloc API version is less than 0x00010500"
-            #endif
-                  ]])],
-                  [AC_MSG_RESULT([yes])],
-                  [AC_MSG_RESULT([no])
-                   AC_MSG_ERROR([Cannot continue])])
+    if test ! -z "$with_hwloc" && test "$with_hwloc" != "no" && test "$prte_hwloc_support" != "1"; then
+        AC_MSG_WARN([HWLOC SUPPORT REQUESTED AND NOT FOUND])
+        AC_MSG_ERROR([CANNOT CONTINUE])
+    fi
 
-            AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
-            AC_COMPILE_IFELSE(
-                  [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-                  [[
+    if test $prte_hwloc_support = "1"; then
+        AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
+        AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+              [[
+    #if HWLOC_API_VERSION < 0x00010500
+    #error "hwloc API version is less than 0x00010500"
+    #endif
+              ]])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+               AC_MSG_ERROR([Cannot continue])])
+    fi
+
+    AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
+    AC_COMPILE_IFELSE(
+        [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+			 [[
             #if HWLOC_API_VERSION < 0x00010800
             #error "hwloc API version is less than 0x00010800"
             #endif
-                  ]])],
-                  [AC_MSG_RESULT([yes])
-                   prte_have_topology_dup=1],
-                  [AC_MSG_RESULT([no])])
-        fi
-
-    fi
+			 ]])],
+        [AC_MSG_RESULT([yes])
+         prte_have_topology_dup=1],
+        [AC_MSG_RESULT([no])])
 
     CPPFLAGS=$prte_check_hwloc_save_CPPFLAGS
     LDFLAGS=$prte_check_hwloc_save_LDFLAGS
     LIBS=$prte_check_hwloc_save_LIBS
 
-    if test "$prte_hwloc_support" == "1"; then
-        AS_IF([test "$prte_hwloc_header_given" != "1"],
-              [PRTE_HWLOC_HEADER="<hwloc.h>"])
+    AC_MSG_CHECKING([will hwloc support be built])
+    if test "$prte_hwloc_support" != "1"; then
+        AC_MSG_RESULT([no])
+        prte_hwloc_source=none
+        prte_hwloc_support_will_build=no
+    else
+        AC_MSG_RESULT([yes])
+        prte_hwloc_source=$prte_hwloc_dir
+        prte_hwloc_support_will_build=yes
         AS_IF([test "$prte_hwloc_standard_header_location" != "yes"],
               [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_hwloc_CPPFLAGS)
                PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_hwloc_CPPFLAGS)])
@@ -149,35 +248,9 @@ AC_DEFUN([PRTE_HWLOC_CONFIG],[
                PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_hwloc_LDFLAGS)])
         PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_hwloc_LIBS)
         PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_hwloc_LIBS)
-        PRTE_HWLOC_HEADER="<hwloc.h>"
     fi
 
-    AC_MSG_CHECKING([hwloc header])
-    AC_DEFINE_UNQUOTED([PRTE_HWLOC_HEADER], [$PRTE_HWLOC_HEADER],
-                       [Location of hwloc.h])
-    AC_MSG_RESULT([$PRTE_HWLOC_HEADER])
-
-    AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC], [$prte_hwloc_support],
-                   [Whether or not we have hwloc support])
-
-    AC_DEFINE_UNQUOTED([PRTE_HWLOC_HEADER_GIVEN], [$prte_hwloc_header_given],
-                       [Whether or not the hwloc header was given to us])
-
-    AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC_TOPOLOGY_DUP], [$prte_have_topology_dup],
-                       [Whether or not hwloc_topology_dup is available])
-
-    AC_MSG_CHECKING([will hwloc support be built])
-    if test "$prte_hwloc_support" != "1"; then
-        AC_MSG_RESULT([no])
-        prte_hwloc_source=none
-        prte_hwloc_support_will_build=no
-    else
-        AC_MSG_RESULT([yes])
-        prte_hwloc_support_will_build=yes
-        prte_hwloc_source=$prte_hwloc_dir
-    fi
-
-    PRTE_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [prte_hwloc], [$prte_hwloc_support_will_build ($prte_hwloc_source)])
+    # Set output variables
 
     PRTE_VAR_SCOPE_POP
-])
+])dnl

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -7,6 +7,8 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2020-2021 Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -14,119 +16,233 @@
 # $HEADER$
 #
 
-# MCA_libevent_CONFIG([action-if-found], [action-if-not-found])
+#
+# We have three modes for building libevent.
+#
+# First is an embedded libevent, where PRTE is being built into
+# another library and assumes that libevent is available, that there
+# is a single header (pointed to by --with-libevent-header) which
+# includes all the Libevent bits, and that the right libevent
+# configuration is used.  This mode is used when --enable-embeded-mode
+# is specified to configure.
+#
+# Second is as a co-built libevent.  In this case, PRTE's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# libevent headers and LIBS will point to where the .la file for
+# libevent will exist.  When co-building, libevent's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-libevent=cobuild option is specified.
+#
+# Third is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# libevent.  This mode is used whenever the other modes are not used.
+#
+# This macro will change the environment in the following way:
+#
+#   * prte_libevent_support - set to 1 if libevent is found and works,
+#         set to 0 otherwise
+#
+# This macro will create the following AC_DEFINEs:
+#
+#   * PRTE_EVENT_HEADER - name of the Libevent header to include.
+#         Generally just <event.h>, unless embedded mode is enabled.
+#         This define is shared with prte_setup_libev.
+#
+#   * PRTE_EVENT2_THREAD_HEADER - name of the Libevent thread header
+#         to include. This is a historical artifact of how embed mode
+#         works and can be removed if/when embed mode dies
+#
+# PRTE_LIBEVENT_CONFIG([action-if-found], [action-if-not-found])
 # --------------------------------------------------------------------
 AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
-    PRTE_VAR_SCOPE_PUSH([prte_event_dir prte_event_libdir prte_event_defaults prte_check_libevent_save_CPPFLAGS prte_check_libevent_save_LDFLAGS prte_check_libevent_save_LIBS])
+    PRTE_VAR_SCOPE_PUSH([libevent_build_mode PRTE_EVENT_HEADER PRTE_EVENT2_THREAD_HEADER libevent_build_result prte_libevent_source])
 
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
-    AC_ARG_WITH([libevent-header],
-                [AS_HELP_STRING([--with-libevent-header=HEADER],
-                                [The value that should be included in C files to include event.h])])
 
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
 
+    AC_ARG_WITH([libevent-header],
+                [AS_HELP_STRING([--with-libevent-header=HEADER],
+                                [The value that should be included in C files to include event.h.  This option only has meaning if --enable-embedded-mode is enabled.])])
+
+    PRTE_EVENT_HEADER="<event.h>"
+    PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
+
     prte_libevent_support=0
-    prte_event_defaults=yes
+    prte_libevent_source=""
+    libevent_build_mode=""
+
+    # figure out our mode...
+    AS_IF([test "$prte_mode" = "embedded"],
+          [_PRTE_LIBEVENT_EMBEDDED_MODE(embedded)],
+          [test "$with_libevent" = "cobuild"],
+          [_PRTE_LIBEVENT_EMBEDDED_MODE(cobuild)],
+          [_PRTE_LIBEVENT_EXTERNAL])
+
+    AS_IF([test $prte_libevent_support -eq 1], [
+        AC_MSG_CHECKING([libevent header])
+        AC_DEFINE_UNQUOTED([PRTE_EVENT_HEADER], [$PRTE_EVENT_HEADER],
+                           [Location of event.h])
+        AC_MSG_RESULT([$PRTE_EVENT_HEADER])
+        AC_MSG_CHECKING([libevent2/thread header])
+        AC_DEFINE_UNQUOTED([PRTE_EVENT2_THREAD_HEADER], [$PRTE_EVENT2_THREAD_HEADER],
+                           [Location of event2/thread.h])
+        AC_MSG_RESULT([$PRTE_EVENT2_THREAD_HEADER])
+
+        libevent_build_result="yes ($prte_libevent_source)"
+    ], [libevent_build_result="no"])
+
+    PRTE_SUMMARY_ADD([[Required Packages]], [[Libevent]], [prte_libevent], [$libevent_build_result])
+
+    PRTE_VAR_SCOPE_POP
+])
+
+AC_DEFUN([_PRTE_LIBEVENT_EMBEDDED_MODE], [
+    AC_MSG_CHECKING([for libevent])
+    AC_MSG_RESULT([$1])
+
+    AS_IF([test -n "$with_libevent_header" && test "$with_libevent_header" != "yes"],
+          [PRTE_EVENT_HEADER="$with_libevent_header"
+           PRTE_EVENT2_THREAD_HEADER="$with_libevent_header"])
+
+    AS_IF([test "$1" == "cobuild"],
+        [AC_MSG_CHECKING([if co-built libevent includes thread support])
+         AC_TRY_COMPILE([#include <event.h>
+#include <event2/thread.h>
+           ],[
+#if !(EVTHREAD_LOCK_API_VERSION >= 1)
+#error "No threads!"
+#endif
+           ],[AC_MSG_RESULT([yes])],
+           [AC_MSG_RESULT([no])
+            AC_MSG_ERROR([No thread support in co-build libevent.  Aborting])])])
+
+    prte_libevent_source=$1
+    prte_libevent_support=1
+])
+
+AC_DEFUN([_PRTE_LIBEVENT_EXTERNAL],[
+    PRTE_VAR_SCOPE_PUSH([prte_event_dir prte_event_libdir prte_event_defaults prte_check_libevent_save_CPPFLAGS prte_check_libevent_save_LDFLAGS prte_check_libevent_save_LIBS])
 
     prte_check_libevent_save_CPPFLAGS="$CPPFLAGS"
     prte_check_libevent_save_LDFLAGS="$LDFLAGS"
     prte_check_libevent_save_LIBS="$LIBS"
+    prte_event_defaults=yes
 
-    if test "x$with_libevent_header" != "x"; then
-        AS_IF([test "$with_libevent_header" = "yes"],
-              [PRTE_EVENT_HEADER="<event.h>"
-               PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"],
-              [PRTE_EVENT_HEADER="\"$with_libevent_header\""
-               PRTE_EVENT2_THREAD_HEADER="\"$with_libevent_header\""])
-        prte_libevent_source="external header"
-        prte_libevent_support=1
+    # get rid of the trailing slash(es)
+    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
 
-    else
-        # get rid of any trailing slash(es)
-        libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-        libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
-
-        if test "$libevent_prefix" != "no"; then
-            AC_MSG_CHECKING([for libevent in])
-            if test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"; then
-                prte_event_defaults=no
-                prte_event_dir=$libevent_prefix
-                if test -d $libevent_prefix/lib64; then
-                    prte_event_libdir=$libevent_prefix/lib64
-                elif test -d $libevent_prefix/lib; then
-                    prte_event_libdir=$libevent_prefix/lib
-                elif test -d $libevent_prefix; then
-                    prte_event_libdir=$libevent_prefix
-                else
-                    AC_MSG_RESULT([Could not find $libevent_prefix/lib, $libevent_prefix/lib64, or $libevent_prefix])
-                    AC_MSG_ERROR([Can not continue])
-                fi
-                AC_MSG_RESULT([$prte_event_dir and $prte_event_libdir])
+    if test "$libevent_prefix" != "no"; then
+        AC_MSG_CHECKING([for libevent in])
+        if test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"; then
+            prte_event_defaults=no
+            prte_event_dir=$libevent_prefix/include
+            if test -d $libevent_prefix/lib; then
+                prte_event_libdir=$libevent_prefix/lib
+            elif test -d $libevent_prefix/lib64; then
+                prte_event_libdir=$libevent_prefix/lib64
+            elif test -d $libevent_prefix; then
+                prte_event_libdir=$libevent_prefix
             else
-                prte_event_defaults=yes
-                prte_event_dir=/usr
-                if test -d /usr/lib64; then
-                    prte_event_libdir=/usr/lib64
-                    AC_MSG_RESULT([(default search paths)])
-                elif test -d /usr/lib; then
-                    prte_event_libdir=/usr/lib
-                    AC_MSG_RESULT([(default search paths)])
-                else
-                    AC_MSG_RESULT([default paths not found])
-                    prte_libevent_support=0
-                fi
+                AC_MSG_RESULT([Could not find $libevent_prefix/lib, $libevent_prefix/lib64, or $libevent_prefix])
+                AC_MSG_ERROR([Can not continue])
             fi
-            AS_IF([test ! -z "$libeventdir_prefix" && "$libeventdir_prefix" != "yes"],
-                  [prte_event_libdir="$libeventdir_prefix"])
-
-            PRTE_CHECK_PACKAGE([prte_libevent],
-                               [event.h],
-                               [event_core],
-                               [event_config_new],
-                               [-levent_pthreads],
-                               [$prte_event_dir],
-                               [$prte_event_libdir],
-                               [prte_libevent_support=1],
-                               [prte_libevent_support=0])
-
-            # need to add resulting flags to global ones so we can
-            # test for thread support
-            AS_IF([test "$prte_event_defaults" = "no"],
-                  [PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_libevent_CPPFLAGS)
-                   PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_libevent_LDFLAGS)])
-            PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_libevent_LIBS)
-
-            if test $prte_libevent_support -eq 1; then
-                # Ensure that this libevent has the symbol
-                # "evthread_set_lock_callbacks", which will only exist if
-                # libevent was configured with thread support.
-                AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
-                             [],
-                             [AC_MSG_WARN([libevent does not have thread support])
-                              AC_MSG_WARN([PRTE requires libevent to be compiled with])
-                              AC_MSG_WARN([thread support enabled])
-                              prte_libevent_support=0])
-            fi
-            if test $prte_libevent_support -eq 1; then
-                AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
-                             [],
-                             [AC_MSG_WARN([libevent does not have thread support])
-                              AC_MSG_WARN([PRTE requires libevent to be compiled with])
-                              AC_MSG_WARN([thread support enabled])
-                              prte_libevent_support=0])
+            AC_MSG_RESULT([$prte_event_dir and $prte_event_libdir])
+        else
+            prte_event_defaults=yes
+            prte_event_dir=/usr/include
+            if test -d /usr/lib; then
+                prte_event_libdir=/usr/lib
+                AC_MSG_RESULT([(default search paths)])
+            elif test -d /usr/lib64; then
+                prte_event_libdir=/usr/lib64
+                AC_MSG_RESULT([(default search paths)])
+            else
+                AC_MSG_RESULT([default paths not found])
+                prte_libevent_support=0
             fi
         fi
-        prte_libevent_source=$prte_event_dir
+        AS_IF([test ! -z "$libeventdir_prefix" && "$libeventdir_prefix" != "yes"],
+              [prte_event_libdir="$libeventdir_prefix"])
+
+        PRTE_CHECK_PACKAGE([prte_libevent],
+                           [event.h],
+                           [event_core],
+                           [event_config_new],
+                           [-levent_pthreads],
+                           [$prte_event_dir],
+                           [$prte_event_libdir],
+                           [prte_libevent_support=1],
+                           [prte_libevent_support=0])
+
+        # Check to see if the above check failed because it conflicted with LSF's libevent.so
+        # This can happen if LSF's library is in the LDFLAGS envar or default search
+        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+        # in Libevent's libevent.so
+        if test $prte_libevent_support -eq 0; then
+            AC_CHECK_LIB([event], [event_getcode4name],
+                         [AC_MSG_WARN([===================================================================])
+                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                          AC_MSG_WARN([LSF library path.])
+                          AC_MSG_WARN([===================================================================])
+                          ])
+        fi
+
+        # need to add resulting flags to global ones so we can
+        # test for thread support
+        AS_IF([test "$prte_event_defaults" = "no"],
+              [PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_libevent_CPPFLAGS)
+               PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_libevent_LDFLAGS)])
+        PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_libevent_LIBS)
+
+        if test $prte_libevent_support -eq 1; then
+            # Ensure that this libevent has the symbol
+            # "evthread_set_lock_callbacks", which will only exist if
+            # libevent was configured with thread support.
+            AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
+                         [],
+                         [AC_MSG_WARN([External libevent does not have thread support])
+                          AC_MSG_WARN([Prte requires libevent to be compiled with])
+                          AC_MSG_WARN([thread support enabled])
+                          prte_libevent_support=0])
+        fi
+        if test $prte_libevent_support -eq 1; then
+            AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
+                         [],
+                         [AC_MSG_WARN([External libevent does not have thread support])
+                          AC_MSG_WARN([Prte requires libevent to be compiled with])
+                          AC_MSG_WARN([thread support enabled])
+                          prte_libevent_support=0])
+        fi
     fi
+
+    CPPFLAGS="$prte_check_libevent_save_CPPFLAGS"
+    LDFLAGS="$prte_check_libevent_save_LDFLAGS"
+    LIBS="$prte_check_libevent_save_LIBS"
 
     AC_MSG_CHECKING([will libevent support be built])
     if test $prte_libevent_support -eq 1; then
         AC_MSG_RESULT([yes])
+        # Set output variables
+        PRTE_EVENT_HEADER="<event.h>"
+        PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
+        AC_DEFINE_UNQUOTED([PRTE_EVENT_HEADER], [$PRTE_EVENT_HEADER],
+                           [Location of event.h])
+        prte_libevent_source=$prte_event_dir
         AS_IF([test "$prte_event_defaults" = "no"],
               [PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_libevent_CPPFLAGS)
                PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_libevent_CPPFLAGS)
@@ -134,24 +250,9 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
                PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_libevent_LDFLAGS)])
         PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_libevent_LIBS)
         PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_libevent_LIBS)
-        PRTE_EVENT_HEADER="<event.h>"
-        PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
-        # Set output variables
-        AC_DEFINE_UNQUOTED([PRTE_EVENT_HEADER], [$PRTE_EVENT_HEADER],
-                           [Location of event.h])
-        AC_DEFINE_UNQUOTED([PRTE_EVENT2_THREAD_HEADER], [$PRTE_EVENT2_THREAD_HEADER],
-                           [Location of event2/thread.h])
-        PRTE_SUMMARY_ADD([[Required Packages]],[[Libevent]], [prte_libevent], [yes ($prte_libevent_source)])
     else
         AC_MSG_RESULT([no])
     fi
 
-    # restore global flags
-    CPPFLAGS="$prte_check_libevent_save_CPPFLAGS"
-    LDFLAGS="$prte_check_libevent_save_LDFLAGS"
-    LIBS="$prte_check_libevent_save_LIBS"
-
-    AC_DEFINE_UNQUOTED([PRTE_HAVE_LIBEVENT], [$prte_libevent_support], [Whether we are building against libevent])
-
     PRTE_VAR_SCOPE_POP
-])
+])dnl

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -1,4 +1,4 @@
-# -*- shell-script ; indent-tabs-mode:nil -*-
+# -*- autoconf ; indent-tabs-mode:nil -*-
 #
 # Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
 #                         University Research and Technology
@@ -18,6 +18,8 @@
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,9 +27,33 @@
 # $HEADER$
 #
 
+#
+# We have three modes for building PMIx.
+#
+# First is an embedded PMIx, where PRTE is being built into
+# another library and assumes that PMIx is available, that there
+# is a single header (pointed to by --with-pmix-header) which
+# includes all the PMIx bits, and that the right PMIx
+# configuration is used.  This mode is used when --enable-embeded-mode
+# is specified to configure.
+#
+# Second is as a co-built hwloc.  In this case, PRTE's CPPFLAGS
+# will be set before configure to include the right -Is to pick up
+# PMIx headers and LIBS will point to where the .la file for
+# PMIx will exist.  When co-building, PMIX's configure will be
+# run already, but the library will not yet be built.  It is ok to run
+# any compile-time (not link-time) tests in this mode.  This mode is
+# used when the --with-pmix=cobuild option is specified.
+#
+# Third is an external package.  In this case, all compile and link
+# time tests can be run.  This macro must do any CPPFLAGS/LDFLAGS/LIBS
+# modifications it desires in order to compile and link against
+# PMIx.  This mode is used whenever the other modes are not used.
+#
+# PRTE_CHECK_PMIX[action-if-found], [action-if-not-found])
+# --------------------------------------------------------------------
 AC_DEFUN([PRTE_CHECK_PMIX],[
-
-    PRTE_VAR_SCOPE_PUSH([prte_external_pmix_save_CPPFLAGS prte_external_pmix_save_LDFLAGS prte_external_pmix_save_LIBS prte_external_pmix_version_found prte_external_pmix_version])
+    PRTE_VAR_SCOPE_PUSH([prte_pmix_support prte_pmix_source prte_pmix_support_will_build prte_pmix_header_given])
 
     AC_ARG_WITH([pmix],
                 [AS_HELP_STRING([--with-pmix(=DIR)],
@@ -45,148 +71,189 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                   [AS_HELP_STRING([--enable-pmix-devel-support],
                                   [Add necessary wrapper flags to enable access to PMIx devel headers])])
 
-    if test "x$with_pmix_header" != "x"; then
-        AS_IF([test "$with_pmix_header" = "yes"],
-              [PRTE_PMIX_HEADER="<pmix.h>"
-               prte_pmix_header_given=0],
-              [PRTE_PMIX_HEADER="\"$with_pmix_header\""
-               prte_pmix_header_given=1])
-        pmix_ext_install_dir="external header"
+    prte_pmix_support=0
+    prte_pmix_source=""
+    prte_pmix_support_will_build=no
+    prte_pmix_header_given=0
+    PRTE_PMIX_HEADER="<pmix.h>"
 
-    elif test "$with_pmix" = "no"; then
-        AC_MSG_WARN([PRTE requires PMIx support using])
-        AC_MSG_WARN([an external copy that you supply.])
-        AC_MSG_ERROR([Cannot continue])
+    # figure out our mode...
+    AS_IF([test "$prte_mode" = "embedded"],
+          [_PRTE_PMIX_EMBEDDED_MODE(embedded)],
+          [test "$with_pmix" = "cobuild"],
+          [_PRTE_PMIX_EMBEDDED_MODE(cobuild)],
+	  [test "$with_pmix" = "no"],
+          [AC_MSG_WARN([PRTE requires a PMIx 4.0 or newer library to build.])
+           AC_MSG_ERROR([Cannot continue])],
+          [_PRTE_PMIX_EXTERNAL])
 
-    else
-        prte_pmix_header_given=0
-        PRTE_PMIX_HEADER="<pmix.h>"
-        # check for external pmix lib */
-        AS_IF([test -z "$with_pmix"],
-              [pmix_ext_install_dir=/usr],
-              [pmix_ext_install_dir=$with_pmix])
+    AS_IF([test $prte_pmix_support -eq 1],
+          [AC_MSG_CHECKING([pmix header])
+           AC_MSG_RESULT([$PRTE_PMIX_HEADER])])
 
-        # Make sure we have the headers and libs in the correct location
-        PRTE_CHECK_WITHDIR([pmix], [$pmix_ext_install_dir/include], [pmix.h])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER], [$PRTE_PMIX_HEADER],
+                   [Location of pmix.h])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER_GIVEN], [$prte_pmix_header_given],
+                       [Whether or not the pmix header was given to us])
 
-        AS_IF([test -n "$with_pmix_libdir"],
-              [AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir])
-               files=`ls $with_pmix_libdir/libpmix.* 2> /dev/null | wc -l`
-               AS_IF([test "$files" -gt 0],
-                     [AC_MSG_RESULT([found])
-                      pmix_ext_install_libdir=$with_pmix_libdir],
-                     [AC_MSG_RESULT([not found])
-                      AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib64])
-                      files=`ls $with_pmix_libdir/lib64/libpmix.* 2> /dev/null | wc -l`
-                      AS_IF([test "$files" -gt 0],
-                            [AC_MSG_RESULT([found])
-                             pmix_ext_install_libdir=$with_pmix_libdir/lib64],
-                            [AC_MSG_RESULT([not found])
-                             AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib])
-                             files=`ls $with_pmix_libdir/lib/libpmix.* 2> /dev/null | wc -l`
-                             AS_IF([test "$files" -gt 0],
-                                   [AC_MSG_RESULT([found])
-                                    pmix_ext_install_libdir=$with_pmix_libdir/lib],
-                                    [AC_MSG_RESULT([not found])
-                                     AC_MSG_ERROR([Cannot continue])])])])],
-              [# check for presence of lib64 directory - if found, see if the
-               # desired library is present and matches our build requirements
-               AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib64])
-               files=`ls $pmix_ext_install_dir/lib64/libpmix.* 2> /dev/null | wc -l`
-               AS_IF([test "$files" -gt 0],
-               [AC_MSG_RESULT([found])
-                pmix_ext_install_libdir=$pmix_ext_install_dir/lib64],
-               [AC_MSG_RESULT([not found])
-                AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib])
-                files=`ls $pmix_ext_install_dir/lib/libpmix.* 2> /dev/null | wc -l`
-                AS_IF([test "$files" -gt 0],
+    PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]], [pmix], [$prte_pmix_support_will_build ($prte_pmix_source)])
+
+    PRTE_VAR_SCOPE_POP
+])
+
+AC_DEFUN([_PRTE_PMIX_EMBEDDED_MODE], [
+    AC_MSG_CHECKING([for PMIx])
+    AC_MSG_RESULT([$1])
+
+    AS_IF([test "$1" == "embedded"], [
+        AS_IF([test -n "$with_pmix_header" && test "$with_pmix_header" != "yes"],
+              [prte_pmix_header_given=1
+               PRTE_PMIX_HEADER="$with_pmix_header"])])
+
+    AS_IF([test "$1" == "cobuild"],
+           [AC_MSG_CHECKING([if cobuild PMIx version is 4.1 or greater])
+            AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <pmix.h>]],
+              [[
+    #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+    #  error "PMIx version not version 4.1 or above"
+    #endif
+              ]])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+               AC_MSG_ERROR([Cannot continue])])])
+
+    prte_pmix_support=1
+    prte_pmix_source=$1
+    prte_pmix_support_will_build=yes
+])
+
+AC_DEFUN([_PRTE_PMIX_EXTERNAL], [
+    PRTE_VAR_SCOPE_PUSH([prte_external_pmix_save_CPPFLAGS prte_external_pmix_save_LDFLAGS prte_external_pmix_save_LIBS prte_external_pmix_version_found prte_external_pmix_version pmix_ext_install_dir])
+
+    # check for external pmix lib */
+    AS_IF([test -z "$with_pmix"],
+          [pmix_ext_install_dir=/usr],
+          [pmix_ext_install_dir=$with_pmix])
+
+    # Make sure we have the headers and libs in the correct location
+    PRTE_CHECK_WITHDIR([pmix], [$pmix_ext_install_dir/include], [pmix.h])
+
+    AS_IF([test -n "$with_pmix_libdir"],
+          [AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir])
+           files=`ls $with_pmix_libdir/libpmix.* 2> /dev/null | wc -l`
+           AS_IF([test "$files" -gt 0],
+                 [AC_MSG_RESULT([found])
+                  pmix_ext_install_libdir=$with_pmix_libdir],
+                 [AC_MSG_RESULT([not found])
+                  AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib64])
+                  files=`ls $with_pmix_libdir/lib64/libpmix.* 2> /dev/null | wc -l`
+                  AS_IF([test "$files" -gt 0],
+                        [AC_MSG_RESULT([found])
+                         pmix_ext_install_libdir=$with_pmix_libdir/lib64],
+                        [AC_MSG_RESULT([not found])
+                         AC_MSG_CHECKING([libpmix.* in $with_pmix_libdir/lib])
+                         files=`ls $with_pmix_libdir/lib/libpmix.* 2> /dev/null | wc -l`
+                         AS_IF([test "$files" -gt 0],
+                               [AC_MSG_RESULT([found])
+                                pmix_ext_install_libdir=$with_pmix_libdir/lib],
+                                [AC_MSG_RESULT([not found])
+                                 AC_MSG_ERROR([Cannot continue])])])])],
+          [# check for presence of lib64 directory - if found, see if the
+           # desired library is present and matches our build requirements
+           AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib64])
+           files=`ls $pmix_ext_install_dir/lib64/libpmix.* 2> /dev/null | wc -l`
+           AS_IF([test "$files" -gt 0],
+           [AC_MSG_RESULT([found])
+            pmix_ext_install_libdir=$pmix_ext_install_dir/lib64],
+           [AC_MSG_RESULT([not found])
+            AC_MSG_CHECKING([libpmix.* in $pmix_ext_install_dir/lib])
+            files=`ls $pmix_ext_install_dir/lib/libpmix.* 2> /dev/null | wc -l`
+            AS_IF([test "$files" -gt 0],
+                  [AC_MSG_RESULT([found])
+                   pmix_ext_install_libdir=$pmix_ext_install_dir/lib],
+                  [AC_MSG_RESULT([not found])
+                   AC_MSG_ERROR([Cannot continue])])])])
+
+    # check the version
+    prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
+    prte_external_pmix_save_LDFLAGS=$LDFLAGS
+    prte_external_pmix_save_LIBS=$LIBS
+
+    # if the pmix_version.h file does not exist, then
+    # this must be from a pre-1.1.5 version
+    AC_MSG_CHECKING([for PMIx version file])
+    CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
+    AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
+           [AC_MSG_RESULT([not found - assuming pre-v2.0])
+            AC_MSG_WARN([PRTE does not support PMIx versions])
+            AC_MSG_WARN([less than v4.01 as only PMIx-based tools can])
+            AC_MSG_WARN([can connect to the server.])
+            AC_MSG_ERROR([Please select a newer version and configure again])],
+           [AC_MSG_RESULT([found])
+            prte_external_pmix_version_found=0])
+
+    # if it does exist, then we need to parse it to find
+    # the actual release series
+    AC_MSG_CHECKING([version 4x])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <pmix_version.h>
+                                        #if (PMIX_VERSION_MAJOR < 4L)
+                                        #error "not version 4 or above"
+                                        #endif
+                                       ], [])],
                       [AC_MSG_RESULT([found])
-                       pmix_ext_install_libdir=$pmix_ext_install_dir/lib],
-                      [AC_MSG_RESULT([not found])
-                       AC_MSG_ERROR([Cannot continue])])])])
+                       prte_external_pmix_version=4x
+                       prte_external_pmix_version_found=4],
+                      [AC_MSG_RESULT([not found])])
 
-        # check the version
-        prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
-        prte_external_pmix_save_LDFLAGS=$LDFLAGS
-        prte_external_pmix_save_LIBS=$LIBS
+    AS_IF([test "$prte_external_pmix_version_found" = "4"],
+           [AC_MSG_CHECKING([version 4.1 or greater])
+            AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                #include <pmix_version.h>
+                                                #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+                                                #error "not version 4.1 or above"
+                                                #endif
+                                               ], [])],
+                              [AC_MSG_RESULT([found])],
+                              [AC_MSG_RESULT([not found])
+                               prte_external_pmix_version_found=0])])
 
-        # if the pmix_version.h file does not exist, then
-        # this must be from a pre-1.1.5 version
-        AC_MSG_CHECKING([for PMIx version file])
-        CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
-        AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
-               [AC_MSG_RESULT([not found - assuming pre-v2.0])
-                AC_MSG_WARN([PRTE does not support PMIx versions])
-                AC_MSG_WARN([less than v4.01 as only PMIx-based tools can])
-                AC_MSG_WARN([can connect to the server.])
-                AC_MSG_ERROR([Please select a newer version and configure again])],
-               [AC_MSG_RESULT([found])
-                prte_external_pmix_version_found=0])
+    # restore the global flags
+    CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
+    LDFLAGS=$prte_external_pmix_save_LDFLAGS
+    LIBS=$prte_external_pmix_save_LIBS
 
-        # if it does exist, then we need to parse it to find
-        # the actual release series
-        AC_MSG_CHECKING([version 4x])
-        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                            #include <pmix_version.h>
-                                            #if (PMIX_VERSION_MAJOR < 4L)
-                                            #error "not version 4 or above"
-                                            #endif
-                                           ], [])],
-                          [AC_MSG_RESULT([found])
-                           prte_external_pmix_version=4x
-                           prte_external_pmix_version_found=4],
-                          [AC_MSG_RESULT([not found])])
+    AS_IF([test "$prte_external_pmix_version_found" = "0"],
+          [AC_MSG_WARN([PRTE does not support PMIx versions])
+           AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
+           AC_MSG_WARN([can connect to the server.])
+           AC_MSG_ERROR([Please select a newer version and configure again])])
 
-        AS_IF([test "$prte_external_pmix_version_found" = "4"],
-              [AC_MSG_CHECKING([version 4.1 or greater])
-                AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                    #include <pmix_version.h>
-                                                    #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
-                                                    #error "not version 4.1 or above"
-                                                    #endif
-                                                   ], [])],
-                                  [AC_MSG_RESULT([found])],
-                                  [AC_MSG_RESULT([not found])
-                                   prte_external_pmix_version_found=0])])
+    AS_IF([test "x$prte_external_pmix_version" = "x"],
+          [AC_MSG_WARN([PMIx version information could not])
+           AC_MSG_WARN([be detected])
+           AC_MSG_ERROR([cannot continue])])
 
-        # restore the global flags
-        CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
-        LDFLAGS=$prte_external_pmix_save_LDFLAGS
-        LIBS=$prte_external_pmix_save_LIBS
+    AS_IF([test "$pmix_ext_install_dir" != "/usr"],
+          [prte_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
+           prte_pmix_LDFLAGS="-L$pmix_ext_install_libdir"])
 
-        AS_IF([test "$prte_external_pmix_version_found" = "0"],
-              [AC_MSG_WARN([PRTE does not support PMIx versions])
-               AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
-               AC_MSG_WARN([can connect to the server.])
-               AC_MSG_ERROR([Please select a newer version and configure again])])
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
+    PRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [$prte_pmix_CPPFLAGS])
 
-        AS_IF([test "x$prte_external_pmix_version" = "x"],
-              [AC_MSG_WARN([PMIx version information could not])
-               AC_MSG_WARN([be detected])
-               AC_MSG_ERROR([cannot continue])])
+    AS_IF([test "$enable_pmix_devel_support" = "yes"],
+          [PRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include/pmix -I$pmix_ext_install_dir/include/pmix/src -I$pmix_ext_install_dir/include/pmix/src/include])])
 
-        AS_IF([test "$pmix_ext_install_dir" != "/usr"],
-              [prte_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
-               prte_pmix_LDFLAGS="-L$pmix_ext_install_libdir"])
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
+    PRTE_WRAPPER_FLAGS_ADD([LDFLAGS], [$prte_pmix_LDFLAGS])
 
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
-        PRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [$prte_pmix_CPPFLAGS])
+    prte_pmix_LIBS=-lpmix
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
+    PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_pmix_LIBS)
 
-        AS_IF([test "$enable_pmix_devel_support" = "yes"],
-              [PRTE_WRAPPER_FLAGS_ADD([CPPFLAGS], [-I$pmix_ext_install_dir/include/pmix -I$pmix_ext_install_dir/include/pmix/src -I$pmix_ext_install_dir/include/pmix/src/include])])
-
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
-        PRTE_WRAPPER_FLAGS_ADD([LDFLAGS], [$prte_pmix_LDFLAGS])
-
-        prte_pmix_LIBS=-lpmix
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
-        PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_pmix_LIBS)
-    fi
-
-    AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER], [$PRTE_PMIX_HEADER], [PMIx header to use])
-    AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER_GIVEN], [$prte_pmix_header_given], [Whether or not the PMIx header was explicitly passed])
-
-    PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]],[pmix],[yes ($pmix_ext_install_dir)])
+    prte_pmix_support_will_build=yes
+    prte_pmix_source=$pmix_ext_install_dir
 
     PRTE_VAR_SCOPE_POP
 ])


### PR DESCRIPTION
Similar to work previously done in PMIx, support building PRTE as a
3rd-party Open MPI library, but without the co-dependent headers (I
call this "cobuild").  THis is step 1 in cleaning up all the header
redirection bits (which will require changes in Open MPI as well).

Signed-off-by: Brian Barrett <bbarrett@amazon.com>