### PR TITLE
Get the "--display topo" option to work

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -552,6 +552,26 @@ next_state:
     /* set total slots alloc */
     jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
 
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO, (void**)&hosts, PMIX_STRING)) {
+        hostlist = pmix_argv_split(hosts, ',');
+        free(hosts);
+        for (j=0; NULL != hostlist[j]; j++) {
+            node = prte_node_match(NULL, hostlist[j]);
+            if (NULL == node) {
+                continue;
+            }
+            prte_output(prte_clean_output,
+                        "=================================================================\n");
+            prte_output(prte_clean_output, "TOPOLOGY FOR NODE %s", node->name);
+            prte_hwloc_print(&ptr, NULL, node->topology->topo);
+            prte_output(prte_clean_output, ptr);
+            free(ptr);
+            prte_output(prte_clean_output,
+                        "=================================================================\n");
+        }
+        pmix_argv_free(hostlist);
+    }
+
     /* set the job state to the next position */
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOCATION_COMPLETE);
 

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -104,6 +104,9 @@ PRTE_EXPORT int prte_schizo_base_add_directive(pmix_cli_result_t *results,
 PRTE_EXPORT int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
                                                char *deprecated, char *target,
                                                char *qualifier, bool report);
+PRTE_EXPORT int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo);
+PRTE_EXPORT int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo);
+
 
 
 END_C_DECLS

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -201,20 +201,6 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
         tmp = tmp2;
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO, NULL, PMIX_BOOL)
-        && NULL != src->topology) {
-        pmix_asprintf(&tmp2, "%s\n            Detected Resources:\n", tmp);
-        free(tmp);
-        tmp = tmp2;
-
-        tmp2 = NULL;
-        prte_hwloc_print(&tmp2, NULL, src->topology->topo);
-        pmix_asprintf(&tmp3, "%s%s", tmp, tmp2);
-        free(tmp);
-        free(tmp2);
-        tmp = tmp3;
-    }
-
 PRINT_PROCS:
     /* we want to print these procs in their job-rank'd order, but they
      * will be in the node array based on the order in which they were

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -329,7 +329,7 @@ prte_node_rank_t prte_get_proc_node_rank(const pmix_proc_t *proc)
 
 prte_node_t* prte_node_match(pmix_list_t *nodes, const char *name)
 {
-    int m;
+    int m, n;
     prte_node_t *nptr;
     char *nm;
 
@@ -340,23 +340,41 @@ prte_node_t* prte_node_match(pmix_list_t *nodes, const char *name)
         nm = (char*)name;
     }
 
-    PMIX_LIST_FOREACH(nptr, nodes, prte_node_t) {
-        /* start with the simple check */
-        if (0 == strcmp(nptr->name, nm)) {
-            return nptr;
-        }
-    }
-
-    /* see if it is an alias for something already on the list */
-    PMIX_LIST_FOREACH(nptr, nodes, prte_node_t) {
-        if (NULL == nptr->aliases) {
-            continue;
-        }
-        /* no choice but an exhaustive search - fortunately, these lists are short! */
-        for (m = 0; NULL != nptr->aliases[m]; m++) {
-            if (0 == strcmp(name, nptr->aliases[m])) {
-                /* this is the node! */
+    if (NULL != nodes) {
+        PMIX_LIST_FOREACH(nptr, nodes, prte_node_t) {
+            if (0 == strcmp(nptr->name, nm)) {
                 return nptr;
+            }
+            if (NULL == nptr->aliases) {
+                continue;
+            }
+            /* no choice but an exhaustive search - fortunately, these lists are short! */
+            for (m = 0; NULL != nptr->aliases[m]; m++) {
+                if (0 == strcmp(name, nptr->aliases[m])) {
+                    /* this is the node! */
+                    return nptr;
+                }
+            }
+        }
+    } else {
+        /* check the node pool */
+        for (n=0; n < prte_node_pool->size; n++) {
+            nptr = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, n);
+            if (NULL == nptr) {
+                continue;
+            }
+            if (0 == strcmp(nptr->name, nm)) {
+                return nptr;
+            }
+            if (NULL == nptr->aliases) {
+                continue;
+            }
+            /* no choice but an exhaustive search - fortunately, these lists are short! */
+            for (m = 0; NULL != nptr->aliases[m]; m++) {
+                if (0 == strcmp(name, nptr->aliases[m])) {
+                    /* this is the node! */
+                    return nptr;
+                }
             }
         }
     }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -303,8 +303,6 @@ int prun(int argc, char *argv[])
     char hostname[PRTE_PATH_MAX];
     pmix_rank_t rank;
     pmix_status_t code;
-    char *outdir = NULL;
-    char *outfile = NULL;
     char *personality;
     pmix_proc_t parent;
     pmix_cli_result_t results;
@@ -479,8 +477,10 @@ int prun(int argc, char *argv[])
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DO_NOT_CONNECT)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_DO_NOT_CONNECT, NULL, PMIX_BOOL);
+
     } else if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYS_SERVER_FIRST)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+
     } else if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYS_SERVER_ONLY)) {
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_TO_SYSTEM, NULL, PMIX_BOOL);
     }
@@ -491,7 +491,7 @@ int prun(int argc, char *argv[])
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
     }
 
-    opt = pmix_cmd_line_get_param(&results, "num-connect-retries");
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_NUM_CONNECT_RETRIES);
     if (NULL != opt) {
         ui32 = strtol(opt->values[0], NULL, 10);
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_MAX_RETRIES, &ui32, PMIX_UINT32);
@@ -623,142 +623,21 @@ int prun(int argc, char *argv[])
     /* get display options */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DISPLAY);
     if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n++) {
-            targv = pmix_argv_split(opt->values[n], ',');
-
-            for (int idx = 0; idx < pmix_argv_count(targv); idx++) {
-                if (0 == strncasecmp(targv[idx], PRTE_CLI_ALLOC, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPALLOC, PMIX_STRING);
-                }
-                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAP)) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPLAY, PMIX_STRING);
-                }
-                if (0 == strncasecmp(targv[idx], PRTE_CLI_BIND, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, ":"PRTE_CLI_REPORT, PMIX_STRING);
-                }
-                if (0 == strcasecmp(targv[idx], PRTE_CLI_MAPDEV)) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPDEV, PMIX_STRING);
-                }
-                if (0 == strncasecmp(targv[idx], PRTE_CLI_TOPO, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, ":"PRTE_CLI_DISPTOPO, PMIX_STRING);
-                }
-            }
-            pmix_argv_free(targv);
+        ret = prte_schizo_base_parse_display(opt, jinfo);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            goto DONE;
         }
     }
 
     /* cannot have both files and directory set for output */
-    outdir = NULL;
-    outfile = NULL;
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n++) {
-            targv = pmix_argv_split(opt->values[n], ',');
-
-            for (int idx = 0; NULL != targv[idx]; idx++) {
-                /* check for qualifiers */
-                cptr = strchr(targv[idx], ':');
-                if (NULL != cptr) {
-                    *cptr = '\0';
-                    ++cptr;
-                    /* could be multiple qualifiers, so separate them */
-                    options = pmix_argv_split(cptr, ',');
-                    for (int m=0; NULL != options[m]; m++) {
-                        if (0 == strcasecmp(options[m], PRTE_CLI_NOCOPY)) {
-                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
-                        } else if (0 == strcasecmp(options[m], PRTE_CLI_PATTERN)) {
-                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
-                        } else if (0 == strcasecmp(options[m], PRTE_CLI_RAW)) {
-                            PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
-                        }
-                    }
-                    pmix_argv_free(options);
-                }
-                if (0 == strlen(targv[idx])) {
-                    // only qualifiers were given
-                    continue;
-                }
-                /* remove any '=' sign in the directive */
-                if (NULL != (ptr = strchr(targv[idx], '='))) {
-                    *ptr = '\0';
-                    ++ptr;
-                }
-                if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, &flag, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_DET, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TAG_FULL, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_RANK, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_TIMESTAMP, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, &flag, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_XML, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_MERGE_ERROUT, strlen(targv[idx]))) {
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_DIR, strlen(targv[idx]))) {
-                    if (NULL != outfile) {
-                        pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
-                        return PRTE_ERR_FATAL;
-                    }
-                    if (NULL == ptr) {
-                        pmix_show_help("help-prte-rmaps-base.txt",
-                                       "missing-qualifier", true,
-                                       "output", "directory", "directory");
-                        return PRTE_ERR_FATAL;
-                    }
-                    /* If the given filename isn't an absolute path, then
-                     * convert it to one so the name will be relative to
-                     * the directory where prun was given as that is what
-                     * the user will have seen */
-                    if (!pmix_path_is_absolute(ptr)) {
-                        char cwd[PRTE_PATH_MAX];
-                        if (NULL == getcwd(cwd, sizeof(cwd))) {
-                            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                            goto DONE;
-                        }
-                        outdir = pmix_os_path(false, cwd, ptr, NULL);
-                    } else {
-                        outdir = strdup(ptr);
-                    }
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
-                } else if (0 == strncasecmp(targv[idx], PRTE_CLI_FILE, strlen(targv[idx]))) {
-                    if (NULL != outdir) {
-                        pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, outdir);
-                        return PRTE_ERR_FATAL;
-                    }
-                    if (NULL == ptr) {
-                        pmix_show_help("help-prte-rmaps-base.txt",
-                                       "missing-qualifier", true,
-                                       "output", "filename", "filename");
-                        return PRTE_ERR_FATAL;
-                    }
-                    /* If the given filename isn't an absolute path, then
-                     * convert it to one so the name will be relative to
-                     * the directory where prun was given as that is what
-                     * the user will have seen */
-                    if (!pmix_path_is_absolute(ptr)) {
-                        char cwd[PRTE_PATH_MAX];
-                        if (NULL == getcwd(cwd, sizeof(cwd))) {
-                            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                            goto DONE;
-                        }
-                        outfile = pmix_os_path(false, cwd, ptr, NULL);
-                    } else {
-                        outfile = strdup(ptr);
-                    }
-                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
-                }
-            }
-            pmix_argv_free(targv);
+        ret = prte_schizo_base_parse_output(opt, jinfo);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            goto DONE;
         }
-    }
-    if (NULL != outdir) {
-        free(outdir);
-    }
-    if (NULL != outfile) {
-        free(outfile);
     }
 
     /* check what user wants us to do with stdin */
@@ -874,11 +753,11 @@ int prun(int argc, char *argv[])
     /* transfer any returned ENVARS to the job_info */
     if (NULL != mylock.info) {
         for (n = 0; n < mylock.ninfo; n++) {
-            if (0 == strncmp(mylock.info[n].key, PMIX_SET_ENVAR, PMIX_MAX_KEYLEN)
-                || 0 == strncmp(mylock.info[n].key, PMIX_ADD_ENVAR, PMIX_MAX_KEYLEN)
-                || 0 == strncmp(mylock.info[n].key, PMIX_UNSET_ENVAR, PMIX_MAX_KEYLEN)
-                || 0 == strncmp(mylock.info[n].key, PMIX_PREPEND_ENVAR, PMIX_MAX_KEYLEN)
-                || 0 == strncmp(mylock.info[n].key, PMIX_APPEND_ENVAR, PMIX_MAX_KEYLEN)) {
+            if (PMIX_CHECK_KEY(&mylock.info[n], PMIX_SET_ENVAR) ||
+                PMIX_CHECK_KEY(&mylock.info[n], PMIX_ADD_ENVAR) ||
+                PMIX_CHECK_KEY(&mylock.info[n], PMIX_UNSET_ENVAR) ||
+                PMIX_CHECK_KEY(&mylock.info[n], PMIX_PREPEND_ENVAR) ||
+                PMIX_CHECK_KEY(&mylock.info[n], PMIX_APPEND_ENVAR)) {
                 PMIX_INFO_LIST_XFER(ret, jinfo, &mylock.info[n]);
             }
         }

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -196,7 +196,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_MAP        "map"
 #define PRTE_CLI_BIND       "bind"
 #define PRTE_CLI_MAPDEV     "map-devel"
-#define PRTE_CLI_TOPO       "topo"
+#define PRTE_CLI_TOPO       "topo="
 
 /* define the command line qualifiers PRRTE recognizes */
 
@@ -222,12 +222,47 @@ BEGIN_C_DECLS
 #define PRTE_CLI_DISPALLOC  "displayalloc"
 // PRTE_CLI_DISPLAY reused here
 #define PRTE_CLI_DISPDEV    "displaydevel"
-#define PRTE_CLI_DISPTOPO   "displaytopo"
 
 // Output qualifiers
 #define PRTE_CLI_NOCOPY     "nocopy"
 #define PRTE_CLI_RAW        "raw"
 #define PRTE_CLI_PATTERN    "pattern"
+
+/* USAGE:
+ *  param "a" is the input command line string
+ *  param "b" is the defined CLI option
+ */
+static inline bool prte_check_cli_option(char *a, char *b)
+{
+    size_t len1, len2, len;
+
+    len1 = strlen(a);
+    len2 = strlen(b);
+
+    /* we have some cases where more than one CLI option
+     * start with the same chars (e.g., "map" and
+     * "map-devel". So if one param has a '-' in it, then
+     * the matching param string must also include the '-'
+     */
+    if (NULL != strchr(b, '-') &&
+        NULL == strchr(a, '-')) {
+        return false;
+    }
+    if (NULL != strchr(a, '-') &&
+        NULL == strchr(b, '-')) {
+        return false;
+    }
+
+    len = (len1 < len2) ? len1 : len2;
+    if (0 == strncasecmp(a, b, len)) {
+        return true;
+    }
+
+    return false;
+}
+
+#define PRTE_CHECK_CLI_OPTION(a, b) \
+    prte_check_cli_option(a, b)
 
 END_C_DECLS
 


### PR DESCRIPTION
Modify the option to take a comma-delimited list of node names
so you can specify whose topology you want to see. Implement it
to occur right after allocation, and ensure it can be specified
on a per-job basis.

Fix CLI option checking to better handle the case of user-shortened
option name input, taking into account that some options (e.g., "map"
and "map-devel") start with the same substring.

Refs https://github.com/open-mpi/ompi/issues/10698
Signed-off-by: Ralph Castain <rhc@pmix.org>