### PR TITLE
Cleanup the timeout support to maintain legacy behavior

### DIFF
--- a/src/mca/plm/base/help-plm-base.txt
+++ b/src/mca/plm/base/help-plm-base.txt
@@ -175,12 +175,3 @@ detected that the following node differs in endianness:
   Local endian:  %s
 
 Please correct the situation and try again.
-#
-[timeout]
-The user-provided time limit for job execution has been reached:
-
-  Timeout: %d seconds
-
-The job will now be aborted.  Please check your code and/or
-adjust/remove the job execution time limit (as specified by --timeout
-command line option or MPIEXEC_TIMEOUT environment variable).

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -167,6 +167,10 @@ static prte_cmd_line_init_t ompi_cmd_line_init[] = {
      "Report all job and process states upon timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
     {'\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
      "Get stack traces of all application procs on timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
+#ifdef PMIX_SPAWN_TIMEOUT
+    {'\0', "spawn-timeout", 1, PRTE_CMD_LINE_TYPE_INT,
+     "Timeout the job if spawn takes more than the specified number of seconds", PRTE_CMD_LINE_OTYPE_DEBUG},
+#endif
 
     {'\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
      "Allow execution as root (STRONGLY DISCOURAGED)", PRTE_CMD_LINE_OTYPE_DVM}, /* End of list */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -158,6 +158,10 @@ static prte_cmd_line_init_t prte_cmd_line_init[] = {
      "Report all job and process states upon timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
     {'\0', "get-stack-traces", 0, PRTE_CMD_LINE_TYPE_BOOL,
      "Get stack traces of all application procs on timeout", PRTE_CMD_LINE_OTYPE_DEBUG},
+#ifdef PMIX_SPAWN_TIMEOUT
+    {'\0', "spawn-timeout", 1, PRTE_CMD_LINE_TYPE_INT,
+     "Timeout the job if spawn takes more than the specified number of seconds", PRTE_CMD_LINE_OTYPE_DEBUG},
+#endif
 
     {'\0', "allow-run-as-root", 0, PRTE_CMD_LINE_TYPE_BOOL,
      "Allow execution as root (STRONGLY DISCOURAGED)", PRTE_CMD_LINE_OTYPE_DVM}, /* End of list */

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -520,10 +520,10 @@ static void check_complete(int fd, short args, void *cbdata)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         (NULL == jdata) ? "NULL" : PRTE_JOBID_PRINT(jdata->nspace));
 
-    if (NULL != jdata
-        && prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, (void **) &timer,
-                              PMIX_POINTER)) {
+    if (NULL != jdata &&
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, (void **) &timer, PMIX_POINTER)) {
         /* timer is an prte_timer_t object */
+        prte_event_evtimer_del(timer->ev);
         PRTE_RELEASE(timer);
         prte_remove_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT);
     }

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -670,9 +670,22 @@ static void interim(int sd, short args, void *cbdata)
                 }
             }
 
+#ifdef PMIX_SPAWN_TIMEOUT
+        } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TIMEOUT) ||
+                   PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
+            prte_add_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
+                               &info->value.data.integer, PMIX_INT);
+#else
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
+            prte_add_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
+                               &info->value.data.integer, PMIX_INT);
+#endif
+
+#ifdef PMIX_JOB_TIMEOUT
+        } else if (PMIX_CHECK_KEY(info, PMIX_JOB_TIMEOUT)) {
             prte_add_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT, PRTE_ATTR_GLOBAL,
                                &info->value.data.integer, PMIX_INT);
+#endif
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT_STACKTRACES)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1067,8 +1067,8 @@ int prte(int argc, char *argv[])
      * as that is what MPICH used
      */
     timeoutenv = NULL;
-    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "timeout", 0, 0))
-        || NULL != (timeoutenv = getenv("MPIEXEC_TIMEOUT"))) {
+    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "timeout", 0, 0)) ||
+        NULL != (timeoutenv = getenv("MPIEXEC_TIMEOUT"))) {
         if (NULL != timeoutenv) {
             i = strtol(timeoutenv, NULL, 10);
             /* both cannot be present, or they must agree */
@@ -1081,7 +1081,11 @@ int prte(int argc, char *argv[])
         } else {
             i = pval->value.data.integer;
         }
+#ifdef PMIX_JOB_TIMEOUT
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_TIMEOUT, &i, PMIX_INT);
+#else
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT, &i, PMIX_INT);
+#endif
     }
     if (prte_cmd_line_is_taken(prte_cmd_line, "get-stack-traces")) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_STACKTRACES, NULL, PMIX_BOOL);
@@ -1089,6 +1093,12 @@ int prte(int argc, char *argv[])
     if (prte_cmd_line_is_taken(prte_cmd_line, "report-state-on-timeout")) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_REPORT_STATE, NULL, PMIX_BOOL);
     }
+#ifdef PMIX_SPAWN_TIMEOUT
+    if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "spawn-timeout", 0, 0))) {
+        i = pval->value.data.integer;
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_SPAWN_TIMEOUT, &i, PMIX_INT);
+    }
+#endif
 
     /* give the schizo components a chance to add to the job info */
     prte_schizo.job_info(prte_cmd_line, jinfo);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -364,6 +364,9 @@ typedef struct {
     prte_list_t children;
     /* track the launcher of these jobs */
     pmix_nspace_t launcher;
+    /* track the number of stack traces recv'd */
+    uint32_t ntraces;
+    char **traces;
 } prte_job_t;
 PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_job_t);
 
@@ -538,7 +541,6 @@ PRTE_EXPORT extern bool prte_routing_is_enabled;
 PRTE_EXPORT extern bool prte_job_term_ordered;
 PRTE_EXPORT extern bool prte_prteds_term_ordered;
 PRTE_EXPORT extern bool prte_allowed_exit_without_sync;
-PRTE_EXPORT extern int prte_startup_timeout;
 
 PRTE_EXPORT extern int prte_timeout_usec_per_proc;
 PRTE_EXPORT extern float prte_max_timeout;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -393,14 +393,6 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prted_debug_failure_delay);
 
-    prte_startup_timeout = 0;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "startup_timeout",
-                                      "Seconds to wait for startup or job launch before declaring "
-                                      "failed_to_start [default: 0 => do not check]",
-                                      PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0,
-                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_startup_timeout);
-
     /* default hostfile */
     prte_default_hostfile = NULL;
     (void)

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -302,8 +302,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB-SNAPC-FINI-BARRIER-ID";
         case PRTE_JOB_NUM_NONZERO_EXIT:
             return "JOB-NUM-NONZERO-EXIT";
-        case PRTE_JOB_FAILURE_TIMER_EVENT:
-            return "JOB-FAILURE-TIMER-EVENT";
+        case PRTE_SPAWN_TIMEOUT_EVENT:
+            return "SPAWN-TIMEOUT-EVENT";
         case PRTE_JOB_ABORTED_PROC:
             return "JOB-ABORTED-PROC";
         case PRTE_JOB_MAPPER:
@@ -460,6 +460,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "ENVARS-HARVESTED";
         case PRTE_JOB_OUTPUT_NOCOPY:
             return "DO-NOT-COPY-OUTPUT";
+        case PRTE_SPAWN_TIMEOUT:
+            return "SPAWN-TIMEOUT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -115,8 +115,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_SNAPC_INIT_BAR             (PRTE_JOB_START_KEY + 8) // prte_grpcomm_coll_id_t - collective id
 #define PRTE_JOB_SNAPC_FINI_BAR             (PRTE_JOB_START_KEY + 9) // prte_grpcomm_coll_id_t - collective id
 #define PRTE_JOB_NUM_NONZERO_EXIT           (PRTE_JOB_START_KEY + 10) // int32 - number of procs with non-zero exit codes
-#define PRTE_JOB_FAILURE_TIMER_EVENT        (PRTE_JOB_START_KEY + 11) // prte_ptr (prte_timer_t*) - timer event for failure detect/response
-                                                                  // if fails to launch
+#define PRTE_SPAWN_TIMEOUT_EVENT            (PRTE_JOB_START_KEY + 11) // prte_ptr (prte_timer_t*) - timer event for failure detect/response
+                                                                      // if fails to launch
 #define PRTE_JOB_ABORTED_PROC               (PRTE_JOB_START_KEY + 12) // prte_ptr (prte_proc_t*) - proc that caused abort to happen
 #define PRTE_JOB_MAPPER                     (PRTE_JOB_START_KEY + 13) // bool - job consists of MapReduce mappers
 #define PRTE_JOB_REDUCER                    (PRTE_JOB_START_KEY + 14) // bool - job consists of MapReduce reducers
@@ -197,6 +197,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY + 90) // envars have already been harvested
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY + 91) // bool - do not copy output to stdout/err
 #define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY + 92) // bool - tag stdout/stderr with rank
+#define PRTE_SPAWN_TIMEOUT                  (PRTE_JOB_START_KEY + 93) // int32 - number of seconds to spawn before terminating it as timed out
 
 #define PRTE_JOB_MAX_KEY 300
 


### PR DESCRIPTION
We want the --timeout option to specify total execution time
limit, but we also want to maintain the spawn time limit feature.
So split the two (when PMIx supports it) and provide both
features.

Signed-off-by: Ralph Castain <rhc@pmix.org>