### PR TITLE
Ensure the proc PIDs are updated upon launch

### DIFF
--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -407,8 +407,8 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
                 }
 
                 PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                     "%s plm:base:receive got update_proc_state for vpid %u state %s exit_code %d",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), vpid, prte_proc_state_to_str(state),
+                                     "%s plm:base:receive got update_proc_state for vpid %u pid %d state %s exit_code %d",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), vpid, (int)pid, prte_proc_state_to_str(state),
                                      (int) exit_code));
 
                 if (NULL != jdata) {
@@ -592,6 +592,14 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
                 PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FORCED_EXIT);
                 goto CLEANUP;
             }
+            /* unpack the pid */
+            count = 1;
+            rc = PMIx_Data_unpack(NULL, buffer, &pid, &count, PMIX_PID);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto CLEANUP;
+            }
+            proc->pid = pid;
             /* unpack the state */
             count = 1;
             rc = PMIx_Data_unpack(NULL, buffer, &state, &count, PMIX_UINT32);

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -92,7 +92,8 @@ static void _query(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s processing query",
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s processing query",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     PMIX_CONSTRUCT(&results, pmix_list_t);
@@ -122,19 +123,18 @@ static void _query(int sd, short args, void *cbdata)
                     matched = 0;
                     for (k = 0; k < prte_job_data->size; k++) {
                         jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, k);
-                        if (NULL != jdata
-                            && PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string,
-                                                 jdata->nspace)) {
-                            matched = 1;
-                            break;
+                        if (NULL != jdata) {
+                            if (PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string, jdata->nspace)) {
+                                matched = 1;
+                                break;
+                            }
                         }
                     }
                     if (0 == matched) {
-                        prte_output_verbose(
-                            2, prte_pmix_server_globals.output,
-                            "%s qualifier key \"%s\" : value \"%s\" is an unknown namespace",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->qualifiers[n].key,
-                            q->qualifiers[n].value.data.string);
+                        prte_output_verbose(2, prte_pmix_server_globals.output,
+                                            "%s qualifier key \"%s\" : value \"%s\" is an unknown namespace",
+                                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->qualifiers[n].key,
+                                            q->qualifiers[n].value.data.string);
                         ret = PMIX_ERR_BAD_PARAM;
                         goto done;
                     }
@@ -152,7 +152,8 @@ static void _query(int sd, short args, void *cbdata)
             }
         }
         for (n = 0; NULL != q->keys[n]; n++) {
-            prte_output_verbose(2, prte_pmix_server_globals.output, "%s processing key %s",
+            prte_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s processing key %s",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->keys[n]);
             if (0 == strcmp(q->keys[n], PMIX_QUERY_NAMESPACES)) {
                 /* get the current jobids */
@@ -272,9 +273,8 @@ static void _query(int sd, short args, void *cbdata)
                     }
 #else
                     /* get it from the v2 API */
-                    if (0
-                        != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
-                                                           HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
+                    if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
+                                                             HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
                         PMIX_RELEASE(kv);
                         continue;
                     }


### PR DESCRIPTION
We do get the pids later on as well, but we need to
ensure they are available right away, so add them to
the "procs have been started" message back to the
DVM controller.

Thanks to @david-edwards-arm for the report

Fixes #1250 
Signed-off-by: Ralph Castain <rhc@pmix.org>