### PR TITLE
Fix PRTE_RML_SEND() call to squash bug/warning.

### DIFF
--- a/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
+++ b/src/mca/grpcomm/bmg/grpcomm_bmg_module.c
@@ -153,7 +153,7 @@ static int rbcast(pmix_data_buffer_t *buf)
                 PRTE_ERROR_LOG(rc);
                 return rc;
             }
-            PRTE_RML_SEND(rc, &daemon, buf, PRTE_RML_TAG_RBCAST);
+            PRTE_RML_SEND(rc, daemon.rank, buf, PRTE_RML_TAG_RBCAST);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
             }


### PR DESCRIPTION
New macro expects a rank for the second argument.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>