### PR TITLE
Fix mapping by pe-list when oversubscribed

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -75,6 +75,7 @@ no nodes were found or all the available nodes were already used.
 
 Note that since the -nolocal option was given no processes can be
 launched on the local node.
+#
 [prte-rmaps-base:no-available-resources]
 No nodes are available for this job, either due to a failure to
 allocate nodes to the job, or allocated nodes being marked

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -192,6 +192,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
     } else {
         type = HWLOC_OBJ_CORE;
     }
+
     /* the CPU numbers would have been given to us based on the total
      * available CPUs on the machine. Thus, we cannot use the node->available
      * CPU set as we are removing CPUs for accounting purposes there.
@@ -253,10 +254,6 @@ static int bind_to_cpuset(prte_job_t *jdata,
         hwloc_bitmap_andnot(node->available, node->available, obj->cpuset);
 #endif
     }
-    char *tmp;
-    hwloc_bitmap_list_asprintf(&tmp, node->available);
-
-    free(tmp);
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -488,7 +488,11 @@ ranking:
      * override it */
     if (!PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
         did_map = false;
-        if (inherit) {
+        if (options.oversubscribe) {
+            /* if we are oversubscribing, then do not bind */
+            jdata->map->binding = PRTE_BIND_TO_NONE;
+            did_map = true;
+        } else if (inherit) {
             if (NULL != parent) {
                 jdata->map->binding = parent->map->binding;
                 did_map = true;

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -739,7 +739,11 @@ bool prte_rmaps_base_check_avail(prte_job_t *jdata,
     }
 
     if (PRTE_BIND_TO_NONE == options->bind) {
-        options->target = NULL;
+        if (NULL != options->job_cpuset) {
+            options->target = hwloc_bitmap_dup(options->job_cpuset);
+        } else {
+            options->target = NULL;
+        }
         avail = true;
         goto done;
     }
@@ -860,6 +864,10 @@ int prte_rmaps_base_check_oversubscribed(prte_job_t *jdata,
          */
         PRTE_FLAG_SET(node, PRTE_NODE_FLAG_OVERSUBSCRIBED);
         PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_OVERSUBSCRIBED);
+        if (options->oversubscribe) {
+            return PRTE_SUCCESS;
+        }
+
         /* check for permission */
         if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
             /* if we weren't given a directive either way, then we will error out

--- a/src/mca/rmaps/round_robin/help-prte-rmaps-rr.txt
+++ b/src/mca/rmaps/round_robin/help-prte-rmaps-rr.txt
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,12 +26,13 @@ RMAPS found multiple applications to be launched, with
 at least one that failed to specify the number of processes to execute.
 When specifying multiple applications, you must specify how many processes
 of each to launch via the -np argument.
-
+#
 [prte-rmaps-rr:per-node-and-too-many-procs]
 There are not enough nodes in your allocation to satisfy your request to launch
 %d processes on a per-node basis - only %d nodes were available.
 
 Either request fewer processes, or obtain a larger allocation.
+#
 [prte-rmaps-rr:n-per-node-and-too-many-procs]
 There are not enough nodes in your allocation to satisfy your request to launch
 %d processes on a %d per-node basis - only %d nodes with a total of %d slots were available.
@@ -40,7 +42,7 @@ Either request fewer processes, or obtain a larger allocation.
 There are not enough slots on the nodes in your allocation to satisfy your request to launch on a %d process-per-node basis - only %d slots/node were available.
 
 Either request fewer processes/node, or obtain a larger allocation.
-
+#
 [prte-rmaps-rr:no-np-and-user-map]
 You have specified a rank-to-node/slot mapping, but failed to provide
 the number of processes to be executed. For some reason, this information
@@ -54,3 +56,36 @@ to meet the requested mapping.
   Application: %s
   Number of procs:  %d
   Number of resources: %d
+#
+[prte-rmaps-rr:not-enough-cpus]
+There are not enough slots available in the system or not enough
+CPUs in the specified PE-LIST to map the number of processes requested
+by the application:
+
+  app:  %s
+  Number of procs: %d
+  pe-list: %s
+
+Either request fewer procs for your application, make more slots
+available for use, or expand the pe-list.
+
+A "slot" is the PRRTE term for an allocatable unit where we can
+launch a process.  The number of slots available are defined by the
+environment in which PRRTE processes are run:
+
+  1. Hostfile, via "slots=N" clauses (N defaults to number of
+     processor cores if not provided)
+  2. The --host command line parameter, via a ":N" suffix on the
+     hostname (N defaults to 1 if not provided)
+  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
+  4. If none of a hostfile, the --host command line parameter, or an
+     RM is present, PRRTE defaults to the number of processor cores
+
+In all the above cases, if you want PRRTE to default to the number
+of hardware threads instead of the number of processor cores, use the
+--use-hwthread-cpus option.
+
+Alternatively, you can use the --map-by :OVERSUBSCRIBE option to ignore
+the number of available slots and size of the pe-list when placing the
+processes.
+#


### PR DESCRIPTION
Do a second pass to complete placement of remaining procs. Ensure that we correctly bind the remainder to all CPUs in the list. Make the error message
when unable to place all requested procs a little
clearer.

Signed-off-by: Ralph Castain <rhc@pmix.org>