### PR TITLE
Only order DVM termination once

### DIFF
--- a/src/mca/plm/base/plm_base_prted_cmds.c
+++ b/src/mca/plm/base/plm_base_prted_cmds.c
@@ -74,10 +74,15 @@ int prte_plm_base_prted_exit(prte_daemon_cmd_flag_t command)
     prte_grpcomm_signature_t *sig;
 
     PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                         "%s plm:base:orted_cmd sending orted_exit commands",
+                         "%s plm:base:prted_cmd sending prted_exit commands",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
-    /* flag that orteds are being terminated */
+    /* don't call this more than once */
+    if (prte_prteds_term_ordered) {
+        return PRTE_SUCCESS;
+    }
+
+    /* flag that prteds are being terminated */
     prte_prteds_term_ordered = true;
     cmmnd = command;
 

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -357,8 +357,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
         }
         /* kill the local procs */
         prte_odls.kill_local_procs(NULL);
-        /* flag that prteds were ordered to terminate */
-        prte_prteds_term_ordered = true;
         /* if all my routes and local children are gone, then terminate ourselves */
         if (0 == (ret = prte_routed.num_routes())) {
             for (i = 0; i < prte_local_children->size; i++) {
@@ -414,8 +412,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                                 PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
         PRTE_PMIX_WAIT_THREAD(&lk);
         PRTE_PMIX_DESTRUCT_LOCK(&lk);
-        /* flag that prteds were ordered to terminate */
-        prte_prteds_term_ordered = true;
         if (PRTE_PROC_IS_MASTER) {
             /* if all my routes and local children are gone, then terminate ourselves */
             if (0 == prte_routed.num_routes()) {


### PR DESCRIPTION
Basically a port of https://github.com/open-mpi/ompi/pull/9435,
only simplified. As noted there, this isn't really a problem
over here, but it makes sense to ensure we don't try to order
it more than once.

Signed-off-by: Ralph Castain <rhc@pmix.org>