### PR TITLE
starting round robin at first core on each node

### DIFF
--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
- * Copyright (c) 2021      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -660,7 +660,7 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app, pmix_list_t 
             /* if this is a comm_spawn situation, start with the object
              * where the parent left off and increment */
             if (!PMIX_NSPACE_INVALID(jdata->originator.nspace) && UINT_MAX != jdata->bkmark_obj) {
-                start = (jdata->bkmark_obj + 1) % nobjs;
+                start = node->num_procs % nobjs;
             }
             /* compute the number of procs to go on this node */
             if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {


### PR DESCRIPTION
The previous code was using a single global trying to let spawn pick back
up where it left off, but that variable didn't change on a per-node basis.
So in a 2-host run for example
  -host hostA:2,hostB:1
it was mapping
> hostA:
>   R0: [xx/../../..][../../../..]
>   R1: [../xx/../..][../../../..]
> hostB:
>   R2: [../../xx/..][../../../..]

Signed-off-by: Mark Allen <markalle@us.ibm.com>

----------------------------------------------------------------------------

There's a confusing aspect to this where some runs "work" even though all the runs look very suspicious in the round robin mapper.

First here are two outputs, one "good" and one "bad"
ssh c685f8n02 mpirun --map-by core --host c685f8n02:2,c685f8n03:1 --report-bindings ./x
pretty-printed affinity:
```
H0: [<aaaa/bbbb/..../..../..../..../..../..../..../..../..../..../..../..../....
      ..../..../..../..../..../..../....>][<..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../..../..../..../..../..../..../....>]
      Lranks 0-1
H1: [<aaaa/..../..../..../..../..../..../..../..../..../..../..../..../..../....
      ..../..../..../..../..../..../....>][<..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../..../..../..../..../..../..../....>]
      Lrank 0
```
But a similar run (where I change the mpirun node from n02 to n03):
ssh c685f8n03 mpirun --map-by core --host c685f8n02:2,c685f8n03:1 --report-bindings ./x
pretty-printed affinity:
```
H0: [<aaaa/bbbb/..../..../..../..../..../..../..../..../..../..../..../..../....
      ..../..../..../..../..../..../....>][<..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../..../..../..../..../..../..../....>]
      Lranks 0-1
H1: [<..../..../aaaa/..../..../..../..../..../..../..../..../..../..../..../....
      ..../..../..../..../..../..../....>][<..../..../..../..../..../..../..../.
      ../..../..../..../..../..../..../..../..../..../..../..../..../..../....>]
      Lrank 0
```

And even the "good" case I think is still a problem, because when I printf as it goes through prte_rmaps_rr_byobj() if I let the code use the `start = (jdata->bkmark_obj + 1) % nobjs` like before this PR, then it walks the 3 ranks doing prte_hwloc_base_get_obj_by_type() with index 0, then 1, then 2.  That last one being on a new node where I want it to be using index 0.  But when it uses index 2 it gets back an obj with cpuset 0x00000f00 and that's what it puts into proc.attributes PRTE_PROC_HWLOC_LOCALE.

Somehow after that in the "good" runs it manages to change that later and get the correct final result, although in a way that's more disturbing considering the mapper chose 0x00000f00 for that rank.

Anyway if we use the change from this PR, then the three get_obj_by_type() calls use index 0, then 1, then 0 so the mapper indexing starts at the first obj on each host.