### PR TITLE
Added specfile BuildRequires

### DIFF
--- a/contrib/dist/linux/prrte.spec
+++ b/contrib/dist/linux/prrte.spec
@@ -201,6 +201,11 @@ Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: %{_prefix}
 Provides: prrte = %{version}
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+BuildRequires: %toolchain
+BuildRequires: flex
+BuildRequires: libevent-devel
+BuildRequires: pmix >= 4.2.0
+BuildRequires: hwloc-devel
 %if %{disable_auto_requires}
 AutoReq: no
 %endif


### PR DESCRIPTION
Without BuildRequires specified, prrte cannot be built with mock.

See also #1425

Signed-off-by: Jonathon Anderson <janderson@ciq.co>