### PR TITLE
Fix indirect slurm launch

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -764,7 +764,7 @@ int pmix_server_init(void)
 
     /* if we were launched by a debugger, then we need to have
      * notification of our termination sent */
-    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+    if (PRTE_PROC_IS_MASTER && NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
         if (PMIX_SUCCESS != prc) {
             PMIX_INFO_LIST_RELEASE(ilist);


### PR DESCRIPTION
Do not allow Slurm to forward PRRTE or PMIx envars
as that causes confusion on the backend.

Fixes https://github.com/openpmix/prrte/issues/1251
Fixes https://github.com/openpmix/prrte/issues/1252
Signed-off-by: Ralph Castain <rhc@pmix.org>