### PR TITLE
Fix second pass on map-by-obj

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -29,7 +29,7 @@ slots that were requested by the application:
 
   %s
 
-Either request fewer slots for your application, or make more slots
+Either request fewer procs for your application, or make more slots
 available for use.
 
 A "slot" is the PRRTE term for an allocatable unit where we can


### PR DESCRIPTION
Computation of balance was using the wrong variable
in the denominator.

Refs https://github.com/open-mpi/ompi/pull/10702
Refs https://github.com/open-mpi/ompi/issues/10698
Signed-off-by: Ralph Castain <rhc@pmix.org>