### PR TITLE
Separate out the runtime controls options

### DIFF
--- a/examples/bad_exit.c
+++ b/examples/bad_exit.c
@@ -126,6 +126,8 @@ int main(int argc, char **argv)
 done:
     if (0 == myproc.rank) {
         exit(1);
+    } else {
+        sleep(3);
     }
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -24,6 +24,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/output.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/prte_cmd_line.h"
 
 /*
  * Globals
@@ -531,7 +532,6 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
     prte_binding_policy_t tmp;
     char **quals, *myspec, *ptr;
     prte_job_t *jdata = (prte_job_t *) jdat;
-    size_t len;
 
     /* set default */
     tmp = 0;
@@ -550,15 +550,17 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
         ++ptr;
         quals = pmix_argv_split(ptr, ':');
         for (i = 0; NULL != quals[i]; i++) {
-            len = strlen(quals[i]);
-            if (0 == strncasecmp(quals[i], "if-supported", len)) {
+            if (PRTE_CHECK_CLI_OPTION(quals[i], PRTE_CLI_IF_SUPP)) {
                 tmp |= PRTE_BIND_IF_SUPPORTED;
-            } else if (0 == strncasecmp(quals[i], "overload-allowed", len)) {
+
+            } else if (PRTE_CHECK_CLI_OPTION(quals[i], PRTE_CLI_OVERLOAD)) {
                 tmp |= (PRTE_BIND_ALLOW_OVERLOAD | PRTE_BIND_OVERLOAD_GIVEN);
-            } else if (0 == strncasecmp(quals[i], "no-overload", len)) {
+
+            } else if (PRTE_CHECK_CLI_OPTION(quals[i], PRTE_CLI_NOOVERLOAD)) {
                 tmp = (tmp & ~PRTE_BIND_ALLOW_OVERLOAD);
                 tmp |= PRTE_BIND_OVERLOAD_GIVEN;
-            } else if (0 == strncasecmp(quals[i], "REPORT", len)) {
+
+            } else if (PRTE_CHECK_CLI_OPTION(quals[i], PRTE_CLI_REPORT)) {
                 if (NULL == jdata) {
                     pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                    "binding policy", quals[i]);
@@ -567,6 +569,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                 }
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_REPORT_BINDINGS, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
+
             } else {
                 /* unknown option */
                 pmix_show_help("help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
@@ -578,30 +581,35 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
         pmix_argv_free(quals);
     }
 
-    len = strlen(myspec);
-    if (0 < len) {
-        if (0 == strncasecmp(myspec, "none", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NONE);
-        } else if (0 == strncasecmp(myspec, "hwthread", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
-        } else if (0 == strncasecmp(myspec, "core", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_CORE);
-        } else if (0 == strncasecmp(myspec, "l1cache", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L1CACHE);
-        } else if (0 == strncasecmp(myspec, "l2cache", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L2CACHE);
-        } else if (0 == strncasecmp(myspec, "l3cache", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L3CACHE);
-        } else if (0 == strncasecmp(myspec, "numa", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NUMA);
-        } else if (0 == strncasecmp(myspec, "package", len)) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
-        } else {
-            pmix_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
-                           spec);
-            free(myspec);
-            return PRTE_ERR_BAD_PARAM;
-        }
+    if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_NONE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NONE);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_HWT)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_CORE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_CORE);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_L1CACHE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L1CACHE);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_L2CACHE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L2CACHE);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_L3CACHE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L3CACHE);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_NUMA)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NUMA);
+
+    } else if (PRTE_CHECK_CLI_OPTION(myspec, PRTE_CLI_PACKAGE)) {
+        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
+
+    } else {
+        pmix_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
+                       spec);
+        free(myspec);
+        return PRTE_ERR_BAD_PARAM;
     }
     free(myspec);
 

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -378,6 +378,8 @@ static void proc_errors(int fd, short args, void *cbdata)
     prte_proc_state_t state = caddy->proc_state;
     int i;
     int32_t i32, *i32ptr;
+    bool flag;
+    bool *fptr = &flag;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -679,6 +681,8 @@ keep_going:
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
                              pptr->exit_code));
         jdata->exit_code = pptr->exit_code;
+        PRTE_FLAG_UNSET(pptr, PRTE_PROC_FLAG_ALIVE);
+        jdata->num_terminated++;
         /* track the number of non-zero exits */
         i32 = 0;
         i32ptr = &i32;
@@ -687,7 +691,9 @@ keep_going:
         ++i32;
         prte_set_attribute(&jdata->attributes, PRTE_JOB_NUM_NONZERO_EXIT, PRTE_ATTR_LOCAL, i32ptr,
                            PMIX_INT32);
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL)) {
+        flag = true;
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void*)&fptr, PMIX_BOOL);
+        if (flag) {
             if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
                 jdata->state = PRTE_JOB_STATE_NON_ZERO_TERM;
                 /* point to the first rank to cause the problem */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1523,6 +1523,8 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
     prte_job_t *jobdat;
     prte_proc_state_t state = PRTE_PROC_STATE_WAITPID_FIRED;
     prte_proc_t *cptr;
+    bool flag = false;
+    bool *fptr = &flag;
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
     prte_output_verbose(5, prte_odls_base_framework.framework_output,
@@ -1610,8 +1612,9 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                  * felt it was non-normal - in this latter case, we do not
                  * require that the proc deregister before terminating
                  */
-                if (0 != proc->exit_code &&
-                    prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL)) {
+                flag = false;
+                prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
+                if (0 != proc->exit_code && flag) {
                     state = PRTE_PROC_STATE_TERM_NON_ZERO;
                     PRTE_OUTPUT_VERBOSE(
                         (5, prte_odls_base_framework.framework_output,
@@ -1674,8 +1677,9 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
              * none of them will. This is considered acceptable. Still
              * flag it as abnormal if the exit code was non-zero
              */
-            if (0 != proc->exit_code &&
-                prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL)) {
+            flag = false;
+            prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
+            if (0 != proc->exit_code && flag) {
                 state = PRTE_PROC_STATE_TERM_NON_ZERO;
             } else {
                 state = PRTE_PROC_STATE_WAITPID_FIRED;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1949,15 +1949,6 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     if (prte_allow_run_as_root) {
         pmix_argv_append(argc, argv, "--allow-run-as-root");
     }
-    if (prte_map_stddiag_to_stderr) {
-        pmix_argv_append(argc, argv, "--prtemca");
-        pmix_argv_append(argc, argv, "prte_map_stddiag_to_stderr");
-        pmix_argv_append(argc, argv, "1");
-    } else if (prte_map_stddiag_to_stdout) {
-        pmix_argv_append(argc, argv, "--prtemca");
-        pmix_argv_append(argc, argv, "prte_map_stddiag_to_stdout");
-        pmix_argv_append(argc, argv, "1");
-    }
 
     /* the following is not an mca param */
     if (NULL != getenv("PRTE_TEST_PRTED_SUICIDE")) {

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -76,6 +76,7 @@ typedef struct {
      * when the directive comes thru MCA param */
     char *file;
     hwloc_cpuset_t available, baseset;  // scratch for binding calculation
+    bool abort_non_zero_exit;  // default setting for aborting on non-zero proc exit
 } prte_rmaps_base_t;
 
 /**
@@ -124,6 +125,10 @@ PRTE_EXPORT int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *spec
 PRTE_EXPORT int prte_rmaps_base_set_default_ranking(prte_job_t *jdata,
                                                     prte_rmaps_options_t *options);
 PRTE_EXPORT int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec);
+
+PRTE_EXPORT int prte_rmaps_base_set_default_rto(prte_job_t *jdata,
+                                                prte_rmaps_options_t *options);
+PRTE_EXPORT int prte_rmaps_base_set_runtime_options(prte_job_t *jdata, char *spec);
 
 PRTE_EXPORT void prte_rmaps_base_display_map(prte_job_t *jdata);
 PRTE_EXPORT void prte_rmaps_base_report_bindings(prte_job_t *jdata,

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -677,10 +677,6 @@ to the --map-by option (except where noted):
     be bound to the first CPU in the list, the second proc shall be
     bound to the second CPU, etc.)
 
--   DONOTLAUNCH directs PRRTE to map but not launch the specified job.
-    This is provided to help explore possible process placement patterns
-    before actually starting execution.
-
 Note that directives and qualifiers are case-insensitive
 and can be shortened to the minimum number of characters
 to uniquely identify them. Thus, "L1CACHE" can be given

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -103,6 +103,15 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     memset(&options, 0, sizeof(prte_rmaps_options_t));
     options.stream = prte_rmaps_base_framework.framework_output;
     options.verbosity = 5;  // usual value for base-level functions
+    if (!jdata->map->rtos_set) {
+        /* set the runtime options first */
+        if (NULL != schizo->set_default_rto) {
+            rc = schizo->set_default_rto(jdata, &options);
+        } else {
+            rc = prte_rmaps_base_set_default_rto(jdata, &options);
+        }
+    }
+    /* check and set some general options */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
         options.donotlaunch = true;
     }

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -57,6 +57,7 @@ struct prte_job_map_t {
     prte_mapping_policy_t mapping;
     prte_ranking_policy_t ranking;
     prte_binding_policy_t binding;
+    bool rtos_set;
     /* *** */
     /* number of new daemons required to be launched
      * to support this job map

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -29,7 +29,8 @@ Supported values include:
     processes in this job that includes local and node ranks, assigned
     bindings, and other data
 
--   TOPO displays the topology of the nodes allocated to the job
+-   TOPO=LIST displays the topology of each node in the comma-delimited list
+    that is allocated to the job
 
 No qualifiers are defined for this directive.
 #
@@ -447,3 +448,38 @@ application compiled with Open MPI, "mpich" for one built against
 the MPICH library, or "oshmem" for an OpenSHMEM application compiled
 against SUNY's reference library.
 #
+#  RUNTIME-OPTIONS
+#
+[runtime-options]
+The "runtime-options" command line directive must be accompanied by a
+comma-delimited list of case-insensitive options that control the runtime
+behavior of the job. The full directive need not be provided - only enough
+characters are required to uniquely identify the directive.
+
+Runtime options are typically "true" or "false", though this is not a
+requirement on developers. Since the value of each option may need to
+be set (e.g., to override a default set by MCA parameter), the syntax
+of the command line directive includes the use of an '=' character to
+allow inclusion of a value for the option. For example, one can set
+the ABORT-NONZERO-STATUS option to "true" by specifying it as
+"ABORT-NONZERO-STATUS=1". Note that boolean options can be set to "true"
+using a non-zero integer or a case-insensitive string of the word "true".
+For the latter representation, the user need only provide at least the
+'T' character. The same policy applies to setting a boolean option to
+"false".
+
+Note that a boolean option will default to "true" if provided without
+a value. Thus, "--runtime-options abort-nonzero" is sufficient to set the
+"ABORT-NONZERO-STATUS" option to "true".
+
+Supported values include:
+
+-   ABORT-NONZERO-STATUS[=(bool)] directs the runtime to not abort a running
+    job if a process exits with non-zero status if set to true.
+
+-   DONOTLAUNCH directs the runtime to map but not launch the specified
+    job. This is provided to help explore possible process placement patterns
+    before actually starting execution.
+
+The runtime-options command line option has no qualifiers. Note that directives
+are case-insensitive.

--- a/src/mca/schizo/prte/help-schizo-prterun.txt
+++ b/src/mca/schizo/prte/help-schizo-prterun.txt
@@ -79,14 +79,14 @@ option to the help request as "--help <option>".
 
 
 /*****      Launch Options       *****/
-
--n|--np <arg0>                       Number of processes to run
--N|--npernode <arg0>                        Run one process per node
+   --runtime-options <arg0>          Comma-delimited list of runtime directives for the job (e.g., do not
+                                     abort if a process exits on non-zero status)
+-c|--np <arg0>                       Number of processes to run
+-n|--n <arg0>                        Number of processes to run
+-N|--npernode <arg0>                 Run designated number of processes on each node
    --personality <arg0>              Specify the personality to be used
 -H|--host <arg0>                     List of hosts to invoke processes on
    --hostfile <arg0>                 Provide a hostfile
-   --initial-errhandler <arg0>       Specify the initial error handler that is attached to predefined
-                                     communicators during the first MPI call.
    --machinefile <arg0>              Provide a hostfile (synonym for hostfile)
    --pmixmca <arg0> <arg1>           Pass context-specific PMIx MCA parameters; they are considered global if
                                      only one context is specified (arg0 is the parameter name; arg1 is the parameter value)
@@ -317,6 +317,9 @@ Specify procs to receive stdin [rank, "all", "none"] (default: 0, indicating ran
 #
 [bind-to]
 #include#help-prte-hwloc-base#bind-to-option
+#
+[runtime-options]
+#include#help-schizo-cli#runtime-options
 #
 [rankfile]
 Name of file to specify explicit task mapping

--- a/src/mca/schizo/prte/help-schizo-prun.txt
+++ b/src/mca/schizo/prte/help-schizo-prun.txt
@@ -70,49 +70,17 @@ option to the help request as "--help <option>".
 
 
 
-/*****      Mapping Options      *****/
+/*****      Placement Options      *****/
 
-   --map-by <arg0>                   Mapping Policy for job [slot | hwthread | core (default:np<=2) | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node | seq | dist |
-                                     ppr | rankfile | PE-LIST=a,b (comma-delimited ranges of cpus to use for
-                                     this job)] with supported colon-delimited qualifiers: PE=y (for
-                                     multiple cpus/proc), SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL,
-                                     HWTCPUS, CORECPUS, DEVICE(for dist policy), INHERIT, NOINHERIT, DONOTLAUNCH,
-                                     FILE=<path> for seq and rankfile options, ORDERED to indicate that the
-                                     CPUs specified in PE-LIST should be assigned to individual procs in
-                                     specified order (i.e., the first proc on a node is bound to the first
-                                     CPU in the list, the second proc to the second CPU, etc.). The PE-LIST
-                                     option without the ORDERED qualifier will result in each proc being
-                                     bound to the complete list of CPUs.
-
-
-
-/*****      Ranking Options      *****/
-
-   --rank-by <arg0>                  Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node], with
-                                     modifier :SPAN or :FILL
-
-
-
-/*****      Binding Options      *****/
-
-   --bind-to <arg0>                  Binding policy for job. Allowed values: none, hwthread, core, l1cache,
-                                     l2cache, l3cache, numa, package, ("none" is the default when
-                                     oversubscribed, "core" is the default when np<=2, and "numa" is the
-                                     default when np>2). Allowed colon-delimited qualifiers: overload-allowed,
-                                     if-supported
-
-
-
-/*****     Developer Options     *****/
-
-   --do-not-launch                   Perform all necessary operations to prepare to launch the application,
-                                     but do not actually launch it (usually used to test mapping patterns)
+   --map-by <arg0>                   Mapping Policy for job
+   --rank-by <arg0>                  Ranking Policy for job
+   --bind-to <arg0>                  Binding policy for job.
 
 
 
 /*****      Launch Options       *****/
+   --runtime-options <arg0>          Comma-delimited list of runtime directives for the job (e.g., do not
+                                     abort if a process exits on non-zero status)
 -c|--np <arg0>                       Number of processes to run
 -n|--n <arg0>                        Number of processes to run
 -N <arg0>                            Number of processes to run per node
@@ -128,7 +96,6 @@ option to the help request as "--help <option>".
    --tune <arg0>                     File(s) containing MCA params for tuning operations
    --preload-files <arg0>            Preload the comma separated list of files to the remote machines current
                                      working directory before starting the remote process.
-   --prtemca <arg0> <arg1>           Pass context-specific PRTE MCA parameters to the DVM
    --pset <arg0>                     User-specified name assigned to the processes in their given application
    --rankfile <arg0>                 Name of file to specify explicit task mapping
 -s|--preload-binary                  Preload the binary on the remote machine before starting the remote
@@ -248,6 +215,9 @@ Pipe to monitor - DVM will terminate upon closure
 #
 [bind-to]
 #include#help-prte-hwloc-base#bind-to-option
+#
+[runtime-options]
+#include#help-schizo-cli#runtime-options
 #
 [display]
 #include#help-schizo-cli#display

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -208,6 +208,9 @@ static struct option prterunoptions[] = {
     /* Binding options */
     PMIX_OPTION_DEFINE(PRTE_CLI_BINDTO, PMIX_ARG_REQD),
 
+    /* Runtime options */
+    PMIX_OPTION_DEFINE(PRTE_CLI_RTOS, PMIX_ARG_REQD),
+
     /* display options */
     PMIX_OPTION_DEFINE(PRTE_CLI_DISPLAY, PMIX_ARG_REQD),
 
@@ -316,6 +319,9 @@ static struct option prunoptions[] = {
 
     /* Binding options */
     PMIX_OPTION_DEFINE(PRTE_CLI_BINDTO, PMIX_ARG_REQD),
+
+    /* Runtime options */
+    PMIX_OPTION_DEFINE(PRTE_CLI_RTOS, PMIX_ARG_REQD),
 
     /* display options */
     PMIX_OPTION_DEFINE(PRTE_CLI_DISPLAY, PMIX_ARG_REQD),

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -90,6 +90,9 @@ typedef int (*prte_schizo_base_module_set_default_ranking_fn_t)(prte_job_t *jdat
 typedef int (*prte_schizo_base_module_set_default_binding_fn_t)(prte_job_t *jdata,
                                                                 prte_rmaps_options_t *options);
 
+typedef int (*prte_schizo_base_module_set_default_rto_fn_t)(prte_job_t *jdata,
+                                                            prte_rmaps_options_t *options);
+
 /* do whatever preparation work
  * is required to setup the app for execution. This is intended to be
  * used by prun and other launcher tools to, for example, change
@@ -123,6 +126,7 @@ typedef struct {
     prte_schizo_base_module_set_default_mapping_fn_t    set_default_mapping;
     prte_schizo_base_module_set_default_ranking_fn_t    set_default_ranking;
     prte_schizo_base_module_set_default_binding_fn_t    set_default_binding;
+    prte_schizo_base_module_set_default_rto_fn_t        set_default_rto;
     prte_schizo_base_module_setup_app_fn_t              setup_app;
     prte_schizo_base_module_setup_fork_fn_t             setup_fork;
     prte_schizo_base_module_job_info_fn_t               job_info;

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -346,9 +346,6 @@ static void track_procs(int fd, short argc, void *cbdata)
     /* get the job object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        prte_output(0, "%s ERROR: %s NOT FOUND %s",
-                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
-                    prte_proc_state_to_str(state));
         goto cleanup;
     }
     if (PRTE_PROC_STATE_READY_FOR_DEBUG == state) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -424,6 +424,14 @@ static void interim(int sd, short args, void *cbdata)
                 goto complete;
             }
 
+            /***   RUNTIME OPTIONS  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_RUNTIME_OPTIONS)) {
+            rc = prte_rmaps_base_set_runtime_options(jdata, info->value.data.string);
+            if (PRTE_SUCCESS != rc) {
+                goto complete;
+            }
+            jdata->map->rtos_set = true;
+
             /*** EXEC AGENT ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_EXEC_AGENT)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_EXEC_AGENT, PRTE_ATTR_GLOBAL,
@@ -744,13 +752,11 @@ static void interim(int sd, short args, void *cbdata)
                                    &flag, PMIX_BOOL);
             }
 
-#ifdef PMIX_ABORT_NONZERO_EXIT
-        } else if (PMIX_CHECK_KEY(info, PMIX_ABORT_NONZERO_EXIT)) {
-            flag = PMIX_INFO_TRUE(info);
-            if (!flag) {
-                prte_add_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, PRTE_ATTR_GLOBAL,
-                                   &flag, PMIX_BOOL);
-            }
+#ifdef PMIX_CONTROLS
+        } else if (PMIX_CHECK_KEY(info, PMIX_CONTROLS)) {
+            prte_add_attribute(&jdata->attributes, PRTE_JOB_CONTROLS,
+                               PRTE_ATTR_GLOBAL,
+                               &info->value.data.string, PMIX_STRING);
 #endif
 
             /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -148,9 +148,6 @@ char *prte_report_events_uri = NULL;
 /* report bindings */
 bool prte_report_bindings = false;
 
-/* barrier control */
-bool prte_do_not_barrier = false;
-
 /* process recovery */
 bool prte_enable_recovery = false;
 int32_t prte_max_restarts = 0;
@@ -164,10 +161,6 @@ int prte_stat_history_size = -1;
 
 /* envars to forward */
 char **prte_forwarded_envars = NULL;
-
-/* map stddiag output to stderr so it isn't forwarded to mpirun */
-bool prte_map_stddiag_to_stderr = false;
-bool prte_map_stddiag_to_stdout = false;
 
 /* maximum size of virtual machine - used to subdivide allocation */
 int prte_max_vm_size = -1;
@@ -725,6 +718,7 @@ static void prte_job_map_construct(prte_job_map_t *map)
     map->mapping = 0;
     map->ranking = 0;
     map->binding = 0;
+    map->rtos_set = false;
     map->num_new_daemons = 0;
     map->daemon_vpid_start = PMIX_RANK_INVALID;
     map->num_nodes = 0;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -592,8 +592,6 @@ PRTE_EXPORT extern char *prte_report_events_uri;
 /* process recovery */
 PRTE_EXPORT extern bool prte_enable_recovery;
 PRTE_EXPORT extern int32_t prte_max_restarts;
-/* barrier control */
-PRTE_EXPORT extern bool prte_do_not_barrier;
 
 /* exit status reporting */
 PRTE_EXPORT extern bool prte_report_child_jobs_separately;
@@ -604,10 +602,6 @@ PRTE_EXPORT extern int prte_stat_history_size;
 
 /* envars to forward */
 PRTE_EXPORT extern char **prte_forwarded_envars;
-
-/* map stddiag output to stderr so it isn't forwarded to mpirun */
-PRTE_EXPORT extern bool prte_map_stddiag_to_stderr;
-PRTE_EXPORT extern bool prte_map_stddiag_to_stdout;
 
 /* maximum size of virtual machine - used to subdivide allocation */
 PRTE_EXPORT extern int prte_max_vm_size;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -478,28 +478,6 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_allocation_required);
 
-    /* whether or not to map stddiag to stderr */
-    prte_map_stddiag_to_stderr = false;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "map_stddiag_to_stderr",
-        "Map output from prte_output to stderr of the local process [default: no]",
-        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_map_stddiag_to_stderr);
-
-    /* whether or not to map stddiag to stderr */
-    prte_map_stddiag_to_stdout = false;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "map_stddiag_to_stdout",
-        "Map output from prte_output to stdout of the local process [default: no]",
-        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_map_stddiag_to_stdout);
-    if (prte_map_stddiag_to_stderr && prte_map_stddiag_to_stdout) {
-        prte_output(0,
-                    "The options \"prte_map_stddiag_to_stderr\" and \"prte_map_stddiag_to_stdout\" "
-                    "are mutually exclusive. They cannot both be set to true.");
-        return PRTE_ERROR;
-    }
-
     /* generate new terminal windows to display output from specified ranks */
     prte_xterm = NULL;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "xterm",
@@ -514,11 +492,6 @@ int prte_register_params(void)
          * back to the controlling terminal
          */
         prte_leave_session_attached = true;
-        /* also want to redirect stddiag output from prte_output
-         * to stderr from the process so those messages show
-         * up in the xterm window instead of being forwarded to mpirun
-         */
-        prte_map_stddiag_to_stderr = true;
     }
 
     /* whether or not to report launch progress */
@@ -539,13 +512,6 @@ int prte_register_params(void)
     if (NULL != prte_report_events_uri) {
         prte_report_events = true;
     }
-
-    /* barrier control */
-    prte_do_not_barrier = false;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "do_not_barrier",
-                                      "Do not barrier in prte_init", PRTE_MCA_BASE_VAR_TYPE_BOOL,
-                                      NULL, 0, PRTE_MCA_BASE_VAR_FLAG_INTERNAL, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_do_not_barrier);
 
     prte_enable_recovery = false;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "enable_recovery",

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -106,6 +106,8 @@ static char *print_aborted_job(prte_job_t *job,
                                prte_node_t *node)
 {
     char *output = NULL;
+    bool flag;
+    bool *fptr = &flag;
 
     if (PRTE_PROC_STATE_FAILED_TO_START == proc->state ||
         PRTE_PROC_STATE_FAILED_TO_LAUNCH == proc->state) {
@@ -280,12 +282,15 @@ static char *print_aborted_job(prte_job_t *job,
                                        prte_tool_basename, PRTE_NAME_PRINT(&proc->name),
                                        node->name);
         return output;
-    } else if (prte_get_attribute(&job->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL) &&
-               PRTE_PROC_STATE_TERM_NON_ZERO == proc->state) {
-        output = pmix_show_help_string("help-prun.txt", "prun:non-zero-exit", true,
-                                       prte_tool_basename, PRTE_NAME_PRINT(&proc->name),
-                                       proc->exit_code);
-        return output;
+    } else if (PRTE_PROC_STATE_TERM_NON_ZERO == proc->state) {
+        flag = false;
+        prte_get_attribute(&job->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
+        if (flag) {
+            output = pmix_show_help_string("help-prun.txt", "prun:non-zero-exit", true,
+                                           prte_tool_basename, PRTE_NAME_PRINT(&proc->name),
+                                           proc->exit_code);
+            return output;
+        }
     }
 
     /* nothing here */

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -801,7 +801,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* cannot have both files and directory set for output */
+    /* get output options */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
         ret = prte_schizo_base_parse_output(opt, jinfo);
@@ -809,6 +809,12 @@ int main(int argc, char *argv[])
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             goto DONE;
         }
+    }
+
+    /* check for runtime options */
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_RTOS);
+    if (NULL != opt) {
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RUNTIME_OPTIONS, opt->values[0], PMIX_STRING);
     }
 
     /* check what user wants us to do with stdin */

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -630,7 +630,7 @@ int prun(int argc, char *argv[])
         }
     }
 
-    /* cannot have both files and directory set for output */
+    /* check for output options */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
         ret = prte_schizo_base_parse_output(opt, jinfo);
@@ -638,6 +638,12 @@ int prun(int argc, char *argv[])
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             goto DONE;
         }
+    }
+
+    /* check for runtime options */
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_RTOS);
+    if (NULL != opt) {
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RUNTIME_OPTIONS, opt->values[0], PMIX_STRING);
     }
 
     /* check what user wants us to do with stdin */
@@ -687,7 +693,13 @@ int prun(int argc, char *argv[])
         /* mark this job as continuously operating */
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_CONTINUOUS, &flag, PMIX_BOOL);
     }
-
+#ifdef PMIX_ABORT_NONZERO_EXIT
+    /* if ignore non-zero exit was specified */
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_TERM_NONZERO)) {
+        /* mark this job to not terminate if a proc exits with non-zero status */
+        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_ABORT_NONZERO_EXIT, NULL, PMIX_BOOL);
+    }
+#endif
     /* if stop-on-exec was specified */
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STOP_ON_EXEC)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DEBUG_STOP_ON_EXEC, &flag, PMIX_BOOL);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -481,6 +481,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "FULL NSPACE IN OUTPUT TAG";
         case PRTE_JOB_TERM_NONZERO_EXIT:
             return "TERM IF NONZERO EXIT";
+        case PRTE_JOB_CONTROLS:
+            return "JOB CONTROLS";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -208,6 +208,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_TAG_OUTPUT_DETAILED        (PRTE_JOB_START_KEY + 100) // bool - include [hostname:pid] in output stream tag
 #define PRTE_JOB_TAG_OUTPUT_FULLNAME        (PRTE_JOB_START_KEY + 101) // bool - use full namespace in output stream tag
 #define PRTE_JOB_TERM_NONZERO_EXIT          (PRTE_JOB_START_KEY + 102) // bool - terminate job if a proc exits with non-zero status
+#define PRTE_JOB_CONTROLS                   (PRTE_JOB_START_KEY + 103) // char* - Directives controlling job behavior
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -113,12 +113,14 @@ BEGIN_C_DECLS
 #define PRTE_CLI_DISABLE_RECOVERY       "disable-recovery"          // none
 #define PRTE_CLI_CONTINUOUS             "continuous"                // none
 #define PRTE_CLI_EXEC_AGENT             "exec-agent"                // required
-#define PRTE_CLI_TERM_NONZERO           "ignore-non-zero-termination"  // none
 
 // Placement options
 #define PRTE_CLI_MAPBY                  "map-by"                    // required
 #define PRTE_CLI_RANKBY                 "rank-by"                   // required
 #define PRTE_CLI_BINDTO                 "bind-to"                   // required
+
+// Runtime options
+#define PRTE_CLI_RTOS                   "runtime-options"           // required
 
 // Debug options
 #define PRTE_CLI_DO_NOT_LAUNCH          "do-not-launch"             // none
@@ -198,6 +200,11 @@ BEGIN_C_DECLS
 #define PRTE_CLI_MAPDEV     "map-devel"
 #define PRTE_CLI_TOPO       "topo="
 
+// Runtime directives
+#define PRTE_CLI_ABORT_NZ   "abort-nonzero-status"
+#define PRTE_CLI_NOLAUNCH   "donotlaunch"
+
+
 /* define the command line qualifiers PRRTE recognizes */
 
 // Placement qualifiers
@@ -213,7 +220,6 @@ BEGIN_C_DECLS
 #define PRTE_CLI_NOINHERIT  "noinherit"
 #define PRTE_CLI_QDIR       "dir="
 #define PRTE_CLI_QFILE      "file="
-#define PRTE_CLI_NOLAUNCH   "donotlaunch"
 #define PRTE_CLI_OVERLOAD   "overload-allowed"
 #define PRTE_CLI_NOOVERLOAD "no-overload"
 #define PRTE_CLI_IF_SUPP    "if-supported"
@@ -263,6 +269,34 @@ static inline bool prte_check_cli_option(char *a, char *b)
 
 #define PRTE_CHECK_CLI_OPTION(a, b) \
     prte_check_cli_option(a, b)
+
+/* check if an option is "true" */
+static inline bool prte_check_true(char *a)
+{
+    int n;
+    size_t len1, len;
+    char *negs[] = {
+        "false",
+        "0",
+        "no",
+        NULL
+    };
+
+    if (NULL == a) {
+        return true;  // default
+    }
+    len1 = strlen(a);
+
+    for (n=0; NULL != negs[n]; n++) {
+        len = (len1 < strlen(negs[n])) ? len1 : strlen(negs[n]);
+        if (0 == strncasecmp(a, negs[n], len)) {
+            return false;
+        }
+    }
+    return true;
+}
+#define PRTE_CHECK_TRUE(a) \
+    prte_check_true(a)
 
 END_C_DECLS
 


### PR DESCRIPTION
We have been overloading the `--map-by` directive with runtime
controls such as do-not-launch. This creates confusion as both
developers and users lose track of what is shown to the user
in help and other cmd line operations vs what PRRTE internally
accepts.

Reduce the confusion by making runtime options a first class
citizen. Define a new `--runtime-options <args>` cmd line
option that takes a comma-delimited list of directives. Update
the help files to match.

Refs https://github.com/open-mpi/ompi/issues/10698
Signed-off-by: Ralph Castain <rhc@pmix.org>