### PR TITLE
Fix setting of runtime options

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1616,13 +1616,13 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                  * require that the proc deregister before terminating
                  */
                 if (0 != proc->exit_code && flag) {
-                    state = PRTE_PROC_STATE_TERM_NON_ZERO;
                     PMIX_OUTPUT_VERBOSE(
                         (5, prte_odls_base_framework.framework_output,
                          "%s odls:waitpid_fired child process %s terminated normally "
                          "but with a non-zero exit status - it "
                          "will be treated as an abnormal termination",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
+                    state = PRTE_PROC_STATE_TERM_NON_ZERO;
                 } else {
                     /* indicate the waitpid fired */
                     state = PRTE_PROC_STATE_WAITPID_FIRED;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -691,7 +691,6 @@ void prte_plm_base_setup_job_complete(int fd, short args, void *cbdata)
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
-
     /* nothing to do here but move along */
     PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_ALLOCATE);
     PMIX_RELEASE(caddy);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -94,14 +94,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     memset(&options, 0, sizeof(prte_rmaps_options_t));
     options.stream = prte_rmaps_base_framework.framework_output;
     options.verbosity = 5;  // usual value for base-level functions
-    if (!jdata->map->rtos_set) {
-        /* set the runtime options first */
-        if (NULL != schizo->set_default_rto) {
-            rc = schizo->set_default_rto(jdata, &options);
-        } else {
-            rc = prte_rmaps_base_set_default_rto(jdata, &options);
-        }
-    }
+
     /* check and set some general options */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
         options.donotlaunch = true;

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -51,7 +51,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/base/base.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
-#include "src/mca/rmaps/rmaps_types.h"
+#include "src/mca/rmaps/base/base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/pmix_init_util.h"
 
@@ -65,6 +65,8 @@ static void allow_run_as_root(pmix_cli_result_t *results);
 static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
 static void job_info(pmix_cli_result_t *results,
                      void *jobinfo);
+static int set_default_rto(prte_job_t *jdata,
+                           prte_rmaps_options_t *options);
 
 prte_schizo_base_module_t prte_schizo_prte_module = {
     .name = "prte",
@@ -73,7 +75,8 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .setup_fork = setup_fork,
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
-    .job_info = job_info
+    .job_info = job_info,
+    .set_default_rto = set_default_rto
 };
 
 static struct option prteoptions[] = {
@@ -1166,4 +1169,10 @@ static void job_info(pmix_cli_result_t *results,
                      void *jobinfo)
 {
     return;
+}
+
+static int set_default_rto(prte_job_t *jdata,
+                           prte_rmaps_options_t *options)
+{
+    return prte_rmaps_base_set_runtime_options(jdata, NULL);
 }


### PR DESCRIPTION
Provide a chance for default options to be set, and then overwritten by user-provided values. Ensure those are preserved throughout the job lifecycle.

Signed-off-by: Ralph Castain <rhc@pmix.org>