### PR TITLE
Rewrite CHECK_PACKAGE to support pkg-config

### DIFF
--- a/config/oac_check_package.m4
+++ b/config/oac_check_package.m4
@@ -1,0 +1,598 @@
+dnl -*- autoconf -*-
+dnl
+dnl The macros in this file depend on 3 helper macros being defined.  These are
+dnl likely similar to existing macros, so are not defined here with the
+dnl expectation the caller will provide them (likely through an m4_copy).  The
+dnl three macros are:
+dnl  - OAC_LOG_COMMAND([command], [action-if-success], [action-if-fail])
+dnl  - OAC_LOG_MSG([msg], [non-empty-string if prefix])
+dnl  - OAC_APPEND([variable], [data to append])
+dnl
+dnl In PMIX, for example, the following would provide the required behavior:
+dnl   m4_copy([PMIX_LOG_COMMAND], [OAC_LOG_COMMAND])
+dnl   m4_copy([PMIX_LOG_MSG], [OAC_LOG_MSG])
+dnl   m4_copy([PMIX_APPEND], [OAC_APPEND])
+
+
+dnl OAC_CHECK_PACKAGE: Search for the availability of a package
+dnl
+dnl 1 -> package name
+dnl 2 -> prefix value
+dnl 3 -> headers (space separated list)
+dnl 4 -> libraries (space separated list)
+dnl 5 -> function name
+dnl 6 -> action if found
+dnl 7 -> action if not found
+dnl
+dnl OAC_CHECK_PACKAGE has an argument length problem.  Technically, M4
+dnl macros may only have 9 arguments, as argument values must be in the
+dnl form of $X, where X is a single digit.  This means we do some argument
+dnl compression (life would be easier if the libraries and headers were
+dnl split into primary and support) and use the M4 environment for passing
+dnl some infrequently used arguments.
+dnl
+dnl OAC_CHECK_PACKAGE tries to find the correct CPPFLAGS, LDFLAGS, and libraries
+dnl to use a particular package.  It then verifies that the header is available
+dnl via AC_CHECK_HEADERS and that the function specified is available via
+dnl AC_CHECK_FUNC using the specified flags.  To find the flags and libraries,
+dnl OAC_CHECK_PACKAGE follows a 4 step search path:
+dnl
+dnl   1. If <package name>.pc is available to package config, the package config
+dnl      data is used.
+dnl   2. If a OMPI-style wrapper compiler is found, the information from the
+dnl      wrapper compiler is used (NOTE: THIS IS OFF BY DEFAULT)
+dnl   3. If with_<package> and/or with_<package>_libdir are specified, the
+dnl      filesystem is examined to look for the specified header and library
+dnl      in the specified path.
+dnl   4. We try to find the specified header and function with no change
+dnl      in CPPFLAGS or LDFLAGS and adding the specified libraries to LIBS.
+dnl
+dnl It is the resposibility of the caller to register arguments of the form
+dnl with-<package name>, with-<package name>-libdir, and with-package name>-incdir.
+dnl All three are optional, nothing will break if the caller doesn't specify them
+dnl (and indeed, if the package being searched for isn't libnl3, it's likely the
+dnl with-<package name>-incdir is a complete waste of energe).
+dnl
+dnl By default, OAC_CHECK_PACKAGE will use <package name> for the module name to specify
+dnl to pkg-config, meaning there is a <package name>.pc in the filesystem.  If a
+dnl different module name should be used, add a macro to the M4 environment named
+dnl <package name>_pkgconfig_module with the value of the pkgconfig module name
+dnl to use.  For exmaple, if the libevent module name is libevent_core, you could
+dnl specify:
+dnl
+dnl    m4_define([libevent_pkgconfig_module], [libevent_core])
+dnl
+dnl Similarly, by default, OAC_CHECK_PACKAGE will use <package name>cc for the name
+dnl of the wrapper compiler to investigate.  This can be modified with the
+dnl <package name>_wrapper_compiler macro in the m4 environment.
+dnl
+dnl Using pkg-config is on by default and using the wrapper compilers is off by
+dnl default.  The use of either can be controlled by setting the SHELL environment
+dnl variables <package name>_USE_PKG_CONFIG and <package name>_USE_WRAPPER_COMPILER
+dnl to 0 (to explicitly disable) or 1 (to explicitly enable).
+dnl
+dnl On return, <action if found> will be evaluated if it appears that the package is
+dnl available.  <action if not found> will be evaluated if it appears that the package
+dnl is not available.  If it appears the package is available, the following SHELL
+dnl environment variables will be set:
+dnl
+dnl   <prefix>_CPPFLAGS - CPPFLAGS to add when compiling sources depending on the package
+dnl   <prefix>_LDFLAGS - LDFLAGS to add when linking against the package
+dnl   <prefix>_LIBS - Libraries to link to access the package
+dnl   <prefix>_STATIC_LIBS - Libraries to link to access the package when building a
+dnl                          staticly linked executable.
+dnl   <prefix>_SUMMARY - A summary of the check package output, suitable for inclusion
+dnl                          in a configure summary table.  Will start with yes/no.
+dnl   <prefix>_DETECT_METHOD - The method used to find the right flags.  Will be one of
+dnl                          'pkg-config', 'wrapper compiler', or empty string
+dnl
+dnl Note that STATIC_LIBS should not be added to LIBS unnecessarily.  Even if the library
+dnl being built is being built as a static library, that does not mean adding STATIC_LIBS
+dnl to LIBS is the right call.  Only when the executable is only linked against static
+dnl libraries should STATIC_LIBS be added to LIBS.
+AC_DEFUN([OAC_CHECK_PACKAGE],[
+# ****************************** START CHECK PACKAGE FOR $1 ******************************
+    check_package_$2_save_CPPFLAGS="${CPPFLAGS}"
+    check_package_$2_save_LDFLAGS="${LDFLAGS}"
+    check_package_$2_save_LIBS="${LIBS}"
+
+    $2_CPPFLAGS=
+    $2_LDFLAGS=
+    $2_LIBS=
+    $2_STATIC_LIBS=
+
+    check_package_happy=1
+    check_package_have_flags=0
+    check_package_type=
+
+    # build a sane environment
+    AS_IF([test "$with_$1" = "no"],
+          [AC_MSG_NOTICE([Package $1 disabled by user])
+           check_package_happy=0],
+          [test "${with_$1}" = "yes"],
+          [check_package_prefix=],
+          [check_package_prefix="${with_$1}"])
+    check_package_libdir=
+    AS_IF([test "${with_$1_libdir}" = "no" -o "${with_$1_libdir}" = "yes"],
+          [AC_MSG_ERROR(["yes" or "no" are not valid arguments for --with-$1-libdir])],
+          [test -n "${with_$1_libdir}"],
+          [check_package_libdir="${with_$1_libdir}"])
+    check_package_incdir=
+    AS_IF([test "${with_$1_incdir}" = "no" -o "${with_$1_incdir}" = "yes"],
+          [AC_MSG_ERROR(["yes" or "no" are not valid arguments for --with-$1-incdir])],
+          [test -n "${with_$1_incdir}"],
+          [check_package_incdir="${with_$1_incdir}"])
+
+    AS_IF([test ${check_package_happy} -eq 1 -a ${check_package_have_flags} -eq 0],
+          [_OAC_CHECK_PACKAGE_PKGCONFIG([$1], [$2],
+                [check_package_type="pkg-config"
+                 check_package_have_flags=1])])
+
+    AS_IF([test ${check_package_happy} -eq 1 -a ${check_package_have_flags} -eq 0],
+          [_OAC_CHECK_PACKAGE_WRAPPER_COMPILER([$1], [$2],
+                [check_package_type="wrapper compiler"
+                 check_package_have_flags=1])])
+
+    AS_IF([test ${check_package_happy} -eq 1 -a ${check_package_have_flags} -eq 0],
+          [_OAC_CHECK_PACKAGE_GENERIC([$1], [$2], [$3], [$4],
+                [check_package_type=""
+                 check_package_have_flags=1])])
+
+    AS_IF([test ${check_package_have_flags} -eq 0], [check_package_happy=0])
+
+    AS_IF([test ${check_package_happy} -eq 1],
+          [_OAC_CHECK_PACKAGE_VERIFY([$1], [$2], [$3], [$5],
+                                 [check_package_happy=1], [check_package_happy=0])])
+
+    $2_DETECT_METHOD="${check_package_type}"
+    AS_IF([test -n "${check_package_type}"],
+          [check_package_type="${check_package_type}: "])
+
+    AS_IF([test ${check_package_happy} -eq 1],
+          [AS_IF([test -z "${check_package_prefix}"],
+                 [$2_SUMMARY="yes (${check_package_type}default search paths)"],
+                 [$2_SUMMARY="yes (${check_package_type}${check_package_prefix})"])
+           $6],
+	  [AS_IF([test "${with_$1}" = "no"],
+                 [$2_SUMMARY="no (explicitly disabled)"],
+                 [$2_SUMMARY="no (not found)"])
+	   AS_UNSET([$2_CPPFLAGS])
+	   AS_UNSET([$2_LDFLAGS])
+	   AS_UNSET([$2_STATIC_LIBS])
+	   AS_UNSET([$2_LIBS])
+           $7])
+
+    CPPFLAGS="${check_package_$2_save_CPPFLAGS}"
+    LDFLAGS="${check_package_$2_save_LDFLAGS}"
+    LIBS="${check_package_$2_save_LIBS}"
+
+    AS_UNSET([check_package_$2_save_CPPFLAGS])
+    AS_UNSET([check_package_$2_save_LDFLAGS])
+    AS_UNSET([check_package_$2_save_LIBS])
+    AS_UNSET([check_package_happy])
+    AS_UNSET([check_package_have_flags])
+    AS_UNSET([check_package_prefix])
+    AS_UNSET([check_package_libdir])
+    AS_UNSET([check_package_incdir])
+    AS_UNSET([check_package_pcfilename])
+
+# ****************************** END CHECK PACKAGE FOR $1 ******************************
+])
+
+
+dnl OAC_CHECK_PACKAGE_VERIFY_COMMANDS - macros to expand during
+dnl   verification we have a working package
+dnl
+dnl 1 -> macro name (must be double quoted)
+dnl
+dnl If extra verification is required (such as the libnl1 vs. libnl3 disaster),
+dnl callers (like the libnl verification code) can register a hook for
+dnl every time OAC_CHECK_PACKAGE verifies that a package actually links.  This
+dnl check will only be run after it is verified that the header can be found
+dnl and that the function specified is found when linking.
+dnl
+dnl The macro specified must take 6 arguments:
+dnl     1 -> package name
+dnl     2 -> prefix
+dnl     3 -> headers (space separated list)
+dnl     4 -> function name
+dnl     5 -> action if found
+dnl     6 -> action if not found
+dnl
+dnl The CPPFLAGS / LDFLAGS / LIBS can be retrieved via ${$2_CPPFLAGS},
+dnl ${$2_LDFLAGS}, and ${$2_LIBS}, respectively.
+dnl
+dnl Note that, because M4 really likes to expand macro names, the argument
+dnl to OAC_CHECK_PACKAGE_VERIFY_COMMANDS must be overquoted.  That is,
+dnl if the macro name to be called is LIBNL_PACKAGE_VERIFY, the call to
+dnl register should be:
+dnl
+dnl    OAC_CHECK_PACKAGE_VERIFY_COMMANDS([[LIBNL_PACKAGE_VERIFY]])
+dnl
+dnl If you see the macro being invoked without arguments, that almost certainly
+dnl means you forgot to double quote.
+AC_DEFUN([OAC_CHECK_PACKAGE_VERIFY_COMMANDS],
+[m4_append([OAC_CHECK_PACKAGE_VERIFY_COMMAND_LIST], m4_dquote([$1]), [,])])
+
+
+dnl ************************************* PKG-CONFIG *************************************
+
+
+dnl no arguments; here for an AC_REQUIRE to set $PKG_CONFIG
+AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG_INIT], [
+  AC_CHECK_PROG([PKG_CONFIG], [pkg-config], [pkg-config])
+])
+
+
+dnl 1 -> package
+dnl 2 -> prefix
+dnl 3 -> action if found flags
+AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG], [
+    m4_ifdef([$1_pkgconfig_module],
+             [m4_define([pcname], [$1_pkgconfig_module])],
+             [m4_define([pcname], [$1])])
+    AS_IF([test "${$1_USE_PKG_CONFIG}" != "0"],
+          [# search for the package using pkg-config.  If the user provided a
+           # --with-$1 or --with-$1-libdir argument, be explicit about where
+           # we look for the pkg-config file, so we don't find the wrong one.
+           # If they specified --with-$1 only, we look in
+           # prefix/lib64/pkgconfig and if we don't find a file there, assume
+           # prefix/lib is the right answer.
+          AC_CACHE_CHECK([for $1 pkg-config name],
+               [check_package_cv_$1_pcfilename],
+               [check_package_cv_$1_pcfilename="pcname"
+                AS_IF([test -n "${check_package_libdir}"],
+                      [check_package_cv_$1_pcfilename="${check_package_libdir}/pkgconfig/pcname.pc"],
+                      [test -z "${check_package_prefix}"],
+                      [check_package_cv_$1_pcfilename="pcname"],
+                      [test -r "${check_package_prefix}/lib/pkgconfig/pcname.pc" -a -r "${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
+                      [AC_MSG_ERROR([Found pcname in both ${check_package_prefix}/lib/pkgconfig and
+${check_package_prefix}/lib64/pkgconfig.  This is confusing.  Please add --with-$1-libdir=PATH
+to configure to help disambiguate.])],
+                      [test -r "${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
+                      [check_package_cv_$1_pcfilename="${check_package_prefix}/lib64/pkgconfig/pcname.pc"],
+                      [check_package_cv_$1_pcfilename="${check_package_prefix}/lib/pkgconfig/pcname.pc"])])
+         _OAC_CHECK_PACKAGE_PKGCONFIG_INTERNAL([$1], [$2], [${check_package_cv_$1_pcfilename}], [$3])])
+])
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 3 -> pcfile name (may be full path)
+dnl 4 -> action if found flag
+AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG_INTERNAL], [
+    AC_REQUIRE([_OAC_CHECK_PACKAGE_PKGCONFIG_INIT])
+
+    check_package_pkgconfig_internal_happy=1
+
+    AC_CACHE_CHECK([if $1 pkg-config module exists],
+         [check_package_cv_$1_pkg_config_exists],
+         [check_package_cv_$1_pkg_config_exists=no
+          _OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--exists], [check_package_pkgconfig_internal_result], [check_package_cv_$1_pkg_config_exists=yes])])
+    AS_IF([test "${check_package_cv_$1_pkg_config_exists}" = "no"],
+          [check_package_pkgconfig_internal_happy=0])
+
+    AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 pkg-config cflags],
+                [check_package_cv_$1_pkg_config_cppflags],
+                [check_package_pkgconfig_internal_happy=0
+                 _OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--cflags],
+                      [check_package_cv_$1_pkg_config_cppflags], [check_package_pkgconfig_internal_happy=1])])
+	   AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+                 [$2_CPPFLAGS="${check_package_cv_$1_pkg_config_cppflags}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 cppflags from pkg-config])])])
+
+    AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 pkg-config ldflags],
+                [check_package_cv_$1_pkg_config_ldflags],
+                [check_package_pkgconfig_internal_happy=0
+                _OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--static --libs-only-L --libs-only-other],
+                     [check_package_cv_$1_pkg_config_ldflags], [check_package_pkgconfig_internal_happy=1])])
+	   AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+                 [$2_LDFLAGS="${check_package_cv_$1_pkg_config_ldflags}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 ldflags from pkg-config])])])
+
+    AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 pkg-config libs],
+                [check_package_cv_$1_pkg_config_libs],
+                [check_package_pkgconfig_internal_happy=0
+                 _OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--libs-only-l],
+                      [check_package_cv_$1_pkg_config_libs], [check_package_pkgconfig_internal_happy=1])])
+	   AS_IF([test $check_package_pkgconfig_internal_happy -eq 1],
+                 [$2_LIBS="${check_package_cv_$1_pkg_config_libs}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 libs from pkg-config])])])
+
+    AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 pkg-config static libs],
+                [check_package_cv_$1_pkg_config_static_libs],
+                [check_package_pkgconfig_internal_happy=0
+                 _OAC_CHECK_PACKAGE_PKGCONFIG_RUN([$3], [--static --libs-only-l],
+                      [check_package_cv_$1_pkg_config_static_libs], [check_package_pkgconfig_internal_happy=1])])
+	   AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1],
+                 [$2_STATIC_LIBS="${check_package_cv_$1_pkg_config_static_libs}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 libs from pkg-config])])])
+
+    AS_IF([test ${check_package_pkgconfig_internal_happy} -eq 1], [$4])
+
+    AS_UNSET([check_package_pkgconfig_internal_happy])
+    AS_UNSET([check_package_pkgconfig_internal_result])
+])
+
+
+dnl 1 -> pc module/filename
+dnl 2 -> argument string
+dnl 3 -> result assignment string
+dnl 4 -> action if found
+AC_DEFUN([_OAC_CHECK_PACKAGE_PKGCONFIG_RUN], [
+  AS_IF([test -n "${PKG_CONFIG}"],
+        [OAC_LOG_COMMAND([check_package_pkgconfig_run_results=`${PKG_CONFIG} $2 $1 2>&1`],
+             [AS_VAR_COPY([$3], [check_package_pkgconfig_run_results])
+              $4])
+         OAC_LOG_MSG([pkg-config output: ${check_package_pkgconfig_run_results}], [1])])
+  AS_UNSET([check_package_pkgconfig_run_results])
+])
+
+
+dnl ************************************* WRAPPER COMPILERS *************************************
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 3 -> action if found flags
+dnl
+dnl wrapper compiler is off by default; must be explicitly enabled
+AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_COMPILER], [
+    m4_ifdef([$1_wrapper_compiler],
+             [m4_define([wrapper_compiler_name], [$1_wrapper_compiler])],
+             [m4_define([wrapper_compiler_name], [$1cc])])
+    AS_IF([test "${$1_USE_WRAPPER_COMPILER}" == "1"],
+          [# search for the package using wrapper compilers.  If the user
+           # provided a --with-$1 argument, be explicit about where we look
+           # for the compiler, so we don't find the wrong one.
+           AC_CACHE_CHECK([for $1 wrapper compiler],
+                [check_package_cv_$1_wrapper_compiler],
+                [AS_IF([test -z "${check_package_prefix}"],
+                       [check_package_cv_$1_wrapper_compiler="wrapper_compiler_name"],
+                       [check_package_cv_$1_wrapper_compiler="${check_package_prefix}/bin/wrapper_compiler_name"])])
+           _OAC_CHECK_PACKAGE_WRAPPER_INTERNAL([$1], [$2], [${check_package_cv_$1_wrapper_compiler}], [$3])])
+])
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 2 -> wrapper compiler
+dnl 3 -> action if found flag
+AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_INTERNAL], [
+    check_package_wrapper_internal_happy=1
+
+    AC_CACHE_CHECK([if $1 wrapper compiler works],
+         [check_package_cv_$1_wrapper_compiler_works],
+         [check_package_cv_$1_wrapper_compiler_works=no
+          _OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [--showme:version], [check_package_wrapper_internal_result], [check_package_cv_$1_wrapper_compiler_works=yes])])
+    AS_IF([test "${check_package_cv_$1_wrapper_compiler_works}" = "no"],
+          [check_package_wrapper_internal_happy=0])
+
+    AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 wrapper compiler cppflags],
+                [check_package_cv_$1_wrapper_compiler_cppflags],
+                [_OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [--showme:incdirs],
+                      [check_package_wrapper_internal_result], [check_package_wrapper_internal_happy=1])
+                 AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                       [for check_package_wrapper_internal_tmp in ${check_package_wrapper_internal_result} ; do
+                            OAC_APPEND([check_package_cv_$1_wrapper_compiler_cppflags], ["-I${check_package_wrapper_internal_tmp}"])
+                        done])])
+	   AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                 [$2_CPPFLAGS="${check_package_cv_$1_wrapper_compiler_cppflags}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 cppflags from wrapper compiler])])])
+
+    AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 wrapper compiler ldflags],
+                [check_package_cv_$1_wrapper_compiler_ldflags],
+                [_OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [--showme:libdirs],
+                      [check_package_wrapper_internal_result], [check_package_wrapper_internal_happy=1])
+                 AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                       [for check_package_wrapper_internal_tmp in ${check_package_wrapper_internal_result} ; do
+                            OAC_APPEND([check_package_cv_$1_wrapper_compiler_ldflags], ["-L${check_package_wrapper_internal_tmp}"])
+                        done])])
+	   AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                 [$2_LDFLAGS="${check_package_cv_$1_wrapper_compiler_ldflags}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 ldflags from wrapper compiler])])])
+
+    AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 wrapper compiler libs],
+                [check_package_cv_$1_wrapper_compiler_libs],
+                [_OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [--showme:libs],
+                      [check_package_wrapper_internal_result], [check_package_wrapper_internal_happy=1])
+                 AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                       [for check_package_wrapper_internal_tmp in ${check_package_wrapper_internal_result} ; do
+                            OAC_APPEND([check_package_cv_$1_wrapper_compiler_libs], ["-l${check_package_wrapper_internal_tmp}"])
+                        done])])
+	   AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                 [$2_LIBS="$check_package_cv_$1_wrapper_compiler_libs"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 libs from wrapper compiler])])])
+
+    AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+          [AC_CACHE_CHECK([for $1 wrapper compiler static libs],
+                [check_package_cv_$1_wrapper_compiler_static_libs],
+                [_OAC_CHECK_PACKAGE_WRAPPER_RUN([$3], [-static --showme:libs],
+                      [check_package_wrapper_internal_result], [check_package_wrapper_internal_happy=1])
+                 AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                       [for check_package_wrapper_internal_tmp in ${check_package_wrapper_internal_result} ; do
+                            OAC_APPEND([check_package_cv_$1_wrapper_compiler_static_libs], ["-l${check_package_wrapper_internal_tmp}"])
+                        done])])
+	   AS_IF([test ${check_package_wrapper_internal_happy} -eq 1],
+                 [$2_STATIC_LIBS="${check_package_cv_$1_wrapper_compiler_static_libs}"],
+                 [AC_MSG_RESULT([error])
+                  AC_MSG_ERROR([An error occurred retrieving $1 static libs from wrapper compiler])])])
+
+    AS_IF([test $check_package_wrapper_internal_happy -eq 1], [$4])
+
+    AS_UNSET([check_package_wrapper_internal_happy])
+    AS_UNSET([check_package_wrapper_internal_result])
+    AS_UNSET([check_package_wrapper_internal_tmp])
+])
+
+
+dnl 1 -> wrapper compiler
+dnl 2 -> argument string
+dnl 3 -> result assignment string
+dnl 4 -> action if found
+AC_DEFUN([_OAC_CHECK_PACKAGE_WRAPPER_RUN], [
+    OAC_LOG_COMMAND([check_package_wrapper_run_results=`$1 $2 2>&1`],
+             [AS_VAR_COPY([$3], [check_package_wrapper_run_results])
+              $4])
+         OAC_LOG_MSG([wrapper output: ${check_package_wrapper_run_results}], [1])
+    AS_UNSET([check_package_wrapper_run_results])
+])
+
+
+dnl ************************************* GENERIC GUESSING *************************************
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 3 -> headers (space separated list)
+dnl 4 -> libraries (space separated list)
+dnl 5 -> action if found flags
+AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC], [
+    check_package_generic_happy=0
+
+    AS_IF([test -n "${check_package_prefix}"],
+          [_OAC_CHECK_PACKAGE_GENERIC_PREFIX([$1], [$2], [$3], [$4], [check_package_generic_happy=1])],
+          [AC_MSG_NOTICE([Searching for $1 in default search paths])
+           $1_CPPFLAGS=
+           $1_LDFLAGS=
+           check_package_generic_happy=1])
+
+    AS_IF([test ${check_package_generic_happy} -eq 1],
+          [for check_package_generic_lib in $4 ; do
+               check_package_generic_lib=`echo ${check_package_generic_lib} | sed -e 's/^-l//'`
+               OAC_APPEND([$2_LIBS], ["-l${check_package_generic_lib}"])
+               OAC_APPEND([$2_STATIC_LIBS], ["-l${check_package_generic_lib}"])
+           done
+
+           AC_MSG_CHECKING([for $1 cppflags])
+           AC_MSG_RESULT([$$2_CPPFLAGS])
+           AC_MSG_CHECKING([for $1 ldflags])
+           AC_MSG_RESULT([$$2_LDFLAGS])
+           AC_MSG_CHECKING([for $1 libs])
+           AC_MSG_RESULT([$$2_LIBS])
+           AC_MSG_CHECKING([for $1 static libs])
+           AC_MSG_RESULT([$$2_STATIC_LIBS])
+
+           $5])
+
+    AS_UNSET([check_package_generic_happy])
+    AS_UNSET([check_package_generic_lib])
+])
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 3 -> headers (space separated list)
+dnl 4 -> libraries (space separated list)
+dnl 5 -> action if found flags
+AC_DEFUN([_OAC_CHECK_PACKAGE_GENERIC_PREFIX], [
+    check_package_generic_search_header=`echo "$3" | cut -f1 -d' '`
+    check_package_generic_search_lib=`echo "$4" | cut -f1 -d' ' | sed -e 's/^-l//'`
+
+    check_package_generic_prefix_happy=0
+    AS_IF([test -n "${check_package_incdir}"],
+          [check_package_generic_incdir="${check_package_incdir}"],
+          [check_package_generic_incdir="${check_package_prefix}/include"])
+    AC_MSG_CHECKING([for $1 header at ${check_package_generic_incdir}])
+    AS_IF([test -r ${check_package_generic_incdir}/${check_package_generic_search_header}],
+          [check_package_generic_prefix_happy=1
+           $2_CPPFLAGS="-I${check_package_generic_incdir}"
+           AC_MSG_RESULT([found])],
+          [AC_MSG_RESULT([not found])])
+
+    AS_IF([test ${check_package_generic_prefix_happy} -eq 1],
+          [check_package_generic_prefix_happy=0
+           AS_IF([test -n "${check_package_libdir}"],
+                 [AC_MSG_CHECKING([for $1 library in ${check_package_libdir}])
+                  ls ${check_package_libdir}/lib${check_package_generic_search_lib}.*  1>&/dev/null 2>&1
+                  AS_IF([test $? -eq 0],
+                        [check_package_generic_prefix_happy=1
+                         $2_LDFLAGS="-L${check_package_libdir}"
+                         AC_MSG_RESULT([foound])],
+                        [AC_MSG_RESULT([not found])])],
+                 [check_package_generic_prefix_lib=0
+                  check_package_generic_prefix_lib64=0
+
+                  ls ${check_package_prefix}/lib/lib${check_package_generic_search_lib}.*  1>&/dev/null 2>&1
+                  AS_IF([test $? -eq 0], [check_package_generic_prefix_lib=1])
+                  ls ${check_package_prefix}/lib64/lib${check_package_generic_search_lib}.*  1>&/dev/null 2>&1
+                  AS_IF([test $? -eq 0], [check_package_generic_prefix_lib64=1])
+
+                  AC_MSG_CHECKING([for $1 library in ${check_package_prefix}])
+                  AS_IF([test ${check_package_generic_prefix_lib} -eq 1 -a ${check_package_generic_prefix_lib64} -eq 1],
+                        [AC_MSG_ERROR([Found library $check_package_generic_search_lib in both ${check_package_prefix}/lib and
+${check_package_prefix}/lib64.  This has confused configure.  Please add --with-$1-libdir=PATH to configure to help
+disambiguate.])],
+                        [test ${check_package_generic_prefix_lib} -eq 1],
+                        [check_package_generic_prefix_happy=1
+                         $2_LDFLAGS=-L${check_package_prefix}/lib
+                         AC_MSG_RESULT([found -- lib])],
+                        [test $check_package_generic_prefix_lib64 -eq 1],
+                        [check_package_generic_prefix_happy=1
+                         libdir_prefix=${check_package_prefix}/lib64
+                         AC_MSG_RESULT([found -- lib64])],
+                        [AC_MSG_RESULT([not found])])])])
+
+    AS_IF([test ${check_package_generic_prefix_happy} -eq 1], [$5])
+
+    AS_UNSET([check_package_generic_search_header])
+    AS_UNSET([check_package_generic_search_lib])
+    AS_UNSET([check_package_generic_incdir])
+])
+
+
+dnl ************************************* OPERATIONAL CHECK *************************************
+
+
+dnl 1 -> package name
+dnl 2 -> prefix
+dnl 3 -> headers (space separated list)
+dnl 4 -> function name
+dnl 5 -> action if found
+dnl 6 -> action if not found
+AC_DEFUN([_OAC_CHECK_PACKAGE_VERIFY],[
+    check_package_verify_search_header=`echo "$3" | cut -f1 -d' '`
+
+    OAC_APPEND([CPPFLAGS], [${$2_CPPFLAGS}])
+    OAC_APPEND([LDFLAGS], [${$2_LDFLAGS}])
+    OAC_APPEND([LIBS], [${$2_LIBS}])
+
+    check_package_verify_happy=1
+
+    AS_IF([test ${check_package_verify_happy} -eq 1],
+          [AC_CHECK_HEADER([${check_package_verify_search_header}],
+                           [check_package_verify_happy=1], [check_package_verify_happy=0])])
+
+    dnl Note that we use AC_CHEC_FUNC here instead of AC_CHECK_LIB, because we're pretty sure we've
+    dnl found the library already (and have added it to LIBS).  Now we're just trying to verify
+    dnl that the library we found contains the bits we need.
+    AS_IF([test ${check_package_verify_happy} -eq 1],
+          [AC_CHECK_FUNC([$4],  [check_package_verify_happy=1], [check_package_verify_happy=0])])
+
+    m4_ifdef([OAC_CHEC_PACKAGE_VERIFY_COMMAND_LIST],
+        [m4_foreach([list_item], [OAC_CHECK_PACKAGE_VERIFY_COMMAND_LIST],
+               [AS_IF([test ${check_package_verify_happy} -eq 1],
+                      [m4_apply(m4_unquote([list_item]), [[$1], [$2], [$3], [$4],
+                                                          [check_package_verify_happy=1],
+                                                          [check_package_verify_happy=0]])])])])
+
+    AS_IF([test ${check_package_verify_happy} -eq 1],
+          [$5], [$6])
+
+    AS_UNSET([check_package_verify_search_header])
+    AS_UNSET([check_package_verify_happy])
+])

--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -46,39 +46,14 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
     AS_IF([test "$with_hwloc_extra_libs" = "yes" -o "$with_hwloc_extra_libs" = "no"],
 	  [AC_MSG_ERROR([--with-hwloc-extra-libs requires an argument other than yes or no])])
 
-    # get rid of any trailing slash(es)
-    hwloc_prefix=$(echo $with_hwloc | sed -e 'sX/*$XXg')
-    hwlocdir_prefix=$(echo $with_hwloc_libdir | sed -e 'sX/*$XXg')
-
-    AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
-                 [prte_hwloc_dir="$hwloc_prefix"],
-                 [prte_hwloc_dir=""])
-
-    AS_IF([test ! -z "$hwlocdir_prefix" && test "$hwlocdir_prefix" != "yes"],
-                 [prte_hwloc_libdir="$hwlocdir_prefix"],
-                 [AS_IF([test ! -z "$hwloc_prefix" && test "$hwloc_prefix" != "yes"],
-                        [if test -d $hwloc_prefix/lib64; then
-                            prte_hwloc_libdir=$hwloc_prefix/lib64
-                         elif test -d $hwloc_prefix/lib; then
-                            prte_hwloc_libdir=$hwloc_prefix/lib
-                         else
-                            AC_MSG_WARN([Could not find $hwloc_prefix/lib or $hwloc_prefix/lib64])
-                            AC_MSG_ERROR([Can not continue])
-                         fi
-                        ],
-                        [prte_hwloc_libdir=""])])
-
     AS_IF([test "$enable_hwloc_lib_checks" != "no"],
-          [PRTE_CHECK_PACKAGE([prte_hwloc],
-                              [hwloc.h],
-                              [hwloc],
-                              [hwloc_topology_init],
-                              [$with_hwloc_extra_libs],
-                              [$prte_hwloc_dir],
-                              [$prte_hwloc_libdir],
-                              [],
-                              [prte_hwloc_support=0],
-                              [])],
+          [OAC_CHECK_PACKAGE([hwloc],
+                             [prte_hwloc],
+                             [hwloc.h],
+                             [hwloc $with_hwloc_extra_libs],
+                             [hwloc_topology_init],
+                             [],
+                             [prte_hwloc_support=0])],
           [PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_hwloc_extra_libs])])
 
     if test $prte_hwloc_support -eq 0; then
@@ -142,14 +117,7 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
     AC_DEFINE_UNQUOTED([PRTE_HAVE_HWLOC_TOPOLOGY_DUP], [$prte_have_topology_dup],
                        [Whether or not hwloc_topology_dup is available])
 
-    prte_hwloc_support_will_build=yes
-    if test -z "$prte_hwloc_dir"; then
-        prte_hwloc_source="Standard locations"
-    else
-        prte_hwloc_source=$prte_hwloc_dir
-    fi
-
-    PRTE_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [prte_hwloc], [$prte_hwloc_support_will_build ($prte_hwloc_source)])
+    PRTE_SUMMARY_ADD([[Required Packages]],[[HWLOC]], [prte_hwloc], [$prte_hwloc_SUMMARY])
 
     PRTE_VAR_SCOPE_POP
 ])

--- a/config/prte_setup_libev.m4
+++ b/config/prte_setup_libev.m4
@@ -56,42 +56,18 @@ AC_DEFUN([PRTE_LIBEV_CONFIG],[
 	  [AC_MSG_ERROR([--with-libev-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test $prte_libev_support -eq 1],
-          [PRTE_CHECK_WITHDIR([libev], [$with_libev], [include/event.h])
-           PRTE_CHECK_WITHDIR([libev-libdir], [$with_libev_libdir], [libev.*])
-
-           AC_MSG_CHECKING([for libev in])
-           prte_check_libev_save_CPPFLAGS="$CPPFLAGS"
+          [prte_check_libev_save_CPPFLAGS="$CPPFLAGS"
            prte_check_libeve_save_LDFLAGS="$LDFLAGS"
            prte_check_libev_save_LIBS="$LIBS"
-           if test -n "$with_libev" -a "$with_libev" != "yes"; then
-               prte_libev_dir=$with_libev/include
-               AS_IF([test -z "$with_libev_libdir" || test "$with_libev_libdir" = "yes"],
-                     [if test -d $with_libev/lib; then
-                          prte_libev_libdir=$with_libev/lib
-                      elif test -d $with_libev/lib64; then
-                          prte_libev_libdir=$with_libev/lib64
-                      else
-                          AC_MSG_RESULT([Could not find $with_libev/lib or $with_libev/lib64])
-                          AC_MSG_ERROR([Can not continue])
-                      fi
-                      AC_MSG_RESULT([$prte_libev_dir and $prte_libev_libdir])],
-                     [AC_MSG_RESULT([$with_libev_libdir])])
-           else
-               AC_MSG_RESULT([(default search paths)])
-           fi
-           AS_IF([test ! -z "$with_libev_libdir" && test "$with_libev_libdir" != "yes"],
-                 [prte_libev_libdir="$with_libev_libdir"])
 
            AS_IF([test "$enable_libev_lib_checks" != "no"],
-                 [PRTE_CHECK_PACKAGE([prte_libev],
-                                     [event.h],
-                                     [ev],
-                                     [ev_async_send],
-                                     [$with_libev_extra_libs],
-                                     [$prte_libev_dir],
-                                     [$prte_libev_libdir],
-                                     [],
-                                     [prte_libev_support=0])],
+                 [OAC_CHECK_PACKAGE([libev],
+                                    [prte_libev],
+                                    [event.h],
+                                    [ev ${with_libev_extra_libs}],
+                                    [ev_async_send],
+                                    [],
+                                    [prte_libev_support=0])],
                  [PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_libev_extra_libs])])
 
            CPPFLAGS="$prte_check_libev_save_CPPFLAGS"
@@ -109,7 +85,7 @@ AC_DEFUN([PRTE_LIBEV_CONFIG],[
     if test $prte_libev_support -eq 1; then
         AC_MSG_RESULT([yes])
         $1
-        PRTE_SUMMARY_ADD([[Required Packages]], [[Libev]], [prte_libev], [yes ($prte_libev_dir)])
+        PRTE_SUMMARY_ADD([[Required Packages]], [[Libev]], [prte_libev], [$prte_libev_SUMMARY])
     else
         AC_MSG_RESULT([no])
         # if they asked us to use it, then this is an error

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -56,46 +56,18 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
 	  [AC_MSG_ERROR([--with-libevent-extra-libs requires an argument other than yes or no])])
 
     AS_IF([test $prte_libevent_support -eq 1],
-          [PRTE_CHECK_WITHDIR([libevent], [$with_libevent], [include/event.h])
-           PRTE_CHECK_WITHDIR([libevent-libdir], [$with_libevent_libdir], [libevent.*])
-
-           prte_check_libevent_save_CPPFLAGS="$CPPFLAGS"
+          [prte_check_libevent_save_CPPFLAGS="$CPPFLAGS"
            prte_check_libevent_save_LDFLAGS="$LDFLAGS"
            prte_check_libevent_save_LIBS="$LIBS"
 
-           # get rid of any trailing slash(es)
-           libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
-           libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
-
-           AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-                 [prte_event_dir="$libevent_prefix"],
-                 [prte_event_dir=""])
-
-           AS_IF([test ! -z "$libeventdir_prefix" -a "$libeventdir_prefix" != "yes"],
-                 [prte_event_libdir="$libeventdir_prefix"],
-                 [AS_IF([test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"],
-                        [if test -d $libevent_prefix/lib64; then
-                            prte_event_libdir=$libevent_prefix/lib64
-                         elif test -d $libevent_prefix/lib; then
-                            prte_event_libdir=$libevent_prefix/lib
-                         else
-                            AC_MSG_WARN([Could not find $libevent_prefix/lib or $libevent_prefix/lib64])
-                            AC_MSG_ERROR([Can not continue])
-                         fi
-                        ],
-                        [prte_event_libdir=""])])
-
            AS_IF([test "$enable_libevent_lib_checks" != "no"],
-                 [PRTE_CHECK_PACKAGE([prte_libevent],
-                                     [event.h],
-                                     [event_core],
-                                     [event_config_new],
-                                     [-levent_pthreads $with_libevent_extra_libs],
-                                     [$prte_event_dir],
-                                     [$prte_event_libdir],
-                                     [],
-                                     [prte_libevent_support=0],
-                                     [])],
+                 [OAC_CHECK_PACKAGE([libevent],
+                                    [prte_libevent],
+                                    [event.h],
+                                    [event_core event_pthreads $with_libevent_extra_libs],
+                                    [event_config_new],
+                                    [],
+                                    [prte_libevent_support=0])],
                  [PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_libevent_extra_libs])])])
 
     # Check to see if the above check failed because it conflicted with LSF's libevent.so
@@ -173,11 +145,6 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
                            AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
                            prte_libevent_support=0])
     fi
-    if test -z "$prte_event_dir"; then
-        prte_libevent_source="Standard locations"
-    else
-        prte_libevent_source=$prte_event_dir
-    fi
 
     # restore global flags
     CPPFLAGS="$prte_check_libevent_save_CPPFLAGS"
@@ -194,7 +161,7 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
         PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$prte_libevent_LIBS])
 
         # Set output variables
-        PRTE_SUMMARY_ADD([[Required Packages]],[[Libevent]], [prte_libevent], [yes ($prte_libevent_source)])
+        PRTE_SUMMARY_ADD([[Required Packages]],[[Libevent]], [prte_libevent], [$prte_libevent_SUMMARY])
 
         $1
     else

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -29,7 +29,7 @@
 
 AC_DEFUN([PRTE_CHECK_PMIX],[
 
-    PRTE_VAR_SCOPE_PUSH([prte_external_pmix_save_CPPFLAGS prte_external_pmix_save_LDFLAGS prte_external_pmix_save_LIBS prte_external_pmix_version_found prte_external_pmix_version])
+    PRTE_VAR_SCOPE_PUSH([prte_external_pmix_save_CPPFLAGS prte_pmix_support found_pmixcc])
 
     AC_ARG_WITH([pmix],
                 [AS_HELP_STRING([--with-pmix(=DIR)],
@@ -37,9 +37,6 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     AC_ARG_WITH([pmix-libdir],
                 [AS_HELP_STRING([--with-pmix-libdir=DIR],
                                 [Look for libpmix in the given directory DIR, DIR/lib or DIR/lib64])])
-    AC_ARG_WITH([pmix-incdir],
-                 [AS_HELP_STRING([--with-pmix-incdir],
-                                 [Look for PMIx devel headers in the given directory])])
     AC_ARG_WITH([pmix-extra-libs],
                 [AS_HELP_STRING([--with-pmix-extra-libs=LIBS],
                                 [Add LIBS as dependencies of pmix])])
@@ -58,83 +55,25 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     AS_IF([test "$with_pmix_extra_libs" = "yes" -o "$with_pmix_extra_libs" = "no"],
 	  [AC_MSG_ERROR([--with-pmix-extra-libs requires an argument other than yes or no])])
 
-    AS_IF([test "$with_pmix_incdir" = "yes" -o "$with_pmix_incdir" = "no"],
-	  [AC_MSG_ERROR([--with-pmix-incdir requires an argument other than yes or no])])
-
-    # get rid of any trailing slash(es)
-    pmix_prefix=$(echo $with_pmix | sed -e 'sX/*$XXg')
-    pmixdir_prefix=$(echo $with_pmix_libdir | sed -e 'sX/*$XXg')
-
-    # check for external pmix header */
-    AS_IF([test ! -z "$pmix_prefix" && test "$pmix_prefix" != "yes"],
-                 [pmix_ext_install_dir="$pmix_prefix"],
-                 [pmix_ext_install_dir=""])
-
-    AS_IF([test ! -z "$pmixdir_prefix" && test "$pmixdir_prefix" != "yes"],
-                 [pmix_ext_install_libdir="$pmixdir_prefix"],
-                 [AS_IF([test ! -z "$pmix_prefix" && test "$pmix_prefix" != "yes"],
-                        [if test -d $pmix_prefix/lib64; then
-                            pmix_ext_install_libdir=$pmix_prefix/lib64
-                         elif test -d $pmix_prefix/lib; then
-                            pmix_ext_install_libdir=$pmix_prefix/lib
-                         else
-                            AC_MSG_WARN([Could not find $pmix_prefix/lib or $pmix_prefix/lib64])
-                            AC_MSG_ERROR([Can not continue])
-                         fi
-                        ],
-                        [pmix_ext_install_libdir=""])])
-
-echo "--> $pmix_ext_install_dir"
-echo "--> $pmix_ext_install_libdir"
-
     AS_IF([test "$enable_pmix_lib_checks" != "no"],
-          [PRTE_CHECK_PACKAGE([prte_pmix],
-                              [pmix.h],
-                              [pmix],
-                              [PMIx_Init],
-                              [$with_pmix_extra_libs],
-                              [$pmix_ext_install_dir],
-                              [$pmix_ext_install_libdir],
-                              [],
-                              [prte_pmix_support=0],
-                              [])],
+          [dnl Need to explicitly enable wrapper compiler to get the dependent libraries
+           dnl when pkg-config is not available.
+           pmix_USE_WRAPPER_COMPILER=1
+           OAC_CHECK_PACKAGE([pmix],
+                             [prte_pmix],
+                             [pmix.h],
+                             [pmix $with_pmix_extra_libs],
+                             [PMIx_Init],
+                             [],
+                             [prte_pmix_support=0])],
           [PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LIBS], [$with_pmix_extra_libs])])
 
     AS_IF([test $prte_pmix_support -eq 0],
           [AC_MSG_WARN([PRRTE requires PMIx support using an external copy that you supply.])
            AC_MSG_ERROR([Cannot continue.])])
 
-    # need to add one level of indirection so that we can
-    # access the PMIx headers
-    if test ! -z "$pmix_ext_install_dir"; then
-        prte_pmix_CPPFLAGS="$prte_pmix_CPPFLAGS -I$pmix_ext_install_dir/include/pmix"
-    else
-        # if PMIx was installed in a standard location, then we must
-        # be given the location of the PMIx implementation headers
-        if test -z "$with_pmix_incdir"; then
-            AC_MSG_WARN([When building with PMIx installed in a standard])
-            AC_MSG_WARN([location, you must specify where the PMIx implementation])
-            AC_MSG_WARN([headers can be found using the --with-pmix-incdir option.])
-            AC_MSG_ERROR([Cannot continue.])
-        fi
-        prte_pmix_CPPFLAGS="$prte_pmix_CPPFLAGS -I$with_pmix_incdir"
-    fi
-
     prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
-    prte_external_pmix_save_LDFLAGS=$LDFLAGS
-    prte_external_pmix_save_LIBS=$LIBS
-
-    # need to add resulting flags to global ones so we can
-    # test the version
-    if test ! -z "$prte_pmix_CPPFLAGS"; then
-        PRTE_FLAGS_PREPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
-    fi
-    if test ! -z "$prte_pmix_LDFLAGS"; then
-        PRTE_FLAGS_PREPEND_UNIQ(LDFLAGS, $prte_pmix_LDFLAGS)
-    fi
-    if test ! -z "$prte_pmix_LIBS"; then
-        PRTE_FLAGS_PREPEND_UNIQ(LIBS, $prte_pmix_LIBS)
-    fi
+    PRTE_FLAGS_PREPEND_UNIQ(CPPFLAGS, $prte_pmix_CPPFLAGS)
 
     # if the version file exists, then we need to parse it to find
     # the actual release series
@@ -145,66 +84,36 @@ echo "--> $pmix_ext_install_libdir"
                                         #error "not version 5 or above"
                                         #endif
                                        ], [])],
-                      [AC_MSG_RESULT([found])
-                       prte_external_pmix_version=5x
-                       prte_external_pmix_version_found=5],
+                      [AC_MSG_RESULT([found])],
                       [AC_MSG_RESULT([not found])
-                       prte_external_pmix_version_found=0])
+                       AC_MSG_WARN([PRTE does not support PMIx versions])
+                       AC_MSG_WARN([less than v5.0 as it requires access])
+                       AC_MSG_WARN([to the internal PMIx library headers.])
+                       AC_MSG_ERROR([Please select a newer version and configure again])])
+
+    AC_CHECK_HEADER([src/util/pmix_argv.h], [],
+                    [AC_MSG_ERROR([Could not find PMIx devel headers.  Can not continue.])])
 
     # restore the global flags
     CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
-    LDFLAGS=$prte_external_pmix_save_LDFLAGS
-    LIBS=$prte_external_pmix_save_LIBS
 
-    AS_IF([test "$prte_external_pmix_version_found" = "0"],
-          [AC_MSG_WARN([PRTE does not support PMIx versions])
-           AC_MSG_WARN([less than v5.0 as it requires access])
-           AC_MSG_WARN([to the internal PMIx library headers.])
-           AC_MSG_ERROR([Please select a newer version and configure again])])
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
+    PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
 
-    if test ! -z "$prte_pmix_CPPFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_CPPFLAGS, $prte_pmix_CPPFLAGS)
-    fi
-    if test ! -z "$prte_pmix_LDFLAGS"; then
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
-    fi
-    if test ! -z "$prte_pmix_LIBS"; then
-        PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
-    fi
+    found_pmixcc=0
+    PMIXCC_PATH="pmixcc"
+    AS_IF([test -n "${with_pmix}"],
+          [PMIXCC_PATH="${with_pmix}/bin/$PMIXCC_PATH"])
+    PRTE_LOG_COMMAND([pmixcc_showme_results=`$PMIXCC_PATH --showme:version 2>&1`], [found_pmixcc=1])
+    PRTE_LOG_MSG([pmixcc version: $pmixcc_showme_results])
+    AS_IF([test $found_pmixcc -eq 0],
+          [AC_MSG_WARN([Could not find $PMIXCC_PATH])
+           PMIXCC_PATH=])
+    AM_CONDITIONAL([PRTE_HAVE_PMIXCC], [test $found_pmixcc -eq 1])
+    AC_SUBST([PMIXCC_PATH])
 
-    if test -z "$pmix_ext_install_dir"; then
-        prte_pmix_source="Standard locations"
-    else
-        prte_pmix_source=$pmix_ext_install_dir
-    fi
-
-    PMIXCC_PATH=""
-    if test -z "$pmix_ext_install_dir"; then
-        PRTE_WHICH([pmixcc], [PMIXCC_PATH])
-        AS_IF([test -z "$PMIXCC_PATH"],
-                [AC_MSG_WARN([Could not find pmixcc in PATH])
-                 prte_pmixcc_happy=no],
-                [prte_pmixcc_happy=yes])
-    else
-        PMIXCC_PATH=$pmix_ext_install_dir/bin
-        if test -d $PMIXCC_PATH; then
-            PMIXCC_PATH=$PMIXCC_PATH/pmixcc
-            if test -e $PMIXCC_PATH; then
-                prte_pmixcc_happy=yes
-
-            else
-                AC_MSG_WARN([Could not find usable $PMIXCC_PATH])
-                prte_pmixcc_happy=no
-            fi
-        else
-            AC_MSG_WARN([Could not find $PMIXCC_PATH])
-            prte_pmixcc_happy=no
-        fi
-    fi
-    AM_CONDITIONAL(PRTE_HAVE_PMIXCC, test "$prte_pmixcc_happy" = "yes")
-    AC_SUBST(PMIXCC_PATH)
-
-    PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]],[pmix],[yes ($prte_pmix_source)])
+    PRTE_SUMMARY_ADD([[Required Packages]],[[PMIx]],[pmix],[$prte_pmix_SUMMARY])
 
     PRTE_VAR_SCOPE_POP
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,13 @@ PRTE_LOAD_PLATFORM
 
 PRTE_CONFIGURE_SETUP
 
+# compatability for oac_check_package
+m4_copy([PRTE_LOG_COMMAND], [OAC_LOG_COMMAND])
+m4_copy([PRTE_LOG_MSG], [OAC_LOG_MSG])
+AC_DEFUN([OAC_APPEND], [
+  AS_IF([test -z "$$1"], [$1="$2"], [$1="$$1 $2"])
+])
+
 prte_show_title "Configuring PRTE"
 
 #


### PR DESCRIPTION
Rewrite the CHECK_PACKAGE macro to support getting package
information from either pkg-config or OMPI-style wrapper
compilers, as well as to remove some of the copy-n-paste
code that was surrounding PRTE_CHECK_PACKAGE calls (like
cleaning up libdir/incdir).

Update the hwloc, libevent, and pmix checks to use the new
CHECK_PACKAGE macro.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>