### PR TITLE
prrte: fix core dump while printing stack-trace

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -333,6 +333,8 @@ static void stack_trace_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t
     prte_pointer_array_t parray;
     int rc;
     pmix_byte_object_t bo;
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&blob);    
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     prte_output_verbose(5, prte_plm_base_framework.framework_output,


### PR DESCRIPTION
(cherry-picked from commit: 5ee9b5abba1b81ad0c90e06d85fb8a8e0e706564)

Signed-off-by: Aboorva Devarajan <abodevar@in.ibm.com>