### PR TITLE
Remove the "report" qualifier from "--bind-to"

### DIFF
--- a/src/hwloc/help-prte-hwloc-base.txt
+++ b/src/hwloc/help-prte-hwloc-base.txt
@@ -153,9 +153,6 @@ combination of one or more of the following to the --bind-to option:
 -   IF-SUPPORTED indicates that the job should continue to
     be launched and executed even if binding cannot be
     performed as requested.
-
--   REPORT outputs a report on the bindings for the processes
-    to stderr
 #
 [bind-upwards]
 Binding is performed to the first available specified object type

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -362,7 +362,6 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_OVERLOAD,
         PRTE_CLI_NOOVERLOAD,
         PRTE_CLI_IF_SUPP,
-        PRTE_CLI_REPORT,
         NULL
     };
 


### PR DESCRIPTION
The report qualifier was stale - we use the
"--display bind" option.

Closes #937 
Signed-off-by: Ralph Castain <rhc@pmix.org>