### PR TITLE
Add Github action and update make_dist_tarball

### DIFF
--- a/.github/workflows/run-special.yml
+++ b/.github/workflows/run-special.yml
@@ -1,0 +1,31 @@
+name: PRRTE Special Builds Testing
+
+on:
+  pull_request:
+    # We don't need this to be run on all types of PR behavior
+    # See
+    #  - https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+    #  - https://frontside.com/blog/2020-05-26-github-actions-pull_request
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: jjhursey/pmix-xver-tester
+
+jobs:
+  special-builds:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Check out the code
+        uses: actions/checkout@v1
+      # Run the container tester
+      - name: Special Builds
+        run: docker run --rm -v ${GITHUB_WORKSPACE}:/home/pmixer/prrte --env PR_TARGET_BRANCH=${GITHUB_BASE_REF} -w /home/pmixer/pmix-tests/ci-builds ${{ env.IMAGE_NAME }}:latest /bin/bash -c 'git pull && ./run-all-prrte.sh && echo SUCCESS'
+        shell: bash

--- a/contrib/dist/make_dist_tarball
+++ b/contrib/dist/make_dist_tarball
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -73,6 +73,7 @@ while test "$1" != ""; do
         --no-greek) nogreek=1 ;;
         --highok) highok=1 ;;
         --autogen-args) autogen_args=$2; shift ;;
+        --config-args=*) config_args="${i#*=}"; shift ;;
         --distdir) distdir=$2; shift ;;
         --dirtyok) dirty_ok=1 ;;
         --verok) gnu_version_ignore=1;;
@@ -86,6 +87,7 @@ Valid arguments:
   --no-greek      Do not build the greek tarball
   --highok        Ok if Autotools versions are too high
   --autogen-args  Arguments to pass to autogen
+  --config-args  Arguments to pass to configure
   --distdir       Move the tarball(s) to this directory when done
   --dirtyok       Ok if the source tree is dirty
   --verok         Ignore result of autotools version checking
@@ -267,7 +269,7 @@ make_tarball() {
     #
     echo "*** Running configure..."
     rm -f success
-    (./configure 2>&1 && touch success) | tee config.out
+    (./configure $config_args 2>&1 && touch success) | tee config.out
     if test ! -f success; then
         echo "Configure failed.  Aborting"
         exit 1
@@ -301,7 +303,7 @@ make_tarball() {
     # move
     #
     echo "*** Moving tarballs..."
-    mv prte-* $distdir
+    mv prrte-* $distdir
 
     echo "*** All done"
 }
@@ -314,13 +316,15 @@ start=`date`
 echo "*** Start time: $start"
 
 echo "*** Checking tools versions..."
-check_gnu_version m4 $M4_TARGET_VERSION
-check_gnu_version automake $AM_TARGET_VERSION
-check_gnu_version autoconf $AC_TARGET_VERSION
-check_gnu_version libtool $LT_TARGET_VERSION
-# Windows needs a recent version of flex; old versions don't generate
-# Windows-friendly *_lex.c files.
-check_gnu_version flex $FLEX_TARGET_VERSION
+if test "$gnu_version_ignore" = "0"; then
+    check_gnu_version m4 $M4_TARGET_VERSION
+    check_gnu_version automake $AM_TARGET_VERSION
+    check_gnu_version autoconf $AC_TARGET_VERSION
+    check_gnu_version libtool $LT_TARGET_VERSION
+    # Windows needs a recent version of flex; old versions don't generate
+    # Windows-friendly *_lex.c files.
+    check_gnu_version flex $FLEX_TARGET_VERSION
+fi
 
 #
 # Verify that we're in a top PRTE dir


### PR DESCRIPTION
[Add a GitHub Action for the PRRTE Special Builds](https://github.com/openpmix/prrte/commit/b72957e1dddb31d1a228570cb1e3264af952c3a0)

 * These run in the same container as the cross-version checks
   which are already running in OpenPMIx's GitHub Actions.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/75221ce7b6fe41a6e147f2600eb93825f9234bb0)

[Few small changes to make_dist_tarball](https://github.com/openpmix/prrte/commit/55b39792a481b2e23fb89e4ae4925d50b47d7188)

Allow passing of configure args on the cmd line. If --verok is
given, then don't output all the warnings about incorrect tool
versions as it confuses people. Fix a typo in the end - the
tarballs to be moved to dstdir are named "prrte-"

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7393663b444eb814f3f789dfbb15154efdadcf71)