### PR TITLE
Correctly determine when to daemonize backend prted

### DIFF
--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -322,7 +322,7 @@ int main(int argc, char *argv[])
     /* detach from controlling terminal
      * otherwise, remain attached so output can get to us
      */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DAEMONIZE)) {
+    if (!prte_leave_session_attached && !prte_debug_daemons_flag) {
         pipe(wait_pipe);
         prte_state_base_parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);


### PR DESCRIPTION
We don't pass the --daemonize cmd line option to the prted's,
so look only at the --leave-session-attached and --debug-daemons
options

Signed-off-by: Ralph Castain <rhc@pmix.org>