### PR TITLE
Revise passing of runtime options

### DIFF
--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -378,8 +378,6 @@ static void proc_errors(int fd, short args, void *cbdata)
     prte_proc_state_t state = caddy->proc_state;
     int i;
     int32_t i32, *i32ptr;
-    bool flag;
-    bool *fptr = &flag;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -691,9 +689,7 @@ keep_going:
         ++i32;
         prte_set_attribute(&jdata->attributes, PRTE_JOB_NUM_NONZERO_EXIT, PRTE_ATTR_LOCAL, i32ptr,
                            PMIX_INT32);
-        flag = true;
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void*)&fptr, PMIX_BOOL);
-        if (flag) {
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL)) {
             if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
                 jdata->state = PRTE_JOB_STATE_NON_ZERO_TERM;
                 /* point to the first rank to cause the problem */

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -183,29 +183,27 @@ static int rte_init(int argc, char **argv)
     }
 
     /* setup my session directory here as the OOB may need it */
-    if (prte_create_session_dirs) {
-        PRTE_OUTPUT_VERBOSE(
-            (2, prte_debug_output, "%s setting up session dir with\n\ttmpdir: %s\n\thost %s",
-             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-             (NULL == prte_process_info.tmpdir_base) ? "UNDEF" : prte_process_info.tmpdir_base,
-             prte_process_info.nodename));
-        /* take a pass thru the session directory code to fillin the
-         * tmpdir names - don't create anything yet
-         */
-        if (PRTE_SUCCESS != (ret = prte_session_dir(false, PRTE_PROC_MY_NAME))) {
-            error = "prte_session_dir define";
-            goto error;
-        }
-        /* clear the session directory just in case there are
-         * stale directories laying around
-         */
-        prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+    PRTE_OUTPUT_VERBOSE(
+        (2, prte_debug_output, "%s setting up session dir with\n\ttmpdir: %s\n\thost %s",
+         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+         (NULL == prte_process_info.tmpdir_base) ? "UNDEF" : prte_process_info.tmpdir_base,
+         prte_process_info.nodename));
+    /* take a pass thru the session directory code to fillin the
+     * tmpdir names - don't create anything yet
+     */
+    if (PRTE_SUCCESS != (ret = prte_session_dir(false, PRTE_PROC_MY_NAME))) {
+        error = "prte_session_dir define";
+        goto error;
+    }
+    /* clear the session directory just in case there are
+     * stale directories laying around
+     */
+    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
 
-        /* now actually create the directory tree */
-        if (PRTE_SUCCESS != (ret = prte_session_dir(true, PRTE_PROC_MY_NAME))) {
-            error = "prte_session_dir";
-            goto error;
-        }
+    /* now actually create the directory tree */
+    if (PRTE_SUCCESS != (ret = prte_session_dir(true, PRTE_PROC_MY_NAME))) {
+        error = "prte_session_dir";
+        goto error;
     }
 
     /* setup the PMIx server - we need this here in case the
@@ -449,16 +447,14 @@ static int rte_init(int argc, char **argv)
         goto error;
     }
 
-    if (prte_create_session_dirs) {
-        /* set the prte_output hnp file location to be in the
-         * proc-specific session directory. */
-        prte_output_set_output_file_info(prte_process_info.proc_session_dir, "output-", NULL, NULL);
-        /* save my contact info in a file for others to find */
-        if (NULL == prte_process_info.jobfam_session_dir) {
-            /* has to be set here! */
-            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-            goto error;
-        }
+    /* set the prte_output hnp file location to be in the
+     * proc-specific session directory. */
+    prte_output_set_output_file_info(prte_process_info.proc_session_dir, "output-", NULL, NULL);
+    /* save my contact info in a file for others to find */
+    if (NULL == prte_process_info.jobfam_session_dir) {
+        /* has to be set here! */
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        goto error;
     }
 
     /* setup I/O forwarding system - must come after we init routes */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1597,6 +1597,7 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
 
         /* provide a default state */
         state = PRTE_PROC_STATE_WAITPID_FIRED;
+        flag = prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL);
 
         /* check to see if a sync was required and if it was received */
         if (PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_REG)) {
@@ -1609,8 +1610,6 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                  * felt it was non-normal - in this latter case, we do not
                  * require that the proc deregister before terminating
                  */
-                flag = false;
-                prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
                 if (0 != proc->exit_code && flag) {
                     state = PRTE_PROC_STATE_TERM_NON_ZERO;
                     PRTE_OUTPUT_VERBOSE(
@@ -1674,8 +1673,6 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
              * none of them will. This is considered acceptable. Still
              * flag it as abnormal if the exit code was non-zero
              */
-            flag = false;
-            prte_get_attribute(&jobdat->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
             if (0 != proc->exit_code && flag) {
                 state = PRTE_PROC_STATE_TERM_NON_ZERO;
             } else {

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -127,7 +127,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
     prte_app_context_t *app, *child_app;
     pmix_proc_t name, *nptr;
     pid_t pid;
-    bool debugging, found, *fptr;
+    bool debugging, found;
     int i, room;
     char **env;
     char *prefix_dir, *tmp;
@@ -633,9 +633,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
         }
         /* record that we heard back from a daemon during app launch */
         jdata->num_daemons_reported++;
-        found = false;
-        fptr = &found;
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, (void**)&fptr, PMIX_BOOL);
+        found = prte_get_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, NULL, PMIX_BOOL);
         if (found) {
             if (0 == jdata->num_daemons_reported % 100 ||
                 jdata->num_daemons_reported == prte_process_info.num_daemons) {

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -256,8 +256,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     pmix_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    if (!prte_enable_recovery) {
-        /* kill the job if any orteds die */
+    if (!PRTE_FLAG_TEST(state->jdata, PRTE_JOB_FLAG_RECOVERABLE)) {
+        /* kill the job if any prteds die */
         pmix_argv_append(&argc, &argv, "--kill-on-bad-exit");
     }
 

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -483,10 +483,69 @@ Supported values include:
     before actually starting execution. No value need be passed as this is
     not an option that can be set by default in PRRTE.
 
--   SHOW-PROGRESS=(bool) requests that the runtime provide progress reports
+-   SHOW-PROGRESS[=(bool)] requests that the runtime provide progress reports
     on its startup procedure - i.e., the launch of its daemons in support
     of a job. This is typically used to debug DVM startup on large systems.
+    Defaults to true in absence of a given value.
 
+-   RECOVER[=(bool)] if set to true, this directs the runtime to recover a
+    process that has failed by restarting it. Defaults to true in absence
+    of a given value.
+
+-   CONTINUOUS[=(bool)] if set to true, this informs the runtime that the
+    processes in this job shall run until explicitly terminated. Defaults
+    to true in absence of a given value.
+
+-   MAX-RESTARTS=<int> indicates the maximum number of times a given process
+    shall be restarted
+
+-   EXEC-AGENT=<path> indicates the executable that shall be used to start
+    an application process. The resulting command for starting an application
+    process will be "<path> app <app-argv>". The path may contain its own
+    command line arguments.
+
+-   STOP-ON-EXEC[(=<bool or ranks>)] directs the runtime to stop the indicated
+    application process(es) immediately upon exec'ing it. If a boolean value is
+    provided, then the directive will apply to all processes in the job. Otherwise,
+    a comma-delimited list of rank ranges can be specified. Used for debugging.
+    Defaults to "true" in the absence of a specified value.
+
+-   STOP-IN-INIT[(=<bool or ranks>)] indicates that the runtime should direct the
+    indicated application process(es) to stop in PMIx_Init. If a boolean value is
+    provided, then the directive will apply to all processes in the job. Otherwise,
+    a comma-delimited list of rank ranges can be specified. Used for debugging.
+    Defaults to "true" in the absence of a specified value.
+
+-   STOP-IN-APP=<label> indicates that the runtime should direct application processes
+    to stop at some pre-defined place in the application corresponding to the provided
+    label. Used for debugging.
+
+-   TIMEOUT=<string> directs the runtime to terminate the job after it has executed for
+    the specified time. Time is specified in colon-delimited format - e.g.,
+     "01:20:13:05" to indicate 1 day, 20 hours, 13 minutes and 5 seconds. Time specified
+     without colons will be assumed to have been given in seconds.
+
+-   SPAWN-TIMEOUT=<string> directs the runtime to terminate the job if job launch is
+    not completed within the specified time. Time is specified in colon-delimited
+    format - e.g., "01:20:13:05" to indicate 1 day, 20 hours, 13 minutes and 5 seconds.
+    Time specified without colons will be assumed to have been given in seconds.
+
+-   REPORT-STATE-ON-TIMEOUT[(=bool)] directs the runtime to provide a detailed report
+    on job and application process state upon job timeout. Defaults to "true" in the
+    absence of a specified value.
+
+-   GET-STACK-TRACES[(=bool)] requests that the runtime provide stack traces on all
+    application processes still executing upon timeout. Defaults to "true" in the
+    absence of a specified value.
+
+-   REPORT-CHILD-JOBS-SEPARATELY[(=bool)] directs the runtime to report the exit status
+    of any child jobs spawned by the primary job separately. If false, then the final
+    exit status reported will be zero if the primary job and all spawned jobs exit
+    normally, or the first non-zero status returned by either primary or child jobs.
+
+-   AGGREGATE-HELP-MESSAGES[(=bool)] directs the runtime to aggregate help messages,
+    reporting each unique help message once accompanied by the number of processes
+    that reported it
 
 The runtime-options command line option has no qualifiers. Note that directives
 are case-insensitive.

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -359,11 +359,10 @@ void prte_state_base_local_launch_complete(int fd, short argc, void *cbdata)
 {
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
     prte_job_t *jdata = state->jdata;
-    bool found = false, *fptr;
+    bool found = false;
     PRTE_HIDE_UNUSED_PARAMS(fd, argc);
 
-    fptr = &found;
-    prte_get_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, (void**)&fptr, PMIX_BOOL);
+    found = prte_get_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, NULL, PMIX_BOOL);
     if (found) {
         if (0 == jdata->num_daemons_reported % 100 ||
             jdata->num_daemons_reported == prte_process_info.num_daemons) {
@@ -798,8 +797,7 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
 
     i32ptr = &i32;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NUM_NONZERO_EXIT, (void **) &i32ptr, PMIX_INT32)) {
-        flag = false;
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void*)&flag, PMIX_BOOL);
+        flag = prte_get_attribute(&jdata->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL);
         if (flag) {
             if (!prte_report_child_jobs_separately || 1 == PRTE_LOCAL_JOBID(jdata->nspace)) {
                 /* update the exit code */

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1543,6 +1543,27 @@ static void pmix_server_log(int status, pmix_proc_t *sender,
     }
 }
 
+int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info)
+{
+    prte_info_item_t *kv;
+    pmix_list_t *cache;
+
+    /* cache for inclusion with job info at registration */
+    kv = PMIX_NEW(prte_info_item_t);
+    PMIX_INFO_XFER(&kv->info, info);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE,
+                           (void **) &cache, PMIX_POINTER)) {
+        pmix_list_append(cache, &kv->super);
+    } else {
+        cache = PMIX_NEW(pmix_list_t);
+        pmix_list_append(cache, &kv->super);
+        prte_set_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, PRTE_ATTR_GLOBAL,
+                           (void *) cache, PMIX_POINTER);
+
+    }
+    return 0;
+}
+
 /****    INSTANTIATE LOCAL OBJECTS    ****/
 static void opcon(prte_pmix_server_op_caddy_t *p)
 {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -50,6 +50,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/prte_cmd_line.h"
 
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
@@ -190,14 +191,12 @@ callback:
     PMIX_RELEASE(req);
 }
 
-static int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
-
 static void interim(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     pmix_proc_t *requestor = &cd->proc;
     pmix_envar_t envar;
-    prte_job_t *jdata;
+    prte_job_t *jdata, *djob;
     prte_app_context_t *app;
     pmix_app_t *papp;
     pmix_info_t *info;
@@ -296,28 +295,28 @@ static void interim(int sd, short args, void *cbdata)
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_add_attribute(&app->attributes, PRTE_APP_SET_ENVAR, PRTE_ATTR_GLOBAL,
+                    prte_set_attribute(&app->attributes, PRTE_APP_SET_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_add_attribute(&app->attributes, PRTE_APP_ADD_ENVAR, PRTE_ATTR_GLOBAL,
+                    prte_set_attribute(&app->attributes, PRTE_APP_ADD_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-                    prte_add_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
+                    prte_set_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
                 } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_add_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR, PRTE_ATTR_GLOBAL,
+                    prte_set_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_add_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR, PRTE_ATTR_GLOBAL,
+                    prte_set_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envar, PMIX_ENVAR);
 
                 } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {
@@ -428,53 +427,40 @@ static void interim(int sd, short args, void *cbdata)
                 goto complete;
             }
 
-            /***   RUNTIME OPTIONS  ***/
+            /***   RUNTIME OPTIONS  - SHOULD ONLY APPEAR IF NOT PRE-PROCESSED BY SCHIZO ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_RUNTIME_OPTIONS)) {
             rc = prte_rmaps_base_set_runtime_options(jdata, info->value.data.string);
             if (PRTE_SUCCESS != rc) {
                 goto complete;
             }
-            jdata->map->rtos_set = true;
+            jdata->map->rtos_set = true;  // protect against doing this again in rmaps_map_job
 
-            /*** EXEC AGENT ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_EXEC_AGENT)) {
+            /*** ABORT_NON_ZERO  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_ABORT_NON_ZERO_TERM)) {
+            flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_EXEC_AGENT, PRTE_ATTR_GLOBAL,
-                               info->value.data.string, PMIX_STRING);
+                               &flag, PMIX_BOOL);
 
-            /***   CPUS/RANK   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_CPUS_PER_PROC)) {
-            u16 = info->value.data.uint32;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC,
-                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
-
-            /***   NO USE LOCAL   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_NO_PROCS_ON_HEAD)) {
+            /*** DO_NOT_LAUNCH  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DO_NOT_LAUNCH)) {
             flag = PMIX_INFO_TRUE(info);
-            if (flag) {
-                PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_USE_LOCAL);
-            } else {
-                PRTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_USE_LOCAL);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+            /* if we are not in a persistent DVM, then make sure we also
+             * apply this to the daemons */
+            if (!prte_persistent) {
+                djob = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+                prte_set_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, PRTE_ATTR_GLOBAL,
+                                   &flag, PMIX_BOOL);
             }
-            /* mark that the user specified it */
-            PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_LOCAL_GIVEN);
 
-            /***   OVERSUBSCRIBE   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_NO_OVERSUBSCRIBE)) {
+                /*** SHOW_PROGRESS  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SHOW_LAUNCH_PROGRESS)) {
             flag = PMIX_INFO_TRUE(info);
-            if (flag) {
-                PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
-            } else {
-                PRTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
-            }
-            /* mark that the user specified it */
-            PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
 
-            /***   CPU LIST  ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_CPU_LIST)) {
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_CPUSET, PRTE_ATTR_GLOBAL,
-                               info->value.data.string, PMIX_STRING);
-
-            /***   RECOVERABLE  ***/
+            /*** RECOVER  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_JOB_RECOVERABLE)) {
             flag = PMIX_INFO_TRUE(info);
             if (flag) {
@@ -482,49 +468,33 @@ static void interim(int sd, short args, void *cbdata)
             } else {
                 PRTE_FLAG_UNSET(jdata, PRTE_JOB_FLAG_RECOVERABLE);
             }
+            /* mark that the recovery policy has been defined so it doesn't
+             * get overwritten later with defaults */
+            flag = true;
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_RECOVER_DEFINED, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+
+            /*** CONTINUOUS  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_JOB_CONTINUOUS)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS_OP, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
 
             /***   MAX RESTARTS  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAX_RESTARTS)) {
             for (i = 0; i < jdata->apps->size; i++) {
-                if (NULL
-                    == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i))) {
+                app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i);
+                if (NULL == app) {
                     continue;
                 }
                 prte_set_attribute(&app->attributes, PRTE_APP_MAX_RESTARTS, PRTE_ATTR_GLOBAL,
                                    &info->value.data.uint32, PMIX_INT32);
             }
 
-            /***   CONTINUOUS OPERATION  ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_JOB_CONTINUOUS)) {
-            flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS_OP, PRTE_ATTR_GLOBAL, &flag,
-                               PMIX_BOOL);
-
-            /***   NON-PMI JOB   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_NON_PMI)) {
-            flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_NON_PRTE_JOB, PRTE_ATTR_GLOBAL, &flag,
-                               PMIX_BOOL);
-
-        } else if (PMIX_CHECK_KEY(info, PMIX_PARENT_ID)) {
-            PMIX_XFER_PROCID(&jdata->originator, info->value.data.proc);
-
-            /***   SPAWN REQUESTOR IS TOOL   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_REQUESTOR_IS_TOOL)) {
-            flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_DVM_JOB, PRTE_ATTR_GLOBAL, &flag,
-                               PMIX_BOOL);
-            if (flag) {
-                /* request that IO be forwarded to the requesting tool */
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_FWDIO_TO_TOOL, PRTE_ATTR_GLOBAL,
-                                   &flag, PMIX_BOOL);
-            }
-
-            /***   NOTIFY UPON JOB COMPLETION   ***/
-        } else if (PMIX_CHECK_KEY(info, PMIX_NOTIFY_COMPLETION)) {
-            flag = PMIX_INFO_TRUE(info);
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_COMPLETION, PRTE_ATTR_GLOBAL,
-                               &flag, PMIX_BOOL);
+           /*** EXEC AGENT ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_EXEC_AGENT)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_EXEC_AGENT, PRTE_ATTR_GLOBAL,
+                               info->value.data.string, PMIX_STRING);
 
             /***   STOP ON EXEC FOR DEBUGGER   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_ON_EXEC)) {
@@ -564,23 +534,69 @@ static void interim(int sd, short args, void *cbdata)
             pmix_server_cache_job_info(jdata, info);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_APP)) {
-            if (PMIX_PROC_RANK == info->value.type) {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
-                                   &info->value.data.rank, PMIX_PROC_RANK);
-            } else if (PMIX_BOOL == info->value.type) {
-                flag = PMIX_INFO_TRUE(info);
-                if (flag) {
-                    rank = PMIX_RANK_WILDCARD;
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
-                                       &rank, PMIX_PROC_RANK);
-                }
-            } else {
-                /* we cannot support the request at this time */
-                rc = PRTE_ERR_NOT_SUPPORTED;
-                goto complete;
-            }
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
+                               info->value.data.string, PMIX_STRING);
             /* also must add to job-level cache */
             pmix_server_cache_job_info(jdata, info);
+
+            /***   CPUS/RANK   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_CPUS_PER_PROC)) {
+            u16 = info->value.data.uint32;
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC,
+                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
+
+            /***   NO USE LOCAL   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_NO_PROCS_ON_HEAD)) {
+            flag = PMIX_INFO_TRUE(info);
+            if (flag) {
+                PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_USE_LOCAL);
+            } else {
+                PRTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_USE_LOCAL);
+            }
+            /* mark that the user specified it */
+            PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_LOCAL_GIVEN);
+
+            /***   OVERSUBSCRIBE   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_NO_OVERSUBSCRIBE)) {
+            flag = PMIX_INFO_TRUE(info);
+            if (flag) {
+                PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+            } else {
+                PRTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+            }
+            /* mark that the user specified it */
+            PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
+
+            /***   CPU LIST  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_CPU_LIST)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_CPUSET, PRTE_ATTR_GLOBAL,
+                               info->value.data.string, PMIX_STRING);
+
+            /***   NON-PMI JOB   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_NON_PMI)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_NON_PRTE_JOB, PRTE_ATTR_GLOBAL, &flag,
+                               PMIX_BOOL);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_PARENT_ID)) {
+            PMIX_XFER_PROCID(&jdata->originator, info->value.data.proc);
+
+            /***   SPAWN REQUESTOR IS TOOL   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_REQUESTOR_IS_TOOL)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DVM_JOB, PRTE_ATTR_GLOBAL, &flag,
+                               PMIX_BOOL);
+            if (flag) {
+                /* request that IO be forwarded to the requesting tool */
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FWDIO_TO_TOOL, PRTE_ATTR_GLOBAL,
+                                   &flag, PMIX_BOOL);
+            }
+
+            /***   NOTIFY UPON JOB COMPLETION   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_NOTIFY_COMPLETION)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_COMPLETION, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
 
             /***   TAG STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_OUTPUT) ||
@@ -696,72 +712,90 @@ static void interim(int sd, short args, void *cbdata)
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
                                PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR, PRTE_ATTR_GLOBAL, &envar,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR, PRTE_ATTR_GLOBAL, &envar,
                                PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
                                info->value.data.string, PMIX_STRING);
         } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
                                PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
                                PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TIMEOUT) ||
                    PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
-            prte_add_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
-                               &info->value.data.integer, PMIX_INT);
+            if (PMIX_STRING == info->value.type) {
+                rc = PRTE_CONVERT_TIME(info->value.data.string);
+            } else {
+                PMIX_VALUE_GET_NUMBER(i, &info->value, rc, int);
+                if (PMIX_SUCCESS != i) {
+                    rc = i;
+                    goto complete;
+                }
+            }
+            prte_set_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT,
+                               PRTE_ATTR_GLOBAL, &rc, PMIX_INT);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
-            prte_add_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
+            prte_set_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
                                &info->value.data.integer, PMIX_INT);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_JOB_TIMEOUT)) {
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT, PRTE_ATTR_GLOBAL,
-                               &info->value.data.integer, PMIX_INT);
+            if (PMIX_STRING == info->value.type) {
+                rc = PRTE_CONVERT_TIME(info->value.data.string);
+            } else {
+                PMIX_VALUE_GET_NUMBER(i, &info->value, rc, int);
+                if (PMIX_SUCCESS != i) {
+                    rc = i;
+                    goto complete;
+                }
+            }
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT,
+                               PRTE_ATTR_GLOBAL, &rc, PMIX_INT);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT_STACKTRACES)) {
             flag = PMIX_INFO_TRUE(info);
             if (flag) {
-                prte_add_attribute(&jdata->attributes, PRTE_JOB_STACKTRACES, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_STACKTRACES, PRTE_ATTR_GLOBAL,
                                    &flag, PMIX_BOOL);
             }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT_REPORT_STATE)) {
             flag = PMIX_INFO_TRUE(info);
             if (flag) {
-                prte_add_attribute(&jdata->attributes, PRTE_JOB_REPORT_STATE, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_REPORT_STATE, PRTE_ATTR_GLOBAL,
                                    &flag, PMIX_BOOL);
             }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_LOG_AGG)) {
             flag = PMIX_INFO_TRUE(info);
             if (!flag) {
-                prte_add_attribute(&jdata->attributes, PRTE_JOB_NOAGG_HELP, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_NOAGG_HELP, PRTE_ATTR_GLOBAL,
                                    &flag, PMIX_BOOL);
             }
 
-#ifdef PMIX_CONTROLS
-        } else if (PMIX_CHECK_KEY(info, PMIX_CONTROLS)) {
-            prte_add_attribute(&jdata->attributes, PRTE_JOB_CONTROLS,
-                               PRTE_ATTR_GLOBAL,
-                               &info->value.data.string, PMIX_STRING);
-#endif
+        } else if (PMIX_CHECK_KEY(info, PMIX_AGGREGATE_HELP)) {
+            flag = PMIX_INFO_TRUE(info);
+            if (!flag) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_NOAGG_HELP, PRTE_ATTR_GLOBAL,
+                                   &flag, PMIX_BOOL);
+            }
 
             /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {
@@ -804,26 +838,6 @@ complete:
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
     }
     PMIX_RELEASE(cd);
-}
-
-static int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info)
-{
-    prte_info_item_t *kv;
-    pmix_list_t *cache;
-
-    /* cache for inclusion with job info at registration */
-    kv = PMIX_NEW(prte_info_item_t);
-    PMIX_INFO_XFER(&kv->info, info);
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, (void **) &cache,
-                           PMIX_POINTER)) {
-        pmix_list_append(cache, &kv->super);
-    } else {
-        cache = PMIX_NEW(pmix_list_t);
-        pmix_list_append(cache, &kv->super);
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, PRTE_ATTR_GLOBAL, (void *) cache,
-                           PMIX_POINTER);
-    }
-    return 0;
 }
 
 int pmix_server_spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[], size_t ninfo,

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -350,6 +350,8 @@ PRTE_EXPORT extern void pmix_server_jobid_return(int status, pmix_proc_t *sender
 
 PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
 
+PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
+
 /* exposed shared variables */
 typedef struct {
     pmix_list_item_t super;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -72,6 +72,7 @@ pmix_pointer_array_t *prte_cache = NULL;
 bool prte_persistent = true;
 bool prte_add_pid_to_session_dirname = false;
 bool prte_allow_run_as_root = false;
+bool prte_show_launch_progress = false;
 
 /* PRTE OOB port flags */
 bool prte_static_ports = false;
@@ -149,6 +150,7 @@ bool prte_report_bindings = false;
 /* process recovery */
 bool prte_enable_recovery = false;
 int32_t prte_max_restarts = 0;
+bool prte_continuous_op = false;
 
 /* exit status reporting */
 bool prte_report_child_jobs_separately = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -63,7 +63,6 @@ BEGIN_C_DECLS
 PRTE_EXPORT extern int prte_debug_verbosity;           /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern char *prte_prohibited_session_dirs; /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern char *prte_job_ident;           /* instantiated in src/runtime/prte_globals.c */
-PRTE_EXPORT extern bool prte_create_session_dirs;  /* instantiated in src/runtime/prte_init.c */
 PRTE_EXPORT extern bool prte_execute_quiet;        /* instantiated in src/runtime/prte_globals.c */
 PRTE_EXPORT extern bool prte_report_silent_errors; /* instantiated in src/runtime/prte_globals.c */
 PRTE_EXPORT extern bool prte_event_base_active;    /* instantiated in src/runtime/prte_init.c */
@@ -73,6 +72,8 @@ PRTE_EXPORT extern char *prte_tool_basename;       // argv[0] of prun or one of 
 PRTE_EXPORT extern char *prte_tool_actual;         // actual tool executable
 PRTE_EXPORT extern char *prte_progress_thread_cpus;
 PRTE_EXPORT extern bool prte_bind_progress_thread_reqd;
+PRTE_EXPORT extern bool prte_show_launch_progress;
+PRTE_EXPORT extern bool prte_continuous_op;
 
 /**
  * Global indicating where this process was bound to at launch (will

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -136,17 +136,16 @@ int prte_register_params(void)
      */
     string = strdup("stderr");
     prte_stacktrace_output_filename = string;
-    ret = prte_mca_base_var_register(
-        "prte", "prte", NULL, "stacktrace_output",
-        "Specifies where the stack trace output stream goes.  "
-        "Accepts one of the following: none (disabled), stderr (default), stdout, file[:filename]. "
-        "  "
-        "If 'filename' is not specified, a default filename of 'stacktrace' is used.  "
-        "The 'filename' is appended with either '.PID' or '.RANK.PID', if RANK is available.  "
-        "The 'filename' can be an absolute path or a relative path to the current working "
-        "directory.",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
-        PRTE_MCA_BASE_VAR_SCOPE_LOCAL, &prte_stacktrace_output_filename);
+    ret = prte_mca_base_var_register("prte", "prte", NULL, "stacktrace_output",
+                                     "Specifies where the stack trace output stream goes.  "
+                                     "Accepts one of the following: none (disabled), stderr (default), stdout, file[:filename]. "
+                                     "  "
+                                     "If 'filename' is not specified, a default filename of 'stacktrace' is used.  "
+                                     "The 'filename' is appended with either '.PID' or '.RANK.PID', if RANK is available.  "
+                                     "The 'filename' can be an absolute path or a relative path to the current working "
+                                     "directory.",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
+                                     PRTE_MCA_BASE_VAR_SCOPE_LOCAL, &prte_stacktrace_output_filename);
     free(string);
     if (0 > ret) {
         return ret;
@@ -161,12 +160,11 @@ int prte_register_params(void)
        - 169.254.0.0/16 for DHCP onlink iff there's no DHCP server
     */
     prte_net_private_ipv4 = "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16;169.254.0.0/16";
-    ret = prte_mca_base_var_register(
-        "prte", "prte", "net", "private_ipv4",
-        "Semicolon-delimited list of CIDR notation entries specifying what networks are considered "
-        "\"private\" (default value based on RFC1918 and RFC3330)",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
-        PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_net_private_ipv4);
+    ret = prte_mca_base_var_register("prte", "prte", "net", "private_ipv4",
+                                     "Semicolon-delimited list of CIDR notation entries specifying what networks are considered "
+                                     "\"private\" (default value based on RFC1918 and RFC3330)",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
+                                     PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_net_private_ipv4);
     if (0 > ret) {
         return ret;
     }
@@ -210,12 +208,11 @@ int prte_register_params(void)
     }
 
     prte_set_max_sys_limits = NULL;
-    ret = prte_mca_base_var_register(
-        "prte", "prte", NULL, "set_max_sys_limits",
-        "Set the specified system-imposed limits to the specified value, including \"unlimited\"."
-        "Supported params: core, filesize, maxmem, openfiles, stacksize, maxchildren",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
-        PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_set_max_sys_limits);
+    ret = prte_mca_base_var_register("prte", "prte", NULL, "set_max_sys_limits",
+                                     "Set the specified system-imposed limits to the specified value, including \"unlimited\"."
+                                     "Supported params: core, filesize, maxmem, openfiles, stacksize, maxchildren",
+                                     PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_SETTABLE, PRTE_INFO_LVL_3,
+                                     PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_set_max_sys_limits);
     if (0 > ret) {
         return ret;
     }
@@ -266,8 +263,8 @@ int prte_register_params(void)
     /* if a global tmpdir was specified, then we do not allow specification
      * of the local or remote values to avoid confusion
      */
-    if (NULL != prte_tmpdir_base
-        && (NULL != prte_local_tmpdir_base || NULL != prte_remote_tmpdir_base)) {
+    if (NULL != prte_tmpdir_base &&
+        (NULL != prte_local_tmpdir_base || NULL != prte_remote_tmpdir_base)) {
         prte_output(prte_clean_output,
                     "------------------------------------------------------------------\n"
                     "The MCA param prte_tmpdir_base was specified, which sets the base\n"
@@ -302,34 +299,6 @@ int prte_register_params(void)
         prte_process_info.tmpdir_base = strdup(prte_remote_tmpdir_base);
     }
 
-    prte_top_session_dir = NULL;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "top_session_dir",
-                                      "Top of the session directory tree for applications",
-                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_top_session_dir);
-
-    if (NULL != prte_top_session_dir) {
-        if (NULL != prte_process_info.top_session_dir) {
-            free(prte_process_info.top_session_dir);
-        }
-        prte_process_info.top_session_dir = strdup(prte_top_session_dir);
-    }
-
-    prte_jobfam_session_dir = NULL;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "jobfam_session_dir",
-                                      "The jobfamily session directory for applications",
-                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_ALL_EQ, &prte_jobfam_session_dir);
-
-    if (NULL != prte_jobfam_session_dir) {
-        if (NULL != prte_process_info.jobfam_session_dir) {
-            free(prte_process_info.jobfam_session_dir);
-        }
-        prte_process_info.jobfam_session_dir = strdup(prte_jobfam_session_dir);
-    }
-
     prte_prohibited_session_dirs = NULL;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "no_session_dirs",
                                       "Prohibited locations for session directories (multiple "
@@ -337,12 +306,6 @@ int prte_register_params(void)
                                       PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
                                       PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_ALL, &prte_prohibited_session_dirs);
-
-    prte_create_session_dirs = true;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "create_session_dirs",
-                                      "Create session directories", PRTE_MCA_BASE_VAR_TYPE_BOOL,
-                                      NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_ALL, &prte_create_session_dirs);
 
     prte_add_pid_to_session_dirname = false;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "add_pid_to_session_dirname",
@@ -393,6 +356,12 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prted_debug_failure_delay);
 
+    prte_show_launch_progress = false;
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "show_progress",
+                                      "Provide progress reports on DVM startup",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_show_launch_progress);
+
     /* default hostfile */
     prte_default_hostfile = NULL;
     (void)
@@ -432,19 +401,11 @@ int prte_register_params(void)
         prte_default_dash_host = NULL;
     }
 
-    prte_hostname_cutoff = 1000;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "hostname_cutoff",
-        "Pass hostnames to all procs when #nodes is less than cutoff [default:1000]",
-        PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_3,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_hostname_cutoff);
-
     prte_show_resolved_nodenames = false;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "show_resolved_nodenames",
-        "Display any node names that are resolved to a different name [default: false]",
-        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_show_resolved_nodenames);
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "show_resolved_nodenames",
+                                      "Display any node names that are resolved to a different name [default: false]",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_show_resolved_nodenames);
 
     prte_do_not_resolve = true;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "do_not_resolve",
@@ -456,95 +417,56 @@ int prte_register_params(void)
 
     /* allow specification of the launch agent */
     prte_launch_agent = "prted";
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "launch_agent",
-        "Command used to start processes on remote nodes [default: prted]",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_launch_agent);
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "launch_agent",
+                                      "Executable for DVM daemons on remote nodes [default: prted]",
+                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_launch_agent);
 
     prte_fork_agent_string = NULL;
-    (void)
-        prte_mca_base_var_register("prte", "prte", NULL, "fork_agent",
-                                   "Command used to fork processes on remote nodes [default: NULL]",
-                                   PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                   PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                   PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_fork_agent_string);
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "exec_agent",
+                                      "Command used to exec application processes [default: NULL]",
+                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
+                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_fork_agent_string);
 
     /* whether or not to require RM allocation */
     prte_allocation_required = false;
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "allocation_required",
-        "Whether or not an allocation by a resource manager is required [default: no]",
-        PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_allocation_required);
-
-    /* generate new terminal windows to display output from specified ranks */
-    prte_xterm = NULL;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "xterm",
-                                      "Create a new xterm window and display output from the "
-                                      "specified ranks there [default: none]",
-                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_xterm);
-    if (NULL != prte_xterm) {
-        /* if an xterm request is given, we have to leave any ssh
-         * sessions attached so the xterm window manager can get
-         * back to the controlling terminal
-         */
-        prte_leave_session_attached = true;
-    }
-
-    /* tool communication controls */
-    prte_report_events_uri = NULL;
-    (void) prte_mca_base_var_register("prte", "prte", NULL, "report_events",
-                                      "URI to which events are to be reported [default: NULL]",
-                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0,
-                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_report_events_uri);
-    if (NULL != prte_report_events_uri) {
-        prte_report_events = true;
-    }
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "allocation_required",
+                                      "Whether or not an allocation by a resource manager is required [default: no]",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_allocation_required);
 
     prte_enable_recovery = false;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "enable_recovery",
-                                      "Enable recovery from process failure [Default = disabled]",
+                                      "Set default policy for process recovery from failure to enabled",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                       PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_enable_recovery);
 
     prte_max_restarts = 0;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "max_restarts",
-                                      "Max number of times to restart a failed process",
+                                      "Set default max number of times to restart a failed process",
                                       PRTE_MCA_BASE_VAR_TYPE_INT, NULL, 0,
                                       PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_max_restarts);
 
-    if (!prte_enable_recovery && prte_max_restarts != 0) {
-        if (PRTE_PROC_IS_MASTER) {
-            prte_output(prte_clean_output,
-                        "------------------------------------------------------------------\n"
-                        "The MCA param prte_enable_recovery was not set to true, but\n"
-                        "a value was provided for the number of restarts:\n\n"
-                        "Max restarts: %d\n"
-                        "We are enabling process recovery and continuing execution. To avoid\n"
-                        "this warning in the future, please set the prte_enable_recovery\n"
-                        "param to non-zero.\n"
-                        "------------------------------------------------------------------",
-                        prte_max_restarts);
-        }
-        prte_enable_recovery = true;
-    }
+    prte_continuous_op = false;
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "continuous_operation",
+                                      "Set default policy for processes to run continuously until explicitly terminated",
+                                      PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
+                                      PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_continuous_op);
 
     prte_allowed_exit_without_sync = false;
     (void) prte_mca_base_var_register(
         "prte", "prte", NULL, "allowed_exit_without_sync",
-        "Process exiting without calling finalize will not trigger job termination",
+        "Set default process exiting without calling finalize policy to not trigger job termination",
         PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
         PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_allowed_exit_without_sync);
 
     prte_report_child_jobs_separately = false;
     (void) prte_mca_base_var_register("prte", "prte", NULL, "report_child_jobs_separately",
-                                      "Return the exit status of the primary job only",
+                                      "Set default to return the exit status of the primary job only",
                                       PRTE_MCA_BASE_VAR_TYPE_BOOL, NULL, 0,
                                       PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
                                       PRTE_MCA_BASE_VAR_SCOPE_READONLY,
@@ -563,14 +485,13 @@ int prte_register_params(void)
                                       PRTE_INFO_LVL_9, PRTE_MCA_BASE_VAR_SCOPE_READONLY,
                                       &prte_max_vm_size);
 
-    (void) prte_mca_base_var_register(
-        "prte", "prte", NULL, "set_default_slots",
-        "Set the number of slots on nodes that lack such info to the"
-        " number of specified objects [a number, \"cores\" (default),"
-        " \"packages\", \"hwthreads\" (default if hwthreads_as_cpus is set),"
-        " or \"none\" to skip this option]",
-        PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
-        PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_set_slots);
+    (void) prte_mca_base_var_register("prte", "prte", NULL, "set_default_slots",
+                                      "Set the number of slots on nodes that lack such info to the"
+                                      " number of specified objects [a number, \"cores\" (default),"
+                                      " \"packages\", \"hwthreads\" (default if hwthreads_as_cpus is set),"
+                                      " or \"none\" to skip this option]",
+                                      PRTE_MCA_BASE_VAR_TYPE_STRING, NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_9,
+                                      PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_set_slots);
 
     /* allow specification of the cores to be used by daemons */
     prte_daemon_cores = NULL;
@@ -600,7 +521,7 @@ int prte_register_params(void)
         PRTE_MCA_BASE_VAR_SCOPE_ALL, &prte_data_server_uri);
 
     prte_mca_base_var_register("prte", "prte", NULL, "pmix_verbose",
-                               "Verbosity for PRTE-level PMIx code", PRTE_MCA_BASE_VAR_TYPE_INT,
+                               "Verbosity for PRRTE-level PMIx code", PRTE_MCA_BASE_VAR_TYPE_INT,
                                NULL, 0, PRTE_MCA_BASE_VAR_FLAG_NONE, PRTE_INFO_LVL_5,
                                PRTE_MCA_BASE_VAR_SCOPE_READONLY, &prte_pmix_verbose_output);
 

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -107,8 +107,6 @@ static char *print_aborted_job(prte_job_t *job,
                                prte_node_t *node)
 {
     char *output = NULL;
-    bool flag;
-    bool *fptr = &flag;
 
     if (PRTE_PROC_STATE_FAILED_TO_START == proc->state ||
         PRTE_PROC_STATE_FAILED_TO_LAUNCH == proc->state) {
@@ -284,9 +282,7 @@ static char *print_aborted_job(prte_job_t *job,
                                        node->name);
         return output;
     } else if (PRTE_PROC_STATE_TERM_NON_ZERO == proc->state) {
-        flag = false;
-        prte_get_attribute(&job->attributes, PRTE_JOB_TERM_NONZERO_EXIT, (void**)&fptr, PMIX_BOOL);
-        if (flag) {
+        if (prte_get_attribute(&job->attributes, PRTE_JOB_TERM_NONZERO_EXIT, NULL, PMIX_BOOL)) {
             output = pmix_show_help_string("help-prun.txt", "prun:non-zero-exit", true,
                                            prte_tool_basename, PRTE_NAME_PRINT(&proc->name),
                                            proc->exit_code);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -136,23 +136,6 @@ prte_attribute_t *prte_fetch_attribute(pmix_list_t *attributes, prte_attribute_t
     return NULL;
 }
 
-int prte_add_attribute(pmix_list_t *attributes, prte_attribute_key_t key, bool local, void *data,
-                       pmix_data_type_t type)
-{
-    prte_attribute_t *kv;
-    int rc;
-
-    kv = PMIX_NEW(prte_attribute_t);
-    kv->key = key;
-    kv->local = local;
-    if (PRTE_SUCCESS != (rc = prte_attr_load(kv, data, type))) {
-        PMIX_RELEASE(kv);
-        return rc;
-    }
-    pmix_list_append(attributes, &kv->super);
-    return PRTE_SUCCESS;
-}
-
 int prte_prepend_attribute(pmix_list_t *attributes, prte_attribute_key_t key, bool local,
                            void *data, pmix_data_type_t type)
 {
@@ -485,6 +468,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB CONTROLS";
         case PRTE_JOB_SHOW_PROGRESS:
             return "SHOW LAUNCH PROGRESS";
+        case PRTE_JOB_RECOVERABLE:
+            return "JOB IS RECOVERABLE";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -123,8 +123,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_COMBINER                   (PRTE_JOB_START_KEY +  15) // bool - job consists of MapReduce combiners
 #define PRTE_JOB_INDEX_ARGV                 (PRTE_JOB_START_KEY +  16) // bool - automatically index argvs
 #define PRTE_JOB_NO_VM                      (PRTE_JOB_START_KEY +  17) // bool - do not use VM launch
-#define PRTE_JOB_SPIN_FOR_DEBUG             (PRTE_JOB_START_KEY +  18) // bool - job consists of continuously operating apps
-#define PRTE_JOB_CONTINUOUS_OP              (PRTE_JOB_START_KEY +  19) // bool - recovery policy defined for job
+#define PRTE_JOB_SPIN_FOR_DEBUG             (PRTE_JOB_START_KEY +  18) // bool - the prted's are to spin while waiting for debugger
+#define PRTE_JOB_CONTINUOUS_OP              (PRTE_JOB_START_KEY +  19) // bool - job consists of continuously operating apps
 #define PRTE_JOB_RECOVER_DEFINED            (PRTE_JOB_START_KEY +  20) // bool - recovery policy has been defined
 #define PRTE_JOB_NON_PRTE_JOB               (PRTE_JOB_START_KEY +  22) // bool - non-prte job
 #define PRTE_JOB_STDOUT_TARGET              (PRTE_JOB_START_KEY +  23) // pmix_nspace_t - job that is to receive the stdout (on its
@@ -194,7 +194,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_DEBUG_DAEMONS_PER_NODE     (PRTE_JOB_START_KEY +  86) // uint16_t - Number of debug daemons per node
 #define PRTE_JOB_DEBUG_DAEMONS_PER_PROC     (PRTE_JOB_START_KEY +  87) // uint16_t - Number of debug daemons per application proc
 #define PRTE_JOB_STOP_IN_INIT               (PRTE_JOB_START_KEY +  88) // pmix_rank_t of procs to stop
-#define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY +  89) // pmix_rank_t of procs to stop
+#define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY +  89) // char* of application label where the procs are to stop
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY +  90) // envars have already been harvested
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY +  91) // bool - do not copy output to stdout/err
 #define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY +  92) // bool - tag stdout/stderr with rank
@@ -210,6 +210,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_TERM_NONZERO_EXIT          (PRTE_JOB_START_KEY + 102) // bool - terminate job if a proc exits with non-zero status
 #define PRTE_JOB_CONTROLS                   (PRTE_JOB_START_KEY + 103) // char* - Directives controlling job behavior
 #define PRTE_JOB_SHOW_PROGRESS              (PRTE_JOB_START_KEY + 104) // bool - show launch progress of this job
+#define PRTE_JOB_RECOVERABLE                (PRTE_JOB_START_KEY + 105) // bool - job processes can be recovered, do not terminate upon
+                                                                       //        process failure
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 
@@ -285,9 +287,6 @@ PRTE_EXPORT void prte_remove_attribute(pmix_list_t *attributes, prte_attribute_k
 
 PRTE_EXPORT prte_attribute_t *prte_fetch_attribute(pmix_list_t *attributes, prte_attribute_t *prev,
                                                    prte_attribute_key_t key);
-
-PRTE_EXPORT int prte_add_attribute(pmix_list_t *attributes, prte_attribute_key_t key, bool local,
-                                   void *data, pmix_data_type_t type);
 
 PRTE_EXPORT int prte_prepend_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                                        bool local, void *data, pmix_data_type_t type);

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -356,8 +356,8 @@ int prte_session_dir_cleanup(pmix_nspace_t jobid)
         return PRTE_SUCCESS;
     }
 
-    if (!prte_create_session_dirs || prte_process_info.rm_session_dirs) {
-        /* we haven't created them or RM will clean them up for us*/
+    if (prte_process_info.rm_session_dirs) {
+        /* RM will clean them up for us */
         return PRTE_SUCCESS;
     }
 
@@ -426,12 +426,13 @@ int prte_session_dir_finalize(pmix_proc_t *proc)
 {
     int ret;
 
-    if (!prte_create_session_dirs || prte_process_info.rm_session_dirs) {
-        /* we haven't created them or RM will clean them up for us*/
+    if (prte_process_info.rm_session_dirs) {
+        /* RM will clean them up for us */
         return PRTE_SUCCESS;
     }
 
-    if (NULL == prte_process_info.job_session_dir || NULL == prte_process_info.proc_session_dir) {
+    if (NULL == prte_process_info.job_session_dir ||
+        NULL == prte_process_info.proc_session_dir) {
         /* this should never happen - it means we are calling
          * cleanup *before* properly setting up the session
          * dir system. This leaves open the possibility of


### PR DESCRIPTION
Some runtime options were passed solely as MCA params
while others were mixes of params and cmd line options.
PRRTE is primarily a persistent DVM, and while we are
reusing it as a "one-shot" launcher, we have to preserve
the ability to pass any option by cmd line unless that
option cannot be supported by anything other than a param.

Collect the various runtime options and set them up as
follows:

* MCA params set default values. Note that these are
  only read at time of prte startup

* cmd line options override the defaults, as they should.
  However, they are not processed by pushing their
  equivalent MCA param into the environment - they are
  processed as cmd line options and directly set the
  PRRTE internal variables

* spawn cmds override both of the above as these are
  coming from tools and/or apps.

A new --runtime-options cmd line option is provided,
though support is included for using individual
options should schizo components choose to do so. The
list of directives supported by --runtime-options is
detailed by the --help runtime-options command, and
can be found in schizo/base/help-schizo-cli.txt

Signed-off-by: Ralph Castain <rhc@pmix.org>