### PR TITLE
Ensure the proctable includes absolute paths to executable

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -37,6 +37,8 @@
 #include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_os_path.h"
+#include "src/util/pmix_path.h"
 #include "src/util/output.h"
 
 #include "src/mca/errmgr/errmgr.h"
@@ -387,8 +389,8 @@ static void _query(int sd, short args, void *cbdata)
                 procinfo = (pmix_proc_info_t *) darray->array;
                 p = 0;
                 for (k = 0; k < jdata->procs->size; k++) {
-                    if (NULL
-                        == (proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, k))) {
+                    proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, k);
+                    if (NULL == proct) {
                         continue;
                     }
                     PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
@@ -398,7 +400,11 @@ static void _query(int sd, short args, void *cbdata)
                     app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps,
                                                                              proct->app_idx);
                     if (NULL != app && NULL != app->app) {
-                        procinfo[p].executable_name = strdup(app->app);
+                        if (pmix_path_is_absolute(app->app)) {
+                            procinfo[p].executable_name = strdup(app->app);
+                        } else {
+                            procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
+                        }
                     }
                     procinfo[p].pid = proct->pid;
                     procinfo[p].exit_code = proct->exit_code;
@@ -441,7 +447,11 @@ static void _query(int sd, short args, void *cbdata)
                         app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps,
                                                                                  proct->app_idx);
                         if (NULL != app && NULL != app->app) {
-                            procinfo[p].executable_name = strdup(app->app);
+                            if (pmix_path_is_absolute(app->app)) {
+                                procinfo[p].executable_name = strdup(app->app);
+                            } else {
+                                procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
+                            }
                         }
                         procinfo[p].pid = proct->pid;
                         procinfo[p].exit_code = proct->exit_code;


### PR DESCRIPTION
The requestor has no way of knowing the cwd used for the
executable path if it is given in relative syntax, so use
the appropriate utilities to ensure it is always returned
in absolute path format.

Thanks to @david-edwards-arm for the report AND the
initial patch! Both much appreciated.

Fixes #1249 

Signed-off-by: Ralph Castain <rhc@pmix.org>