### PR TITLE
Error out if generic MCA param is unknown

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -122,3 +122,16 @@ ERROR: %s was unable to identify the proxy for your command.
 
 Please specify a personality or ask the library developer's to address
 the problem.
+#
+[unrecog-generic-param]
+The command line contains a generic MCA param that is not
+recognized by either the default or active personalities:
+
+  Param name:   %s
+  Param value:  %s
+
+Please modify the command line to either specify the personality
+this parameter belongs to (e.g., "--prtemca" for a PRRTE param,
+"--pmixmca" for a PMIx param, "--omca" for an OMPI param) or
+ensure that the generic param is correct and known to the active
+personality.

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -443,6 +443,10 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                 }
             }
             if (!ignore) {
+                /* replace the generic directive with a PRRTE specific
+                 * one so we know this has been processed */
+                free(argv[i]);
+                argv[i] = strdup("--prtemca");
                 if (NULL == target) {
                     /* push it into our environment */
                     asprintf(&param, "PRTE_MCA_%s", p1);
@@ -526,6 +530,10 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                 }
             }
             if (!ignore) {
+                /* replace the generic directive with a PRRTE specific
+                 * one so we know this has been processed */
+                free(argv[i]);
+                argv[i] = strdup("--pmixmca");
                 if (NULL == target) {
                     /* push it into our environment */
                     asprintf(&param, "PMIX_MCA_%s", p1);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1154,6 +1154,13 @@ static int parse_cli(int argc, int start, char **argv, char ***target)
                 free(p2);
                 i += 2;
                 continue;
+            } else {
+                /* this is an unrecognized generic param */
+                prte_show_help("help-schizo-base.txt", "unrecog-generic-param",
+                               true, p1, p2);
+                free(p1);
+                free(p2);
+                return PRTE_ERR_SILENT;
             }
         }
         if (0 == strcmp("--map-by", argv[i])) {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -436,10 +436,20 @@ static int check_help(prte_cmd_line_t *cli, char **argv)
 
 static int parse_cli(int argc, int start, char **argv, char ***target)
 {
+    int i;
+    
     prte_output_verbose(1, prte_schizo_base_framework.framework_output, "%s schizo:prte: parse_cli",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
-    /* we already did this in the tool */
+    for (i = 0; i < (argc - start); ++i) {
+        if (0 == strcmp("--mca", argv[i])) {
+            /* this is an unrecognized generic param */
+            prte_show_help("help-schizo-base.txt", "unrecog-generic-param",
+                           true, argv[i+1], argv[i+2]);
+            return PRTE_ERR_SILENT;
+        }
+    }
+
     return PRTE_SUCCESS;
 }
 


### PR DESCRIPTION
If PRRTE, PMIx, and the active schizo personality
do not recognize a generic MCA param on the command
line, then generate a "show help" message and error out.

Signed-off-by: Ralph Castain <rhc@pmix.org>