### PR TITLE
v2.1: schizo/ompi: Convert all single dashes to double dashes.

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -50,8 +50,8 @@ This may result in unexpected behavior.
 WARNING: All multi-character command line options must be prefixed with double
 dashes, not a single dash:
 
-  Deprecated option:   %s
-  Corrected option:    %s
+  Deprecated option(s):   %s
+  Corrected  option(s):   %s
 
 We have updated this for you and will proceed. However, this will be treated
 as an error in a future release. Please update your command line.


### PR DESCRIPTION
This will preserve backwards compatability with the ompi v4
series with v5 and current master.

First, this restores the silent conversion of all single dash
args to multi-dash arguments.

Second, it will track and eventually print all offending ompi
args in a show-help message.

It does this by appending all single dash arguments
to an array, along with their position found in the arg list.
This is key, since we don't really knoew where the user executable
is on the list, and it isn't easy to tell. Luckily, pmix_arg_parse()
will store where the ompi args stops in results->tail. Therefore
all we need to know is if each offending argument came before results->tail
or not to decide if a warning should be printed for it. This will prevent
prte from erronously warning if the user executable is taking a single dash
option.

Prrte will parse the app arguments again later, so any changes to them
here are thrown away. The executable arguments are not impacted.

Refs https://github.com/open-mpi/ompi/issues/10097

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit 381a521d444a30c7598b0f2f89058121a1684b44)