### PR TITLE
schizo_ompi: use the OMPI_MCA_PREFIXES env var

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -319,7 +319,7 @@ static int setup_app(prte_pmix_app_t *app)
         free(value);
     }
 
-    /* see if we were given a class path 
+    /* see if we were given a class path
      * See https://docs.oracle.com/javase/8/docs/technotes/tools/findingclasses.html
      * for more info about rules for the ways to set the class path
      */
@@ -475,7 +475,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         return prte_pmix_convert_status(rc);
     }
 
-    /* 
+    /*
      * If warning is enabled, list all offending
      * single dash params are before the last found
      * argument by the parser (results -> tail).

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
@@ -1370,15 +1370,14 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
     return PRTE_SUCCESS;
 }
 
+// These frameworks are current as of 16 Sep, 2022, and are the list
+// of frameworks that are planned to be in Open MPI v5.0.0.
 static char *ompi_frameworks[] = {
     /* OPAL frameworks */
     "allocator",
     "backtrace",
     "btl",
-    "compress",
-    "crs",
     "dl",
-    "event",
     "hwloc",
     "if",
     "installdirs",
@@ -1388,11 +1387,10 @@ static char *ompi_frameworks[] = {
     "mpool",
     "patcher",
     "pmix",
-    "pstat",
     "rcache",
     "reachable",
-    "smsc",
     "shmem",
+    "smsc",
     "threads",
     "timer",
     /* OMPI frameworks */
@@ -1407,6 +1405,7 @@ static char *ompi_frameworks[] = {
     "mtl",
     "op",
     "osc",
+    "part",
     "pml",
     "sharedfp",
     "topo",


### PR DESCRIPTION
This PR is in conjunction with https://github.com/open-mpi/ompi/pull/10836

-----

3 commits:

- trivial whitespace cleanup
- update the list of hard-coded Open MPI framework names to match what will be shipped in Open MPI v5.0.0
- look for the env var `$OMPI_MCA_PREFIXES`.  If it exists, use that as the definitive list of Open MPI MCA variable prefixes rather than the hard-coded list