### PR TITLE
Cleanup configuration logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1076,7 +1076,7 @@ PRTE_CHECK_PMIX
 
 prte_show_title "Configure HWLOC"
 
-PRTE_HWLOC_CONFIG
+PRTE_SETUP_HWLOC
 
 ##################################
 # MCA

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -26,11 +26,9 @@
 #endif
 #include <stdarg.h>
 #include <stdint.h>
-#include PRTE_HWLOC_HEADER
-#if !PRTE_HWLOC_HEADER_GIVEN
-#    if HWLOC_API_VERSION >= 0x20000
-#        include <hwloc/shmem.h>
-#    endif
+#include <hwloc.h>
+#if HWLOC_API_VERSION >= 0x20000
+#   include <hwloc/shmem.h>
 #endif
 
 #include "src/class/prte_list.h"

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -32,12 +32,10 @@
 #include "src/util/printf.h"
 #include "src/util/proc_info.h"
 
-#include PRTE_PMIX_HEADER
-#if !PRTE_PMIX_HEADER_GIVEN
-#    include <pmix_server.h>
-#    include <pmix_tool.h>
-#    include <pmix_version.h>
-#endif
+#include <pmix.h>
+#include <pmix_server.h>
+#include <pmix_tool.h>
+#include <pmix_version.h>
 
 BEGIN_C_DECLS
 

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -42,10 +42,7 @@
 #include "types.h"
 
 #include "src/hwloc/hwloc-internal.h"
-#include PRTE_PMIX_HEADER
-#if !PRTE_PMIX_HEADER_GIVEN
-#    include <pmix_common.h>
-#endif
+#include <pmix.h>
 
 BEGIN_C_DECLS
 


### PR DESCRIPTION
Port of https://github.com/openpmix/openpmix/pull/2385

We still weren't dealing with the scenario where there is
a copy of HWLOC in the standard location, but we pass our
own path to a different HWLOC install that we want to use.
Problem turned out to be the common mistake we keep rolling
back to making - AC_CHECK_HEADERS _always_ looks in the default
paths in addition to whetever you may add. Ditto for its
AC_SEARCH_LIBS companion.

So you have to be more careful about handling this situation. We
periodically seem to forget and rollback the configure logic
into this error, so try to provide a big comment explaining
why you can't do it.

If I felt like taking the time to search for it, I could swear
I could just have copied that comment from prior times...

<shrug>

Also, remove the stale abstraction names for event and hwloc headers

Signed-off-by: Ralph Castain <rhc@pmix.org>
