### PR TITLE
Cleanup a bit in prep for PMIx sync to v5 std

### DIFF
--- a/examples/server.c
+++ b/examples/server.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -572,6 +572,7 @@ static pmix_status_t publish_fn(const pmix_proc_t *proc, const pmix_info_t info[
 {
     pmix_locdat_t *p;
     size_t n;
+    pmix_status_t rc = PMIX_SUCCESS;
 
     pmix_output(0, "SERVER: PUBLISH");
 
@@ -580,13 +581,16 @@ static pmix_status_t publish_fn(const pmix_proc_t *proc, const pmix_info_t info[
         (void) strncpy(p->pdata.proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
         p->pdata.proc.rank = proc->rank;
         (void) strncpy(p->pdata.key, info[n].key, PMIX_MAX_KEYLEN);
-        pmix_value_xfer(&p->pdata.value, (pmix_value_t *) &info[n].value);
+        PMIX_VALUE_XFER(rc, &p->pdata.value, (pmix_value_t *) &info[n].value);
+        if (PMIX_SUCCESS != rc) {
+            break;
+        }
         pmix_list_append(&pubdata, &p->super);
     }
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, cbdata);
+        cbfunc(rc, cbdata);
     }
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_info_t info[],
@@ -609,7 +613,10 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_
                 (void) strncpy(p2->pdata.proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
                 p2->pdata.proc.rank = p->pdata.proc.rank;
                 (void) strncpy(p2->pdata.key, p->pdata.key, PMIX_MAX_KEYLEN);
-                pmix_value_xfer(&p2->pdata.value, &p->pdata.value);
+                PMIX_VALUE_XFER(ret, &p2->pdata.value, &p->pdata.value);
+                if (PMIX_SUCCESS != ret) {
+                    break;
+                }
                 pmix_list_append(&results, &p2->super);
                 break;
             }
@@ -624,7 +631,10 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_
                 (void) strncpy(pd[i].proc.nspace, p->pdata.proc.nspace, PMIX_MAX_NSLEN);
                 pd[i].proc.rank = p->pdata.proc.rank;
                 (void) strncpy(pd[i].key, p->pdata.key, PMIX_MAX_KEYLEN);
-                pmix_value_xfer(&pd[i].value, &p->pdata.value);
+                PMIX_VALUE_XFER(ret, &pd[i].value, &p->pdata.value);
+                if (PMIX_SUCCESS != ret) {
+                    break;
+                }
             }
         }
     }

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -559,7 +559,12 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender, pmix_data_buffer
                 goto release;
             }
             PMIX_LOAD_KEY(pdata[n].key, info.key);
-            pmix_value_xfer(&pdata[n].value, &info.value);
+            PMIX_VALUE_XFER_DIRECT(ret, &pdata[n].value, &info.value);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                goto release;
+            }
             PMIX_INFO_DESTRUCT(&info);
         }
     }


### PR DESCRIPTION
Use the appropriate macros instead of directly calling
the backing functions so PRRTE can work across PMIx
versions

Signed-off-by: Ralph Castain <rhc@pmix.org>