### PR TITLE
Add MCA parameter to include pid in top-level session dirname

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -71,6 +71,7 @@ char *prte_tool_basename = NULL;
 bool prte_dvm_ready = false;
 prte_pointer_array_t *prte_cache = NULL;
 bool prte_persistent = true;
+bool prte_add_pid_to_session_dirname = false;
 
 /* PRTE OOB port flags */
 bool prte_static_ports = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -500,6 +500,7 @@ PRTE_EXPORT extern char *prte_data_server_uri;
 PRTE_EXPORT extern bool prte_dvm_ready;
 PRTE_EXPORT extern prte_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
+PRTE_EXPORT extern bool prte_add_pid_to_session_dirname;
 
 /* PRTE OOB port flags */
 PRTE_EXPORT extern bool prte_static_ports;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -352,6 +352,14 @@ int prte_register_params(void)
                                       NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_ALL, &prte_create_session_dirs);
 
+    prte_add_pid_to_session_dirname = false;
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "add_pid_to_session_dirname",
+                                      "Add pid to the DVM top-level session directory name",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
+                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY,
+                                      &prte_add_pid_to_session_dirname);
+
     prte_execute_quiet = false;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "execute_quiet",
                                       "Do not output error and help messages",

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -136,6 +136,7 @@ int prte_setup_top_session_dir(void)
     int rc = PRTE_SUCCESS;
     /* get the effective uid */
     uid_t uid = geteuid();
+    pid_t pid = getpid();
 
     /* construct the top_session_dir if we need */
     if (NULL == prte_process_info.top_session_dir) {
@@ -147,13 +148,22 @@ int prte_setup_top_session_dir(void)
             rc = PRTE_ERR_BAD_PARAM;
             goto exit;
         }
-
-        if (0 > prte_asprintf(&prte_process_info.top_session_dir, "%s/prte.%s.%lu",
-                              prte_process_info.tmpdir_base, prte_process_info.nodename,
-                              (unsigned long) uid)) {
-            prte_process_info.top_session_dir = NULL;
-            rc = PRTE_ERR_OUT_OF_RESOURCE;
-            goto exit;
+        if (prte_add_pid_to_session_dirname) {
+            if (0 > prte_asprintf(&prte_process_info.top_session_dir, "%s/prte.%s.%lu.%lu",
+                                  prte_process_info.tmpdir_base, prte_process_info.nodename,
+                                  (unsigned long)pid, (unsigned long) uid)) {
+                prte_process_info.top_session_dir = NULL;
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                goto exit;
+            }
+        } else {
+            if (0 > prte_asprintf(&prte_process_info.top_session_dir, "%s/prte.%s.%lu",
+                                  prte_process_info.tmpdir_base, prte_process_info.nodename,
+                                  (unsigned long) uid)) {
+                prte_process_info.top_session_dir = NULL;
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                goto exit;
+            }
         }
     }
 exit:


### PR DESCRIPTION
Allow user to request additional inter-prte isolation by adding
the pid to the top-level session dirname

Refs https://github.com/open-mpi/ompi/issues/7393
Signed-off-by: Ralph Castain <rhc@pmix.org>