### PR TITLE
Cleanup the configure logic

### DIFF
--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -22,10 +22,6 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
     AC_ARG_WITH([libevent],
                 [AS_HELP_STRING([--with-libevent=DIR],
                                 [Search for libevent headers and libraries in DIR ])])
-    AC_ARG_WITH([libevent-header],
-                [AS_HELP_STRING([--with-libevent-header=HEADER],
-                                [The value that should be included in C files to include event.h])])
-
     AC_ARG_WITH([libevent-libdir],
                 [AS_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
@@ -36,136 +32,125 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
     prte_check_libevent_save_LDFLAGS="$LDFLAGS"
     prte_check_libevent_save_LIBS="$LIBS"
 
-    if test "x$with_libevent_header" != "x"; then
-        AS_IF([test "$with_libevent_header" = "yes"],
-              [PRTE_EVENT_HEADER="<event.h>"
-               PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"],
-              [PRTE_EVENT_HEADER="\"$with_libevent_header\""
-               PRTE_EVENT2_THREAD_HEADER="\"$with_libevent_header\""])
-        prte_libevent_source="external header"
-        prte_libevent_support=1
+    # get rid of any trailing slash(es)
+    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
 
-    else
-        # get rid of any trailing slash(es)
-        libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-        libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
-
-        AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-              [prte_event_dir="$libevent_prefix"],
-              [prte_event_dir=""])
-        _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
-                                   [prte_libevent_support=1],
-                                   [prte_libevent_support=0])
-        if test $prte_libevent_support -eq 0 && test -z $prte_event_dir; then
-            # try default locations
-            if test -d /usr/include; then
-                prte_event_dir=/usr
-                _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
-                                           [prte_libevent_support=1],
-                                           [prte_libevent_support=0])
-            fi
-            if test $prte_libevent_support -eq 0 && test -d /usr/local/include; then
-                prte_event_dir=/usr/local
-                _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
-                                           [prte_libevent_support=1],
-                                           [prte_libevent_support=0])
-            fi
+    AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+          [prte_event_dir="$libevent_prefix"],
+          [prte_event_dir=""])
+    _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
+                               [prte_libevent_support=1],
+                               [prte_libevent_support=0])
+    if test $prte_libevent_support -eq 0 && test -z $prte_event_dir; then
+        # try default locations
+        if test -d /usr/include; then
+            prte_event_dir=/usr
+            _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
+                                       [prte_libevent_support=1],
+                                       [prte_libevent_support=0])
         fi
-
-        if test $prte_libevent_support -eq 1; then
-            AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
-                         [prte_event_libdir="$libeventdir_prefix"],
-                         [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-                                [if test -d $libevent_prefix/lib64; then
-                                    prte_event_libdir=$libevent_prefix/lib64
-                                 elif test -d $libevent_prefix/lib; then
-                                    prte_event_libdir=$libevent_prefix/lib
-                                 else
-                                    AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
-                                    AC_MSG_ERROR([Can not continue])
-                                 fi
-                                ],
-                                [prte_event_libdir=""])])
-            _PRTE_CHECK_PACKAGE_LIB([prte_libevent], [event_core], [event_config_new],
-                                    [-levent_pthreads], [$prte_event_dir],
-                                    [$prte_event_libdir],
-                                    [prte_libevent_support=1],
-                                    [prte_libevent_support=0])
-
-            # Check to see if the above check failed because it conflicted with LSF's libevent.so
-            # This can happen if LSF's library is in the LDFLAGS envar or default search
-            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-            # in Libevent's libevent.so
-            if test $prte_libevent_support -eq 0; then
-                AC_CHECK_LIB([event], [event_getcode4name],
-                             [AC_MSG_WARN([===================================================================])
-                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                              AC_MSG_WARN([])
-                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                              AC_MSG_WARN([LSF library path.])
-                              AC_MSG_WARN([===================================================================])
-                              ])
-            fi
+        if test $prte_libevent_support -eq 0 && test -d /usr/local/include; then
+            prte_event_dir=/usr/local
+            _PRTE_CHECK_PACKAGE_HEADER([prte_libevent], [event.h], [$prte_event_dir],
+                                       [prte_libevent_support=1],
+                                       [prte_libevent_support=0])
         fi
-
-        if test $prte_libevent_support -eq 1; then
-            # need to add resulting flags to global ones so we can
-            # test for thread support
-            if test ! -z "$prte_libevent_CPPFLAGS"; then
-                PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_libevent_CPPFLAGS)
-            fi
-            if test ! -z "$prte_libevent_LDFLAGS"; then
-                PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_libevent_LDFLAGS)
-            fi
-            if test ! -z "$prte_libevent_LIBS"; then
-                PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_libevent_LIBS)
-            fi
-
-            # Ensure that this libevent has the symbol
-            # "evthread_set_lock_callbacks", which will only exist if
-            # libevent was configured with thread support.
-            AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
-                         [],
-                         [AC_MSG_WARN([libevent does not have thread support])
-                          AC_MSG_WARN([PRTE requires libevent to be compiled with])
-                          AC_MSG_WARN([thread support enabled])
-                          prte_libevent_support=0])
-        fi
-
-        if test $prte_libevent_support -eq 1; then
-            AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
-                         [],
-                         [AC_MSG_WARN([libevent does not have thread support])
-                          AC_MSG_WARN([PRTE requires libevent to be compiled with])
-                          AC_MSG_WARN([thread support enabled])
-                          prte_libevent_support=0])
-        fi
-
-        if test $prte_libevent_support -eq 1; then
-            # Pin the "oldest supported" version to 2.0.21
-            AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                               [[
-                                                 #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                                 #error "libevent API version is less than 0x02001500"
-                                                 #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                                 #error "libevent API version is less than 0x02001500"
-                                                 #endif
-                                               ]])],
-                              [AC_MSG_RESULT([yes])],
-                              [AC_MSG_RESULT([no])
-                               AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                               prte_libevent_support=0])
-        fi
-        prte_libevent_source=$prte_event_dir
-        PRTE_EVENT_HEADER="<event.h>"
-        PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
     fi
+
+    if test $prte_libevent_support -eq 1; then
+        AS_IF([test ! -z "$libeventdir_prefix" && test "$libeventdir_prefix" != "yes"],
+                     [prte_event_libdir="$libeventdir_prefix"],
+                     [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
+                            [if test -d $libevent_prefix/lib64; then
+                                prte_event_libdir=$libevent_prefix/lib64
+                             elif test -d $libevent_prefix/lib; then
+                                prte_event_libdir=$libevent_prefix/lib
+                             else
+                                AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
+                                AC_MSG_ERROR([Can not continue])
+                             fi
+                            ],
+                            [prte_event_libdir=""])])
+        _PRTE_CHECK_PACKAGE_LIB([prte_libevent], [event_core], [event_config_new],
+                                [-levent_pthreads], [$prte_event_dir],
+                                [$prte_event_libdir],
+                                [prte_libevent_support=1],
+                                [prte_libevent_support=0])
+
+        # Check to see if the above check failed because it conflicted with LSF's libevent.so
+        # This can happen if LSF's library is in the LDFLAGS envar or default search
+        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+        # in Libevent's libevent.so
+        if test $prte_libevent_support -eq 0; then
+            AC_CHECK_LIB([event], [event_getcode4name],
+                         [AC_MSG_WARN([===================================================================])
+                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                          AC_MSG_WARN([])
+                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                          AC_MSG_WARN([LSF library path.])
+                          AC_MSG_WARN([===================================================================])
+                          ])
+        fi
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+        # need to add resulting flags to global ones so we can
+        # test for thread support
+        if test ! -z "$prte_libevent_CPPFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_libevent_CPPFLAGS)
+        fi
+        if test ! -z "$prte_libevent_LDFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_libevent_LDFLAGS)
+        fi
+        if test ! -z "$prte_libevent_LIBS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_libevent_LIBS)
+        fi
+
+        # Ensure that this libevent has the symbol
+        # "evthread_set_lock_callbacks", which will only exist if
+        # libevent was configured with thread support.
+        AC_CHECK_LIB([event_core], [evthread_set_lock_callbacks],
+                     [],
+                     [AC_MSG_WARN([libevent does not have thread support])
+                      AC_MSG_WARN([PRTE requires libevent to be compiled with])
+                      AC_MSG_WARN([thread support enabled])
+                      prte_libevent_support=0])
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+        AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
+                     [],
+                     [AC_MSG_WARN([libevent does not have thread support])
+                      AC_MSG_WARN([PRTE requires libevent to be compiled with])
+                      AC_MSG_WARN([thread support enabled])
+                      prte_libevent_support=0])
+    fi
+
+    if test $prte_libevent_support -eq 1; then
+        # Pin the "oldest supported" version to 2.0.21
+        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
+                                           [[
+                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
+                                             #error "libevent API version is less than 0x02001500"
+                                             #endif
+                                           ]])],
+                          [AC_MSG_RESULT([yes])],
+                          [AC_MSG_RESULT([no])
+                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
+                           prte_libevent_support=0])
+    fi
+    prte_libevent_source=$prte_event_dir
+    PRTE_EVENT_HEADER="<event.h>"
+    PRTE_EVENT2_THREAD_HEADER="<event2/thread.h>"
 
     AC_MSG_CHECKING([will libevent support be built])
     if test $prte_libevent_support -eq 1; then

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -37,169 +37,153 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                 [AS_HELP_STRING([--with-pmix-libdir=DIR],
                                 [Look for libpmix in the given directory DIR, DIR/lib or DIR/lib64])])
 
-    AC_ARG_WITH([pmix-header],
-                [AS_HELP_STRING([--with-pmix-header=HEADER],
-                                [The value that should be included in C files to include pmix.h])])
-
     AC_ARG_ENABLE([pmix-devel-support],
                   [AS_HELP_STRING([--enable-pmix-devel-support],
                                   [Add necessary wrapper flags to enable access to PMIx devel headers])])
 
     prte_pmix_support=0
 
-    if test "x$with_pmix_header" != "x"; then
-        AS_IF([test "$with_pmix_header" = "yes"],
-              [PRTE_PMIX_HEADER="<pmix.h>"
-               prte_pmix_header_given=0],
-              [PRTE_PMIX_HEADER="\"$with_pmix_header\""
-               prte_pmix_header_given=1])
-        pmix_ext_install_dir="external header"
-        prte_pmix_support=1
-
-    elif test "$with_pmix" = "no"; then
+    if test "$with_pmix" = "no"; then
         AC_MSG_WARN([PRTE requires PMIx support using])
         AC_MSG_WARN([an external copy that you supply.])
         AC_MSG_ERROR([Cannot continue])
+    fi
 
-    else
-        # get rid of any trailing slash(es)
-        pmix_prefix=$(echo $with_pmix | sed -e 'sX/*$XXg')
-        pmixdir_prefix=$(echo $with_pmix_libdir | sed -e 'sX/*$XXg')
+    # get rid of any trailing slash(es)
+    pmix_prefix=$(echo $with_pmix | sed -e 'sX/*$XXg')
+    pmixdir_prefix=$(echo $with_pmix_libdir | sed -e 'sX/*$XXg')
 
-        prte_pmix_header_given=0
-        PRTE_PMIX_HEADER="<pmix.h>"
-        # check for external pmix header */
-        AS_IF([test ! -z "$with_pmix" && test "$with_pmix" != "yes"],
-                     [pmix_ext_install_dir="$with_pmix"],
-                     [pmix_ext_install_dir=""])
-        _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
-                                   [prte_pmix_support=1],
-                                   [prte_pmix_support=0])
+    prte_pmix_header_given=0
+    PRTE_PMIX_HEADER="<pmix.h>"
+    # check for external pmix header */
+    AS_IF([test ! -z "$with_pmix" && test "$with_pmix" != "yes"],
+                 [pmix_ext_install_dir="$with_pmix"],
+                 [pmix_ext_install_dir=""])
+    _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
+                               [prte_pmix_support=1],
+                               [prte_pmix_support=0])
 
-        if test $prte_pmix_support -eq 0 && test -z "$pmix_ext_install_dir"; then
-            # try default locations
-            if test -d /usr/include; then
-                pmix_ext_install_dir=/usr
-                _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
-                                           [prte_pmix_support=1],
-                                           [prte_pmix_support=0])
-            fi
-            if test $prte_pmix_support -eq 0 && test -d /usr/local/include; then
-                pmix_ext_install_dir=/usr/local
-                _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
-                                           [prte_pmix_support=1],
-                                           [prte_pmix_support=0])
-            fi
+    if test $prte_pmix_support -eq 0 && test -z "$pmix_ext_install_dir"; then
+        # try default locations
+        if test -d /usr/include; then
+            pmix_ext_install_dir=/usr
+            _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
+                                       [prte_pmix_support=1],
+                                       [prte_pmix_support=0])
         fi
-
-        if test $prte_pmix_support -eq 0; then
-            AC_MSG_WARN([PRTE requires PMIx support using])
-            AC_MSG_WARN([an external copy that you supply.])
-            AC_MSG_WARN([A copy could not be found in $pmix_ext_install_dir.])
-            AC_MSG_ERROR([Cannot continue])
+        if test $prte_pmix_support -eq 0 && test -d /usr/local/include; then
+            pmix_ext_install_dir=/usr/local
+            _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix.h], [$pmix_ext_install_dir],
+                                       [prte_pmix_support=1],
+                                       [prte_pmix_support=0])
         fi
+    fi
 
-        # check for external pmix library - the lib search already includes
-        # default locations, so no need to separately check there
-        AS_IF([test ! -z "$with_pmix_libdir" && test "$with_pmix_libdir" != "yes"],
-                     [pmix_ext_install_libdir="$with_pmix_libdir"],
-                     [AS_IF([test ! -z "$with_pmix" && test "$with_pmix" != "yes"],
-                            [pmix_ext_install_libdir="$with_pmix"/lib],
-                            [pmix_ext_install_libdir=""])])
-        _PRTE_CHECK_PACKAGE_LIB([prte_pmix], [pmix], [PMIx_Init],
-                                [], [$pmix_ext_install_dir],
-                                [$pmix_ext_install_libdir],
-                                [],
-                                [AC_MSG_WARN([PRTE requires PMIx support using])
-                                 AC_MSG_WARN([an external copy that you supply.])
-                                 AC_MSG_WARN([The library was not found in $pmix_ext_install_libdir.])
-                                 AC_MSG_ERROR([Cannot continue])])
+    if test $prte_pmix_support -eq 0; then
+        AC_MSG_WARN([PRTE requires PMIx support using])
+        AC_MSG_WARN([an external copy that you supply.])
+        AC_MSG_WARN([A copy could not be found in $pmix_ext_install_dir.])
+        AC_MSG_ERROR([Cannot continue])
+    fi
 
-        prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
-        prte_external_pmix_save_LDFLAGS=$LDFLAGS
-        prte_external_pmix_save_LIBS=$LIBS
+    # check for external pmix library - the lib search already includes
+    # default locations, so no need to separately check there
+    AS_IF([test ! -z "$with_pmix_libdir" && test "$with_pmix_libdir" != "yes"],
+                 [pmix_ext_install_libdir="$with_pmix_libdir"],
+                 [AS_IF([test ! -z "$with_pmix" && test "$with_pmix" != "yes"],
+                        [pmix_ext_install_libdir="$with_pmix"/lib],
+                        [pmix_ext_install_libdir=""])])
+    _PRTE_CHECK_PACKAGE_LIB([prte_pmix], [pmix], [PMIx_Init],
+                            [], [$pmix_ext_install_dir],
+                            [$pmix_ext_install_libdir],
+                            [],
+                            [AC_MSG_WARN([PRTE requires PMIx support using])
+                             AC_MSG_WARN([an external copy that you supply.])
+                             AC_MSG_WARN([The library was not found in $pmix_ext_install_libdir.])
+                             AC_MSG_ERROR([Cannot continue])])
 
-        # need to add resulting flags to global ones so we can
-        # test the version
-        if test ! -z "$prte_pmix_CPPFLAGS"; then
-            PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
-        fi
-        if test ! -z "$prte_pmix_LDFLAGS"; then
-            PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
-        fi
-        if test ! -z "$prte_pmix_LIBS"; then
-            PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_pmix_LIBS)
-        fi
+    prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
+    prte_external_pmix_save_LDFLAGS=$LDFLAGS
+    prte_external_pmix_save_LIBS=$LIBS
 
-        # if the pmix_version.h file does not exist, then
-        # this must be from a pre-1.1.5 version
-        _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix_version.h], [$pmix_ext_install_dir],
-                                   [],
-                                   [AC_MSG_WARN([PRTE does not support PMIx versions])
-                                    AC_MSG_WARN([less than v4.1 as only PMIx-based tools])
-                                    AC_MSG_WARN([can connect to the server.])
-                                    AC_MSG_ERROR([Please select a newer version and configure again])])
+    # need to add resulting flags to global ones so we can
+    # test the version
+    if test ! -z "$prte_pmix_CPPFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LDFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LIBS"; then
+        PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_pmix_LIBS)
+    fi
+
+    # if the pmix_version.h file does not exist, then
+    # this must be from a pre-1.1.5 version
+    _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix_version.h], [$pmix_ext_install_dir],
+                               [],
+                               [AC_MSG_WARN([PRTE does not support PMIx versions])
+                                AC_MSG_WARN([less than v4.1 as only PMIx-based tools])
+                                AC_MSG_WARN([can connect to the server.])
+                                AC_MSG_ERROR([Please select a newer version and configure again])])
 
 
-        # if it does exist, then we need to parse it to find
-        # the actual release series
-        AC_MSG_CHECKING([version 4x])
-        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                            #include <pmix_version.h>
-                                            #if (PMIX_VERSION_MAJOR < 4L)
-                                            #error "not version 4 or above"
-                                            #endif
-                                           ], [])],
-                          [AC_MSG_RESULT([found])
-                           prte_external_pmix_version=4x
-                           prte_external_pmix_version_found=4],
-                          [AC_MSG_RESULT([not found])])
+    # if it does exist, then we need to parse it to find
+    # the actual release series
+    AC_MSG_CHECKING([version 4x])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <pmix_version.h>
+                                        #if (PMIX_VERSION_MAJOR < 4L)
+                                        #error "not version 4 or above"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([found])
+                       prte_external_pmix_version=4x
+                       prte_external_pmix_version_found=4],
+                      [AC_MSG_RESULT([not found])])
 
-        AS_IF([test "$prte_external_pmix_version_found" = "4"],
-              [AC_MSG_CHECKING([version 4.1 or greater])
-                AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                    #include <pmix_version.h>
-                                                    #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
-                                                    #error "not version 4.1 or above"
-                                                    #endif
-                                                   ], [])],
-                                  [AC_MSG_RESULT([found])],
-                                  [AC_MSG_RESULT([not found])
-                                   prte_external_pmix_version_found=0])])
+    AS_IF([test "$prte_external_pmix_version_found" = "4"],
+          [AC_MSG_CHECKING([version 4.1 or greater])
+            AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                #include <pmix_version.h>
+                                                #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+                                                #error "not version 4.1 or above"
+                                                #endif
+                                               ], [])],
+                              [AC_MSG_RESULT([found])],
+                              [AC_MSG_RESULT([not found])
+                               prte_external_pmix_version_found=0])])
 
-        # restore the global flags
-        CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
-        LDFLAGS=$prte_external_pmix_save_LDFLAGS
-        LIBS=$prte_external_pmix_save_LIBS
+    # restore the global flags
+    CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
+    LDFLAGS=$prte_external_pmix_save_LDFLAGS
+    LIBS=$prte_external_pmix_save_LIBS
 
-        AS_IF([test "$prte_external_pmix_version_found" = "0"],
-              [AC_MSG_WARN([PRTE does not support PMIx versions])
-               AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
-               AC_MSG_WARN([can connect to the server.])
-               AC_MSG_ERROR([Please select a newer version and configure again])])
+    AS_IF([test "$prte_external_pmix_version_found" = "0"],
+          [AC_MSG_WARN([PRTE does not support PMIx versions])
+           AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
+           AC_MSG_WARN([can connect to the server.])
+           AC_MSG_ERROR([Please select a newer version and configure again])])
 
-        AS_IF([test "x$prte_external_pmix_version" = "x"],
-              [AC_MSG_WARN([PMIx version information could not])
-               AC_MSG_WARN([be detected])
-               AC_MSG_ERROR([cannot continue])])
+    AS_IF([test "x$prte_external_pmix_version" = "x"],
+          [AC_MSG_WARN([PMIx version information could not])
+           AC_MSG_WARN([be detected])
+           AC_MSG_ERROR([cannot continue])])
 
-        if test ! -z "$prte_pmix_CPPFLAGS"; then
-            PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
-            PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_pmix_CPPFLAGS)
-        fi
-        if test ! -z "$prte_pmix_LDFLAGS"; then
-            PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
-            PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_pmix_LDFLAGS)
-        fi
-        if test ! -z "$prte_pmix_LIBS"; then
-            PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
-            PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_pmix_LIBS)
-        fi
-
+    if test ! -z "$prte_pmix_CPPFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
+        PRTE_WRAPPER_FLAGS_ADD(CPPFLAGS, $prte_pmix_CPPFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LDFLAGS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
+        PRTE_WRAPPER_FLAGS_ADD(LDFLAGS, $prte_pmix_LDFLAGS)
+    fi
+    if test ! -z "$prte_pmix_LIBS"; then
+        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
+        PRTE_WRAPPER_FLAGS_ADD(LIBS, $prte_pmix_LIBS)
     fi
 
     AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER], [$PRTE_PMIX_HEADER], [PMIx header to use])
-    AC_DEFINE_UNQUOTED([PRTE_PMIX_HEADER_GIVEN], [$prte_pmix_header_given], [Whether or not the PMIx header was explicitly passed])
 
     PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]],[pmix],[yes ($pmix_ext_install_dir)])
 


### PR DESCRIPTION
Remove the "header" options from the libevent, hwloc, and pmix
configure logic. Rely instead on the CPPFLAGS/LDFLAGS/LIBS
support for finding libraries when not specified.

Signed-off-by: Ralph Castain <rhc@pmix.org>