### PR TITLE
build: Do not use pkg-config with libevent

### DIFF
--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -61,7 +61,11 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
            prte_check_libevent_save_LIBS="$LIBS"
 
            AS_IF([test "$enable_libevent_lib_checks" != "no"],
-                 [OAC_CHECK_PACKAGE([libevent],
+                 [dnl Do not use pkg-config for libevent, because we need the pthreads interface
+                  dnl and the libevent_pthreads module will always pull in libevent instead of
+                  dnl libevent_core.
+                  libevent_USE_PKG_CONFIG=0
+                  OAC_CHECK_PACKAGE([libevent],
                                     [prte_libevent],
                                     [event.h],
                                     [event_core event_pthreads $with_libevent_extra_libs],


### PR DESCRIPTION
If pkg-config is installed, we should not use the libevent pkg-config
modules for configuration.  If we want pthread support, we would need
the libevent_pthreads module, which includes the full libevent instead
of libevent_core, which we don't want for LSF-ish reasons.

Patch 2488aa introduced a bug where we were looking for (and finding)
the libevent pkg-config module, which included the full libevent
library and no pthreads.  This surprisingly didn't break anything,
noticable, but isn't right.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>