### PR TITLE
Return the PMIx version of "not supported"

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1245,5 +1245,5 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client, pmix_alloc_directi
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     /* PRTE currently has no way of supporting allocation requests */
-    return PRTE_ERR_NOT_SUPPORTED;
+    return PMIX_ERR_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Otherwise, the PMIx server returns some odd PMIx
error that has the same value as the PRRTE version.

Fixes #1384 

Signed-off-by: Ralph Castain <rhc@pmix.org>