### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -53,7 +53,9 @@ prte_plm_globals_t prte_plm_globals = {
     .daemonlaunchstart = {0, 0},
     .tree_spawn_cmd = PMIX_DATA_BUFFER_STATIC_INIT,
     .daemon_nodes_assigned_at_launch = true,
-    .node_regex_threshold = 0
+    .node_regex_threshold = 0,
+    .daemon1_has_reported = false,
+    .cache = NULL
 };
 
 /*

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -65,6 +65,8 @@ typedef struct {
     bool daemon_nodes_assigned_at_launch;
     size_t node_regex_threshold;
     pmix_list_t daemon_cache;
+    bool daemon1_has_reported;
+    char **cache;
 } prte_plm_globals_t;
 /**
  * Global instance of PLM framework data

--- a/src/mca/schizo/ompi/help-schizo-ompi.txt
+++ b/src/mca/schizo/ompi/help-schizo-ompi.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -402,6 +403,7 @@ the output to the stdout/err streams).
 #
 [stream-buffering]
 Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2 fully buffered]
+Can also be set via the MCA parameter: --mca ompi_stream_buffering VALUE
 #
 [stdin]
 Specify procs to receive stdin [rank, "all", "none"] (default: 0, indicating rank 0)

--- a/src/mca/schizo/ompi/help-schizo-ompi.txt
+++ b/src/mca/schizo/ompi/help-schizo-ompi.txt
@@ -137,8 +137,6 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
    --set-cwd-to-session-dir          Set the working directory of the started processes to their session
                                      directory
    --show-progress                   Output a brief periodic report on launch progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2
-                                     fully buffered]
    --wd <arg0>                       Synonym for --wdir
    --wdir <arg0>                     Set the working directory of the started processes
 -x <arg0>                            Export an environment variable, optionally specifying a value (e.g., "-x

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018-2021 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
@@ -140,7 +140,7 @@ static struct option ompioptions[] = {
 
     /* output options */
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STREAM_BUF, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE("stream-buffering", PMIX_ARG_REQD),
 
     /* input options */
     PMIX_OPTION_DEFINE(PRTE_CLI_STDIN, PMIX_ARG_REQD),
@@ -1511,6 +1511,16 @@ static int parse_env(char **srcenv, char ***dstenv,
         pmix_setenv("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
     }
 
+    if (NULL != (opt = pmix_cmd_line_get_param(results, "stream-buffering"))) {
+        uint16_t u16;
+        u16 = strtol(opt->values[0], NULL, 10);
+        if (0 != u16 && 1 != u16 && 2 != u16) {
+            /* bad value */
+            pmix_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
+        }
+        pmix_setenv("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
+    }
+
     /* now look for any "--mca" options - note that it is an error
      * for the same MCA param to be given more than once if the
      * values differ */
@@ -2145,20 +2155,5 @@ static int set_default_ranking(prte_job_t *jdata,
 static void job_info(pmix_cli_result_t *results,
                      void *jobinfo)
 {
-    pmix_cli_item_t *opt;
-    uint16_t u16;
-    pmix_status_t rc;
-
-    if (NULL != (opt = pmix_cmd_line_get_param(results, "stream-buffering"))) {
-        u16 = strtol(opt->values[0], NULL, 10);
-        if (0 != u16 && 1 != u16 && 2 != u16) {
-            /* bad value */
-            pmix_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
-            return;
-        }
-        PMIX_INFO_LIST_ADD(rc, jobinfo, "OMPI_STREAM_BUFFERING", &u16, PMIX_UINT16);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
-    }
+    ;
 }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -140,7 +140,6 @@ static struct option ompioptions[] = {
 
     /* output options */
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE("stream-buffering", PMIX_ARG_REQD),
 
     /* input options */
     PMIX_OPTION_DEFINE(PRTE_CLI_STDIN, PMIX_ARG_REQD),
@@ -235,6 +234,7 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE("rankfile", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("output-proctable", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("debug", PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE("stream-buffering", PMIX_ARG_REQD),
 
     PMIX_OPTION_END
 };
@@ -1511,8 +1511,14 @@ static int parse_env(char **srcenv, char ***dstenv,
         pmix_setenv("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
     }
 
+    /* --stream-buffering will be deprecated starting with Open MPI v5 */
     if (NULL != (opt = pmix_cmd_line_get_param(results, "stream-buffering"))) {
         uint16_t u16;
+        if (prte_schizo_ompi_component.warn_deprecations) {
+            pmix_show_help("help-schizo-base.txt", "deprecated-inform", true, "stream-buffering",
+                           "This CLI option will be deprecated starting in Open MPI v5. "
+                           "If you need this functionality use the Open MPI MCA option: ompi_stream_buffering");
+        }
         u16 = strtol(opt->values[0], NULL, 10);
         if (0 != u16 && 1 != u16 && 2 != u16) {
             /* bad value */

--- a/src/mca/schizo/prte/help-schizo-prte.txt
+++ b/src/mca/schizo/prte/help-schizo-prte.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -53,7 +54,6 @@ option to the help request as "--help <option>".
    --pmixmca <arg0> <arg1>           Pass PMIx MCA parameters
    --prtemca <arg0> <arg1>           Pass PRTE MCA parameters to the DVM
    --show-progress                   Output a brief periodic report on DVM startup progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr
 -x <arg0>                            Export an environment variable, optionally specifying a value
    --allow-run-as-root               Allow execution as root (STRONGLY DISCOURAGED)
    --daemonize                       Daemonize the DVM daemons into the background
@@ -182,9 +182,6 @@ Provide a hostfile (synonym for "hostfile")
 #
 [host]
 #include#help-schizo-cli#dash-host
-#
-[stream-buffering]
-#include#help-schizo-cli#stream-buffering
 #
 [display]
 #include#help-schizo-cli#display

--- a/src/mca/schizo/prte/help-schizo-prted.txt
+++ b/src/mca/schizo/prte/help-schizo-prted.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -169,8 +170,6 @@ option to the help request as "--help <option>".
    --set-cwd-to-session-dir          Set the working directory of the started processes to their session
                                      directory
    --show-progress                   Output a brief periodic report on launch progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2
-                                     fully buffered]
    --wd <arg0>                       Synonym for --wdir
    --wdir <arg0>                     Set the working directory of the started processes
 -x <arg0>                            Export an environment variable, optionally specifying a value (e.g., "-x

--- a/src/mca/schizo/prte/help-schizo-prterun.txt
+++ b/src/mca/schizo/prte/help-schizo-prterun.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -101,8 +102,6 @@ option to the help request as "--help <option>".
    --set-cwd-to-session-dir          Set the working directory of the started processes to their session
                                      directory
    --show-progress                   Output a brief periodic report on launch progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2
-                                     fully buffered]
    --wd <arg0>                       Synonym for --wdir
    --wdir <arg0>                     Set the working directory of the started processes
 -x <arg0>                            Export an environment variable, optionally specifying a value
@@ -302,9 +301,6 @@ remote process.
 #
 [output]
 #include#help-schizo-cli#output
-#
-[stream-buffering]
-#include#help-schizo-cli#stream-buffering
 #
 [stdin]
 Specify procs to receive stdin [rank, "all", "none"] (default: 0, indicating rank 0)

--- a/src/mca/schizo/prte/help-schizo-prun.txt
+++ b/src/mca/schizo/prte/help-schizo-prun.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -103,8 +104,6 @@ option to the help request as "--help <option>".
    --set-cwd-to-session-dir          Set the working directory of the started processes to their session
                                      directory
    --show-progress                   Output a brief periodic report on launch progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2
-                                     fully buffered]
    --wd <arg0>                       Synonym for --wdir
    --wdir <arg0>                     Set the working directory of the started processes
 -x <arg0>                            Export an environment variable, optionally specifying a value (e.g., "-x

--- a/src/mca/schizo/prte/help-schizo-pterm.txt
+++ b/src/mca/schizo/prte/help-schizo-pterm.txt
@@ -1,6 +1,7 @@
 # -*- text -*-
 #
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -164,8 +165,6 @@ option to the help request as "--help <option>".
    --set-cwd-to-session-dir          Set the working directory of the started processes to their session
                                      directory
    --show-progress                   Output a brief periodic report on launch progress
-   --stream-buffering <arg0>         Adjust buffering for stdout/stderr [0 unbuffered] [1 line buffered] [2
-                                     fully buffered]
    --wd <arg0>                       Synonym for --wdir
    --wdir <arg0>                     Set the working directory of the started processes
 -x <arg0>                            Export an environment variable, optionally specifying a value (e.g., "-x

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -122,7 +122,6 @@ static struct option prteoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_RTOS, PMIX_ARG_REQD),
 
     // output options
-    PMIX_OPTION_DEFINE(PRTE_CLI_STREAM_BUF, PMIX_ARG_REQD),
 
     /* developer options */
     PMIX_OPTION_DEFINE(PRTE_CLI_DISPLAY, PMIX_ARG_REQD),
@@ -195,7 +194,6 @@ static struct option prterunoptions[] = {
 
     // output options
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STREAM_BUF, PMIX_ARG_REQD),
 
     // input options
     PMIX_OPTION_DEFINE(PRTE_CLI_STDIN, PMIX_ARG_REQD),
@@ -306,7 +304,6 @@ static struct option prunoptions[] = {
 
     // output options
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STREAM_BUF, PMIX_ARG_REQD),
 
     // input options
     PMIX_OPTION_DEFINE(PRTE_CLI_STDIN, PMIX_ARG_REQD),

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -63,8 +63,6 @@ int prte_clean_output = -1;
 /* globals used by RTE */
 bool prte_debug_daemons_file_flag = false;
 bool prte_leave_session_attached = false;
-bool prte_coprocessors_detected = false;
-pmix_hash_table_t *prte_coprocessors = NULL;
 char *prte_topo_signature = NULL;
 char *prte_data_server_uri = NULL;
 char *prte_tool_basename = NULL;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -508,8 +508,6 @@ PRTE_EXPORT bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2);
 PRTE_EXPORT extern bool prte_debug_daemons_flag;
 PRTE_EXPORT extern bool prte_debug_daemons_file_flag;
 PRTE_EXPORT extern bool prte_leave_session_attached;
-PRTE_EXPORT extern bool prte_coprocessors_detected;
-PRTE_EXPORT extern pmix_hash_table_t *prte_coprocessors;
 PRTE_EXPORT extern char *prte_topo_signature;
 PRTE_EXPORT extern char *prte_data_server_uri;
 PRTE_EXPORT extern bool prte_dvm_ready;

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -580,8 +580,6 @@ int main(int argc, char *argv[])
     }
     pmix_argv_free(nonlocal);
 
-    /* always send back our topology signature - this is a small string
-     * and won't hurt anything */
     prc = PMIx_Data_pack(NULL, &buffer, &prte_topo_signature, 1, PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -14,7 +14,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -98,7 +98,6 @@ BEGIN_C_DECLS
 #define PRTE_CLI_SHOW_PROGRESS          "show-progress"             // none
 #define PRTE_CLI_HOSTFILE               "hostfile"                  // required
 #define PRTE_CLI_HOST                   "host"                      // required
-#define PRTE_CLI_STREAM_BUF             "stream-buffering"          // required
 #define PRTE_CLI_REPORT_CHILD_SEP       "report-child-jobs-separately"  // none
 #define PRTE_CLI_PATH                   "path"                      // required
 #define PRTE_CLI_PSET                   "pset"                      // required


### PR DESCRIPTION
[stream-buffering is an OMPI option, so make it an MCA](https://github.com/openpmix/prrte/commit/fedc9109a620b6a0cf860daa9c677cf61e6e24db)

 * It looks like `--stream-buffering` CLI was copied from the OMPI schizo
   to others, but is not processed by others.
 * In OMPI make this an MCA parameter, and translate the `--stream-buffering`
   to that MCA parameter.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1207c6494a566edd1777509e484c563696241269)

[Deprecated the --stream-buffering CLI option](https://github.com/openpmix/prrte/commit/c62e02adb1120e43e08b1f96e81b9e36bc7ce788)

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1a90bcd32e5f2e50d3b73d201692107672f4be51)

[Fix hetero topology operations](https://github.com/openpmix/prrte/commit/57b56450e6c8c8948e2bcb724902f23f5ce8777a)

Resolve some race conditions that resulted in hangs
and potentially incorrect topology assignments.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/adc8fd769d3808f8f0f33ffbdf198111f4f12e43)
