### PR TITLE
Support a broader range of IO output formats

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -921,6 +921,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
     pmix_proc_t pproc;
     pmix_status_t ret;
     char *ptr;
+    pmix_value_t pidval = PMIX_VALUE_STATIC_INIT;
 
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
@@ -1076,7 +1077,16 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         state = PRTE_PROC_STATE_FAILED_TO_START;
         goto errorout;
     }
-
+    if (PRTE_PROC_IS_MASTER) {
+        /* locally store the pid */
+        pidval.type = PMIX_PID;
+        pidval.data.pid = child->pid;
+        /* store the PID for later retrieval */
+        rc = PMIx_Store_internal(&child->name, PMIX_PROC_PID, &pidval);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+    }
     PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_RUNNING);
     PMIX_RELEASE(cd);
     return;

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -132,6 +132,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
     char **env;
     char *prefix_dir, *tmp;
     pmix_rank_t tgt, *tptr;
+    pmix_value_t pidval = PMIX_VALUE_STATIC_INIT;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     PRTE_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
@@ -598,6 +599,13 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
                 goto CLEANUP;
             }
             proc->pid = pid;
+            pidval.type = PMIX_PID;
+            pidval.data.pid = pid;
+            /* store the PID for later retrieval */
+            rc = PMIx_Store_internal(&proc->name, PMIX_PROC_PID, &pidval);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
             /* unpack the state */
             count = 1;
             rc = PMIx_Data_unpack(NULL, buffer, &state, &count, PMIX_UINT32);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -571,6 +571,18 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, &flag,
                                PMIX_BOOL);
 
+            /*** DETAILED OIUTPUT TAG */
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_DETAILED_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT_DETAILED,
+                               PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
+
+            /*** FULL NAMESPACE IN OUTPUT TAG */
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_FULLNAME_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT_FULLNAME,
+                               PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
+
             /***   RANK STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_IOF_RANK_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -328,6 +328,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
     }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT_DETAILED, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TAG_DETAILED_OUTPUT, &flag, PMIX_BOOL);
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT_FULLNAME, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_TAG_FULLNAME_OUTPUT, &flag, PMIX_BOOL);
+    }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RANK_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_RANK_OUTPUT, &flag, PMIX_BOOL);
     }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -859,6 +859,10 @@ int main(int argc, char *argv[])
                 }
                 if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_DET, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_FULL, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
                 } else if (0 == strncasecmp(targv[idx], PRTE_CLI_RANK, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
                 } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TIMESTAMP, strlen(targv[idx]))) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -435,7 +435,7 @@ int prun(int argc, char *argv[])
 
     /** setup callbacks for signals we should forward */
     PMIX_CONSTRUCT(&prte_ess_base_signals, pmix_list_t);
-    opt = pmix_cmd_line_get_param(&results, "forward-signals");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_FWD_SIGNALS);
     if (NULL != opt) {
         param = opt->values[0];
     } else {
@@ -477,15 +477,15 @@ int prun(int argc, char *argv[])
     }
     PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_RANK, &rank, PMIX_PROC_RANK);
 
-    if (pmix_cmd_line_is_taken(&results, "do-not-connect")) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DO_NOT_CONNECT)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
-    } else if (pmix_cmd_line_is_taken(&results, "system-server-first")) {
+    } else if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYS_SERVER_FIRST)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
-    } else if (pmix_cmd_line_is_taken(&results, "system-server-only")) {
+    } else if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYS_SERVER_ONLY)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
     }
 
-    opt = pmix_cmd_line_get_param(&results, "wait-to-connect");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_WAIT_TO_CONNECT);
     if (NULL != opt) {
         ui32 = strtol(opt->values[0], NULL, 10);
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
@@ -497,7 +497,7 @@ int prun(int argc, char *argv[])
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_MAX_RETRIES, &ui32, PMIX_UINT32);
     }
 
-    opt = pmix_cmd_line_get_param(&results, "pid");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_PID);
     if (NULL != opt) {
         /* see if it is an integer value */
         char *leftover;
@@ -541,7 +541,7 @@ int prun(int argc, char *argv[])
                 return PRTE_ERR_BAD_PARAM;
         }
     }
-    opt = pmix_cmd_line_get_param(&results, "namespace");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_NAMESPACE);
     if (NULL != opt) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_SERVER_NSPACE, opt->values[0], PMIX_STRING);
     }
@@ -562,7 +562,7 @@ int prun(int argc, char *argv[])
     PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
 
     /* if they specified the URI, then pass it along */
-    opt = pmix_cmd_line_get_param(&results, "dvm-uri");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DVM_URI);
     if (NULL != opt) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_SERVER_URI, opt->values[0], PMIX_STRING);
     }
@@ -621,26 +621,26 @@ int prun(int argc, char *argv[])
     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, personality, PMIX_STRING);
 
     /* get display options */
-    opt = pmix_cmd_line_get_param(&results, "display");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DISPLAY);
     if (NULL != opt) {
         for (n=0; NULL != opt->values[n]; n++) {
             targv = pmix_argv_split(opt->values[n], ',');
 
             for (int idx = 0; idx < pmix_argv_count(targv); idx++) {
-                if (0 == strncasecmp(targv[idx], "allocation", strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYALLOC", PMIX_STRING);
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_ALLOC, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPALLOC, PMIX_STRING);
                 }
-                if (0 == strcasecmp(targv[idx], "map")) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAY", PMIX_STRING);
+                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAP)) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPLAY, PMIX_STRING);
                 }
-                if (0 == strncasecmp(targv[idx], "bind", strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":REPORT", PMIX_STRING);
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_BIND, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":"PRTE_CLI_REPORT, PMIX_STRING);
                 }
-                if (0 == strcasecmp(targv[idx], "map-devel")) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYDEVEL", PMIX_STRING);
+                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAPDEV)) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPDEV, PMIX_STRING);
                 }
-                if (0 == strncasecmp(targv[idx], "topo", strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":DISPLAYTOPO", PMIX_STRING);
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_TOPO, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPTOPO, PMIX_STRING);
                 }
             }
             pmix_argv_free(targv);
@@ -650,7 +650,7 @@ int prun(int argc, char *argv[])
     /* cannot have both files and directory set for output */
     outdir = NULL;
     outfile = NULL;
-    opt = pmix_cmd_line_get_param(&results, "output");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
         for (n=0; NULL != opt->values[n]; n++) {
             targv = pmix_argv_split(opt->values[n], ',');
@@ -664,12 +664,12 @@ int prun(int argc, char *argv[])
                     /* could be multiple qualifiers, so separate them */
                     options = pmix_argv_split(cptr, ',');
                     for (int m=0; NULL != options[m]; m++) {
-                        if (0 == strcasecmp(options[m], "nocopy")) {
+                        if (0 == strcasecmp(options[m], PRTE_CLI_NOCOPY)) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
-                        } else if (0 == strcasecmp(options[m], "pattern")) {
+                        } else if (0 == strcasecmp(options[m], PRTE_CLI_PATTERN)) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
     #ifdef PMIX_IOF_OUTPUT_RAW
-                        } else if (0 == strcasecmp(options[m], "raw")) {
+                        } else if (0 == strcasecmp(options[m], PRTE_CLI_RAW)) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
     #endif
                         }
@@ -685,19 +685,21 @@ int prun(int argc, char *argv[])
                     *ptr = '\0';
                     ++ptr;
                 }
-                if (0 == strncasecmp(targv[idx], "tag", strlen(targv[idx]))) {
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
-                }
-                if (0 == strncasecmp(targv[idx], "timestamp", strlen(targv[idx]))) {
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_DET, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_FULL, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_RANK, strlen(targv[idx]))) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TIMESTAMP, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
-                }
-                if (0 == strncasecmp(targv[idx], "xml", strlen(targv[idx]))) {
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_XML, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
-                }
-                if (0 == strncasecmp(targv[idx], "merge-stderr-to-stdout", strlen(targv[idx]))) {
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_MERGE_ERROUT, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
-                }
-                if (0 == strncasecmp(targv[idx], "directory", strlen(targv[idx]))) {
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_DIR, strlen(targv[idx]))) {
                     if (NULL != outfile) {
                         pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
                         return PRTE_ERR_FATAL;
@@ -723,8 +725,7 @@ int prun(int argc, char *argv[])
                         outdir = strdup(ptr);
                     }
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
-                }
-                if (0 == strncasecmp(targv[idx], "file", strlen(targv[idx]))) {
+                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_FILE, strlen(targv[idx]))) {
                     if (NULL != outdir) {
                         pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
                         return PRTE_ERR_FATAL;
@@ -805,13 +806,13 @@ int prun(int argc, char *argv[])
         }
     }
     /* if continuous operation was specified */
-    if (pmix_cmd_line_is_taken(&results, "continuous")) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_CONTINUOUS)) {
         /* mark this job as continuously operating */
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_CONTINUOUS, &flag, PMIX_BOOL);
     }
 
     /* if stop-on-exec was specified */
-    if (pmix_cmd_line_is_taken(&results, "stop-on-exec")) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STOP_ON_EXEC)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DEBUG_STOP_ON_EXEC, &flag, PMIX_BOOL);
     }
 
@@ -819,7 +820,7 @@ int prun(int argc, char *argv[])
      * as that is what MPICH used
      */
     i = 0;
-    opt = pmix_cmd_line_get_param(&results, "timeout");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_TIMEOUT);
     if (NULL != opt) {
         i = strtol(opt->values[0], NULL, 10);
     } else if (NULL != (param = getenv("MPIEXEC_TIMEOUT"))) {
@@ -833,14 +834,14 @@ int prun(int argc, char *argv[])
 #endif
     }
 
-    if (pmix_cmd_line_is_taken(&results, "get-stack-traces")) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STACK_TRACES)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_STACKTRACES, &flag, PMIX_BOOL);
     }
-    if (pmix_cmd_line_is_taken(&results, "report-state-on-timeout")) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_REPORT_STATE)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_REPORT_STATE, &flag, PMIX_BOOL);
     }
 #ifdef PMIX_SPAWN_TIMEOUT
-    opt = pmix_cmd_line_get_param(&results, "spawn-timeout");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_SPAWN_TIMEOUT);
     if (NULL != opt) {
         i = strtol(opt->values[0], NULL, 10);
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_SPAWN_TIMEOUT, &i, PMIX_INT);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -475,6 +475,10 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "NUM PROCS TO COLOCATE PER PROC";
         case PRTE_JOB_COLOCATE_NPERNODE:
             return "NUM PROCS TO COLOCATE PER NODE";
+        case PRTE_JOB_TAG_OUTPUT_DETAILED:
+            return "DETAILED OUTPUT TAG";
+        case PRTE_JOB_TAG_OUTPUT_FULLNAME:
+            return "FULL NSPACE IN OUTPUT TAG";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -84,7 +84,7 @@ typedef uint8_t prte_node_flags_t;
 #define PRTE_NODE_SERIAL_NUMBER (PRTE_NODE_START_KEY + 5) // string - serial number: used if node is a coprocessor
 #define PRTE_NODE_PORT          (PRTE_NODE_START_KEY + 6) // int32 - Alternate port to be passed to plm
 
-#define PRTE_NODE_MAX_KEY 200
+#define PRTE_NODE_MAX_KEY (PRTE_NODE_START_KEY + 100)
 
 /*** JOB FLAGS - included in prte_job_t transmissions ***/
 typedef uint16_t prte_job_flags_t;
@@ -205,8 +205,10 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_COLOCATE_PROCS             (PRTE_JOB_START_KEY +  97) // pmix_data_array_t - colocate this job's procs with the given ones
 #define PRTE_JOB_COLOCATE_NPERPROC          (PRTE_JOB_START_KEY +  98) // uint16_t - number of procs to colocate at each proc
 #define PRTE_JOB_COLOCATE_NPERNODE          (PRTE_JOB_START_KEY +  99) // uint16_t - number of procs to colocate on node of each proc
+#define PRTE_JOB_TAG_OUTPUT_DETAILED        (PRTE_JOB_START_KEY + 100) // bool - include [hostname:pid] in output stream tag
+#define PRTE_JOB_TAG_OUTPUT_FULLNAME        (PRTE_JOB_START_KEY + 101) // bool - use full namespace in output stream tag
 
-#define PRTE_JOB_MAX_KEY 300
+#define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 
 /*** PROC FLAGS - never sent anywhere ***/
 typedef uint16_t prte_proc_flags_t;
@@ -240,7 +242,7 @@ typedef uint16_t prte_proc_flags_t;
 #define PRTE_PROC_CGROUP            (PRTE_PROC_START_KEY + 13) // string - name of cgroup this proc shall be assigned to
 #define PRTE_PROC_NBEATS            (PRTE_PROC_START_KEY + 14) // int32 - number of heartbeats in current window
 
-#define PRTE_PROC_MAX_KEY 400
+#define PRTE_PROC_MAX_KEY (PRTE_PROC_START_KEY + 100)
 
 /*** RML ATTRIBUTE keys ***/
 #define PRTE_RML_START_KEY              PRTE_PROC_MAX_KEY
@@ -256,7 +258,9 @@ typedef uint16_t prte_proc_flags_t;
 #define PRTE_RML_PROTOCOL_ATTRIB        (PRTE_RML_START_KEY + 9) // string - comma delimited list of protocols to be considered (e.g., tcp,udp)
 #define PRTE_RML_ROUTED_ATTRIB          (PRTE_RML_START_KEY + 10) // string - comma delimited list of routed modules to be considered
 
-#define PRTE_ATTR_KEY_MAX 1000
+#define PRTE_RML_MAX_KEY (PRTE_RML_START_KEY + 100)
+
+#define PRTE_ATTR_KEY_MAX PRTE_RML_MAX_KEY
 
 /*** FLAG OPS ***/
 #define PRTE_FLAG_SET(p, f)   ((p)->flags |= (f))

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -181,6 +181,8 @@ BEGIN_C_DECLS
 
 // Output directives
 #define PRTE_CLI_TAG        "tag"
+#define PRTE_CLI_TAG_DET    "tag-detailed"
+#define PRTE_CLI_TAG_FULL   "tag-fullname"
 #define PRTE_CLI_RANK       "rank"
 #define PRTE_CLI_TIMESTAMP  "timestamp"
 #define PRTE_CLI_XML        "xml"


### PR DESCRIPTION
Formats include:

* tag - prepend [jobid,rank]<stream>: to output. The "jobid"
  is taken as the portion of the nspace after a @ character.
  As this is not a universal standard, the "jobid" will be
  replaced by the full namespace if the @ is not found.

* tag-fullname - prepend [nspace,rank]<stream>: to output

* tag-detailed => prepend [jobid,rank][hostname:pid]<stream>: to
  output. The hostname and pid will be reported as "unknown" if
  not found inside the PMIx local data of the server.
  Combining tag-fullname with tag-detailed is supported.

* rank - prepend [rank]<stream> to output

* xml - output in a pseudo-xml format. This can be combined
  with tag-fullname and/or tag-detailed

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit e7776792f5aa67bfffdd737f44af26e4bc62e14b)