### PR TITLE
Fix some hotel-related issues

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -454,9 +454,12 @@ static void eviction_cbfunc(struct prte_hotel_t *hotel, int room_num, void *occu
                 /* it has - ask our local pmix server for the data */
                 PMIX_VALUE_RELEASE(pval);
                 /* check us back into hotel so the modex_resp function can safely remove us */
-                prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-                if (PMIX_SUCCESS
-                    != (prc = PMIx_server_dmodex_request(&req->tproc, modex_resp, req))) {
+                prc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
+                if (PRTE_SUCCESS != prc) {
+                    goto error_condition;
+                }
+                prc = PMIx_server_dmodex_request(&req->tproc, modex_resp, req);
+                if (PMIX_SUCCESS != prc) {
                     PMIX_ERROR_LOG(prc);
                     send_error(rc, &req->tproc, &req->proxy, req->remote_room_num);
                     prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
@@ -470,7 +473,7 @@ static void eviction_cbfunc(struct prte_hotel_t *hotel, int room_num, void *occu
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
         }
         /* not done yet - check us back in */
-        rc = prte_hotel_recheck(&prte_pmix_server_globals.reqs, req, req->room_num);
+        rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
         if (PRTE_SUCCESS == rc) {
             prte_output_verbose(2, prte_pmix_server_globals.output,
                                 "%s server:evict checked back in to room %d",
@@ -482,6 +485,7 @@ static void eviction_cbfunc(struct prte_hotel_t *hotel, int room_num, void *occu
         prte_show_help("help-prted.txt", "timedout", true, req->operation);
     }
 
+error_condition:
     /* don't let the caller hang */
     if (0 <= req->remote_room_num) {
         send_error(rc, &req->tproc, &req->proxy, req->remote_room_num);

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -224,17 +224,9 @@ static void dmodex_req(int sd, short args, void *cbdata)
             PMIX_VALUE_RELEASE(pval);
             /* mark that the result is to return to us */
             req->proxy = *PRTE_PROC_MY_NAME;
-            /* save the request in the hotel until the
+            /* save the request in the local_req array until the
              * data is returned */
-            if (PRTE_SUCCESS
-                != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                               prte_pmix_server_globals.num_rooms);
-                /* can't just return as that would cause the requestor
-                 * to hang, so instead execute the callback */
-                prc = prte_pmix_convert_rc(rc);
-                goto callback;
-            }
+            req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
             /* set the "remote" room number to our own */
             req->remote_room_num = req->room_num;
             PRTE_RETAIN(req);
@@ -248,29 +240,17 @@ static void dmodex_req(int sd, short args, void *cbdata)
         }
     }
 
-    /* adjust the timeout to reflect the size of the job as it can take some
-     * amount of time to start the job */
-    PRTE_ADJUST_TIMEOUT(req);
-
     /* has anyone already requested data for this target? If so,
      * then the data is already on its way */
-    for (rnum = 0; rnum < prte_pmix_server_globals.reqs.num_rooms; rnum++) {
-        prte_hotel_knock(&prte_pmix_server_globals.reqs, rnum, (void **) &r);
+    for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
+        r = (pmix_server_req_t*)prte_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
         if (NULL == r) {
             continue;
         }
         if (PMIX_CHECK_PROCID(&r->target, &req->tproc)) {
-            /* save the request in the hotel until the
+            /* save the request in the array until the
              * data is returned */
-            if (PRTE_SUCCESS
-                != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-                prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                               prte_pmix_server_globals.num_rooms);
-                /* can't just return as that would cause the requestor
-                 * to hang, so instead execute the callback */
-                prc = prte_pmix_convert_rc(rc);
-                goto callback;
-            }
+            req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
             return;
         }
     }
@@ -281,15 +261,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
          * condition where we are being asked about a process
          * that we don't know about yet. In this case, just
          * record the request and we will process it later */
-        if (PRTE_SUCCESS
-            != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-            prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                           prte_pmix_server_globals.num_rooms);
-            /* can't just return as that would cause the requestor
-             * to hang, so instead execute the callback */
-            prc = prte_pmix_convert_rc(rc);
-            goto callback;
-        }
+        req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
         return;
     }
     /* if this is a request for rank=WILDCARD, then they want the job-level data
@@ -334,15 +306,11 @@ static void dmodex_req(int sd, short args, void *cbdata)
     req->proxy = dmn->name;
     /* track the request so we know the function and cbdata
      * to callback upon completion */
-    if (PRTE_SUCCESS
-        != (rc = prte_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num))) {
-        prte_show_help("help-prted.txt", "noroom", true, req->operation,
-                       prte_pmix_server_globals.num_rooms);
-        prc = prte_pmix_convert_rc(rc);
-        goto callback;
-    }
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s:%d MY REQ ROOM IS %d FOR KEY %s",
-                        __FILE__, __LINE__, req->room_num, (NULL == req->key) ? "NULL" : req->key);
+    req->room_num = prte_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s:%d MY REQ ROOM IS %d FOR KEY %s",
+                        __FILE__, __LINE__, req->room_num,
+                        (NULL == req->key) ? "NULL" : req->key);
     /* if we are the host daemon, then this is a local request, so
      * just wait for the data to come in */
     if (PRTE_PROC_MY_NAME->rank == dmn->name.rank) {
@@ -353,28 +321,28 @@ static void dmodex_req(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(buf);
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->tproc, 1, PMIX_PROC))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* include the request room number for quick retrieval */
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->room_num, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* add any qualifiers */
     if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(prc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     if (0 < req->ninfo) {
         if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(prc);
-            prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+            prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
             PMIX_DATA_BUFFER_RELEASE(buf);
             goto callback;
         }
@@ -385,8 +353,8 @@ static void dmodex_req(int sd, short args, void *cbdata)
         != (rc = prte_rml.send_buffer_nb(&dmn->name, buf, PRTE_RML_TAG_DIRECT_MODEX,
                                          prte_rml_send_callback, NULL))) {
         PRTE_ERROR_LOG(rc);
-        prte_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
-        PRTE_RELEASE(buf);
+        prte_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        PMIX_DATA_BUFFER_RELEASE(buf);
         prc = prte_pmix_convert_rc(rc);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -365,6 +365,7 @@ typedef struct {
     int output;
     prte_hotel_t reqs;
     int num_rooms;
+    prte_pointer_array_t local_reqs;
     int timeout;
     bool wait_for_server;
     pmix_proc_t server;


### PR DESCRIPTION
[Use pmix_hotel_checkin() in eviction callback.](https://github.com/openpmix/prrte/commit/6bc8c3950ade18fa7d2aeef19adf3a2961c253f5)

The request was checked out of the hotel in PMIx, and the
pmix_hotel_recheck() routine tries to put it back into the same
room it was previously.

This seems problematic - as that call doesn't update the last
unoccupied room - and the hotel will get in a bad state because of it.
I'm also not sure that 're-checking' into the old room is
correct, since it is possible that someone else got checked
into that room, and pmix_hotel_recheck() will silently kick that
occupent out.

Also - add a status check for the first pmix_hotel_checkin() call
to make it consistent with the second. I hate goto's, but
it makes the change simple.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/58ed3dd5c29768a90f8af153aa20205885e6c62c)

[Use a pointer array to track our local requests](https://github.com/openpmix/prrte/commit/5e4042e51fff0e1711820e30cd442fb106f1bc24)

Consolidate the timeout responsibility onto the daemon
that is performing the operation, removing it from the
remote requestor. This eliminates a potential race condition
where the requestor might timeout and remove its tracker
for the operation, and then the daemon performing the op
sends a response.

This does open a problem whereby a requestor could never
respond to the request should the remote daemon fail.
However, we can (and eventually should) deal with that
in the errmgr when we receive notification of a daemon
failure.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ac9c591fff6a74e3af84bffb3838f7a42cf4c380)