### PR TITLE
Fix a typo and expand debugger example range to cover MPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ examples/debugger/hello
 examples/debugger/direct-multi
 examples/debugger/indirect-multi
 examples/debugger/stdincheck
+examples/debugger/mpihello
 examples/legacy
 examples/colocate
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -50,6 +50,7 @@ EXTRA_DIST += \
         examples/debugger/indirect-multi.c \
         examples/debugger/hello.c \
         examples/debugger/stdincheck.c \
+        examples/debugger/mpihello.c \
         examples/dmodex.c \
         examples/dynamic.c \
         examples/error_notify.c \

--- a/examples/debugger/mpihello.c
+++ b/examples/debugger/mpihello.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
+ *
+ * Sample MPI "hello world" application in C
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+
+int main(int argc, char *argv[])
+{
+    int rank, size, len;
+    char version[MPI_MAX_LIBRARY_VERSION_STRING];
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Get_library_version(version, &len);
+    printf("Hello, world, I am %d of %d, (%s, %d)\n", rank, size, version, len);
+    MPI_Finalize();
+
+    return 0;
+}

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -550,7 +550,7 @@ static void interim(int sd, short args, void *cbdata)
 
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_STOP_IN_APP)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, PRTE_ATTR_GLOBAL,
-                               info->value.data.string, PMIX_STRING);
+                               &info->value.data.rank, PMIX_PROC_RANK);
             /* also must add to job-level cache */
             pmix_server_cache_job_info(jdata, info);
 


### PR DESCRIPTION
Fix a typo in pmix_server_dyn.c that incorrectly identified PMIX_DEBUGGER_STOP_IN_APP as providing a string - it provides a pmix_rank_t.

Extend the indirect.c debugger example so that it passes "stop-in-app" when using either "mpirun" or "mpiexec" launchers. This directs an MPI app to stop in MPI_Init instead of PMIx_Init, which more closely mimics real world.

Add a mpihello.c example for testing MPI apps. Note that it requires mpicc to be available to compile it, so it is not added to the debugger examples Makefile.

Signed-off-by: Ralph Castain <rhc@pmix.org>