### PR TITLE
Fix synthetic topo support and too early sanity check

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -192,6 +192,7 @@ extern char *prte_hwloc_print_null;
 PRTE_EXPORT char *prte_hwloc_base_print_locality(prte_hwloc_locality_t locality);
 
 PRTE_EXPORT extern char *prte_hwloc_base_topo_file;
+PRTE_EXPORT extern bool prte_hwloc_synthetic_topo;
 
 /* convenience macro for debugging */
 #define PRTE_HWLOC_SHOW_BINDING(n, v, t)                                                        \

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -38,6 +38,7 @@ char *prte_hwloc_default_cpu_list = NULL;
 char *prte_hwloc_base_topo_file = NULL;
 int prte_hwloc_base_output = -1;
 bool prte_hwloc_default_use_hwthread_cpus = false;
+bool prte_hwloc_synthetic_topo = false;
 
 hwloc_obj_type_t prte_hwloc_levels[] = {
     HWLOC_OBJ_MACHINE,

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -170,7 +170,8 @@ hwloc_cpuset_t prte_hwloc_base_setup_summary(hwloc_topology_t topo)
 
     avail = hwloc_bitmap_alloc();
     /* get the cpus we are bound to */
-    if (0 <= hwloc_get_cpubind(topo, avail, HWLOC_CPUBIND_PROCESS)) {
+    if (!prte_hwloc_synthetic_topo &&
+        0 <= hwloc_get_cpubind(topo, avail, HWLOC_CPUBIND_PROCESS)) {
         return avail;
     }
 
@@ -282,6 +283,7 @@ int prte_hwloc_base_get_topology(void)
         if (PRTE_SUCCESS != (rc = prte_hwloc_base_set_topology(prte_hwloc_base_topo_file))) {
             return rc;
         }
+        prte_hwloc_synthetic_topo = true;
     }
 
     /* fill prte_cache_line_size global with the smallest L1 cache

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -404,11 +404,7 @@ static int rte_init(int argc, char **argv)
         goto error;
     }
 
-    /* if a topology file was given, then the rmaps framework open
-     * will have reset our topology. Ensure we always get the right
-     * one by setting our node topology afterwards
-     */
-    /* add it to the array of known topologies */
+    /* add the topology to the array of known topologies */
     t = PMIX_NEW(prte_topology_t);
     t->topo = prte_hwloc_topology;
     /* generate the signature */

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -126,6 +126,8 @@ PRTE_EXPORT int prte_rmaps_base_set_default_ranking(prte_job_t *jdata,
 PRTE_EXPORT int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec);
 
 PRTE_EXPORT void prte_rmaps_base_display_map(prte_job_t *jdata);
+PRTE_EXPORT void prte_rmaps_base_report_bindings(prte_job_t *jdata,
+                                                 prte_rmaps_options_t *options);
 
 PRTE_EXPORT int prte_rmaps_base_get_ncpus(prte_node_t *node,
                                           hwloc_obj_t obj,

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -391,8 +391,6 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         NULL
     };
 
-    bool hwtcpus = false;
-
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_MAPBY)) {
         pmix_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_MAPBY);
         return PRTE_ERR_SILENT;
@@ -431,9 +429,6 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     /* quick check that we have valid directives */
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_MAPBY);
     if (NULL != opt) {
-        if (NULL != strcasestr(opt->values[0], PRTE_CLI_HWTCPUS)) {
-            hwtcpus = true;
-        }
         if (!prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, opt->values[0])) {
             return PRTE_ERR_SILENT;
         }
@@ -449,12 +444,6 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_BINDTO);
     if (NULL != opt) {
         if (!prte_schizo_base_check_directives(PRTE_CLI_BINDTO, binders, bndquals, opt->values[0])) {
-            return PRTE_ERR_SILENT;
-        }
-        if (0 == strncasecmp(opt->values[0], PRTE_CLI_HWT, strlen(PRTE_CLI_HWT)) && !hwtcpus) {
-            /* if we are told to bind-to hwt, then we have to be treating
-             * hwt's as the allocatable unit */
-            pmix_show_help("help-prte-rmaps-base.txt", "invalid-combination", true);
             return PRTE_ERR_SILENT;
         }
     }

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -55,8 +55,6 @@
 
 #include "src/prted/prted.h"
 
-static void set_classpath_jar_file(prte_pmix_app_t *app, int index, char *jarfile);
-
 /*
  * This function takes a "char ***app_env" parameter to handle the
  * specific case:
@@ -326,17 +324,4 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     /* All done */
 
     return PRTE_SUCCESS;
-}
-
-static void set_classpath_jar_file(prte_pmix_app_t *app, int index, char *jarfile)
-{
-    if (NULL == strstr(app->app.argv[index], jarfile)) {
-        /* nope - need to add it */
-        char *fmt = ':' == app->app.argv[index][strlen(app->app.argv[index] - 1)] ? "%s%s/%s"
-                                                                                  : "%s:%s/%s";
-        char *str;
-        pmix_asprintf(&str, fmt, app->app.argv[index], prte_install_dirs.libdir, jarfile);
-        free(app->app.argv[index]);
-        app->app.argv[index] = str;
-    }
 }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -668,10 +668,8 @@ int prun(int argc, char *argv[])
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                         } else if (0 == strcasecmp(options[m], PRTE_CLI_PATTERN)) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
-    #ifdef PMIX_IOF_OUTPUT_RAW
                         } else if (0 == strcasecmp(options[m], PRTE_CLI_RAW)) {
                             PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
-    #endif
                         }
                     }
                     pmix_argv_free(options);
@@ -827,11 +825,7 @@ int prun(int argc, char *argv[])
         i = strtol(param, NULL, 10);
     }
     if (0 != i) {
-#ifdef PMIX_JOB_TIMEOUT
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_TIMEOUT, &i, PMIX_INT);
-#else
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT, &i, PMIX_INT);
-#endif
     }
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STACK_TRACES)) {
@@ -840,20 +834,16 @@ int prun(int argc, char *argv[])
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_REPORT_STATE)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_REPORT_STATE, &flag, PMIX_BOOL);
     }
-#ifdef PMIX_SPAWN_TIMEOUT
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_SPAWN_TIMEOUT);
     if (NULL != opt) {
         i = strtol(opt->values[0], NULL, 10);
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_SPAWN_TIMEOUT, &i, PMIX_INT);
     }
-#endif
-#ifdef PMIX_LOG_AGG
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DO_NOT_AGG_HELP);
     if (NULL != opt) {
         flag = false;
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_LOG_AGG, &flag, PMIX_BOOL);
     }
-#endif
 
     /* give the schizo components a chance to add to the job info */
     schizo->job_info(&results, jinfo);


### PR DESCRIPTION
Don't apply the local binding window on a synthetic topology
as the binding window is looking at the real topo. Don't
check for hwt support in the sanity checker as the default
policy isn't seen by prun - let the mapper operation detect
any problem. Remove some #ifdef protections as we now require
at least PMIx v4.2, so those definitions are guaranteed to
exist.

Refs #1442 
Signed-off-by: Ralph Castain <rhc@pmix.org>