### PR TITLE
Circulate and report local completion status for collectives

### DIFF
--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -73,12 +73,14 @@ static int finalize(void);
 /******************
  * dvm module
  ******************/
-prte_errmgr_base_module_t prte_errmgr_dvm_module = {.init = init,
-                                                    .finalize = finalize,
-                                                    .logfn = prte_errmgr_base_log,
-                                                    .abort = prte_errmgr_base_abort,
-                                                    .abort_peers = prte_errmgr_base_abort_peers,
-                                                    .enable_detector = NULL};
+prte_errmgr_base_module_t prte_errmgr_dvm_module = {
+    .init = init,
+    .finalize = finalize,
+    .logfn = prte_errmgr_base_log,
+    .abort = prte_errmgr_base_abort,
+    .abort_peers = prte_errmgr_base_abort_peers,
+    .enable_detector = NULL
+};
 
 /*
  * Local functions

--- a/src/mca/grpcomm/base/base.h
+++ b/src/mca/grpcomm/base/base.h
@@ -83,7 +83,8 @@ PRTE_EXPORT int prte_grpcomm_API_xcast(prte_grpcomm_signature_t *sig, prte_rml_t
                                        pmix_data_buffer_t *buf);
 
 PRTE_EXPORT int prte_grpcomm_API_allgather(prte_grpcomm_signature_t *sig, pmix_data_buffer_t *buf,
-                                           int mode, prte_grpcomm_cbfunc_t cbfunc, void *cbdata);
+                                           int mode, pmix_status_t local_status,
+                                           prte_grpcomm_cbfunc_t cbfunc, void *cbdata);
 /* reliable broadcast API */
 PRTE_EXPORT int prte_grpcomm_API_rbcast(prte_grpcomm_signature_t *sig, prte_rml_tag_t tag,
                                         pmix_data_buffer_t *buf);

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -132,6 +132,7 @@ PRTE_CLASS_INSTANCE(prte_grpcomm_signature_t, prte_object_t, scon, sdes);
 static void ccon(prte_grpcomm_coll_t *p)
 {
     p->sig = NULL;
+    p->status = PMIX_SUCCESS;
     PMIX_DATA_BUFFER_CONSTRUCT(&p->bucket);
     PRTE_CONSTRUCT(&p->distance_mask_recv, prte_bitmap_t);
     p->dmns = NULL;

--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -44,13 +44,15 @@ static int register_cb_type(prte_grpcomm_rbcast_cb_t callback);
 static int unregister_cb_type(int type);
 
 /* Module def */
-prte_grpcomm_base_module_t prte_grpcomm_bmg_module = {.init = bmg_init,
-                                                      .finalize = bmg_finalize,
-                                                      .xcast = NULL,
-                                                      .allgather = NULL,
-                                                      .rbcast = rbcast,
-                                                      .register_cb = register_cb_type,
-                                                      .unregister_cb = unregister_cb_type};
+prte_grpcomm_base_module_t prte_grpcomm_bmg_module = {
+    .init = bmg_init,
+    .finalize = bmg_finalize,
+    .xcast = NULL,
+    .allgather = NULL,
+    .rbcast = rbcast,
+    .register_cb = register_cb_type,
+    .unregister_cb = unregister_cb_type
+};
 
 /* Internal functions */
 static void rbcast_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -42,16 +42,20 @@
 static int init(void);
 static void finalize(void);
 static int xcast(pmix_rank_t *vpids, size_t nprocs, pmix_data_buffer_t *buf);
-static int allgather(prte_grpcomm_coll_t *coll, pmix_data_buffer_t *buf, int mode);
+static int allgather(prte_grpcomm_coll_t *coll,
+                     pmix_data_buffer_t *buf,
+                     int mode, pmix_status_t local_status);
 
 /* Module def */
-prte_grpcomm_base_module_t prte_grpcomm_direct_module = {.init = init,
-                                                         .finalize = finalize,
-                                                         .xcast = xcast,
-                                                         .allgather = allgather,
-                                                         .rbcast = NULL,
-                                                         .register_cb = NULL,
-                                                         .unregister_cb = NULL};
+prte_grpcomm_base_module_t prte_grpcomm_direct_module = {
+    .init = init,
+    .finalize = finalize,
+    .xcast = xcast,
+    .allgather = allgather,
+    .rbcast = NULL,
+    .register_cb = NULL,
+    .unregister_cb = NULL
+};
 
 /* internal functions */
 static void xcast_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
@@ -72,13 +76,13 @@ static int init(void)
     PRTE_CONSTRUCT(&tracker, prte_list_t);
 
     /* post the receives */
-    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST, PRTE_RML_PERSISTENT, xcast_recv,
-                            NULL);
-    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_ALLGATHER_DIRECT, PRTE_RML_PERSISTENT,
-                            allgather_recv, NULL);
+    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST,
+                            PRTE_RML_PERSISTENT, xcast_recv, NULL);
+    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_ALLGATHER_DIRECT,
+                            PRTE_RML_PERSISTENT, allgather_recv, NULL);
     /* setup recv for barrier release */
-    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_COLL_RELEASE, PRTE_RML_PERSISTENT,
-                            barrier_release, NULL);
+    prte_rml.recv_buffer_nb(PRTE_NAME_WILDCARD, PRTE_RML_TAG_COLL_RELEASE,
+                            PRTE_RML_PERSISTENT, barrier_release, NULL);
 
     return PRTE_SUCCESS;
 }
@@ -106,13 +110,15 @@ static int xcast(pmix_rank_t *vpids, size_t nprocs, pmix_data_buffer_t *buf)
     return PRTE_SUCCESS;
 }
 
-static int allgather(prte_grpcomm_coll_t *coll, pmix_data_buffer_t *buf, int mode)
+static int allgather(prte_grpcomm_coll_t *coll, pmix_data_buffer_t *buf,
+                     int mode, pmix_status_t local_status)
 {
     int rc;
     pmix_data_buffer_t *relay;
 
     PRTE_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                         "%s grpcomm:direct: allgather", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+                         "%s grpcomm:direct: allgather",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
     /* the base functions pushed us into the event library
      * before calling us, so we can safely access global data
@@ -141,6 +147,14 @@ static int allgather(prte_grpcomm_coll_t *coll, pmix_data_buffer_t *buf, int mod
         return rc;
     }
 
+    /* pack the local_status */
+    rc = PMIx_Data_pack(NULL, relay, &local_status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        return rc;
+    }
+
     /* pass along the payload */
     rc = PMIx_Data_copy_payload(relay, buf);
     if (PMIX_SUCCESS != rc) {
@@ -155,19 +169,22 @@ static int allgather(prte_grpcomm_coll_t *coll, pmix_data_buffer_t *buf, int mod
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
     /* send the info to ourselves for tracking */
-    rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_NAME, relay, PRTE_RML_TAG_ALLGATHER_DIRECT,
+    rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_NAME, relay,
+                                 PRTE_RML_TAG_ALLGATHER_DIRECT,
                                  prte_rml_send_callback, NULL);
     return rc;
 }
 
-static void allgather_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+static void allgather_recv(int status, pmix_proc_t *sender,
+                           pmix_data_buffer_t *buffer,
                            prte_rml_tag_t tag, void *cbdata)
 {
     int32_t cnt;
-    int rc, ret, mode;
+    int rc, mode;
     prte_grpcomm_signature_t sig;
     pmix_data_buffer_t *reply;
     prte_grpcomm_coll_t *coll;
+    pmix_status_t local_status;
 
     PRTE_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct allgather recvd from %s",
@@ -202,6 +219,18 @@ static void allgather_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *
         PMIX_ERROR_LOG(rc);
         return;
     }
+
+    /* unpack their local status */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &local_status, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (PMIX_SUCCESS != local_status) {
+        coll->status = local_status;
+    }
+
     /* increment nprocs reported for collective */
     coll->nreported++;
     /* capture any provided content */
@@ -239,10 +268,8 @@ static void allgather_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *
                 PMIX_PROC_FREE(sig.signature, sig.sz);
                 return;
             }
-            /* pack the status - success since the allgather completed. This
-             * would be an error if we timeout instead */
-            ret = PRTE_SUCCESS;
-            rc = PMIx_Data_pack(NULL, reply, &ret, 1, PMIX_INT32);
+            /* pack the status */
+            rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_INT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
@@ -319,7 +346,8 @@ static void allgather_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *
                 return;
             }
             /* send the info to our parent */
-            rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_PARENT, reply, PRTE_RML_TAG_ALLGATHER_DIRECT,
+            rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_PARENT, reply,
+                                         PRTE_RML_TAG_ALLGATHER_DIRECT,
                                          prte_rml_send_callback, NULL);
         }
     }

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -74,6 +74,7 @@ typedef struct {
     prte_list_item_t super;
     /* collective's signature */
     prte_grpcomm_signature_t *sig;
+    pmix_status_t status;
     /* collection bucket */
     pmix_data_buffer_t bucket;
     /* participating daemons */
@@ -122,7 +123,8 @@ typedef int (*prte_grpcomm_base_module_xcast_fn_t)(pmix_rank_t *vpids, size_t np
  * NOTE: this is a non-blocking call. The callback function cached in
  * the prte_grpcomm_coll_t will be invoked upon completion. */
 typedef int (*prte_grpcomm_base_module_allgather_fn_t)(prte_grpcomm_coll_t *coll,
-                                                       pmix_data_buffer_t *buf, int mode);
+                                                       pmix_data_buffer_t *buf, int mode,
+                                                       pmix_status_t local_status);
 
 /* Reliable broadcast a message thru BMG.
  * only need to provide a message buffer, dont need create dmns
@@ -169,7 +171,9 @@ typedef int (*prte_grpcomm_base_API_xcast_fn_t)(prte_grpcomm_signature_t *sig, p
  * will be invoked upon completion. */
 typedef int (*prte_grpcomm_base_API_allgather_fn_t)(prte_grpcomm_signature_t *sig,
                                                     pmix_data_buffer_t *buf, int mode,
+                                                    pmix_status_t local_status,
                                                     prte_grpcomm_cbfunc_t cbfunc, void *cbdata);
+
 /* Reliable broadcast a message. Caller will provide an array
  * of daemon. A NULL pointer indicates that all known daemons are in the BMG.
  * A pointer to a name that includes ORTE_VPID_WILDCARD

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1099,7 +1099,7 @@ static void _cnct(int sd, short args, void *cbdata)
 
     /* pass it to the global collective algorithm */
     /* pass along any data that was collected locally */
-    rc = prte_grpcomm.allgather(md->sig, &dbuf, 1, connect_release, md);
+    rc = prte_grpcomm.allgather(md->sig, &dbuf, 1, cd->status, connect_release, md);
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_RELEASE(md);
@@ -1136,6 +1136,13 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     op->nprocs = nprocs;
     op->info = (pmix_info_t *) info;
     op->ninfo = ninfo;
+    if (NULL != info) {
+        if (PMIX_CHECK_KEY(&info[ninfo-1], PMIX_LOCAL_COLLECTIVE_STATUS)) {
+            op->status = info[ninfo-1].value.data.status;
+        }
+    } else {
+        op->status = PMIX_SUCCESS;
+    }
     op->cbfunc = cbfunc;
     op->cbdata = cbdata;
     prte_event_set(prte_event_base, &(op->ev), -1, PRTE_EV_WRITE, _cnct, op);
@@ -1178,8 +1185,8 @@ pmix_status_t pmix_server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
 
-    if (PMIX_SUCCESS
-        != (rc = pmix_server_fencenb_fn(procs, nprocs, info, ninfo, NULL, 0, mdxcbfunc, cd))) {
+    rc = pmix_server_fencenb_fn(procs, nprocs, info, ninfo, NULL, 0, mdxcbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PRTE_RELEASE(cd);
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -949,8 +949,9 @@ complete:
     }
 }
 
-pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid, const pmix_proc_t procs[],
-                                   size_t nprocs, const pmix_info_t directives[], size_t ndirs,
+pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
+                                   const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t directives[], size_t ndirs,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_mdx_caddy_t *cd;
@@ -1028,7 +1029,9 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid, const 
         }
     }
     /* pass it to the global collective algorithm */
-    if (PRTE_SUCCESS != (rc = prte_grpcomm.allgather(cd->sig, cd->buf, mode, group_release, cd))) {
+    if (PRTE_SUCCESS != (rc = prte_grpcomm.allgather(cd->sig, cd->buf,
+                                                     mode, PMIX_SUCCESS,
+                                                     group_release, cd))) {
         PRTE_ERROR_LOG(rc);
         PRTE_RELEASE(cd);
         return PMIX_ERROR;

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -118,7 +118,7 @@ PRTE_CLASS_DECLARATION(pmix_server_req_t);
 typedef struct {
     prte_object_t super;
     prte_event_t ev;
-    int status;
+    pmix_status_t status;
     pmix_status_t *codes;
     size_t ncodes;
     pmix_proc_t proc;


### PR DESCRIPTION
PMIx servers will pass the local collective status to the
host server. Look for it and circulate, returning the error
if any of the participating daemons receive a non-success
local collective status

Signed-off-by: Ralph Castain <rhc@pmix.org>