### PR TITLE
Include topology in allocated node info

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -435,7 +435,7 @@ int prte_ess_base_prted_setup(void)
     t->sig = strdup(prte_topo_signature);
     /* save the topology - note that this may have to be moved later
      * to ensure a common array position with the DVM master */
-    pmix_pointer_array_add(prte_node_topologies, t);
+    t->index = pmix_pointer_array_add(prte_node_topologies, t);
     if (15 < pmix_output_get_verbosity(prte_ess_base_framework.framework_output)) {
         char *output = NULL;
         pmix_topology_t topo;

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -390,7 +390,7 @@ static int rte_init(int argc, char **argv)
     /* generate the signature */
     prte_topo_signature = prte_hwloc_base_get_topo_signature(prte_hwloc_topology);
     t->sig = strdup(prte_topo_signature);
-    pmix_pointer_array_add(prte_node_topologies, t);
+    t->index = pmix_pointer_array_add(prte_node_topologies, t);
     node->topology = t;
     node->available = prte_hwloc_base_filter_cpus(prte_hwloc_topology);
     if (15 < pmix_output_get_verbosity(prte_ess_base_framework.framework_output)) {


### PR DESCRIPTION
Pass the topology array and the index for each
node into that array.

Signed-off-by: Ralph Castain <rhc@pmix.org>