### PR TITLE
Use a pointer array to track our local requests

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -67,12 +67,13 @@ void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret)
     }
 
     /* retrieve the request */
-    pmix_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, room, (void **) &req);
+    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
     if (NULL == req) {
         /* we are hosed */
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         return;
     }
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, room, NULL);
 
     /* execute the callback */
     if (NULL != req->spcbfunc) {
@@ -138,18 +139,12 @@ static void spawn(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(req);
 
-    /* add this request to our tracker hotel */
-    PRTE_ADJUST_TIMEOUT(req);
-    rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-    if (PRTE_SUCCESS != rc) {
-        prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                       prte_pmix_server_globals.num_rooms);
-        goto callback;
-    }
+    /* add this request to our tracker array */
+    req->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
     /* include the request room number for quick retrieval */
-    prte_set_attribute(&req->jdata->attributes, PRTE_JOB_ROOM_NUM, PRTE_ATTR_GLOBAL, &req->room_num,
-                       PMIX_INT);
+    prte_set_attribute(&req->jdata->attributes, PRTE_JOB_ROOM_NUM,
+                       PRTE_ATTR_GLOBAL, &req->room_num, PMIX_INT);
 
     /* construct a spawn message */
     PMIX_DATA_BUFFER_CREATE(buf);
@@ -159,7 +154,7 @@ static void spawn(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         goto callback;
     }
 
@@ -167,7 +162,7 @@ static void spawn(int sd, short args, void *cbdata)
     rc = prte_job_pack(buf, req->jdata);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
@@ -176,7 +171,7 @@ static void spawn(int sd, short args, void *cbdata)
     PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_PLM);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
-        pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -484,7 +484,9 @@ void pmix_server_jobid_return(int status, pmix_proc_t *sender,
     }
 
     /* retrieve the request */
-    pmix_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, room, (void **) &req);
+    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, room, NULL);
+
     if (NULL == req) {
         /* we are hosed */
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
@@ -587,16 +589,7 @@ static void _toolconn(int sd, short args, void *cbdata)
             free(tmp);
             prte_plm_globals.next_jobid++;
         } else {
-            rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, cd, &cd->room_num);
-            if (PMIX_SUCCESS != rc) {
-                prte_show_help("help-prted.txt", "noroom", true, cd->operation,
-                               prte_pmix_server_globals.num_rooms);
-                if (NULL != cd->toolcbfunc) {
-                    cd->toolcbfunc(PMIX_ERR_OUT_OF_RESOURCE, NULL, cd->cbdata);
-                }
-                PMIX_RELEASE(cd);
-                return;
-            }
+            cd->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
             /* we need to send this to the HNP for a jobid */
             PMIX_DATA_BUFFER_CREATE(buf);
             rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
@@ -613,8 +606,7 @@ static void _toolconn(int sd, short args, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 xrc = prte_pmix_convert_rc(rc);
-                pmix_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs,
-                                                        cd->room_num, (void **) &cd);
+                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->room_num, NULL);
                 PMIX_DATA_BUFFER_RELEASE(buf);
                 if (NULL != cd->toolcbfunc) {
                     cd->toolcbfunc(xrc, NULL, cd->cbdata);

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -365,6 +365,7 @@ typedef struct {
     int output;
     pmix_hotel_t reqs;
     int num_rooms;
+    pmix_pointer_array_t local_reqs;
     int timeout;
     bool wait_for_server;
     pmix_proc_t server;


### PR DESCRIPTION
Consolidate the timeout responsibility onto the daemon
that is performing the operation, removing it from the
remote requestor. This eliminates a potential race condition
where the requestor might timeout and remove its tracker
for the operation, and then the daemon performing the op
sends a response.

This does open a problem whereby a requestor could never
respond to the request should the remote daemon fail.
However, we can (and eventually should) deal with that
in the errmgr when we receive notification of a daemon
failure.

Signed-off-by: Ralph Castain <rhc@pmix.org>