### PR TITLE
Protect against PMIx v4.1.1-only definitions

### DIFF
--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -468,6 +468,17 @@ PRTE_EXPORT int prte_pmix_register_cleanup(char *path, bool directory, bool igno
 #define PMIX_ERROR_LOG(r) \
     prte_output(0, "[%s:%d] PMIx Error: %s", __FILE__, __LINE__, PMIx_Error_string((r)))
 
+#ifndef PMIX_DATA_BUFFER_STATIC_INIT
+    #define PMIX_DATA_BUFFER_STATIC_INIT    \
+    {                                       \
+        .base_ptr = NULL,                   \
+        .pack_ptr = NULL,                   \
+        .unpack_ptr = NULL,                 \
+        .bytes_allocated = 0,               \
+        .bytes_used = 0                     \
+    }
+#endif
+
 END_C_DECLS
 
 #endif

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -676,6 +676,7 @@ int pmix_server_init(void)
         }
     }
 
+#ifdef PMIX_SINGLETON
     /* if we were started to support a singleton, then let the server library know */
     if (NULL != prte_pmix_server_globals.singleton) {
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SINGLETON,
@@ -685,6 +686,7 @@ int pmix_server_init(void)
             return rc;
         }
     }
+#endif
 
     /* if we are the MASTER, then we are the scheduler
      * as well as a gateway */


### PR DESCRIPTION
We want to continue to support back to PMIx v4.1.0

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ebac40d56210d2b1e59675054de763d26349824f)