### PR TITLE
Handle clean shutdown of stdin

### DIFF
--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -61,6 +61,10 @@ int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
          PRTE_NAME_PRINT(name), (NULL == channel) ? -1 : channel->fd));
 
+    if (NULL == channel) {
+        return 0;
+    }
+
     /* setup output object */
     output = PMIX_NEW(prte_iof_write_output_t);
 

--- a/src/mca/iof/hnp/iof_hnp.h
+++ b/src/mca/iof/hnp/iof_hnp.h
@@ -64,7 +64,6 @@ BEGIN_C_DECLS
 struct prte_iof_hnp_component_t {
     prte_iof_base_component_t super;
     pmix_list_t procs;
-    prte_iof_read_event_t *stdinev;
     prte_event_t stdinsig;
 };
 typedef struct prte_iof_hnp_component_t prte_iof_hnp_component_t;

--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -89,22 +89,6 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
         goto CLEAN_RETURN;
     }
 
-    if (PRTE_IOF_XON & stream) {
-        /* re-start the stdin read event */
-        if (NULL != prte_iof_hnp_component.stdinev && !prte_job_term_ordered
-            && !prte_iof_hnp_component.stdinev->active) {
-            PRTE_IOF_READ_ACTIVATE(prte_iof_hnp_component.stdinev);
-        }
-        goto CLEAN_RETURN;
-    } else if (PRTE_IOF_XOFF & stream) {
-        /* stop the stdin read event */
-        if (NULL != prte_iof_hnp_component.stdinev && !prte_iof_hnp_component.stdinev->active) {
-            prte_event_del(prte_iof_hnp_component.stdinev->ev);
-            prte_iof_hnp_component.stdinev->active = false;
-        }
-        goto CLEAN_RETURN;
-    }
-
     /* get name of the process whose io we are discussing */
     count = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &origin, &count, PMIX_PROC);

--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -84,15 +84,12 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
         return rc;
     }
 
-    /* if data is NULL, then we are done */
-    if (NULL != data) {
-        /* pack the data - if numbytes is zero, we will pack zero bytes */
-        rc = PMIx_Data_pack(NULL, buf, data, numbytes, PMIX_BYTE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            return rc;
-        }
+    /* pack the data - if numbytes is zero, we will pack zero bytes */
+    rc = PMIx_Data_pack(NULL, buf, data, numbytes, PMIX_BYTE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
     }
 
     /* if the target is wildcard, then this needs to go to everyone - xcast it */

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -78,9 +78,7 @@ static int finalize(void);
 /* The API's in this module are solely used to support LOCAL
  * procs - i.e., procs that are co-located to the daemon. Output
  * from local procs is automatically sent to the HNP for output
- * and possible forwarding to other requestors. The HNP automatically
- * determines and wires up the stdin configuration, so we don't
- * have to do anything here.
+ * and possible forwarding to other requestors.
  */
 
 prte_iof_base_module_t prte_iof_prted_module = {


### PR DESCRIPTION
Ensure we forward a zero-byte blob at the end of
stdin so the backend daemons can shutdown their
stdin channels, thus allowing them to properly
cleanup and declare the job as "done".

Signed-off-by: Ralph Castain <rhc@pmix.org>