### PR TITLE
Add missing commits and new additions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,6 +69,12 @@ PMIx version that meets the PMIx cross-version requirements (i.e., a
 minimum of PMIx v2.5).
 
 Detailed changes:
+PR #1528: Add missing commits and new additions
+  - Complete help text on notifications
+  - BuildRequires: gcc
+  - Plug a memory leak
+  - schizo/ompi: Fix --use-hwthead-cpus option
+  - Fix --preload-binary
 PR #1522: Roll version to rc2
 PR #1518: schizo_ompi: use the OMPI_MCA_PREFIXES env var
 PR #1517: Multiple commits

--- a/VERSION
+++ b/VERSION
@@ -26,7 +26,7 @@ release=0
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc2
+greek=rc3
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/contrib/dist/linux/prrte.spec
+++ b/contrib/dist/linux/prrte.spec
@@ -201,7 +201,7 @@ Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 Prefix: %{_prefix}
 Provides: prrte = %{version}
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
-BuildRequires: %toolchain
+BuildRequires: gcc
 BuildRequires: flex
 BuildRequires: libevent-devel
 BuildRequires: pmix >= 4.2.0

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -897,6 +897,7 @@ static int map_colocate(prte_job_t *jdata,
                     }
                     jdata->num_procs += 1;
                     app->num_procs += 1;
+                    PMIX_RELEASE(proc); 
                 }
             }
         }
@@ -956,6 +957,7 @@ static int map_colocate(prte_job_t *jdata,
                 }
                 jdata->num_procs += 1;
                 app->num_procs += 1;
+                PMIX_RELEASE(proc);
             }
         }
     }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -719,7 +719,12 @@ cleanup:
         }
     }
     if (NULL != options.job_cpuset) {
-        free(options.job_cpuset);
+        hwloc_bitmap_free(options.job_cpuset);
+        options.job_cpuset = NULL;
+    }
+    if (NULL != options.target) {
+        hwloc_bitmap_free(options.target);
+        options.target = NULL;
     }
     /* cleanup */
     PMIX_RELEASE(caddy);

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -166,7 +166,7 @@ char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping)
     default:
         map = "UNKNOWN";
     }
-    pmix_asprintf(&mymap, "%s:", map);
+
     if (PRTE_MAPPING_NO_USE_LOCAL & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
         pmix_argv_append_nosize(&qls, "NO_USE_LOCAL");
     }

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -281,11 +281,14 @@ static int ppr_mapper(prte_job_t *jdata,
                     rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
                     if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                         /* move to next node */
+                        PMIX_RELEASE(proc);
                         break;
                     } else if (PRTE_SUCCESS != rc) {
                         /* got an error */
+                        PMIX_RELEASE(proc);
                         return rc;
                     }
+                    PMIX_RELEASE(proc);
                 }
             } else {
                 /* get the number of resources on this node */
@@ -324,11 +327,14 @@ static int ppr_mapper(prte_job_t *jdata,
                         rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
                         if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                             /* move to next node */
+                            PMIX_RELEASE(proc);
                             break;
                         } else if (PRTE_SUCCESS != rc) {
                             /* got an error */
+                            PMIX_RELEASE(proc);
                             return rc;
                         }
+                        PMIX_RELEASE(proc);
                     }
                 }
             }

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -322,17 +322,21 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
             /* check if we are oversubscribed */
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
             if (PRTE_SUCCESS != rc) {
+                PMIX_RELEASE(proc);
                 goto error;
             }
-          /* set the vpid */
+            /* set the vpid */
             proc->name.rank = rank;
             /* insert the proc into the proper place */
+            PMIX_RETAIN(proc);
             rc = pmix_pointer_array_set_item(jdata->procs, proc->name.rank, proc);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
+                PMIX_RELEASE(proc);
                 goto error;
             }
             jdata->num_procs++;
+            PMIX_RELEASE(proc);
         }
         /* update the starting point */
         vpid_start += app->num_procs;

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -150,11 +150,14 @@ pass:
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
             if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                 /* move to next node */
+                PMIX_RELEASE(proc);
                 break;
             } else if (PRTE_SUCCESS != rc) {
                 /* got an error */
+                PMIX_RELEASE(proc);
                 goto errout;
             }
+            PMIX_RELEASE(proc);
         }
 
         if (nprocs_mapped == app->num_procs) {
@@ -304,11 +307,14 @@ pass:
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
             if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                 /* move to next node */
+                PMIX_RELEASE(proc);
                 break;
             } else if (PRTE_SUCCESS != rc) {
                 /* got an error */
+                PMIX_RELEASE(proc);
                 goto errout;
             }
+            PMIX_RELEASE(proc);
         }
         if (nprocs_mapped == app->num_procs) {
             return PRTE_SUCCESS;
@@ -441,11 +447,14 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
             if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                 /* move to next node */
+                PMIX_RELEASE(proc);
                 break;
             } else if (PRTE_SUCCESS != rc) {
                 /* got an error */
+                PMIX_RELEASE(proc);
                 goto errout;
             }
+            PMIX_RELEASE(proc);
         }
         if (nprocs_mapped == app->num_procs) {
             return PRTE_SUCCESS;
@@ -681,11 +690,14 @@ pass:
                     if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                         /* move to next node */
                         nodefull = true;
+                        PMIX_RELEASE(proc);
                         break;
                     } else if (PRTE_SUCCESS != rc) {
                         /* got an error */
+                        PMIX_RELEASE(proc);
                         goto errout;
                     }
+                    PMIX_RELEASE(proc);
                 }
             }
         } else {
@@ -720,11 +732,14 @@ pass:
                     if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                         /* move to next node */
                         nodefull = true;
+                        PMIX_RELEASE(proc);
                         break;
                     } else if (PRTE_SUCCESS != rc) {
                         /* got an error */
+                        PMIX_RELEASE(proc);
                         goto errout;
                     }
+                    PMIX_RELEASE(proc);
                 }
             }
         }

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -164,6 +164,11 @@ pass:
             return PRTE_SUCCESS;
         }
         options->bind = savebind;
+        if(NULL != options->target)
+        {
+            hwloc_bitmap_free(options->target);
+            options->target = NULL;
+        }
     }
 
     if (second_pass) {
@@ -320,6 +325,11 @@ pass:
             return PRTE_SUCCESS;
         }
         options->bind = savebind;
+        if(NULL != options->target)
+        {
+            hwloc_bitmap_free(options->target);
+            options->target = NULL;
+        }
     }
 
     if (second_pass) {
@@ -458,6 +468,11 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
         }
         if (nprocs_mapped == app->num_procs) {
             return PRTE_SUCCESS;
+        }
+        if(NULL != options->target)
+        {
+            hwloc_bitmap_free(options->target);
+            options->target = NULL;
         }
     }
 
@@ -686,6 +701,11 @@ pass:
                     }
                     options->nobjs++;
                     nprocs_mapped++;
+                    if(NULL != options->target)
+                    {
+                        hwloc_bitmap_free(options->target);
+                        options->target = NULL;
+                    }
                     rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
                     if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                         /* move to next node */
@@ -740,6 +760,11 @@ pass:
                         goto errout;
                     }
                     PMIX_RELEASE(proc);
+                }
+                if(NULL != options->target)
+                {
+                    hwloc_bitmap_free(options->target);
+                    options->target = NULL;
                 }
             }
         }

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -360,6 +360,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
             }
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
             if (PRTE_SUCCESS != rc) {
+                PMIX_RELEASE(proc);
                 goto error;
             }
             pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
@@ -368,6 +369,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
 
             /* move to next node */
             sq = (seq_node_t *) pmix_list_get_next(&sq->super);
+            PMIX_RELEASE(proc);
         }
 
         /** track the total number of processes we mapped */

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -589,10 +589,19 @@ the cause of the event to the extent to which this is known.
 
 Supported job events include:
 
--   PMIX_READY_FOR_DEBUG
--   PMIX_LAUNCH_COMPLETE
--   PMIX_ERR_JOB_CANCELED
--   PMIX_ERR_JOB_FAILED_TO_LAUNCH
+-   PMIX_READY_FOR_DEBUG indicates that all processes in the reported nspace have
+    reached the specified debug stopping point.
+
+-   PMIX_LAUNCH_COMPLETE indicates that the reported nspace has been launched - i.e.,
+    the involved PRRTE daemons all report that their respective child processes
+    have completed fork/exec.
+
+-   PMIX_ERR_JOB_CANCELED indicates that the job was cancelled by user command, usually
+    issued via an appropriate PMIx-enabled tool.
+
+-   PMIX_ERR_JOB_FAILED_TO_LAUNCH indicates that the specified job failed to launch.
+    This can be due to a variety of factors that include inability to find the
+    executable on at least one involved node.
 
 
 Supported process events include:
@@ -604,17 +613,34 @@ Supported process events include:
     shutdown of the process. Notification will include the process ID that exited
     in this manner.
 
--   PMIX_EVENT_PROC_TERMINATED
+-   PMIX_EVENT_PROC_TERMINATED indicates that the reported process terminated normally.
+    Notification will include the process ID that exited and its exit status.
 
--   PMIX_ERR_PROC_KILLED_BY_CMD
+-   PMIX_ERR_PROC_KILLED_BY_CMD indicates that the reported process was killed by
+    PRRTE command. This typically occurs in response to a Ctrl-C (or equivalent)
+    being applied to the PRRTE launcher, thereby instructing PRRTE to forcibly
+    terminate its processes. The event currently will only be issued in the
+    case where forcible termination is commanded via a tool that can pass the
+    process IDs that are specifically to be terminated - otherwise, in the case
+    of the Ctrl-C event previously described, all processes in the job will be
+    terminated, leaving none to be notified. Notification will include the process
+    ID that was terminated.
 
--   PMIX_ERR_PROC_FAILED_TO_START
+-   PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED indicates that the specified process
+    exceeded a previously-set sensor boundary - e.g., it may have grown beyond
+    a defined memory limit. Such events may or may not automatically trigger
+    termination by command, depending upon the behavior of the sensor. Notification
+    will include the process ID that exceeded the sensor boundary plus whatever
+    information the sensor provides regarding measurements and bounds.
 
--   PMIX_ERR_PROC_SENSOR_BOUND_EXCEEDED
+-   PMIX_ERR_PROC_ABORTED_BY_SIG indicates that the specified process was killed
+    by a signal - e.g., a segmentation fault/violation or an externally applied
+    signal. Notifications will include the process ID that was killed and the
+    corresponding reported signal.
 
--   PMIX_ERR_PROC_ABORTED
-
--   PMIX_ERR_PROC_REQUESTED_ABORT
+-   PMIX_ERR_PROC_REQUESTED_ABORT indicates that the specified process has aborted
+    by calling the PMIx_Abort function. Notification will include the process ID
+    that called abort and its exit status.
 
 -   PMIX_ERR_EXIT_NONZERO_TERM indicates that the specified process terminated with
     a non-zero exit status. This notification is only generated in the case where

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -625,7 +625,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         /* --use-hwthread-cpus -> --bind-to hwthread */
         else if (0 == strcmp(option, "use-hwthread-cpus")) {
             rc = prte_schizo_base_add_qualifier(results, option,
-                                                PRTE_CLI_BINDTO, PRTE_CLI_HWT,
+                                                PRTE_CLI_MAPBY, PRTE_CLI_HWTCPUS,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -305,6 +305,9 @@ static void interim(int sd, short args, void *cbdata)
                     prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
 
+                } else if (PMIX_CHECK_KEY(info, PMIX_PRELOAD_BIN)) {
+                    prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_BIN, PRTE_ATTR_GLOBAL,
+                                       NULL, PMIX_BOOL);
                     /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
                     /* there can be multiple of these, so we add them to the attribute list */
                 } else if (PMIX_CHECK_KEY(info, PMIX_SET_ENVAR)) {

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -221,6 +221,12 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PRELOAD_FILES, opt->values[0], PMIX_STRING);
     }
 
+    /* check for preload binary */
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_PRELOAD_BIN);
+    if (NULL != opt) {
+        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PRELOAD_BIN, NULL, PMIX_BOOL);
+    }
+
     /* Do not try to find argv[0] here -- the starter is responsible
      for that because it may not be relevant to try to find it on
      the node where prun is executing.  So just strdup() argv[0]


### PR DESCRIPTION
[Complete help text on notifications](https://github.com/openpmix/prrte/commit/dacb3e2f5ff81f58efbb83e69add8848e94b6c73)

Explain what PMIx events are supported and their meaning.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ace5861981cb7ff435039113335231093e72645e)

[BuildRequires: gcc](https://github.com/openpmix/prrte/commit/fdbf7d104aae530d8279466ce093de23382de7db)

Make gcc requirement explicit

Signed-off-by: Jonathon Anderson <janderson@ciq.co>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e44125c23f9277bd52528fc5f938842933571eaf)

[Plug a memory leak](https://github.com/openpmix/prrte/commit/4037f96dc5442cfabaacf9ce04d0481555954aac)

Remove a redundant call to pmix_asprintf.

Signed-off-by: Heena Sirwani <heena.sirwani@itwm.fraunhofer.de>
(cherry picked from commit https://github.com/openpmix/prrte/commit/688f7bb580f92b5a6c20cdadce168ae67b82df89)

[schizo/ompi: Fix --use-hwthread-cpus option.](https://github.com/openpmix/prrte/commit/3665f27d5b4f3ec3db7618ca433b8d36fc208d35)

There was a typo in the translation.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1c0547125e9f176b90591b3b6bcf4a702643dd62)

[Fix --preload-binary.](https://github.com/openpmix/prrte/commit/510b2863b311fcf8b02331331af7e46a71c5aff0)

There was some missing backend glue preventing the option
from doing anything.

Signed-off-by: Austen Lauria <awlauria@us.ibm.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/90dec94826917f99a7e3fa75c77a6432666d79e1)

Not entirely true, but two of the commits (for NEWS and VERSION) are not cherry-picks and the bot doesn't check the individual commits:
bot:notacherrypick
