### PR TITLE
Fix the load-balancing and span round-robin mappers

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -137,6 +137,7 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
             }
             if (NULL == node->topology) {
                 node->topology = t;
+                node->available = prte_hwloc_base_filter_cpus(node->topology->topo);
             }
             node->state = PRTE_NODE_STATE_UP;
         }

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -645,7 +645,7 @@ int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec)
             /* default to by-slot */
             PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SLOT);
 
-        } else if (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
+        } else if (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping)) {
             /* default to by-span */
             PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SPAN);
 

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -773,10 +773,10 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --do-not-launch  ->  --map-by :donotlaunch */
+        /* --do-not-launch  ->  --runtime-options donotlaunch */
         else if (0 == strcmp(option, "do-not-launch")) {
-            rc = prte_schizo_base_add_qualifier(results, option,
-                                                PRTE_CLI_MAPBY, PRTE_CLI_NOLAUNCH,
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_NOLAUNCH,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }


### PR DESCRIPTION
I'm sure someone will eventually come up with a faster algorithm for doing the span mapping, but let's just get something working for now. Fix the rank-by default when mapping by span. Ensure we load-balance when mapping-by and object. Fix the "do-not-launch" deprecated option handling in schizo/prte.

Refs #1576
Signed-off-by: Ralph Castain <rhc@pmix.org>