### PR TITLE
Actually support the output-proctable option

### DIFF
--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -531,7 +531,13 @@ Supported values include:
 -   DEFAULT-EXEC-AGENT directs the runtime to use the system default exec
     agent to start an application process. No value need be passed as this is
     not an option that can be set by default in PRRTE.
-    
+
+-   OUTPUT-PROCTABLE[(=channel)] directs the runtime to report the convential
+    debugger process table (includes PID and host location of each process in
+    the application). Output is directed to stdout if the channel is "-",
+    stderr if "+", or into the specified file otherwise. If no channel is
+    specified, output will be directed to stdout.
+
 -   STOP-ON-EXEC[(=<bool or ranks>)] directs the runtime to stop the indicated
     application process(es) immediately upon exec'ing it. If a boolean value is
     provided, then the directive will apply to all processes in the job. Otherwise,

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -408,6 +408,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_REPORT_CHILD_SEP,
         PRTE_CLI_AGG_HELP,
         PRTE_CLI_NOTIFY_ERRORS,
+        PRTE_CLI_OUTPUT_PROCTABLE,
         NULL
     };
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -236,7 +236,7 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE("amca", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("am", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("rankfile", PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE("output-proctable", PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT_PROCTABLE, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_DEFINE("debug", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("stream-buffering", PMIX_ARG_REQD),
 
@@ -806,11 +806,17 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --output-proctable  ->  --display map-devel */
-        else if (0 == strcmp(option, "output-proctable")) {
+        /* --output-proctable  ->  --runtime-options output-proctable */
+        else if (0 == strcmp(option, PRTE_CLI_OUTPUT_PROCTABLE)) {
+            if (NULL != opt->values && NULL != opt->values[0]) {
+                pmix_asprintf(&p2, "%s=%s", PRTE_CLI_OUTPUT_PROCTABLE, opt->values[0]);
+            } else {
+                p2 = strdup(PRTE_CLI_OUTPUT_PROCTABLE);
+            }
             rc = prte_schizo_base_add_directive(results, option,
-                                                PRTE_CLI_DISPLAY, PRTE_CLI_MAPDEV,
+                                                PRTE_CLI_RTOS, p2,
                                                 warn);
+            free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
         /* --display-map  ->  --display map */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -250,6 +250,7 @@ static struct option prterunoptions[] = {
     PMIX_OPTION_DEFINE("ppr", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("debug", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("do-not-launch", PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT_PROCTABLE, PMIX_ARG_OPTIONAL),
 
     PMIX_OPTION_END
 };
@@ -365,6 +366,7 @@ static struct option prunoptions[] = {
     PMIX_OPTION_DEFINE("ppr", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("debug", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("do-not-launch", PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT_PROCTABLE, PMIX_ARG_OPTIONAL),
 
     PMIX_OPTION_END
 };
@@ -719,11 +721,17 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --output-proctable  ->  --display map-devel */
-        else if (0 == strcmp(option, "output-proctable")) {
+        /* --output-proctable  ->  --runtime-options output-proctable */
+        else if (0 == strcmp(option, PRTE_CLI_OUTPUT_PROCTABLE)) {
+            if (NULL != opt->values && NULL != opt->values[0]) {
+                pmix_asprintf(&p2, "%s=%s", PRTE_CLI_OUTPUT_PROCTABLE, opt->values[0]);
+            } else {
+                p2 = strdup(PRTE_CLI_OUTPUT_PROCTABLE);
+            }
             rc = prte_schizo_base_add_directive(results, option,
-                                                PRTE_CLI_DISPLAY, PRTE_CLI_MAPDEV,
+                                                PRTE_CLI_RTOS, p2,
                                                 warn);
+            free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
         /* --display-map  ->  --display map */

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -357,6 +357,14 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_NOAGG_HELP, PRTE_ATTR_GLOBAL,
                                    &flag, PMIX_BOOL);
 
+            } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_OUTPUT_PROCTABLE)) {
+                if (NULL == ptr || '\0' == *ptr) {
+                    /* no value provided, so assume stdout */
+                    ptr = "-";
+                }
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_PROCTABLE,
+                                    PRTE_ATTR_GLOBAL, ptr, PMIX_STRING);
+
             } else {
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true,
                                "runtime options", spec);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -484,6 +484,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "NOTIFY ERRORS";
         case PRTE_JOB_AUTORESTART:
             return "AUTORESTART";
+        case PRTE_JOB_OUTPUT_PROCTABLE:
+            return "OUTPUT PROCTABLE";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -213,6 +213,8 @@ typedef uint16_t prte_job_flags_t;
                                                                        //        process failure
 #define PRTE_JOB_NOTIFY_ERRORS              (PRTE_JOB_START_KEY + 106) // bool - provide PMIx events on errors
 #define PRTE_JOB_AUTORESTART                (PRTE_JOB_START_KEY + 107) // bool - automatically restart failed processes
+#define PRTE_JOB_OUTPUT_PROCTABLE           (PRTE_JOB_START_KEY + 108) // char* - string specifying where the output is to go, with a '-'
+                                                                       //         indicating stdout, '+' indicating stderr, else path
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -208,6 +208,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_REPORT_CHILD_SEP   "report-child-jobs-separately"  // optional arg
 #define PRTE_CLI_AGG_HELP           "aggregate-help"                // optional arg
 #define PRTE_CLI_NOTIFY_ERRORS      "notifyerrors"                  // optional flag
+#define PRTE_CLI_OUTPUT_PROCTABLE   "output-proctable"              // optional arg
 
 
 /* define the command line qualifiers PRRTE recognizes */


### PR DESCRIPTION
Translate --output-proctable to the runtime-options directive and handle the optional filename argument. Implement the backend support to print out the proctable when requested:
```shell
(rank, host, exe, pid) = (0, Ralphs-iMac-2, /bin/hostname, 74111)
```

Signed-off-by: Ralph Castain <rhc@pmix.org>