### PR TITLE
Translate legacy OMPI params

### DIFF
--- a/src/mca/base/Makefile.am
+++ b/src/mca/base/Makefile.am
@@ -59,7 +59,8 @@ libprrte_mca_base_la_SOURCES = \
         prte_mca_base_var_group.c \
         prte_mca_base_components_register.c \
         prte_mca_base_framework.c \
-        prte_mca_base_alias.c
+        prte_mca_base_alias.c \
+        prte_mca_base_parse_paramfile.c
 
 # Conditionally install the header files
 

--- a/src/mca/base/prte_mca_base_open.c
+++ b/src/mca/base/prte_mca_base_open.c
@@ -84,7 +84,7 @@ int prte_mca_base_open(void)
         /* define the system and user default paths */
 #if PRTE_WANT_HOME_CONFIG_FILES
         prte_mca_base_system_default_path = strdup(prte_install_dirs.prtelibdir);
-        value = (char *) prte_home_directory();
+        value = (char *) prte_home_directory(-1);
         if (NULL == value) {
             prte_output(0, "Error: Unable to get the user home directory\n");
             return PRTE_ERROR;

--- a/src/mca/base/prte_mca_base_parse_paramfile.c
+++ b/src/mca/base/prte_mca_base_parse_paramfile.c
@@ -1,0 +1,79 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "src/class/prte_list.h"
+#include "src/mca/base/base.h"
+#include "src/mca/base/prte_mca_base_vari.h"
+#include "src/mca/mca.h"
+#include "src/util/keyval_parse.h"
+
+static void save_value(const char *file, int lineno, const char *name, const char *value);
+
+static prte_list_t *_param_list;
+
+int prte_mca_base_parse_paramfile(const char *paramfile, prte_list_t *list)
+{
+    _param_list = list;
+
+    return prte_util_keyval_parse(paramfile, save_value);
+}
+
+static void save_value(const char *file, int lineno, const char *name, const char *value)
+{
+    prte_mca_base_var_file_value_t *fv;
+    bool found = false;
+
+    /* First traverse through the list and ensure that we don't
+       already have a param of this name.  If we do, just replace the
+       value. */
+
+    PRTE_LIST_FOREACH (fv, _param_list, prte_mca_base_var_file_value_t) {
+        if (0 == strcmp(name, fv->mbvfv_var)) {
+            if (NULL != fv->mbvfv_value) {
+                free(fv->mbvfv_value);
+            }
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        /* We didn't already have the param, so append it to the list */
+        fv = PRTE_NEW(prte_mca_base_var_file_value_t);
+        if (NULL == fv) {
+            return;
+        }
+
+        fv->mbvfv_var = strdup(name);
+        prte_list_append(_param_list, &fv->super);
+    }
+
+    fv->mbvfv_value = value ? strdup(value) : NULL;
+    fv->mbvfv_file = strdup(file);
+    fv->mbvfv_lineno = lineno;
+}

--- a/src/mca/base/prte_mca_base_var.c
+++ b/src/mca/base/prte_mca_base_var.c
@@ -294,7 +294,7 @@ int prte_mca_base_var_init(void)
          * INTO THE ENVIRONMENT */
 
         /* We may need this later */
-        home = (char *) prte_home_directory();
+        home = (char *) prte_home_directory(-1);
 
         /* start with the system default param file */
         tmp = prte_os_path(false, prte_install_dirs.sysconfdir, "prte-mca-params.conf", NULL);

--- a/src/mca/base/prte_mca_base_vari.h
+++ b/src/mca/base/prte_mca_base_vari.h
@@ -121,6 +121,8 @@ PRTE_EXPORT int prte_mca_base_var_group_get_internal(const int group_index,
                                                      prte_mca_base_var_group_t **group,
                                                      bool invalidok);
 
+PRTE_EXPORT int prte_mca_base_parse_paramfile(const char *paramfile, prte_list_t *list);
+
 /**
  * \internal
  *

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -99,6 +99,8 @@ PRTE_EXPORT bool prte_schizo_base_check_directives(char *directive,
 PRTE_EXPORT bool prte_schizo_base_check_qualifiers(char *directive,
                                                    char **valid,
                                                    char *qual);
+PRTE_EXPORT bool prte_schizo_base_check_prte_param(char *param);
+PRTE_EXPORT bool prte_schizo_base_check_pmix_param(char *param);
 
 END_C_DECLS
 

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -353,6 +353,22 @@ static char *prte_frameworks[] = {
     NULL,
 };
 
+bool prte_schizo_base_check_prte_param(char *param)
+{
+    char **tmp;
+    size_t n;
+
+    tmp = prte_argv_split(param, '_');
+    for (n=0; NULL != prte_frameworks[n]; n++) {
+        if (0 == strncmp(tmp[0], prte_frameworks[n], strlen(prte_frameworks[n]))) {
+            prte_argv_free(tmp);
+            return true;
+        }
+    }
+    prte_argv_free(tmp);
+    return false;
+}
+
 int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target)
 {
     int i, j;
@@ -410,13 +426,17 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                  * one so we know this has been processed */
                 free(argv[i]);
                 argv[i] = strdup("--prtemca");
-                /* if this refers to the "if" framework, convert to "pif" */
+                /* if this refers to the "if" framework, convert to "prteif" */
                 if (0 == strncasecmp(p1, "if", 2)) {
-                    prte_asprintf(&param, "pif_%s", &p1[3]);
+                    prte_asprintf(&param, "prteif_%s", &p1[3]);
                     free(p1);
                     p1 = param;
                 } else if (0 == strncasecmp(p1, "reachable", strlen("reachable"))) {
-                    prte_asprintf(&param, "preachable_%s", &p1[strlen("reachable_")]);
+                    prte_asprintf(&param, "prtereachable_%s", &p1[strlen("reachable_")]);
+                    free(p1);
+                    p1 = param;
+                } else if (0 == strncasecmp(p1, "dl", strlen("dl"))) {
+                    prte_asprintf(&param, "prtedl_%s", &p1[strlen("dl_")]);
                     free(p1);
                     p1 = param;
                 }
@@ -467,6 +487,22 @@ static char *pmix_frameworks[] = {
     "ptl",
     NULL
 };
+
+bool prte_schizo_base_check_pmix_param(char *param)
+{
+    char **tmp;
+    size_t n;
+
+    tmp = prte_argv_split(param, '_');
+    for (n=0; NULL != pmix_frameworks[n]; n++) {
+        if (0 == strncmp(tmp[0], pmix_frameworks[n], strlen(pmix_frameworks[n]))) {
+            prte_argv_free(tmp);
+            return true;
+        }
+    }
+    prte_argv_free(tmp);
+    return false;
+}
 
 int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target)
 {
@@ -527,6 +563,20 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                  * one so we know this has been processed */
                 free(argv[i]);
                 argv[i] = strdup("--pmixmca");
+                /* if this refers to the "if" framework, convert to "pif" */
+                if (0 == strncasecmp(p1, "if", 2)) {
+                    prte_asprintf(&param, "pif_%s", &p1[3]);
+                    free(p1);
+                    p1 = param;
+                } else if (0 == strncasecmp(p1, "reachable", strlen("reachable"))) {
+                    prte_asprintf(&param, "preachable_%s", &p1[strlen("reachable_")]);
+                    free(p1);
+                    p1 = param;
+                } else if (0 == strncasecmp(p1, "dl", strlen("dl"))) {
+                    prte_asprintf(&param, "pdl_%s", &p1[strlen("dl_")]);
+                    free(p1);
+                    p1 = param;
+                }
                 if (NULL == target) {
                     /* push it into our environment */
                     asprintf(&param, "PMIX_MCA_%s", p1);

--- a/src/util/context_fns.c
+++ b/src/util/context_fns.c
@@ -79,7 +79,7 @@ int prte_util_check_context_cwd(prte_app_context_t *context, bool want_chdir)
         was a system-supplied default directory, so it's ok
         to not go there.  Try to go to the $HOME directory
         instead. */
-        tmp = prte_home_directory();
+        tmp = prte_home_directory(-1);
         if (NULL != tmp) {
             /* Try $HOME.  Same test as above. */
             good = true;

--- a/src/util/prte_environ.c
+++ b/src/util/prte_environ.c
@@ -24,9 +24,16 @@
 
 #include "prte_config.h"
 
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pwd.h>
 
 #include "constants.h"
 #include "src/util/argv.h"
@@ -258,9 +265,17 @@ const char *prte_tmp_directory(void)
     return str;
 }
 
-const char *prte_home_directory(void)
+const char *prte_home_directory(uid_t uid)
 {
-    char *home = getenv("HOME");
+    const char *home = NULL;
+
+    if (-1 == uid || uid == geteuid()) {
+        home = getenv("HOME");
+    }
+    if (NULL == home) {
+        struct passwd *pw = getpwuid(uid);
+        home = pw->pw_dir;
+    }
 
     return home;
 }

--- a/src/util/prte_environ.h
+++ b/src/util/prte_environ.h
@@ -132,7 +132,7 @@ PRTE_EXPORT int prte_unsetenv(const char *name, char ***env) __prte_attribute_no
 /* A consistent way to retrieve the home and tmp directory on all supported
  * platforms.
  */
-PRTE_EXPORT const char *prte_home_directory(void);
+PRTE_EXPORT const char *prte_home_directory(uid_t uid);
 PRTE_EXPORT const char *prte_tmp_directory(void);
 
 /* Some care is needed with environ on OS X when dealing with shared


### PR DESCRIPTION
Look at the environment, system default MCA param file, and
user default MCA param file. Translate any relevant values
to their PRRTE/PMIx equivalents.

Signed-off-by: Ralph Castain <rhc@pmix.org>