### PR TITLE
Updates to track master branch

### DIFF
--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -127,6 +127,10 @@ PRTE_EXPORT int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec
 
 PRTE_EXPORT void prte_rmaps_base_display_map(prte_job_t *jdata);
 
+PRTE_EXPORT int prte_rmaps_base_get_ncpus(prte_node_t *node,
+                                          hwloc_obj_t obj,
+                                          prte_rmaps_options_t *options);
+
 PRTE_EXPORT bool prte_rmaps_base_check_avail(prte_job_t *jdata,
                                              prte_app_context_t *app,
                                              prte_node_t *node,

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -334,6 +334,8 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
             }
             jdata->num_procs++;
         }
+        /* compute local/app ranks */
+        rc = prte_rmaps_base_compute_vpids(jdata, app, options);
         /* update the starting point */
         vpid_start += app->num_procs;
         /* cleanup the node list - it can differ from one app_context

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -369,6 +369,8 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
             /* move to next node */
             sq = (seq_node_t *) pmix_list_get_next(&sq->super);
         }
+        /* compute local/app ranks */
+        rc = prte_rmaps_base_compute_vpids(jdata, app, options);
 
         /** track the total number of processes we mapped */
         jdata->num_procs += app->num_procs;
@@ -381,26 +383,6 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
         }
         if (NULL != hosts) {
             free(hosts);
-        }
-    }
-
-    /* compute local ranks */
-    for (i=0; i < jdata->map->nodes->size; i++) {
-        node = (prte_node_t*)pmix_pointer_array_get_item(jdata->map->nodes, i);
-        if (NULL == node) {
-            continue;
-        }
-        vpid = 0;
-        for (n=0; n < node->procs->size; n++) {
-            proc = (prte_proc_t*)pmix_pointer_array_get_item(node->procs, n);
-            if (NULL == proc) {
-                continue;
-            }
-            if (!PMIX_CHECK_NSPACE(proc->name.nspace, jdata->nspace)) {
-                continue;
-            }
-            proc->local_rank = vpid;
-            ++vpid;
         }
     }
 


### PR DESCRIPTION
[Allow mapping in overload scenario if bind not specified](https://github.com/openpmix/prrte/commit/a14726722c26cfcbed3f425b4f2f00de339777d8)

If the number of procs is greater than the number of CPUs
on a node, but less or equal to the number of slots,
then we are not oversubscribed but we are overloaded. If
the user didn't specify a required binding, then we set
the binding policy to do-not-bind for that node

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/6ef02ea7a1472d191ca757123de07b34829aec85)

[Ensure rankfile and seq mappers computer local and app ranks](https://github.com/openpmix/prrte/commit/71c0e26f83afe33f80a2b49b24385740d7ce1971)

The OMPI personality module in PMIx is looking for the local
and app ranks, so the two mappers that map-by user need to
compute those values.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/0b580da7c8952a95a39a2cdb5d13b3453fb934ce)
