### PR TITLE
Avoid use of MCA params for singleton and report-uri

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -647,6 +647,20 @@ int pmix_server_init(void)
         prte_list_append(&ilist, &kv->super);
     }
 
+    /* if requested, tell the server library to output our PMIx URI */
+    if (NULL != prte_pmix_server_globals.report_uri) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_TCP_REPORT_URI, prte_pmix_server_globals.report_uri, PMIX_STRING);
+        prte_list_append(&ilist, &kv->super);
+    }
+
+    /* if we were started to support a singleton, then let the server library know */
+    if (NULL != prte_pmix_server_globals.singleton) {
+        kv = PRTE_NEW(prte_info_item_t);
+        PMIX_INFO_LOAD(&kv->info, PMIX_SINGLETON, prte_pmix_server_globals.singleton, PMIX_STRING);
+        prte_list_append(&ilist, &kv->super);
+    }
+
     /* if we are the MASTER, then we are the scheduler
      * as well as a gateway */
     if (PRTE_PROC_IS_MASTER) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -372,6 +372,8 @@ typedef struct {
     bool pubsub_init;
     bool session_server;
     bool system_server;
+    char *report_uri;
+    char *singleton;
     pmix_device_type_t generate_dist;
     prte_list_t tools;
     prte_list_t psets;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -528,7 +528,7 @@ int prte(int argc, char *argv[])
     prte_setenv("PRTE_MCA_pmix_session_server", "1", true, &environ);
     /* if we were asked to report a uri, set the MCA param to do so */
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "report-uri", 0, 0))) {
-        prte_setenv("PMIX_MCA_ptl_base_report_uri", pval->value.data.string, true, &environ);
+        prte_pmix_server_globals.report_uri = strdup(pval->value.data.string);
     }
     /* don't aggregate help messages as that will apply job-to-job */
     prte_setenv("PRTE_MCA_prte_base_help_aggregate", "0", true, &environ);
@@ -536,7 +536,7 @@ int prte(int argc, char *argv[])
     /* if we are supporting a singleton, push its ID into the environ
      * so it can get picked up and registered by server init */
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "singleton", 0, 0))) {
-        prte_setenv("PMIX_MCA_singleton", pval->value.data.string, true, &environ);
+        prte_pmix_server_globals.singleton = strdup(pval->value.data.string);
     }
 
     /* Setup MCA params */


### PR DESCRIPTION
This can cause problems because PMIx will pick them up
and forward them to all daemons and app procs, resulting
in confusion.

Signed-off-by: Ralph Castain <rhc@pmix.org>