### PR TITLE
Minor infrastructure and example cleanup

### DIFF
--- a/contrib/dist/linux/buildrpm.sh
+++ b/contrib/dist/linux/buildrpm.sh
@@ -267,10 +267,7 @@ fi
 # Find where the top RPM-building directory is
 #
 
-file=~/.rpmmacros
-if test -r $file; then
-    rpmtopdir=${rpmtopdir:-"`grep %_topdir $file | awk '{ print $2 }'`"}
-fi
+rpmtopdir=$HOME/RPMBUILD
 if test "$rpmtopdir" != ""; then
         rpmbuild_options="$rpmbuild_options --define '_topdir $rpmtopdir'"
     if test ! -d "$rpmtopdir"; then

--- a/examples/legacy.c
+++ b/examples/legacy.c
@@ -50,9 +50,11 @@ int main(int argc, char **argv)
     myrel_t myrel;
     pmix_status_t dbg = PMIX_ERR_DEBUGGER_RELEASE;
     pid_t pid;
+    char hostname[1024];
 
     pid = getpid();
-    fprintf(stderr, "Client %lu: Running\n", (unsigned long) pid);
+    gethostname(hostname, 1024);
+    fprintf(stderr, "Client %lu: Running on node %s\n", (unsigned long) pid, hostname);
 
     /* init us - note that the call to "init" includes the return of
      * any job-related info provided by the RM. This includes any


### PR DESCRIPTION
The logic to find rpmhome in the buildrpm.sh script
has not worked for years. Replace it with something
simpler. Add the hostname to the legacy example
output.

Signed-off-by: Ralph Castain <rhc@pmix.org>