### PR TITLE
Rankfile slots fix and LSF support fix for LSB_AFFINITY_HOSTFILE

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -312,7 +312,7 @@ PRTE_EXPORT bool prte_hwloc_base_single_cpu(hwloc_cpuset_t cpuset);
  * cpus of given type, and produce a cpuset for the described binding
  */
 PRTE_EXPORT int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
-                                               hwloc_cpuset_t cpumask);
+                                                bool use_hwthread_cpus, hwloc_cpuset_t cpumask);
 
 PRTE_EXPORT char *prte_hwloc_base_find_coprocessors(hwloc_topology_t topo);
 PRTE_EXPORT char *prte_hwloc_base_check_on_coprocessor(void);

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -751,7 +751,7 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
 }
 
 int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
-                                   hwloc_cpuset_t cpumask)
+                                   bool use_hwthread_cpus, hwloc_cpuset_t cpumask)
 {
     char **item, **rngs, *lst;
     int rc, i, j, k;
@@ -825,7 +825,7 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                     for (j = 0; NULL != list[j]; j++) {
                         core_id = atoi(list[j]);
                         /* find the specified available cpu */
-                        if (NULL == (pu = prte_hwloc_base_get_pu(topo, false, core_id))) {
+                        if (NULL == (pu = prte_hwloc_base_get_pu(topo, use_hwthread_cpus, core_id))) {
                             pmix_argv_free(range);
                             pmix_argv_free(item);
                             pmix_argv_free(rngs);
@@ -843,7 +843,7 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                     upper_range = atoi(range[1]);
                     for (core_id = lower_range; core_id <= upper_range; core_id++) {
                         /* find the specified logical available cpu */
-                        if (NULL == (pu = prte_hwloc_base_get_pu(topo, false, core_id))) {
+                        if (NULL == (pu = prte_hwloc_base_get_pu(topo, use_hwthread_cpus, core_id))) {
                             pmix_argv_free(range);
                             pmix_argv_free(item);
                             pmix_argv_free(rngs);

--- a/src/mca/ras/lsf/help-ras-lsf.txt
+++ b/src/mca/ras/lsf/help-ras-lsf.txt
@@ -29,19 +29,3 @@ LSF or your cluster.
 While trying to determine what resources are available, LSF returned
 a list of available nodes from which we were unable to extract anything
 usable. This may indicate a problem with LSF or your cluster.
-[affinity-file-not-found]
-The affinity file provided in LSB_AFFINITY_HOSTFILE could not be found:
-
-  File:  %s
-
-We cannot continue.
-[affinity-file-found-not-used]
-The affinity file provided in LSB_AFFINITY_HOSTFILE could not be used:
-
-  File:   %s
-  Reason: %s
-
-Use the MCA parameter below to skip processing the LSB_AFFINITY_HOSTFILE
-and ignore any binding provided by LSF for this job. Doing so may
-require you to use the affinity options provided by PRTE.
-  --mca ras_lsf_skip_affinity_file true

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -60,11 +60,8 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 {
     char **nodelist;
     prte_node_t *node;
-    int i, num_nodes;
-    char *affinity_file;
-    struct stat buf;
+    int i, num_nodes, rc;
     char *ptr;
-    bool directives_given = false;
 
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {
@@ -106,77 +103,6 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     /* release the nodelist from lsf */
     pmix_argv_free(nodelist);
-
-    /* check to see if any mapping or binding directives were given */
-    if (NULL != jdata && NULL != jdata->map) {
-        if ((PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping))
-            || PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
-            directives_given = true;
-        }
-    } else if ((PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping))
-               || PRTE_BINDING_POLICY_IS_SET(prte_hwloc_default_binding_policy)) {
-        directives_given = true;
-    }
-
-    /* check for an affinity file */
-    if (!prte_ras_lsf_skip_affinity_file && !directives_given
-        && NULL != (affinity_file = getenv("LSB_AFFINITY_HOSTFILE"))) {
-        /* check to see if the file is empty - if it is,
-         * then affinity wasn't actually set for this job */
-        if (0 != stat(affinity_file, &buf)) {
-            pmix_show_help("help-ras-lsf.txt", "affinity-file-not-found", true, affinity_file);
-            return PRTE_ERR_SILENT;
-        }
-        if (0 == buf.st_size) {
-            /* no affinity, so just return */
-            return PRTE_SUCCESS;
-        }
-#if 1
-        // Phsical CPU IDs are no longer supported. See the Issue below:
-        //   https://github.com/openpmix/prrte/issues/791
-        // Until that is resolved throw an error if we detect that the user is
-        // trying to use LSF level affinity options.
-        if (NULL != affinity_file) { // Always true
-            pmix_show_help("help-ras-lsf.txt", "affinity-file-found-not-used", true, affinity_file,
-                           "Physical CPU ID mapping is not supported");
-            return PRTE_ERR_SILENT;
-        }
-#else
-        /* the affinity file sequentially lists rank locations, with
-         * cpusets given as physical cpu-ids. Setup the job object
-         * so it knows to process this accordingly */
-        if (NULL == jdata->map) {
-            jdata->map = PMIX_NEW(prte_job_map_t);
-        }
-        PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_SEQ);
-        jdata->map->req_mapper = strdup("seq"); // need sequential mapper
-        /* tell the sequential mapper that all cpusets are to be treated as "physical" */
-        // TODO - Physical CPUs are no longer supported by PRRTE. Need a fix the following
-        //        attribute is no longer valid.
-        // prte_set_attribute(&jdata->attributes, PRTE_JOB_PHYSICAL_CPUIDS, true, NULL, PMIX_BOOL);
-        /* LSF provides its info as hwthreads, so set the hwthread-as-cpus flag */
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, true, NULL, PMIX_BOOL);
-        /* don't override something provided by the user, but default to bind-to hwthread */
-        if (!PRTE_BINDING_POLICY_IS_SET(prte_hwloc_default_binding_policy)) {
-            PRTE_SET_BINDING_POLICY(prte_hwloc_default_binding_policy, PRTE_BIND_TO_HWTHREAD);
-        }
-        /*
-         * Do not set the hostfile attribute on each app_context since that
-         * would confuse the sequential mapper when it tries to assign bindings
-         * when running an MPMD job.
-         * Instead just overwrite the prte_default_hostfile so it will be
-         * general for all of the app_contexts.
-         */
-        if (NULL != prte_default_hostfile) {
-            free(prte_default_hostfile);
-            prte_default_hostfile = NULL;
-        }
-        prte_default_hostfile = strdup(affinity_file);
-        pmix_output_verbose(10, prte_ras_base_framework.framework_output,
-                            "ras/lsf: Set default_hostfile to %s", prte_default_hostfile);
-#endif
-        return PRTE_SUCCESS;
-    }
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
+++ b/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
@@ -77,3 +77,28 @@ a non-existent CPU:
   Available CPUs: %s
 
 Please correct the line and try again.
+[lsf-affinity-file-not-found]
+The affinity file provided in LSB_AFFINITY_HOSTFILE could not be found:
+
+  File:  %s
+
+We cannot continue.
+[lsf-affinity-file-failed-convert]
+The affinity file provided in LSB_AFFINITY_HOSTFILE could not be converted
+to a rankfile:
+
+  File:  %s
+
+We cannot continue.
+[rmaps:proc-slots-overloaded]
+A process attempted to bind to resources already allocated on a node
+to a different process.
+ Process : %s
+ Node    : %s
+ Process Requested CPU Set : %s
+ Node Available CPU Set    : %s
+ Overlapping CPU Set       : %s
+
+If this is intentional then you must pass the "overload-allowed"
+qualifier to the --bind-to option.
+  --bind-to :overload-allowed

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.h
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.h
@@ -15,6 +15,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,6 +39,8 @@
 
 BEGIN_C_DECLS
 
+#define RMAPS_RANK_FILE_MAX_SLOTS 64
+
 int prte_rmaps_rank_file_lex_destroy(void);
 
 struct prte_rmaps_rf_component_t {
@@ -54,7 +57,7 @@ typedef struct cpu_package_t cpu_package_t;
 struct prte_rmaps_rank_file_map_t {
     pmix_object_t super;
     char *node_name;
-    char slot_list[64];
+    char slot_list[RMAPS_RANK_FILE_MAX_SLOTS];
 };
 typedef struct prte_rmaps_rank_file_map_t prte_rmaps_rank_file_map_t;
 

--- a/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -61,7 +61,13 @@ prte_rmaps_rf_component_t prte_mca_rmaps_rank_file_component = {
 
 static int prte_rmaps_rank_file_query(pmix_mca_base_module_t **module, int *priority)
 {
-    *priority = 0;
+    /*
+     * Set the rankfile priority to the highest:
+     * - If we are in an LSF environment with affinity information (LSB_AFFINITY_HOSTFILE)
+     *   then we need to force this component.
+     * - If the user did not explicitly request this component, then it is skipped.
+     */
+    *priority = 100;
     *module = (pmix_mca_base_module_t *) &prte_rmaps_rank_file_module;
     return PRTE_SUCCESS;
 }
@@ -69,7 +75,7 @@ static int prte_rmaps_rank_file_query(pmix_mca_base_module_t **module, int *prio
 static void rf_map_construct(prte_rmaps_rank_file_map_t *ptr)
 {
     ptr->node_name = NULL;
-    memset(ptr->slot_list, (char) 0x00, 64);
+    memset(ptr->slot_list, (char) 0x00, RMAPS_RANK_FILE_MAX_SLOTS);
 }
 static void rf_map_destruct(prte_rmaps_rank_file_map_t *ptr)
 {


### PR DESCRIPTION
 * Fixes #791
 * Fix support for LSF allocations with predefined affinity.
   - The affinity is reported in the `LSB_AFFINITY_HOSTFILE`
   - Each line of the file describes the affinity (node, cpu, memory)
     for a single rank.
   - This maps better to the rank file mapper, so switch from `seq`
     to the `rank_file` mapper.
     - Move the `LSB_AFFINITY_HOSTFILE` processing to the `rank_file` mapper.
   - LSF reports CPU IDs as physical hardware threads.
     - Since PRRTE does not support physical hardware thread ids
       we convert these IDs to logical IDs when building the rankfile.
 * Fix up the rank_file mapper
   - Check for oversubscription before adding the process to the node
     which will allow us to fill up the node completely.
   - If a slots specification was provided then honor it instead of
     ignoring it.