### PR TITLE
Add initial support for the Hydra launcher

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -88,11 +88,18 @@ PRTE_EXPORT char *prte_schizo_base_getline(FILE *fp);
 PRTE_EXPORT bool prte_schizo_base_check_ini(char *cmdpath, char *file);
 PRTE_EXPORT char *prte_schizo_base_strip_quotes(char *p);
 PRTE_EXPORT int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline, int *argc,
-                                                        char ***argv, char **options,
+                                                        char ***argv, char **options, bool single_dash_okay,
                                                         prte_schizo_convertor_fn_t convert);
 PRTE_EXPORT int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target);
 PRTE_EXPORT int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target);
 PRTE_EXPORT int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line);
+PRTE_EXPORT bool prte_schizo_base_check_directives(char *directive,
+                                                   char **valid,
+                                                   char **quals,
+                                                   char *dir);
+PRTE_EXPORT bool prte_schizo_base_check_qualifiers(char *directive,
+                                                   char **valid,
+                                                   char *qual);
 
 END_C_DECLS
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -362,9 +362,9 @@ int prte_schizo_base_convert(char ***argv, int idx, int ntodelete, char *option,
     return PRTE_SUCCESS;
 }
 
-static bool check_qualifiers(char *directive,
-                             char **valid,
-                             char *qual)
+bool prte_schizo_base_check_qualifiers(char *directive,
+                                       char **valid,
+                                       char *qual)
 {
     size_t n, len, l1, l2;
     char *v;
@@ -385,10 +385,10 @@ static bool check_qualifiers(char *directive,
     return false;
 }
 
-static bool check_directives(char *directive,
-                             char **valid,
-                             char **quals,
-                             char *dir)
+bool prte_schizo_base_check_directives(char *directive,
+                                       char **valid,
+                                       char **quals,
+                                       char *dir)
 {
     size_t n, m, len, l1, l2;
     char **args, **qls, *v, *q;
@@ -399,7 +399,13 @@ static bool check_directives(char *directive,
 
     /* if it starts with a ':', then these are just modifiers */
     if (':' == dir[0]) {
-        return check_qualifiers(directive, quals, &dir[1]);
+        return prte_schizo_base_check_qualifiers(directive, quals, &dir[1]);
+    }
+    /* always accept the "help" directive */
+    if (0 == strcasecmp(dir, "help") ||
+        0 == strcasecmp(dir, "-help") ||
+        0 == strcasecmp(dir, "--help")) {
+        return true;
     }
 
     args = prte_argv_split(dir, ':');
@@ -459,7 +465,7 @@ static bool check_directives(char *directive,
                     qls = prte_argv_split(args[1], ',');
                 }
                for (m=0; NULL != qls[m]; m++) {
-                    if (!check_qualifiers(directive, quals, qls[m])) {
+                    if (!prte_schizo_base_check_qualifiers(directive, quals, qls[m])) {
                         prte_argv_free(qls);
                         prte_argv_free(args);
                         return false;
@@ -531,19 +537,19 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
         if (NULL != strcasestr(pval->value.data.string, "HWTCPUS")) {
             hwtcpus = true;
         }
-        if (!check_directives("map-by", mappers, mapquals, pval->value.data.string)) {
+        if (!prte_schizo_base_check_directives("map-by", mappers, mapquals, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
     }
 
     if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rank-by", 0, 0))) {
-        if (!check_directives("rank-by", rankers, rkquals, pval->value.data.string)) {
+        if (!prte_schizo_base_check_directives("rank-by", rankers, rkquals, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
     }
 
     if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "bind-to", 0, 0))) {
-        if (!check_directives("bind-to", binders, bndquals, pval->value.data.string)) {
+        if (!prte_schizo_base_check_directives("bind-to", binders, bndquals, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
         if (0 == strncasecmp(pval->value.data.string, "HWTHREAD", strlen("HWTHREAD")) && !hwtcpus) {
@@ -555,13 +561,13 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
     }
 
     if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "output", 0, 0))) {
-        if (!check_directives("output", outputs, outquals, pval->value.data.string)) {
+        if (!prte_schizo_base_check_directives("output", outputs, outquals, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
     }
 
     if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "display", 0, 0))) {
-        if (!check_directives("display", displays, NULL, pval->value.data.string)) {
+        if (!prte_schizo_base_check_directives("display", displays, NULL, pval->value.data.string)) {
             return PRTE_ERR_SILENT;
         }
     }

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -177,7 +177,8 @@ void prte_schizo_base_finalize(void)
 }
 
 int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***argv,
-                                            char **options, prte_schizo_convertor_fn_t convert)
+                                            char **options, bool single_dash_okay,
+                                            prte_schizo_convertor_fn_t convert)
 {
     int pargc;
     char **pargs, *p2;
@@ -214,7 +215,7 @@ int prte_schizo_base_process_deprecated_cli(prte_cmd_line_t *cmdline, int *argc,
              * change it and don't emit an error */
             if (0 == strcmp(p2, "-np")) {
                 free(p2);
-            } else {
+            } else if (!single_dash_okay) {
                 prte_show_help("help-schizo-base.txt", "single-dash-error", true, p2, pargs[i]);
                 free(p2);
                 ret = PRTE_OPERATION_SUCCEEDED;

--- a/src/mca/schizo/hydra/Makefile.am
+++ b/src/mca/schizo/hydra/Makefile.am
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CFLAGS = \
+            -DDEFAULT_PARAM_FILE_PATH="\"@AMCA_PARAM_SETS_DIR@\""
+
+sources = \
+          schizo_hydra_component.c \
+          schizo_hydra.h \
+          schizo_hydra.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_schizo_hydra_DSO
+component_noinst =
+component_install = mca_schizo_hydra.la
+else
+component_noinst = libmca_schizo_hydra.la
+component_install =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_schizo_hydra_la_SOURCES = $(sources)
+mca_schizo_hydra_la_LDFLAGS = -module -avoid-version
+mca_schizo_hydra_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_schizo_hydra_la_SOURCES = $(sources)
+libmca_schizo_hydra_la_LDFLAGS = -module -avoid-version

--- a/src/mca/schizo/hydra/schizo_hydra.c
+++ b/src/mca/schizo/hydra/schizo_hydra.c
@@ -1,0 +1,894 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "prte_config.h"
+#include "types.h"
+
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+
+#include <ctype.h>
+
+#ifdef HAVE_SYS_UTSNAME_H
+#    include <sys/utsname.h>
+#endif
+
+#include "src/util/argv.h"
+#include "src/util/keyval_parse.h"
+#include "src/util/name_fns.h"
+#include "src/util/os_dirpath.h"
+#include "src/util/os_path.h"
+#include "src/util/path.h"
+#include "src/util/prte_environ.h"
+#include "src/util/session_dir.h"
+#include "src/util/show_help.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/ess/base/base.h"
+#include "src/mca/rmaps/rmaps_types.h"
+#include "src/runtime/prte_globals.h"
+
+#include "schizo_hydra.h"
+#include "src/mca/schizo/base/base.h"
+
+static int define_cli(prte_cmd_line_t *cli);
+static int check_help(prte_cmd_line_t *cli, char **argv);
+static int parse_cli(int argc, int start, char **argv, char ***target);
+static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***argv);
+static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, bool cmdline);
+static int detect_proxy(char *argv);
+static void allow_run_as_root(prte_cmd_line_t *cmd_line);
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
+static int check_sanity(prte_cmd_line_t *cmd_line);
+
+prte_schizo_base_module_t prte_schizo_hydra_module = {
+    .name = "hydra",
+    .define_cli = define_cli,
+    .check_help = check_help,
+    .parse_cli = parse_cli,
+    .parse_deprecated_cli = parse_deprecated_cli,
+    .parse_env = parse_env,
+    .detect_proxy = detect_proxy,
+    .allow_run_as_root = allow_run_as_root,
+    .job_info = job_info,
+    .check_sanity = check_sanity
+};
+
+static prte_cmd_line_init_t hydra_cmd_line_init[] = {
+    /* basic options */
+    {'h', "help", 0, PRTE_CMD_LINE_TYPE_BOOL, "This help message", PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'V', "version", 0, PRTE_CMD_LINE_TYPE_BOOL, "Print version and exit",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'v', "verbose", 0, PRTE_CMD_LINE_TYPE_BOOL, "Be verbose", PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'q', "quiet", 0, PRTE_CMD_LINE_TYPE_BOOL, "Suppress helpful messages",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'\0', "parsable", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "When used in conjunction with other parameters, the output is displayed in a "
+     "machine-parsable format",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'\0', "parseable", 0, PRTE_CMD_LINE_TYPE_BOOL, "Synonym for --parsable",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+
+    /* mpirun options */
+    /* Specify the launch agent to be used */
+    {'\0', "launch-agent", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Name of daemon executable used to start processes on remote nodes (default: prted)",
+     PRTE_CMD_LINE_OTYPE_DVM},
+    /* maximum size of VM - typically used to subdivide an allocation */
+    {'\0', "max-vm-size", 1, PRTE_CMD_LINE_TYPE_INT, "Number of daemons to start",
+     PRTE_CMD_LINE_OTYPE_DVM},
+    {'\0', "debug-daemons", 0, PRTE_CMD_LINE_TYPE_BOOL, "Debug daemons", PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "debug-daemons-file", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Enable debugging of any PRTE daemons used by this application, storing output in files",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "leave-session-attached", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Do not discard stdout/stderr of remote PRTE daemons", PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "tmpdir", 1, PRTE_CMD_LINE_TYPE_STRING, "Set the root for the session directory tree",
+     PRTE_CMD_LINE_OTYPE_DVM},
+    {'\0', "prefix", 1, PRTE_CMD_LINE_TYPE_STRING, "Prefix to be used to look for RTE executables",
+     PRTE_CMD_LINE_OTYPE_DVM},
+    {'\0', "noprefix", 0, PRTE_CMD_LINE_TYPE_BOOL, "Disable automatic --prefix behavior",
+     PRTE_CMD_LINE_OTYPE_DVM},
+
+    /* setup MCA parameters */
+    {'\0', "omca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass context-specific HYDRA MCA parameters; they are considered global if --gmca is not used "
+     "and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "gomca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass global HYDRA MCA parameters that are applicable to all contexts (arg0 is the parameter "
+     "name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "mca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass context-specific MCA parameters; they are considered global if --gmca is not used and "
+     "only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    /* setup MCA parameters */
+    {'\0', "prtemca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass context-specific PRTE MCA parameters; they are considered global if --gmca is not used "
+     "and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "pmixmca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass context-specific PMIx MCA parameters; they are considered global if --gmca is not used "
+     "and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "gpmixmca", 2, PRTE_CMD_LINE_TYPE_STRING,
+     "Pass global PMIx MCA parameters that are applicable to all contexts (arg0 is the parameter "
+     "name; arg1 is the parameter value)",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "tune", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "File(s) containing MCA params for tuning DVM operations", PRTE_CMD_LINE_OTYPE_DVM},
+
+    /* forward signals */
+    {'\0', "forward-signals", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Comma-delimited list of additional signals (names or integers) to forward to "
+     "application processes [\"none\" => forward nothing]. Signals provided by "
+     "default include SIGTSTP, SIGUSR1, SIGUSR2, SIGABRT, SIGALRM, and SIGCONT",
+     PRTE_CMD_LINE_OTYPE_DVM},
+
+    {'\0', "debug", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Top-level PRTE debug switch (default: false) "
+     "This CLI option will be deprecated starting in Open MPI v5",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "debug-verbose", 1, PRTE_CMD_LINE_TYPE_INT,
+     "Verbosity level for PRTE debug messages (default: 1)", PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'d', "debug-devel", 0, PRTE_CMD_LINE_TYPE_BOOL, "Enable debugging of PRTE",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+
+    {'\0', "timeout", 1, PRTE_CMD_LINE_TYPE_INT,
+     "Timeout the job after the specified number of seconds", PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "report-state-on-timeout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Report all job and process states upon timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Get stack traces of all application procs on timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
+
+    {'\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Allow execution as root (STRONGLY DISCOURAGED)", PRTE_CMD_LINE_OTYPE_DVM}, /* End of list */
+    /* fwd mpirun port */
+    {'\0', "fwd-mpirun-port", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Forward mpirun port to compute node daemons so all will use it", PRTE_CMD_LINE_OTYPE_DVM},
+
+    /* Conventional options - for historical compatibility, support
+     * both single and multi dash versions */
+    /* Number of processes; -c, -n, --n, -np, and --np are all
+     synonyms */
+    {'c', "np", 1, PRTE_CMD_LINE_TYPE_INT, "Number of processes to run",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'n', "n", 1, PRTE_CMD_LINE_TYPE_INT, "Number of processes to run",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    {'N', NULL, 1, PRTE_CMD_LINE_TYPE_INT, "Number of processes to run per node",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+    /* Use an appfile */
+    {'\0', "app", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Provide an appfile; ignore all other command line options", PRTE_CMD_LINE_OTYPE_GENERAL},
+
+    /* output options */
+    {'\0', "output", 1, PRTE_CMD_LINE_TYPE_STRING,
+        "Comma-delimited list of options that control how output is generated."
+        "Allowed values: tag, timestamp, xml, merge-stderr-to-stdout, dir=DIRNAME, file=filename."
+        " The dir option redirects output from application processes into DIRNAME/job/rank/std[out,err,diag]."
+        " The file option redirects output from application processes into filename.rank.[out,err,diag]."
+        " If merge is specified, the dir and file options will put both stdout and stderr into a"
+        " file with the \"out\" suffix. In both cases, "
+        "the provided name will be converted to an absolute path. Supported qualifiers include NOCOPY"
+        " (do not copy the output to the stdout/err streams).",
+        PRTE_CMD_LINE_OTYPE_OUTPUT},
+    /* exit status reporting */
+    {'\0', "report-child-jobs-separately", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Return the exit status of the primary job only", PRTE_CMD_LINE_OTYPE_OUTPUT},
+    /* select XML output */
+    {'\0', "xml", 0, PRTE_CMD_LINE_TYPE_BOOL, "Provide all output in XML format",
+     PRTE_CMD_LINE_OTYPE_OUTPUT},
+    /* tag output */
+    {'\0', "tag-output", 0, PRTE_CMD_LINE_TYPE_BOOL, "Tag all output with [job,rank]",
+     PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "timestamp-output", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Timestamp all application process output", PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "output-directory", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Redirect output from application processes into filename/job/rank/std[out,err,diag]. A "
+     "relative path value will be converted to an absolute path. The directory name may include a "
+     "colon followed by a comma-delimited list of optional case-insensitive directives. Supported "
+     "directives currently include NOJOBID (do not include a job-id directory level) and NOCOPY "
+     "(do not copy the output to the stdout/err streams)",
+     PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "output-filename", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Redirect output from application processes into filename.rank. A relative path value will be "
+     "converted to an absolute path. The directory name may include a colon followed by a "
+     "comma-delimited list of optional case-insensitive directives. Supported directives currently "
+     "include NOCOPY (do not copy the output to the stdout/err streams)",
+     PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "merge-stderr-to-stdout", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Merge stderr to stdout for each process", PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "xterm", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Create a new xterm window and display output from the specified ranks there",
+     PRTE_CMD_LINE_OTYPE_OUTPUT},
+    {'\0', "stream-buffering", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+
+    /* input options */
+    /* select stdin option */
+    {'\0', "stdin", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Specify procs to receive stdin [rank, all, none] (default: 0, indicating rank 0)",
+     PRTE_CMD_LINE_OTYPE_INPUT},
+
+    /* debugger options */
+    {'\0', "output-proctable", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Print the complete proctable to stdout [-], stderr [+], or a file [anything else] after "
+     "launch",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "stop-on-exec", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "If supported, stop each process at start of execution", PRTE_CMD_LINE_OTYPE_DEBUG},
+
+    /* launch options */
+    /* Preload the binary on the remote machine */
+    {'s', "preload-binary", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Preload the binary on the remote machine before starting the remote process.",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    /* Preload files on the remote machine */
+    {'\0', "preload-files", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Preload the comma separated list of files to the remote machines current working directory "
+     "before starting the remote process.",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    /* Export environment variables; potentially used multiple times,
+     so it does not make sense to set into a variable */
+    {'x', NULL, 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Export an environment variable, optionally specifying a value (e.g., \"-x foo\" exports the "
+     "environment variable foo and takes its value from the current environment; \"-x foo=bar\" "
+     "exports the environment variable name foo and sets its value to \"bar\" in the started "
+     "processes; \"-x foo*\" exports all current environmental variables starting with \"foo\")",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "wdir", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Set the working directory of the started processes", PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "wd", 1, PRTE_CMD_LINE_TYPE_STRING, "Synonym for --wdir", PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "set-cwd-to-session-dir", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Set the working directory of the started processes to their session directory",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "path", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "PATH to be used to look for executables to start processes", PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "show-progress", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Output a brief periodic report on launch progress", PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "pset", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "User-specified name assigned to the processes in their given application",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    /* Set a hostfile */
+    {'\0', "hostfile", 1, PRTE_CMD_LINE_TYPE_STRING, "Provide a hostfile",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "machinefile", 1, PRTE_CMD_LINE_TYPE_STRING, "Provide a hostfile",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'\0', "default-hostfile", 1, PRTE_CMD_LINE_TYPE_STRING, "Provide a default hostfile",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+    {'H', "host", 1, PRTE_CMD_LINE_TYPE_STRING, "List of hosts to invoke processes on",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+
+    /* placement options */
+    /* Mapping options */
+    {'\0', "map-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache | "
+     "l2cache | l3cache | package (default:np>2) | node | seq | dist | ppr |,"
+     "rankfile]"
+     " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
+     "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
+     "DEVICE(for dist policy), INHERIT, NOINHERIT, PE-LIST=a,b (comma-delimited "
+     "ranges of cpus to use for this job), FILE=<path> for seq and rankfile options",
+     PRTE_CMD_LINE_OTYPE_MAPPING},
+
+    /* Ranking options */
+    {'\0', "rank-by", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache "
+     "| l2cache | l3cache | package (default:np>2) | node], with modifier :SPAN or :FILL",
+     PRTE_CMD_LINE_OTYPE_RANKING},
+
+    /* Binding options */
+    {'\0', "bind-to", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Process binding",
+     PRTE_CMD_LINE_OTYPE_BINDING},
+
+    /* rankfile */
+    {'\0', "rankfile", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Name of file to specify explicit task mapping", PRTE_CMD_LINE_OTYPE_LAUNCH},
+
+    /* display options */
+    {'\0', "display", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Comma-delimited list of options for displaying information about the allocation and job."
+     "Allowed values: allocation, bind, map, map-devel, topo",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+    /* developer options */
+    {'\0', "do-not-launch", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Perform all necessary operations to prepare to launch the application, but do not actually "
+     "launch it (usually used to test mapping patterns)",
+     PRTE_CMD_LINE_OTYPE_DEVEL},
+    {'\0', "display-devel-map", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display a detailed process map (mostly intended for developers) just before launch",
+     PRTE_CMD_LINE_OTYPE_DEVEL},
+    {'\0', "display-topo", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display the topology as part of the process map (mostly intended for developers) just before "
+     "launch",
+     PRTE_CMD_LINE_OTYPE_DEVEL},
+    {'\0', "report-bindings", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Whether to report process bindings to stderr", PRTE_CMD_LINE_OTYPE_DEVEL},
+    {'\0', "display-devel-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display a detailed list (mostly intended for developers) of the allocation being used by "
+     "this job",
+     PRTE_CMD_LINE_OTYPE_DEVEL},
+    {'\0', "display-map", 0, PRTE_CMD_LINE_TYPE_BOOL, "Display the process map just before launch",
+     PRTE_CMD_LINE_OTYPE_DEBUG},
+    {'\0', "display-allocation", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display the allocation being used by this job", PRTE_CMD_LINE_OTYPE_DEBUG},
+
+#if PRTE_ENABLE_FT
+    {'\0', "enable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Enable recovery from process failure [Default = disabled]", PRTE_CMD_LINE_OTYPE_FT},
+    {'\0', "max-restarts", 1, PRTE_CMD_LINE_TYPE_INT,
+     "Max number of times to restart a failed process", PRTE_CMD_LINE_OTYPE_FT},
+    {'\0', "disable-recovery", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Disable recovery (resets all recovery options to off)", PRTE_CMD_LINE_OTYPE_FT},
+    {'\0', "continuous", 0, PRTE_CMD_LINE_TYPE_BOOL, "Job is to run until explicitly terminated",
+     PRTE_CMD_LINE_OTYPE_FT},
+    {'\0', "with-ft", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Specify the type(s) of error handling that the application will use.",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+#endif
+
+    /* mpiexec mandated form launch key parameters */
+    {'\0', "initial-errhandler", 1, PRTE_CMD_LINE_TYPE_STRING,
+     "Specify the initial error handler that is attached to predefined communicators during the "
+     "first MPI call.",
+     PRTE_CMD_LINE_OTYPE_LAUNCH},
+
+    /* Display Commumication Protocol : MPI_Init */
+    {'\0', "display-comm", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display table of communication methods between ranks during MPI_Init",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+
+    /* Display Commumication Protocol : MPI_Finalize */
+    {'\0', "display-comm-finalize", 0, PRTE_CMD_LINE_TYPE_BOOL,
+     "Display table of communication methods between ranks during MPI_Finalize",
+     PRTE_CMD_LINE_OTYPE_GENERAL},
+
+    /* End of list */
+    {'\0', NULL, 0, PRTE_CMD_LINE_TYPE_NULL, NULL}};
+
+static int define_cli(prte_cmd_line_t *cli)
+{
+    int rc;
+
+    prte_output_verbose(1, prte_schizo_base_framework.framework_output,
+                        "%s schizo:hydra: define_cli", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+    /* protect against bozo error */
+    if (NULL == cli) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    rc = prte_cmd_line_add(cli, hydra_cmd_line_init);
+    return rc;
+}
+
+typedef struct {
+    char *option;
+    char *description;
+} options_t;
+
+static options_t opthelp[] = {
+    {"--bind-to",
+        "-bind-to: Process-core binding type to use\n\n"
+        "     Binding type options:\n"
+        "        Default:\n"
+        "            none             -- no binding (default)\n\n"
+        "        Architecture unaware options:\n"
+        "            rr               -- round-robin as OS assigned processor IDs\n"
+        "            user:0+2,1+4,3,2 -- user specified binding\n\n"
+        "        Architecture aware options (part within the {} braces are optional):\n"
+        "            machine          -- bind to machine\n"
+        "            numa{:<n>}       -- bind to 'n' numa domains\n"
+        "            socket{:<n>}     -- bind to 'n' sockets\n"
+        "            core{:<n>}       -- bind to 'n' cores\n"
+        "            hwthread{:<n>}   -- bind to 'n' hardware threads\n"
+        "            l1cache{:<n>}    -- bind to 'n' L1 cache domains\n"
+        "            l2cache{:<n>}    -- bind to 'n' L2 cache domains\n"
+        "            l3cache{:<n>}    -- bind to 'n' L3 cache domain\n"
+        "            l4cache{:<n>}    -- bind to 'n' L4 cache domain\n"
+        "            l5cache{:<n>}    -- bind to 'n' L5 cache domain\n"
+    },
+    {"--map-by",
+        "-map-by: Order of bind mapping to use\n\n"
+        "    Options (T: hwthread; C: core; S: socket; N: NUMA domain; B: motherboard):\n"
+        "        Default: <same option as binding>\n\n"
+        "        Architecture aware options (part within the {} braces are optional):\n"
+        "            machine          -- map by machine\n"
+        "            numa{:<n>}       -- map by 'n' numa domains\n"
+        "            socket{:<n>}     -- map by 'n' sockets\n"
+        "            core{:<n>}       -- map by 'n' cores\n"
+        "            hwthread{:<n>}   -- map by 'n' hardware threads\n"
+        "            l1cache{:<n>}    -- map by 'n' L1 cache domains\n"
+        "            l2cache{:<n>}    -- map by 'n' L2 cache domains\n"
+        "            l3cache{:<n>}    -- map by 'n' L3 cache domain\n"
+        "            l4cache{:<n>}    -- map by 'n' L4 cache domain\n"
+        "            l5cache{:<n>}    -- map by 'n' L5 cache domain\n"
+    },
+    {NULL, NULL}
+};
+
+static char *genhelp =
+    "\nGlobal options (passed to all executables):\n"
+    "\n  Global environment options:\n"
+    "    -genv {name} {value}             environment variable name and value\n"
+    "    -genvlist {env1,env2,...}        environment variable list to pass\n"
+    "    -genvnone                        do not pass any environment variables\n"
+    "    -genvall                         pass all environment variables not managed\n"
+    "                                          by the launcher (default)\n"
+    "\n  Other global options:\n"
+    "    -f {name}                        file containing the host names\n"
+    "    -hosts {host list}               comma separated host list\n"
+    "    -wdir {dirname}                  working directory to use\n"
+    "    -configfile {name}               config file containing MPMD launch options\n"
+    "\n\nLocal options (passed to individual executables):\n"
+    "\n      Local environment options:\n"
+    "    -env {name} {value}              environment variable name and value\n"
+    "    -envlist {env1,env2,...}         environment variable list to pass\n"
+    "    -envnone                         do not pass any environment variables\n"
+    "    -envall                          pass all environment variables (default)\n"
+    "\n  Other local options:\n"
+    "    -n/-np {value}                   number of processes\n"
+    "    {exec_name} {args}               executable name and arguments\n"
+    "\n\nHydra specific options (treated as global):\n"
+    "\n  Launch options:\n"
+    "    -launcher                        launcher to use (ssh rsh fork slurm ll lsf sge manual persist)\n"
+    "    -launcher-exec                   executable to use to launch processes\n"
+    "    -enable-x/-disable-x             enable or disable X forwarding\n"
+    "\n  Resource management kernel options:\n"
+    "    -rmk                             resource management kernel to use (user slurm ll lsf sge pbs cobalt)\n"
+    "\n  Processor topology options:\n"
+    "    -topolib                         processor topology library (hwloc)\n"
+    "    -bind-to                         process binding\n"
+    "    -map-by                          process mapping\n"
+    "    -membind                         memory binding policy\n"
+    "\n  Demux engine options:\n"
+    "    -demux                           demux engine (poll select)\n"
+    "\n  Other Hydra options:\n"
+    "    -verbose                         verbose mode\n"
+    "    -info                            build information\n"
+    "    -print-all-exitcodes             print exit codes of all processes\n"
+    "    -iface                           network interface to use\n"
+    "    -ppn                             processes per node\n"
+    "    -profile                         turn on internal profiling\n"
+    "    -prepend-rank                    prepend rank to output\n"
+    "    -prepend-pattern                 prepend pattern to output\n"
+    "    -outfile-pattern                 direct stdout to file\n"
+    "    -errfile-pattern                 direct stderr to file\n"
+    "    -nameserver                      name server information (host:port format)\n"
+    "    -disable-auto-cleanup            don't cleanup processes on error\n"
+    "    -disable-hostname-propagation    let MPICH auto-detect the hostname\n"
+    "    -order-nodes                     order nodes as ascending/descending cores\n"
+    "    -localhost                       local hostname for the launching node\n"
+    "    -usize                           universe size (SYSTEM, INFINITE, <value>)\n"
+    "    -pmi-port                        use the PMI_PORT model\n"
+    "    -skip-launch-node                do not run MPI processes on the launch node\n"
+    "    -gpus-per-proc                   number of GPUs per process (default: auto)\n"
+;
+
+static int check_help(prte_cmd_line_t *cli, char **argv)
+{
+    size_t n;
+    char *option;
+
+    if (prte_cmd_line_is_taken(cli, "help")) {
+        fprintf(stdout, "\nUsage: %s [global opts] [local opts for exec1] [exec1] [exec1 args] :"
+                        "[local opts for exec2] [exec2] [exec2 args] : ...\n%s",
+                prte_tool_basename, genhelp);
+        /* If someone asks for help, that should be all we do */
+        return PRTE_ERR_SILENT;
+    } else {
+        /* check if an option was given that has a value of "--help" as
+         * that indicates a request for option-specific help */
+        option = NULL;
+        for (n=1; NULL != argv[n]; n++) {
+            if (0 == strcmp(argv[n], "--help") ||
+                0 == strcmp(argv[n], "-help")) {
+                /* the argv before this one must be the option they
+                 * are seeking help about */
+                option = argv[n-1];
+                break;
+            }
+        }
+        if (NULL != option) {
+            /* see if more detailed help message is available
+             * for this option */
+            for (n=0; NULL != opthelp[n].option; n++) {
+                if (0 == strcmp(opthelp[n].option, option)) {
+                    fprintf(stdout, "\n%s", opthelp[n].description);
+                    break;
+                }
+            }
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+static void check_and_replace(char **argv, int idx,
+                              char *replacement)
+{
+    char *tmp = NULL, *ptr;
+
+    if (NULL != (ptr = strchr(argv[idx], ':'))) {
+        tmp = strdup(ptr);
+    }
+    free(argv[idx]);
+    if (NULL == tmp) {
+        argv[idx] = strdup(replacement);
+    } else {
+        prte_asprintf(&argv[idx], "%s%s", replacement, tmp);
+        free(tmp);
+    }
+}
+
+static int convert_deprecated_cli(char *option, char ***argv, int i)
+{
+    char **pargs, *p2, *modifier;
+    int rc = PRTE_SUCCESS;
+
+    pargs = *argv;
+
+    /* -prepend-rank  ->  "--output rank */
+    if (0 == strcmp(option, "--prepend-rank")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--output", NULL, "rank", false);
+        rc = PRTE_ERR_SILENT;
+        return rc;
+    }
+
+    /* --skip-launch-node -> --map-by :nolocal */
+    if (0 == strcmp(option, "--skip-launch-node")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--map-by", NULL, "NOLOCAL", true);
+        return rc;
+    }
+
+    if (0 == strcmp(option, "--map-by")) {
+        /* need to perform the following mappings:
+         *  - "machine"  => "slot"
+         *  - "socket"   => "package"
+         */
+        if (NULL != strcasestr(pargs[i+1], "machine")) {
+            check_and_replace(pargs, i+1, "slot");
+        } else if (NULL != strcasestr(pargs[i+1], "socket")) {
+            check_and_replace(pargs, i+1, "package");
+        } else if ('T' == pargs[i+1][0]) {
+            /* shorthand for "hwthread" */
+            check_and_replace(pargs, i+1, "hwthread");
+        } else if ('C' == pargs[i+1][0]) {
+            /* shorthand for "core" */
+            check_and_replace(pargs, i+1, "core");
+        } else if ('S' == pargs[i+1][0]) {
+            /* shorthand for "socket" */
+            check_and_replace(pargs, i+1, "package");
+        } else if ('N' == pargs[i+1][0]) {
+            /* shorthand for "numa" */
+            check_and_replace(pargs, i+1, "numa");
+        } else if ('B' == pargs[i+1][0]) {
+            /* shorthand for "motherboard" */
+            check_and_replace(pargs, i+1, "slot");
+        }
+        return PRTE_OPERATION_SUCCEEDED;
+    }
+
+    if (0 == strcmp(option, "--bind-to")) {
+        /* need to perform the following mappings:
+         *  - "rr"       => "core"
+         *  - "machine"  => "none"
+         *  - "socket"   => "package"
+         */
+        if (NULL != strcasestr(pargs[i+1], "rr")) {
+            check_and_replace(pargs, i+1, "core");
+        } else if (NULL != strcasestr(pargs[i+1], "machine")) {
+            check_and_replace(pargs, i+1, "none");
+        } else if (NULL != strcasestr(pargs[i+1], "socket")) {
+            check_and_replace(pargs, i+1, "package");
+        } else if ('T' == pargs[i+1][0]) {
+            /* shorthand for "hwthread" */
+            check_and_replace(pargs, i+1, "hwthread");
+        } else if ('C' == pargs[i+1][0]) {
+            /* shorthand for "core" */
+            check_and_replace(pargs, i+1, "core");
+        } else if ('S' == pargs[i+1][0]) {
+            /* shorthand for "socket" */
+            check_and_replace(pargs, i+1, "package");
+        } else if ('N' == pargs[i+1][0]) {
+            /* shorthand for "numa" */
+            check_and_replace(pargs, i+1, "numa");
+        } else if ('B' == pargs[i+1][0]) {
+            /* shorthand for "motherboard" */
+            check_and_replace(pargs, i+1, "slot");
+        }
+        return PRTE_OPERATION_SUCCEEDED;
+    }
+
+    /* --outfile-pattern -> --output file= */
+    if (0 == strcmp(option, "--outfile-pattern")) {
+        prte_asprintf(&p2, "file=%s:pattern", pargs[i+1]);
+        rc = prte_schizo_base_convert(argv, i, 2, "--output", NULL, p2, false);
+        return PRTE_ERR_SILENT;
+    }
+
+    return rc;
+}
+
+static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***argv)
+{
+    pmix_status_t rc;
+
+    char *options[] = {"--genv",
+                       "--genvlist",
+                       "--genvnone",
+                       "--genvall",
+                       "--f",
+                       "--hosts",
+                       "--wdir",
+                       "--env",
+                       "--envlist",
+                       "--envnone",
+                       "--envall",
+                       "--launcher",
+                       "--launcher-exec",
+                       "--enable-x",
+                       "--disable-x",
+                       "--rmk",
+                       "--topolib",
+                       "--bind-to",
+                       "--map-by",
+                       "--membend",
+                       "--demux",
+                       "--verbose",
+                       "--info",
+                       "--print-all-exitcodes",
+                       "--iface",
+                       "--ppn",
+                       "--profile",
+                       "--prepend-rank",
+                       "--prepend-pattern",
+                       "--outfile-pattern",
+                       "--errfile-pattern",
+                       "--nameserver",
+                       "--disable-auto-cleanup",
+                       "--disable-hostname-propagation",
+                       "--order-nodes",
+                       "--localhost",
+                       "--usize",
+                       "--pmi-port",
+                       "--skip-launch-node",
+                       "--gpus-per-proc",
+                       NULL};
+
+    rc = prte_schizo_base_process_deprecated_cli(cmdline, argc, argv, options,
+                                                 true, convert_deprecated_cli);
+
+    return rc;
+}
+
+static int parse_cli(int argc, int start, char **argv, char ***target)
+{
+    int i;
+
+    prte_output_verbose(1, prte_schizo_base_framework.framework_output,
+                        "%s schizo:hydra: parse_cli",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+    for (i = 0; i < (argc - start); i++) {
+         if (0 == strcmp("--map-by", argv[i])) {
+            /* if they set "inherit", then make this the default for prte */
+            if (NULL != strcasestr(argv[i + 1], "inherit")
+                && NULL == strcasestr(argv[i + 1], "noinherit")) {
+                if (NULL == target) {
+                    /* push it into our environment */
+                    prte_setenv("PRTE_MCA_rmaps_default_inherit", "1", true, &environ);
+                    prte_setenv("PRTE_MCA_rmaps_default_mapping_policy", argv[i + 1], true,
+                                &environ);
+                } else {
+                    prte_argv_append_nosize(target, "--prtemca");
+                    prte_argv_append_nosize(target, "rmaps_default_inherit");
+                    prte_argv_append_nosize(target, "1");
+                    prte_argv_append_nosize(target, "--prtemca");
+                    prte_argv_append_nosize(target, "rmaps_default_mapping_policy");
+                    prte_argv_append_nosize(target, argv[i + 1]);
+                }
+            }
+             break;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, bool cmdline)
+{
+    char *p1, *p2;
+    prte_value_t *pval;
+    int i, j;
+
+    prte_output_verbose(1, prte_schizo_base_framework.framework_output,
+                        "%s schizo:hydra: parse_env",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+    /* if they are filling out a cmd line, then we don't
+     * have anything to contribute */
+    if (cmdline) {
+        return PRTE_ERR_TAKE_NEXT_OPTION;
+    }
+
+    if (0 < (j = prte_cmd_line_get_ninsts(cmd_line, "genv"))) {
+        for (i = 0; i < j; ++i) {
+            /* the first value on the list is the name of the param */
+            pval = prte_cmd_line_get_param(cmd_line, "genv", i, 0);
+            p1 = prte_schizo_base_strip_quotes(pval->value.data.string);
+            /* next value on the list is the value */
+            pval = prte_cmd_line_get_param(cmd_line, "genv", i, 1);
+            p2 = prte_schizo_base_strip_quotes(pval->value.data.string);
+            prte_setenv(p1, p2, true, dstenv);
+            free(p1);
+            free(p2);
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+static int detect_proxy(char *personalities)
+{
+    char *evar;
+
+    prte_output_verbose(2, prte_schizo_base_framework.framework_output,
+                        "%s[%s]: detect proxy with %s (%s)",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__,
+                        (NULL == personalities) ? "NULL" : personalities,
+                        prte_tool_basename);
+
+    /* COMMAND-LINE OVERRRIDES ALL */
+    /* this is a list of personalities we need to check -
+     * if it contains "hydra" or "mpich", then we are available */
+    if (NULL != personalities) {
+        if (NULL != strstr(personalities, "hydra") ||
+            NULL != strstr(personalities, "mpich")) {
+            return 100;
+        }
+        return 0;
+    }
+
+    /* if we were told the proxy, then use it */
+    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
+        if (0 == strcmp(evar, "hydra") ||
+            0 == strcmp(evar, "mpich")) {
+            return 100;
+        } else {
+            return 0;
+        }
+    }
+
+    /* if neither of those were true, then it cannot be us */
+    return 0;
+}
+
+static void allow_run_as_root(prte_cmd_line_t *cmd_line)
+{
+    /* hydra always allows run-as-root */
+    return;
+}
+
+static void job_info(prte_cmd_line_t *cmdline, void *jobinfo)
+{
+}
+
+static int check_sanity(prte_cmd_line_t *cmd_line)
+{
+    prte_value_t *pval;
+    char *mappers[] = {"slot", "hwthread", "core", "l1cache", "l2cache",  "l3cache", "l4cache", "l5cache", "package",
+                       "node", "seq",      "dist", "ppr",     "rankfile", NULL};
+    char *mapquals[] = {"pe=", "span", "oversubscribe", "nooversubscribe", "nolocal",
+                        "hwtcpus", "corecpus", "device=", "inherit", "noinherit", "pe-list=",
+                        "file=", "donotlaunch", NULL};
+
+    char *rankers[] = {"slot",    "hwthread", "core", "l1cache", "l2cache",
+                       "l3cache", "package",  "node", NULL};
+    char *rkquals[] = {"span", "fill", NULL};
+
+    char *binders[] = {"none",    "hwthread", "core",    "l1cache",
+                       "l2cache", "l3cache",  "package", NULL};
+    char *bndquals[] = {"overload-allowed", "if-supported", "ordered", "report", NULL};
+
+    char *outputs[] = {"tag", "rank", "timestamp", "xml", "merge-stderr-to-stdout", "directory", "filename", NULL};
+    char *outquals[] = {"nocopy", "pattern", NULL};
+
+    char *displays[] = {"allocation", "map", "bind", "map-devel", "topo", NULL};
+
+    bool hwtcpus = false;
+
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "map-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "map-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "rank-by")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "rank-by");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "bind-to")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "bind-to");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "output")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "output");
+        return PRTE_ERR_SILENT;
+    }
+    if (1 < prte_cmd_line_get_ninsts(cmd_line, "display")) {
+        prte_show_help("help-schizo-base.txt", "multi-instances", true, "display");
+        return PRTE_ERR_SILENT;
+    }
+
+    /* quick check that we have valid directives */
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "map-by", 0, 0))) {
+        if (NULL != strcasestr(pval->value.data.string, "HWTCPUS")) {
+            hwtcpus = true;
+        }
+        if (!prte_schizo_base_check_directives("map-by", mappers, mapquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "rank-by", 0, 0))) {
+        if (!prte_schizo_base_check_directives("rank-by", rankers, rkquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "bind-to", 0, 0))) {
+        if (!prte_schizo_base_check_directives("bind-to", binders, bndquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+        if (0 == strncasecmp(pval->value.data.string, "HWTHREAD", strlen("HWTHREAD")) && !hwtcpus) {
+            /* if we are told to bind-to hwt, then we have to be treating
+             * hwt's as the allocatable unit */
+            prte_show_help("help-prte-rmaps-base.txt", "invalid-combination", true);
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "output", 0, 0))) {
+        if (!prte_schizo_base_check_directives("output", outputs, outquals, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    if (NULL != (pval = prte_cmd_line_get_param(cmd_line, "display", 0, 0))) {
+        if (!prte_schizo_base_check_directives("display", displays, NULL, pval->value.data.string)) {
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}

--- a/src/mca/schizo/hydra/schizo_hydra.h
+++ b/src/mca/schizo/hydra/schizo_hydra.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _MCA_SCHIZO_HYDRA_H_
+#define _MCA_SCHIZO_HYDRA_H_
+
+#include "prte_config.h"
+
+#include "types.h"
+
+#include "src/mca/base/base.h"
+#include "src/mca/schizo/schizo.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    prte_schizo_base_component_t super;
+    int priority;
+} prte_schizo_hydra_component_t;
+
+PRTE_MODULE_EXPORT extern prte_schizo_hydra_component_t prte_schizo_hydra_component;
+extern prte_schizo_base_module_t prte_schizo_hydra_module;
+
+END_C_DECLS
+
+#endif /* MCA_SCHIZO_HYDRA_H_ */

--- a/src/mca/schizo/hydra/schizo_hydra_component.c
+++ b/src/mca/schizo/hydra/schizo_hydra_component.c
@@ -1,0 +1,54 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "types.h"
+
+#include "src/util/show_help.h"
+
+#include "src/runtime/prte_globals.h"
+
+#include "schizo_hydra.h"
+#include "src/mca/schizo/schizo.h"
+
+static int component_query(prte_mca_base_module_t **module, int *priority);
+
+/*
+ * Struct of function pointers and all that to let us be initialized
+ */
+prte_schizo_hydra_component_t prte_schizo_hydra_component = {
+    .super = {
+        .base_version = {
+            PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+            .mca_component_name = "hydra",
+            PRTE_MCA_BASE_MAKE_VERSION(component, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
+                                        PRTE_RELEASE_VERSION),
+            .mca_query_component = component_query,
+        },
+        .base_data = {
+            /* The component is checkpoint ready */
+            PRTE_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        },
+    },
+    .priority = 40
+};
+
+static int component_query(prte_mca_base_module_t **module, int *priority)
+{
+    *module = (prte_mca_base_module_t *) &prte_schizo_hydra_module;
+    *priority = prte_schizo_hydra_component.priority;
+    return PRTE_SUCCESS;
+}

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -59,6 +59,7 @@
 #include "src/mca/schizo/base/base.h"
 
 static int define_cli(prte_cmd_line_t *cli);
+static int check_help(prte_cmd_line_t *cli, char **argv);
 static int parse_cli(int argc, int start, char **argv, char ***target);
 static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***argv);
 static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, bool cmdline);
@@ -66,15 +67,18 @@ static int detect_proxy(char *argv);
 static void allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 
-prte_schizo_base_module_t prte_schizo_ompi_module = {.name = "ompi",
-                                                     .define_cli = define_cli,
-                                                     .parse_cli = parse_cli,
-                                                     .parse_deprecated_cli = parse_deprecated_cli,
-                                                     .parse_env = parse_env,
-                                                     .detect_proxy = detect_proxy,
-                                                     .allow_run_as_root = allow_run_as_root,
-                                                     .job_info = job_info,
-                                                     .check_sanity = prte_schizo_base_sanity};
+prte_schizo_base_module_t prte_schizo_ompi_module = {
+    .name = "ompi",
+    .define_cli = define_cli,
+    .check_help = check_help,
+    .parse_cli = parse_cli,
+    .parse_deprecated_cli = parse_deprecated_cli,
+    .parse_env = parse_env,
+    .detect_proxy = detect_proxy,
+    .allow_run_as_root = allow_run_as_root,
+    .job_info = job_info,
+    .check_sanity = prte_schizo_base_sanity
+};
 
 static prte_cmd_line_init_t ompi_cmd_line_init[] = {
     /* basic options */
@@ -389,6 +393,27 @@ static int define_cli(prte_cmd_line_t *cli)
     return rc;
 }
 
+static int check_help(prte_cmd_line_t *cli, char **argv)
+{
+    if (prte_cmd_line_is_taken(cli, "help")) {
+        char *str, *args = NULL;
+        args = prte_cmd_line_get_usage_msg(cli, false);
+        str = prte_show_help_string("help-prun.txt", "prun:usage", false, prte_tool_basename,
+                                    "PRTE", PRTE_VERSION, prte_tool_basename, args,
+                                    PACKAGE_BUGREPORT);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(args);
+
+        /* If someone asks for help, that should be all we do */
+        return PRTE_ERR_SILENT;
+    }
+
+    return PRTE_SUCCESS;
+}
+
 static int convert_deprecated_cli(char *option, char ***argv, int i)
 {
     char **pargs, *p2, *modifier;
@@ -591,7 +616,7 @@ static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***arg
                        NULL};
 
     rc = prte_schizo_base_process_deprecated_cli(cmdline, argc, argv, options,
-                                                 convert_deprecated_cli);
+                                                 false, convert_deprecated_cli);
 
     return rc;
 }
@@ -1487,6 +1512,16 @@ static int detect_proxy(char *personalities)
                         (NULL == personalities) ? "NULL" : personalities,
                         prte_tool_basename);
 
+    /* COMMAND-LINE OVERRIDES ALL */
+    if (NULL != personalities) {
+        /* this is a list of personalities we need to check -
+         * if it contains "ompi", then we are available */
+        if (NULL != strstr(personalities, "ompi")) {
+            return 100;
+        }
+        return 0;
+    }
+
     /* if we were told the proxy, then use it */
     if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
         if (0 == strcmp(evar, "ompi")) {
@@ -1494,16 +1529,6 @@ static int detect_proxy(char *personalities)
         } else {
             return 0;
         }
-    }
-
-    if (NULL == personalities) {
-        return 0;
-    }
-
-    /* this is a list of personalities we need to check -
-     * if it contains "ompi", then we are available */
-    if (NULL != strstr(personalities, "ompi")) {
-        return 100;
     }
 
     /* if neither of those were true, then it cannot be us */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -56,6 +56,7 @@
 #include "src/mca/schizo/base/base.h"
 
 static int define_cli(prte_cmd_line_t *cli);
+static int check_help(prte_cmd_line_t *cli, char **argv);
 static int parse_cli(int argc, int start, char **argv, char ***target);
 static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***argv);
 static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, bool cmdline);
@@ -64,16 +65,19 @@ static int detect_proxy(char *argv);
 static void allow_run_as_root(prte_cmd_line_t *cmd_line);
 static void job_info(prte_cmd_line_t *cmdline, void *jobinfo);
 
-prte_schizo_base_module_t prte_schizo_prte_module = {.name = "prte",
-                                                     .define_cli = define_cli,
-                                                     .parse_cli = parse_cli,
-                                                     .parse_deprecated_cli = parse_deprecated_cli,
-                                                     .parse_env = parse_env,
-                                                     .setup_fork = setup_fork,
-                                                     .detect_proxy = detect_proxy,
-                                                     .allow_run_as_root = allow_run_as_root,
-                                                     .check_sanity = prte_schizo_base_sanity,
-                                                     .job_info = job_info};
+prte_schizo_base_module_t prte_schizo_prte_module = {
+    .name = "prte",
+    .define_cli = define_cli,
+    .check_help = check_help,
+    .parse_cli = parse_cli,
+    .parse_deprecated_cli = parse_deprecated_cli,
+    .parse_env = parse_env,
+    .setup_fork = setup_fork,
+    .detect_proxy = detect_proxy,
+    .allow_run_as_root = allow_run_as_root,
+    .check_sanity = prte_schizo_base_sanity,
+    .job_info = job_info
+};
 
 static prte_cmd_line_init_t prte_cmd_line_init[] = {
     /* basic options */
@@ -409,6 +413,27 @@ static int define_cli(prte_cmd_line_t *cli)
     return PRTE_SUCCESS;
 }
 
+static int check_help(prte_cmd_line_t *cli, char **argv)
+{
+    if (prte_cmd_line_is_taken(cli, "help")) {
+        char *str, *args = NULL;
+        args = prte_cmd_line_get_usage_msg(cli, false);
+        str = prte_show_help_string("help-prun.txt", "prun:usage", false, prte_tool_basename,
+                                    "PRTE", PRTE_VERSION, prte_tool_basename, args,
+                                    PACKAGE_BUGREPORT);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(args);
+
+        /* If someone asks for help, that should be all we do */
+        return PRTE_ERR_SILENT;
+    }
+
+    return PRTE_SUCCESS;
+}
+
 static int parse_cli(int argc, int start, char **argv, char ***target)
 {
     prte_output_verbose(1, prte_schizo_base_framework.framework_output, "%s schizo:prte: parse_cli",
@@ -612,7 +637,7 @@ static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***arg
                        NULL};
 
     rc = prte_schizo_base_process_deprecated_cli(cmdline, argc, argv, options,
-                                                 convert_deprecated_cli);
+                                                 false, convert_deprecated_cli);
 
     return rc;
 }
@@ -942,6 +967,17 @@ static int detect_proxy(char *personalities)
                         (NULL == personalities) ? "NULL" : personalities,
                         prte_tool_basename);
 
+    /* COMMAND-LINE OVERRRULES ALL */
+    if (NULL != personalities) {
+        /* this is a list of personalities we need to check -
+         * if it contains "prte", then we are available but
+         * at a low priority */
+        if (NULL != strstr(personalities, "prte")) {
+            return prte_schizo_prte_component.priority;
+        }
+        return 0;
+    }
+
     /* if we were told the proxy, then use it */
     if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
         if (0 == strcmp(evar, "prte")) {
@@ -951,17 +987,6 @@ static int detect_proxy(char *personalities)
             /* they asked for somebody else */
             return 0;
         }
-    }
-
-    if (NULL == personalities) {
-        return prte_schizo_prte_component.priority;
-    }
-
-    /* this is a list of personalities we need to check -
-     * if it contains "prte", then we are available but
-     * at a low priority */
-    if (NULL != strstr(personalities, "prte")) {
-        return prte_schizo_prte_component.priority;
     }
 
     /* if neither of those were true, then just use our default */

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -62,6 +62,10 @@ typedef int (*prte_schizo_base_module_init_fn_t)(void);
  * message that will be displayed */
 typedef int (*prte_schizo_base_module_define_cli_fn_t)(prte_cmd_line_t *cli);
 
+/* allow the active schizo component to print its own help message
+ * in its own format */
+typedef int (*prte_schizo_base_module_check_help_fn_t)(prte_cmd_line_t *cli, char **argv);
+
 /* parse a tool command line
  * starting from the given location according to the cmd line options
  * known to this module's personality. First, of course, check that
@@ -124,33 +128,34 @@ typedef int (*prte_schizo_base_module_check_sanity_fn_t)(prte_cmd_line_t *cmdlin
  */
 typedef struct {
     char *name;
-    prte_schizo_base_module_init_fn_t init;
-    prte_schizo_base_module_define_cli_fn_t define_cli;
-    prte_schizo_base_module_parse_cli_fn_t parse_cli;
-    prte_schizo_base_parse_deprecated_cli_fn_t parse_deprecated_cli;
-    prte_schizo_base_module_parse_env_fn_t parse_env;
-    prte_schizo_base_detect_proxy_fn_t detect_proxy;
-    prte_schizo_base_module_allow_run_as_root_fn_t allow_run_as_root;
-    prte_schizo_base_module_setup_app_fn_t setup_app;
-    prte_schizo_base_module_setup_fork_fn_t setup_fork;
-    prte_schizo_base_module_setup_child_fn_t setup_child;
-    prte_schizo_base_module_job_info_fn_t job_info;
-    prte_schizo_base_module_check_sanity_fn_t check_sanity;
-    prte_schizo_base_module_finalize_fn_t finalize;
+    prte_schizo_base_module_init_fn_t               init;
+    prte_schizo_base_module_define_cli_fn_t         define_cli;
+    prte_schizo_base_module_check_help_fn_t         check_help;
+    prte_schizo_base_module_parse_cli_fn_t          parse_cli;
+    prte_schizo_base_parse_deprecated_cli_fn_t      parse_deprecated_cli;
+    prte_schizo_base_module_parse_env_fn_t          parse_env;
+    prte_schizo_base_detect_proxy_fn_t              detect_proxy;
+    prte_schizo_base_module_allow_run_as_root_fn_t  allow_run_as_root;
+    prte_schizo_base_module_setup_app_fn_t          setup_app;
+    prte_schizo_base_module_setup_fork_fn_t         setup_fork;
+    prte_schizo_base_module_setup_child_fn_t        setup_child;
+    prte_schizo_base_module_job_info_fn_t           job_info;
+    prte_schizo_base_module_check_sanity_fn_t       check_sanity;
+    prte_schizo_base_module_finalize_fn_t           finalize;
 } prte_schizo_base_module_t;
 
 typedef prte_schizo_base_module_t *(*prte_schizo_API_detect_proxy_fn_t)(char *cmdpath);
 
 typedef struct {
-    prte_schizo_base_module_init_fn_t init;
-    prte_schizo_base_module_parse_env_fn_t parse_env;
-    prte_schizo_API_detect_proxy_fn_t detect_proxy;
-    prte_schizo_base_module_setup_app_fn_t setup_app;
-    prte_schizo_base_module_setup_fork_fn_t setup_fork;
-    prte_schizo_base_module_setup_child_fn_t setup_child;
-    prte_schizo_base_module_job_info_fn_t job_info;
-    prte_schizo_base_module_check_sanity_fn_t check_sanity;
-    prte_schizo_base_module_finalize_fn_t finalize;
+    prte_schizo_base_module_init_fn_t           init;
+    prte_schizo_base_module_parse_env_fn_t      parse_env;
+    prte_schizo_API_detect_proxy_fn_t           detect_proxy;
+    prte_schizo_base_module_setup_app_fn_t      setup_app;
+    prte_schizo_base_module_setup_fork_fn_t     setup_fork;
+    prte_schizo_base_module_setup_child_fn_t    setup_child;
+    prte_schizo_base_module_job_info_fn_t       job_info;
+    prte_schizo_base_module_check_sanity_fn_t   check_sanity;
+    prte_schizo_base_module_finalize_fn_t       finalize;
 } prte_schizo_API_module_t;
 
 PRTE_EXPORT extern prte_schizo_API_module_t prte_schizo;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -541,15 +541,21 @@ static void interim(int sd, short args, void *cbdata)
             pmix_server_cache_job_info(jdata, info);
 
             /***   TAG STDOUT   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_TAG_OUTPUT)
-                   || PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT) ||
+                   PMIX_CHECK_KEY(info, PMIX_TAG_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, &flag,
                                PMIX_BOOL);
 
+            /***   RANK STDOUT   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_RANK_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_RANK_OUTPUT, PRTE_ATTR_GLOBAL, &flag,
+                               PMIX_BOOL);
+
             /***   TIMESTAMP OUTPUT   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_TIMESTAMP_OUTPUT)
-                   || PMIX_CHECK_KEY(info, PMIX_IOF_TIMESTAMP_OUTPUT)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TIMESTAMP_OUTPUT)
+                   || PMIX_CHECK_KEY(info, PMIX_TIMESTAMP_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
@@ -561,21 +567,25 @@ static void interim(int sd, short args, void *cbdata)
                                PMIX_BOOL);
 
             /***   OUTPUT TO FILES   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_FILE)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_FILE) ||
+                   PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_FILE)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_FILE, PRTE_ATTR_GLOBAL,
                                info->value.data.string, PMIX_STRING);
 
-        } else if (PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_TO_DIRECTORY) ||
+                   PMIX_CHECK_KEY(info, PMIX_OUTPUT_TO_DIRECTORY)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_DIRECTORY, PRTE_ATTR_GLOBAL,
                                info->value.data.string, PMIX_STRING);
 
-        } else if (PMIX_CHECK_KEY(info, PMIX_OUTPUT_NOCOPY)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_FILE_ONLY) ||
+                   PMIX_CHECK_KEY(info, PMIX_OUTPUT_NOCOPY)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
             /***   MERGE STDERR TO STDOUT   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_MERGE_STDERR_STDOUT)) {
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_MERGE_STDERR_STDOUT) ||
+                   PMIX_CHECK_KEY(info, PMIX_MERGE_STDERR_STDOUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -357,8 +357,13 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
 
     /* check for output directives */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
-       kv = PRTE_NEW(prte_info_item_t);
+        kv = PRTE_NEW(prte_info_item_t);
         PMIX_INFO_LOAD(&kv->info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
+        prte_list_append(info, &kv->super);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RANK_OUTPUT, NULL, PMIX_BOOL)) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
         prte_list_append(info, &kv->super);
     }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -261,7 +261,7 @@ int prte(int argc, char *argv[])
     bool donotlaunch = false;
     prte_schizo_base_module_t *schizo;
     prte_ess_base_signal_t *sig;
-    char **targv;
+    char **targv, **options;
     char *outdir = NULL;
     char *outfile = NULL;
     pmix_status_t code;
@@ -333,9 +333,9 @@ int prte(int argc, char *argv[])
     signal(SIGHUP, abort_signal_callback);
 
     /* open the SCHIZO framework */
-    if (PRTE_SUCCESS
-        != (rc = prte_mca_base_framework_open(&prte_schizo_base_framework,
-                                              PRTE_MCA_BASE_OPEN_DEFAULT))) {
+    rc = prte_mca_base_framework_open(&prte_schizo_base_framework,
+                                      PRTE_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }
@@ -463,19 +463,9 @@ int prte(int argc, char *argv[])
     }
 
     /* Check for help request */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "help")) {
-        char *str, *args = NULL;
-        args = prte_cmd_line_get_usage_msg(prte_cmd_line, false);
-        str = prte_show_help_string("help-prun.txt", "prun:usage", false, prte_tool_basename,
-                                    "PRTE", PRTE_VERSION, prte_tool_basename, args,
-                                    PACKAGE_BUGREPORT);
-        if (NULL != str) {
-            printf("%s", str);
-            free(str);
-        }
-        free(args);
-
-        /* If someone asks for help, that should be all we do */
+    rc = schizo->check_help(prte_cmd_line, pargv);
+    if (PRTE_ERR_SILENT == rc) {
+        /* help was printed */
         exit(0);
     }
 
@@ -922,25 +912,22 @@ int prte(int argc, char *argv[])
     outfile = NULL;
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output", 0, 0))) {
         targv = prte_argv_split(pval->value.data.string, ',');
-
         for (int idx = 0; idx < prte_argv_count(targv); idx++) {
             /* remove any '=' sign in the directive */
             if (NULL != (ptr = strchr(targv[idx], '='))) {
                 *ptr = '\0';
             }
             if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
-            }
-            if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
-            }
-            if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":XMLOUTPUT", PMIX_STRING);
-            }
-            if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
-            }
-            if (0 == strncasecmp(targv[idx], "directory", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
+            } else if (0 == strncasecmp(targv[idx], "rank", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, &flag, PMIX_BOOL);
+            } else if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
+            } else if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
+            } else if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
+            } else if (0 == strncasecmp(targv[idx], "directory", strlen(targv[idx]))) {
                 if (NULL != outfile) {
                     prte_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
                     return PRTE_ERR_FATAL;
@@ -957,7 +944,7 @@ int prte(int argc, char *argv[])
                     *cptr = '\0';
                     ++cptr;
                     if (0 == strcasecmp(cptr, "nocopy")) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                     }
                 }
                 /* If the given filename isn't an absolute path, then
@@ -974,9 +961,8 @@ int prte(int argc, char *argv[])
                 } else {
                     outdir = strdup(ptr);
                 }
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
-            }
-            if (0 == strncasecmp(targv[idx], "file", strlen(targv[idx]))) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
+            } else if (0 == strncasecmp(targv[idx], "file", strlen(targv[idx]))) {
                 if (NULL != outdir) {
                     prte_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
                     return PRTE_ERR_FATAL;
@@ -992,8 +978,13 @@ int prte(int argc, char *argv[])
                 if (NULL != (cptr = strchr(ptr, ':'))) {
                     *cptr = '\0';
                     ++cptr;
-                    if (0 != strcasecmp(cptr, "nocopy")) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                    options = prte_argv_split(cptr, ',');
+                    for (int m=0; NULL != options[m]; m++) {
+                        if (0 == strcasecmp(options[m], "nocopy")) {
+                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
+                        } else if (0 == strcasecmp(options[m], "pattern")) {
+                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
+                        }
                     }
                 }
                 /* If the given filename isn't an absolute path, then
@@ -1010,7 +1001,7 @@ int prte(int argc, char *argv[])
                 } else {
                     outfile = strdup(ptr);
                 }
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_FILE, outfile, PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
             }
         }
         prte_argv_free(targv);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -523,19 +523,9 @@ int prun(int argc, char *argv[])
     }
 
     /* Check for help request */
-    if (prte_cmd_line_is_taken(prte_cmd_line, "help")) {
-        char *str, *args = NULL;
-        args = prte_cmd_line_get_usage_msg(prte_cmd_line, false);
-        str = prte_show_help_string("help-prun.txt", "prun:usage", false, prte_tool_basename,
-                                    "PRTE", PRTE_VERSION, prte_tool_basename, args,
-                                    PACKAGE_BUGREPORT);
-        if (NULL != str) {
-            printf("%s", str);
-            free(str);
-        }
-        free(args);
-
-        /* If someone asks for help, that should be all we do */
+    rc = schizo->check_help(prte_cmd_line, pargv);
+    if (PRTE_ERR_SILENT == rc) {
+        /* help was printed */
         exit(0);
     }
 
@@ -768,16 +758,16 @@ int prun(int argc, char *argv[])
                 *ptr = '\0';
             }
             if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TAG_OUTPUT, &flag, PMIX_BOOL);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
             }
             if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
             }
             if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":XMLOUTPUT", PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
             }
             if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
             }
             if (0 == strncasecmp(targv[idx], "directory", strlen(targv[idx]))) {
                 if (NULL != outfile) {
@@ -796,7 +786,7 @@ int prun(int argc, char *argv[])
                     *cptr = '\0';
                     ++cptr;
                     if (0 == strcasecmp(cptr, "nocopy")) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                     }
                 }
                 /* If the given filename isn't an absolute path, then
@@ -813,7 +803,7 @@ int prun(int argc, char *argv[])
                 } else {
                     outdir = strdup(ptr);
                 }
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
             }
             if (0 == strncasecmp(targv[idx], "file", strlen(targv[idx]))) {
                 if (NULL != outdir) {
@@ -832,7 +822,7 @@ int prun(int argc, char *argv[])
                     *cptr = '\0';
                     ++cptr;
                     if (0 == strcasecmp(cptr, "nocopy")) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                     }
                 }
                 /* If the given filename isn't an absolute path, then
@@ -849,7 +839,7 @@ int prun(int argc, char *argv[])
                 } else {
                     outfile = strdup(ptr);
                 }
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_OUTPUT_TO_FILE, outfile, PMIX_STRING);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
             }
         }
         prte_argv_free(targv);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -372,6 +372,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE-JOB-MERGE-STDERR-STDOUT";
         case PRTE_JOB_TAG_OUTPUT:
             return "PRTE-JOB-TAG-OUTPUT";
+        case PRTE_JOB_RANK_OUTPUT:
+            return "PRTE-JOB-RANK-OUTPUT";
         case PRTE_JOB_TIMESTAMP_OUTPUT:
             return "PRTE-JOB-TIMESTAMP-OUTPUT";
         case PRTE_JOB_MULTI_DAEMON_SIM:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -196,6 +196,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY + 89) // pmix_rank_t of procs to stop
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY + 90) // envars have already been harvested
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY + 91) // bool - do not copy output to stdout/err
+#define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY + 92) // bool - tag stdout/stderr with rank
 
 #define PRTE_JOB_MAX_KEY 300
 


### PR DESCRIPTION
Add a new "hydra" personality to the schizo framework with
initial implementation of a translator from hydra cmd line
syntax to PRRTE internals. This seems to work better than
trying to create an entirely new cmd line as the code in
prte and prun looks at the cmd line directly when interpreting
it.

Raises the question: should we just define a single cmd line
and use translators for alternatives? Seems like it would be
the right way to go based on this experience.

Signed-off-by: Ralph Castain <rhc@pmix.org>