### PR TITLE
Fix segmentation fault caused by wrong size for vpids buffer

### DIFF
--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -190,7 +190,7 @@ int prte_util_nidmap_create(prte_pointer_array_t *pool, pmix_data_buffer_t *buff
         /* mark that this was not compressed */
         compressed = false;
         bo.bytes = (char *) vpids;
-        bo.size = nbytes * ndaemons;
+        bo.size = ndaemons * sizeof(pmix_rank_t);
     }
     /* indicate compression */
     rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &compressed, 1, PMIX_BOOL);


### PR DESCRIPTION
`prterun` command caused a segmentation fault in my environment consisting of 256 nodes.
I found that a too large size was set for `vpids`, although `vpids` is allocated with the size `nbytes`.

Signed-off-by: Shumpei Shiina <s417.lama@gmail.com>