### PR TITLE
java: add ease-of-use feature for ompi java apps

### DIFF
--- a/src/mca/schizo/ompi/help-schizo-ompi.txt
+++ b/src/mca/schizo/ompi/help-schizo-ompi.txt
@@ -491,6 +491,9 @@ Disable recovery (resets all recovery options to off)
 #
 [continuous]
 Job is to run until explicitly terminated
+[openmpi-install-path-not-found]
+An internal Open MPI environment variable needed for Java support was not set.
+Open MPI 5.0.0 or newer is required for this support.
 #
 #
 #  DEPRECATED OPTIONS

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -6,6 +6,8 @@
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,7 +96,7 @@ typedef int (*prte_schizo_base_module_set_default_binding_fn_t)(prte_job_t *jdat
  * an executable's relative-path to an absolute-path, or add a command
  * required for starting a particular kind of application (e.g., adding
  * "java" to start a Java application) */
-typedef int (*prte_schizo_base_module_setup_app_fn_t)(prte_app_context_t *app);
+typedef int (*prte_schizo_base_module_setup_app_fn_t)(prte_pmix_app_t *app);
 
 /* add any personality-specific envars required at the job level prior
  * to beginning to execute local procs */

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -19,6 +19,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      Triad National Security, LLC.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -231,6 +233,17 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
                        "strdup returned NULL", errno);
         rc = PRTE_ERR_NOT_FOUND;
         goto cleanup;
+    }
+
+    /*
+     * does the schizo being used have a setup_app method?
+     * if so call here
+     */
+    if(NULL != schizo->setup_app) {
+        rc = schizo->setup_app(app);
+        if (PRTE_SUCCESS != rc) {
+            goto cleanup;
+        }
     }
 
     // parse any environment-related cmd line options


### PR DESCRIPTION
Put into prte a convenience feature for java open mpi apps that was present with orte.

Without this support, java users need to know about the name of the
jar file for ompi java classes and the support library used by
these classes.

Namely this PR avoids users having to do something like this on the java command line:

mpirun -np 4 java -classpath /home/me/ompi-er/install_main_java/lib/mpi.jar:. -Djava.library.path=/home/me/ompi-er/install_main_java/lib Hello

Related to https://github.com/open-mpi/ompi/pull/10701

Signed-off-by: Howard Pritchard <howardp@lanl.gov>