### PR TITLE
Fix a pair of tools issues and hotel problem

### DIFF
--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -208,7 +208,7 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
 
     /* do we already have this process in our list? */
     proct = NULL;
-    PRTE_LIST_FOREACH(pptr, &prte_iof_hnp_component.procs, prte_iof_proc_t)
+    PRTE_LIST_FOREACH(proct, &prte_iof_hnp_component.procs, prte_iof_proc_t)
     {
         if (PMIX_CHECK_PROCID(&proct->name, dst_name)) {
             /* did they direct that the data go to this proc? */
@@ -258,7 +258,7 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
                                                                 sz))) {
                     /* if the addressee is unknown, remove the sink from the list */
                     if (PRTE_ERR_ADDRESSEE_UNKNOWN == rc) {
-                        PMIX_RELEASE(proct->stdinev);
+                        PRTE_RELEASE(proct->stdinev);
                     }
                 }
             }
@@ -407,7 +407,7 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
     PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                          "%s hnp:stdin:write:handler writing %d data to %d",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                         (int)pmix_list_get_size(&wev->outputs), wev->fd));
+                         (int)prte_list_get_size(&wev->outputs), wev->fd));
 
     wev->pending = false;
 

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -84,14 +84,16 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz);
  * which operates independently and is in the iof_hnp_receive.c file
  */
 
-prte_iof_base_module_t prte_iof_hnp_module = {.init = init,
-                                              .push = hnp_push,
-                                              .pull = hnp_pull,
-                                              .close = hnp_close,
-                                              .output = hnp_output,
-                                              .complete = hnp_complete,
-                                              .finalize = finalize,
-                                              .push_stdin = push_stdin};
+prte_iof_base_module_t prte_iof_hnp_module = {
+    .init = init,
+    .push = hnp_push,
+    .pull = hnp_pull,
+    .close = hnp_close,
+    .output = hnp_output,
+    .complete = hnp_complete,
+    .finalize = finalize,
+    .push_stdin = push_stdin
+};
 
 /* Initialize the module */
 static int init(void)
@@ -192,7 +194,7 @@ SETUP:
  */
 static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
 {
-    prte_iof_proc_t *proct, *pptr;
+    prte_iof_proc_t *proct;
     int rc;
 
     /* don't do this if the dst vpid is invalid */
@@ -208,63 +210,57 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
     proct = NULL;
     PRTE_LIST_FOREACH(pptr, &prte_iof_hnp_component.procs, prte_iof_proc_t)
     {
-        if (PMIX_CHECK_PROCID(&pptr->name, dst_name)) {
-            /* found it */
-            proct = pptr;
-        }
-    }
-    if (NULL == proct) {
-        return PRTE_ERR_NOT_FOUND;
-    }
-
-    /* did they direct that the data go to this proc? */
-    if (NULL == proct->stdinev) {
-        /* nope - ignore it */
-        return PRTE_SUCCESS;
-    }
-
-    /* if the daemon is me, then this is a local sink */
-    if (PMIX_CHECK_PROCID(PRTE_PROC_MY_NAME, &proct->stdinev->daemon)) {
-        PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                             "%s read %d bytes from stdin - writing to %s",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) sz,
-                             PRTE_NAME_PRINT(&proct->name)));
-        /* send the bytes down the pipe - we even send 0 byte events
-         * down the pipe so it forces out any preceding data before
-         * closing the output stream
-         */
-        if (NULL != proct->stdinev->wev) {
-            if (PRTE_IOF_MAX_INPUT_BUFFERS < prte_iof_base_write_output(&proct->name,
-                                                                        PRTE_IOF_STDIN, data, sz,
-                                                                        proct->stdinev->wev)) {
-                /* getting too backed up - stop the read event for now if it is still active */
-
-                PRTE_OUTPUT_VERBOSE(
-                    (1, prte_iof_base_framework.framework_output, "buffer backed up - holding"));
-                return PRTE_ERR_OUT_OF_RESOURCE;
+        if (PMIX_CHECK_PROCID(&proct->name, dst_name)) {
+            /* did they direct that the data go to this proc? */
+            if (NULL == proct->stdinev) {
+                /* nope - ignore it */
+                continue;
             }
-        }
-    } else {
-        PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                             "%s sending %d bytes from stdinev to daemon %s",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) sz,
-                             PRTE_NAME_PRINT(&proct->stdinev->daemon)));
 
-        /* send the data to the daemon so it can
-         * write it to the proc's fd - in this case,
-         * we pass sink->name to indicate who is to
-         * receive the data. If the connection closed,
-         * numbytes will be zero so zero bytes will be
-         * sent - this will tell the daemon to close
-         * the fd for stdin to that proc
-         */
-        if (PRTE_SUCCESS
-            != (rc = prte_iof_hnp_send_data_to_endpoint(&proct->stdinev->daemon,
-                                                        &proct->stdinev->name, PRTE_IOF_STDIN, data,
-                                                        sz))) {
-            /* if the addressee is unknown, remove the sink from the list */
-            if (PRTE_ERR_ADDRESSEE_UNKNOWN == rc) {
-                PRTE_RELEASE(proct->stdinev);
+            /* if the daemon is me, then this is a local sink */
+            if (PMIX_CHECK_PROCID(PRTE_PROC_MY_NAME, &proct->stdinev->daemon)) {
+                PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                                     "%s read %d bytes from stdin - writing to %s",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) sz,
+                                     PRTE_NAME_PRINT(&proct->name)));
+                /* send the bytes down the pipe - we even send 0 byte events
+                 * down the pipe so it forces out any preceding data before
+                 * closing the output stream
+                 */
+                if (NULL != proct->stdinev->wev) {
+                    if (PRTE_IOF_MAX_INPUT_BUFFERS < prte_iof_base_write_output(&proct->name,
+                                                                                PRTE_IOF_STDIN, data, sz,
+                                                                                proct->stdinev->wev)) {
+                        /* getting too backed up - stop the read event for now if it is still active */
+
+                        PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                                             "buffer backed up - holding"));
+                        return PRTE_ERR_OUT_OF_RESOURCE;
+                    }
+                }
+            } else {
+                PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                                     "%s sending %d bytes from stdinev to daemon %s",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) sz,
+                                     PRTE_NAME_PRINT(&proct->stdinev->daemon)));
+
+                /* send the data to the daemon so it can
+                 * write it to the proc's fd - in this case,
+                 * we pass sink->name to indicate who is to
+                 * receive the data. If the connection closed,
+                 * numbytes will be zero so zero bytes will be
+                 * sent - this will tell the daemon to close
+                 * the fd for stdin to that proc
+                 */
+                if (PRTE_SUCCESS
+                    != (rc = prte_iof_hnp_send_data_to_endpoint(&proct->stdinev->daemon,
+                                                                &proct->stdinev->name, PRTE_IOF_STDIN, data,
+                                                                sz))) {
+                    /* if the addressee is unknown, remove the sink from the list */
+                    if (PRTE_ERR_ADDRESSEE_UNKNOWN == rc) {
+                        PMIX_RELEASE(proct->stdinev);
+                    }
+                }
             }
         }
     }
@@ -409,8 +405,9 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
     PRTE_ACQUIRE_OBJECT(sink);
 
     PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                         "%s hnp:stdin:write:handler writing data to %d",
-                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), wev->fd));
+                         "%s hnp:stdin:write:handler writing %d data to %d",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         (int)pmix_list_get_size(&wev->outputs), wev->fd));
 
     wev->pending = false;
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -582,6 +582,8 @@ int pmix_server_init(void)
     PRTE_CONSTRUCT(&prte_pmix_server_globals.reqs, prte_hotel_t);
     PRTE_CONSTRUCT(&prte_pmix_server_globals.psets, prte_list_t);
     PRTE_CONSTRUCT(&prte_pmix_server_globals.tools, prte_list_t);
+    PRTE_CONSTRUCT(&prte_pmix_server_globals.local_reqs, prte_pointer_array_t);
+    prte_pointer_array_init(&prte_pmix_server_globals.local_reqs, 128, INT_MAX, 2);
 
     /* by the time we init the server, we should know how many nodes we
      * have in our environment - with the exception of mpirun. If the
@@ -919,14 +921,24 @@ void pmix_server_finalize(void)
     /* finalize our local data server */
     prte_data_server_finalize();
 
-    /* shutdown the local server */
-    PMIx_server_finalize();
-
     /* cleanup collectives */
+    pmix_server_req_t *cd;
+    for (int i = 0; i < prte_pmix_server_globals.num_rooms; i++) {
+      prte_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, i, (void **) &cd);
+      if (NULL != cd) {
+          PRTE_RELEASE(cd);
+      }
+    }
+
     PRTE_DESTRUCT(&prte_pmix_server_globals.reqs);
+    PRTE_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PRTE_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PRTE_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
     free(mytopology.source);
+
+    /* shutdown the local server */
+    PMIx_server_finalize();
+
     prte_pmix_server_globals.initialized = false;
 }
 
@@ -967,8 +979,10 @@ static void _mdxresp(int sd, short args, void *cbdata)
 
     PRTE_ACQUIRE_OBJECT(req);
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s XMITTING DATA FOR PROC %s:%u",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->tproc.nspace, req->tproc.rank);
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s XMITTING DATA FOR PROC %s:%u",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        req->tproc.nspace, req->tproc.rank);
 
     /* check us out of the hotel */
     prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
@@ -1061,7 +1075,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender, pmix_data_buf
         return;
     }
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s dmdx:recv request from proc %s for proc %s:%u",
+                        "%s dmdx:recv processing request from proc %s for proc %s:%u",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender), pproc.nspace,
                         pproc.rank);
     /* and the remote daemon's tracking room number */
@@ -1248,7 +1262,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
     pmix_status_t prc, pret;
 
     prte_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s dmdx:recv response from proc %s with %d bytes",
+                        "%s dmdx:recv response recvd from proc %s with %d bytes",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender),
                         (int) buffer->bytes_used);
 
@@ -1301,9 +1315,8 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
         }
     }
 
-    /* check the request out of the tracking hotel */
-    prte_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, room_num,
-                                            (void **) &req);
+    /* get the request out of the tracking array */
+    req = (pmix_server_req_t*)prte_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room_num);
     /* return the returned data to the requestor */
     if (NULL != req) {
         if (NULL != req->mdxcbfunc) {
@@ -1312,13 +1325,14 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
         }
         PRTE_RELEASE(req);
     } else {
-        prte_output_verbose(2, prte_pmix_server_globals.output, "REQ WAS NULL IN ROOM %d",
+        prte_output_verbose(2, prte_pmix_server_globals.output,
+                            "REQ WAS NULL IN ROOM %d",
                             room_num);
     }
 
     /* now see if anyone else was waiting for data from this target */
-    for (rnum = 0; rnum < prte_pmix_server_globals.reqs.num_rooms; rnum++) {
-        prte_hotel_knock(&prte_pmix_server_globals.reqs, rnum, (void **) &req);
+    for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
+        req = (pmix_server_req_t*)prte_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
         if (NULL == req) {
             continue;
         }
@@ -1327,7 +1341,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
                 PRTE_RETAIN(d);
                 req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
             }
-            prte_hotel_checkout(&prte_pmix_server_globals.reqs, rnum);
+            prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, rnum, NULL);
             PRTE_RELEASE(req);
         }
     }

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -224,17 +224,9 @@ static void dmodex_req(int sd, short args, void *cbdata)
             PMIX_VALUE_RELEASE(pval);
             /* mark that the result is to return to us */
             req->proxy = *PRTE_PROC_MY_NAME;
-            /* save the request in the hotel until the
+            /* save the request in the local_req array until the
              * data is returned */
-            if (PRTE_SUCCESS
-                != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                               prte_pmix_server_globals.num_rooms);
-                /* can't just return as that would cause the requestor
-                 * to hang, so instead execute the callback */
-                prc = prte_pmix_convert_rc(rc);
-                goto callback;
-            }
+            req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
             /* set the "remote" room number to our own */
             req->remote_room_num = req->room_num;
             PRTE_RETAIN(req);
@@ -248,29 +240,17 @@ static void dmodex_req(int sd, short args, void *cbdata)
         }
     }
 
-    /* adjust the timeout to reflect the size of the job as it can take some
-     * amount of time to start the job */
-    PRTE_ADJUST_TIMEOUT(req);
-
     /* has anyone already requested data for this target? If so,
      * then the data is already on its way */
-    for (rnum = 0; rnum < prte_pmix_server_globals.reqs.num_rooms; rnum++) {
-        prte_hotel_knock(&prte_pmix_server_globals.reqs, rnum, (void **) &r);
+    for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
+        r = (pmix_server_req_t*)prte_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
         if (NULL == r) {
             continue;
         }
         if (PMIX_CHECK_PROCID(&r->target, &req->tproc)) {
-            /* save the request in the hotel until the
+            /* save the request in the array until the
              * data is returned */
-            if (PRTE_SUCCESS
-                != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                               prte_pmix_server_globals.num_rooms);
-                /* can't just return as that would cause the requestor
-                 * to hang, so instead execute the callback */
-                prc = prte_pmix_convert_rc(rc);
-                goto callback;
-            }
+            req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
             return;
         }
     }
@@ -281,15 +261,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
          * condition where we are being asked about a process
          * that we don't know about yet. In this case, just
          * record the request and we will process it later */
-        if (PRTE_SUCCESS
-            != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-            prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                           prte_pmix_server_globals.num_rooms);
-            /* can't just return as that would cause the requestor
-             * to hang, so instead execute the callback */
-            prc = prte_pmix_convert_rc(rc);
-            goto callback;
-        }
+        req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
         return;
     }
     /* if this is a request for rank=WILDCARD, then they want the job-level data
@@ -334,15 +306,11 @@ static void dmodex_req(int sd, short args, void *cbdata)
     req->proxy = dmn->name;
     /* track the request so we know the function and cbdata
      * to callback upon completion */
-    if (PRTE_SUCCESS
-        != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                       prte_pmix_server_globals.num_rooms);
-        prc = prte_pmix_convert_rc(rc);
-        goto callback;
-    }
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s:%d MY REQ ROOM IS %d FOR KEY %s",
-                        __FILE__, __LINE__, req->room_num, (NULL == req->key) ? "NULL" : req->key);
+    req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s:%d MY REQ ROOM IS %d FOR KEY %s",
+                        __FILE__, __LINE__, req->room_num,
+                        (NULL == req->key) ? "NULL" : req->key);
     /* if we are the host daemon, then this is a local request, so
      * just wait for the data to come in */
     if (PRTE_PROC_MY_NAME->rank == dmn->name.rank) {
@@ -353,28 +321,28 @@ static void dmodex_req(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(buf);
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->tproc, 1, PMIX_PROC))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* include the request room number for quick retrieval */
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->room_num, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* add any qualifiers */
     if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     if (0 < req->ninfo) {
         if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(prc);
-            prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+            prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
             PMIX_DATA_BUFFER_RELEASE(buf);
             goto callback;
         }
@@ -385,8 +353,8 @@ static void dmodex_req(int sd, short args, void *cbdata)
         != (rc = prte_rml.send_buffer_nb(&dmn->name, buf, PRTE_RML_TAG_DIRECT_MODEX,
                                          prte_rml_send_callback, NULL))) {
         PRTE_ERROR_LOG(rc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
-        PRTE_RELEASE(buf);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        PMIX_DATA_BUFFER_RELEASE(buf);
         prc = prte_pmix_convert_rc(rc);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -761,8 +761,10 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_p
     prte_grpcomm_signature_t *sig;
     pmix_proc_t *proct;
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s job control request from %s:%d",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), requestor->nspace, requestor->rank);
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s job control request from %s:%d",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        requestor->nspace, requestor->rank);
 
     for (m = 0; m < ndirs; m++) {
         if (0 == strncmp(directives[m].key, PMIX_JOB_CTRL_KILL, PMIX_MAX_KEYLEN)) {
@@ -1090,8 +1092,10 @@ static void pmix_server_stdin_push(int sd, short args, void *cbdata)
     size_t n;
 
     for (n = 0; n < cd->nprocs; n++) {
-        PRTE_OUTPUT_VERBOSE((1, prte_debug_output, "%s pmix_server_stdin_push to dest %s: size %zu",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&cd->procs[n]),
+        PRTE_OUTPUT_VERBOSE((1, prte_pmix_server_globals.output,
+                             "%s pmix_server_stdin_push to dest %s: size %zu",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(&cd->procs[n]),
                              bo->size));
         prte_iof.push_stdin(&cd->procs[n], (uint8_t *) bo->bytes, bo->size);
     }

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -365,6 +365,7 @@ typedef struct {
     int output;
     prte_hotel_t reqs;
     int num_rooms;
+    prte_pointer_array_t local_reqs;
     int timeout;
     bool wait_for_server;
     pmix_proc_t server;

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -389,7 +389,7 @@ static void _query(int sd, short args, void *cbdata)
                 procinfo = (pmix_proc_info_t *) darray->array;
                 p = 0;
                 for (k = 0; k < jdata->procs->size; k++) {
-                    proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, k);
+                    proct = (prte_proc_t *) prte_pointer_array_get_item(jdata->procs, k);
                     if (NULL == proct) {
                         continue;
                     }
@@ -400,7 +400,7 @@ static void _query(int sd, short args, void *cbdata)
                     app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps,
                                                                              proct->app_idx);
                     if (NULL != app && NULL != app->app) {
-                        if (pmix_path_is_absolute(app->app)) {
+                        if (prte_path_is_absolute(app->app)) {
                             procinfo[p].executable_name = strdup(app->app);
                         } else {
                             procinfo[p].executable_name = prte_os_path(false, app->cwd, app->app, NULL);
@@ -447,7 +447,7 @@ static void _query(int sd, short args, void *cbdata)
                         app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps,
                                                                                  proct->app_idx);
                         if (NULL != app && NULL != app->app) {
-                            if (pmix_path_is_absolute(app->app)) {
+                            if (prte_path_is_absolute(app->app)) {
                                 procinfo[p].executable_name = strdup(app->app);
                             } else {
                                 procinfo[p].executable_name = prte_os_path(false, app->cwd, app->app, NULL);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1130,19 +1130,33 @@ int main(int argc, char *argv[])
         prte_output(0, "JOB %s EXECUTING", PRTE_JOBID_PRINT(spawnednspace));
     }
 
-    /* push our stdin to the apps */
-    PMIX_LOAD_PROCID(&pname, spawnednspace, 0); // forward stdin to rank=0
-    PMIX_INFO_CREATE(iptr, 1);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
-    if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
-        prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
-    } else if (PMIX_SUCCESS == ret) {
-        PRTE_PMIX_WAIT_THREAD(&lock);
+    /* check what user wants us to do with stdin */
+    PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
+    if (NULL != opt) {
+        if (0 == strcmp(opt->values[0], "all")) {
+            pname.rank = PMIX_RANK_WILDCARD;
+        } else if (0 == strcmp(opt->values[0], "none")) {
+            pname.rank = PMIX_RANK_INVALID;
+        } else {
+            pname.rank = 0;
+        }
+    } else {
+        pname.rank = 0;
     }
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PMIX_INFO_FREE(iptr, 1);
+    if (PMIX_RANK_INVALID != pname.rank) {
+        PMIX_INFO_CREATE(iptr, 1);
+        PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
+        PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
+        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
+            prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
+        } else if (PMIX_SUCCESS == ret) {
+            PRTE_PMIX_WAIT_THREAD(&lock);
+        }
+        PRTE_PMIX_DESTRUCT_LOCK(&lock);
+        PMIX_INFO_FREE(iptr, 1);
+    }
 
 proceed:
     /* loop the event lib until an exit event is detected */

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1132,7 +1132,7 @@ int main(int argc, char *argv[])
 
     /* check what user wants us to do with stdin */
     PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
+    opt = prte_cmd_line_get_param(&results, PRTE_CLI_STDIN);
     if (NULL != opt) {
         if (0 == strcmp(opt->values[0], "all")) {
             pname.rank = PMIX_RANK_WILDCARD;

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -960,7 +960,7 @@ int prun(int argc, char *argv[])
 
     /* check what user wants us to do with stdin */
     PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
+    opt = prte_cmd_line_get_param(&results, PRTE_CLI_STDIN);
     if (NULL != opt) {
         if (0 == strcmp(opt->values[0], "all")) {
             pname.rank = PMIX_RANK_WILDCARD;

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -958,19 +958,33 @@ int prun(int argc, char *argv[])
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(iptr, 2);
 
-    /* push our stdin to the apps */
-    PMIX_LOAD_PROCID(&pname, spawnednspace, 0); // forward stdin to rank=0
-    PMIX_INFO_CREATE(iptr, 1);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
-    if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
-        prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
-    } else if (PMIX_SUCCESS == ret) {
-        PRTE_PMIX_WAIT_THREAD(&lock);
+    /* check what user wants us to do with stdin */
+    PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
+    if (NULL != opt) {
+        if (0 == strcmp(opt->values[0], "all")) {
+            pname.rank = PMIX_RANK_WILDCARD;
+        } else if (0 == strcmp(opt->values[0], "none")) {
+            pname.rank = PMIX_RANK_INVALID;
+        } else {
+            pname.rank = 0;
+        }
+    } else {
+        pname.rank = 0;
     }
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PMIX_INFO_FREE(iptr, 1);
+    if (PMIX_RANK_INVALID != pname.rank) {
+        PMIX_INFO_CREATE(iptr, 1);
+        PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
+        PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
+        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
+            prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
+        } else if (PMIX_SUCCESS == ret) {
+            PRTE_PMIX_WAIT_THREAD(&lock);
+        }
+        PRTE_PMIX_DESTRUCT_LOCK(&lock);
+        PMIX_INFO_FREE(iptr, 1);
+    }
 
     /* register to be notified when
      * our job completes */


### PR DESCRIPTION
[Ensure the proctable includes absolute paths to executable](https://github.com/openpmix/prrte/commit/1b74da59b3d246ddecaf7e17262a92581fa6ff89)

The requestor has no way of knowing the cwd used for the
executable path if it is given in relative syntax, so use
the appropriate utilities to ensure it is always returned
in absolute path format.

Thanks to @david-edwards-arm for the report AND the
initial patch! Both much appreciated.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ee9119d1d95a1c0d2eee5de817084d4f5e7d6c62)

[Ensure that stdin goes to all specified targets](https://github.com/openpmix/prrte/commit/467dbe58c27afcf13ad2a0596c44b9f24abc3a73)

Currently support only rank=0, rank=all, or none.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8450055f92bb6d16fdf0e45046b86c63b8fe1df9)

[Use pmix_hotel_checkin() in eviction callback.](https://github.com/openpmix/prrte/pull/1274/commits/c2cfd003f1975d45b71d2aa022c9e77bb789a256)
[c2cfd00](https://github.com/openpmix/prrte/pull/1274/commits/c2cfd003f1975d45b71d2aa022c9e77bb789a256)

The request was checked out of the hotel in PMIx, and the
pmix_hotel_recheck() routine tries to put it back into the same
room it was previously.

This seems problematic - as that call doesn't update the last
unoccupied room - and the hotel will get in a bad state because of it.
I'm also not sure that 're-checking' into the old room is
correct, since it is possible that someone else got checked
into that room, and pmix_hotel_recheck() will silently kick that
occupent out.

Also - add a status check for the first pmix_hotel_checkin() call
to make it consistent with the second. I hate goto's, but
it makes the change simple.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/rhc54/prrte/commit/58ed3dd5c29768a90f8af153aa20205885e6c62c)

[Use a pointer array to track our local requests](https://github.com/openpmix/prrte/pull/1274/commits/8a6eea1b779d984cd1f10235cdbb823c9151eaba)
[8a6eea1](https://github.com/openpmix/prrte/pull/1274/commits/8a6eea1b779d984cd1f10235cdbb823c9151eaba)

Consolidate the timeout responsibility onto the daemon
that is performing the operation, removing it from the
remote requestor. This eliminates a potential race condition
where the requestor might timeout and remove its tracker
for the operation, and then the daemon performing the op
sends a response.

This does open a problem whereby a requestor could never
respond to the request should the remote daemon fail.
However, we can (and eventually should) deal with that
in the errmgr when we receive notification of a daemon
failure.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/prrte/commit/ac9c591fff6a74e3af84bffb3838f7a42cf4c380)