### PR TITLE
Ensure prterun outputs the job's IOF when no tool is present

### DIFF
--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -885,6 +885,11 @@ int prte(int argc, char *argv[])
         PMIX_VALUE_RELEASE(val);
     }
 
+    /* if we don't have a parent, then we need to output this job's IOF */
+    if (PMIX_CHECK_PROCID(&parent, &prte_process_info.myproc)) {
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_LOCAL_OUTPUT, NULL, PMIX_BOOL);
+    }
+
     /* pass the personality */
     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, personality, PMIX_STRING);
 


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>