### PR TITLE
Fix one more place in dmodex example

### DIFF
--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -202,7 +202,6 @@ int main(int argc, char **argv)
         if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, n)) {
             exit(1);
         }
-        (void) strncpy(proc.nspace, tmp, PMIX_MAX_NSLEN);
         if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp, NULL, 0, valcbfunc, tmp))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n, tmp,
                     rc);


### PR DESCRIPTION
Missed one place where the incorrect namespace is used

Signed-off-by: Ralph Castain <rhc@pmix.org>