### PR TITLE
v2.1: Revise show_help to use PMIx IOF

### DIFF
--- a/src/mca/errmgr/base/help-errmgr-base.txt
+++ b/src/mca/errmgr/base/help-errmgr-base.txt
@@ -15,6 +15,7 @@
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2022      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,8 +35,11 @@ address is unknown:
 The message could not be delivered, and we are aborting.
 #
 [failed-daemon-launch]
-PRTE was unable to reliably start one or more daemons.
+%s was unable to reliably start one or more daemons.
 This usually is caused by:
+
+* the inability to resolve specified hostnames - please check
+  above for any output regarding this possibility
 
 * not finding the required libraries and/or binaries on
   one or more nodes. Please check your PATH and LD_LIBRARY_PATH

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -649,7 +649,8 @@ keep_going:
         /* if this was a daemon, report it */
         if (PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
             /* output a message indicating we failed to launch a daemon */
-            prte_show_help("help-errmgr-base.txt", "failed-daemon-launch", true);
+            prte_show_help("help-errmgr-base.txt", "failed-daemon-launch",
+                           true, prte_tool_basename);
         }
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FAILED_TO_START);
         break;

--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -250,6 +250,10 @@ PRTE_EXPORT int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag
                                            prte_iof_write_event_t *channel);
 PRTE_EXPORT void prte_iof_base_write_handler(int fd, short event, void *cbdata);
 
+PRTE_EXPORT int prte_iof_base_output(const pmix_proc_t *peer,
+                                     prte_iof_tag_t source_tag,
+                                     const char *msg);
+
 END_C_DECLS
 
 #endif /* MCA_IOF_BASE_H */

--- a/src/mca/iof/iof.h
+++ b/src/mca/iof/iof.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -156,12 +156,6 @@ typedef int (*prte_iof_base_pull_fn_t)(const pmix_proc_t *peer, prte_iof_tag_t s
  */
 typedef int (*prte_iof_base_close_fn_t)(const pmix_proc_t *peer, prte_iof_tag_t source_tag);
 
-/**
- * Output something via the IOF subsystem
- */
-typedef int (*prte_iof_base_output_fn_t)(const pmix_proc_t *peer, prte_iof_tag_t source_tag,
-                                         const char *msg);
-
 typedef int (*prte_iof_base_push_stdin_fn_t)(const pmix_proc_t *dst_name, uint8_t *data, size_t sz);
 
 /* Flag that a job is complete */
@@ -178,7 +172,6 @@ struct prte_iof_base_module_2_0_0_t {
     prte_iof_base_push_fn_t push;
     prte_iof_base_pull_fn_t pull;
     prte_iof_base_close_fn_t close;
-    prte_iof_base_output_fn_t output;
     prte_iof_base_complete_fn_t complete;
     prte_iof_base_finalize_fn_t finalize;
     prte_iof_base_push_stdin_fn_t push_stdin;

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -70,7 +70,6 @@ static int prted_pull(const pmix_proc_t *src_name, prte_iof_tag_t src_tag, int f
 
 static int prted_close(const pmix_proc_t *peer, prte_iof_tag_t source_tag);
 
-static int prted_output(const pmix_proc_t *peer, prte_iof_tag_t source_tag, const char *msg);
 
 static void prted_complete(const prte_job_t *jdata);
 
@@ -89,7 +88,6 @@ prte_iof_base_module_t prte_iof_prted_module = {
     .push = prted_push,
     .pull = prted_pull,
     .close = prted_close,
-    .output = prted_output,
     .complete = prted_complete,
     .finalize = finalize,
 };
@@ -395,50 +393,4 @@ CHECK:
             prte_iof_prted_send_xonxoff(PRTE_IOF_XON);
         }
     }
-}
-
-static int prted_output(const pmix_proc_t *peer, prte_iof_tag_t source_tag, const char *msg)
-{
-    pmix_data_buffer_t *buf;
-    int rc;
-
-    /* prep the buffer */
-    PMIX_DATA_BUFFER_CREATE(buf);
-
-    /* pack the stream first - we do this so that flow control messages can
-     * consist solely of the tag
-     */
-    rc = PMIx_Data_pack(NULL, buf, &source_tag, 1, PMIX_UINT16);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        return rc;
-    }
-
-    /* pack name of process that gave us this data */
-    rc = PMIx_Data_pack(NULL, buf, (pmix_proc_t *) peer, 1, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        return rc;
-    }
-
-    /* pack the data - for compatibility, we have to pack this as PRTE_BYTE,
-     * so ensure we include the NULL string terminator */
-    rc = PMIx_Data_pack(NULL, buf, (void *) msg, strlen(msg) + 1, PMIX_BYTE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        return rc;
-    }
-
-    /* start non-blocking RML call to forward received data */
-    PRTE_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                         "%s iof:prted:output sending %d bytes to HNP",
-                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) strlen(msg) + 1));
-
-    prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, buf, PRTE_RML_TAG_IOF_HNP, prte_rml_send_callback,
-                            NULL);
-
-    return PRTE_SUCCESS;
 }

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "src/mca/iof/iof.h"
+#include "src/mca/iof/base/base.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/rml/rml.h"
 #include "src/pmix/pmix-internal.h"
@@ -53,7 +53,6 @@ bool prte_help_want_aggregate = false;
 static const char *default_filename = "help-messages";
 static const char *dash_line
     = "--------------------------------------------------------------------------\n";
-static int output_stream = -1;
 static char **search_dirs = NULL;
 static bool show_help_initialized = false;
 
@@ -108,6 +107,46 @@ static time_t show_help_time_last_displayed = 0;
 static bool show_help_timer_set = false;
 static prte_event_t show_help_timer_event;
 
+/* pass info the PMIx server for handling */
+static void lkcbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
+
+    PRTE_POST_OBJECT(lk);
+    lk->status = prte_pmix_convert_status(status);
+    PRTE_PMIX_WAKEUP_THREAD(lk);
+}
+
+static void local_delivery(const char *msg)
+{
+    pmix_byte_object_t bo;
+    prte_pmix_lock_t lock;
+    pmix_status_t rc;
+    int ret;
+
+    /* setup the byte object */
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+    if (NULL != msg) {
+        bo.bytes = (char *) msg;
+        bo.size = strlen(msg) + 1;
+    }
+    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+    rc = PMIx_server_IOF_deliver(&prte_process_info.myproc,
+                                 PMIX_FWD_STDDIAG_CHANNEL,
+                                 &bo, NULL, 0, lkcbfunc, (void *) &lock);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    } else {
+        /* wait for completion */
+        PRTE_PMIX_WAIT_THREAD(&lock);
+        if (PMIX_SUCCESS != lock.status) {
+            PMIX_ERROR_LOG(lock.status);
+        }
+    }
+    PRTE_PMIX_DESTRUCT_LOCK(&lock);
+}
+
+
 /*
  * Local functions
  */
@@ -117,16 +156,9 @@ static int show_help(const char *filename, const char *topic, const char *output
 
 int prte_show_help_init(void)
 {
-    prte_output_stream_t lds;
-
     if (show_help_initialized) {
         return PRTE_SUCCESS;
     }
-
-    PRTE_CONSTRUCT(&lds, prte_output_stream_t);
-    lds.lds_want_stderr = true;
-    output_stream = prte_output_open(&lds);
-    PRTE_DESTRUCT(&lds);
 
     PRTE_CONSTRUCT(&abd_tuples, prte_list_t);
 
@@ -152,8 +184,6 @@ void prte_show_help_finalize(void)
         return;
     }
 
-    prte_output_close(output_stream);
-    output_stream = -1;
     PRTE_LIST_DESTRUCT(&abd_tuples);
 
     /* destruct the search list */
@@ -212,6 +242,50 @@ static int array2string(char **outstring, int want_error_header, char **lines)
     return PRTE_SUCCESS;
 }
 
+static int send_hnp(const char *filename,
+                    const char *topic,
+                    const char *output)
+{
+    pmix_data_buffer_t *buf;
+    int rc;
+
+    /* build the message to the HNP */
+    PMIX_DATA_BUFFER_CREATE(buf);
+    /* pack the filename of the show_help text file */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &filename, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        rc = prte_pmix_convert_status(rc);
+        return rc;
+    }
+    /* pack the topic tag */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &topic, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        rc = prte_pmix_convert_status(rc);
+        return rc;
+    }
+    /* pack the string */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &output, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        rc = prte_pmix_convert_status(rc);
+        return rc;
+    }
+
+    /* send it via RML to the HNP */
+    if (0 > (rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, buf, PRTE_RML_TAG_SHOW_HELP,
+                                          prte_rml_send_callback, NULL))) {
+        PMIX_DATA_BUFFER_RELEASE(buf);
+    }
+
+    return rc;
+}
+
+
 /*
  * Find the right file to open
  */
@@ -219,8 +293,9 @@ static int open_file(const char *base, const char *topic)
 {
     char *filename;
     char *err_msg = NULL;
+    char *tmp;
     size_t base_len;
-    int i;
+    int i, rc;
 
     /* If no filename was supplied, use the default */
 
@@ -256,10 +331,17 @@ static int open_file(const char *base, const char *topic)
 
     /* If we still couldn't open it, then something is wrong */
     if (NULL == prte_show_help_yyin) {
-        prte_output(output_stream,
-                    "%sSorry!  You were supposed to get help about:\n    %s\nBut I couldn't open "
-                    "the help file:\n    %s.  Sorry!\n%s",
-                    dash_line, topic, err_msg, dash_line);
+        prte_asprintf(&tmp, "%sSorry!  You were supposed to get help about:\n    %s\nBut I couldn't open "
+                      "the help file:\n    %s.  Sorry!\n%s",
+                      dash_line, topic, err_msg, dash_line);
+        local_delivery(tmp);
+        if (PRTE_PROC_IS_DAEMON) {
+            rc = send_hnp(base, topic, tmp);
+            if (PRTE_SUCCESS != rc) {
+                PRTE_ERROR_LOG(rc);
+            }
+        }
+        free(tmp);
         free(err_msg);
         return PRTE_ERR_NOT_FOUND;
     }
@@ -308,10 +390,17 @@ static int find_topic(const char *base, const char *topic)
             break;
 
         case PRTE_SHOW_HELP_PARSE_DONE:
-            prte_output(output_stream,
-                        "%sSorry!  You were supposed to get help about:\n    %s\nfrom the file:\n  "
-                        "  %s\nBut I couldn't find that topic in the file.  Sorry!\n%s",
-                        dash_line, topic, base, dash_line);
+            prte_asprintf(&tmp, "%sSorry!  You were supposed to get help about:\n    %s\nfrom the file:\n  "
+                          "  %s\nBut I couldn't find that topic in the file.  Sorry!\n%s",
+                          dash_line, topic, base, dash_line);
+            local_delivery(tmp);
+            if (PRTE_PROC_IS_DAEMON) {
+                ret = send_hnp(base, topic, tmp);
+                if (PRTE_SUCCESS != ret) {
+                    PRTE_ERROR_LOG(ret);
+                }
+            }
+            free(tmp);
             return PRTE_ERR_NOT_FOUND;
 
         default:
@@ -408,22 +497,6 @@ char *prte_show_help_string(const char *filename, const char *topic, int want_er
     return output;
 }
 
-int prte_show_vhelp(const char *filename, const char *topic, int want_error_header, va_list arglist)
-{
-    char *output;
-
-    /* Convert it to a single string */
-    output = prte_show_help_vstring(filename, topic, want_error_header, arglist);
-
-    /* If we got a single string, output it with formatting */
-    if (NULL != output) {
-        prte_output(output_stream, "%s", output);
-        free(output);
-    }
-
-    return (NULL == output) ? PRTE_ERROR : PRTE_SUCCESS;
-}
-
 int prte_show_help(const char *filename, const char *topic, int want_error_header, ...)
 {
     va_list arglist;
@@ -455,7 +528,6 @@ int prte_show_help_norender(const char *filename, const char *topic,
 {
     int rc = PRTE_SUCCESS;
     int8_t have_output = 1;
-    pmix_data_buffer_t *buf;
     bool am_inside = false;
     PRTE_HIDE_UNUSED_PARAMS(want_error_header);
 
@@ -469,136 +541,24 @@ int prte_show_help_norender(const char *filename, const char *topic,
         goto CLEANUP;
     }
 
-    /* otherwise, we relay the output message to
-     * the HNP for processing
-     */
+    /* pass to the PMIx server in case we have a tool
+     * attached to us */
+    local_delivery(output);
+
+    /* relay the output message to the HNP for processing */
 
     /* JMS Note that we *may* have a recursion situation here where
        the RML could call show_help.  Need to think about this
        properly, but put a safeguard in here for sure for the time
        being. */
-    if (am_inside) {
-        rc = show_help(filename, topic, output, PRTE_PROC_MY_NAME);
-    } else {
+    if (!am_inside && PRTE_PROC_IS_DAEMON) {
         am_inside = true;
-
-        /* build the message to the HNP */
-        PMIX_DATA_BUFFER_CREATE(buf);
-        /* pack the filename of the show_help text file */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &filename, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto CLEANUP;
-        }
-        /* pack the topic tag */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &topic, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto CLEANUP;
-        }
-        /* pack the flag that we have a string */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &have_output, 1, PMIX_INT8);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto CLEANUP;
-        }
-        /* pack the resulting string */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &output, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto CLEANUP;
-        }
-
-        /* send it via RML to the HNP */
-
-        if (PRTE_SUCCESS
-            != (rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, buf, PRTE_RML_TAG_SHOW_HELP,
-                                             prte_rml_send_callback, NULL))) {
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            /* okay, that didn't work, output locally  */
-            prte_output(output_stream, "%s", output);
-        } else {
-            rc = PRTE_SUCCESS;
-        }
+        rc = send_hnp(filename, topic, output);
         am_inside = false;
     }
 
 CLEANUP:
     return rc;
-}
-
-int prte_show_help_suppress(const char *filename, const char *topic)
-{
-    int rc = PRTE_SUCCESS;
-    int8_t have_output = 0;
-    pmix_data_buffer_t *buf;
-    static bool am_inside = false;
-
-    if (prte_execute_quiet) {
-        return PRTE_SUCCESS;
-    }
-
-    /* If we are the HNP, or the RML has not yet been setup, or ROUTED
-       has not been setup, or we weren't given an HNP, then all we can
-       do is process this locally. */
-    if (PRTE_PROC_IS_MASTER || NULL == prte_rml.send_buffer_nb || NULL == prte_routed.get_route
-        || NULL == prte_process_info.my_hnp_uri) {
-        rc = show_help(filename, topic, NULL, PRTE_PROC_MY_NAME);
-        return rc;
-    }
-
-    /* otherwise, we relay the output message to
-     * the HNP for processing
-     */
-
-    /* JMS Note that we *may* have a recursion situation here where
-       the RML could call show_help.  Need to think about this
-       properly, but put a safeguard in here for sure for the time
-       being. */
-    if (am_inside) {
-        rc = show_help(filename, topic, NULL, PRTE_PROC_MY_NAME);
-    } else {
-        am_inside = true;
-
-        /* build the message to the HNP */
-        PMIX_DATA_BUFFER_CREATE(buf);
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &filename, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            return PRTE_SUCCESS;
-        }
-        /* pack the topic tag */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &topic, 1, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            return PRTE_SUCCESS;
-        }
-        /* pack the flag that we DO NOT have a string */
-        rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &have_output, 1, PMIX_INT8);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            return PRTE_SUCCESS;
-        }
-        /* send it to the HNP */
-        if (PRTE_SUCCESS
-            != (rc = prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, buf, PRTE_RML_TAG_SHOW_HELP,
-                                             prte_rml_send_callback, NULL))) {
-            PRTE_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            /* okay, that didn't work, just process locally error, just ignore return  */
-            show_help(filename, topic, NULL, PRTE_PROC_MY_NAME);
-        }
-        am_inside = false;
-    }
-
-    return PRTE_SUCCESS;
 }
 
 /*
@@ -689,6 +649,7 @@ static void show_accumulated_duplicates(int fd, short event, void *context)
 {
     time_t now = time(NULL);
     tuple_list_item_t *tli;
+    char *tmp;
     PRTE_HIDE_UNUSED_PARAMS(fd, event, context);
 
     /* Loop through all the messages we've displayed and see if any
@@ -698,15 +659,18 @@ static void show_accumulated_duplicates(int fd, short event, void *context)
     {
         if (tli->tli_display && tli->tli_count_since_last_display > 0) {
             static bool first = true;
-            prte_output(0, "%d more process%s sent help message %s / %s",
-                        tli->tli_count_since_last_display,
-                        (tli->tli_count_since_last_display > 1) ? "es have" : " has",
-                        tli->tli_filename, tli->tli_topic);
+            prte_asprintf(&tmp, "%d more process%s sent help message %s / %s",
+                          tli->tli_count_since_last_display,
+                          (tli->tli_count_since_last_display > 1) ? "es have" : " has",
+                          tli->tli_filename, tli->tli_topic);
+            local_delivery(tmp);
+            free(tmp);
             tli->tli_count_since_last_display = 0;
 
             if (first) {
-                prte_output(0, "Set MCA parameter \"prte_base_help_aggregate\" to 0 to see all "
-                               "help / error messages");
+                tmp = "Set MCA parameter \"prte_base_help_aggregate\" to 0 to see all "
+                      "help / error messages";
+                local_delivery(tmp);
                 first = false;
             }
         }
@@ -778,11 +742,7 @@ static int show_help(const char *filename, const char *topic, const char *output
     }
     /* Not already displayed */
     else if (PRTE_ERR_NOT_FOUND == rc) {
-        if (NULL != prte_iof.output) {
-            /* send it to any connected tools */
-            prte_iof.output(sender, PRTE_IOF_STDDIAG, output);
-        }
-        prte_output(output_stream, "%s", output);
+        local_delivery(output);
         if (!show_help_timer_set) {
             show_help_time_last_displayed = now;
         }
@@ -816,7 +776,6 @@ void prte_show_help_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *bu
     char *output = NULL;
     char *filename = NULL, *topic = NULL;
     int32_t n;
-    int8_t have_output;
     int rc;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
@@ -837,22 +796,12 @@ void prte_show_help_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *bu
         PMIX_ERROR_LOG(rc);
         goto cleanup;
     }
-    /* unpack the flag */
+    /* unpack output string */
     n = 1;
-    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &have_output, &n, PMIX_INT8);
+    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &output, &n, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto cleanup;
-    }
-
-    /* If we have an output string, unpack it */
-    if (have_output) {
-        n = 1;
-        rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &output, &n, PMIX_STRING);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            goto cleanup;
-        }
     }
 
     /* Send it to show_help */

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -136,13 +136,6 @@ PRTE_EXPORT void prte_show_help_finalize(void);
 PRTE_EXPORT int prte_show_help(const char *filename, const char *topic, int want_error_header, ...);
 
 /**
- * This function does the same thing as prte_show_help(), but accepts
- * a va_list form of varargs.
- */
-PRTE_EXPORT int prte_show_vhelp(const char *filename, const char *topic, int want_error_header,
-                                va_list ap);
-
-/**
  * This function does the same thing as prte_show_help(), but returns
  * its output in a string (that must be freed by the caller).
  */
@@ -177,15 +170,6 @@ PRTE_EXPORT int prte_show_help_norender(const char *filename, const char *topic,
  * interfering with the linked PRTE libs when they need to do show_help.
  */
 PRTE_EXPORT int prte_show_help_add_dir(const char *directory);
-
-/**
- * Pretend that this message has already been shown.
- *
- * Sends a control message to the HNP that will effectively suppress
- * this message from being shown.  Primitive *-wildcarding is
- * possible.
- */
-PRTE_EXPORT int prte_show_help_suppress(const char *filename, const char *topic);
 
 PRTE_EXPORT void prte_show_help_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                                      prte_rml_tag_t tag, void *cbdata);


### PR DESCRIPTION
When a daemon or the controller emits a "show_help" message,
we want it to go to any attached tools that request the
STDDIAG channel. In addition, we want it to output to stderr
if the user has requested that we do so. In the case of output
to the local screen, ensure it only comes once.

While we are at it, fix the "unable to launch daemons" message
so it includes the case of unresolved nodenames.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 7ae2c083189db0881d2eff29d71bd507be02bad3)