### PR TITLE
Fix issues impact cygwin

### DIFF
--- a/config/prte_check_ptrace.m4
+++ b/config/prte_check_ptrace.m4
@@ -23,10 +23,10 @@ AC_DEFUN([PRTE_CHECK_PTRACE],[
     prte_detach_cmd=
 
     AC_CHECK_HEADER([sys/ptrace.h],
-                    [prte_have_ptrace_header=1],
+                    [prte_have_ptrace_header=1
+                     # must manually define the header protection since check_header doesn't do it
+                     AC_DEFINE_UNQUOTED([HAVE_SYS_PTRACE_H], [1], [Whether or not we have the ptrace header])],
                     [prte_have_ptrace_header=0])
-    # must manually define the header protection since check_header doesn't know it
-    AC_DEFINE_UNQUOTED([HAVE_SYS_PTRACE_H], [$prte_have_ptrace_header], [Whether or not we have the ptrace header])
 
     AC_CHECK_FUNC([ptrace],
                   [prte_have_ptrace=yes],

--- a/src/mca/prteif/prteif.h
+++ b/src/mca/prteif/prteif.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,7 +71,7 @@ BEGIN_C_DECLS
 #endif
 
 #define DEFAULT_NUMBER_INTERFACES 10
-#define MAX_IFCONF_SIZE           10 * 1024 * 1024
+#define MAX_IFCONF_SIZE           10485760
 
 typedef struct prte_if_t {
     prte_list_item_t super;


### PR DESCRIPTION
HAVE_SYS_PTRACE_H should only be defined if we
actually have that header.
Make definition of max size in prteif header be a
fixed integer (might be something about GCC 11)

Signed-off-by: Ralph Castain <rhc@pmix.org>