### PR TITLE
Broaden ability to require PRRTE to discover slots

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -135,9 +135,6 @@ static int prte_rmaps_base_open(pmix_mca_base_open_flag_t flags)
     prte_rmaps_base.ranking = 0;
     prte_rmaps_base.inherit = rmaps_base_inherit;
     prte_rmaps_base.hwthread_cpus = false;
-    if (NULL == prte_set_slots) {
-        prte_set_slots = strdup("core");
-    }
     prte_rmaps_base.available = hwloc_bitmap_alloc();
     prte_rmaps_base.baseset = hwloc_bitmap_alloc();
 

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -97,6 +97,7 @@ bool prte_hnp_is_allocated = false;
 bool prte_allocation_required = false;
 bool prte_managed_allocation = false;
 char *prte_set_slots = NULL;
+bool prte_set_slots_override = false;
 bool prte_nidmap_communicated = false;
 bool prte_node_info_communicated = false;
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -542,6 +542,7 @@ PRTE_EXPORT extern bool prte_hnp_is_allocated;
 PRTE_EXPORT extern bool prte_allocation_required;
 PRTE_EXPORT extern bool prte_managed_allocation;
 PRTE_EXPORT extern char *prte_set_slots;
+PRTE_EXPORT extern bool prte_set_slots_override;
 PRTE_EXPORT extern bool prte_hnp_connected;
 PRTE_EXPORT extern bool prte_nidmap_communicated;
 PRTE_EXPORT extern bool prte_node_info_communicated;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -56,6 +56,7 @@ static char *prte_local_tmpdir_base = NULL;
 static char *prte_remote_tmpdir_base = NULL;
 static char *prte_top_session_dir = NULL;
 static char *prte_jobfam_session_dir = NULL;
+static char *local_setup_slots = NULL;
 
 char *prte_signal_string = NULL;
 char *prte_stacktrace_output_filename = NULL;
@@ -434,13 +435,28 @@ int prte_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &prte_max_vm_size);
 
+    local_setup_slots = NULL;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "set_default_slots",
                                       "Set the number of slots on nodes that lack such info to the"
                                       " number of specified objects [a number, \"cores\" (default),"
-                                      " \"packages\", \"hwthreads\" (default if hwthreads_as_cpus is set),"
-                                      " or \"none\" to skip this option]",
+                                      " \"packages\", or \"hwthreads\" (default if hwthreads_as_cpus"
+                                      " is set), or a fixed number to be applied to all nodes",
                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                      &prte_set_slots);
+                                      &local_setup_slots);
+    if (NULL == local_setup_slots) {
+        prte_set_slots = strdup("core");
+    } else {
+        prte_set_slots = strdup(local_setup_slots);
+    }
+
+    prte_set_slots_override = false;
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "set_default_slots_override",
+                                      "Set the number of slots on nodes to the number of "
+                                      "objects specified by prte_set_default_slots regardless "
+                                      "whather we are in a managed allocation or specifications "
+                                      "were given in a hostfile",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_set_slots_override);
 
     /* allow specification of the cores to be used by daemons */
     prte_daemon_cores = NULL;


### PR DESCRIPTION
Allo user to direct PRRTE to disvover slots even in a managed allocation. Remove the "none" specifier
as PRRTE must have a slot count - replace it with
a simple number as that option was missing from the description.

Signed-off-by: Ralph Castain <rhc@pmix.org>