### PR TITLE
v2.1: Reset getopt() to 0, not 1. 

### DIFF
--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -111,7 +111,7 @@ int prte_cmd_line_parse(char **pargv, char *shorts,
 
     /* reset the parser - must be done each time we use it
      * to avoid hysteresis */
-    optind = 1;
+    optind = 0;
     opterr = 0;
     optopt = 0;
     optarg = NULL;
@@ -121,7 +121,8 @@ int prte_cmd_line_parse(char **pargv, char *shorts,
         argind = optind;
         // This is the executable, or we are at the last argument.
         // Don't process any further.
-        if (optind == argc || '-' != argv[optind][0]) {
+        // Check for > 0 to ignore the launcher itself.
+        if (optind == argc || (optind > 0 && '-' != argv[optind][0])) {
             break;
         }
         opt = getopt_long(argc, argv, shorts, myoptions, &option_index);


### PR DESCRIPTION
prrte currently calls parse_cli() twice, once to parse
the schizo command line and once for the app command line.
According to the getopt_long() docs, it should be reset on the
second invocation when parsing the same command line:

"A program that scans multiple argument vectors, or rescans the
 same vector more than once, and wants to make use of GNU
 extensions such as '+' and '-' at the start of optstring, or
 changes the value of POSIXLY_CORRECT between scans, must
 reinitialize getopt() by resetting optind to 0, rather than the
 traditional value of 1.  (Resetting to 0 forces the invocation of
 an internal initialization routine that rechecks POSIXLY_CORRECT
 and checks for GNU extensions in optstring.)"
https://man7.org/linux/man-pages/man3/getopt.3.html

Since prrte makes use of '-' at the start of opt-string - this seems
to apply. I made the mistake of resetting this to 1 to fix a different
bug, instead make sure we don't check for a '-' on the first optind
to ignore prterun/mpirun/prun/ect.

Introduced here: https://github.com/openpmix/prrte/commit/16d99f20ce35933747dd7d51ab7ecde5c4fbaacb

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>