### PR TITLE
Add support for querying process group attributes.

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -279,6 +279,9 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_QUERY_NUM_PSETS",
                          "PMIX_QUERY_PSET_NAMES",
                          "PMIX_JOB_SIZE",
+                         "PMIX_QUERY_NUM_GROUPS",
+                         "PMIX_QUERY_GROUP_NAMES",
+                         "PMIX_QUERY_GROUP_MEMBERSHIP",
                          NULL}},
     {.function = "PMIx_Query_info_nb",
      .attrs = (char *[]){"PMIX_QUERY_NAMESPACES",
@@ -293,6 +296,9 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_QUERY_NUM_PSETS",
                          "PMIX_QUERY_PSET_NAMES",
                          "PMIX_JOB_SIZE",
+                         "PMIX_QUERY_NUM_GROUPS",
+                         "PMIX_QUERY_GROUP_NAMES",
+                         "PMIX_QUERY_GROUP_MEMBERSHIP",
                          NULL}},
     {.function = "PMIx_Log", .attrs = (char *[]){"NONE", NULL}},
     {.function = "PMIx_Log_nb", .attrs = (char *[]){"NONE", NULL}},
@@ -582,6 +588,7 @@ int pmix_server_init(void)
     /* setup the server's state variables */
     PMIX_CONSTRUCT(&prte_pmix_server_globals.reqs, pmix_hotel_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.psets, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.tools, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.local_reqs, pmix_pointer_array_t);
     pmix_pointer_array_init(&prte_pmix_server_globals.local_reqs, 128, INT_MAX, 2);
@@ -941,6 +948,7 @@ void pmix_server_finalize(void)
     PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.groups);
 
     /* shutdown the local server */
     prte_pmix_server_globals.initialized = false;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -988,19 +988,19 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
     }
 
     if (PMIX_GROUP_CONSTRUCT == op) {
-        /* add it to our list of known process sets */
+        /* add it to our list of known groups */
         pset = PMIX_NEW(pmix_server_pset_t);
         pset->name = strdup(gpid);
         pset->num_members = nprocs;
         PMIX_PROC_CREATE(pset->members, pset->num_members);
         memcpy(pset->members, procs, nprocs * sizeof(pmix_proc_t));
-        pmix_list_append(&prte_pmix_server_globals.psets, &pset->super);
+        pmix_list_append(&prte_pmix_server_globals.groups, &pset->super);
     } else if (PMIX_GROUP_DESTRUCT == op) {
         /* find this process set on our list of groups */
-        PMIX_LIST_FOREACH(pset, &prte_pmix_server_globals.psets, pmix_server_pset_t)
+        PMIX_LIST_FOREACH(pset, &prte_pmix_server_globals.groups, pmix_server_pset_t)
         {
             if (0 == strcmp(pset->name, gpid)) {
-                pmix_list_remove_item(&prte_pmix_server_globals.psets, &pset->super);
+                pmix_list_remove_item(&prte_pmix_server_globals.groups, &pset->super);
                 PMIX_RELEASE(pset);
                 break;
             }

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -378,6 +378,7 @@ typedef struct {
     pmix_device_type_t generate_dist;
     pmix_list_t tools;
     pmix_list_t psets;
+    pmix_list_t groups;
 } pmix_server_globals_t;
 
 extern pmix_server_globals_t prte_pmix_server_globals;


### PR DESCRIPTION
Adds support for querying process group attributes - PMIX_QUERY_NUM_GROUPS, 
PMIX_QUERY_GROUP_NAMES and PMIX_QUERY_GROUP_MEMBERSHIP.

Signed-off-by: Heena Sirwani <heenasirwani@gmail.com>