### PR TITLE
 Use PMIx_Log() for show_help() messages.

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -252,12 +252,6 @@ static int rte_init(int argc, char **argv)
     /* it is now safe to start the pmix server */
     pmix_server_start();
 
-    /* and register our show_help recv */
-    PRTE_RML_RECV(PRTE_NAME_WILDCARD,
-                  PRTE_RML_TAG_SHOW_HELP,
-                  PRTE_RML_PERSISTENT,
-                  prte_show_help_recv, NULL);
-
     /*
      * Group communications
      */

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1365,15 +1365,31 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
     PMIX_RELEASE(d); // maintain accounting
 }
 
+
+static void log_cbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_log_info_t *info = (prte_log_info_t *) cbdata;
+    if(PMIX_SUCCESS != status && PMIX_OPERATION_SUCCEEDED != status) {
+        prte_output(prte_pmix_server_globals.output, "%s", info->msg);
+    }
+    PMIX_INFO_DESTRUCT(info->info);
+    if(info->dirs) {
+        PMIX_INFO_DESTRUCT(info->dirs);
+    }
+    free(info->msg);
+    free(info);
+}
+
+
 static void pmix_server_log(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                             prte_rml_tag_t tg, void *cbdata)
 {
     int rc;
     int32_t cnt;
-    size_t n, ninfo;
-    pmix_info_t *info, directives[2];
+    size_t n, ninfo, ndirs;
+    pmix_info_t *info, *directives, *directives_new;
     pmix_status_t ret;
-    pmix_byte_object_t *boptr;
+    pmix_byte_object_t boptr;
     pmix_data_buffer_t pbkt;
 
     /* unpack the number of info */
@@ -1384,7 +1400,16 @@ static void pmix_server_log(int status, pmix_proc_t *sender, pmix_data_buffer_t 
         return;
     }
 
-    /* unpack the blob */
+   /* unpack the number of directives */
+   cnt = 1;
+   rc = PMIx_Data_unpack(NULL, buffer, &ndirs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    PMIX_BYTE_OBJECT_CONSTRUCT(&boptr);
+    /* unpack the info blob */
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &boptr, &cnt, PMIX_BYTE_OBJECT);
     if (PMIX_SUCCESS != rc) {
@@ -1394,7 +1419,7 @@ static void pmix_server_log(int status, pmix_proc_t *sender, pmix_data_buffer_t 
 
     PMIX_INFO_CREATE(info, ninfo);
     PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
-    rc = PMIx_Data_load(&pbkt, boptr);
+    rc = PMIx_Data_load(&pbkt, &boptr);
     for (n = 0; n < ninfo; n++) {
         cnt = 1;
         ret = PMIx_Data_unpack(NULL, &pbkt, (void *) &info[n], &cnt, PMIX_INFO);
@@ -1402,21 +1427,63 @@ static void pmix_server_log(int status, pmix_proc_t *sender, pmix_data_buffer_t 
             PMIX_ERROR_LOG(ret);
             PMIX_INFO_FREE(info, ninfo);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_BYTE_OBJECT_DESTRUCT(&boptr);
             return;
         }
     }
     PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+    PMIX_BYTE_OBJECT_DESTRUCT(&boptr);
 
-    /* mark that we only want it logged once */
-    PMIX_INFO_LOAD(&directives[0], PMIX_LOG_ONCE, NULL, PMIX_BOOL);
+    PMIX_BYTE_OBJECT_CONSTRUCT(&boptr);
+    /* unpack the directives blob */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &boptr, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_BYTE_OBJECT_CONSTRUCT(&boptr);
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    PMIX_INFO_CREATE(directives, ndirs);
+    PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
+    rc = PMIx_Data_load(&pbkt, &boptr);
+    for (n = 0; n < ndirs; n++) {
+        cnt = 1;
+        ret = PMIx_Data_unpack(NULL, &pbkt, (void *) &directives[n], &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_INFO_FREE(directives, ndirs);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_BYTE_OBJECT_CONSTRUCT(&boptr);
+            return;
+        }
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+    PMIX_BYTE_OBJECT_CONSTRUCT(&boptr);
+
+    /* Transfer directives, and mark that we only want it logged once */
+    PMIX_INFO_CREATE(directives_new, ndirs + 2);
+    for (n = 0; n < ndirs; n++) {
+        PMIX_INFO_XFER(&directives_new[n], &directives[n]);
+    }
+
+    bool no_loop = true;
+    PMIX_INFO_LOAD(&directives_new[n++], PMIX_LOG_ONCE, &no_loop, PMIX_BOOL);
     /* protect against infinite loop should the PMIx server push
      * this back up to us */
-    PMIX_INFO_LOAD(&directives[1], "prte.log.noloop", NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&directives_new[n++], "prte.log.noloop", &no_loop, PMIX_BOOL);
 
+    prte_log_info_t *data = calloc(1, sizeof(prte_log_info_t));
+    data->info = info;
+    data->dirs = directives_new;
     /* pass the array down to be logged */
-    PMIx_Log(info, ninfo, directives, 2);
-    PMIX_INFO_FREE(info, ninfo + 1);
-    PMIX_INFO_DESTRUCT(&directives[1]);
+    rc = PMIx_Log_nb(info, ninfo, directives_new, n, log_cbfunc, data);
+    if(PMIX_SUCCESS != rc) {
+        PMIX_INFO_FREE(info, ninfo);
+        PMIX_INFO_FREE(directives_new, n);
+        PMIX_INFO_FREE(directives, ndirs);
+        free(data);
+    }
 }
 
 /****    INSTANTIATE LOCAL OBJECTS    ****/

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -141,9 +141,6 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 #define PRTE_RML_TAG_ALLGATHER_BRUCKS 34
 #define PRTE_RML_TAG_ALLGATHER_RCD    35
 
-/* show help */
-#define PRTE_RML_TAG_SHOW_HELP 36
-
 /* debugger release */
 #define PRTE_RML_TAG_DEBUGGER_RELEASE 37
 

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -462,8 +462,9 @@ int main(int argc, char *argv[])
     if (NULL != opt) {
         prte_pmix_server_globals.report_uri = strdup(opt->values[0]);
     }
-    /* don't aggregate help messages as that will apply job-to-job */
-    pmix_setenv("PRTE_MCA_prte_base_help_aggregate", "0", true, &environ);
+
+    /* aggregate messages from prte. */
+    pmix_setenv("PRTE_MCA_prte_base_help_aggregate", "1", true, &environ);
 
     /* if we are supporting a singleton, push its ID into the environ
      * so it can get picked up and registered by server init */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -343,6 +343,8 @@ int main(int argc, char *argv[])
     /* ensure we silence any compression warnings */
     pmix_setenv("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
 
+    /* Aggregate any show helps from prted. */
+    pmix_setenv("PRTE_MCA_prte_base_help_aggregate", "1", true, &environ);
     if (PRTE_SUCCESS != (ret = prte_init(&argc, &argv, PRTE_PROC_DAEMON))) {
         PRTE_ERROR_LOG(ret);
         return ret;

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -35,7 +35,6 @@
 
 #include "src/mca/iof/base/base.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
-#include "src/rml/rml.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/pmix_argv.h"
@@ -56,111 +55,58 @@ static const char *dash_line
 static char **search_dirs = NULL;
 static bool show_help_initialized = false;
 
-/* List items for holding (filename, topic) tuples */
-typedef struct {
-    pmix_list_item_t super;
-    /* The filename */
-    char *tli_filename;
-    /* The topic */
-    char *tli_topic;
-    /* List of process names that have displayed this (filename, topic) */
-    pmix_list_t tli_processes;
-    /* Time this message was displayed */
-    time_t tli_time_displayed;
-    /* Count of processes since last display (i.e., "new" processes
-       that have showed this message that have not yet been output) */
-    int tli_count_since_last_display;
-    /* Do we want to display these? */
-    bool tli_display;
-} tuple_list_item_t;
-static void tuple_list_item_constructor(tuple_list_item_t *obj)
-{
-    obj->tli_filename = NULL;
-    obj->tli_topic = NULL;
-    PMIX_CONSTRUCT(&(obj->tli_processes), pmix_list_t);
-    obj->tli_time_displayed = time(NULL);
-    obj->tli_count_since_last_display = 0;
-    obj->tli_display = true;
-}
-
-static void tuple_list_item_destructor(tuple_list_item_t *obj)
-{
-    if (NULL != obj->tli_filename) {
-        free(obj->tli_filename);
-    }
-    if (NULL != obj->tli_topic) {
-        free(obj->tli_topic);
-    }
-    PMIX_LIST_DESTRUCT(&(obj->tli_processes));
-}
-static PMIX_CLASS_INSTANCE(tuple_list_item_t, pmix_list_item_t, tuple_list_item_constructor,
-                           tuple_list_item_destructor);
-
-/* List of (filename, topic) tuples that have already been displayed */
-static pmix_list_t abd_tuples;
-
-/* How long to wait between displaying duplicate show_help notices */
-static struct timeval show_help_interval = {5, 0};
-
-/* Timer for displaying duplicate help message notices */
-static time_t show_help_time_last_displayed = 0;
-static bool show_help_timer_set = false;
-static prte_event_t show_help_timer_event;
-
-/* pass info the PMIx server for handling */
-static void lkcbfunc(pmix_status_t status, void *cbdata)
-{
-    prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
-
-    PMIX_POST_OBJECT(lk);
-    lk->status = prte_pmix_convert_status(status);
-    PRTE_PMIX_WAKEUP_THREAD(lk);
-}
-
-static void local_delivery(const char *msg)
-{
-    pmix_byte_object_t bo;
-    prte_pmix_lock_t lock;
-    pmix_status_t rc;
-    int ret;
-
-    /* setup the byte object */
-    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
-    if (NULL != msg) {
-        bo.bytes = (char *) msg;
-        bo.size = strlen(msg) + 1;
-    }
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    rc = PMIx_server_IOF_deliver(&prte_process_info.myproc,
-                                 PMIX_FWD_STDDIAG_CHANNEL,
-                                 &bo, NULL, 0, lkcbfunc, (void *) &lock);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-    } else {
-        /* wait for completion */
-        PRTE_PMIX_WAIT_THREAD(&lock);
-        if (PMIX_SUCCESS != lock.status) {
-            PMIX_ERROR_LOG(lock.status);
-        }
-    }
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-}
-
-
 /*
  * Local functions
  */
-static void show_accumulated_duplicates(int fd, short event, void *context);
-static int show_help(const char *filename, const char *topic, const char *output,
-                     pmix_proc_t *sender);
+static void prte_show_help_cbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_log_info_t *info = (prte_log_info_t *) cbdata;
+    if(PMIX_SUCCESS != status && PMIX_OPERATION_SUCCEEDED != status) {
+        fprintf(stderr, "%s", info -> msg);
+    }
+    PMIX_INFO_DESTRUCT(info -> info);
+    if(info -> dirs) {
+        PMIX_INFO_DESTRUCT(info -> dirs);
+    }
+    free(info -> msg);
+    free(info);
+}
+
+static void local_delivery(const char *file, const char *topic, char *msg) {
+
+    pmix_info_t *info, *dirs;
+    int ninfo = 0, ndirs = 0;
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[ninfo++], PMIX_LOG_STDERR, msg, PMIX_STRING);
+
+    prte_log_info_t *cbdata = calloc(1, sizeof(prte_log_info_t));
+    if(prte_help_want_aggregate) {
+        PMIX_INFO_CREATE(dirs, 3);
+        PMIX_INFO_LOAD(&dirs[ndirs++], PMIX_LOG_AGG, &prte_help_want_aggregate, PMIX_BOOL);
+        PMIX_INFO_LOAD(&dirs[ndirs++], PMIX_LOG_KEY, file, PMIX_STRING);
+        PMIX_INFO_LOAD(&dirs[ndirs++], PMIX_LOG_VAL, topic, PMIX_STRING);
+        cbdata -> dirs = dirs;
+    }
+
+    cbdata -> info = info;
+    cbdata -> msg  = msg;
+
+    prte_status_t rc = PMIx_Log_nb(info, ninfo, dirs, ndirs, prte_show_help_cbfunc, cbdata);
+    if(PMIX_SUCCESS != rc) {
+        PMIX_INFO_DESTRUCT(info);
+        if(prte_help_want_aggregate) {
+            PMIX_INFO_DESTRUCT(dirs);
+        }
+        free(msg);
+        free(cbdata);
+    }
+}
 
 int prte_show_help_init(void)
 {
     if (show_help_initialized) {
         return PRTE_SUCCESS;
     }
-
-    PMIX_CONSTRUCT(&abd_tuples, pmix_list_t);
 
     pmix_argv_append_nosize(&search_dirs, prte_install_dirs.prtedatadir);
     show_help_initialized = true;
@@ -175,16 +121,9 @@ void prte_show_help_finalize(void)
 
     /* Shutdown show_help, showing final messages */
     if (PRTE_PROC_IS_MASTER) {
-        show_accumulated_duplicates(0, 0, NULL);
-        PMIX_LIST_DESTRUCT(&abd_tuples);
-        if (show_help_timer_set) {
-            prte_event_evtimer_del(&show_help_timer_event);
-        }
         show_help_initialized = false;
         return;
     }
-
-    PMIX_LIST_DESTRUCT(&abd_tuples);
 
     /* destruct the search list */
     if (NULL != search_dirs) {
@@ -242,49 +181,6 @@ static int array2string(char **outstring, int want_error_header, char **lines)
     return PRTE_SUCCESS;
 }
 
-static int send_hnp(const char *filename,
-                    const char *topic,
-                    const char *output)
-{
-    pmix_data_buffer_t *buf;
-    int rc;
-
-    /* build the message to the HNP */
-    PMIX_DATA_BUFFER_CREATE(buf);
-    /* pack the filename of the show_help text file */
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &filename, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        rc = prte_pmix_convert_status(rc);
-        return rc;
-    }
-    /* pack the topic tag */
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &topic, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        rc = prte_pmix_convert_status(rc);
-        return rc;
-    }
-    /* pack the string */
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buf, &output, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        rc = prte_pmix_convert_status(rc);
-        return rc;
-    }
-
-    /* send it via RML to the HNP */
-    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SHOW_HELP);
-    if (PRTE_SUCCESS != rc) {
-        PMIX_DATA_BUFFER_RELEASE(buf);
-    }
-
-    return rc;
-}
-
 
 /*
  * Find the right file to open
@@ -334,14 +230,7 @@ static int open_file(const char *base, const char *topic)
         pmix_asprintf(&tmp, "%sSorry!  You were supposed to get help about:\n    %s\nBut I couldn't open "
                       "the help file:\n    %s.  Sorry!\n%s",
                       dash_line, topic, err_msg, dash_line);
-        local_delivery(tmp);
-        if (PRTE_PROC_IS_DAEMON) {
-            rc = send_hnp(base, topic, tmp);
-            if (PRTE_SUCCESS != rc) {
-                PRTE_ERROR_LOG(rc);
-            }
-        }
-        free(tmp);
+        local_delivery(topic, err_msg, tmp);
         free(err_msg);
         return PRTE_ERR_NOT_FOUND;
     }
@@ -393,14 +282,7 @@ static int find_topic(const char *base, const char *topic)
             pmix_asprintf(&tmp, "%sSorry!  You were supposed to get help about:\n    %s\nfrom the file:\n  "
                           "  %s\nBut I couldn't find that topic in the file.  Sorry!\n%s",
                           dash_line, topic, base, dash_line);
-            local_delivery(tmp);
-            if (PRTE_PROC_IS_DAEMON) {
-                ret = send_hnp(base, topic, tmp);
-                if (PRTE_SUCCESS != ret) {
-                    PRTE_ERROR_LOG(ret);
-                }
-            }
-            free(tmp);
+            local_delivery(topic, base, tmp);
             return PRTE_ERR_NOT_FOUND;
 
         default:
@@ -513,7 +395,6 @@ int prte_show_help(const char *filename, const char *topic, int want_error_heade
     }
 
     rc = prte_show_help_norender(filename, topic, want_error_header, output);
-    free(output);
     return rc;
 }
 
@@ -528,292 +409,16 @@ int prte_show_help_norender(const char *filename, const char *topic,
 {
     int rc = PRTE_SUCCESS;
     int8_t have_output = 1;
-    bool am_inside = false;
     PRTE_HIDE_UNUSED_PARAMS(want_error_header);
-
-    /* if we are the HNP, or the RML has not yet been setup,
-     * or ROUTED has not been setup,
-     * or we weren't given an HNP, then all we can do is process this locally
-     */
-    if (PRTE_PROC_IS_MASTER || NULL == prte_process_info.my_hnp_uri) {
-        rc = show_help(filename, topic, output, PRTE_PROC_MY_NAME);
-        goto CLEANUP;
-    }
 
     /* pass to the PMIx server in case we have a tool
      * attached to us */
-    local_delivery(output);
-
-    /* relay the output message to the HNP for processing */
-
-    /* JMS Note that we *may* have a recursion situation here where
-       the RML could call show_help.  Need to think about this
-       properly, but put a safeguard in here for sure for the time
-       being. */
-    if (!am_inside && PRTE_PROC_IS_DAEMON) {
-        am_inside = true;
-        rc = send_hnp(filename, topic, output);
-        am_inside = false;
+    if(output) {
+        // strdup() it - so show_help owns a copy of this string,
+        // and let the caller do what they want with the original string.
+        local_delivery(filename, topic, strdup(output));
     }
 
 CLEANUP:
     return rc;
-}
-
-/*
- * Returns PRTE_SUCCESS if the strings match; PRTE_ERROR otherwise.
- */
-static int match(const char *a, const char *b)
-{
-    int rc = PRTE_ERROR;
-    char *p1, *p2, *tmp1 = NULL, *tmp2 = NULL;
-    size_t min;
-
-    /* Check straight string match first */
-    if (0 == strcmp(a, b))
-        return PRTE_SUCCESS;
-
-    if (NULL != strchr(a, '*') || NULL != strchr(b, '*')) {
-        tmp1 = strdup(a);
-        if (NULL == tmp1) {
-            return PRTE_ERR_OUT_OF_RESOURCE;
-        }
-        tmp2 = strdup(b);
-        if (NULL == tmp2) {
-            free(tmp1);
-            return PRTE_ERR_OUT_OF_RESOURCE;
-        }
-        p1 = strchr(tmp1, '*');
-        p2 = strchr(tmp2, '*');
-
-        if (NULL != p1) {
-            *p1 = '\0';
-        }
-        if (NULL != p2) {
-            *p2 = '\0';
-        }
-        min = strlen(tmp1);
-        if (strlen(tmp2) < min) {
-            min = strlen(tmp2);
-        }
-        if (0 == min || 0 == strncmp(tmp1, tmp2, min)) {
-            rc = PRTE_SUCCESS;
-        }
-        free(tmp1);
-        free(tmp2);
-        return rc;
-    }
-
-    /* No match */
-    return PRTE_ERROR;
-}
-
-/*
- * Check to see if a given (filename, topic) tuple has been displayed
- * already.  Return PRTE_SUCCESS if so, or PRTE_ERR_NOT_FOUND if not.
- *
- * Always return a tuple_list_item_t representing this (filename,
- * topic) entry in the list of "already been displayed tuples" (if it
- * wasn't in the list already, this function will create a new entry
- * in the list and return it).
- *
- * Note that a list is not an overly-efficient mechanism for this kind
- * of data.  The assupmtion is that there will only be a small numebr
- * of (filename, topic) tuples displayed so the storage required will
- * be fairly small, and linear searches will be fast enough.
- */
-static int get_tli(const char *filename, const char *topic, tuple_list_item_t **tli)
-{
-    /* Search the list for a duplicate. */
-    PMIX_LIST_FOREACH(*tli, &abd_tuples, tuple_list_item_t)
-    {
-        if (PRTE_SUCCESS == match((*tli)->tli_filename, filename)
-            && PRTE_SUCCESS == match((*tli)->tli_topic, topic)) {
-            return PRTE_SUCCESS;
-        }
-    }
-
-    /* Nope, we didn't find it -- make a new one */
-    *tli = PMIX_NEW(tuple_list_item_t);
-    if (NULL == *tli) {
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-    (*tli)->tli_filename = strdup(filename);
-    (*tli)->tli_topic = strdup(topic);
-    pmix_list_append(&abd_tuples, &((*tli)->super));
-    return PRTE_ERR_NOT_FOUND;
-}
-
-static void show_accumulated_duplicates(int fd, short event, void *context)
-{
-    time_t now = time(NULL);
-    tuple_list_item_t *tli;
-    char *tmp;
-    PRTE_HIDE_UNUSED_PARAMS(fd, event, context);
-
-    /* Loop through all the messages we've displayed and see if any
-       processes have sent duplicates that have not yet been displayed
-       yet */
-    PMIX_LIST_FOREACH(tli, &abd_tuples, tuple_list_item_t)
-    {
-        if (tli->tli_display && tli->tli_count_since_last_display > 0) {
-            static bool first = true;
-            pmix_asprintf(&tmp, "%d more process%s sent help message %s / %s",
-                          tli->tli_count_since_last_display,
-                          (tli->tli_count_since_last_display > 1) ? "es have" : " has",
-                          tli->tli_filename, tli->tli_topic);
-            local_delivery(tmp);
-            free(tmp);
-            tli->tli_count_since_last_display = 0;
-
-            if (first) {
-                tmp = "Set MCA parameter \"prte_base_help_aggregate\" to 0 to see all "
-                      "help / error messages";
-                local_delivery(tmp);
-                first = false;
-            }
-        }
-    }
-
-    show_help_time_last_displayed = now;
-    show_help_timer_set = false;
-}
-
-static int show_help(const char *filename, const char *topic, const char *output,
-                     pmix_proc_t *sender)
-{
-    int rc;
-    tuple_list_item_t *tli = NULL;
-    prte_namelist_t *pnli;
-    time_t now = time(NULL);
-
-    /* If we're aggregating, check for duplicates.  Otherwise, don't
-       track duplicates at all and always display the message. */
-    if (prte_help_want_aggregate) {
-        rc = get_tli(filename, topic, &tli);
-    } else {
-        rc = PRTE_ERR_NOT_FOUND;
-    }
-
-    /* If there's no output string (i.e., this is a control message
-       asking us to suppress), then skip to the end. */
-    if (NULL == output) {
-        tli->tli_display = false;
-        goto after_output;
-    }
-
-    /* Was it already displayed? */
-    if (PRTE_SUCCESS == rc) {
-        /* Yes.  But do we want to print anything?  That's complicated.
-
-           We always show the first message of a given (filename,
-           topic) tuple as soon as it arrives.  But we don't want to
-           show duplicate notices often, because we could get overrun
-           with them.  So we want to gather them up and say "We got N
-           duplicates" every once in a while.
-
-           And keep in mind that at termination, we'll unconditionally
-           show all accumulated duplicate notices.
-
-           A simple scheme is as follows:
-           - when the first of a (filename, topic) tuple arrives
-             - print the message
-             - if a timer is not set, set T=now
-           - when a duplicate (filename, topic) tuple arrives
-             - if now>(T+5) and timer is not set (due to
-               non-pre-emptiveness of our libevent, a timer *could* be
-               set!)
-               - print all accumulated duplicates
-               - reset T=now
-             - else if a timer was not set, set the timer for T+5
-             - else if a timer was set, do nothing (just wait)
-           - set T=now when the timer expires
-        */
-        ++tli->tli_count_since_last_display;
-        if (now > show_help_time_last_displayed + 5 && !show_help_timer_set) {
-            show_accumulated_duplicates(0, 0, NULL);
-        } else if (!show_help_timer_set) {
-            prte_event_evtimer_set(prte_event_base, &show_help_timer_event,
-                                   show_accumulated_duplicates, NULL);
-            prte_event_evtimer_add(&show_help_timer_event, &show_help_interval);
-            show_help_timer_set = true;
-        }
-    }
-    /* Not already displayed */
-    else if (PRTE_ERR_NOT_FOUND == rc) {
-        local_delivery(output);
-        if (!show_help_timer_set) {
-            show_help_time_last_displayed = now;
-        }
-    }
-    /* Some other error occurred */
-    else {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
-
-after_output:
-    /* If we're aggregating, add this process name to the list */
-    if (prte_help_want_aggregate) {
-        pnli = PMIX_NEW(prte_namelist_t);
-        if (NULL == pnli) {
-            rc = PRTE_ERR_OUT_OF_RESOURCE;
-            PRTE_ERROR_LOG(rc);
-            return rc;
-        }
-        pnli->name = *sender;
-        pmix_list_append(&(tli->tli_processes), &(pnli->super));
-    }
-    return PRTE_SUCCESS;
-}
-
-/* Note that this function is called from ess/hnp, so don't make it
-   static */
-void prte_show_help_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
-                         prte_rml_tag_t tag, void *cbdata)
-{
-    char *output = NULL;
-    char *filename = NULL, *topic = NULL;
-    int32_t n;
-    int rc;
-    PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
-
-    PRTE_OUTPUT_VERBOSE((5, prte_debug_output, "%s got show_help from %s",
-                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)));
-
-    /* unpack the filename of the show_help text file */
-    n = 1;
-    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &filename, &n, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto cleanup;
-    }
-    /* unpack the topic tag */
-    n = 1;
-    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &topic, &n, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto cleanup;
-    }
-    /* unpack output string */
-    n = 1;
-    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buffer, &output, &n, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto cleanup;
-    }
-
-    /* Send it to show_help */
-    rc = show_help(filename, topic, output, sender);
-
-cleanup:
-    if (NULL != output) {
-        free(output);
-    }
-    if (NULL != filename) {
-        free(filename);
-    }
-    if (NULL != topic) {
-        free(topic);
-    }
 }

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -103,6 +103,13 @@
 
 BEGIN_C_DECLS
 
+typedef struct {
+    pmix_info_t *info;
+    pmix_info_t *dirs;
+    char *msg;
+} prte_log_info_t;
+
+
 /**
  * \internal
  *
@@ -170,9 +177,6 @@ PRTE_EXPORT int prte_show_help_norender(const char *filename, const char *topic,
  * interfering with the linked PRTE libs when they need to do show_help.
  */
 PRTE_EXPORT int prte_show_help_add_dir(const char *directory);
-
-PRTE_EXPORT void prte_show_help_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
-                                     prte_rml_tag_t tag, void *cbdata);
 
 END_C_DECLS
 


### PR DESCRIPTION
This moves a lot of dead code in show_help.c to OpenPMIx,
which will now do the de-duping and aggregation for us
via the PMIx_Log() function.

Otherwise the other big change is that the directives
are now packaged up as well as the infos. Othwewise
when prrte is forwarding the logging messages to the hnp,
it will miss out on any aggregation requests.

PMIx side change: https://github.com/openpmix/openpmix/pull/2569

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>