### PR TITLE
Cleanup handling of allocated node names

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -2340,11 +2340,11 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output, "%s checking node %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), nptr->name));
             for (i = 0; i < prte_node_pool->size; i++) {
-                if (NULL
-                    == (node = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool, i))) {
+                node = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool, i);
+                if (NULL == node) {
                     continue;
                 }
-                if (0 != strcmp(node->name, nptr->name)) {
+                if (!prte_nptr_match(node, nptr)) {
                     continue;
                 }
                 /* have a match - now see if we want this node */

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -998,7 +998,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
     prte_plm_ssh_caddy_t *caddy;
     prte_list_t coll;
-    char *username;
+    char *username, *nname;
     int port, *portptr;
     prte_namelist_t *child;
 
@@ -1117,7 +1117,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
              * prefer to find some other node so we can tell what the remote
              * shell is, if necessary
              */
-            if (0 != strcmp(node->name, prte_process_info.nodename)) {
+            if (!prte_check_host_is_local(node->name)) {
                 break;
             }
         }
@@ -1190,13 +1190,18 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
         /* setup node name */
         free(argv[node_name_index1]);
+        if (NULL == node->rawname) {
+            nname = node->name;
+        } else {
+            nname = node->rawname;
+        }
         username = NULL;
         if (prte_get_attribute(&node->attributes, PRTE_NODE_USERNAME, (void **) &username,
                                PMIX_STRING)) {
-            prte_asprintf(&argv[node_name_index1], "%s@%s", username, node->name);
+            prte_asprintf(&argv[node_name_index1], "%s@%s", username, nname);
             free(username);
         } else {
-            argv[node_name_index1] = strdup(node->name);
+            argv[node_name_index1] = strdup(nname);
         }
 
         /* pass the vpid */

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -282,6 +282,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         PRTE_LIST_FOREACH(node, &nodes, prte_node_t) {
             if (!prte_net_isaddr(node->name) &&
                 NULL != (ptr = strchr(node->name, '.'))) {
+                node->rawname = strdup(node->name);
                 if (prte_keep_fqdn_hostnames) {
                     /* retain the non-fqdn name as an alias */
                     *ptr = '\0';

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -149,6 +149,12 @@ int prte_ras_base_node_insert(prte_list_t *nodes, prte_job_t *jdata)
             }
             /* if the node name is different, store it as an alias */
             prte_argv_append_unique_nosize(&hnp_node->aliases, node->name);
+            if (NULL != node->rawname) {
+                if (NULL != hnp_node->rawname) {
+                    free(hnp_node->rawname);
+                }
+                hnp_node->rawname = strdup(node->rawname);
+            }
             /* don't keep duplicate copy */
             PRTE_RELEASE(node);
             /* create copies, if required */

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -589,6 +589,7 @@ static void prte_node_construct(prte_node_t *node)
 {
     node->index = -1;
     node->name = NULL;
+    node->rawname = NULL;
     node->aliases = NULL;
     node->daemon = NULL;
 
@@ -617,6 +618,10 @@ static void prte_node_destruct(prte_node_t *node)
     if (NULL != node->name) {
         free(node->name);
         node->name = NULL;
+    }
+    if (NULL != node->rawname) {
+        free(node->rawname);
+        node->rawname = NULL;
     }
     if (NULL != node->aliases) {
         prte_argv_free(node->aliases);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -258,6 +258,7 @@ typedef struct {
     int32_t index;
     /** String node name */
     char *name;
+    char *rawname;  // name originally given in allocation, if different from name
     /** aliases */
     char **aliases;
     /* daemon on this node */

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -21,6 +21,7 @@
 #include "src/event/event-internal.h"
 #include "src/runtime/prte_globals.h"
 #include "src/threads/threads.h"
+#include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/fd.h"
 

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -180,6 +180,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
                     node->name = strdup(node_name);
                 } else {
                     node->name = strdup(alias);
+                    node->rawname = strdup(node_name);
                 }
                 if (NULL != username) {
                     prte_set_attribute(&node->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_LOCAL,
@@ -223,6 +224,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
                 node->name = strdup(node_name);
             } else {
                 node->name = strdup(alias);
+                node->rawname = strdup(node_name);
             }
             node->slots = 1;
             if (NULL != username) {
@@ -266,6 +268,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
             node->name = strdup(prte_util_hostfile_value.sval);
         } else {
             node->name = strdup(alias);
+            node->rawname = strdup(prte_util_hostfile_value.sval);
         }
         if (NULL != alias && 0 != strcmp(alias, node->name)) {
             // new node object, so alias must be unique
@@ -339,6 +342,7 @@ static int hostfile_parse_line(int token, prte_list_t *updates, prte_list_t *exc
         if (NULL != alias) {
             prte_argv_append_unique_nosize(&node->aliases, alias);
             free(alias);
+            node->rawname = strdup(node_name);
         }
         PRTE_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                              "%s hostfile: node %s slots %d nodes-given %s",


### PR DESCRIPTION
Some systems absolutely require the node name used in an
ssh launch to exactly match that provided in an allocation.
Add the ability to track that name (as opposed to a version
that has the FQDN stripped) and use it in the ssh launcher.

Signed-off-by: Ralph Castain <rhc@pmix.org>