### PR TITLE
Fix stdin forwarding across nodes

### DIFF
--- a/src/mca/iof/hnp/iof_hnp.h
+++ b/src/mca/iof/hnp/iof_hnp.h
@@ -79,7 +79,9 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata);
 void prte_iof_hnp_stdin_cb(int fd, short event, void *cbdata);
 bool prte_iof_hnp_stdin_check(int fd);
 
-int prte_iof_hnp_send_data_to_endpoint(pmix_proc_t *host, pmix_proc_t *target, prte_iof_tag_t tag,
+int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
+                                       const pmix_proc_t *target,
+                                       prte_iof_tag_t tag,
                                        unsigned char *data, int numbytes);
 
 END_C_DECLS

--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -42,7 +42,9 @@
 
 #include "iof_hnp.h"
 
-int prte_iof_hnp_send_data_to_endpoint(pmix_proc_t *host, pmix_proc_t *target, prte_iof_tag_t tag,
+int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
+                                       const pmix_proc_t *target,
+                                       prte_iof_tag_t tag,
                                        unsigned char *data, int numbytes)
 {
     pmix_data_buffer_t *buf;
@@ -75,7 +77,7 @@ int prte_iof_hnp_send_data_to_endpoint(pmix_proc_t *host, pmix_proc_t *target, p
      * recipient (if the tag is stdin and we are sending to a daemon),
      * or the source (if we are sending to anyone else)
      */
-    rc = PMIx_Data_pack(NULL, buf, target, 1, PMIX_PROC);
+    rc = PMIx_Data_pack(NULL, buf, (void*)target, 1, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);


### PR DESCRIPTION
If all procs in a job are to receive the info, then
we need to broadcast it to all daemons.

Fixes https://github.com/openpmix/prrte/issues/1259

Signed-off-by: Ralph Castain <rhc@pmix.org>