### PR TITLE
Fix some tool-related issues

### DIFF
--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -761,8 +761,10 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_p
     prte_grpcomm_signature_t *sig;
     pmix_proc_t *proct;
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s job control request from %s:%d",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), requestor->nspace, requestor->rank);
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s job control request from %s:%d",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        requestor->nspace, requestor->rank);
 
     for (m = 0; m < ndirs; m++) {
         if (0 == strncmp(directives[m].key, PMIX_JOB_CTRL_KILL, PMIX_MAX_KEYLEN)) {
@@ -1090,8 +1092,10 @@ static void pmix_server_stdin_push(int sd, short args, void *cbdata)
     size_t n;
 
     for (n = 0; n < cd->nprocs; n++) {
-        PRTE_OUTPUT_VERBOSE((1, prte_debug_output, "%s pmix_server_stdin_push to dest %s: size %zu",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&cd->procs[n]),
+        PRTE_OUTPUT_VERBOSE((1, prte_pmix_server_globals.output,
+                             "%s pmix_server_stdin_push to dest %s: size %zu",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(&cd->procs[n]),
                              bo->size));
         prte_iof.push_stdin(&cd->procs[n], (uint8_t *) bo->bytes, bo->size);
     }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -383,7 +383,7 @@ static void _query(int sd, short args, void *cbdata)
                 procinfo = (pmix_proc_info_t *) darray->array;
                 p = 0;
                 for (k = 0; k < jdata->procs->size; k++) {
-                    proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, k);
+                    proct = (prte_proc_t *) prte_pointer_array_get_item(jdata->procs, k);
                     if (NULL == proct) {
                         continue;
                     }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -37,6 +37,8 @@
 #include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/util/argv.h"
+#include "src/util/os_path.h"
+#include "src/util/path.h"
 #include "src/util/output.h"
 
 #include "src/mca/errmgr/errmgr.h"
@@ -263,16 +265,14 @@ static void _query(int sd, short args, void *cbdata)
                     kv = PRTE_NEW(prte_info_item_t);
 #if HWLOC_API_VERSION < 0x20000
                     /* get this from the v1.x API */
-                    if (0
-                        != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len)) {
+                    if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len)) {
                         PRTE_RELEASE(kv);
                         continue;
                     }
 #else
                     /* get it from the v2 API */
-                    if (0
-                        != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
-                                                           HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
+                    if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
+                                                             HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
                         PRTE_RELEASE(kv);
                         continue;
                     }
@@ -288,9 +288,7 @@ static void _query(int sd, short args, void *cbdata)
                     char *xmlbuffer = NULL;
                     int len;
                     kv = PRTE_NEW(prte_info_item_t);
-                    if (0
-                        != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
-                                                           0)) {
+                    if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len, 0)) {
                         PRTE_RELEASE(kv);
                         continue;
                     }
@@ -310,9 +308,7 @@ static void _query(int sd, short args, void *cbdata)
                     /* find the node object */
                     node = NULL;
                     for (k = 0; k < prte_node_pool->size; k++) {
-                        if (NULL
-                            == (ndptr = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool,
-                                                                                    k))) {
+                        if (NULL == (ndptr = (prte_node_t *) prte_pointer_array_get_item(prte_node_pool, k))) {
                             continue;
                         }
                         if (0 == strcmp(hostname, ndptr->name)) {
@@ -387,8 +383,8 @@ static void _query(int sd, short args, void *cbdata)
                 procinfo = (pmix_proc_info_t *) darray->array;
                 p = 0;
                 for (k = 0; k < jdata->procs->size; k++) {
-                    if (NULL
-                        == (proct = (prte_proc_t *) prte_pointer_array_get_item(jdata->procs, k))) {
+                    proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, k);
+                    if (NULL == proct) {
                         continue;
                     }
                     PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
@@ -398,7 +394,11 @@ static void _query(int sd, short args, void *cbdata)
                     app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps,
                                                                              proct->app_idx);
                     if (NULL != app && NULL != app->app) {
-                        procinfo[p].executable_name = strdup(app->app);
+                        if (prte_path_is_absolute(app->app)) {
+                            procinfo[p].executable_name = strdup(app->app);
+                        } else {
+                            procinfo[p].executable_name = prte_os_path(false, app->cwd, app->app, NULL);
+                        }
                     }
                     procinfo[p].pid = proct->pid;
                     procinfo[p].exit_code = proct->exit_code;
@@ -441,7 +441,11 @@ static void _query(int sd, short args, void *cbdata)
                         app = (prte_app_context_t *) prte_pointer_array_get_item(jdata->apps,
                                                                                  proct->app_idx);
                         if (NULL != app && NULL != app->app) {
-                            procinfo[p].executable_name = strdup(app->app);
+                            if (prte_path_is_absolute(app->app)) {
+                                procinfo[p].executable_name = strdup(app->app);
+                            } else {
+                                procinfo[p].executable_name = prte_os_path(false, app->cwd, app->app, NULL);
+                            }
                         }
                         procinfo[p].pid = proct->pid;
                         procinfo[p].exit_code = proct->exit_code;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -1232,19 +1232,33 @@ int prte(int argc, char *argv[])
         prte_output(0, "JOB %s EXECUTING", PRTE_JOBID_PRINT(spawnednspace));
     }
 
-    /* push our stdin to the apps */
-    PMIX_LOAD_PROCID(&pname, spawnednspace, 0); // forward stdin to rank=0
-    PMIX_INFO_CREATE(iptr, 1);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
-    if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
-        prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
-    } else if (PMIX_SUCCESS == ret) {
-        PRTE_PMIX_WAIT_THREAD(&lock);
+    /* check what user wants us to do with stdin */
+    PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
+    pval = prte_cmd_line_get_param(prte_cmd_line, "stdin", 0, 0);
+    if (NULL != pval) {
+        if (0 == strcmp(pval->value.data.string, "all")) {
+            pname.rank = PMIX_RANK_WILDCARD;
+        } else if (0 == strcmp(pval->value.data.string, "none")) {
+            pname.rank = PMIX_RANK_INVALID;
+        } else {
+            pname.rank = 0;
+        }
+    } else {
+        pname.rank = 0;
     }
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PMIX_INFO_FREE(iptr, 1);
+    if (PMIX_RANK_INVALID != pname.rank) {
+        PMIX_INFO_CREATE(iptr, 1);
+        PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
+        PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+        ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
+        if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
+            prte_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
+        } else if (PMIX_SUCCESS == ret) {
+            PRTE_PMIX_WAIT_THREAD(&lock);
+        }
+        PRTE_PMIX_DESTRUCT_LOCK(&lock);
+        PMIX_INFO_FREE(iptr, 1);
+    }
 
 proceed:
     /* loop the event lib until an exit event is detected */


### PR DESCRIPTION
[Ensure the proctable includes absolute paths to executable](https://github.com/openpmix/prrte/commit/9a8ecc72382aac8d3f3e6abfe12b3225810956e6)

The requestor has no way of knowing the cwd used for the
executable path if it is given in relative syntax, so use
the appropriate utilities to ensure it is always returned
in absolute path format.

Thanks to @david-edwards-arm for the report AND the
initial patch! Both much appreciated.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ee9119d1d95a1c0d2eee5de817084d4f5e7d6c62)
(cherry picked from commit https://github.com/openpmix/prrte/commit/ac766d4dea54c3abb454d39207f79c4435831071)

[Ensure that stdin goes to all specified targets](https://github.com/openpmix/prrte/commit/286cd7b26a5ca69a96e1e7184e7221a322bb3e84)

Currently support only rank=0, rank=all, or none.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8450055f92bb6d16fdf0e45046b86c63b8fe1df9)
(cherry picked from commit https://github.com/openpmix/prrte/commit/dd12d395dbf02331513ab31ab9e9993c275c6d60)