### PR TITLE
Ensure daemons know they were ordered to terminate

### DIFF
--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -357,6 +357,8 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
         }
         /* kill the local procs */
         prte_odls.kill_local_procs(NULL);
+        // ensure daemons know we were ordered to terminate
+        prte_prteds_term_ordered = true;
         /* if all my routes and local children are gone, then terminate ourselves */
         if (0 == (ret = prte_routed.num_routes())) {
             for (i = 0; i < prte_local_children->size; i++) {
@@ -412,6 +414,8 @@ void prte_daemon_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffe
                                 PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
         PRTE_PMIX_WAIT_THREAD(&lk);
         PRTE_PMIX_DESTRUCT_LOCK(&lk);
+        // ensure daemons know we were ordered to terminate
+        prte_prteds_term_ordered = true;
         if (PRTE_PROC_IS_MASTER) {
             /* if all my routes and local children are gone, then terminate ourselves */
             if (0 == prte_routed.num_routes()) {


### PR DESCRIPTION
Back out a bit of #1102 to ensure the prte_prteds_term_ordered
is set on daemons

Signed-off-by: Ralph Castain <rhc@pmix.org>