### PR TITLE
Cleanups associated with IOF operations

### DIFF
--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -53,7 +53,7 @@ static void lkcbfunc(pmix_status_t status, void *cbdata)
 {
     prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
 
-    PRTE_POST_OBJECT(lk);
+    PRTE_ACQUIRE_OBJECT(lk);
     lk->status = prte_pmix_convert_status(status);
     PRTE_PMIX_WAKEUP_THREAD(lk);
 }
@@ -98,13 +98,8 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
                 PRTE_IOF_READ_ACTIVATE(rev);
                 return;
             }
-
-            PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                 "%s iof:hnp:read handler %s Error on connection:%d",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proct->name),
-                                 fd));
         }
-        /* numbytes must have been zero, so go down and close the fd etc */
+        /* go down and close the fd etc */
         goto CLEAN_RETURN;
     }
 

--- a/src/mca/iof/prted/iof_prted_read.c
+++ b/src/mca/iof/prted/iof_prted_read.c
@@ -49,7 +49,7 @@ static void lkcbfunc(pmix_status_t status, void *cbdata)
 {
     prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
 
-    PRTE_POST_OBJECT(lk);
+    PRTE_ACQUIRE_OBJECT(lk);
     lk->status = prte_pmix_convert_status(status);
     PRTE_PMIX_WAKEUP_THREAD(lk);
 }
@@ -96,13 +96,8 @@ void prte_iof_prted_read_handler(int fd, short event, void *cbdata)
                 PRTE_IOF_READ_ACTIVATE(rev);
                 return;
             }
-
-            PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                                 "%s iof:prted:read handler %s Error on connection:%d",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proct->name),
-                                 fd));
         }
-        /* numbytes must have been zero, so go down and close the fd etc */
+        /* go down and close the fd etc */
         goto CLEAN_RETURN;
     }
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -567,6 +567,7 @@ int pmix_server_init(void)
     char *tmp;
     pmix_status_t prc;
     prte_pmix_lock_t lock;
+    bool flag;
 
     if (prte_pmix_server_globals.initialized) {
         return PRTE_SUCCESS;
@@ -657,14 +658,16 @@ int pmix_server_init(void)
         prte_list_append(&ilist, &kv->super);
         /* if we are also persistent, then we do not output IOF ourselves */
         if (prte_persistent) {
-            bool flag = false;
-            kv = PRTE_NEW(prte_info_item_t);
-            PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
-            prte_list_append(&ilist, &kv->super);
+            flag = false;
+        } else {
+            flag = true;
         }
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
+        prte_list_append(&ilist, &kv->super);
     } else {
         /* prted's never locally output */
-        bool flag = false;
+        flag = false;
         kv = PRTE_NEW(prte_info_item_t);
         PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
         prte_list_append(&ilist, &kv->super);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -253,7 +253,7 @@ int prte(int argc, char *argv[])
     prte_app_context_t *dapp;
     bool proxyrun = false;
     void *jinfo;
-    pmix_proc_t pname, parent;
+    pmix_proc_t pname;
     pmix_value_t *val;
     pmix_data_array_t darray;
     char **hostfiles = NULL;
@@ -739,13 +739,13 @@ int prte(int argc, char *argv[])
     /* see if we ourselves were spawned by someone */
     ret = PMIx_Get(&prte_process_info.myproc, PMIX_PARENT_ID, NULL, 0, &val);
     if (PMIX_SUCCESS == ret) {
-        PMIX_LOAD_PROCID(&parent, val->data.proc->nspace, val->data.proc->rank);
+        PMIX_LOAD_PROCID(&prte_process_info.my_parent, val->data.proc->nspace, val->data.proc->rank);
         PMIX_VALUE_RELEASE(val);
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_REQUESTOR_IS_TOOL, NULL, PMIX_BOOL);
         /* indicate that we are launching on behalf of a parent */
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PARENT_ID, &parent, PMIX_PROC);
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PARENT_ID, &prte_process_info.my_parent, PMIX_PROC);
     } else {
-        PMIX_LOAD_PROCID(&parent, prte_process_info.myproc.nspace, prte_process_info.myproc.rank);
+        PMIX_LOAD_PROCID(&prte_process_info.my_parent, prte_process_info.myproc.nspace, prte_process_info.myproc.rank);
     }
 
     /* add any hostfile directives to the daemon job */
@@ -878,11 +878,6 @@ int prte(int argc, char *argv[])
             PMIX_INFO_LIST_XFER(ret, jinfo, &iptr[n]);
         }
         PMIX_VALUE_RELEASE(val);
-    }
-
-    /* if we don't have a parent, then we need to output this job's IOF */
-    if (PMIX_CHECK_PROCID(&parent, &prte_process_info.myproc)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_LOCAL_OUTPUT, NULL, PMIX_BOOL);
     }
 
     /* pass the personality */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -327,7 +327,7 @@ int main(int argc, char *argv[])
 
     /* get our schizo module */
     prte_unsetenv("PRTE_MCA_schizo_proxy", &environ);
-    schizo = prte_schizo.detect_proxy(NULL);
+    schizo = prte_schizo.detect_proxy("prte");
     if (NULL == schizo || 0 != strcmp(schizo->name, "prte")) {
         prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "NONE");
         return 1;
@@ -341,9 +341,6 @@ int main(int argc, char *argv[])
         }
         return ret;
     }
-
-    /* purge any ess/prte flags set in the environ when we were launched */
-    prte_unsetenv("PRTE_MCA_ess", &prte_launch_environ);
 
     /* set debug flags */
     prte_debug_flag = prte_cmd_line_is_taken(prte_cmd_line, "debug");


### PR DESCRIPTION
Daemons never directly locally output IOF, so do not
include a "local output" flag in a job's info as the
daemon will see it and think it needs to locally output.

Signed-off-by: Ralph Castain <rhc@pmix.org>