### PR TITLE
Ensure an error gets reported when rankfile fails

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -389,7 +389,8 @@ PRTE_EXPORT int prte_hwloc_base_memory_set(prte_hwloc_base_memory_segment_t *seg
  * Make a prettyprint string for a hwloc_cpuset_t (e.g., "package
  * 2[core 3]").
  */
-PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_cpuset_t cpuset, bool use_hwthread_cpus,
+PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
+                                           bool use_hwthread_cpus,
                                            hwloc_topology_t topo);
 
 /* get the hwloc object that corresponds to the given processor id  and type */

--- a/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
+++ b/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
@@ -4,7 +4,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -13,23 +13,12 @@
 #
 # This is the US/English general help file for rankle utilities.
 #
-# Voltaire
-[no-hwloc]
-A slot_list containing detailed location info was given, but
-hwloc support is not available:
-
-  Rank:      %d
-  Slot list:  %s
-
-Unfortunately, hwloc support is required for this action.
-Please reconfigure OMPI for hwloc if binding to specified
-cpus is desired.
 [no-rankfile]
-PRTE was unable to open the rankfile:
-    %s
+%s was unable to open the rankfile:
+  Filename: %s
 Check to make sure the path and filename are correct.
 
-usage:  prun --map-by rankfile:file=<path> ./app
+usage:  %s -mca rmaps_rankfile_path rankfile ./app
 
 Examples of proper syntax include:
   cat hostfile
@@ -43,43 +32,6 @@ Examples of proper syntax include:
     rank 2=host4 slot=1-2
     rank 3=host3 slot=0:1;1:0-2
 #
-[parse_error_string]
-PRTE detected a parse error in the rankfile (%s)
-It occured on line number %d on token %d:
-    %s
-Examples of proper syntax include:
-    rank 1=host1 slot=1:0,1
-    rank 0=host2 slot=0:*
-    rank 2=host4 slot=1-2
-    rank 3=host3 slot=0:1;1:0-2
-#
-[parse_error_int]
-PRTE detected a parse error in the rankfile (%s)
-It occured on line number %d on token %d:
-    %d
-Examples of proper syntax include:
-    rank 1=host1 slot=1:0,1
-    rank 0=host2 slot=0:*
-    rank 2=host4 slot=1-2
-    rank 3=host3 slot=0:1;1:0-2
-#
-[parse_error]
-PRTE detected a parse error in the rankfile (%s)
-It occured on line number %d on token %d. Examples of
-proper syntax include:
-    rank 1=host1 slot=1:0,1
-    rank 0=host2 slot=0:*
-    rank 2=host4 slot=1-2
-    rank 3=host3 slot=0:1;1:0-2
-
-#
-[not-all-mapped-alloc]
-Some of the requested ranks are not included in the current allocation.
-    %s
-
-Please verify that you have specified the allocated resources properly in
-the provided rankfile.
-#
 [bad-host]
 The rankfile that was used claimed that a host was either not
 allocated or oversubscribed its slots.  Please review your rank-slot
@@ -92,27 +44,20 @@ some systems may require using full hostnames, such as
 [bad-index]
 Rankfile claimed host %s by index that is bigger than number of allocated hosts.
 #
-[bad-rankfile]
-Error, invalid rank (%d) in the rankfile (%s)
-#
 [bad-assign]
 Error, rank %d is already assigned to %s, check %s
 #
 [bad-syntax]
 Error, invalid syntax in the rankfile (%s)
-syntax must be the fallowing
+syntax must be the following
+
 rank i=host_i slot=string
+
 Examples of proper syntax include:
     rank 1=host1 slot=1:0,1
     rank 0=host2 slot=0:*
     rank 2=host4 slot=1-2
     rank 3=host3 slot=0:1;1:0-2
-#
-[prte-rmaps-rf:multi-apps-and-zero-np]
-RMAPS found multiple applications to be launched, with
-at least one that failed to specify the number of processes to execute.
-When specifying multiple applications, you must specify how many processes
-of each to launch via the -np argument.
 #
 [missing-rank]
 A rank is missing its location specification:
@@ -123,3 +68,12 @@ A rank is missing its location specification:
 All processes must have their location specified in the rank file. Either
 add an entry to the file, or provide a default slot_list to use for
 any unspecified ranks.
+#
+[missing-cpu]
+While parsing the rankfile, %s encountered a line that specified
+a non-existent CPU:
+
+  Slots: %s
+  Available CPUs: %s
+
+Please correct the line and try again.

--- a/src/mca/rmaps/seq/help-prte-rmaps-seq.txt
+++ b/src/mca/rmaps/seq/help-prte-rmaps-seq.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -45,3 +45,26 @@ for use by the sequential mapper in its assignments by using the
 appropriate modifier:
 
   Example: --map-by seq:file=myseqfile
+#
+[missing-cpu]
+While parsing the sequential hostfile, %s encountered a line that
+specified a non-existent CPU:
+
+  Slots: %s
+  Available CPUs: %s
+
+Please correct the line and try again.
+#
+[bad-syntax]
+Error, invalid syntax in sequential hostfile %s.
+
+The sequential mapper requires that there be a node entry for
+every process in the job, and it processes the provided file
+using each node entry to identify the node where that numbered
+rank is to be placed. You can specify the CPU binding for the
+process on its node entry line in the following manner:
+
+A 1:0,1   # put this rank on node A, bound to socket 1, CPUs 0 and 1
+B 1-4     # put this rank on node B, bound to CPUs 1-4
+
+Please correct the syntax and try again.


### PR DESCRIPTION
If someone specifies a non-existent CPU, then generate an
error message instead of just silently failing. Ditto for
the sequential mapper.

Signed-off-by: Ralph Castain <rhc@pmix.org>

dd

Signed-off-by: Ralph Castain <rhc@pmix.org>