### PR TITLE
prte: check if dvm actually got set up

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -22,6 +22,8 @@
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -718,6 +720,13 @@ int main(int argc, char *argv[])
     while (prte_event_base_active && !prte_dvm_ready) {
         prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
     }
+
+    /* check if something went wrong with setting up the dvm, bail out */
+    if (!prte_dvm_ready) {
+        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+        goto DONE;
+    }
+
     opt = prte_cmd_line_get_param(&results, PRTE_CLI_REPORT_PID);
     if (NULL != opt) {
         /* if the string is a "-", then output to stdout */


### PR DESCRIPTION
and if not, error out

related to #1317
related to #1318

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit de5b560e85529e4b2cddadc9dc07a091179ed161)

Conflicts:
	src/tools/prte/prte.c