### PR TITLE
show_help: Don't display the message twice.

### DIFF
--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -773,10 +773,6 @@ static int show_help(const char *filename, const char *topic, const char *output
     }
     /* Not already displayed */
     else if (PRTE_ERR_NOT_FOUND == rc) {
-        if (NULL != prte_iof.output) {
-            /* send it to any connected tools */
-            prte_iof.output(sender, PRTE_IOF_STDDIAG, output);
-        }
         prte_output(output_stream, "%s", output);
         if (!show_help_timer_set) {
             show_help_time_last_displayed = now;


### PR DESCRIPTION
Print the help to stderr only, don't send it to the tool.
This restores behavior to be consistent with that of ORTE.

Refs: https://github.com/open-mpi/ompi/issues/10157

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>