### PR TITLE
Add some missing help verbiage

### DIFF
--- a/src/mca/schizo/prte/help-schizo-prte.txt
+++ b/src/mca/schizo/prte/help-schizo-prte.txt
@@ -39,6 +39,19 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
    --display                         Comma-delimited list of options for displaying information
 
 
+/*****      Output Options       *****/
+
+   --output <arg0>                   Comma-delimited list of options that control how output is
+                                     generated.Allowed values: tag, timestamp, xml, merge-stderr-to-stdout,
+                                     dir=DIRNAME, file=filename. The dir option redirects output from
+                                     application processes into DIRNAME/job/rank/std[out,err,diag]. The file
+                                     option redirects output from application processes into filename.rank. In
+                                     both cases, the provided name will be converted to an absolute path.
+                                     Supported qualifiers include NOCOPY (do not copy the output to the
+                                     stdout/err streams), and RAW (do not buffer the output into complete
+                                     lines, but instead output it as it is received).
+
+
 /*****      Launch Options       *****/
 
    --default-hostfile <arg0>         Provide a default hostfile

--- a/src/mca/schizo/prte/help-schizo-prterun.txt
+++ b/src/mca/schizo/prte/help-schizo-prterun.txt
@@ -57,7 +57,8 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
                                      option redirects output from application processes into filename.rank. In
                                      both cases, the provided name will be converted to an absolute path.
                                      Supported qualifiers include NOCOPY (do not copy the output to the
-                                     stdout/err streams).
+                                     stdout/err streams), and RAW (do not buffer the output into complete
+                                     lines, but instead output it as it is received).
    --report-child-jobs-separately    Return the exit status of the primary job only
    --xterm <arg0>                    Create a new xterm window and display output from the specified ranks
                                      there


### PR DESCRIPTION
prte supports the --output option, and include
the "raw" qualifier to it.

Signed-off-by: Ralph Castain <rhc@pmix.org>