### PR TITLE
Fix the daemon termination race condition

### DIFF
--- a/examples/debugger/indirect-multi.c
+++ b/examples/debugger/indirect-multi.c
@@ -308,7 +308,6 @@ static pmix_status_t spawn_app(char *myuri, int argc, char **argv,
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_NOTIFY_JOB_EVENTS, NULL, PMIX_BOOL);
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_FWD_STDOUT, NULL, PMIX_BOOL); // forward stdout to me
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_FWD_STDERR, NULL, PMIX_BOOL); // forward stderr to me
-    PMIX_INFO_LIST_ADD(rc, linfo, PMIX_SPAWN_TOOL, NULL, PMIX_BOOL); // we are spawning a tool
     PMIX_INFO_LIST_CONVERT(rc, linfo, &darray);
     PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_LAUNCH_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
     PMIX_INFO_LIST_RELEASE(linfo);

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -266,7 +266,6 @@ int main(int argc, char **argv)
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_NOTIFY_JOB_EVENTS, NULL, PMIX_BOOL);
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_FWD_STDOUT, NULL, PMIX_BOOL); // forward stdout to me
     PMIX_INFO_LIST_ADD(rc, linfo, PMIX_FWD_STDERR, NULL, PMIX_BOOL); // forward stderr to me
-    PMIX_INFO_LIST_ADD(rc, linfo, PMIX_SPAWN_TOOL, NULL, PMIX_BOOL); // we are spawning a tool
     PMIX_INFO_LIST_CONVERT(rc, linfo, &darray2);
     PMIX_INFO_LIST_ADD(rc, jinfo, PMIX_LAUNCH_DIRECTIVES, &darray2, PMIX_DATA_ARRAY);
     PMIX_INFO_LIST_RELEASE(linfo);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1237,11 +1237,9 @@ CLEANUP:
                 if (NULL == jdata) {
                     continue;
                 }
-                if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
-                    dvm = false;
-                    if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
-                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-                    }
+                dvm = false;
+                if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
+                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
                 }
             }
             if (dvm) {
@@ -1710,11 +1708,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                     if (NULL == jdata) {
                         continue;
                     }
-                    if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
-                        dvm = false;
-                        if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
-                            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-                        }
+                    dvm = false;
+                    if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
+                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
                     }
                 }
                 if (dvm) {

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -227,31 +227,26 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
             } else {
                 PMIX_LOAD_NSPACE(jdata->launcher, parent->launcher);
             }
-            if (PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
-                /* don't use the parent for anything more */
-                parent = NULL;
-            } else {
-                /* if the prefix was set in the parent's job, we need to transfer
-                 * that prefix to the child's app_context so any further launch of
-                 * orteds can find the correct binary. There always has to be at
-                 * least one app_context in both parent and child, so we don't
-                 * need to check that here. However, be sure not to overwrite
-                 * the prefix if the user already provided it!
-                 */
-                app = (prte_app_context_t *) prte_pointer_array_get_item(parent->apps, 0);
-                child_app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps, 0);
-                if (NULL != app && NULL != child_app) {
-                    prefix_dir = NULL;
-                    if (prte_get_attribute(&app->attributes, PRTE_APP_PREFIX_DIR,
-                                           (void **) &prefix_dir, PMIX_STRING)
-                        && !prte_get_attribute(&child_app->attributes, PRTE_APP_PREFIX_DIR, NULL,
-                                               PMIX_STRING)) {
-                        prte_set_attribute(&child_app->attributes, PRTE_APP_PREFIX_DIR,
-                                           PRTE_ATTR_GLOBAL, prefix_dir, PMIX_STRING);
-                    }
-                    if (NULL != prefix_dir) {
-                        free(prefix_dir);
-                    }
+            /* if the prefix was set in the parent's job, we need to transfer
+             * that prefix to the child's app_context so any further launch of
+             * orteds can find the correct binary. There always has to be at
+             * least one app_context in both parent and child, so we don't
+             * need to check that here. However, be sure not to overwrite
+             * the prefix if the user already provided it!
+             */
+            app = (prte_app_context_t *) prte_pointer_array_get_item(parent->apps, 0);
+            child_app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps, 0);
+            if (NULL != app && NULL != child_app) {
+                prefix_dir = NULL;
+                if (prte_get_attribute(&app->attributes, PRTE_APP_PREFIX_DIR,
+                                       (void **) &prefix_dir, PMIX_STRING)
+                    && !prte_get_attribute(&child_app->attributes, PRTE_APP_PREFIX_DIR, NULL,
+                                           PMIX_STRING)) {
+                    prte_set_attribute(&child_app->attributes, PRTE_APP_PREFIX_DIR,
+                                       PRTE_ATTR_GLOBAL, prefix_dir, PMIX_STRING);
+                }
+                if (NULL != prefix_dir) {
+                    free(prefix_dir);
                 }
             }
         }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -254,21 +254,14 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                                           PMIX_BOOL)) {
                 inherit = false;
                 parent = NULL;
-            } else if (PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
-                /* ensure we inherit the defaults as this is equivalent to an initial launch */
-                inherit = true;
-                parent = NULL;
             } else {
                 inherit = prte_rmaps_base.inherit;
             }
             prte_output_verbose(
                 5, prte_rmaps_base_framework.framework_output,
-                "mca:rmaps: dynamic job %s %s inherit launch directives - parent %s is %s",
+                "mca:rmaps: dynamic job %s %s inherit launch directives - parent %s",
                 PRTE_JOBID_PRINT(jdata->nspace), inherit ? "will" : "will not",
-                (NULL == parent) ? "N/A" : PRTE_JOBID_PRINT((parent->nspace)),
-                (NULL == parent)
-                    ? "NULL"
-                    : ((PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL) ? "TOOL" : "NON-TOOL")));
+                (NULL == parent) ? "N/A" : PRTE_JOBID_PRINT((parent->nspace)));
         } else {
             inherit = true;
         }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -414,7 +414,7 @@ addknown:
 complete:
     /* if we are mapping debuggers, then they don't count against
      * the allocation */
-    if (PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
+    if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
         num_slots = INT32_MAX;
         if (!prte_hnp_is_allocated
             || (PRTE_GET_MAPPING_DIRECTIVE(policy) & PRTE_MAPPING_NO_USE_LOCAL)) {
@@ -552,7 +552,7 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata, prte_node_t *node, pr
     proc->node = node;
     /* if this is a debugger job, then it doesn't count against
      * available slots - otherwise, it does */
-    if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
+    if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
         node->num_procs++;
         ++node->slots_inuse;
     }

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -336,7 +336,7 @@ static int ppr_mapper(prte_job_t *jdata)
                 }
             }
 
-            if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)) {
+            if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
                 /* set the total slots used */
                 if ((int) node->num_procs <= node->slots) {
                     node->slots_inuse = (int) node->num_procs;

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -567,7 +567,6 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
     pmix_proc_t parent, target;
     prte_pmix_lock_t lock;
     pmix_rank_t threshold;
-    prte_app_context_t *app;
 
     PRTE_ACQUIRE_OBJECT(caddy);
     proc = &caddy->name;
@@ -616,7 +615,6 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
     if (NULL == pdata) {
         goto cleanup;
     }
-    app = (prte_app_context_t*) prte_pointer_array_get_item(jdata->apps, pdata->app_idx);
 
     if (PRTE_PROC_STATE_RUNNING == state) {
         /* update the proc state */
@@ -686,10 +684,7 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
              * itself.  This covers the case where the process died abnormally
              * and didn't cleanup its own session directory.
              */
-            if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON)  &&
-                !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
-                prte_session_dir_finalize(proc);
-            }
+            prte_session_dir_finalize(proc);
         }
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs
@@ -886,7 +881,7 @@ CHECK_DAEMONS:
                     /* skip procs from another job */
                     continue;
                 }
-                if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON) &&
+                if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL) &&
                     !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
                     node->slots_inuse--;
                     node->num_procs--;

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -579,7 +579,7 @@ static void track_procs(int fd, short argc, void *cbdata)
                             continue;
                         }
                         app = (prte_app_context_t*) prte_pointer_array_get_item(jdata->apps, pptr->app_idx);
-                        if (!PRTE_FLAG_TEST(app, PRTE_APP_DEBUGGER_DAEMON) &&
+                        if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL) &&
                             !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
                             node->slots_inuse--;
                             node->num_procs--;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -288,7 +288,7 @@ static void interim(int sd, short args, void *cbdata)
                                        info->value.data.string, PMIX_STRING);
 
                 } else if (PMIX_CHECK_KEY(info, PMIX_COSPAWN_APP)) {
-                    PRTE_FLAG_SET(app, PRTE_APP_DEBUGGER_DAEMON);
+                    PRTE_FLAG_SET(app, PRTE_APP_FLAG_TOOL);
 
                     /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
                     /* there can be multiple of these, so we add them to the attribute list */
@@ -602,7 +602,7 @@ static void interim(int sd, short args, void *cbdata)
             for (n=0; n < (size_t)jdata->apps->size; n++) {
                 app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, n);
                 if (NULL != app) {
-                    PRTE_FLAG_SET(app, PRTE_APP_DEBUGGER_DAEMON);
+                    PRTE_FLAG_SET(app, PRTE_APP_FLAG_TOOL);
                 }
             }
 
@@ -656,6 +656,12 @@ static void interim(int sd, short args, void *cbdata)
                                PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
+            for (n=0; n < (size_t)jdata->apps->size; n++) {
+                app = (prte_app_context_t*)prte_pointer_array_get_item(jdata->apps, n);
+                if (NULL != app) {
+                    PRTE_FLAG_SET(app, PRTE_APP_FLAG_TOOL);
+                }
+            }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
             prte_add_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT, PRTE_ATTR_GLOBAL,

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -446,9 +446,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     /* get the parent job that spawned this one */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &parentproc, PMIX_PROC)) {
         parent = prte_get_job_data_object(parentproc->nspace);
-        if (NULL != parent
-            && (PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)
-                || PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, parent->nspace))) {
+        if (NULL != parent && PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, parent->nspace)) {
             PMIX_PROC_RELEASE(parentproc);
             parent = NULL;
         }
@@ -486,8 +484,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             /* location, for local procs */
             if (PRTE_PROC_MY_NAME->rank == node->daemon->name.rank) {
                 tmp = NULL;
-                if (prte_get_attribute(&pptr->attributes, PRTE_PROC_CPU_BITMAP, (void **) &tmp,
-                                       PMIX_STRING)
+                if (prte_get_attribute(&pptr->attributes, PRTE_PROC_CPU_BITMAP,
+                                       (void **) &tmp, PMIX_STRING)
                     && NULL != tmp) {
                     /* provide the cpuset string for this proc */
                     kv = PRTE_NEW(prte_info_item_t);

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -131,6 +131,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
     pmix_topology_t ptopo;
     char *tmp;
     pmix_info_t info[4];
+    prte_app_context_t *app;
 
     /* unpack the command */
     n = 1;
@@ -480,7 +481,9 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                         /* skip procs from another job */
                         continue;
                     }
-                    if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+                    app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps, proct->app_idx);
+                    if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL) &&
+                        !(PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL))) {
                         node->slots_inuse--;
                         node->num_procs--;
                     }

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -33,7 +33,7 @@
 /*** ATTRIBUTE FLAGS - never sent anywwhere ***/
 typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_FLAG_USED_ON_NODE  0x01    // is being used on the local node
-#define PRTE_APP_DEBUGGER_DAEMON    0x02    // this app describes daemons to be co-launched
+#define PRTE_APP_FLAG_TOOL          0x02    // this app describes daemons to be co-launched
                                             //    with the application procs in the other apps
                                             //    and does not count against allocation
 


### PR DESCRIPTION
Cleanup definition of "tool" in PRRTE so it is consistent across
the code base. Correctly identify apps as apps and not tools in
the examples. Correctly account for spawned tool procs when
termination the DVM

Fixes #1046 

Signed-off-by: Ralph Castain <rhc@pmix.org>