### PR TITLE
Add a "slurm" personality that supports "srun"

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -86,7 +86,8 @@ prte_schizo_base_module_t prte_schizo_ompi_module = {
     .allow_run_as_root = allow_run_as_root,
     .set_default_ranking = set_default_ranking,
     .job_info = job_info,
-    .set_default_rto = set_default_rto
+    .set_default_rto = set_default_rto,
+    .check_sanity = prte_schizo_base_sanity
 };
 
 static struct option ompioptions[] = {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -77,7 +77,8 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
     .job_info = job_info,
-    .set_default_rto = set_default_rto
+    .set_default_rto = set_default_rto,
+    .check_sanity = prte_schizo_base_sanity
 };
 
 static struct option prteoptions[] = {

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -113,6 +113,9 @@ typedef void (*prte_schizo_base_module_finalize_fn_t)(void);
 typedef void (*prte_schizo_base_module_job_info_fn_t)(pmix_cli_result_t *results,
                                                       void *jobinfo);
 
+/* give the component a chance to validate directives and their values */
+typedef int (*prte_schizo_base_module_check_sanity_fn_t)(pmix_cli_result_t *cmd_line);
+
 /*
  * schizo module version 1.3.0
  */
@@ -130,6 +133,7 @@ typedef struct {
     prte_schizo_base_module_setup_app_fn_t              setup_app;
     prte_schizo_base_module_setup_fork_fn_t             setup_fork;
     prte_schizo_base_module_job_info_fn_t               job_info;
+    prte_schizo_base_module_check_sanity_fn_t           check_sanity;
     prte_schizo_base_module_finalize_fn_t               finalize;
 } prte_schizo_base_module_t;
 

--- a/src/mca/schizo/slurm/Makefile.am
+++ b/src/mca/schizo/slurm/Makefile.am
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2022      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CFLAGS = \
+    -DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\""
+
+dist_prtedata_DATA = \
+    help-schizo-srun.txt
+
+sources = \
+          schizo_slurm_component.c \
+          schizo_slurm.h \
+          schizo_slurm.c
+
+# Make the output library in this directory, and name it either
+# prte_mca_<type>_<name>.la (for DSO builds) or libprtemca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_schizo_slurm_DSO
+component_noinst =
+component_install = prte_mca_schizo_slurm.la
+else
+component_noinst = libprtemca_schizo_slurm.la
+component_install =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+prte_mca_schizo_slurm_la_SOURCES = $(sources)
+prte_mca_schizo_slurm_la_LDFLAGS = -module -avoid-version
+prte_mca_schizo_slurm_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libprtemca_schizo_slurm_la_SOURCES = $(sources)
+libprtemca_schizo_slurm_la_LDFLAGS = -module -avoid-version

--- a/src/mca/schizo/slurm/configure.m4
+++ b/src/mca/schizo/slurm/configure.m4
@@ -1,0 +1,37 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
+#                         All Rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_schizo_slurm_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_prte_schizo_slurm_CONFIG],[
+    AC_CONFIG_FILES([src/mca/schizo/slurm/Makefile])
+
+    AS_IF([test "yes" = "yes"],
+          [$1], [$2])
+
+    PRTE_SUMMARY_ADD([Personalities], [Slurm], [], [yes])
+
+])dnl

--- a/src/mca/schizo/slurm/help-schizo-srun.txt
+++ b/src/mca/schizo/slurm/help-schizo-srun.txt
@@ -1,0 +1,273 @@
+# -*- text -*-
+#
+# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022      IBM Corporation.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+#
+#
+[version]
+%s (%s) %s
+
+%s
+#
+[usage]
+%s (%s) %s
+
+Usage: %s [OPTION]...
+Submit job for execution
+
+The following list of command line options are available. Note that
+more detailed help for any option can be obtained by adding that
+option to the help request as "--help <option>".
+
+/*****      General Options      *****/
+
+-h|--help                            Display help information and exit.
+-h|--help <arg0>                     Help for the specified option
+
+/*****      Placement Options      *****/
+
+ -m|--distribution <arg0>            Specify alternate distribution methods for
+                                     remote processes
+-c|--cpus-per-task <arg0>            Request that ncpus be allocated per process
+
+Report bugs to %s
+#
+[distribution]
+Specify alternate distribution methods for remote processes. This option controls the
+distribution of tasks to the nodes on which resources have been allocated, and the
+distribution of those resources to tasks for binding (task affinity). The first
+distribution method (before the first ":") controls the distribution of tasks to nodes.
+The second distribution method (after the first ":") controls the distribution of
+allocated CPUs across sockets for binding to tasks. The third distribution method (after
+the second ":") controls the distribution of allocated CPUs across cores for binding to
+tasks. The second and third distributions apply only if task affinity is enabled. The third
+distribution is supported only if the task/cgroup plugin is configured. The default value
+for each distribution type is specified by *.
+
+Note that with select/cons_res, the number of CPUs allocated on each socket and node may be
+different. Refer to http://slurm.schedmd.com/mc_support.html for more information on
+resource allocation, distribution of tasks to nodes, and binding of tasks to CPUs.
+
+First distribution method (distribution of tasks across nodes):
+
+    *
+        Use the default method for distributing tasks to nodes (block).
+    block
+        The block distribution method will distribute tasks to a node such that consecutive
+        tasks share a node. For example, consider an allocation of three nodes each with
+        two cpus. A four-task block distribution request will distribute those tasks to the
+        nodes with tasks one and two on the first node, task three on the second node, and
+        task four on the third node. Block distribution is the default behavior if the
+        number of tasks exceeds the number of allocated nodes.
+    cyclic
+        The cyclic distribution method will distribute tasks to a node such that
+        consecutive tasks are distributed over consecutive nodes (in a round-robin
+        fashion). For example, consider an allocation of three nodes each with two cpus. A
+        four-task cyclic distribution request will distribute those tasks to the nodes with
+        tasks one and four on the first node, task two on the second node, and task three
+        on the third node. Note that when SelectType is select/cons_res, the same number of
+        CPUs may not be allocated on each node. Task distribution will be round-robin among
+        all the nodes with CPUs yet to be assigned to tasks. Cyclic distribution is the
+        default behavior if the number of tasks is no larger than the number of allocated
+        nodes.
+    plane
+        The tasks are distributed in blocks of a specified size. The options include a
+        number representing the size of the task block. This is followed by an optional
+        specification of the task distribution scheme within a block of tasks and between
+        the blocks of tasks. The number of tasks distributed to each node is the same as
+        for cyclic distribution, but the taskids assigned to each node depend on the plane
+        size. For more details (including examples and diagrams), please see
+        http://slurm.schedmd.com/mc_support.html
+        and
+        http://slurm.schedmd.com/dist_plane.html
+    arbitrary
+        The arbitrary method of distribution will allocate processes in-order as listed in
+        file designated by the environment variable SLURM_HOSTFILE. If this variable is
+        listed it will over ride any other method specified. If not set the method will
+        default to block. Inside the hostfile must contain at minimum the number of hosts
+        requested and be one per line or comma separated. If specifying a task count (-n,
+        --ntasks=<number>), your tasks will be laid out on the nodes in the order of the
+        file.
+        NOTE: The arbitrary distribution option on a job allocation only controls the nodes
+        to be allocated to the job and not the allocation of CPUs on those nodes. This
+        option is meant primarily to control a job step's task layout in an existing job
+        allocation for the srun command.
+
+    Second distribution method (distribution of CPUs across sockets for binding):
+
+    *
+        Use the default method for distributing CPUs across sockets (cyclic).
+    block
+        The block distribution method will distribute allocated CPUs consecutively from the
+        same socket for binding to tasks, before using the next consecutive socket.
+    cyclic
+        The cyclic distribution method will distribute allocated CPUs for binding to a
+        given task consecutively from the same socket, and from the next consecutive socket
+        for the next task, in a round-robin fashion across sockets.
+    fcyclic
+        The fcyclic distribution method will distribute allocated CPUs for binding to tasks
+        from consecutive sockets in a round-robin fashion across the sockets.
+
+    Third distribution method (distribution of CPUs across cores for binding):
+
+    *
+        Use the default method for distributing CPUs across cores (inherited from second
+        distribution method).
+    block
+        The block distribution method will distribute allocated CPUs consecutively from the
+        same core for binding to tasks, before using the next consecutive core.
+    cyclic
+        The cyclic distribution method will distribute allocated CPUs for binding to a
+        given task consecutively from the same core, and from the next consecutive core for
+        the next task, in a round-robin fashion across cores.
+    fcyclic
+        The fcyclic distribution method will distribute allocated CPUs for binding to tasks
+        from consecutive cores in a round-robin fashion across the cores.
+
+    Optional control for task distribution over nodes:
+
+    Pack
+        Rather than evenly distributing a job step's tasks evenly across it's allocated
+        nodes, pack them as tightly as possible on the nodes.
+    NoPack
+        Rather than packing a job step's tasks as tightly as possible on the nodes,
+        distribute them evenly. This user option will supersede the SelectTypeParameters
+        CR_Pack_Nodes configuration parameter.
+#
+[cpu_bind]
+Bind tasks to CPUs. Used only when the task/affinity or task/cgroup plugin is enabled.
+NOTE: To have Slurm always report on the selected CPU binding for all commands executed in
+a shell, you can enable verbose mode by setting the SLURM_CPU_BIND environment variable
+value to "verbose".
+
+The following informational environment variables are set when --cpu_bind is in use:
+
+        SLURM_CPU_BIND_VERBOSE
+        SLURM_CPU_BIND_TYPE
+        SLURM_CPU_BIND_LIST
+
+See the ENVIRONMENT VARIABLES section for a more detailed description of the individual
+SLURM_CPU_BIND variables. These variable are available only if the task/affinity plugin is
+configured.
+
+When using --cpus-per-task to run multithreaded tasks, be aware that CPU binding is
+inherited from the parent of the process. This means that the multithreaded task should
+either specify or clear the CPU binding itself to avoid having all threads of the
+multithreaded task use the same mask/CPU as the parent. Alternatively, fat masks (masks
+which specify more than one allowed CPU) could be used for the tasks in order to provide
+multiple CPUs for the multithreaded tasks.
+
+By default, a job step has access to every CPU allocated to the job. To ensure that
+distinct CPUs are allocated to each job step, use the --exclusive option.
+
+Note that a job step can be allocated different numbers of CPUs on each node or be
+allocated CPUs not starting at location zero. Therefore one of the options which
+automatically generate the task binding is recommended. Explicitly specified masks or
+bindings are only honored when the job step has been allocated every available CPU on the
+node.
+
+Binding a task to a NUMA locality domain means to bind the task to the set of CPUs that
+belong to the NUMA locality domain or "NUMA node". If NUMA locality domain options are used
+on systems with no NUMA support, then each socket is considered a locality domain.
+
+    Auto Binding
+        Applies only when task/affinity is enabled. If the job step allocation includes an
+        allocation with a number of sockets, cores, or threads equal to the number of tasks
+        times cpus-per-task, then the tasks will by default be bound to the appropriate
+        resources (auto binding). Disable this mode of operation by explicitly setting
+        "--cpu_bind=none". Use TaskPluginParam=autobind=[threads|cores|sockets] to set a
+        default cpu binding in case "auto binding" doesn't find a match.
+
+    Supported options include:
+
+        q[uiet]
+            Quietly bind before task runs (default)
+        v[erbose]
+            Verbosely report binding before task runs
+        no[ne]
+            Do not bind tasks to CPUs (default unless auto binding is applied)
+        rank
+            Automatically bind by task rank. The lowest numbered task on each node is bound
+            to socket (or core or thread) zero, etc. Not supported unless the entire node
+            is allocated to the job.
+        map_cpu:<list>
+            Bind by mapping CPU IDs to tasks as specified where <list> is
+            <cpuid1>,<cpuid2>,...<cpuidN>. The mapping is specified for a node and
+            identical mapping is applied to the tasks on every node (i.e. the lowest task
+            ID on each node is mapped to the first CPU ID specified in the list, etc.). CPU
+            IDs are interpreted as decimal values unless they are preceded with '0x' in
+            which case they are interpreted as hexadecimal values. Not supported unless the
+            entire node is allocated to the job.
+        mask_cpu:<list>
+            Bind by setting CPU masks on tasks as specified where <list> is
+            <mask1>,<mask2>,...<maskN>. The mapping is specified for a node and identical
+            mapping is applied to the tasks on every node (i.e. the lowest task ID on each
+            node is mapped to the first mask specified in the list, etc.). CPU masks are
+            always interpreted as hexadecimal values but can be preceded with an optional
+            '0x'. Not supported unless the entire node is allocated to the job.
+        rank_ldom
+            Bind to a NUMA locality domain by rank. Not supported unless the entire node is
+            allocated to the job.
+        map_ldom:<list>
+            Bind by mapping NUMA locality domain IDs to tasks as specified where <list> is
+            <ldom1>,<ldom2>,...<ldomN>. The locality domain IDs are interpreted as decimal
+            values unless they are preceded with '0x' in which case they are interpreted as
+            hexadecimal values. Not supported unless the entire node is allocated to the
+            job.
+        mask_ldom:<list>
+            Bind by setting NUMA locality domain masks on tasks as specified where <list>
+            is <mask1>,<mask2>,...<maskN>. NUMA locality domain masks are always
+            interpreted as hexadecimal values but can be preceded with an optional '0x'.
+            Not supported unless the entire node is allocated to the job.
+        sockets
+            Automatically generate masks binding tasks to sockets. Only the CPUs on the
+            socket which have been allocated to the job will be used. If the number of
+            tasks differs from the number of allocated sockets this can result in
+            sub-optimal binding.
+        cores
+            Automatically generate masks binding tasks to cores. If the number of tasks
+            differs from the number of allocated cores this can result in sub-optimal
+            binding.
+        threads
+            Automatically generate masks binding tasks to threads. If the number of tasks
+            differs from the number of allocated threads this can result in sub-optimal
+            binding.
+        ldoms
+            Automatically generate masks binding tasks to NUMA locality domains. If the
+            number of tasks differs from the number of allocated locality domains this can
+            result in sub-optimal binding.
+        boards
+            Automatically generate masks binding tasks to boards. If the number of tasks
+            differs from the number of allocated boards this can result in sub-optimal
+            binding. This option is supported by the task/cgroup plugin only.
+        help
+            Show help message for cpu_bind
+#
+[cpus-per-task]
+Request that ncpus be allocated per process. This may be useful if the job is multithreaded
+and requires more than one CPU per task for optimal performance. The default is one CPU per
+process. If -c is specified without -n, as many tasks will be allocated per node as
+possible while satisfying the -c restriction. For instance on a cluster with 8 CPUs per
+node, a job request for 4 nodes and 3 CPUs per task may be allocated 3 or 6 CPUs per node
+(1 or 2 tasks per node) depending upon resource consumption by other jobs. Such a job may
+be unable to execute more than a total of 4 tasks. This option may also be useful to spawn
+tasks without allocating resources to the job step from the job's allocation when running
+multiple job steps with the --exclusive option.
+
+WARNING: There are configurations and options interpreted differently by job and job step
+requests which can result in inconsistencies for this option. For example srun -c2
+--threads-per-core=1 prog may allocate two cores for the job, but if each of those cores
+contains two threads, the job allocation will include four CPUs. The job step allocation
+will then launch two threads per CPU for a total of two tasks.
+
+WARNING: When srun is executed from within salloc or sbatch, there are configurations and
+options which can result in inconsistent allocations when -c has a value greater than -c on
+salloc or sbatch.
+#
+

--- a/src/mca/schizo/slurm/schizo_slurm.c
+++ b/src/mca/schizo/slurm/schizo_slurm.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2011-2017 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2017      UT-Battelle, LLC. All rights reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "prte_config.h"
+#include "types.h"
+
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#include <ctype.h>
+#include <getopt.h>
+
+
+#include "src/util/name_fns.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_basename.h"
+#include "src/util/pmix_os_dirpath.h"
+#include "src/util/pmix_os_path.h"
+#include "src/util/pmix_path.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/prte_cmd_line.h"
+#include "src/util/session_dir.h"
+#include "src/util/pmix_show_help.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/ess/base/base.h"
+#include "src/mca/prteinstalldirs/prteinstalldirs.h"
+#include "src/mca/rmaps/base/base.h"
+#include "src/mca/state/base/base.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/pmix_init_util.h"
+
+#include "schizo_slurm.h"
+#include "src/mca/schizo/base/base.h"
+
+static int parse_cli(char **argv, pmix_cli_result_t *results, bool silent);
+static int parse_env(char **srcenv, char ***dstenv, pmix_cli_result_t *cli);
+static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
+static int detect_proxy(char *argv);
+static void allow_run_as_root(pmix_cli_result_t *results);
+static void job_info(pmix_cli_result_t *results,
+                     void *jobinfo);
+static int set_default_rto(prte_job_t *jdata,
+                           prte_rmaps_options_t *options);
+static int check_sanity(pmix_cli_result_t *results);
+
+prte_schizo_base_module_t prte_schizo_slurm_module = {
+    .name = "slurm",
+    .parse_cli = parse_cli,
+    .parse_env = parse_env,
+    .setup_fork = setup_fork,
+    .detect_proxy = detect_proxy,
+    .allow_run_as_root = allow_run_as_root,
+    .job_info = job_info,
+    .set_default_rto = set_default_rto,
+    .check_sanity = check_sanity
+};
+
+static struct option srunoptions[] = {
+    /* basic options */
+    PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
+    PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_VERSION, PMIX_ARG_NONE, 'V'),
+    PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_PARSEABLE, PMIX_ARG_NONE, 'p'),
+    PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_PARSABLE, PMIX_ARG_NONE, 'p'), // synonym for parseable
+
+    // MCA parameters
+    PMIX_OPTION_DEFINE(PRTE_CLI_PRTEMCA, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PRTE_CLI_PMIXMCA, PMIX_ARG_REQD),
+
+    PMIX_OPTION_SHORT_DEFINE("ntasks", PMIX_ARG_REQD, 'n'),
+    PMIX_OPTION_SHORT_DEFINE("distribution", PMIX_ARG_REQD, 'm'),
+    PMIX_OPTION_DEFINE("cpu_bind", PMIX_ARG_REQD),
+
+    PMIX_OPTION_END
+};
+static char *srunshorts = "h::m:n:";
+
+static int convert_results(pmix_cli_result_t *results);
+
+static int parse_cli(char **argv, pmix_cli_result_t *results,
+                     bool silent)
+{
+    char *shorts, *helpfile;
+    struct option *myoptions;
+    int rc, n;
+    pmix_cli_item_t *opt;
+    PRTE_HIDE_UNUSED_PARAMS(silent);
+
+    if (0 == strcmp(prte_tool_actual, "prte")) {
+        myoptions = srunoptions;
+        shorts = srunshorts;
+        helpfile = "help-schizo-srun.txt";
+    } else {
+        /* this is an error */
+        return PRTE_ERR_NOT_SUPPORTED;
+    }
+
+    pmix_tool_msg = "Report bugs to: https://github.com/openpmix/prrte";
+    pmix_tool_org = "PRRTE";
+    pmix_tool_version = prte_util_make_version_string("all", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
+                                                      PRTE_RELEASE_VERSION, PRTE_GREEK_VERSION, NULL);
+
+    rc = pmix_cmd_line_parse(argv, shorts, myoptions, NULL,
+                             results, helpfile);
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_OPERATION_SUCCEEDED == rc) {
+            /* pmix cmd line interpreter output result
+             * successfully - usually means version or
+             * some other stock output was generated */
+            return PRTE_OPERATION_SUCCEEDED;
+        }
+        rc = prte_pmix_convert_status(rc);
+        return rc;
+    }
+
+    rc = convert_results(results);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    // handle relevant MCA params
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PRTE_CLI_PRTEMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                prte_schizo_base_expose(opt->values[n], "PRTE_MCA_");
+            }
+        } else if (0 == strcmp(opt->key, PRTE_CLI_PMIXMCA)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                prte_schizo_base_expose(opt->values[n], "PMIX_MCA_");
+            }
+        }
+    }
+    return PRTE_SUCCESS;
+}
+
+static int convert_results(pmix_cli_result_t *results)
+{
+    pmix_cli_item_t *opt;
+
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, "ntasks")) {
+            /* translate this to PRTE_CLI_NP */
+            free(opt->key);
+            opt->key = strdup(PRTE_CLI_NP);
+        } else if (0 == strcmp(opt->key, "distribution")) {
+            /* translate this to PRTE_CLI_MAPBY */
+            free(opt->key);
+            opt->key = strdup(PRTE_CLI_MAPBY);
+        } else if (0 == strcmp(opt->key, "cpu_bind")) {
+            free(opt->key);
+            opt->key = strdup(PRTE_CLI_BINDTO);
+        }
+    }
+    return PRTE_SUCCESS;
+}
+
+static int parse_env(char **srcenv, char ***dstenv,
+                     pmix_cli_result_t *cli)
+{
+    PRTE_HIDE_UNUSED_PARAMS(srcenv, dstenv, cli);
+    return PRTE_SUCCESS;
+}
+
+static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
+{
+    PRTE_HIDE_UNUSED_PARAMS(jdata, app);
+    return PRTE_SUCCESS;
+}
+
+static int detect_proxy(char *personalities)
+{
+    char *evar;
+
+    pmix_output_verbose(2, prte_schizo_base_framework.framework_output,
+                        "%s[%s]: detect proxy with %s (%s)",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__,
+                        (NULL == personalities) ? "NULL" : personalities,
+                        prte_tool_basename);
+
+    /* COMMAND-LINE OVERRRULES ALL */
+    if (NULL != personalities) {
+        /* this is a list of personalities we need to check -
+         * if it contains "slurm", then we are available but
+         * at a low priority */
+        if (NULL != strstr(personalities, "slurm")) {
+            return prte_mca_schizo_slurm_component.priority;
+        }
+        return 0;
+    }
+
+    /* if we were told the proxy, then use it */
+    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
+        if (0 == strcmp(evar, "slurm")) {
+            /* they asked exclusively for us */
+            return 100;
+        } else {
+            /* they asked for somebody else */
+            return 0;
+        }
+    }
+
+    /* if the tool is "srun", then use us */
+    if (0 == strcmp(prte_tool_basename, "srun")) {
+        return 100;
+    }
+
+    /* if none of those were true, then it isn't us */
+    return 0;
+}
+
+static void allow_run_as_root(pmix_cli_result_t *cli)
+{
+    char *r1, *r2;
+
+    if (pmix_cmd_line_is_taken(cli, "allow-run-as-root")) {
+        prte_allow_run_as_root = true;
+        return;
+    }
+
+    if (NULL != (r1 = getenv("PRTE_ALLOW_RUN_AS_ROOT"))
+        && NULL != (r2 = getenv("PRTE_ALLOW_RUN_AS_ROOT_CONFIRM"))) {
+        if (0 == strcmp(r1, "1") && 0 == strcmp(r2, "1")) {
+            prte_allow_run_as_root = true;
+            return;
+        }
+    }
+
+    prte_schizo_base_root_error_msg();
+}
+
+static void job_info(pmix_cli_result_t *results,
+                     void *jobinfo)
+{
+    PRTE_HIDE_UNUSED_PARAMS(results, jobinfo);
+    return;
+}
+
+static int set_default_rto(prte_job_t *jdata,
+                           prte_rmaps_options_t *options)
+{
+    PRTE_HIDE_UNUSED_PARAMS(options);
+    return prte_state_base_set_runtime_options(jdata, NULL);
+}
+
+static int check_sanity(pmix_cli_result_t *results)
+{
+    PRTE_HIDE_UNUSED_PARAMS(results);
+    return PRTE_SUCCESS;
+}

--- a/src/mca/schizo/slurm/schizo_slurm.h
+++ b/src/mca/schizo/slurm/schizo_slurm.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef _MCA_SCHIZO_SLURM_H_
+#define _MCA_SCHIZO_SLURM_H_
+
+#include "prte_config.h"
+
+#include "types.h"
+
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/schizo/schizo.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    prte_schizo_base_component_t super;
+    int priority;
+} prte_schizo_slurm_component_t;
+
+PRTE_MODULE_EXPORT extern prte_schizo_slurm_component_t prte_mca_schizo_slurm_component;
+extern prte_schizo_base_module_t prte_schizo_slurm_module;
+
+END_C_DECLS
+
+#endif /* MCA_SCHIZO_SLURM_H_ */

--- a/src/mca/schizo/slurm/schizo_slurm_component.c
+++ b/src/mca/schizo/slurm/schizo_slurm_component.c
@@ -1,0 +1,48 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "types.h"
+
+#include "src/runtime/prte_globals.h"
+
+#include "schizo_slurm.h"
+#include "src/mca/schizo/schizo.h"
+
+static int component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Struct of function pointers and all that to let us be initialized
+ */
+prte_schizo_slurm_component_t prte_mca_schizo_slurm_component = {
+    .super = {
+        PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+        .pmix_mca_component_name = "slurm",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+        .pmix_mca_query_component = component_query
+    },
+    .priority = 25
+};
+
+static int component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *module = (pmix_mca_base_module_t *) &prte_schizo_slurm_module;
+    *priority = prte_mca_schizo_slurm_component.priority;
+    return PRTE_SUCCESS;
+}

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -108,7 +108,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
         return rc;
     }
     // sanity check the results
-    rc = prte_schizo_base_sanity(&results);
+    rc = schizo->check_sanity(&results);
     if (PRTE_SUCCESS != rc) {
         // sanity checker prints the reason
         PMIX_DESTRUCT(&results);

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -50,6 +50,7 @@ prte_LDADD = \
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f prterun$(EXEEXT); $(LN_S) prte$(EXEEXT) prterun$(EXEEXT))
+	(cd $(DESTDIR)$(bindir); rm -f srun$(EXEEXT); $(LN_S) prte$(EXEEXT) srun$(EXEEXT))
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/prterun$(EXEEXT)

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -420,9 +420,9 @@ int main(int argc, char *argv[])
 
     /* decide if we are to use a persistent DVM, or act alone */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DVM);
-    if (NULL != opt && proxyrun) {
+    if (proxyrun && (NULL != opt || NULL != getenv("PRTEPROXY_USE_DVM"))) {
         /* use a persistent DVM - act like prun */
-        if (NULL != opt->values && NULL != opt->values[0]) {
+        if (NULL != opt && NULL != opt->values && NULL != opt->values[0]) {
             /* they provided a directive on how to find the DVM */
             if (0 == strncasecmp(opt->values[0], "file:", 5)) {
                 /* change the key to match what prun expects */


### PR DESCRIPTION
Add a personality for "slurm" that includes a very initial cut at support for the "srun" cmd line. This targets passing of the provided options to a slurmstepd for processing - it does not yet support passing the parsed output to PRRTE for spawn of the specified application.

This is currently a POC - if it proves of interest/successful, then the implementation will be extended to cover more of the srun cmd line and support from PRRTE as the DVM.

Signed-off-by: Ralph Castain <rhc@pmix.org>