### PR TITLE
Remove unneeded pid from printf. 

### DIFF
--- a/examples/debugger/indirect-multi.c
+++ b/examples/debugger/indirect-multi.c
@@ -90,7 +90,7 @@ static void dbgr_complete_fn(size_t evhdlr_registration_id, pmix_status_t status
                          pmix_info_t results[], size_t nresults,
                          pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
-    printf("[%d]%s called with status %s\n", getpid(), __FUNCTION__, PMIx_Error_string(status));
+    printf("%s called with status %s\n", __FUNCTION__, PMIx_Error_string(status));
     /* this example doesn't do anything further */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);


### PR DESCRIPTION
Remove a pid from a printf in indirect-multi.c. This was added for debug purposes and its continued existence
caused CI test baseline compare to fail when it should have passed.

Signed-off-by: David Wootton <dwootton@us.ibm.com>