### PR TITLE
Begin work on the help docs

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -171,7 +171,7 @@ int prte_hwloc_base_register(void)
                                      "Default policy for binding processes. Allowed values: none, hwthread, core, l1cache, "
                                      "l2cache, "
                                      "l3cache, numa, package, (\"none\" is the default when oversubscribed, \"core\" is "
-                                     "the default when np<=2, and \"numa\" is the default when np>2). Allowed "
+                                     "the default otherwise). Allowed "
                                      "colon-delimited qualifiers: "
                                      "overload-allowed, if-supported",
                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
@@ -549,14 +549,15 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
         ++ptr;
         quals = pmix_argv_split(ptr, ':');
         for (i = 0; NULL != quals[i]; i++) {
-            if (0 == strcasecmp(quals[i], "if-supported")) {
+            len = strlen(quals[i]);
+            if (0 == strncasecmp(quals[i], "if-supported", len)) {
                 tmp |= PRTE_BIND_IF_SUPPORTED;
-            } else if (0 == strcasecmp(quals[i], "overload-allowed")) {
+            } else if (0 == strncasecmp(quals[i], "overload-allowed", len)) {
                 tmp |= (PRTE_BIND_ALLOW_OVERLOAD | PRTE_BIND_OVERLOAD_GIVEN);
-            } else if (0 == strcasecmp(quals[i], "no-overload")) {
+            } else if (0 == strncasecmp(quals[i], "no-overload", len)) {
                 tmp = (tmp & ~PRTE_BIND_ALLOW_OVERLOAD);
                 tmp |= PRTE_BIND_OVERLOAD_GIVEN;
-            } else if (0 == strcasecmp(quals[i], "REPORT")) {
+            } else if (0 == strncasecmp(quals[i], "REPORT", len)) {
                 if (NULL == jdata) {
                     pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                    "binding policy", quals[i]);

--- a/src/mca/schizo/base/Makefile.am
+++ b/src/mca/schizo/base/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -9,7 +9,9 @@
 # $HEADER$
 #
 
-dist_prtedata_DATA += base/help-schizo-base.txt
+dist_prtedata_DATA += \
+    base/help-schizo-base.txt \
+    base/help-schizo-cli.txt
 
 headers += \
         base/base.h

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -1,0 +1,448 @@
+# -*- text -*-
+#
+# Copyright (c) 2022 Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#  DISPLAY
+#
+[display]
+The "display" command line directive must be accompanied by a comma-delimited
+list of case-insensitive options indicating what information about the job
+and/or allocation is to be displayed. The full directive need not be provided -
+only enough characters are required to uniquely identify the directive. For
+example, ALL is sufficient to represent the ALLOCATION directive - while MAP
+can not be used to represent MAP-DEVEL (though MAP-D would suffice).
+
+Supported values include:
+
+-   ALLOCATION displays the detected hosts and slot assignments for this job
+
+-   BIND displays the resulting bindings applied to processes in this job
+
+-   MAP displays the resulting locations assigned to processes in this job
+
+-   MAP-DEVEL displays a more detailed report on the locations assigned to
+    processes in this job that includes local and node ranks, assigned
+    bindings, and other data
+
+-   TOPO displays the topology of the nodes allocated to the job
+
+No qualifiers are defined for this directive.
+#
+#  OUTPUT
+#
+[output]
+The "output" command line directive must be accompanied by a comma-delimited
+list of case-insensitive options that control how output is generated. The
+full directive need not be provided - only enough characters are required
+to uniquely identify the directive. For example, MERGE is sufficient to
+represent the MERGE-STDERR-TO-STDOUT directive - while TAG can not be used
+to represent TAG-DETAILED (though TAG-D would suffice).
+
+Supported values include:
+
+-   TAG marks each output line with the [job,rank]<stream>: of the process that
+    generated it
+
+-   TAG-DETAILED marks each output line with a detailed annotation containing
+    [namespace,rank][hostname:pid]<stream>: of the process that generated it
+
+-   TAG-FULLNAME marks each output line with the [namespace,rank]<stream>: of
+    the process that generated it
+
+-   TIMESTAMP prefixes each output line with a [datetime]<stream>: stamp. Note
+    that the timestamp will be the time when the line is output by the DVM and
+    not the time when the source output it
+
+-   XML provides all output in a pseudo-XML format
+
+-   MERGE-STDERR-TO-STDOUT merges stderr into stdout
+
+-   DIR=DIRNAME redirects output from application processes into DIRNAME/job/rank/std[out,err,diag]. The provided name will be
+    converted to an absolute path
+
+-   FILE=FILENAME redirects output from application processes into
+    filename.rank. The provided name will be converted to an absolute
+    path
+
+Supported qualifiers include NOCOPY (do not copy the output to the
+stdout/err streams), and RAW (do not buffer the output into complete
+lines, but instead output it as it is received).
+#
+#  DVM-HOSTFILE
+#
+[dvm-hostfile]
+PRRTE supports several levels of user-specified host lists based on an established
+precedence order. Users can specify a default hostfile that contains a list of
+nodes to be used by the DVM. Only one default hostfile can be provided for a given
+DVM. In addition, users can specify a hostfile that contains a list of nodes to be
+used for a DVM, or can provide a comma-delimited list of nodes to be used for that
+DVM via the --host command line option.
+
+The precedence order applied to these various options depends to some extent on
+the local environment. The following table illustrates how host and hostfile directives
+work together to define the set of hosts upon which a DVM will execute in the absence
+of a resource manager (RM):
+
+ default
+ hostfile      host        hostfile       Result
+----------    ------      ----------      -----------------------------------------
+ unset        unset          unset        The DVM will consist solely of the local
+                                          host where the DVM was started.
+ unset         set           unset        Host option defines resource list for the DVM
+ unset        unset           set         Hostfile defines resource list for the DVM
+ unset         set            set         Hostfile defines resource list for the DVM,
+                                          then host filters the list to define the final
+                                          set of nodes to be used by the DVM
+  set         unset          unset        Default hostfile defines resource list for the DVM
+  set          set           unset        Default hostfile defines resource list for the DVM,
+                                          then host filters the list to define the final
+                                          set of nodes to be used by the DVM
+  set          set            set         Default hostfile defines resource list for the DVM,
+                                          then hostfile filters the list, and then host filters
+                                          the list to define the final set of nodes to be
+                                          used by the DVM
+
+This changes somewhat in the presence of an RM as that entity specifies the
+initial allocation of nodes. In this case, the default hostfile, hostfile and host
+directives are all used to filter the RM's specification so that a user can utilize different
+portions of the allocation for different jobs. This is done according to the same precedence
+order as in the prior table, with the RM providing the initial pool of nodes.
+#
+#  LAUNCHER-HOSTFILE
+#
+[launcher-hostfile]
+
+**************************
+    Relative Indexing
+**************************
+PRRTE supports several levels of user-specified host lists based on an established
+precedence order. Users can specify a default hostfile that contains a list of
+nodes to be used by the DVM. Only one default hostfile can be provided for a given
+DVM. In addition, users can specify a hostfile that contains a list of nodes to be
+used for a DVM, or can provide a comma-delimited list of nodes to be used for that
+DVM via the --host command line option.
+
+The precedence order applied to these various options depends to some extent on
+the local environment. The following table illustrates how host and hostfile directives
+work together to define the set of hosts upon which a DVM will execute in the absence
+of a resource manager (RM):
+
+ default
+ hostfile      host        hostfile       Result
+----------    ------      ----------      -----------------------------------------
+ unset        unset          unset        The DVM will consist solely of the local
+                                          host where the DVM was started.
+ unset         set           unset        Host option defines resource list for the DVM
+ unset        unset           set         Hostfile defines resource list for the DVM
+ unset         set            set         Hostfile defines resource list for the DVM,
+                                          then host filters the list to define the final
+                                          set of nodes to be used by the DVM
+  set         unset          unset        Default hostfile defines resource list for the DVM
+  set          set           unset        Default hostfile defines resource list for the DVM,
+                                          then host filters the list to define the final
+                                          set of nodes to be used by the DVM
+  set          set            set         Default hostfile defines resource list for the DVM,
+                                          then hostfile filters the list, and then host filters
+                                          the list to define the final set of nodes to be
+                                          used by the DVM
+
+This changes somewhat in the presence of an RM as that entity specifies the
+initial allocation of nodes. In this case, the default hostfile, hostfile and host
+directives are all used to filter the RM's specification so that a user can utilize different
+portions of the allocation for different jobs. This is done according to the same precedence
+order as in the prior table, with the RM providing the initial pool of nodes.
+
+Once an initial allocation has been specified (whether by an RM, default hostfile, or hostfile),
+subsequent hostfile and --host specifications can be made using relative indexing. This allows a
+user to stipulate which hosts are to be used for a given app_context without specifying the
+particular host name, but rather its relative position in the allocation.
+
+This can probably best be understood through consideration of a few examples. Consider the case
+where an RM has allocated a set of nodes to the user named "foo1, foo2, foo3, foo4". The user
+wants the first app_context to have exclusive use of the first two nodes, and a second app_context
+to use the last two nodes. Of course, the user could printout the allocation to find the names
+of the nodes allocated to them and then use -host to specify this layout, but this is cumbersome
+and would require hand-manipulation for every invocation.
+
+A simpler method is to utilize PRRTE's relative indexing capability to specify the desired
+layout. In this case, a command line containing:
+
+--host +n1,+n2 ./app1 : --host +n3,+n4 ./app2
+
+would provide the desired pattern. The "+" syntax indicates that the information is being
+provided as a relative index to the existing allocation. Two methods of relative indexing
+are supported:
+.sp
+.TP
+.B +n<#>
+A relative index into the allocation referencing the <#> node. OpenRTE will substitute
+the <#> node in the allocation
+.
+.
+.TP
+.B +e[:<#>]
+A request for <#> empty nodes - i.e., OpenRTE is to substitute this reference with
+<#> nodes that have not yet been used by any other app_context. If the ":<#>" is not
+provided, OpenRTE will substitute the reference with all empty nodes. Note that OpenRTE
+does track the empty nodes that have been assigned in this manner, so multiple
+uses of this option will result in assignment of unique nodes up to the limit of the
+available empty nodes. Requests for more empty nodes than are available will generate
+an error.
+.sp
+.PP
+Relative indexing can be combined with absolute naming of hosts in any arbitrary manner,
+and can be used in hostfiles as well as with the -host command line option. In addition,
+any slot specification provided in hostfiles will be respected - thus, a user can specify
+that only a certain number of slots from a relative indexed host are to be used for a
+given app_context.
+.sp
+Another example may help illustrate this point. Consider the case where a user has a default
+hostfile containing:
+.sp
+.nf
+dummy1 slots=4
+dummy2 slots=4
+dummy3 slots=4
+dummy4 slots=4
+dummy5 slots=4
+.fi
+.sp
+.PP
+This may, for example, be a hostfile that describes a set of commonly-used resources that
+the user wishes to execute applications against. For this particular application, the user
+plans to map byslot, and wants the first two ranks to be on the second node of any allocation,
+the next ranks to land on an empty node, have one rank specifically on dummy4, the next rank
+to be on the second node of the allocation again, and finally any remaining ranks to be on
+whatever empty nodes are left. To accomplish this, the user provides a hostfile of:
+.sp
+.nf
++n2 slots=2
++e:1
+dummy4 slots=1
++n2
++e
+.fi
+.sp
+.PP
+The user can now use this information in combination with OpenRTE's sequential mapper to
+obtain their specific layout:
+.sp
+.nf
+mpirun --default-hostfile dummyhosts -hostfile mylayout -mca rmaps seq ./my_app
+.fi
+.sp
+.PP
+which will result in:
+.nf
+.sp
+rank0 being mapped to dummy3
+.br
+rank1 to dummy1 as the first empty node
+.br
+rank2 to dummy4
+.br
+rank3 to dummy3
+.br
+rank4 to dummy2 and rank5 to dummy5 as the last remaining unused nodes
+.sp
+.fi
+Note that the sequential mapper ignores the number of slots arguments as it only
+maps one rank at a time to each node in the list.
+.sp
+If the default round-robin mapper had been used, then the mapping would have resulted in:
+.sp
+.nf
+ranks 0 and 1 being mapped to dummy3 since two slots were specified
+.br
+ranks 2-5 on dummy1 as the first empty node, which has four slots
+.br
+rank6 on dummy4 since the hostfile specifies only a single slot from that node is to be used
+.br
+ranks 7 and 8 on dummy3 since only two slots remain available
+.br
+ranks 9-12 on dummy2 since it is the next available empty node and has four slots
+.br
+ranks 13-16 on dummy5 since it is the last remaining unused node and has four slots
+.fi
+.sp
+.PP
+Thus, the use of relative indexing can allow for complex mappings to be ported across
+allocations, including those obtained from automated resource managers, without the need
+for manual manipulation of scripts and/or command lines.
+
+PRRTE supports several levels of user-specified host lists based on an established
+precedence order. Users can specify a default hostfile that contains a list of
+nodes available to all app_contexts given on the command line. Only one default
+hostfile can be provided for a given DVM. In addition, users
+can specify a hostfile that contains a list of nodes to be used for a specific
+app_context, or can provide a comma-delimited list of nodes to be used for that
+app_context via the --host command line option.
+
+The precedence order applied to these various options depends to some extent on
+the local environment. The following table illustrates how host and hostfile directives
+work together to define the set of hosts upon which a DVM or job will execute
+in the absence of a resource manager (RM):
+
+ default
+ hostfile      host        hostfile       Result
+----------    ------      ----------      -----------------------------------------
+ unset        unset          unset        The DVM will consist solely of the local
+                                          host where the DVM was started. All jobs
+                                          will be co-located with the DVM master
+ unset         set           unset        Host option defines resource list for the DVM
+                                          or job. Note that the option cannot specify
+                                          resources outside of the DVM's
+ unset        unset           set         Hostfile defines resource list for the DVM
+                                          or job
+ unset         set            set         Hostfile defines resource list for the job,
+                                          then host filters the list to define the final
+                                          set of nodes available to each application
+                                          within the job
+  set         unset          unset        Default hostfile defines resource list for the job
+  set          set           unset        Default hostfile defines resource list for the job,
+                                          then host filters the list to define the final
+                                          set of nodes available to each application
+                                          within the job
+  set          set            set         Default hostfile defines resource list for the job,
+                                          then hostfile filters the list, and then host filters
+                                          the list to define the final set of nodes available
+                                          to each application within the job
+
+This changes somewhat in the presence of an RM as that entity specifies the
+initial allocation of nodes. In this case, the default hostfile, hostfile and host
+directives are all used to filter the RM's specification so that a user can utilize different
+portions of the allocation for different jobs. This is done according to the same precedence
+order as in the prior table, with the RM providing the initial pool of nodes.
+
+
+**************************
+    Relative Indexing
+**************************
+
+Once an initial allocation has been specified (whether by an RM, default hostfile, or hostfile),
+subsequent hostfile and --host specifications can be made using relative indexing. This allows a
+user to stipulate which hosts are to be used for a given app_context without specifying the
+particular host name, but rather its relative position in the allocation.
+
+This can probably best be understood through consideration of a few examples. Consider the case
+where an RM has allocated a set of nodes to the user named "foo1, foo2, foo3, foo4". The user
+wants the first app_context to have exclusive use of the first two nodes, and a second app_context
+to use the last two nodes. Of course, the user could printout the allocation to find the names
+of the nodes allocated to them and then use -host to specify this layout, but this is cumbersome
+and would require hand-manipulation for every invocation.
+
+A simpler method is to utilize PRRTE's relative indexing capability to specify the desired
+layout. In this case, a command line containing:
+
+--host +n1,+n2 ./app1 : --host +n3,+n4 ./app2
+
+would provide the desired pattern. The "+" syntax indicates that the information is being
+provided as a relative index to the existing allocation. Two methods of relative indexing
+are supported:
+.sp
+.TP
+.B +n<#>
+A relative index into the allocation referencing the <#> node. OpenRTE will substitute
+the <#> node in the allocation
+.
+.
+.TP
+.B +e[:<#>]
+A request for <#> empty nodes - i.e., OpenRTE is to substitute this reference with
+<#> nodes that have not yet been used by any other app_context. If the ":<#>" is not
+provided, OpenRTE will substitute the reference with all empty nodes. Note that OpenRTE
+does track the empty nodes that have been assigned in this manner, so multiple
+uses of this option will result in assignment of unique nodes up to the limit of the
+available empty nodes. Requests for more empty nodes than are available will generate
+an error.
+.sp
+.PP
+Relative indexing can be combined with absolute naming of hosts in any arbitrary manner,
+and can be used in hostfiles as well as with the -host command line option. In addition,
+any slot specification provided in hostfiles will be respected - thus, a user can specify
+that only a certain number of slots from a relative indexed host are to be used for a
+given app_context.
+.sp
+Another example may help illustrate this point. Consider the case where a user has a default
+hostfile containing:
+.sp
+.nf
+dummy1 slots=4
+dummy2 slots=4
+dummy3 slots=4
+dummy4 slots=4
+dummy5 slots=4
+.fi
+.sp
+.PP
+This may, for example, be a hostfile that describes a set of commonly-used resources that
+the user wishes to execute applications against. For this particular application, the user
+plans to map byslot, and wants the first two ranks to be on the second node of any allocation,
+the next ranks to land on an empty node, have one rank specifically on dummy4, the next rank
+to be on the second node of the allocation again, and finally any remaining ranks to be on
+whatever empty nodes are left. To accomplish this, the user provides a hostfile of:
+.sp
+.nf
++n2 slots=2
++e:1
+dummy4 slots=1
++n2
++e
+.fi
+.sp
+.PP
+The user can now use this information in combination with OpenRTE's sequential mapper to
+obtain their specific layout:
+.sp
+.nf
+mpirun --default-hostfile dummyhosts -hostfile mylayout -mca rmaps seq ./my_app
+.fi
+.sp
+.PP
+which will result in:
+.nf
+.sp
+rank0 being mapped to dummy3
+.br
+rank1 to dummy1 as the first empty node
+.br
+rank2 to dummy4
+.br
+rank3 to dummy3
+.br
+rank4 to dummy2 and rank5 to dummy5 as the last remaining unused nodes
+.sp
+.fi
+Note that the sequential mapper ignores the number of slots arguments as it only
+maps one rank at a time to each node in the list.
+.sp
+If the default round-robin mapper had been used, then the mapping would have resulted in:
+.sp
+.nf
+ranks 0 and 1 being mapped to dummy3 since two slots were specified
+.br
+ranks 2-5 on dummy1 as the first empty node, which has four slots
+.br
+rank6 on dummy4 since the hostfile specifies only a single slot from that node is to be used
+.br
+ranks 7 and 8 on dummy3 since only two slots remain available
+.br
+ranks 9-12 on dummy2 since it is the next available empty node and has four slots
+.br
+ranks 13-16 on dummy5 since it is the last remaining unused node and has four slots
+.fi
+.sp
+.PP
+Thus, the use of relative indexing can allow for complex mappings to be ported across
+allocations, including those obtained from automated resource managers, without the need
+for manual manipulation of scripts and/or command lines.
+#
+[dash-host]
+
+#
+

--- a/src/mca/schizo/prte/help-schizo-prte.txt
+++ b/src/mca/schizo/prte/help-schizo-prte.txt
@@ -135,7 +135,9 @@ Printout URI on stdout [-], stderr [+], or a file [anything else]
 Suicide instead of clean abort after delay
 #
 [default-hostfile]
-Provide a default hostfile
+Specify a default hostfile.
+
+#include#help-schizo-cli#dvm-hostfile
 #
 [singleton]
 ID of the singleton process that started us
@@ -188,10 +190,12 @@ processes; "-x foo*" exports all current environmental variables starting with "
 Output a brief periodic report on launch progress
 #
 [hostfile]
-Provide a hostfile
+#include#help-schizo-cli#dvm-hostfile
 #
 [machinefile]
 Provide a hostfile (synonym for "hostfile")
+
+#include#help-schizo-cli#dvm-hostfile
 #
 [host]
 Comma-separated list of hosts to use for the DVM
@@ -202,15 +206,6 @@ Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buf
 [do-not-launch]
 Perform all necessary operations to prepare to launch the DVM, but do not actually
 launch it (usually used to test mapping patterns)
-#
-[display]
-Comma-delimited list of options for displaying information about the allocation and DVM.
-Allowed values:
-    allocation
-    bind
-    map
-    map-devel
-    topo
 #
 #
 #  DEPRECATED OPTIONS

--- a/src/mca/schizo/prte/help-schizo-prterun.txt
+++ b/src/mca/schizo/prte/help-schizo-prterun.txt
@@ -19,6 +19,10 @@
 Usage: %s [OPTION]...
 Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
 
+The following list of command line options are available. Note that
+more detailed help for any option can be obtained by adding that
+option to the help request as "--help <option>".
+
 /*****      General Options      *****/
 
 -h|--help                            This help message
@@ -33,9 +37,8 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
                                      the DVM controller to reduce clutter
    --debug-daemons-file              Enable debugging of any PRRTE daemons used by this application, storing
                                      their verbose output in files
-   --display <arg0>                  Comma-delimited list of options for displaying information about the
-                                     allocation and job. Allowed values: allocation, bind, map, map-devel,
-                                     topo
+   --display <arg0>                  Options for displaying information about the allocation and job. Allowed
+                                     values: allocation, bind, map, map-devel, topo. No qualifiers.
    --get-stack-traces                Get stack traces of all application procs on timeout
    --leave-session-attached          Do not discard stdout/stderr of remote PRRTE daemons
    --report-state-on-timeout         Report all job and process states upon timeout
@@ -53,13 +56,7 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
    --output <arg0>                   Comma-delimited list of options that control how output is
                                      generated. Allowed values: tag, tag-detailed, tag-fullname,
                                      timestamp, xml, merge-stderr-to-stdout, dir=DIRNAME,
-                                     file=filename. The dir option redirects output from
-                                     application processes into DIRNAME/job/rank/std[out,err,diag]. The file
-                                     option redirects output from application processes into filename.rank. In
-                                     both cases, the provided name will be converted to an absolute path.
-                                     Supported qualifiers include NOCOPY (do not copy the output to the
-                                     stdout/err streams), and RAW (do not buffer the output into complete
-                                     lines, but instead output it as it is received).
+                                     file=FILENAME. Qualifiers: nocopy, raw
    --report-child-jobs-separately    Return the exit status of the primary job only
    --xterm <arg0>                    Create a new xterm window and display output from the specified ranks
                                      there
@@ -75,10 +72,10 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
 
 /*****      Mapping Options      *****/
 
-   --map-by <arg0>                   Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node | seq | dist |
-                                     ppr | rankfile | PE-LIST=a,b (comma-delimited ranges of cpus to use for
-                                     this job)] with supported colon-delimited qualifiers: PE=y (for
+   --map-by <arg0>                   Mapping Policy for job [slot | hwthread | core | l1cache
+                                     | l2cache | l3cache | numa | package | node | seq
+                                     | ppr | rankfile | PE-LIST=a,b (comma-delimited ranges of cpus to use for
+                                     this job)]. Supported colon-delimited qualifiers include PE=y (for
                                      multiple cpus/proc), SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL,
                                      HWTCPUS, CORECPUS, DEVICE(for dist policy), INHERIT, NOINHERIT, DONOTLAUNCH,
                                      FILE=<path> for seq and rankfile options, ORDERED to indicate that the
@@ -101,9 +98,8 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
 
    --bind-to <arg0>                  Binding policy for job. Allowed values: none, hwthread, core, l1cache,
                                      l2cache, l3cache, numa, package, ("none" is the default when
-                                     oversubscribed, "core" is the default when np<=2, and "numa" is the
-                                     default when np>2). Allowed colon-delimited qualifiers: overload-allowed,
-                                     if-supported
+                                     oversubscribed, "core" is the default otherwise). Allowed qualifiers
+                                     include: overload-allowed, if-supported
 
 
 
@@ -366,24 +362,7 @@ Preload the binary on the remote machine before starting the
 remote process.
 #
 [output]
-Comma-delimited list of options that control how output is generated.
-Allowed values:
-    tag                         Mark each output line with the [job,rank] of the
-                                process that generated it
-    timestamp                   Prefix each output line with a datetime stamp. Note
-                                that the timestamp will be the time when the line
-                                is output by the DVM - not the time when the source
-                                output it
-    xml                         Format all output in XML
-    merge[-stderr-to-stdout]    Merge stderr into stdout
-    dir=DIRNAME                 Redirect output from application processes into files of
-                                the form DIRNAME/job/rank/std[out,err,diag].
-    file=filename               Redirect output from application processes into files of
-                                the form filename.rank.
-
-In both the "dir" and "file" cases, the provided name will be converted to an absolute path.
-Supported qualifiers include NOCOPY (i.e., output shall go only into the files - do not copy
-the output to the stdout/err streams).
+#include#help-schizo-cli#output
 #
 [stream-buffering]
 Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]
@@ -495,13 +474,7 @@ Any object can include qualifiers by adding a colon (:) and any combination of o
 
 #
 [display]
-Comma-delimited list of options for displaying information about the allocation and job.
-Allowed values:
-    allocation
-    bind
-    map
-    map-devel
-    topo
+#include#help-schizo-cli#display
 #
 [do-not-launch]
 Perform all necessary operations to prepare to launch the application, but do not actually

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -803,13 +803,13 @@ int main(int argc, char *argv[])
                 if (0 == strncasecmp(targv[idx], PRTE_CLI_ALLOC, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPALLOC, PMIX_STRING);
                 }
-                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAP)) {
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_MAP, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPLAY, PMIX_STRING);
                 }
                 if (0 == strncasecmp(targv[idx], PRTE_CLI_BIND, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":"PRTE_CLI_REPORT, PMIX_STRING);
                 }
-                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAPDEV)) {
+                if (0 == strncasecmp(targv[idx], PRTE_CLI_MAPDEV, strlen(targv[idx]))) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPDEV, PMIX_STRING);
                 }
                 if (0 == strncasecmp(targv[idx], PRTE_CLI_TOPO, strlen(targv[idx]))) {
@@ -836,12 +836,12 @@ int main(int argc, char *argv[])
                     /* could be multiple qualifiers, so separate them */
                     options = pmix_argv_split(cptr, ',');
                     for (int m=0; NULL != options[m]; m++) {
-                        if (0 == strcasecmp(options[m], PRTE_CLI_NOCOPY)) {
+                        if (0 == strncasecmp(options[m], PRTE_CLI_NOCOPY, strlen(options[m]))) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
-                        } else if (0 == strcasecmp(options[m], PRTE_CLI_PATTERN)) {
+                        } else if (0 == strncasecmp(options[m], PRTE_CLI_PATTERN, strlen(options[m]))) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
 #ifdef PMIX_IOF_OUTPUT_RAW
-                        } else if (0 == strcasecmp(options[m], PRTE_CLI_RAW)) {
+                        } else if (0 == strncasecmp(options[m], PRTE_CLI_RAW, strlen(options[m]))) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
 #endif
                         }


### PR DESCRIPTION
Begin breaking down the help into reusable chunks and
adding more detail to it. Port the help info on hostfile
and dash host from prior work. Cleanup some option
processing to respect the case insensitive and abbreviated
input allowance.

Signed-off-by: Ralph Castain <rhc@pmix.org>