### PR TITLE
configure.ac: abort if gcc is <= v4.8.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2006-2021 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
 # Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
@@ -474,6 +474,23 @@ prte_show_subtitle "Compiler characteristics"
 
 PRTE_CHECK_ATTRIBUTES
 PRTE_CHECK_COMPILER_VERSION_ID
+
+# PRTE only supports GCC >=v4.8.1.  Notes:
+#
+# 1. The default compiler that comes with RHEL 7 is v4.8.5
+#    (version ID 264197).
+# 2. We regularly test with GCC v4.8.1 (version ID 264193).
+# 3. GCC 4.8.0 probably also works; we just haven't tested it.
+#
+# Since we regularly test with 4.8.1, that's what we check for.
+AS_IF([test "$prte_cv_compiler_FAMILYNAME" = "GNU" && \
+           test "$prte_cv_compiler_VERSION" -lt 264193],
+      [AC_MSG_WARN([PRTE no longer supports versions of the GNU compiler suite])
+       AC_MSG_WARN([less than v4.8.1.])
+       AC_MSG_WARN([Please upgrade your GNU compiler suite, or use])
+       AC_MSG_WARN([a different compiler to build PRTE.])
+       AC_MSG_ERROR([Cannot continue])
+      ])
 
 ##################################
 # Assembler Configuration


### PR DESCRIPTION
This is a port from the corresponding
https://github.com/open-mpi/ompi/pull/9398.

PRTE does not compile with GCC 4.4.7 (the default GCC that ships in
RHEL 6).  PRTE *does* compile with GCC 4.8.5 (the default GCC
that ships with RHEL 7).  The Open MPI community regularly tests Open
MPI (including PRTE) with GCC 4.8.1, so we know that works, too.

Hence, abort configure if GCC is used and GCC is < v4.8.1.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>