### PR TITLE
Fix detection of "localhost" nodename

### DIFF
--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -50,6 +50,11 @@ static bool quickmatch(prte_node_t *nd, char *name)
     if (0 == strcmp(nd->name, name)) {
         return true;
     }
+    if (0 == strcmp(nd->name, prte_process_info.nodename) &&
+        (0 == strcmp(name, "localhost") ||
+         0 == strcmp(name, "127.0.0.1"))) {
+        return true;
+    }
     if (NULL != nd->aliases) {
         for (n=0; NULL != nd->aliases[n]; n++) {
             if (0 == strcmp(nd->aliases[n], name)) {


### PR DESCRIPTION
Catch it when computing slots for -host option

Signed-off-by: Ralph Castain <rhc@pmix.org>