### PR TITLE
dist: Do not require Flex on tarball builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -881,7 +881,7 @@ AC_PROG_EGREP
 #
 
 AM_PROG_AS
-AC_PROG_LEX(yywrap)
+AC_PROG_LEX(noyywrap)
 
 # If we don't have Flex and we don't have a generated .c file
 # (distribution tarballs will have the .c file included, but git
@@ -893,7 +893,7 @@ AC_PROG_LEX(yywrap)
 if test -z "$LEX" || \
    test -n "`echo $LEX | $GREP missing`" || \
    test "`basename $LEX`" != "flex"; then
-    if test ! -f "$srcdir/prte/util/show_help_lex.c"; then
+    if test ! -f "$srcdir/src/util/show_help_lex.c"; then
         AC_MSG_WARN([*** Could not find Flex on your system.])
         AC_MSG_WARN([*** Flex is required for developer builds of PRTE.])
         AC_MSG_WARN([*** Other versions of Lex are not supported.])


### PR DESCRIPTION
Two different issues meant that PRRTE would require Flex even when
building from a distribution tarball; this patch fixes both issues.
First issue was looking for the wrong file to make sure the generated
files do not exist before showing an error.  Second issue is that
AC_PROG_LEX(yywrap), the update from AM_PROG_LEX to support Autoconf
2.70, meant that configure was looking for the library to support
Flex.  Setting AC_PROG_LEX(noyywrap) avoids that search, which will
eliminate the scary warning about libraries not found.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>