### PR TITLE
Fix compile warnings and valgrind errors.

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -567,9 +567,6 @@ int prte_ess_base_prted_finalize(void)
         prte_errmgr.finalize();
     }
 
-    /* shutdown the pmix server */
-    pmix_server_finalize();
-
     /* close frameworks */
     (void) prte_mca_base_framework_close(&prte_filem_base_framework);
     (void) prte_mca_base_framework_close(&prte_grpcomm_base_framework);
@@ -590,6 +587,9 @@ int prte_ess_base_prted_finalize(void)
     prte_session_dir_finalize(PRTE_PROC_MY_NAME);
     /* ensure we scrub the session directory tree */
     prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+
+    /* shutdown the pmix server */
+    pmix_server_finalize();
 
     return PRTE_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1187,8 +1187,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender, pmix_data_buf
             /* adjust the timeout to reflect the size of the job as it can take some
              * amount of time to start the job */
             PRTE_ADJUST_TIMEOUT(req);
-            /* we no longer need the info */
-            PMIX_INFO_FREE(info, ninfo);
             /* check us into the hotel */
             rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
             if (PMIX_SUCCESS != rc) {
@@ -1341,6 +1339,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
             PMIX_RETAIN(d);
             req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
         }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_RELEASE(req);
     } else {
         prte_output_verbose(2, prte_pmix_server_globals.output,
@@ -1359,7 +1358,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
                 PMIX_RETAIN(d);
                 req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
             }
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, rnum);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, rnum, NULL);
             PMIX_RELEASE(req);
         }
     }

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -327,28 +327,28 @@ static void dmodex_req(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(buf);
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->tproc, 1, PMIX_PROC))) {
         PMIX_ERROR_LOG(prc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* include the request room number for quick retrieval */
     if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->room_num, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     /* add any qualifiers */
     if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(prc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     if (0 < req->ninfo) {
         if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(prc);
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, req->room_num);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
             PMIX_DATA_BUFFER_RELEASE(buf);
             goto callback;
         }
@@ -358,7 +358,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
     PRTE_RML_SEND(rc, dmn->name.rank, buf, PRTE_RML_TAG_DIRECT_MODEX);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, NULL, req->room_num);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         prc = prte_pmix_convert_rc(rc);
         goto callback;


### PR DESCRIPTION
- Swap args to pmix_pointer_array_set_item().
- Set room to NULL after freeing the req.
- Don't set req-> info to a soon-to-be free'd info pointer.
- Call pmix_server_finalize() on remote daemon last.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>