### PR TITLE
Begin adding support for new server module fn pointer

### DIFF
--- a/src/prted/pmix/Makefile.am
+++ b/src/prted/pmix/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -19,4 +20,5 @@ libprrte_la_SOURCES += \
           prted/pmix/pmix_server_dyn.c \
           prted/pmix/pmix_server_pub.c \
           prted/pmix/pmix_server_gen.c \
-          prted/pmix/pmix_server_queries.c
+          prted/pmix/pmix_server_queries.c \
+          prted/pmix/pmix_server_session.c

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -110,11 +110,12 @@ static pmix_server_module_t pmix_server = {
     .query = pmix_server_query_fn,
     .tool_connected = pmix_tool_connected_fn,
     .log = pmix_server_log_fn,
-    .allocate = pmix_server_alloc_fn,
     .job_control = pmix_server_job_ctrl_fn,
     .iof_pull = pmix_server_iof_pull_fn,
     .push_stdin = pmix_server_stdin_fn,
-    .group = pmix_server_group_fn
+    .group = pmix_server_group_fn,
+    .allocate = pmix_server_alloc_fn,
+    .session_control = pmix_server_session_ctrl_fn
 };
 
 typedef struct {
@@ -299,6 +300,8 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_QUERY_NUM_GROUPS",
                          "PMIX_QUERY_GROUP_NAMES",
                          "PMIX_QUERY_GROUP_MEMBERSHIP",
+                         "PMIX_QUERY_ALLOCATION",
+                         "PMIX_QUERY_ALLOC_STATUS",
                          NULL}},
     {.function = "PMIx_Log", .attrs = (char *[]){"NONE", NULL}},
     {.function = "PMIx_Log_nb", .attrs = (char *[]){"NONE", NULL}},
@@ -333,6 +336,29 @@ static prte_regattr_input_t prte_attributes[] = {
     {.function = "PMIx_Register_event_handler", .attrs = (char *[]){"NONE", NULL}},
     {.function = "PMIx_Deregister_event_handler", .attrs = (char *[]){"N/A", NULL}},
     {.function = "PMIx_Notify_event", .attrs = (char *[]){"NONE", NULL}},
+    {.function = "PMIx_Allocate_resources",
+     .attrs = (char *[]){"PMIX_ALLOC_REQ_ID",
+                         "PMIX_ALLOC_NUM_NODES",
+                         "PMIX_ALLOC_NODE_LIST",
+                         "PMIX_ALLOC_NUM_CPUS",
+                         "PMIX_ALLOC_NUM_CPU_LIST",
+                         "PMIX_ALLOC_CPU_LIST",
+                         "PMIX_ALLOC_MEM_SIZE",
+                         "PMIX_ALLOC_TIME",
+                         "PMIX_ALLOC_QUEUE",
+                         "PMIX_ALLOC_PREEMPTIBLE",
+                         NULL}},
+    {.function = "PMIx_Session_control",
+     .attrs = (char *[]){"PMIX_SESSION_CTRL_ID",
+                         "PMIX_SESSION_APP",
+                         "PMIX_SESSION_PAUSE",
+                         "PMIX_SESSION_RESUME",
+                         "PMIX_SESSION_TERMINATE",
+                         "PMIX_SESSION_PREEMPT",
+                         "PMIX_SESSION_RESTORE",
+                         "PMIX_SESSION_SIGNAL",
+                         "PMIX_SESSION_COMPLETE",
+                         NULL}},
     {.function = ""},
 };
 

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1266,12 +1266,3 @@ pmix_status_t pmix_server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs
 
     return rc;
 }
-
-pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client, pmix_alloc_directive_t directive,
-                                   const pmix_info_t data[], size_t ndata,
-                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
-{
-    /* PRTE currently has no way of supporting allocation requests */
-    PRTE_HIDE_UNUSED_PARAMS(client, directive, data, ndata, cbfunc, cbdata);
-    return PMIX_ERR_NOT_SUPPORTED;
-}

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -569,6 +569,8 @@ static void _toolconn(int sd, short args, void *cbdata)
                 cd->cmdline = strdup(cd->info[n].value.data.string);
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_LAUNCHER)) {
                 cd->launcher = PMIX_INFO_TRUE(&cd->info[n]);
+            } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_SERVER_SCHEDULER)) {
+                cd->scheduler = PMIX_INFO_TRUE(&cd->info[n]);
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_PROC_PID)) {
                 PMIX_VALUE_GET_NUMBER(xrc, &cd->info[n].value, cd->pid, pid_t);
                 if (PMIX_SUCCESS != xrc) {
@@ -583,8 +585,9 @@ static void _toolconn(int sd, short args, void *cbdata)
     }
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s TOOL CONNECTION FROM UID %d GID %d NSPACE %s",
+                        "%s %s CONNECTION FROM UID %d GID %d NSPACE %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        cd->launcher ? "LAUNCHER" : (cd->scheduler ? "SCHEDULER" : "TOOL"),
                         cd->uid, cd->gid, cd->target.nspace);
 
     /* if we are not the HNP or master, and the tool doesn't
@@ -643,7 +646,8 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo, pmix_tool_connectio
 {
     pmix_server_req_t *cd;
 
-    pmix_output_verbose(2, prte_pmix_server_globals.output, "%s TOOL CONNECTION REQUEST RECVD",
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s TOOL CONNECTION REQUEST RECVD",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* need to threadshift this request */

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -91,6 +91,7 @@ typedef struct {
     int remote_room_num;
     bool flag;
     bool launcher;
+    bool scheduler;
     uid_t uid;
     gid_t gid;
     pid_t pid;
@@ -351,6 +352,12 @@ PRTE_EXPORT extern void pmix_server_jobid_return(int status, pmix_proc_t *sender
 PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
+
+PRTE_EXPORT extern pmix_status_t
+pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
+                            uint32_t sessionID,
+                            const pmix_info_t directives[], size_t ndirs,
+                            pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* exposed shared variables */
 typedef struct {

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+
+#include "src/pmix/pmix-internal.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+
+pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
+                                   pmix_alloc_directive_t directive,
+                                   const pmix_info_t data[], size_t ndata,
+                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    /* if we are not the DVM controller, then send it there */
+
+    /* we are the DVM controller, so pass it down so PMIx can
+     * send it to the scheduler */
+
+}
+
+pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
+                                          uint32_t sessionID,
+                                          const pmix_info_t directives[], size_t ndirs,
+                                          pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    /* if we are not the DVM controller, then send it there */
+
+    /* we are the DVM controller, so pass it down so PMIx can
+     * send it to the scheduler */
+
+}


### PR DESCRIPTION
Move the "allocate" module fn to a new file that will include all session-related operations. Add prototype for the new session_control module fn. Ensure the
controller knows that it is the scheduler that just connected to it.

Signed-off-by: Ralph Castain <rhc@pmix.org>