### PR TITLE
Use correct ninfo when passing into APIs and Don't locally output stdout/err if prterun has a parent 

### DIFF
--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -412,8 +412,8 @@ static int cospawn_launch(myrel_t *myrel)
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_DATA_ARRAY_DESTRUCT(&daemon_darray);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "Application failed to launch with error: %s(%d)\n", PMIx_Error_string(rc),
-                rc);
+        fprintf(stderr, "Application failed to launch with error: %s(%d)\n",
+                PMIx_Error_string(rc), rc);
         return rc;
     }
     /* Daemon and application are in same namespace */
@@ -439,7 +439,7 @@ static int cospawn_launch(myrel_t *myrel)
     ninfo = darray.size;
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, info, 2, release_fn, evhandler_reg_callbk,
+    PMIx_Register_event_handler(&code, 1, info, ninfo, release_fn, evhandler_reg_callbk,
                                 (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);

--- a/examples/debugger/indirect-multi.c
+++ b/examples/debugger/indirect-multi.c
@@ -495,7 +495,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LIST_RELEASE(dirs);
     info = (pmix_info_t*)darray.array;
     ninfo = darray.size;
-    PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, &myproc, PMIX_RANGE_CUSTOM, info, 2, NULL, NULL);
+    PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, &myproc, PMIX_RANGE_CUSTOM, info, ninfo, NULL, NULL);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
 
     printf("Waiting for application launch\n");

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -324,7 +324,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LIST_RELEASE(dirs);
     info = darray.array;
     ninfo = darray.size;
-    PMIx_Register_event_handler(&code, 1, info, 2, spawn_cbfunc, evhandler_reg_callbk,
+    PMIx_Register_event_handler(&code, 1, info, ninfo, spawn_cbfunc, evhandler_reg_callbk,
                                 (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
     PMIX_INFO_LIST_RELEASE(dirs);
     info = darray.array;
     ninfo = darray.size;
-    PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, &myproc, PMIX_RANGE_CUSTOM, info, 2, NULL, NULL);
+    PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, &myproc, PMIX_RANGE_CUSTOM, info, ninfo, NULL, NULL);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     printf("WAITING FOR APPLICATION LAUNCH\n");
     /* wait for the IL to have launched its application */

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -675,7 +675,12 @@ int pmix_server_init(void)
         if (prte_persistent) {
             flag = false;
         } else {
-            flag = true;
+            /* if we have a parent, then we don't write out ourselves */
+            if (NULL != getenv("PMIX_LAUNCHER_RNDZ_URI")) {
+                flag = false;
+            } else {
+                flag = true;
+            }
         }
         PMIX_INFO_LOAD(&kv->info, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
         prte_list_append(&ilist, &kv->super);


### PR DESCRIPTION
Use correct ninfo when passing into APIs
Use the value provided by converting the list array instead
of a (in some cases incorrect) hardcoded value.

Don't locally output stdout/err if prterun has a parent

Signed-off-by: Ralph Castain <rhc@pmix.org>