### PR TITLE
Support query of pset membership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ examples/debugger/stdincheck
 examples/debugger/mpihello
 examples/legacy
 examples/colocate
+examples/pset
 
 src/sys/powerpc/atomic-32.s
 src/sys/powerpc/atomic-64.s

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -59,7 +59,8 @@ EXAMPLES = \
 	launcher \
 	showkeys \
 	legacy \
-	colocate
+	colocate \
+	pset
 
 all: $(EXAMPLES)
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -67,4 +67,5 @@ EXTRA_DIST += \
         examples/showkeys.c \
         examples/target.c \
         examples/tool.c \
-	examples/colocate.c
+        examples/colocate.c \
+        examples/pset.c

--- a/examples/pset.c
+++ b/examples/pset.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+int main(int argc, char **argv)
+{
+    int rc;
+    size_t n;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc, *pptr;
+    pid_t pid;
+    pmix_proc_t myproc;
+
+    pid = getpid();
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
+            (unsigned long) pid);
+
+    /* get our pset name */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_PSET_NAME, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get pset name failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    fprintf(stderr, "Client %s:%d pset name %s\n",
+            myproc.nspace, myproc.rank, val->data.string);
+    PMIX_VALUE_FREE(val, 1);
+
+    /* since this is our pset, get our membership */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_PSET_MEMBERS, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get of pset members failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    /* must return a pmix_data_array_t of members */
+    if (PMIX_DATA_ARRAY != val->type) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get of pset members returned incorrect data type: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Data_type_string(val->type));
+        goto done;
+    }
+    fprintf(stderr, "Client %s:%d PMIx_Get returned %d members\n", myproc.nspace, myproc.rank,
+            val->data.darray->size);
+    pptr = (pmix_proc_t*)val->data.darray->array;
+    for (n=0; n < val->data.darray->size; n++) {
+        fprintf(stderr, "\t%s:%d\n", pptr[n].nspace, pptr[n].rank);
+    }
+    PMIX_VALUE_FREE(val, 1);
+
+done:
+    return (rc);
+}

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -582,8 +582,7 @@ static void check_send_notification(prte_job_t *jdata,
     pmix_data_range_t range = PMIX_RANGE_CUSTOM;
     pmix_status_t cret;
 
-  //  pmix_output_verbose(5, prte_state_base_framework.framework_output,
-    pmix_output(0,
+    pmix_output_verbose(5, prte_state_base_framework.framework_output,
                         "%s errmgr:dvm:sending notification %s affected proc %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         PMIx_Error_string(event),
@@ -591,7 +590,6 @@ static void check_send_notification(prte_job_t *jdata,
 
     if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_ERRORS, NULL, PMIX_BOOL) ||
         prte_dvm_abort_ordered) {
-        pmix_output(0, "NOT NOTIFYING");
         return;
     }
     /* we checked for termination due to the specific error we encountered, but
@@ -601,7 +599,6 @@ static void check_send_notification(prte_job_t *jdata,
     if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
         /* this job has already been aborted, so we don't need to notify
          * about the fate of any proc within it */
-        pmix_output(0, "JOB ABORTED");
         return;
     }
     /* notify the other procs of the termination */


### PR DESCRIPTION
Ensure we pass pset membership when registering the job. Support backend queries of membership. Add example that exercises the code.

Signed-off-by: Ralph Castain <rhc@pmix.org>