### PR TITLE
Cleanup race condition in daemon reports

### DIFF
--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -15,7 +15,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,6 +116,8 @@ static int prte_plm_base_close(void)
     if (NULL != prte_plm_globals.base_nspace) {
         free(prte_plm_globals.base_nspace);
     }
+    while (NULL != pmix_list_remove_first(&prte_plm_globals.daemon_cache)); // do not release list items!
+    PMIX_DESTRUCT(&prte_plm_globals.daemon_cache);
 
     return prte_mca_base_framework_components_close(&prte_plm_base_framework, NULL);
 }
@@ -131,6 +133,8 @@ static int prte_plm_base_open(prte_mca_base_open_flag_t flags)
 
     /* default to assigning daemons to nodes at launch */
     prte_plm_globals.daemon_nodes_assigned_at_launch = true;
+
+    PMIX_CONSTRUCT(&prte_plm_globals.daemon_cache, pmix_list_t);
 
     /* Open up all available components */
     return prte_mca_base_framework_components_open(&prte_plm_base_framework, flags);

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -64,6 +64,7 @@ typedef struct {
     /* daemon nodes assigned at launch */
     bool daemon_nodes_assigned_at_launch;
     size_t node_regex_threshold;
+    pmix_list_t daemon_cache;
 } prte_plm_globals_t;
 /**
  * Global instance of PLM framework data


### PR DESCRIPTION
In the case where prterun is operating on a node
with a different topology than the other nodes
AND daemon rank=1 is delayed in sending its callback
message such that one or more other daemons report
first, then we segfault as:

* the first daemon to report records its signature
  and immediately is requested to return its topo

* subsequent daemons with the SAME signature attempt
  to use the NULL topo from the topologies array to
  define their available CPUs

Resolve this by caching any daemons that report prior
to rank=1 so that we can compare their topo to that one.

Fixes #1400 
Signed-off-by: Ralph Castain <rhc@pmix.org>