### PR TITLE
Add an option to disable package checks

### DIFF
--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -139,6 +139,26 @@ else
 fi
 AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
 
+# Sometimes we are in situations where we cannot check the dependent
+# libraries for presence or correctness. Allow the user to ask us to
+# take it all on faith that it will eventually build correctly.
+
+AC_MSG_CHECKING([disable package checks])
+AC_ARG_ENABLE([package-checks],
+              [AS_HELP_STRING([--disable-package-checks],
+                              [Do not check dependent libraries for presence or correctness.
+                               Take it on faith that they will be present when needed. This
+                               is not advisable, but necessary in some circumstances])])
+if test "$enable_package_checks" = "no" ; then
+    PRTE_DISABLE_PACKAGE_CHECKS=1
+    AC_MSG_RESULT([disabled])
+else
+    PRTE_DISABLE_PACKAGE_CHECKS=0
+    AC_MSG_RESULT([enabled by default])
+fi
+AC_DEFINE_UNQUOTED(PRTE_DISABLE_PACKAGE_CHECKS, $PRTE_DISABLE_PACKAGE_CHECKS,
+                   [Disable package checks])
+
 #
 # Do we want the pretty-print stack trace feature?
 #

--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -84,49 +84,54 @@ AC_DEFUN([PRTE_HWLOC_CONFIG],[
                          fi
                         ],
                         [prte_hwloc_libdir=""])])
-    _PRTE_CHECK_PACKAGE_LIB([prte_hwloc], [hwloc], [hwloc_topology_init],
-                            [], [$prte_hwloc_dir],
-                            [$prte_hwloc_libdir],
-                            [],
-                            [AC_MSG_WARN([PRTE requires HWLOC support using])
-                             AC_MSG_WARN([an external copy that you supply.])
-                             AC_MSG_WARN([The library was not found in $prte_hwloc_libdir.])
-                             AC_MSG_ERROR([Cannot continue])])
 
-    # update global flags to test for HWLOC version
-    if test ! -z "$prte_hwloc_CPPFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_hwloc_CPPFLAGS)
-    fi
-    if test ! -z "$prte_hwloc_LDFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_hwloc_LDFLAGS)
-    fi
-    if test ! -z "$prte_hwloc_LIBS"; then
-        PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_hwloc_LIBS)
-    fi
+    if test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
+        _PRTE_CHECK_PACKAGE_LIB([prte_hwloc], [hwloc], [hwloc_topology_init],
+                                [], [$prte_hwloc_dir],
+                                [$prte_hwloc_libdir],
+                                [],
+                                [AC_MSG_WARN([PRTE requires HWLOC support using])
+                                 AC_MSG_WARN([an external copy that you supply.])
+                                 AC_MSG_WARN([The library was not found in $prte_hwloc_libdir.])
+                                 AC_MSG_ERROR([Cannot continue])])
 
-    AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-          [[
-    #if HWLOC_API_VERSION < 0x00010500
-    #error "hwloc API version is less than 0x00010500"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])],
-          [AC_MSG_RESULT([no])
-           AC_MSG_ERROR([Cannot continue])])
+        # update global flags to test for HWLOC version
+        if test ! -z "$prte_hwloc_CPPFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_hwloc_CPPFLAGS)
+        fi
+        if test ! -z "$prte_hwloc_LDFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_hwloc_LDFLAGS)
+        fi
+        if test ! -z "$prte_hwloc_LIBS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_hwloc_LIBS)
+        fi
 
-    AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
-    AC_COMPILE_IFELSE(
-          [AC_LANG_PROGRAM([[#include <hwloc.h>]],
-          [[
-    #if HWLOC_API_VERSION < 0x00010800
-    #error "hwloc API version is less than 0x00010800"
-    #endif
-          ]])],
-          [AC_MSG_RESULT([yes])
-           prte_have_topology_dup=1],
-          [AC_MSG_RESULT([no])])
+        AC_MSG_CHECKING([if external hwloc version is 1.5 or greater])
+        AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+              [[
+        #if HWLOC_API_VERSION < 0x00010500
+        #error "hwloc API version is less than 0x00010500"
+        #endif
+              ]])],
+              [AC_MSG_RESULT([yes])],
+              [AC_MSG_RESULT([no])
+               AC_MSG_ERROR([Cannot continue])])
+
+        AC_MSG_CHECKING([if external hwloc version is 1.8 or greater])
+        AC_COMPILE_IFELSE(
+              [AC_LANG_PROGRAM([[#include <hwloc.h>]],
+              [[
+        #if HWLOC_API_VERSION < 0x00010800
+        #error "hwloc API version is less than 0x00010800"
+        #endif
+              ]])],
+              [AC_MSG_RESULT([yes])
+               prte_have_topology_dup=1],
+              [AC_MSG_RESULT([no])])
+    else
+        prte_have_topology_dup=1
+    fi
 
     # set the header
     PRTE_HWLOC_HEADER="<hwloc.h>"

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -72,34 +72,36 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
                              fi
                             ],
                             [prte_event_libdir=""])])
-        _PRTE_CHECK_PACKAGE_LIB([prte_libevent], [event_core], [event_config_new],
-                                [-levent_pthreads], [$prte_event_dir],
-                                [$prte_event_libdir],
-                                [prte_libevent_support=1],
-                                [prte_libevent_support=0])
+        if test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
+            _PRTE_CHECK_PACKAGE_LIB([prte_libevent], [event_core], [event_config_new],
+                                    [-levent_pthreads], [$prte_event_dir],
+                                    [$prte_event_libdir],
+                                    [prte_libevent_support=1],
+                                    [prte_libevent_support=0])
 
-        # Check to see if the above check failed because it conflicted with LSF's libevent.so
-        # This can happen if LSF's library is in the LDFLAGS envar or default search
-        # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
-        # in Libevent's libevent.so
-        if test $prte_libevent_support -eq 0; then
-            AC_CHECK_LIB([event], [event_getcode4name],
-                         [AC_MSG_WARN([===================================================================])
-                          AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
-                          AC_MSG_WARN([library path. It is possible that you have installed Libevent])
-                          AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
-                          AC_MSG_WARN([])
-                          AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
-                          AC_MSG_WARN([to make sure the libevent system library path occurs before the])
-                          AC_MSG_WARN([LSF library path.])
-                          AC_MSG_WARN([===================================================================])
-                          ])
+            # Check to see if the above check failed because it conflicted with LSF's libevent.so
+            # This can happen if LSF's library is in the LDFLAGS envar or default search
+            # path. The 'event_getcode4name' function is only defined in LSF's libevent.so and not
+            # in Libevent's libevent.so
+            if test $prte_libevent_support -eq 0; then
+                AC_CHECK_LIB([event], [event_getcode4name],
+                             [AC_MSG_WARN([===================================================================])
+                              AC_MSG_WARN([Possible conflicting libevent.so libraries detected on the system.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([LSF provides a libevent.so that is not from Libevent in its])
+                              AC_MSG_WARN([library path. It is possible that you have installed Libevent])
+                              AC_MSG_WARN([on the system, but the linker is picking up the wrong version.])
+                              AC_MSG_WARN([])
+                              AC_MSG_WARN([You will need to address this linker path issue. One way to do so is])
+                              AC_MSG_WARN([to make sure the libevent system library path occurs before the])
+                              AC_MSG_WARN([LSF library path.])
+                              AC_MSG_WARN([===================================================================])
+                              ])
+            fi
         fi
     fi
 
-    if test $prte_libevent_support -eq 1; then
+    if test $prte_libevent_support -eq 1 && test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
         # need to add resulting flags to global ones so we can
         # test for thread support
         if test ! -z "$prte_libevent_CPPFLAGS"; then
@@ -123,7 +125,7 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
                       prte_libevent_support=0])
     fi
 
-    if test $prte_libevent_support -eq 1; then
+    if test $prte_libevent_support -eq 1 && test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
         AC_CHECK_LIB([event_pthreads], [evthread_use_pthreads],
                      [],
                      [AC_MSG_WARN([libevent does not have thread support])
@@ -132,7 +134,7 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
                       prte_libevent_support=0])
     fi
 
-    if test $prte_libevent_support -eq 1; then
+    if test $prte_libevent_support -eq 1 && test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
         # Pin the "oldest supported" version to 2.0.21
         AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -93,82 +93,85 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                  [AS_IF([test ! -z "$with_pmix" && test "$with_pmix" != "yes"],
                         [pmix_ext_install_libdir="$with_pmix"/lib],
                         [pmix_ext_install_libdir=""])])
-    _PRTE_CHECK_PACKAGE_LIB([prte_pmix], [pmix], [PMIx_Init],
-                            [], [$pmix_ext_install_dir],
-                            [$pmix_ext_install_libdir],
-                            [],
-                            [AC_MSG_WARN([PRTE requires PMIx support using])
-                             AC_MSG_WARN([an external copy that you supply.])
-                             AC_MSG_WARN([The library was not found in $pmix_ext_install_libdir.])
-                             AC_MSG_ERROR([Cannot continue])])
 
-    prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
-    prte_external_pmix_save_LDFLAGS=$LDFLAGS
-    prte_external_pmix_save_LIBS=$LIBS
+    if test $PRTE_DISABLE_PACKAGE_CHECKS -eq 0; then
+        _PRTE_CHECK_PACKAGE_LIB([prte_pmix], [pmix], [PMIx_Init],
+                                [], [$pmix_ext_install_dir],
+                                [$pmix_ext_install_libdir],
+                                [],
+                                [AC_MSG_WARN([PRTE requires PMIx support using])
+                                 AC_MSG_WARN([an external copy that you supply.])
+                                 AC_MSG_WARN([The library was not found in $pmix_ext_install_libdir.])
+                                 AC_MSG_ERROR([Cannot continue])])
 
-    # need to add resulting flags to global ones so we can
-    # test the version
-    if test ! -z "$prte_pmix_CPPFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
+        prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
+        prte_external_pmix_save_LDFLAGS=$LDFLAGS
+        prte_external_pmix_save_LIBS=$LIBS
+
+        # need to add resulting flags to global ones so we can
+        # test the version
+        if test ! -z "$prte_pmix_CPPFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
+        fi
+        if test ! -z "$prte_pmix_LDFLAGS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
+        fi
+        if test ! -z "$prte_pmix_LIBS"; then
+            PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_pmix_LIBS)
+        fi
+
+        # if the pmix_version.h file does not exist, then
+        # this must be from a pre-1.1.5 version
+        _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix_version.h], [$pmix_ext_install_dir],
+                                   [],
+                                   [AC_MSG_WARN([PRTE does not support PMIx versions])
+                                    AC_MSG_WARN([less than v4.1 as only PMIx-based tools])
+                                    AC_MSG_WARN([can connect to the server.])
+                                    AC_MSG_ERROR([Please select a newer version and configure again])])
+
+
+        # if it does exist, then we need to parse it to find
+        # the actual release series
+        AC_MSG_CHECKING([version 4x])
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                            #include <pmix_version.h>
+                                            #if (PMIX_VERSION_MAJOR < 4L)
+                                            #error "not version 4 or above"
+                                            #endif
+                                           ], [])],
+                          [AC_MSG_RESULT([found])
+                           prte_external_pmix_version=4x
+                           prte_external_pmix_version_found=4],
+                          [AC_MSG_RESULT([not found])])
+
+        AS_IF([test "$prte_external_pmix_version_found" = "4"],
+              [AC_MSG_CHECKING([version 4.1 or greater])
+                AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                    #include <pmix_version.h>
+                                                    #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
+                                                    #error "not version 4.1 or above"
+                                                    #endif
+                                                   ], [])],
+                                  [AC_MSG_RESULT([found])],
+                                  [AC_MSG_RESULT([not found])
+                                   prte_external_pmix_version_found=0])])
+
+        # restore the global flags
+        CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
+        LDFLAGS=$prte_external_pmix_save_LDFLAGS
+        LIBS=$prte_external_pmix_save_LIBS
+
+        AS_IF([test "$prte_external_pmix_version_found" = "0"],
+              [AC_MSG_WARN([PRTE does not support PMIx versions])
+               AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
+               AC_MSG_WARN([can connect to the server.])
+               AC_MSG_ERROR([Please select a newer version and configure again])])
+
+        AS_IF([test "x$prte_external_pmix_version" = "x"],
+              [AC_MSG_WARN([PMIx version information could not])
+               AC_MSG_WARN([be detected])
+               AC_MSG_ERROR([cannot continue])])
     fi
-    if test ! -z "$prte_pmix_LDFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
-    fi
-    if test ! -z "$prte_pmix_LIBS"; then
-        PRTE_FLAGS_APPEND_UNIQ(LIBS, $prte_pmix_LIBS)
-    fi
-
-    # if the pmix_version.h file does not exist, then
-    # this must be from a pre-1.1.5 version
-    _PRTE_CHECK_PACKAGE_HEADER([prte_pmix], [pmix_version.h], [$pmix_ext_install_dir],
-                               [],
-                               [AC_MSG_WARN([PRTE does not support PMIx versions])
-                                AC_MSG_WARN([less than v4.1 as only PMIx-based tools])
-                                AC_MSG_WARN([can connect to the server.])
-                                AC_MSG_ERROR([Please select a newer version and configure again])])
-
-
-    # if it does exist, then we need to parse it to find
-    # the actual release series
-    AC_MSG_CHECKING([version 4x])
-    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                        #include <pmix_version.h>
-                                        #if (PMIX_VERSION_MAJOR < 4L)
-                                        #error "not version 4 or above"
-                                        #endif
-                                       ], [])],
-                      [AC_MSG_RESULT([found])
-                       prte_external_pmix_version=4x
-                       prte_external_pmix_version_found=4],
-                      [AC_MSG_RESULT([not found])])
-
-    AS_IF([test "$prte_external_pmix_version_found" = "4"],
-          [AC_MSG_CHECKING([version 4.1 or greater])
-            AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                #include <pmix_version.h>
-                                                #if (PMIX_VERSION_MAJOR == 4L && PMIX_VERSION_MINOR < 1L)
-                                                #error "not version 4.1 or above"
-                                                #endif
-                                               ], [])],
-                              [AC_MSG_RESULT([found])],
-                              [AC_MSG_RESULT([not found])
-                               prte_external_pmix_version_found=0])])
-
-    # restore the global flags
-    CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
-    LDFLAGS=$prte_external_pmix_save_LDFLAGS
-    LIBS=$prte_external_pmix_save_LIBS
-
-    AS_IF([test "$prte_external_pmix_version_found" = "0"],
-          [AC_MSG_WARN([PRTE does not support PMIx versions])
-           AC_MSG_WARN([less than v4.1 as only PMIx-based tools can])
-           AC_MSG_WARN([can connect to the server.])
-           AC_MSG_ERROR([Please select a newer version and configure again])])
-
-    AS_IF([test "x$prte_external_pmix_version" = "x"],
-          [AC_MSG_WARN([PMIx version information could not])
-           AC_MSG_WARN([be detected])
-           AC_MSG_ERROR([cannot continue])])
 
     if test ! -z "$prte_pmix_CPPFLAGS"; then
         PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)


### PR DESCRIPTION
There are scenarios where we need to skip the package
library checks for libevent and hwloc - i.e., to simply
trust that the user knows what they are doing, and that
the libraries are both present and functional. In those
rare scenarios, allow the user to disable those checks.

Signed-off-by: Ralph Castain <rhc@pmix.org>