### PR TITLE
Restore use of "--cpu-bind=none".

### DIFF
--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -269,17 +269,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * This will *not* release the orteds from any cpu-set
      * constraint, but will ensure it doesn't get
      * bound to only one processor
-     *
-     * NOTE: We used to pass --cpu_bind=none on the command line.  But
-     * SLURM 19 changed this to --cpu-bind.  There is no easy way to
-     * test at run time which of these two parameters is used (see
-     * https://github.com/open-mpi/ompi/pull/6654).  There was
-     * discussion of using --test-only to see which one works, but
-     * --test-only is only effective if you're not already inside a
-     * SLURM allocation.  Instead, set the env var SLURM_CPU_BIND to
-     * "none", which should do the same thing as --cpu*bind=none.
      */
-    setenv("SLURM_CPU_BIND_TYPE", "none", true);
+    pmix_argv_append(&argc, &argv, "--cpu-bind=none");
 
     /* protect against launchers that forward the entire environment */
     if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {


### PR DESCRIPTION
This was silently replace in e0810859d7 with the SLURM_CPU_BIND_TYPE envvar
which is not parsed by the srun command.

This has been the preferred form since Slurm 17.11.

Remove archaic comment block while here - while it is true that Slurm
version 19.05.0 briefly removed support for the original "--cpu_bind"
form of the argument, this was reverted quickly in 19.05.1 to handle
backwards compatibility with OpenMPI. Still prefer the latest form here,
it is not expected for modern prrte to need to work in Slurm pre-17.11.

Signed-off-by: Tim Wickberg <tim@schedmd.com>