### PR TITLE
Multiple commits

### DIFF
--- a/config/prte_check_os_flavors.m4
+++ b/config/prte_check_os_flavors.m4
@@ -5,6 +5,7 @@ dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2014      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
+dnl Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -22,7 +23,7 @@ AC_DEFUN([PRTE_CHECK_OS_FLAVOR_SPECIFIC],
     AC_MSG_CHECKING([$1])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
      [[#ifndef $1
-      error: this isnt $1
+      #this is not $1, error
       #endif
      ]])],
                       [prte_found_$2=yes],

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -298,7 +298,8 @@ lookup:
     if (PRTE_SUCCESS != ssh_launch_agent_lookup(NULL, NULL)) {
         /* if the user specified an agent and we couldn't find it,
          * then we want to error out and not continue */
-        if (NULL != prte_mca_plm_ssh_component.agent) {
+        if (NULL != prte_mca_plm_ssh_component.agent &&
+            0 != strcmp(prte_mca_plm_ssh_component.agent, "ssh : rsh")) {
             pmix_show_help("help-plm-ssh.txt", "agent-not-found", true,
                            prte_mca_plm_ssh_component.agent);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_NEVER_LAUNCHED);


### PR DESCRIPTION
[Minor change to check_os_flavors](https://github.com/openpmix/prrte/commit/26afe9728caa564e35198971a7e2843975bf0c34)

Backport of https://github.com/open-mpi/ompi/pull/11081

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7eb88f87a2391735578ee03af80bbed3925f84a3)

[Don't emit an error output if not needed](https://github.com/openpmix/prrte/commit/bfff95aed8b8310fbd467d8d4e7c7d4b1cef247b)

If the rsh/ssh agent is the default, then we
don't output an error and cause a fatal shutdown
when rsh/ssh are not present. Let other components
have a chance.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a23bf3b9378071d79dcc80ac28a2c5209aa47c4a)
