### PR TITLE
Revamp the map-by NUMA support

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -127,9 +127,7 @@ typedef struct {
     prte_object_t super;
     hwloc_cpuset_t available;
     prte_list_t summaries;
-
-    /** \brief Additional space for custom data */
-    void *userdata;
+    unsigned numa_cutoff;
 } prte_hwloc_topo_data_t;
 PRTE_EXPORT PRTE_CLASS_DECLARATION(prte_hwloc_topo_data_t);
 

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -38,21 +38,29 @@ char *prte_hwloc_base_topo_file = NULL;
 int prte_hwloc_base_output = -1;
 bool prte_hwloc_default_use_hwthread_cpus = false;
 
-hwloc_obj_type_t prte_hwloc_levels[] = {HWLOC_OBJ_MACHINE, HWLOC_OBJ_NODE,    HWLOC_OBJ_PACKAGE,
-                                        HWLOC_OBJ_L3CACHE, HWLOC_OBJ_L2CACHE, HWLOC_OBJ_L1CACHE,
-                                        HWLOC_OBJ_CORE,    HWLOC_OBJ_PU};
+hwloc_obj_type_t prte_hwloc_levels[] = {
+    HWLOC_OBJ_MACHINE,
+    HWLOC_OBJ_NUMANODE,
+    HWLOC_OBJ_PACKAGE,
+    HWLOC_OBJ_L3CACHE,
+    HWLOC_OBJ_L2CACHE,
+    HWLOC_OBJ_L1CACHE,
+    HWLOC_OBJ_CORE,
+    HWLOC_OBJ_PU
+};
 
-static prte_mca_base_var_enum_value_t hwloc_base_map[] = {{PRTE_HWLOC_BASE_MAP_NONE, "none"},
-                                                          {PRTE_HWLOC_BASE_MAP_LOCAL_ONLY,
-                                                           "local_only"},
-                                                          {0, NULL}};
+static prte_mca_base_var_enum_value_t hwloc_base_map[] = {
+    {PRTE_HWLOC_BASE_MAP_NONE, "none"},
+    {PRTE_HWLOC_BASE_MAP_LOCAL_ONLY, "local_only"},
+    {0, NULL}
+};
 
-static prte_mca_base_var_enum_value_t hwloc_failure_action[] = {{PRTE_HWLOC_BASE_MBFA_SILENT,
-                                                                 "silent"},
-                                                                {PRTE_HWLOC_BASE_MBFA_WARN, "warn"},
-                                                                {PRTE_HWLOC_BASE_MBFA_ERROR,
-                                                                 "error"},
-                                                                {0, NULL}};
+static prte_mca_base_var_enum_value_t hwloc_failure_action[] = {
+    {PRTE_HWLOC_BASE_MBFA_SILENT, "silent"},
+    {PRTE_HWLOC_BASE_MBFA_WARN, "warn"},
+    {PRTE_HWLOC_BASE_MBFA_ERROR, "error"},
+    {0, NULL}
+};
 
 static char *prte_hwloc_base_binding_policy = NULL;
 static int verbosity = 0;
@@ -81,7 +89,7 @@ int prte_hwloc_base_register(void)
 
     /* handle some deprecated options */
     prte_hwloc_default_use_hwthread_cpus = false;
-    (void) prte_mca_base_var_register("opal", "hwloc", "base", "use_hwthreads_as_cpus",
+    (void) prte_mca_base_var_register("prte", "hwloc", "base", "use_hwthreads_as_cpus",
                                       "Use hardware threads as independent cpus",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL,
                                       NULL, 0, PRTE_MCA_BASE_VAR_FLAG_DEPRECATED,
@@ -89,7 +97,7 @@ int prte_hwloc_base_register(void)
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                       &prte_hwloc_default_use_hwthread_cpus);
 
-    (void) prte_mca_base_var_register("opal", "hwloc", "base", "bind_to_core",
+    (void) prte_mca_base_var_register("prte", "hwloc", "base", "bind_to_core",
                                       "Bind processes to cores",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL,
                                       NULL, 0, PRTE_MCA_BASE_VAR_FLAG_DEPRECATED,
@@ -97,7 +105,7 @@ int prte_hwloc_base_register(void)
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                       &bind_to_core);
 
-    (void) prte_mca_base_var_register("opal", "hwloc", "base", "bind_to_socket",
+    (void) prte_mca_base_var_register("prte", "hwloc", "base", "bind_to_socket",
                                       "Bind processes to sockets",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL,
                                       NULL, 0, PRTE_MCA_BASE_VAR_FLAG_DEPRECATED,
@@ -449,7 +457,7 @@ static void topo_data_const(prte_hwloc_topo_data_t *ptr)
 {
     ptr->available = NULL;
     PRTE_CONSTRUCT(&ptr->summaries, prte_list_t);
-    ptr->userdata = NULL;
+    ptr->numa_cutoff = -1;
 }
 static void topo_data_dest(prte_hwloc_topo_data_t *ptr)
 {
@@ -462,7 +470,6 @@ static void topo_data_dest(prte_hwloc_topo_data_t *ptr)
         PRTE_RELEASE(item);
     }
     PRTE_DESTRUCT(&ptr->summaries);
-    ptr->userdata = NULL;
 }
 PRTE_CLASS_INSTANCE(prte_hwloc_topo_data_t, prte_object_t, topo_data_const, topo_data_dest);
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -96,12 +96,12 @@ void prte_plm_base_set_slots(prte_node_t *node)
                 /* some systems don't report sockets - in this case,
                  * use numanodes */
                 node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                 HWLOC_OBJ_NODE, 0);
+                                                                 HWLOC_OBJ_NUMANODE, 0);
             }
         }
     } else if (0 == strncmp(prte_set_slots, "numas", strlen(prte_set_slots))) {
         if (NULL != node->topology && NULL != node->topology->topo) {
-            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NODE,
+            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NUMANODE,
                                                              0);
         }
     } else if (0 == strncmp(prte_set_slots, "hwthreads", strlen(prte_set_slots))) {

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -992,7 +992,7 @@ int prte_rmaps_base_compute_bindings(prte_job_t *jdata)
         hwb = HWLOC_OBJ_PACKAGE;
         break;
     case PRTE_BIND_TO_NUMA:
-        hwb = HWLOC_OBJ_NODE;
+        hwb = HWLOC_OBJ_NUMANODE;
         break;
     case PRTE_BIND_TO_L3CACHE:
         PRTE_HWLOC_MAKE_OBJ_CACHE(3, hwb, clvl);

--- a/src/mca/rmaps/mindist/rmaps_mindist_module.c
+++ b/src/mca/rmaps/mindist/rmaps_mindist_module.c
@@ -375,7 +375,7 @@ static int mindist_map(prte_job_t *jdata)
                 }
                 /* first we need to fill summary object for root with information about nodes
                  * so we call prte_hwloc_base_get_nbobjs_by_type */
-                prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NODE, 0);
+                prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NUMANODE, 0);
                 PRTE_CONSTRUCT(&numa_list, prte_list_t);
                 ret = prte_hwloc_get_sorted_numa_list(node->topology->topo, prte_rmaps_base.device,
                                                       &numa_list);
@@ -400,7 +400,7 @@ static int mindist_map(prte_job_t *jdata)
                         /* get the hwloc object for this numa */
                         if (NULL
                             == (obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                                                      HWLOC_OBJ_NODE, 0,
+                                                                      HWLOC_OBJ_NUMANODE, 0,
                                                                       numa->index))) {
                             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                             return PRTE_ERR_NOT_FOUND;
@@ -560,7 +560,7 @@ static int assign_locations(prte_job_t *jdata)
 
             /* first we need to fill summary object for root with information about nodes
              * so we call prte_hwloc_base_get_nbobjs_by_type */
-            prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NODE, 0);
+            prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, HWLOC_OBJ_NUMANODE, 0);
             PRTE_CONSTRUCT(&numa_list, prte_list_t);
             rc = prte_hwloc_get_sorted_numa_list(node->topology->topo, prte_rmaps_base.device,
                                                  &numa_list);
@@ -582,7 +582,7 @@ static int assign_locations(prte_job_t *jdata)
             {
                 /* get the hwloc object for this numa */
                 if (NULL
-                    == (obj = prte_hwloc_base_get_obj_by_type(node->topology->topo, HWLOC_OBJ_NODE,
+                    == (obj = prte_hwloc_base_get_obj_by_type(node->topology->topo, HWLOC_OBJ_NUMANODE,
                                                               0, numa->index))) {
                     PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                     PRTE_LIST_DESTRUCT(&numa_list);


### PR DESCRIPTION
For each unique topology in the system, compute the max os_index
of the CPU NUMAs by searching for the first instance of an
overlapping NUMA. We assume that any overlap stems from a GPU
NUMA, and that the os_index of such NUMAs starts at 255 and counts
downward. Cache that cutoff and use it when computing number of
NUMA objects and retrieving the Nth NUMA object.

Need to extend this to the distance computations and a few other
areas, but this covers the typical range of use-cases.

Signed-off-by: Ralph Castain <rhc@pmix.org>