### PR TITLE
Allow mapping in overload scenario if bind not specified

### DIFF
--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -127,6 +127,10 @@ PRTE_EXPORT int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec
 
 PRTE_EXPORT void prte_rmaps_base_display_map(prte_job_t *jdata);
 
+PRTE_EXPORT int prte_rmaps_base_get_ncpus(prte_node_t *node,
+                                          hwloc_obj_t obj,
+                                          prte_rmaps_options_t *options);
+
 PRTE_EXPORT bool prte_rmaps_base_check_avail(prte_job_t *jdata,
                                              prte_app_context_t *app,
                                              prte_node_t *node,


### PR DESCRIPTION
If the number of procs is greater than the number of CPUs
on a node, but less or equal to the number of slots,
then we are not oversubscribed but we are overloaded. If
the user didn't specify a required binding, then we set
the binding policy to do-not-bind for that node

Fixes #1395 
Signed-off-by: Ralph Castain <rhc@pmix.org>