### PR TITLE
Updates from master branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -548,7 +548,7 @@ PRTE_SEARCH_LIBS_CORE([sched_yield], [rt])
 # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
 PRTE_SEARCH_LIBS_CORE([ceil], [m])
 
-AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf fork  setsid strsignal syslog  setpgid])
+AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf fork  setsid strsignal syslog setpgid fileno_unlocked])
 
 # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
 # confused.  On others, it's in the standard library, but stubbed with

--- a/src/mca/iof/base/iof_base_setup.c
+++ b/src/mca/iof/base/iof_base_setup.c
@@ -163,14 +163,23 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
         if (tcsetattr(opts->p_stdout[1], TCSANOW, &term_attrs) == -1) {
             return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
+#ifdef HAVE_FILENO_UNLOCKED
+        ret = dup2(opts->p_stdout[1], fileno_unlocked(stdout));
+#else
         ret = dup2(opts->p_stdout[1], fileno(stdout));
+#endif
         if (ret < 0) {
             return PMIX_ERR_PIPE_SETUP_FAILURE;
         }
         close(opts->p_stdout[1]);
     } else {
+#ifdef HAVE_FILENO_UNLOCKED
+        if (opts->p_stdout[1] != fileno_unlocked(stdout)) {
+            ret = dup2(opts->p_stdout[1], fileno_unlocked(stdout));
+#else
         if (opts->p_stdout[1] != fileno(stdout)) {
             ret = dup2(opts->p_stdout[1], fileno(stdout));
+#endif
             if (ret < 0) {
                 return PMIX_ERR_PIPE_SETUP_FAILURE;
             }
@@ -178,8 +187,13 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
         }
     }
     if (opts->connect_stdin) {
+#ifdef HAVE_FILENO_UNLOCKED
+        if (opts->p_stdin[0] != fileno_unlocked(stdin)) {
+            ret = dup2(opts->p_stdin[0], fileno_unlocked(stdin));
+#else
         if (opts->p_stdin[0] != fileno(stdin)) {
             ret = dup2(opts->p_stdin[0], fileno(stdin));
+#endif
             if (ret < 0) {
                 return PMIX_ERR_PIPE_SETUP_FAILURE;
             }
@@ -196,8 +210,13 @@ int prte_iof_base_setup_child(prte_iof_base_io_conf_t *opts,
         close(fd);
     }
 
+#ifdef HAVE_FILENO_UNLOCKED
+    if (opts->p_stderr[1] != fileno_unlocked(stderr)) {
+        ret = dup2(opts->p_stderr[1], fileno_unlocked(stderr));
+#else
     if (opts->p_stderr[1] != fileno(stderr)) {
         ret = dup2(opts->p_stderr[1], fileno(stderr));
+#endif
         if (ret < 0) {
             return PMIX_ERR_PIPE_SETUP_FAILURE;
         }

--- a/src/mca/odls/alps/odls_alps_module.c
+++ b/src/mca/odls/alps/odls_alps_module.c
@@ -536,7 +536,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
         /* Print out what we got.  We already have a rendered string,
            so use pmix_show_help_norender(). */
         if (msg.msg_str_len > 0) {
-            pmix_show_help_norender(file, topic, false, str);
+            pmix_show_help_norender(file, topic, str);
             free(str);
             str = NULL;
         }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -567,7 +567,7 @@ int pmix_server_init(void)
     int rc;
     void *ilist;
     pmix_data_array_t darray;
-    pmix_info_t *info;
+    pmix_info_t *info, myinf;
     size_t n, ninfo;
     char *tmp;
     pmix_status_t prc;
@@ -621,7 +621,11 @@ int pmix_server_init(void)
      * and for passing to any local clients */
     mytopology.source = "hwloc";
     mytopology.topology = prte_hwloc_topology;
-    PMIX_INFO_LIST_ADD(prc, ilist, PMIX_TOPOLOGY2, &mytopology, PMIX_TOPO);
+    PMIX_INFO_CONSTRUCT(&myinf);
+    PMIX_LOAD_KEY(myinf.key, PMIX_TOPOLOGY2);
+    myinf.value.type = PMIX_TOPO;
+    myinf.value.data.topo = &mytopology;
+    PMIX_INFO_LIST_INSERT(prc, ilist, &myinf);
     if (PMIX_SUCCESS != prc) {
         PMIX_INFO_LIST_RELEASE(ilist);
         return rc;
@@ -939,7 +943,6 @@ void pmix_server_finalize(void)
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
 
     /* shutdown the local server */
-    PMIx_server_finalize();
     prte_pmix_server_globals.initialized = false;
 }
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -619,7 +619,7 @@ int pmix_server_init(void)
     /* if PMIx is version 4 or higher, then we can pass our
      * topology object down to the server library for its use
      * and for passing to any local clients */
-    mytopology.source = strdup("hwloc");
+    mytopology.source = "hwloc";
     mytopology.topology = prte_hwloc_topology;
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_TOPOLOGY2, &mytopology, PMIX_TOPO);
     if (PMIX_SUCCESS != prc) {
@@ -907,7 +907,8 @@ void pmix_server_finalize(void)
         return;
     }
 
-    prte_output_verbose(2, prte_pmix_server_globals.output, "%s Finalizing PMIX server",
+    prte_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s Finalizing PMIX server",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* stop receives */
@@ -936,7 +937,6 @@ void pmix_server_finalize(void)
     PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
-    free(mytopology.source);
 
     /* shutdown the local server */
     PMIx_server_finalize();

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -36,6 +36,8 @@
 #include "src/util/output.h"
 
 #include "src/mca/base/prte_mca_base_alias.h"
+#include "src/mca/base/prte_mca_base_var.h"
+#include "src/mca/base/base.h"
 #include "src/mca/ess/base/base.h"
 #include "src/mca/ess/ess.h"
 #include "src/runtime/prte_globals.h"
@@ -136,9 +138,6 @@ int prte_finalize(void)
     }
     PMIX_RELEASE(prte_node_pool);
 
-    free(prte_process_info.nodename);
-    prte_process_info.nodename = NULL;
-
     /* Close the general debug stream */
     prte_output_close(prte_debug_output);
 
@@ -148,6 +147,11 @@ int prte_finalize(void)
     if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
         return rc;
     }
+    (void) prte_mca_base_framework_close(&prte_ess_base_framework);
+    prte_proc_info_finalize();
+
+    prte_output_finalize();
+    prte_mca_base_close();
 
     return PRTE_SUCCESS;
 }

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -151,7 +151,12 @@ int prte_finalize(void)
     prte_proc_info_finalize();
 
     prte_output_finalize();
+    prte_mca_base_var_finalize();
     prte_mca_base_close();
+
+    /* now shutdown PMIx - need to do this last as it finalizes
+     * the utilities and class system we depend upon */
+    PMIx_server_finalize();
 
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
[odls: fix alps compilation problem](https://github.com/openpmix/prrte/commit/bdf2f3881c61acf7f47f57805b83694e05ee60ba)

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f09d98a4f7921a952f077147d151cf6a8fd21db1)

[Incremental valgrind improvements](https://github.com/openpmix/prrte/commit/f130fdf5760787ca153a775ed31ed9de284a65b9)

We don't really care about being valgrind clean in PRRTE
as it isn't a library. However, it can make it easier for
debug if we do a better job of cleanup at finalize, so
begin the process of doing so.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/802d4d4349f7e707bcc092f992c5accef2e32401)

[Use fileno_unlocked if available](https://github.com/openpmix/prrte/commit/cc69ae76ce6125542cd7683c33509da7637b23c5)

This might be a bug in Mac OSX that causes fileno to infrequently
deadlock even though we are doing so in an unthreaded scenario.
However, there is no harm in using fileno_unlocked if it is
available, so do that instead.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/9fe286019ecfe40c0ca72f9944b4bf3da86c754c)

[Avoid PMIx server release of HWLOC topology](https://github.com/openpmix/prrte/commit/e5114d2a0c1e7f3a047be64efcb10bd569b47bcd)

Flag the topology as "persistent" and not to be released
during "info_list" processing.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/48e44f420390fbd6dc42a79216b98572fdd13bb9)
