### PR TITLE
build: Fix output stream bug in summary

### DIFF
--- a/config/prte_summary.m4
+++ b/config/prte_summary.m4
@@ -116,7 +116,7 @@ EOF
         AS_VAR_COPY([prte_summary_section_value], [prte_summary_section_${prte_summary_section}_value])
         echo "${prte_summary_section_name}" >&2
         echo "-----------------------" >&2
-        echo "${prte_summary_section_value}" | sort -f
+        echo "${prte_summary_section_value}" | sort -f >&2
         echo " " >&2
     done
 


### PR DESCRIPTION
a4fc04 introduced a bug where the summary section values were
sent to stdout instead of stderror like the rest of the summary.
This patch fixes that issue.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>