### PR TITLE
Enable support for PMIX_IOF_OUTPUT_RAW attribute

### DIFF
--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -85,12 +85,12 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
     memset(data, 0, PRTE_IOF_BASE_MSG_MAX);
     numbytes = read(fd, data, sizeof(data));
 
-     PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                "%s read %d bytes from %s of %s",
-                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
-                (PRTE_IOF_STDOUT & rev->tag) ? "stdout"
-                : ((PRTE_IOF_STDERR & rev->tag) ? "stderr" : "stddiag"),
-                PRTE_NAME_PRINT(&proct->name)));
+    PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s read %d bytes from %s of %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
+                         (PRTE_IOF_STDOUT & rev->tag) ? "stdout"
+                         : ((PRTE_IOF_STDERR & rev->tag) ? "stderr" : "stddiag"),
+                         PRTE_NAME_PRINT(&proct->name)));
 
     if (NULL == proct) {
         /* this is an error - nothing we can do */

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -538,8 +538,8 @@ int prte_schizo_base_sanity(prte_cmd_line_t *cmd_line)
                        "l2cache", "l3cache", "numa", "package", NULL};
     char *bndquals[] = {"overload-allowed", "if-supported", "ordered", "report", NULL};
 
-    char *outputs[] = {"tag", "timestamp", "xml", "merge-stderr-to-stdout", "directory", "filename", NULL};
-    char *outquals[] = {"nocopy", NULL};
+    char *outputs[] = {"tag", "rank", "timestamp", "xml", "merge-stderr-to-stdout", "directory", "filename", NULL};
+    char *outquals[] = {"nocopy", "raw", NULL};
 
     char *displays[] = {"allocation", "map", "bind", "map-devel", "topo", NULL};
 

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -587,6 +587,14 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+#ifdef PMIX_IOF_OUTPUT_RAW
+            /***   RAW OUTPUT   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_OUTPUT_RAW)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_RAW_OUTPUT, PRTE_ATTR_GLOBAL, &flag,
+                               PMIX_BOOL);
+#endif
+
             /***   STDIN TARGET   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_STDIN_TGT)) {
             if (0 == strcmp(info->value.data.string, "all")) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -89,6 +89,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     size_t ndist;
     pmix_topology_t topo;
     pmix_data_array_t darray, lparray;
+    bool flag, *fptr;
 
     prte_output_verbose(2, prte_pmix_server_globals.output, "%s register nspace for %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdata->nspace));
@@ -322,17 +323,18 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     free(tmp);
 
     /* check for output directives */
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
+    fptr = &flag;
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RANK_OUTPUT, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RANK_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_RANK_OUTPUT, &flag, PMIX_BOOL);
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_XML_OUTPUT, &flag, PMIX_BOOL);
     }
     tmp = NULL;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_FILE, (void **) &tmp, PMIX_STRING)
@@ -346,12 +348,17 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         PMIX_INFO_LIST_ADD(ret, info, PMIX_OUTPUT_TO_DIRECTORY, tmp, PMIX_STRING);
         free(tmp);
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_OUTPUT_NOCOPY, NULL, PMIX_BOOL);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_OUTPUT_NOCOPY, &flag, PMIX_BOOL);
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
     }
+#ifdef PMIX_IOF_OUTPUT_RAW
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RAW_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_OUTPUT_RAW, &flag, PMIX_BOOL);
+    }
+#endif
 
     /* for each app in the job, create an app-array */
     for (n = 0; n < jdata->apps->size; n++) {

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -916,15 +916,40 @@ int prte(int argc, char *argv[])
     outfile = NULL;
     if (NULL != (pval = prte_cmd_line_get_param(prte_cmd_line, "output", 0, 0))) {
         targv = prte_argv_split(pval->value.data.string, ',');
-        for (int idx = 0; idx < prte_argv_count(targv); idx++) {
+        for (int idx = 0; NULL != targv[idx]; idx++) {
+            /* check for qualifiers */
+            cptr = strchr(targv[idx], ':');
+            if (NULL != cptr) {
+                *cptr = '\0';
+                ++cptr;
+                /* could be multiple qualifiers, so separate them */
+                options = prte_argv_split(cptr, ',');
+                for (int m=0; NULL != options[m]; m++) {
+                    if (0 == strcasecmp(options[m], "nocopy")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
+                    } else if (0 == strcasecmp(options[m], "pattern")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
+#ifdef PMIX_IOF_OUTPUT_RAW
+                    } else if (0 == strcasecmp(options[m], "raw")) {
+                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
+#endif
+                    }
+                }
+                prte_argv_free(options);
+            }
+            if (0 == strlen(targv[idx])) {
+                // only qualifiers were given
+                continue;
+            }
             /* remove any '=' sign in the directive */
             if (NULL != (ptr = strchr(targv[idx], '='))) {
                 *ptr = '\0';
+                ++ptr; // step over '=' sign
             }
             if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
             } else if (0 == strncasecmp(targv[idx], "rank", strlen(targv[idx]))) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, &flag, PMIX_BOOL);
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
             } else if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
             } else if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
@@ -941,15 +966,6 @@ int prte(int argc, char *argv[])
                                    "missing-qualifier", true,
                                    "output", "directory", "directory");
                     return PRTE_ERR_FATAL;
-                }
-                ++ptr;
-                /* check for qualifiers */
-                if (NULL != (cptr = strchr(ptr, ':'))) {
-                    *cptr = '\0';
-                    ++cptr;
-                    if (0 == strcasecmp(cptr, "nocopy")) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
-                    }
                 }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
@@ -976,20 +992,6 @@ int prte(int argc, char *argv[])
                                    "missing-qualifier", true,
                                    "output", "filename", "filename");
                     return PRTE_ERR_FATAL;
-                }
-                ++ptr;
-                /* check for qualifiers */
-                if (NULL != (cptr = strchr(ptr, ':'))) {
-                    *cptr = '\0';
-                    ++cptr;
-                    options = prte_argv_split(cptr, ',');
-                    for (int m=0; NULL != options[m]; m++) {
-                        if (0 == strcasecmp(options[m], "nocopy")) {
-                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
-                        } else if (0 == strcasecmp(options[m], "pattern")) {
-                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
-                        }
-                    }
                 }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -464,6 +464,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "DO-NOT-COPY-OUTPUT";
         case PRTE_SPAWN_TIMEOUT:
             return "SPAWN-TIMEOUT";
+        case PRTE_JOB_RAW_OUTPUT:
+            return "DO-NOT-BUFFER-OUTPUT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -198,6 +198,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY + 91) // bool - do not copy output to stdout/err
 #define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY + 92) // bool - tag stdout/stderr with rank
 #define PRTE_SPAWN_TIMEOUT                  (PRTE_JOB_START_KEY + 93) // int32 - number of seconds to spawn before terminating it as timed out
+#define PRTE_JOB_RAW_OUTPUT                 (PRTE_JOB_START_KEY + 94) // bool - do not buffer output
 
 #define PRTE_JOB_MAX_KEY 300
 


### PR DESCRIPTION
Add required check and set for the attribute. Fix a few
places where we were assuming attributes were true when
they could have been stored as false. Add missing directive
and qualifiers for the "output" cmd line option.

Signed-off-by: Ralph Castain <rhc@pmix.org>