### PR TITLE
Upward-port commits mistakenly targeting into v3.0

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2006-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2009-2022 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
@@ -1377,15 +1377,14 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
     return PRTE_SUCCESS;
 }
 
+// These frameworks are current as of 16 Sep, 2022, and are the list
+// of frameworks that are planned to be in Open MPI v5.0.0.
 static char *ompi_frameworks[] = {
     /* OPAL frameworks */
     "allocator",
     "backtrace",
     "btl",
-    "compress",
-    "crs",
     "dl",
-    "event",
     "hwloc",
     "if",
     "installdirs",
@@ -1395,11 +1394,10 @@ static char *ompi_frameworks[] = {
     "mpool",
     "patcher",
     "pmix",
-    "pstat",
     "rcache",
     "reachable",
-    "smsc",
     "shmem",
+    "smsc",
     "threads",
     "timer",
     /* OMPI frameworks */
@@ -1414,6 +1412,7 @@ static char *ompi_frameworks[] = {
     "mtl",
     "op",
     "osc",
+    "part",
     "pml",
     "sharedfp",
     "topo",

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -323,7 +323,7 @@ static int setup_app(prte_pmix_app_t *app)
         free(value);
     }
 
-    /* see if we were given a class path 
+    /* see if we were given a class path
      * See https://docs.oracle.com/javase/8/docs/technotes/tools/findingclasses.html
      * for more info about rules for the ways to set the class path
      */
@@ -479,7 +479,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         return prte_pmix_convert_status(rc);
     }
 
-    /* 
+    /*
      * If warning is enabled, list all offending
      * single dash params are before the last found
      * argument by the parser (results -> tail).

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1379,7 +1379,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
 
 // These frameworks are current as of 16 Sep, 2022, and are the list
 // of frameworks that are planned to be in Open MPI v5.0.0.
-static char *ompi_frameworks[] = {
+static char *ompi_frameworks_static_5_0_0[] = {
+    // Generic prefixes used by OMPI
+    "mca",
+    "opal",
+    "ompi",
+
     /* OPAL frameworks */
     "allocator",
     "backtrace",
@@ -1424,23 +1429,38 @@ static char *ompi_frameworks[] = {
     "sshmem",
     NULL,
 };
+static char **ompi_frameworks = ompi_frameworks_static_5_0_0;
+static bool ompi_frameworks_setup = false;
+
+static void setup_ompi_frameworks(void)
+{
+    if (ompi_frameworks_setup) {
+        return;
+    }
+    ompi_frameworks_setup = true;
+
+    char *env = getenv("OMPI_MCA_PREFIXES");
+    if (NULL == env) {
+        return;
+    }
+
+    // If we found the env variable, it will be a comma-delimited list
+    // of values.  Split it into an argv-style array.
+    char **tmp = pmix_argv_split(env, ',');
+    if (NULL != tmp) {
+        ompi_frameworks = tmp;
+    }
+}
 
 static bool check_generic(char *p1)
 {
-    int j;
+    setup_ompi_frameworks();
 
-    /* this is a generic MCA designation, so see if the parameter it
-     * refers to belongs to a project base or one of our frameworks */
-    if (0 == strncmp("opal_", p1, strlen("opal_")) ||
-        0 == strncmp("ompi_", p1, strlen("ompi_"))) {
-        return true;
-    } else if (0 == strcmp(p1, "mca_base_env_list")) {
-        return true;
-    } else {
-        for (j = 0; NULL != ompi_frameworks[j]; j++) {
-            if (0 == strncmp(p1, ompi_frameworks[j], strlen(ompi_frameworks[j]))) {
-                return true;
-            }
+    /* See if the parameter we were passed belongs to one of the OMPI
+       frameworks or prefixes */
+    for (int j = 0; NULL != ompi_frameworks[j]; j++) {
+        if (0 == strncmp(p1, ompi_frameworks[j], strlen(ompi_frameworks[j]))) {
+            return true;
         }
     }
 


### PR DESCRIPTION
[schizo_ompi: whitespace cleanup](https://github.com/openpmix/prrte/commit/821f754365b2ae0fd6e451cdf72c62f82ffeff50)

No code or logic changes

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a92ce804b0fa9edda0596f12e37613dede0f8894)

[schizo_ompi: update the list of OMPI frameworks](https://github.com/openpmix/prrte/commit/d778d8c885e73446191bf077e2c0d3a6e40cb93a)

These are current as of 16 Sep 2022; this is the set of frameworks
that is planned to be in Open MPI v5.0.0.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/efd5ea6e98d2e42bd449c050a39c1f8283dc1494)

[schizo_ompi: use env var OMPI_MCA_PREFIXES](https://github.com/openpmix/prrte/commit/eae7f059eff850132b77bc25ccce2c13c7c52c83)

If $OMPI_MCA_PREFIXES exists (which will have been set by Open MPI's
mpirun(1) executable), read it in and use that as the list of prefixes
to use to find Open MPI MCA variables passed to the "--mca" parameter.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/71bbd7262539636347e50b8ae9b75d94b46f6a78)
