### PR TITLE
Correctly report --output-directory and --output-filename as deprecated

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -534,9 +534,13 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--timestamp-output")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--output", NULL, "timestamp", true);
     }
-    /* --output-directory DIR  ->  --output dir:DIR */
+    /* --output-directory DIR  ->  --output dir=DIR */
     else if (0 == strcmp(option, "--output-directory")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--output", "dir", pargs[i + 1], true);
+    }
+    /* --output-filename DIR  ->  --output file=file */
+    else if (0 == strcmp(option, "--output-filename")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--output", "file", pargs[i + 1], true);
     }
     /* --xml  ->  --output xml */
     else if (0 == strcmp(option, "--xml")) {
@@ -612,6 +616,8 @@ static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***arg
                        "--timestamp-output",
                        "--xml",
                        "--output-proctable",
+                       "--output-filename",
+                       "--output-directory",
                        "--debug",
                        NULL};
 

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -499,9 +499,13 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     else if (0 == strcmp(option, "--timestamp-output")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--output", NULL, "timestamp", true);
     }
-    /* --output-directory DIR  ->  --output dir:DIR */
+    /* --output-directory DIR  ->  --output dir=DIR */
     else if (0 == strcmp(option, "--output-directory")) {
         rc = prte_schizo_base_convert(argv, i, 1, "--output", "dir", pargs[i + 1], true);
+    }
+    /* --output-filename DIR  ->  --output file=file */
+    else if (0 == strcmp(option, "--output-filename")) {
+        rc = prte_schizo_base_convert(argv, i, 1, "--output", "file", pargs[i + 1], true);
     }
     /* --xml  ->  --output xml */
     else if (0 == strcmp(option, "--xml")) {
@@ -643,6 +647,8 @@ static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***arg
                        "--rank-by",
                        "--bind-to",
                        "--output-proctable",
+                       "--output-filename",
+                       "--output-directory",
                        "--debug",
                        NULL};
 


### PR DESCRIPTION
Ensure we treat these options as deprecated and report/convert them.

Fixes https://github.com/open-mpi/ompi/issues/9309

Signed-off-by: Ralph Castain <rhc@pmix.org>