### PR TITLE
Fix some ordering issues on cleanup, and a couple memory leaks.

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -582,12 +582,6 @@ static int rte_finalize(void)
 {
     char *contact_path;
 
-    /* shutdown the pmix server */
-    pmix_server_finalize();
-    /* output any lingering stdout/err data */
-    fflush(stdout);
-    fflush(stderr);
-
     /* first stage shutdown of the errmgr, deregister the handler but keep
      * the required facilities until the rml and oob are offline */
     prte_errmgr.finalize();
@@ -625,6 +619,12 @@ static int rte_finalize(void)
     prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
 
     free(prte_topo_signature);
+
+    /* shutdown the pmix server */
+    pmix_server_finalize();
+    /* output any lingering stdout/err data */
+    fflush(stdout);
+    fflush(stderr);
 
     return PRTE_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -795,6 +795,7 @@ int pmix_server_init(void)
         rc = prte_pmix_convert_status(prc);
         return rc;
     }
+    PMIX_INFO_LIST_RELEASE(ilist);
     info = (pmix_info_t*)darray.array;
     ninfo = darray.size;
 
@@ -915,14 +916,22 @@ void pmix_server_finalize(void)
     /* finalize our local data server */
     prte_data_server_finalize();
 
-    /* shutdown the local server */
-    PMIx_server_finalize();
-
     /* cleanup collectives */
+    pmix_server_req_t *cd;
+    for (int i = 0; i < prte_pmix_server_globals.num_rooms; i++) {
+      prte_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, i, (void **) &cd);
+      if (NULL != cd) {
+          PRTE_RELEASE(cd);
+      }
+    }
+
     PRTE_DESTRUCT(&prte_pmix_server_globals.reqs);
     PRTE_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PRTE_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
     free(mytopology.source);
+
+    /* shutdown the local server */
+    PMIx_server_finalize();
     prte_pmix_server_globals.initialized = false;
 }
 

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -149,15 +149,15 @@ int prte_finalize(void)
     free(prte_process_info.nodename);
     prte_process_info.nodename = NULL;
 
-    /* call the finalize function for this environment */
-    if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
-        return rc;
-    }
-
     /* Close the general debug stream */
     prte_output_close(prte_debug_output);
 
     prte_mca_base_alias_cleanup();
+
+    /* call the finalize function for this environment */
+    if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
+        return rc;
+    }
 
     /* finalize the class/object system */
     prte_class_finalize();


### PR DESCRIPTION
I was seeing crashes in prteruns cleanup routine, and valgrind
was reporting accesses after free's. Doing this code shuffle seems
to fix it.

While I was at it, I fixed some long hanging leaks.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 5a710e7dc6d6c25fb962c5f3aea9b7dd03578e91)