### PR TITLE
Add atomistic error outputs

### DIFF
--- a/src/mca/iof/base/iof_base_setup.c
+++ b/src/mca/iof/base/iof_base_setup.c
@@ -64,6 +64,7 @@
 #endif
 
 #include "src/mca/errmgr/errmgr.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
@@ -115,19 +116,19 @@ int prte_iof_base_setup_prefork(prte_iof_base_io_conf_t *opts)
     if (ret < 0) {
         opts->usepty = 0;
         if (pipe(opts->p_stdout) < 0) {
-            PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_PIPES);
-            return PRTE_ERR_SYS_LIMITS_PIPES;
+            PMIX_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
+            return PMIX_ERR_SYS_LIMITS_PIPES;
         }
     }
     if (opts->connect_stdin) {
         if (pipe(opts->p_stdin) < 0) {
-            PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_PIPES);
-            return PRTE_ERR_SYS_LIMITS_PIPES;
+            PMIX_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
+            return PMIX_ERR_SYS_LIMITS_PIPES;
         }
     }
     if (pipe(opts->p_stderr) < 0) {
-        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_PIPES);
-        return PRTE_ERR_SYS_LIMITS_PIPES;
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
+        return PMIX_ERR_SYS_LIMITS_PIPES;
     }
     return PRTE_SUCCESS;
 }
@@ -148,7 +149,7 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
         /* disable echo */
         struct termios term_attrs;
         if (tcgetattr(opts->p_stdout[1], &term_attrs) < 0) {
-            return PRTE_ERR_PIPE_SETUP_FAILURE;
+            return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
         term_attrs.c_lflag &= ~(ECHO | ECHOE | ECHOK | ECHOCTL | ECHOKE | ECHONL);
         term_attrs.c_iflag &= ~(ICRNL | INLCR | ISTRIP | INPCK | IXON);
@@ -160,18 +161,18 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
 #endif
             ONLCR);
         if (tcsetattr(opts->p_stdout[1], TCSANOW, &term_attrs) == -1) {
-            return PRTE_ERR_PIPE_SETUP_FAILURE;
+            return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
         ret = dup2(opts->p_stdout[1], fileno(stdout));
         if (ret < 0) {
-            return PRTE_ERR_PIPE_SETUP_FAILURE;
+            return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
         close(opts->p_stdout[1]);
     } else {
         if (opts->p_stdout[1] != fileno(stdout)) {
             ret = dup2(opts->p_stdout[1], fileno(stdout));
             if (ret < 0) {
-                return PRTE_ERR_PIPE_SETUP_FAILURE;
+                return PMIX_ERR_PIPE_SETUP_FAILURE;
             }
             close(opts->p_stdout[1]);
         }
@@ -180,7 +181,7 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
         if (opts->p_stdin[0] != fileno(stdin)) {
             ret = dup2(opts->p_stdin[0], fileno(stdin));
             if (ret < 0) {
-                return PRTE_ERR_PIPE_SETUP_FAILURE;
+                return PMIX_ERR_PIPE_SETUP_FAILURE;
             }
             close(opts->p_stdin[0]);
         }
@@ -198,7 +199,7 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
     if (opts->p_stderr[1] != fileno(stderr)) {
         ret = dup2(opts->p_stderr[1], fileno(stderr));
         if (ret < 0) {
-            return PRTE_ERR_PIPE_SETUP_FAILURE;
+            return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
         close(opts->p_stderr[1]);
     }

--- a/src/mca/odls/alps/odls_alps_module.c
+++ b/src/mca/odls/alps/odls_alps_module.c
@@ -112,6 +112,7 @@
 
 #include "src/class/pmix_pointer_array.h"
 #include "src/hwloc/hwloc-internal.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_fd.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/show_help.h"
@@ -585,12 +586,12 @@ static int odls_alps_fork_local_proc(void *cdptr)
        then the exec() succeeded.  If the parent reads something from
        the pipe, then the child was letting us know why it failed. */
     if (pipe(p) < 0) {
-        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_PIPES);
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
         if (NULL != cd->child) {
             cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-            cd->child->exit_code = PRTE_ERR_SYS_LIMITS_PIPES;
+            cd->child->exit_code = PMIX_ERR_SYS_LIMITS_PIPES;
         }
-        return PRTE_ERR_SYS_LIMITS_PIPES;
+        return PMIX_ERR_SYS_LIMITS_PIPES;
     }
 
     /* Fork off the child */
@@ -600,12 +601,12 @@ static int odls_alps_fork_local_proc(void *cdptr)
     }
 
     if (pid < 0) {
-        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_CHILDREN);
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_LIMITS_CHILDREN);
         if (NULL != cd->child) {
             cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-            cd->child->exit_code = PRTE_ERR_SYS_LIMITS_CHILDREN;
+            cd->child->exit_code = PMIX_ERR_SYS_LIMITS_CHILDREN;
         }
-        return PRTE_ERR_SYS_LIMITS_CHILDREN;
+        return PMIX_ERR_SYS_LIMITS_CHILDREN;
     }
 
     if (pid == 0) {
@@ -631,7 +632,8 @@ int prte_odls_alps_launch_local_procs(pmix_data_buffer_t *data)
     int rc;
 
     /* construct the list of children we are to launch */
-    if (PRTE_SUCCESS != (rc = prte_odls_base_default_construct_child_list(data, &job))) {
+    rc = prte_odls_base_default_construct_child_list(data, &job);
+    if (PRTE_SUCCESS != rc) {
         PRTE_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
                              "%s odls:alps:launch:local failed to construct child list on error %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
@@ -640,8 +642,8 @@ int prte_odls_alps_launch_local_procs(pmix_data_buffer_t *data)
 
     /* get the RDMA credentials and push them into the launch environment */
 
-    if (PRTE_SUCCESS != (rc = prte_odls_alps_get_rdma_creds())) {
-        ;
+    rc = prte_odls_alps_get_rdma_creds();
+    if (PRTE_SUCCESS != rc) {
         PRTE_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
                              "%s odls:alps:launch:failed to get GNI rdma credentials %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
@@ -693,8 +695,8 @@ static int prte_odls_alps_signal_local_procs(const pmix_proc_t *proc, int32_t si
 {
     int rc;
 
-    if (PRTE_SUCCESS
-        != (rc = prte_odls_base_default_signal_local_procs(proc, signal, send_signal))) {
+    rc = prte_odls_base_default_signal_local_procs(proc, signal, send_signal);
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }
@@ -706,8 +708,8 @@ static int prte_odls_alps_restart_proc(prte_proc_t *child)
     int rc;
 
     /* restart the local proc */
-    if (PRTE_SUCCESS
-        != (rc = prte_odls_base_default_restart_proc(child, odls_alps_fork_local_proc))) {
+    rc = prte_odls_base_default_restart_proc(child, odls_alps_fork_local_proc);
+    if (PRTE_SUCCESS != rc) {
         PRTE_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
                              "%s odls:alps:restart_proc failed to launch on error %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +48,23 @@ PRTE_EXPORT int prte_odls_base_select(void);
 PRTE_EXPORT void prte_odls_base_start_threads(prte_job_t *jdata);
 
 PRTE_EXPORT void prte_odls_base_harvest_threads(void);
+
+#define PRTE_ODLS_SET_ERROR(ns, s, j)                                                   \
+do {                                                                                    \
+    int _idx;                                                                           \
+    prte_proc_t *_cld;                                                                  \
+    for (_idx = 0; _idx < prte_local_children->size; _idx++) {                          \
+        _cld = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, _idx);  \
+        if (NULL == _cld) {                                                             \
+            continue;                                                                   \
+        }                                                                               \
+        if (PMIX_CHECK_NSPACE(ns, _cld->name.nspace) &&                                 \
+            (-1 == j || j == _cld->app_idx)) {                                          \
+            _cld->exit_code = s;                                                        \
+            PRTE_ACTIVATE_PROC_STATE(&_cld->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);    \
+        }                                                                               \
+    }                                                                                   \
+} while(0)
 
 END_C_DECLS
 #endif

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -116,6 +116,7 @@
 
 #include "src/class/pmix_pointer_array.h"
 #include "src/hwloc/hwloc-internal.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_fd.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/show_help.h"
@@ -614,12 +615,12 @@ static int odls_default_fork_local_proc(void *cdptr)
        then the exec() succeeded.  If the parent reads something from
        the pipe, then the child was letting us know why it failed. */
     if (pipe(p) < 0) {
-        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_PIPES);
+        PRTE_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
         if (NULL != child) {
             child->state = PRTE_PROC_STATE_FAILED_TO_START;
-            child->exit_code = PRTE_ERR_SYS_LIMITS_PIPES;
+            child->exit_code = PMIX_ERR_SYS_LIMITS_PIPES;
         }
-        return PRTE_ERR_SYS_LIMITS_PIPES;
+        return PMIX_ERR_SYS_LIMITS_PIPES;
     }
 
     /* Fork off the child */
@@ -629,12 +630,12 @@ static int odls_default_fork_local_proc(void *cdptr)
     }
 
     if (pid < 0) {
-        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_CHILDREN);
+        PRTE_ERROR_LOG(PMIX_ERR_SYS_LIMITS_CHILDREN);
         if (NULL != child) {
             child->state = PRTE_PROC_STATE_FAILED_TO_START;
-            child->exit_code = PRTE_ERR_SYS_LIMITS_CHILDREN;
+            child->exit_code = PMIX_ERR_SYS_LIMITS_CHILDREN;
         }
-        return PRTE_ERR_SYS_LIMITS_CHILDREN;
+        return PMIX_ERR_SYS_LIMITS_CHILDREN;
     }
 
     if (pid == 0) {
@@ -657,11 +658,11 @@ int prte_odls_default_launch_local_procs(pmix_data_buffer_t *data)
     pmix_nspace_t job;
 
     /* construct the list of children we are to launch */
-    if (PRTE_SUCCESS != (rc = prte_odls_base_default_construct_child_list(data, &job))) {
-        PRTE_OUTPUT_VERBOSE(
-            (2, prte_odls_base_framework.framework_output,
-             "%s odls:default:launch:local failed to construct child list on error %s",
-             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
+    rc = prte_odls_base_default_construct_child_list(data, &job);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
+                             "%s odls:default:launch:local failed to construct child list on error %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
         return rc;
     }
 
@@ -723,8 +724,8 @@ static int prte_odls_default_signal_local_procs(const pmix_proc_t *proc, int32_t
 {
     int rc;
 
-    if (PRTE_SUCCESS
-        != (rc = prte_odls_base_default_signal_local_procs(proc, signal, send_signal))) {
+    rc = prte_odls_base_default_signal_local_procs(proc, signal, send_signal);
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }
@@ -736,8 +737,8 @@ static int prte_odls_default_restart_proc(prte_proc_t *child)
     int rc;
 
     /* restart the local proc */
-    if (PRTE_SUCCESS
-        != (rc = prte_odls_base_default_restart_proc(child, odls_default_fork_local_proc))) {
+    rc = prte_odls_base_default_restart_proc(child, odls_default_fork_local_proc);
+    if (PRTE_SUCCESS != rc) {
         PRTE_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
                              "%s odls:default:restart_proc failed to launch on error %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -105,25 +105,30 @@ static char *print_aborted_job(prte_job_t *job, prte_app_context_t *approc, prte
 {
     char *output = NULL;
 
-    if (PRTE_PROC_STATE_FAILED_TO_START == proc->state
-        || PRTE_PROC_STATE_FAILED_TO_LAUNCH == proc->state) {
+    if (PRTE_PROC_STATE_FAILED_TO_START == proc->state ||
+        PRTE_PROC_STATE_FAILED_TO_LAUNCH == proc->state) {
         switch (proc->exit_code) {
         case PMIX_ERR_SILENT:
         case PRTE_ERR_SILENT:
             /* say nothing - it was already reported */
             break;
-        case PRTE_ERR_SYS_LIMITS_PIPES:
+        case PMIX_ERR_SYS_LIMITS_PIPES:
             output = prte_show_help_string("help-prun.txt", "prun:sys-limit-pipe", true,
                                            prte_tool_basename, node->name,
                                            (unsigned long) proc->name.rank);
             break;
-        case PRTE_ERR_PIPE_SETUP_FAILURE:
+        case PMIX_ERR_PIPE_SETUP_FAILURE:
             output = prte_show_help_string("help-prun.txt", "prun:pipe-setup-failure", true,
                                            prte_tool_basename, node->name,
                                            (unsigned long) proc->name.rank);
             break;
-        case PRTE_ERR_SYS_LIMITS_CHILDREN:
+        case PMIX_ERR_SYS_LIMITS_CHILDREN:
             output = prte_show_help_string("help-prun.txt", "prun:sys-limit-children", true,
+                                           prte_tool_basename, node->name,
+                                           (unsigned long) proc->name.rank);
+            break;
+        case PMIX_ERR_SYS_LIMITS_FILES:
+            output = prte_show_help_string("help-prun.txt", "prun:sys-limit-files", true,
                                            prte_tool_basename, node->name,
                                            (unsigned long) proc->name.rank);
             break;

--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -198,6 +198,19 @@ increasing your limit descriptor setting (using limit or ulimit commands),
 asking the system administrator for that node to increase the system limit, or
 by rearranging your processes to place fewer of them on that node.
 #
+[prun:sys-limit-files]
+%s was unable to launch the specified application as it encountered an error:
+
+Error: system limit exceeded on number of files that can be open
+Node: %s
+
+when attempting to start process rank %lu.
+
+This can be resolved by setting the mca parameter opal_set_max_sys_limits to 1,
+increasing your limit descriptor setting (using limit or ulimit commands),
+asking the system administrator for that node to increase the system limit, or
+by rearranging your processes to place fewer of them on that node.
+#
 [prun:sys-limit-sockets]
 Error: system limit exceeded on number of network connections that can be open
 


### PR DESCRIPTION
Handle the system limits on pipes, children and files. Also
handle the pipe setup failure.

Signed-off-by: Ralph Castain <rhc@pmix.org>