### PR TITLE
Add smsc framework to ompi generic MCA param table

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1017,6 +1017,7 @@ static char *ompi_frameworks[] = {
     "pstat",
     "rcache",
     "reachable",
+    "smsc",
     "shmem",
     "threads",
     "timer",


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit e6ec52e72bf900222299323276f864fe6222545d)