### PR TITLE
prtereachable: fix problem with nl-route

### DIFF
--- a/src/mca/prtereachable/netlink/Makefile.am
+++ b/src/mca/prtereachable/netlink/Makefile.am
@@ -44,5 +44,5 @@ mca_prtereachable_netlink_la_LIBADD = $(top_builddir)/src/libprrte.la \
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_prtereachable_netlink_la_SOURCES =$(sources)
-libmca_prtereachable_netlink_la_LDFLAGS = -module -avoid-version
+libmca_prtereachable_netlink_la_LDFLAGS = -module -avoid-version $(prte_reachable_netlink_LDFLAGS)
 libmca_prtereachable_netlink_la_LIBADD = $(prte_reachable_netlink_LIBS)


### PR DESCRIPTION
when its in a non-standard path.
observed trying to build main using spack on a system
where nl-route rpms aren't installed.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>