### PR TITLE
doc: Fix --rank-by help output

### DIFF
--- a/src/mca/schizo/ompi/help-schizo-ompi.txt
+++ b/src/mca/schizo/ompi/help-schizo-ompi.txt
@@ -89,9 +89,7 @@ Initiate an instance of the PMIx Reference RTE (PRRTE) DVM
 
 /*****      Ranking Options      *****/
 
-   --rank-by <arg0>                  Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node], with
-                                     modifier :SPAN or :FILL
+   --rank-by <arg0>                  Ranking Policy for job [slot | node | fill | span]
 
 
 

--- a/src/mca/schizo/prte/help-schizo-prted.txt
+++ b/src/mca/schizo/prte/help-schizo-prted.txt
@@ -111,9 +111,7 @@ option to the help request as "--help <option>".
 
 /*****      Ranking Options      *****/
 
-   --rank-by <arg0>                  Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node], with
-                                     modifier :SPAN or :FILL
+   --rank-by <arg0>                  Ranking Policy for job
 
 
 

--- a/src/mca/schizo/prte/help-schizo-pterm.txt
+++ b/src/mca/schizo/prte/help-schizo-pterm.txt
@@ -106,9 +106,7 @@ option to the help request as "--help <option>".
 
 /*****      Ranking Options      *****/
 
-   --rank-by <arg0>                  Ranking Policy for job [slot (default:np<=2) | hwthread | core | l1cache
-                                     | l2cache | l3cache | numa (default:np>2) | package | node], with
-                                     modifier :SPAN or :FILL
+   --rank-by <arg0>                  Ranking Policy for job
 
 
 


### PR DESCRIPTION
 * I noticed the old `--rank-by` specifiers were listed.