### PR TITLE
Incremental valgrind improvements

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -218,13 +218,9 @@ static int init(void)
 
 static int finalize(void)
 {
-    pmix_list_item_t *item;
-
-    /* cleanup the proc state machine */
-    while (NULL != (item = pmix_list_remove_first(&prte_proc_states))) {
-        PMIX_RELEASE(item);
-    }
-    PMIX_DESTRUCT(&prte_proc_states);
+    /* cleanup the state machines */
+    PMIX_LIST_DESTRUCT(&prte_proc_states);
+    PMIX_LIST_DESTRUCT(&prte_job_states);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -147,17 +147,9 @@ static int init(void)
 
 static int finalize(void)
 {
-    pmix_list_item_t *item;
-
     /* cleanup the state machines */
-    while (NULL != (item = pmix_list_remove_first(&prte_job_states))) {
-        PMIX_RELEASE(item);
-    }
-    PMIX_DESTRUCT(&prte_job_states);
-    while (NULL != (item = pmix_list_remove_first(&prte_proc_states))) {
-        PMIX_RELEASE(item);
-    }
-    PMIX_DESTRUCT(&prte_proc_states);
+    PMIX_LIST_DESTRUCT(&prte_proc_states);
+    PMIX_LIST_DESTRUCT(&prte_job_states);
 
     return PRTE_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -619,7 +619,7 @@ int pmix_server_init(void)
     /* if PMIx is version 4 or higher, then we can pass our
      * topology object down to the server library for its use
      * and for passing to any local clients */
-    mytopology.source = strdup("hwloc");
+    mytopology.source = "hwloc";
     mytopology.topology = prte_hwloc_topology;
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_TOPOLOGY2, &mytopology, PMIX_TOPO);
     if (PMIX_SUCCESS != prc) {
@@ -907,7 +907,8 @@ void pmix_server_finalize(void)
         return;
     }
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s Finalizing PMIX server",
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s Finalizing PMIX server",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* stop receives */
@@ -936,7 +937,6 @@ void pmix_server_finalize(void)
     PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
-    free(mytopology.source);
 
     /* shutdown the local server */
     PMIx_server_finalize();

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -36,6 +36,8 @@
 #include "src/util/output.h"
 
 #include "src/mca/base/prte_mca_base_alias.h"
+#include "src/mca/base/prte_mca_base_var.h"
+#include "src/mca/base/base.h"
 #include "src/mca/ess/base/base.h"
 #include "src/mca/ess/ess.h"
 #include "src/runtime/prte_globals.h"
@@ -136,9 +138,6 @@ int prte_finalize(void)
     }
     PMIX_RELEASE(prte_node_pool);
 
-    free(prte_process_info.nodename);
-    prte_process_info.nodename = NULL;
-
     /* Close the general debug stream */
     prte_output_close(prte_debug_output);
 
@@ -148,6 +147,11 @@ int prte_finalize(void)
     if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
         return rc;
     }
+    (void) prte_mca_base_framework_close(&prte_ess_base_framework);
+    prte_proc_info_finalize();
+
+    prte_output_finalize();
+    prte_mca_base_close();
 
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
We don't really care about being valgrind clean in PRRTE
as it isn't a library. However, it can make it easier for
debug if we do a better job of cleanup at finalize, so
begin the process of doing so.

Signed-off-by: Ralph Castain <rhc@pmix.org>