### PR TITLE
Fix some ordering issues on cleanup, and a couple memory leaks.

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -581,12 +581,6 @@ static int rte_finalize(void)
 {
     char *contact_path;
 
-    /* shutdown the pmix server */
-    pmix_server_finalize();
-    /* output any lingering stdout/err data */
-    fflush(stdout);
-    fflush(stderr);
-
     /* first stage shutdown of the errmgr, deregister the handler but keep
      * the required facilities until the rml and oob are offline */
     prte_errmgr.finalize();
@@ -624,6 +618,12 @@ static int rte_finalize(void)
     prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
 
     free(prte_topo_signature);
+
+    /* shutdown the pmix server */
+    pmix_server_finalize();
+    /* output any lingering stdout/err data */
+    fflush(stdout);
+    fflush(stderr);
 
     return PRTE_SUCCESS;
 }

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -140,15 +140,15 @@ int prte_finalize(void)
     free(prte_process_info.nodename);
     prte_process_info.nodename = NULL;
 
-    /* call the finalize function for this environment */
-    if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
-        return rc;
-    }
-
     /* Close the general debug stream */
     prte_output_close(prte_debug_output);
 
     prte_mca_base_alias_cleanup();
+
+    /* call the finalize function for this environment */
+    if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
+        return rc;
+    }
 
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
I was seeing crashes in prteruns cleanup routine, and valgrind
was reporting accesses after free's. Doing this code shuffle seems
to fix it.

While I was at it, I fixed some long hanging leaks.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>