### PR TITLE
Make the plm components all support prefixing the same

### DIFF
--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -91,15 +91,16 @@ static int plm_alps_start_proc(int argc, char **argv, char **env, char *prefix);
 /*
  * Global variable
  */
-prte_plm_base_module_t prte_plm_alps_module = {plm_alps_init,
-                                               prte_plm_base_set_hnp_name,
-                                               plm_alps_launch_job,
-                                               NULL,
-                                               prte_plm_base_prted_terminate_job,
-                                               plm_alps_terminate_orteds,
-                                               prte_plm_base_prted_kill_local_procs,
-                                               plm_alps_signal_job,
-                                               plm_alps_finalize};
+prte_plm_base_module_t prte_plm_alps_module = {
+    .init = plm_alps_init,
+    .set_hnp_name = prte_plm_base_set_hnp_name,
+    .spawn = plm_alps_launch_job,
+    .terminate_job = prte_plm_base_prted_terminate_job,
+    .terminate_orteds = plm_alps_terminate_orteds,
+    .terminate_procs = prte_plm_base_prted_kill_local_procs,
+    .signal_job = plm_alps_signal_job,
+    .finalize = plm_alps_finalize
+};
 
 /*
  * Local variables

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -90,15 +90,16 @@ static int plm_lsf_finalize(void);
 /*
  * Global variable
  */
-prte_plm_base_module_t prte_plm_lsf_module = {plm_lsf_init,
-                                              prte_plm_base_set_hnp_name,
-                                              plm_lsf_launch_job,
-                                              NULL,
-                                              prte_plm_base_prted_terminate_job,
-                                              plm_lsf_terminate_orteds,
-                                              prte_plm_base_prted_kill_local_procs,
-                                              plm_lsf_signal_job,
-                                              plm_lsf_finalize};
+prte_plm_base_module_t prte_plm_lsf_module = {
+    .init = plm_lsf_init,
+    .set_hnp_name = prte_plm_base_set_hnp_name,
+    .spawn = plm_lsf_launch_job,
+    .terminate_job = prte_plm_base_prted_terminate_job,
+    .terminate_orteds = plm_lsf_terminate_orteds,
+    .terminate_procs = prte_plm_base_prted_kill_local_procs,
+    .signal_job = plm_lsf_signal_job,
+    .finalize = plm_lsf_finalize
+};
 
 static void launch_daemons(int fd, short args, void *cbdata);
 
@@ -330,6 +331,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cur_prefix));
             }
             free(app_prefix_dir);
+        }
+    }
+    if (NULL == cur_prefix) {
+        // see if it is in the environment
+        if (NULL != (param = getenv("PRTE_PREFIX"))) {
+            cur_prefix = strdup(param);
         }
     }
 

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -107,16 +107,16 @@ static int remote_spawn(void);
 static int ssh_terminate_prteds(void);
 static int ssh_finalize(void);
 
-prte_plm_base_module_t prte_plm_ssh_module
-    = {.init = ssh_init,
-       .set_hnp_name = prte_plm_base_set_hnp_name,
-       .spawn = ssh_launch,
-       .remote_spawn = remote_spawn,
-       .terminate_job = prte_plm_base_prted_terminate_job,
-       .terminate_orteds = ssh_terminate_prteds,
-       .terminate_procs = prte_plm_base_prted_kill_local_procs,
-       .signal_job = prte_plm_base_prted_signal_local_procs,
-       .finalize = ssh_finalize};
+prte_plm_base_module_t prte_plm_ssh_module = {
+    .init = ssh_init,
+    .set_hnp_name = prte_plm_base_set_hnp_name,
+    .spawn = ssh_launch,
+    .remote_spawn = remote_spawn,
+    .terminate_job = prte_plm_base_prted_terminate_job,
+    .terminate_orteds = ssh_terminate_prteds,
+    .terminate_procs = prte_plm_base_prted_kill_local_procs,
+    .signal_job = prte_plm_base_prted_signal_local_procs,
+    .finalize = ssh_finalize};
 
 typedef struct {
     prte_list_item_t super;


### PR DESCRIPTION
The ssh launcher supports a hierarchy of prefix options
starting with what is given at configure, then in the
environment using PRTE_PREFIX, and then on the cmd line
using the --prefix option. Have the other launchers
follow that same pattern for consistency.

Refs https://github.com/open-mpi/ompi/issues/9446
Signed-off-by: Ralph Castain <rhc@pmix.org>