### PR TITLE
Show the MCA base params in prte_info

### DIFF
--- a/src/mca/base/prte_mca_base_var.c
+++ b/src/mca/base/prte_mca_base_var.c
@@ -71,6 +71,7 @@ static char **prte_mca_base_var_file_list = NULL;
 static bool prte_mca_base_var_suppress_override_warning = false;
 static prte_list_t prte_mca_base_var_file_values;
 static prte_list_t prte_mca_base_envar_file_values;
+static char *prte_mca_base_var_files = NULL;
 
 static int prte_mca_base_var_count = 0;
 
@@ -253,8 +254,8 @@ static void save_value(const char *file, int lineno, const char *name, const cha
  */
 int prte_mca_base_var_init(void)
 {
-    int ret;
-    char *tmp;
+    int ret, n;
+    char *tmp, **filelist = NULL;
     prte_mca_base_var_file_value_t *fv;
 
     if (!prte_mca_base_var_initialized) {
@@ -297,23 +298,35 @@ int prte_mca_base_var_init(void)
 
         /* start with the system default param file */
         tmp = prte_os_path(false, prte_install_dirs.sysconfdir, "prte-mca-params.conf", NULL);
-        ret = prte_util_keyval_parse(tmp, save_value);
+        prte_argv_append_nosize(&filelist, tmp);
         free(tmp);
-        if (PRTE_SUCCESS != ret && PRTE_ERR_NOT_FOUND != ret) {
-            PRTE_ERROR_LOG(ret);
-            return ret;
-        }
-
 #if PRTE_WANT_HOME_CONFIG_FILES
         /* do the user's home default param files */
         tmp = prte_os_path(false, home, ".prte", "mca-params.conf", NULL);
-        ret = prte_util_keyval_parse(tmp, save_value);
+        prte_argv_append_nosize(&filelist, tmp);
         free(tmp);
-        if (PRTE_SUCCESS != ret && PRTE_ERR_NOT_FOUND != ret) {
-            PRTE_ERROR_LOG(ret);
-            return ret;
-        }
 #endif
+
+        /* Initialize a parameter that says where MCA param files can be found.
+         We may change this value so set the scope to PMIX_MCA_BASE_VAR_SCOPE_READONLY */
+        prte_mca_base_var_files = prte_argv_join(filelist, ';');
+        prte_argv_free(filelist);
+        ret = prte_mca_base_var_register("prte", "mca", "base", "param_files",
+                                         "Path for MCA configuration files containing variable values",
+                                         PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
+                                         PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_2,
+                                         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_mca_base_var_files);
+
+        filelist = prte_argv_split(prte_mca_base_var_files, ';');
+        for (n=0; NULL != filelist[n]; n++) {
+            ret = prte_util_keyval_parse(filelist[n], save_value);
+            if (PRTE_SUCCESS != ret && PRTE_ERR_NOT_FOUND != ret) {
+                PRTE_ERROR_LOG(ret);
+                prte_argv_free(filelist);
+                return ret;
+            }
+        }
+        prte_argv_free(filelist);
 
         /* push the results into our environment, but do not overwrite
          * a value if the user already has it set as their environment

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -181,6 +181,7 @@ int main(int argc, char *argv[])
     prte_pointer_array_init(&mca_types, 256, INT_MAX, 128);
 
     /* add a type for prte itself */
+    prte_pointer_array_add(&mca_types, "mca");
     prte_pointer_array_add(&mca_types, "prte");
 
     /* add a type for hwloc */


### PR DESCRIPTION
Ensure we show the base params. Add a param for the
default MCA param files so they appear and user can
specify any custom ones.

Fixes https://github.com/openpmix/prrte/issues/1116
Signed-off-by: Ralph Castain <rhc@pmix.org>