### PR TITLE
Add action to check commits on pull requests

### DIFF
--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -1,0 +1,28 @@
+name: PR Checks CI
+
+# We're using pull_request_target here instead of just pull_request so that the
+# action runs in the context of the base of the pull request, rather than in the
+# context of the merge commit. For more detail about the differences, see:
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+on:
+    pull_request_target:
+        # We don't need this to be run on all types of PR behavior
+        # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request
+        types:
+          - opened
+          - synchronize
+          - edited
+
+permissions: {} # none
+
+jobs:
+  check:
+    permissions:
+      pull-requests: write
+    name: Check Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull Request Commit Checker
+        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        with:
+          token: "${{ secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
The action checks each commit in a pull request to see if

* the committer / author do not match bad patterns ("root@", "localhost", etc.)
* a "Signed-off-by:" line exists
* a "cherry picked from" message appears, if required by config inputs (not required by default)
  * if the message exists, ensure the referenced commit exists

If all commit checks pass, the action successfully completes and the action check for the PR passes. If any commit check fails, the action check fails as well. Additionally, a comment is posted to the pull request, describing which commits failed which test and suggesting the user fix them.

Signed-off-by: Joe Downs <joe@dwns.dev>

-------
### Comment Example:
![image](https://user-images.githubusercontent.com/48387830/191418194-a73cf4e7-c2f3-47fb-a3a6-e2db5afd7291.png)

-----

This PR adds the same functionality as a [PR in the openpmix repo](https://github.com/openpmix/openpmix/pull/2763). Check there for more context, if needed.