### PR TITLE
Fix some default map/rank/bind policy settings

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -302,68 +302,52 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
         /* tools are never bound */
         PRTE_SET_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NONE);
     } else {
-        /* if the user explicitly mapped-by some object, then we default
+        /* if we are mapping by some object, then we default
          * to binding to that object */
         mpol = PRTE_GET_MAPPING_POLICY(jdata->map->mapping);
-        if (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping)) {
-            if (PRTE_MAPPING_BYHWTHREAD == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_HWTHREAD);
-            } else if (PRTE_MAPPING_BYCORE == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_CORE);
-            } else if (PRTE_MAPPING_BYL1CACHE == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byL1", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L1CACHE);
-            } else if (PRTE_MAPPING_BYL2CACHE == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byL2", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L2CACHE);
-            } else if (PRTE_MAPPING_BYL3CACHE == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byL3", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L3CACHE);
-            } else if (PRTE_MAPPING_BYNUMA == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bynuma",
-                                    __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NUMA);
-            } else if (PRTE_MAPPING_BYPACKAGE == mpol) {
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
-            } else {
-                /* we are mapping by node or some other non-object method */
-                if (options->use_hwthreads) {
-                    /* if we are using hwthread cpus, then bind to those */
-                    pmix_output_verbose(options->verbosity, options->stream,
-                                        "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
-                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                    PRTE_BIND_TO_HWTHREAD);
-                } else {
-                    /* otherwise bind to core */
-                    pmix_output_verbose(options->verbosity, options->stream,
-                                        "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
-                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                    PRTE_BIND_TO_CORE);
-                }
-            }
+        if (PRTE_MAPPING_BYHWTHREAD == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_HWTHREAD);
+        } else if (PRTE_MAPPING_BYCORE == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_CORE);
+        } else if (PRTE_MAPPING_BYL1CACHE == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using byL1", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L1CACHE);
+        } else if (PRTE_MAPPING_BYL2CACHE == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using byL2", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L2CACHE);
+        } else if (PRTE_MAPPING_BYL3CACHE == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using byL3", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L3CACHE);
+        } else if (PRTE_MAPPING_BYNUMA == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using bynuma",
+                                __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NUMA);
+        } else if (PRTE_MAPPING_BYPACKAGE == mpol) {
+            pmix_output_verbose(options->verbosity, options->stream,
+                                "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
+            PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
         } else {
+            /* we are mapping by node or some other non-object method */
             if (options->use_hwthreads) {
                 /* if we are using hwthread cpus, then bind to those */
                 pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byhwthread",
-                                    __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_HWTHREAD);
+                                    "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_HWTHREAD);
             } else {
                 /* otherwise bind to core */
                 pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bycore",
-                                    __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_CORE);
+                                    "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_CORE);
             }
         }
     }

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -641,8 +641,21 @@ int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec)
         if (PRTE_MAPPING_BYNODE == mapping) {
             PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_NODE);
 
-        } else if (PRTE_MAPPING_PPR != mapping) {
+        } else if (PRTE_MAPPING_BYSLOT == mapping) {
             /* default to by-slot */
+            PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SLOT);
+
+        } else if (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
+            /* default to by-span */
+            PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SPAN);
+
+        } else if (PRTE_MAPPING_BYHWTHREAD >= mapping &&
+                   PRTE_MAPPING_BYNUMA <= mapping) {
+            /* default to by-slot */
+            PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_FILL);
+
+        } else {
+            /* default to slot */
             PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SLOT);
         }
         jdata->map->ranking = tmp;

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -63,9 +63,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     prte_node_t *node;
     pmix_proc_t *pptr;
     int rc = PRTE_SUCCESS;
+    int n;
     bool did_map, pernode = false;
     prte_rmaps_base_selected_module_t *mod;
     prte_job_t *parent = NULL;
+    prte_app_context_t *app;
     bool inherit = false;
     pmix_proc_t *nptr, *target_proc;
     char *tmp;
@@ -95,6 +97,13 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     memset(&options, 0, sizeof(prte_rmaps_options_t));
     options.stream = prte_rmaps_base_framework.framework_output;
     options.verbosity = 5;  // usual value for base-level functions
+    /* add up all the expected procs */
+    for (n=0; n < jdata->apps->size; n++) {
+        app = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, n);
+        if (NULL != app) {
+            options.nprocs += app->num_procs;
+        }
+    }
 
     /* check and set some general options */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {


### PR DESCRIPTION
Ensure the options.nprocs field is initialized so that the default mapping policy is correctly set. Better delineate the default ranking policies if the mapping policy was provided.

Set the default binding policy based on the mapping policy being used, regardless of whether the user specified it or it is a default policy.

Refs https://github.com/open-mpi/ompi/issues/10734
Signed-off-by: Ralph Castain <rhc@pmix.org>