### PR TITLE
Compute and provide device distances for all procs in job

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -185,12 +185,13 @@ int prte_hwloc_base_register(void)
     }
 
     prte_hwloc_base_topo_file = NULL;
-    (void)
-        prte_mca_base_var_register("prte", "hwloc", "use", "topo_file",
-                                   "Read local topology from file instead of directly sensing it",
-                                   PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                   PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                   PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_hwloc_base_topo_file);
+    ret = prte_mca_base_var_register("prte", "hwloc", "use", "topo_file",
+                                     "Read local topology from file instead of directly sensing it",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
+                                     PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                     PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_hwloc_base_topo_file);
+    (void) prte_mca_base_var_register_synonym(ret, "prte", "ras", "simulator", "topo_files",
+                                              PRTE_MCA_BASE_VAR_SYN_FLAG_DEPRECATED | PRTE_MCA_BASE_VAR_SYN_FLAG_INTERNAL);
 
     /* register parameters */
     return PRTE_SUCCESS;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -514,6 +514,11 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
         } else {
             prte_output(0, "LAUNCH MSG RAW SIZE: %d", (int) jdata->launch_msg.bytes_used);
         }
+        /* go ahead and register the job */
+        rc = prte_pmix_server_register_nspace(jdata);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+        }
         prte_never_launched = true;
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALL_JOBS_COMPLETE);
         PRTE_RELEASE(caddy);

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -57,6 +57,7 @@ typedef struct prte_ras_base_t {
     int total_slots_alloc;
     int multiplier;
     bool launch_orted_on_hn;
+    bool simulated;
 } prte_ras_base_t;
 
 PRTE_EXPORT extern prte_ras_base_t prte_ras_base;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -195,6 +195,10 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
 
     /* convenience */
     jdata = caddy->jdata;
+    if (prte_ras_base.simulated) {
+        prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH,
+                           PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+    }
 
     /* if we already did this, don't do it again - the pool of
      * global resources is set.

--- a/src/mca/ras/base/ras_base_frame.c
+++ b/src/mca/ras/base/ras_base_frame.c
@@ -102,11 +102,6 @@ static int prte_ras_base_close(void)
  *    */
 static int prte_ras_base_open(prte_mca_base_open_flag_t flags)
 {
-    /* set default flags */
-    prte_ras_base.active_module = NULL;
-    prte_ras_base.allocation_read = false;
-    prte_ras_base.total_slots_alloc = 0;
-
     /* Open up all available components */
     return prte_mca_base_framework_components_open(&prte_ras_base_framework, flags);
 }

--- a/src/mca/ras/simulator/ras_sim_component.c
+++ b/src/mca/ras/simulator/ras_sim_component.c
@@ -80,24 +80,14 @@ static int ras_sim_register(void)
         "Comma-separated list of number of max slots on each node to simulate",
         PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_ras_simulator_component.slots_max);
+
     prte_ras_simulator_component.num_nodes = NULL;
     (void) prte_mca_base_component_var_register(
         component, "num_nodes",
         "Comma-separated list of number of nodes to simulate for each topology",
         PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_ras_simulator_component.num_nodes);
-    prte_ras_simulator_component.topofiles = NULL;
-    (void) prte_mca_base_component_var_register(
-        component, "topo_files",
-        "Comma-separated list of files containing xml topology descriptions for simulated nodes",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_ras_simulator_component.topofiles);
-    prte_ras_simulator_component.topologies = NULL;
-    (void) prte_mca_base_component_var_register(
-        component, "topologies",
-        "Comma-separated list of topology descriptions for simulated nodes",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_ras_simulator_component.topologies);
+
     prte_ras_simulator_component.have_cpubind = true;
     (void) prte_mca_base_component_var_register(component, "have_cpubind",
                                                 "Topology supports binding to cpus",
@@ -105,6 +95,7 @@ static int ras_sim_register(void)
                                                 PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                                 PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                                 &prte_ras_simulator_component.have_cpubind);
+
     prte_ras_simulator_component.have_membind = true;
     (void) prte_mca_base_component_var_register(component, "have_membind",
                                                 "Topology supports binding to memory",
@@ -117,15 +108,10 @@ static int ras_sim_register(void)
 
 static int ras_sim_component_query(prte_mca_base_module_t **module, int *priority)
 {
-    prte_job_t *jdata;
-
     if (NULL != prte_ras_simulator_component.num_nodes) {
         *module = (prte_mca_base_module_t *) &prte_ras_sim_module;
         *priority = 1000;
-        /* cannot launch simulated nodes or resolve their names to addresses */
-        jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, PRTE_ATTR_LOCAL, NULL,
-                           PMIX_BOOL);
+        prte_ras_base.simulated = true;
         return PRTE_SUCCESS;
     }
 


### PR DESCRIPTION
Restore the simulator support - now that we provide the
topology to the PMIx server library and use it from there,
we have to ensure that the simulated topology is used in
both PRRTE and PMIx.

Signed-off-by: Ralph Castain <rhc@pmix.org>