### PR TITLE
Protect against proxy confusion

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -388,6 +388,9 @@ int main(int argc, char *argv[])
     if (NULL == personality) {
         personality = schizo->name;
     }
+    /* ensure we don't confuse any downstream PRRTE tools on
+     * choice of proxy since some environments forward their envars */
+    unsetenv("PRTE_MCA_schizo_proxy");
 
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -217,6 +217,10 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* ensure we aren't misdirected on choice of proxy since
+     * some environments forward their envars */
+    unsetenv("PRTE_MCA_schizo_proxy");
+
     /* initialize the globals */
     PMIX_DATA_BUFFER_CREATE(bucket);
     prte_tool_basename = pmix_basename(argv[0]);


### PR DESCRIPTION
If a wrapper set the schizo_proxy envar, we need to
ensure that setting doesn't propagate to any downstream
tools. This requires that prte itself not forward the
envar, but also that prted protects itself against the
host environment having forwarded it.

Signed-off-by: Ralph Castain <rhc@pmix.org>