### PR TITLE
Update the job object's binding policy

### DIFF
--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -257,6 +257,7 @@ static int ppr_mapper(prte_job_t *jdata,
                     options->nprocs <= node->slots_available &&
                     !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
                     options->bind = PRTE_BIND_TO_NONE;
+                    jdata->map->binding = PRTE_BIND_TO_NONE;
                 }
                 /* check availability and set the target cpuset - this
                  * also computes the nprocs to be assigned capped by
@@ -299,6 +300,7 @@ static int ppr_mapper(prte_job_t *jdata,
                     options->nprocs <= node->slots_available &&
                     !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
                     options->bind = PRTE_BIND_TO_NONE;
+                    jdata->map->binding = PRTE_BIND_TO_NONE;
                 }
                 /* map the specified number of procs to each such resource on this node */
                 for (j = 0; j < nobjs && nprocs_mapped < app->num_procs; j++) {

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -113,6 +113,7 @@ pass:
             options->nprocs <= node->slots_available &&
             !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             options->bind = PRTE_BIND_TO_NONE;
+            jdata->map->binding = PRTE_BIND_TO_NONE;
         }
 
         if (!prte_rmaps_base_check_avail(jdata, app, node, node_list, NULL, options)) {
@@ -251,6 +252,7 @@ pass:
             options->nprocs <= node->slots_available &&
             !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             options->bind = PRTE_BIND_TO_NONE;
+            jdata->map->binding = PRTE_BIND_TO_NONE;
         }
 
         if (!prte_rmaps_base_check_avail(jdata, app, node, node_list, NULL, options)) {
@@ -386,6 +388,7 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
             options->nprocs <= node->slots_available &&
             !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             options->bind = PRTE_BIND_TO_NONE;
+            jdata->map->binding = PRTE_BIND_TO_NONE;
         }
 
         if (!prte_rmaps_base_check_avail(jdata, app, node, node_list, NULL, options)) {
@@ -592,6 +595,7 @@ pass:
             nprocs <= node->slots_available &&
             !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             options->bind = PRTE_BIND_TO_NONE;
+            jdata->map->binding = PRTE_BIND_TO_NONE;
         }
 
         nodefull = false;


### PR DESCRIPTION
When changing the policy, be sure to update the value in the
job object so map-devel output has the correct info.

Signed-off-by: Ralph Castain <rhc@pmix.org>