### PR TITLE
Handle default param case for HWT CPUs

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1521,7 +1521,7 @@ char *prte_hwloc_base_cset2str(hwloc_cpuset_t cpuset, bool use_hwthread_cpus, hw
 
     npus = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
     ncores = hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
-    if (npus == ncores) {
+    if (npus == ncores && !use_hwthread_cpus) {
         /* the bits in this bitmap represent cores */
         bits_as_cores = true;
     }

--- a/src/mca/rmaps/base/rmaps_base_ranking.c
+++ b/src/mca/rmaps/base/rmaps_base_ranking.c
@@ -472,7 +472,7 @@ static int rank_by(prte_job_t *jdata,
                     continue;
                 }
                 /* cycle thru the procs on this node */
-                for (j = 0; j < node->procs->size && cnt < app->num_procs; j++) {
+                for (j = 0; j < node->procs->size; j++) {
                     proc = (prte_proc_t *) prte_pointer_array_get_item(node->procs, j);
                     if (NULL == proc) {
                         continue;

--- a/src/mca/rmaps/base/rmaps_base_ranking.c
+++ b/src/mca/rmaps/base/rmaps_base_ranking.c
@@ -872,6 +872,10 @@ rankbyslot:
         prte_output_verbose(5, prte_rmaps_base_framework.framework_output,
                             "mca:rmaps:base: computing vpids by slot for job %s",
                             PRTE_JOBID_PRINT(jdata->nspace));
+        /* if they mapped by core or by hwthread, then rank-by slot is a match */
+        if (PRTE_MAPPING_BYHWTHREAD == mapping || PRTE_MAPPING_BYCORE == mapping) {
+            matched = true;
+        }
         if (PRTE_SUCCESS != (rc = rank_by(jdata, HWLOC_OBJ_PU, 0, matched))) {
             PRTE_ERROR_LOG(rc);
         }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -421,7 +421,7 @@ static int check_help(prte_cmd_line_t *cli, char **argv)
 
 static int convert_deprecated_cli(char *option, char ***argv, int i)
 {
-    char **pargs, *p2, *modifier;
+    char **pargs, *p1, *p2, *tmp, *tmp2, *output, *modifier;
     int rc = PRTE_SUCCESS;
 
     pargs = *argv;
@@ -582,6 +582,96 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
                        "This CLI option will be deprecated starting in Open MPI v5");
         rc = PRTE_ERR_TAKE_NEXT_OPTION;
     }
+    /* --map-by socket ->  --map-by package */
+    else if (0 == strcmp(option, "--map-by")) {
+        /* check the value of the option for "socket" */
+        if (0 == strncasecmp(pargs[i + 1], "socket", strlen("socket"))) {
+            p1 = strdup(pargs[i + 1]); // save the original option
+            /* replace "socket" with "package" */
+            if (NULL == (p2 = strchr(pargs[i + 1], ':'))) {
+                /* no modifiers */
+                tmp = strdup("package");
+            } else {
+                *p2 = '\0';
+                ++p2;
+                prte_asprintf(&tmp, "package:%s", p2);
+            }
+            prte_asprintf(&p2, "%s %s", option, p1);
+            prte_asprintf(&tmp2, "%s %s", option, tmp);
+            /* can't just call show_help as we want every instance to be reported */
+            output = prte_show_help_string("help-schizo-base.txt", "deprecated-converted", true, p2,
+                                           tmp2);
+            fprintf(stderr, "%s\n", output);
+            free(output);
+            free(p1);
+            free(p2);
+            free(tmp2);
+            free(pargs[i + 1]);
+            pargs[i + 1] = tmp;
+            return PRTE_ERR_TAKE_NEXT_OPTION;
+        }
+        rc = PRTE_OPERATION_SUCCEEDED;
+    }
+    /* --rank-by socket ->  --rank-by package */
+    else if (0 == strcmp(option, "--rank-by")) {
+        /* check the value of the option for "socket" */
+        if (0 == strncasecmp(pargs[i + 1], "socket", strlen("socket"))) {
+            p1 = strdup(pargs[i + 1]); // save the original option
+            /* replace "socket" with "package" */
+            if (NULL == (p2 = strchr(pargs[i + 1], ':'))) {
+                /* no modifiers */
+                tmp = strdup("package");
+            } else {
+                *p2 = '\0';
+                ++p2;
+                prte_asprintf(&tmp, "package:%s", p2);
+            }
+            prte_asprintf(&p2, "%s %s", option, p1);
+            prte_asprintf(&tmp2, "%s %s", option, tmp);
+            /* can't just call show_help as we want every instance to be reported */
+            output = prte_show_help_string("help-schizo-base.txt", "deprecated-converted", true, p2,
+                                           tmp2);
+            fprintf(stderr, "%s\n", output);
+            free(output);
+            free(p1);
+            free(p2);
+            free(tmp2);
+            free(pargs[i + 1]);
+            pargs[i + 1] = tmp;
+            return PRTE_ERR_TAKE_NEXT_OPTION;
+        }
+        rc = PRTE_OPERATION_SUCCEEDED;
+    }
+    /* --bind-to socket ->  --bind-to package */
+    else if (0 == strcmp(option, "--bind-to")) {
+        /* check the value of the option for "socket" */
+        if (0 == strncasecmp(pargs[i + 1], "socket", strlen("socket"))) {
+            p1 = strdup(pargs[i + 1]); // save the original option
+            /* replace "socket" with "package" */
+            if (NULL == (p2 = strchr(pargs[i + 1], ':'))) {
+                /* no modifiers */
+                tmp = strdup("package");
+            } else {
+                *p2 = '\0';
+                ++p2;
+                prte_asprintf(&tmp, "package:%s", p2);
+            }
+            prte_asprintf(&p2, "%s %s", option, p1);
+            prte_asprintf(&tmp2, "%s %s", option, tmp);
+            /* can't just call show_help as we want every instance to be reported */
+            output = prte_show_help_string("help-schizo-base.txt", "deprecated-converted", true, p2,
+                                           tmp2);
+            fprintf(stderr, "%s\n", output);
+            free(output);
+            free(p1);
+            free(p2);
+            free(tmp2);
+            free(pargs[i + 1]);
+            pargs[i + 1] = tmp;
+            return PRTE_ERR_TAKE_NEXT_OPTION;
+        }
+        rc = PRTE_OPERATION_SUCCEEDED;
+    }
 
     return rc;
 }
@@ -624,6 +714,9 @@ static int parse_deprecated_cli(prte_cmd_line_t *cmdline, int *argc, char ***arg
                        "--output-filename",
                        "--output-directory",
                        "--debug",
+                       "--map-by",
+                       "--rank-by",
+                       "--bind-to",
                        NULL};
 
     rc = prte_schizo_base_process_deprecated_cli(cmdline, argc, argv, options,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -532,14 +532,6 @@ static int convert_deprecated_cli(char *option, char ***argv, int i)
     }
     /* --map-by socket ->  --map-by package */
     else if (0 == strcmp(option, "--map-by")) {
-        /* if the option consists solely of qualifiers, then add
-         * the "core" default value */
-        if (':' == pargs[i + 1][0]) {
-            prte_asprintf(&p2, "core%s", pargs[i + 1]);
-            free(pargs[i + 1]);
-            pargs[i + 1] = p2;
-            return PRTE_OPERATION_SUCCEEDED;
-        }
         /* check the value of the option for "socket" */
         if (0 == strncasecmp(pargs[i + 1], "socket", strlen("socket"))) {
             p1 = strdup(pargs[i + 1]); // save the original option

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -221,6 +221,8 @@ char *prte_attr_print_list(prte_list_t *attributes)
     return out1;
 }
 
+static char unknownkey[180] = {0};
+
 const char *prte_attr_key_to_str(prte_attribute_key_t key)
 {
     int i;
@@ -513,7 +515,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
         case PRTE_RML_ROUTED_ATTRIB:
             return "RML-DESIRED-ROUTED-MODULES";
         default:
-            return "UNKNOWN-KEY";
+            prte_snprintf(unknownkey, 180, "UNKNOWN-KEY: %d", key);
+            return unknownkey;
         }
     }
 
@@ -527,7 +530,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
     }
 
     /* get here if nobody know what to do */
-    return "UNKNOWN-KEY";
+    prte_snprintf(unknownkey, 180, "UNKNOWN-KEY: %d", key);
+    return unknownkey;
 }
 
 int prte_attr_load(prte_attribute_t *kv, void *data, pmix_data_type_t type)


### PR DESCRIPTION
If someone sets a default param indicating that HWTs are
to be treated as independent CPUs, then we should do so.
Ensure we properly print out the map indicating that these
are HWTs and not cores.

Signed-off-by: Ralph Castain <rhc@pmix.org>