### PR TITLE
build: fix bashisms in configure

### DIFF
--- a/config/prte_check_ptrace.m4
+++ b/config/prte_check_ptrace.m4
@@ -32,7 +32,7 @@ AC_DEFUN([PRTE_CHECK_PTRACE],[
                   [prte_have_ptrace=yes],
                   [prte_have_ptrace=no])
 
-    if test "$prte_have_ptrace_header" == "1" && test "$prte_have_ptrace" == "yes"; then
+    if test "$prte_have_ptrace_header" = "1" && test "$prte_have_ptrace" = "yes"; then
         AC_MSG_CHECKING([PTRACE_TRACEME])
         AC_EGREP_CPP([yes],
                      [#include <sys/ptrace.h>
@@ -106,7 +106,7 @@ AC_DEFUN([PRTE_CHECK_PTRACE],[
     fi
 
     AC_MSG_CHECKING(ptrace stop-on-exec will be supported)
-    AS_IF([test "$prte_have_ptrace_traceme" == "yes" && test "$prte_have_ptrace_detach" == "yes"],
+    AS_IF([test "$prte_have_ptrace_traceme" = "yes" && test "$prte_have_ptrace_detach" = "yes"],
           [AC_MSG_RESULT(yes)
            prte_want_stop_on_exec=1],
           [AC_MSG_RESULT(no)

--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -37,7 +37,7 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
     prte_check_hwloc_save_LIBS="$LIBS"
     prte_have_topology_dup=0
 
-    if test "$with_hwloc" == "no"; then
+    if test "$with_hwloc" = "no"; then
         AC_MSG_WARN([PRRTE requires HWLOC topology library support.])
         AC_MSG_WARN([Please reconfigure so we can find the library.])
         AC_MSG_ERROR([Cannot continue.])


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Signed-off-by: Sam James <sam@gentoo.org>
(cherry picked from commit c623f47c0a1701cb59471aa0171631bf29985e95)