### PR TITLE
Return zero status when outputting help/version info

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -892,6 +892,7 @@ static int map_colocate(prte_job_t *jdata,
             }
         }
     }
+    ret = PRTE_SUCCESS;
 
 done:
     // ensure all the nodes are marked as not mapped

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -303,6 +303,12 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
                              results, "help-schizo-ompi.txt");
     if (PMIX_SUCCESS != rc) {
         pmix_argv_free(pargv);
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* pmix cmd line interpreter output result
+             * successfully - usually means version or
+             * some other stock output was generated */
+            return PRTE_OPERATION_SUCCEEDED;
+        }
         if(warn) {
             for(n = 0; n < cur_caught_pos; n++) {
                 free(caught_single_dashes[n]);

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -477,6 +477,12 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     rc = pmix_cmd_line_parse(argv, shorts, myoptions, NULL,
                              results, helpfile);
     if (PMIX_SUCCESS != rc) {
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* pmix cmd line interpreter output result
+             * successfully - usually means version or
+             * some other stock output was generated */
+            return PRTE_OPERATION_SUCCEEDED;
+        }
         rc = prte_pmix_convert_status(rc);
         return rc;
     }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -399,6 +399,9 @@ int main(int argc, char *argv[])
     rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
     if (PRTE_SUCCESS != rc) {
         PMIX_DESTRUCT(&results);
+        if (PRTE_OPERATION_SUCCEEDED == rc) {
+            return PRTE_SUCCESS;
+        }
         if (PRTE_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
         }

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -145,6 +145,9 @@ int main(int argc, char *argv[])
     ret = schizo->parse_cli(argv, &prte_info_cmd_line, PMIX_CLI_SILENT);
     if (PRTE_SUCCESS != ret) {
         PMIX_DESTRUCT(&prte_info_cmd_line);
+        if (PRTE_OPERATION_SUCCEEDED == rc) {
+            return PRTE_SUCCESS;
+        }
         if (PRTE_ERR_SILENT != ret) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
         }

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -288,11 +288,12 @@ int main(int argc, char *argv[])
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     ret = schizo->parse_cli(pargv, &results, PMIX_CLI_SILENT);
     if (PRTE_SUCCESS != ret) {
+        if (PRTE_OPERATION_SUCCEEDED == ret) {
+            return PRTE_SUCCESS;
+        }
         if (PRTE_ERR_SILENT != ret) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename,
                     prte_strerror(ret));
-        } else {
-            ret = PRTE_SUCCESS;  // printed version or help
         }
         return ret;
     }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -416,10 +416,11 @@ int prun(int argc, char *argv[])
     rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
     if (PRTE_SUCCESS != rc) {
         PMIX_DESTRUCT(&results);
+        if (PRTE_OPERATION_SUCCEEDED == rc) {
+            return PRTE_SUCCESS;
+        }
         if (PRTE_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
-        } else {
-            rc = PRTE_SUCCESS;
         }
         return rc;
     }


### PR DESCRIPTION
Any time we ask for help or version info, we should
return a zero status when done.

Signed-off-by: Ralph Castain <rhc@pmix.org>