### PR TITLE
Cached num numas

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -19,7 +19,7 @@
  * Copyright (C) 2018      Mellanox Technologies, Ltd.
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
- * Copyright (c) 2019-2020 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -223,6 +223,8 @@ int prte_hwloc_base_filter_cpus(hwloc_topology_t topo)
     sum = (prte_hwloc_topo_data_t *) root->userdata;
 
     /* should only ever enter here once, but check anyway */
+    /* (?) but sum->available isn't exclusively set here so */
+    /* this doesn't guarantee filter_cpus has already been called */
     if (NULL != sum->available) {
         return PRTE_SUCCESS;
     }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1648,6 +1648,13 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                     root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
                 }
                 sum = (prte_hwloc_topo_data_t *) root->userdata;
+                /* If we set sum->available without first calling filter_cpus()
+                 * then any subsequent filter_cpus() call will early-return
+                 * and it won't set up a cached value for sum->num_numas.  I'm
+                 * uncertain if fixing by calling filter_cpus() here is better,
+                 * or if the early-return in filter_cpus() is the problem.
+                 */
+                prte_hwloc_base_filter_cpus(topo);
                 sum->available = prte_hwloc_base_setup_summary(topo);
                 /* cleanup */
                 PMIX_DATA_BUFFER_DESTRUCT(data);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -1239,7 +1239,13 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender, pmix_data_bu
     /* setup the summary data for this topology as we will need
      * it when we go to map/bind procs to it */
     root = hwloc_get_root_obj(topo);
-    root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+    /* I made a PR to add an "if" around several root->userdata = PMIX_NEW()
+     * locations.  But this is the only one I actually saw cause a problem
+     * at runtime where it threw away previously cached data.
+     */
+    if (NULL == root->userdata) {
+        root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+    }
     sum = (prte_hwloc_topo_data_t *) root->userdata;
     sum->available = prte_hwloc_base_setup_summary(topo);
 
@@ -1638,7 +1644,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                 /* setup the summary data for this topology as we will need
                  * it when we go to map/bind procs to it */
                 root = hwloc_get_root_obj(topo);
-                root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+                if (NULL == root->userdata) {
+                    root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+                }
                 sum = (prte_hwloc_topo_data_t *) root->userdata;
                 sum->available = prte_hwloc_base_setup_summary(topo);
                 /* cleanup */

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -859,6 +859,13 @@ int prte_util_parse_node_info(pmix_data_buffer_t *buf)
                     root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
                 }
                 sum = (prte_hwloc_topo_data_t *) root->userdata;
+                /* I'm concerned about how this sets up sum->available thus if
+                 * a prte_hwloc_base_filter_cpus() happens in the future that
+                 * function will early-return without caching a sum->num_numas.
+                 * But I'm not currently adding a filter_cpus() call here since
+                 * I don't have a testcase that's exercising this codepath to
+                 * be confident adding that call here is a good fix.
+                 */
                 sum->available = prte_hwloc_base_setup_summary(topo);
                 t2->index = pmix_pointer_array_add(prte_node_topologies, t2);
             }

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -854,7 +855,9 @@ int prte_util_parse_node_info(pmix_data_buffer_t *buf)
                 t2->topo = topo;
                 /* need to ensure the summary is setup */
                 root = hwloc_get_root_obj(topo);
-                root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+                if (NULL == root->userdata) {
+                    root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
+                }
                 sum = (prte_hwloc_topo_data_t *) root->userdata;
                 sum->available = prte_hwloc_base_setup_summary(topo);
                 t2->index = pmix_pointer_array_add(prte_node_topologies, t2);


### PR DESCRIPTION
There were a couple problems with the caching of num_numas that are set up inside prte_hwloc_base_filter_cpus().

One of these commits is for a case where a value is set but then overwritten when a new topo->userdata = PMIX_NEW() is called after a userdata had already been set up.

The other commit is for a case where prte_hwloc_base_filter_cpus() early-returns because it thinks it's already been called.  I'm not sure it should be keying off of sum->available the way it is, since sum->available is set in other places.  My fix for that involves adding the filter_cpus() in front of the sum->available setting in the codepath where I observed the failure