### PR TITLE
Fix a few bugs/leaks in the OOB subsystem

### DIFF
--- a/src/mca/oob/tcp/oob_tcp_component.c
+++ b/src/mca/oob/tcp/oob_tcp_component.c
@@ -837,6 +837,7 @@ void prte_oob_tcp_component_set_module(int fd, short args, void *cbdata)
     if (NULL == bpr) {
         bpr = PMIX_NEW(prte_oob_base_peer_t);
         PMIX_XFER_PROCID(&bpr->name, &pop->peer);
+        pmix_list_append(&prte_oob_base.peers, &bpr->super);
     }
     pmix_bitmap_set_bit(&bpr->addressable, prte_oob_tcp_component.super.idx);
     bpr->component = &prte_oob_tcp_component.super;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1417,6 +1417,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
         PRTE_FLAG_SET(daemon, PRTE_PROC_FLAG_ALIVE);
         /* unload its contact info */
         PMIX_VALUE_CONSTRUCT(&cnctinfo);
+        cnctinfo.type = PMIX_STRING;
         idx = 1;
         ret = PMIx_Data_unpack(NULL, buffer, &cnctinfo.data.string, &idx, PMIX_STRING);
         if (PMIX_SUCCESS != ret) {

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1247,6 +1247,7 @@ static void clean_abort(int fd, short flags, void *arg)
      * so need to tell them that!
      */
     prte_execute_quiet = true;
+    prte_abnormal_term_ordered = true;
     /* We are in an event handler; the job completed procedure
      will delete the signal handler that is currently running
      (which is a Bad Thing), so we can't call it directly.


### PR DESCRIPTION
Correctly identify the type of data being stored when
storing a returned daemon URI. Don't go looking for
a URI if we are terminating - if we don't know how to
talk to someone, this is not the time to create new
connections. Ensure we properly record the peer when
it connects to us.

Signed-off-by: Ralph Castain <rhc@pmix.org>