### PR TITLE
schizos: add --version output for ompi and prte.

### DIFF
--- a/src/mca/schizo/ompi/help-schizo-ompi.txt
+++ b/src/mca/schizo/ompi/help-schizo-ompi.txt
@@ -8,6 +8,11 @@
 # $HEADER$
 #
 #
+[version]
+%s (%s) %s
+
+%s
+#
 [usage]
 %s (%s) %s
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -47,6 +47,7 @@
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/prte_cmd_line.h"
+#include "src/runtime/pmix_init_util.h"
 #include "src/util/session_dir.h"
 #include "src/util/show_help.h"
 
@@ -280,6 +281,17 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
             pargv[n] = strdup("--with-ft");
         }
 #endif
+    }
+
+    const char *tool_version = getenv("OMPI_VERSION");
+    const char *tool_name    = getenv("OMPI_TOOL_NAME");
+    // If the user is using prterun --personality ompi, these
+    // won't be set, and thus this is not mpirun/mpiexec.
+    if(tool_version && tool_name) {
+        pmix_tool_version  = tool_version;
+        pmix_tool_basename = tool_name;
+        pmix_tool_org      = "Open MPI";
+        pmix_tool_msg      = "Report bugs to https://www.open-mpi.org/community/help/";
     }
 
     rc = pmix_cmd_line_parse(pargv, ompishorts, ompioptions, NULL,

--- a/src/mca/schizo/prte/help-schizo-prte.txt
+++ b/src/mca/schizo/prte/help-schizo-prte.txt
@@ -8,6 +8,11 @@
 # $HEADER$
 #
 #
+[version]
+%s (%s) %s
+
+%s
+#
 [usage]
 %s (%s) %s
 

--- a/src/mca/schizo/prte/help-schizo-prted.txt
+++ b/src/mca/schizo/prte/help-schizo-prted.txt
@@ -8,6 +8,11 @@
 # $HEADER$
 #
 #
+[version]
+%s (%s) %s
+
+%s
+#
 [usage-prte]
 %s (%s) %s
 

--- a/src/mca/schizo/prte/help-schizo-prterun.txt
+++ b/src/mca/schizo/prte/help-schizo-prterun.txt
@@ -8,6 +8,11 @@
 # $HEADER$
 #
 #
+[version]
+%s (%s) %s
+
+%s
+#
 [usage]
 %s (%s) %s
 

--- a/src/mca/schizo/prte/help-schizo-prun.txt
+++ b/src/mca/schizo/prte/help-schizo-prun.txt
@@ -9,6 +9,11 @@
 #
 #
 #
+[version]
+%s (%s) %s
+
+%s
+#
 [usage]
 %s (%s) %s
 

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -53,6 +53,7 @@
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/runtime/prte_globals.h"
+#include "src/runtime/pmix_init_util.h"
 
 #include "schizo_prte.h"
 #include "src/mca/schizo/base/base.h"
@@ -459,6 +460,8 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         shorts = pinfoshorts;
         helpfile = "help-schizo-pinfo.txt";
     }
+    pmix_tool_msg = "Report bugs to: https://github.com/openpmix/prrte";
+
     rc = pmix_cmd_line_parse(argv, shorts, myoptions, NULL,
                              results, helpfile);
     if (PMIX_SUCCESS != rc) {


### PR DESCRIPTION
For mpirun/mpiexec, grab the tool name from the environment.
This is set before the exec of prterun.

Refs: https://github.com/open-mpi/ompi/pull/10120
Refs: https://github.com/open-mpi/ompi/issues/10096
Refs: https://github.com/openpmix/openpmix/pull/2514

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>