### PR TITLE
Update to compatibility with PMIx master branch

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -22,7 +22,7 @@
 # $HEADER$
 #
 
-# Use the PSRVR-provided wrapper compiler
+# Use the PRRTE-provided wrapper compiler
 
 CC = pcc
 

--- a/examples/debugger/debugger.h
+++ b/examples/debugger/debugger.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +32,7 @@
 #include <unistd.h>
 
 #include <pmix_tool.h>
+#include <pmix_version.h>
 
 typedef struct {
     pthread_mutex_t mutex;
@@ -93,3 +94,75 @@ typedef struct {
     int exit_code;
     bool exit_code_given;
 } myrel_t;
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        pmix_argv_join(a, b)
+#else
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        PMIx_Argv_join(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        pmix_argv_split(a, b)
+#else
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        PMIx_Argv_split(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        pmix_argv_split_with_empty(a, b)
+#else
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        PMIx_Argv_split_with_empty(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        pmix_argv_count(a)
+#else
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        PMIx_Argv_count(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        pmix_argv_free(a)
+#else
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        PMIx_Argv_free(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        pmix_argv_append_unique_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        PMIx_Argv_append_unique_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        pmix_argv_append_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        PMIx_Argv_append_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        pmix_argv_copy(a)
+#else
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        PMIx_Argv_copy(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        pmix_setenv(a, b, c, d)
+#else
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        PMIx_Setenv(a, b, c, d)
+#endif

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
         }
     }
     if (!found) {
-        char *tmp = pmix_argv_join(launchers, ',');
+        char *tmp = PMIX_ARGV_JOIN_COMPAT(launchers, ',');
         fprintf(stderr, "Wrong test, dude - unknown launcher\n");
         fprintf(stderr, "Known launchers: %s\n", tmp);
         free(tmp);

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -130,14 +130,14 @@ int main(int argc, char **argv)
         goto done;
     }
     /* split the returned string to get the rank of each local peer */
-    peers = pmix_argv_split(val->data.string, ',');
+    peers = PMIX_ARGV_SPLIT_COMPAT(val->data.string, ',');
     PMIX_VALUE_RELEASE(val);
-    nlocal = pmix_argv_count(peers);
+    nlocal = PMIX_ARGV_COUNT_COMPAT(peers);
     if (nprocs == nlocal) {
         all_local = true;
     } else {
         all_local = false;
-        locals = (pmix_rank_t *) malloc(pmix_argv_count(peers) * sizeof(pmix_rank_t));
+        locals = (pmix_rank_t *) malloc(PMIX_ARGV_COUNT_COMPAT(peers) * sizeof(pmix_rank_t));
         for (n = 0; NULL != peers[n]; n++) {
             locals[n] = strtoul(peers[n], NULL, 10);
         }

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -33,6 +33,7 @@
 #include <stdarg.h>
 
 #include <pmix_common.h>
+#include <pmix_version.h>
 
 typedef struct {
     pthread_mutex_t mutex;
@@ -137,3 +138,75 @@ static inline void examples_hide_unused_params(int x, ...)
     va_start(ap, x);
     va_end(ap);
 }
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        pmix_argv_join(a, b)
+#else
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        PMIx_Argv_join(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        pmix_argv_split(a, b)
+#else
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        PMIx_Argv_split(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        pmix_argv_split_with_empty(a, b)
+#else
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        PMIx_Argv_split_with_empty(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        pmix_argv_count(a)
+#else
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        PMIx_Argv_count(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        pmix_argv_free(a)
+#else
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        PMIx_Argv_free(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        pmix_argv_append_unique_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        PMIx_Argv_append_unique_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        pmix_argv_append_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        PMIx_Argv_append_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        pmix_argv_copy(a)
+#else
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        PMIx_Argv_copy(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        pmix_setenv(a, b, c, d)
+#else
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        PMIx_Setenv(a, b, c, d)
+#endif

--- a/examples/server.c
+++ b/examples/server.c
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
         } else if (0 == strcmp("-e", argv[n]) && NULL != argv[n + 1]) {
             executable = strdup(argv[n + 1]);
             for (k = n + 2; NULL != argv[k]; k++) {
-                pmix_argv_append_nosize(&client_argv, argv[k]);
+                PMIX_ARGV_APPEND_COMPAT(&client_argv, argv[k]);
             }
             n += k;
         }
@@ -265,17 +265,17 @@ int main(int argc, char **argv)
     atmp = NULL;
     for (n = 0; n < nprocs; n++) {
         asprintf(&tmp, "%d", n);
-        pmix_argv_append_nosize(&atmp, tmp);
+        PMIX_ARGV_APPEND_COMPAT(&atmp, tmp);
         free(tmp);
     }
-    tmp = pmix_argv_join(atmp, ',');
-    pmix_argv_free(atmp);
+    tmp = PMIX_ARGV_JOIN_COMPAT(atmp, ',');
+    PMIX_ARGV_FREE_COMPAT(atmp);
     /* register the nspace */
     x = PMIX_NEW(myxfer_t);
     set_namespace(nprocs, tmp, "foobar", opcbfunc, x);
 
     /* set common argv and env */
-    client_env = pmix_argv_copy(environ);
+    client_env = PMIX_ARGV_COPY_COMPAT(environ);
     pmix_argv_prepend_nosize(&client_argv, executable);
 
     wakeup = nprocs;
@@ -339,8 +339,8 @@ int main(int argc, char **argv)
         }
     }
     free(executable);
-    pmix_argv_free(client_argv);
-    pmix_argv_free(client_env);
+    PMIX_ARGV_FREE_COMPAT(client_argv);
+    PMIX_ARGV_FREE_COMPAT(client_env);
 
     /* hang around until the client(s) finalize */
     while (0 < wakeup) {

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -512,7 +512,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
     if (NULL != ptr) {
         *ptr = '\0';
         ++ptr;
-        quals = pmix_argv_split(ptr, ':');
+        quals = PMIX_ARGV_SPLIT_COMPAT(ptr, ':');
         for (i = 0; NULL != quals[i]; i++) {
             if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_IF_SUPP)) {
                 tmp |= PRTE_BIND_IF_SUPPORTED;
@@ -537,12 +537,12 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
             } else {
                 /* unknown option */
                 pmix_show_help("help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
-                pmix_argv_free(quals);
+                PMIX_ARGV_FREE_COMPAT(quals);
                 free(myspec);
                 return PRTE_ERR_BAD_PARAM;
             }
         }
-        pmix_argv_free(quals);
+        PMIX_ARGV_FREE_COMPAT(quals);
     }
 
     if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NONE)) {

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -229,7 +229,7 @@ int prte_ess_base_setup_signals(char *mysignals)
      * have asked for some we already cover, and so we ignore any duplicates */
     if (NULL != mysignals) {
         /* if they told us "none", then dump the list */
-        signals = pmix_argv_split(mysignals, ',');
+        signals = PMIX_ARGV_SPLIT_COMPAT(mysignals, ',');
         for (i = 0; NULL != signals[i]; i++) {
             sval = 0;
             if (0 != strncmp(signals[i], "SIG", 3)) {
@@ -239,7 +239,7 @@ int prte_ess_base_setup_signals(char *mysignals)
                 if (0 != errno || '\0' != *tmp) {
                     pmix_show_help("help-ess-base.txt", "ess-base:unknown-signal", true, signals[i],
                                    forwarded_signals);
-                    pmix_argv_free(signals);
+                    PMIX_ARGV_FREE_COMPAT(signals);
                     return PRTE_ERR_SILENT;
                 }
             }
@@ -267,7 +267,7 @@ int prte_ess_base_setup_signals(char *mysignals)
                     if (!known_signals[j].can_forward) {
                         pmix_show_help("help-ess-base.txt", "ess-base:cannot-forward", true,
                                        known_signals[j].signame, forwarded_signals);
-                        pmix_argv_free(signals);
+                        PMIX_ARGV_FREE_COMPAT(signals);
                         return PRTE_ERR_SILENT;
                     }
                     found = true;
@@ -280,14 +280,14 @@ int prte_ess_base_setup_signals(char *mysignals)
                 if (0 == strncmp(signals[i], "SIG", 3)) {
                     pmix_show_help("help-ess-base.txt", "ess-base:unknown-signal", true, signals[i],
                                    forwarded_signals);
-                    pmix_argv_free(signals);
+                    PMIX_ARGV_FREE_COMPAT(signals);
                     return PRTE_ERR_SILENT;
                 }
 
                 ESS_ADDSIGNAL(sval, signals[i]);
             }
         }
-        pmix_argv_free(signals);
+        PMIX_ARGV_FREE_COMPAT(signals);
     }
     return PRTE_SUCCESS;
 }

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -282,7 +282,7 @@ static int rte_init(int argc, char **argv)
     /* every job requires at least one app */
     app = PMIX_NEW(prte_app_context_t);
     app->app = strdup(argv[0]);
-    app->argv = pmix_argv_copy(argv);
+    app->argv = PMIX_ARGV_COPY_COMPAT(argv);
     pmix_pointer_array_set_item(jdata->apps, 0, app);
     jdata->num_apps++;
     /* create and store a node object where we are */
@@ -326,7 +326,7 @@ static int rte_init(int argc, char **argv)
     PRTE_FLAG_SET(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
     node->state = PRTE_NODE_STATE_UP;
     /* get our aliases - will include all the interface aliases captured in prte_init */
-    node->aliases = pmix_argv_copy(prte_process_info.aliases);
+    node->aliases = PMIX_ARGV_COPY_COMPAT(prte_process_info.aliases);
     /* record that the daemon job is running */
     jdata->num_procs = 1;
     jdata->state = PRTE_JOB_STATE_RUNNING;

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -283,7 +283,7 @@ static int raw_preposition_files(prte_job_t *jdata,
         }
         if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, (void **) &filestring,
                                PMIX_STRING)) {
-            files = pmix_argv_split(filestring, ',');
+            files = PMIX_ARGV_SPLIT_COMPAT(filestring, ',');
             free(filestring);
             for (j = 0; NULL != files[j]; j++) {
                 fs = PMIX_NEW(prte_filem_base_file_set_t);
@@ -372,11 +372,11 @@ static int raw_preposition_files(prte_job_t *jdata,
             /* replace the app's file list with the revised one so we
              * can find them on the remote end
              */
-            filestring = pmix_argv_join(files, ',');
+            filestring = PMIX_ARGV_JOIN_COMPAT(files, ',');
             prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, PRTE_ATTR_GLOBAL,
                                filestring, PMIX_STRING);
             /* cleanup for the next app */
-            pmix_argv_free(files);
+            PMIX_ARGV_FREE_COMPAT(files);
             free(filestring);
         }
     }
@@ -625,13 +625,13 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
     /* get the list of files this app wants */
     if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, (void **) &filestring,
                            PMIX_STRING)) {
-        files = pmix_argv_split(filestring, ',');
+        files = PMIX_ARGV_SPLIT_COMPAT(filestring, ',');
         free(filestring);
     }
     if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_BIN, NULL, PMIX_BOOL)) {
         /* add the app itself to the list */
         bname = pmix_basename(app->app);
-        pmix_argv_append_nosize(&files, bname);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&files, bname);
         free(bname);
     }
 
@@ -720,7 +720,7 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
             }
         }
     }
-    pmix_argv_free(files);
+    PMIX_ARGV_FREE_COMPAT(files);
     return PRTE_SUCCESS;
 }
 
@@ -913,7 +913,7 @@ static int link_archive(prte_filem_raw_incoming_t *inbnd)
         PMIX_OUTPUT_VERBOSE((10, prte_filem_base_framework.framework_output,
                              "%s filem:raw: adding path %s to link points",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), path));
-        pmix_argv_append_nosize(&inbnd->link_pts, path);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&inbnd->link_pts, path);
     }
     /* close */
     pclose(fp);
@@ -1114,7 +1114,7 @@ static void write_handler(int fd, short event, void *cbdata)
                 /* just link to the top as this will be the
                  * name we will want in each proc's session dir
                  */
-                pmix_argv_append_nosize(&sink->link_pts, sink->top);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&sink->link_pts, sink->top);
                 send_complete(sink->file, PRTE_SUCCESS);
             } else {
                 /* unarchive the file */
@@ -1281,7 +1281,7 @@ static void in_destruct(prte_filem_raw_incoming_t *ptr)
     if (NULL != ptr->fullpath) {
         free(ptr->fullpath);
     }
-    pmix_argv_free(ptr->link_pts);
+    PMIX_ARGV_FREE_COMPAT(ptr->link_pts);
     PMIX_LIST_DESTRUCT(&ptr->outputs);
 }
 PMIX_CLASS_INSTANCE(prte_filem_raw_incoming_t,

--- a/src/mca/odls/alps/odls_alps_utils.c
+++ b/src/mca/odls/alps/odls_alps_utils.c
@@ -179,10 +179,10 @@ int prte_odls_alps_get_rdma_creds(void)
         ptr += len;
     }
     sprintf(ptr, "%d", rdmacred_buf[num_creds - 1].ptag);
-    ret = pmix_setenv("PMI_GNI_PTAG", env_buffer, false, &prte_launch_environ);
+    ret = PMIX_SETENV_COMPAT("PMI_GNI_PTAG", env_buffer, false, &prte_launch_environ);
     if (ret != PMIX_SUCCESS) {
         PMIX_OUTPUT_VERBOSE((20, prte_odls_base_framework.framework_output,
-                             "%s odls:alps: pmix_setenv for PMI_GNI_TAG failed - returned %d",
+                             "%s odls:alps: PMIX_SETENV_COMPAT for PMI_GNI_TAG failed - returned %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ret));
         ret = prte_pmix_convert_status(ret);
         goto fn_exit;
@@ -204,10 +204,10 @@ int prte_odls_alps_get_rdma_creds(void)
         ptr += len;
     }
     sprintf(ptr, "%d", rdmacred_buf[num_creds - 1].cookie);
-    ret = pmix_setenv("PMI_GNI_COOKIE", env_buffer, false, &prte_launch_environ);
+    ret = PMIX_SETENV_COMPAT("PMI_GNI_COOKIE", env_buffer, false, &prte_launch_environ);
     if (ret != PMIX_SUCCESS) {
         PMIX_OUTPUT_VERBOSE((20, prte_odls_base_framework.framework_output,
-                             "%s odls:alps: pmix_setenv for PMI_GNI_COOKIE returned %d",
+                             "%s odls:alps: PMIX_SETENV_COMPAT for PMI_GNI_COOKIE returned %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ret));
         ret = prte_pmix_convert_status(ret);
         goto fn_exit;
@@ -229,10 +229,10 @@ int prte_odls_alps_get_rdma_creds(void)
         ptr += len;
     }
     sprintf(ptr, "%d", rdmacred_buf[num_creds - 1].local_addr);
-    ret = pmix_setenv("PMI_GNI_LOC_ADDR", env_buffer, false, &prte_launch_environ);
+    ret = PMIX_SETENV_COMPAT("PMI_GNI_LOC_ADDR", env_buffer, false, &prte_launch_environ);
     if (ret != PMIX_SUCCESS) {
         PMIX_OUTPUT_VERBOSE((20, prte_odls_base_framework.framework_output,
-                             "%s odls:alps: pmix_setenv for PMI_GNI_LOC_ADDR returned %d",
+                             "%s odls:alps: PMIX_SETENV_COMPAT for PMI_GNI_LOC_ADDR returned %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ret));
         ret = prte_pmix_convert_status(ret);
         goto fn_exit;
@@ -254,10 +254,10 @@ int prte_odls_alps_get_rdma_creds(void)
         ptr += len;
     }
     sprintf(ptr, "%d", rdmacred_buf[num_creds - 1].device_id);
-    ret = pmix_setenv("PMI_GNI_DEV_ID", env_buffer, false, &prte_launch_environ);
+    ret = PMIX_SETENV_COMPAT("PMI_GNI_DEV_ID", env_buffer, false, &prte_launch_environ);
     if (ret != PMIX_SUCCESS) {
         PMIX_OUTPUT_VERBOSE((20, prte_odls_base_framework.framework_output,
-                             "%s odls:alps: pmix_setenv for PMI_GNI_DEV_ID returned %d",
+                             "%s odls:alps: PMIX_SETENV_COMPAT for PMI_GNI_DEV_ID returned %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ret));
         ret = prte_pmix_convert_status(ret);
         goto fn_exit;

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -282,20 +282,20 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
     for (i = 0; i < map->nodes->size; i++) {
         micro = NULL;
         if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(map->nodes, i))) {
-            pmix_argv_append_nosize(&list, node->name);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, node->name);
             /* assemble all the ranks for this job that are on this node */
             for (k = 0; k < node->procs->size; k++) {
                 if (NULL != (pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, k))) {
                     if (PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
-                        pmix_argv_append_nosize(&micro, PRTE_VPID_PRINT(pptr->name.rank));
+                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&micro, PRTE_VPID_PRINT(pptr->name.rank));
                     }
                 }
             }
             /* assemble the rank/node map */
             if (NULL != micro) {
-                tmp = pmix_argv_join(micro, ',');
-                pmix_argv_free(micro);
-                pmix_argv_append_nosize(&procs, tmp);
+                tmp = PMIX_ARGV_JOIN_COMPAT(micro, ',');
+                PMIX_ARGV_FREE_COMPAT(micro);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&procs, tmp);
                 free(tmp);
             }
         }
@@ -303,8 +303,8 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
 
     /* let the PMIx server generate the nodemap regex */
     if (NULL != list) {
-        tmp = pmix_argv_join(list, ',');
-        pmix_argv_free(list);
+        tmp = PMIX_ARGV_JOIN_COMPAT(list, ',');
+        PMIX_ARGV_FREE_COMPAT(list);
         list = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -319,8 +319,8 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
 
     /* let the PMIx server generate the procmap regex */
     if (NULL != procs) {
-        tmp = pmix_argv_join(procs, ';');
-        pmix_argv_free(procs);
+        tmp = PMIX_ARGV_JOIN_COMPAT(procs, ';');
+        PMIX_ARGV_FREE_COMPAT(procs);
         procs = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -335,7 +335,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
 
     /* add in the personality */
     if (NULL != jdata->personality) {
-        tmp = pmix_argv_join(jdata->personality, ',');
+        tmp = PMIX_ARGV_JOIN_COMPAT(jdata->personality, ',');
         PMIX_INFO_LIST_ADD(ret, ilist, PMIX_PERSONALITY, tmp, PMIX_STRING);
         free(tmp);
     }
@@ -578,7 +578,7 @@ next:
         }
         /* get the associated schizo module */
         if (NULL != jdata->personality) {
-            tmp = pmix_argv_join(jdata->personality, ',');
+            tmp = PMIX_ARGV_JOIN_COMPAT(jdata->personality, ',');
         } else {
             tmp = NULL;
         }
@@ -829,7 +829,7 @@ static int setup_path(prte_app_context_t *app, char **wdir)
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         *wdir = strdup(dir);
-        pmix_setenv("PWD", dir, true, &app->env);
+        PMIX_SETENV_COMPAT("PWD", dir, true, &app->env);
     } else {
         /* Try to change to the app's cwd and check that the app
            exists and is executable The function will
@@ -861,7 +861,7 @@ static int setup_path(prte_app_context_t *app, char **wdir)
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         *wdir = strdup(dir);
-        pmix_setenv("PWD", dir, true, &app->env);
+        PMIX_SETENV_COMPAT("PWD", dir, true, &app->env);
     }
 
 CLEANUP:
@@ -932,7 +932,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     /* thread-protect common values */
-    cd->env = pmix_argv_copy(prte_launch_environ);
+    cd->env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
     if (NULL != app->env) {
         for (i = 0; NULL != app->env[i]; i++) {
             /* find the '=' sign.
@@ -950,7 +950,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
             }
             *ptr = '\0';
             ++ptr;
-            pmix_setenv(tmp, ptr, true, &cd->env);
+            PMIX_SETENV_COMPAT(tmp, ptr, true, &cd->env);
             free(tmp);
         }
     }
@@ -997,13 +997,13 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
             if (PMIX_RANK_WILDCARD == nm->name.rank || child->name.rank == nm->name.rank) {
                 /* we want this one - modify the app's command to include
                  * the prte xterm cmd that starts with the xtermcmd */
-                cd->argv = pmix_argv_copy(prte_odls_globals.xtermcmd);
+                cd->argv = PMIX_ARGV_COPY_COMPAT(prte_odls_globals.xtermcmd);
                 /* insert the rank into the correct place as a window title */
                 free(cd->argv[2]);
                 pmix_asprintf(&cd->argv[2], "Rank %s", PRTE_VPID_PRINT(child->name.rank));
                 /* add in the argv from the app */
                 for (i = 0; NULL != app->argv[i]; i++) {
-                    pmix_argv_append_nosize(&cd->argv, app->argv[i]);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cd->argv, app->argv[i]);
                 }
                 /* use the xterm cmd as the app string */
                 cd->cmd = strdup(prte_odls_globals.xtermcmd[0]);
@@ -1019,14 +1019,14 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         }
         if (!found) {
             cd->cmd = strdup(app->app);
-            cd->argv = pmix_argv_copy(app->argv);
+            cd->argv = PMIX_ARGV_COPY_COMPAT(app->argv);
         }
     } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_EXEC_AGENT, (void**)&ptr, PMIX_STRING)) {
         /* we were given a fork agent - use it */
-        cd->argv = pmix_argv_split(ptr, ' ');
+        cd->argv = PMIX_ARGV_SPLIT_COMPAT(ptr, ' ');
         /* add in the argv from the app */
         for (i = 0; NULL != app->argv[i]; i++) {
-            pmix_argv_append_nosize(&cd->argv, app->argv[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cd->argv, app->argv[i]);
         }
         cd->cmd = pmix_path_findv(cd->argv[0], X_OK, prte_launch_environ, NULL);
         if (NULL == cd->cmd) {
@@ -1039,10 +1039,10 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         free(ptr);
     } else if (NULL != prte_odls_globals.exec_agent) {
         /* we were given a fork agent - use it */
-        cd->argv = pmix_argv_split(prte_odls_globals.exec_agent, ' ');
+        cd->argv = PMIX_ARGV_SPLIT_COMPAT(prte_odls_globals.exec_agent, ' ');
         /* add in the argv from the app */
         for (i = 0; NULL != app->argv[i]; i++) {
-            pmix_argv_append_nosize(&cd->argv, app->argv[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cd->argv, app->argv[i]);
         }
         cd->cmd = pmix_path_findv(cd->argv[0], X_OK, prte_launch_environ, NULL);
         if (NULL == cd->cmd) {
@@ -1053,7 +1053,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         }
     } else {
         cd->cmd = strdup(app->app);
-        cd->argv = pmix_argv_copy(app->argv);
+        cd->argv = PMIX_ARGV_COPY_COMPAT(app->argv);
     }
 
     /* if we are indexing the argv by rank, do so now */

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -140,7 +140,7 @@ void prte_odls_base_harvest_threads(void)
         prte_odls_globals.ev_bases[0] = prte_event_base;
         prte_odls_globals.num_threads = 0;
         if (NULL != prte_odls_globals.ev_threads) {
-            pmix_argv_free(prte_odls_globals.ev_threads);
+            PMIX_ARGV_FREE_COMPAT(prte_odls_globals.ev_threads);
             prte_odls_globals.ev_threads = NULL;
         }
     }
@@ -199,7 +199,7 @@ startup:
         for (i = 0; i < prte_odls_globals.num_threads; i++) {
             pmix_asprintf(&tmp, "PRTE-ODLS-%d", i);
             prte_odls_globals.ev_bases[i] = prte_progress_thread_init(tmp);
-            pmix_argv_append_nosize(&prte_odls_globals.ev_threads, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.ev_threads, tmp);
             free(tmp);
         }
     }
@@ -276,7 +276,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
         /* construct a list of ranks to be displayed */
         xterm_hold = false;
         pmix_util_parse_range_options(prte_xterm, &ranks);
-        for (i = 0; i < pmix_argv_count(ranks); i++) {
+        for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ranks); i++) {
             if (0 == strcmp(ranks[i], "BANG")) {
                 xterm_hold = true;
                 continue;
@@ -300,21 +300,21 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
             }
             pmix_list_append(&prte_odls_globals.xterm_ranks, &nm->super);
         }
-        pmix_argv_free(ranks);
+        PMIX_ARGV_FREE_COMPAT(ranks);
         /* construct the xtermcmd */
         prte_odls_globals.xtermcmd = NULL;
         tmp = pmix_find_absolute_path("xterm");
         if (NULL == tmp) {
             return PRTE_ERROR;
         }
-        pmix_argv_append_nosize(&prte_odls_globals.xtermcmd, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, tmp);
         free(tmp);
-        pmix_argv_append_nosize(&prte_odls_globals.xtermcmd, "-T");
-        pmix_argv_append_nosize(&prte_odls_globals.xtermcmd, "save");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-T");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "save");
         if (xterm_hold) {
-            pmix_argv_append_nosize(&prte_odls_globals.xtermcmd, "-hold");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-hold");
         }
-        pmix_argv_append_nosize(&prte_odls_globals.xtermcmd, "-e");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-e");
     }
 
     /* Open up all available components */
@@ -356,10 +356,10 @@ static void scdes(prte_odls_spawn_caddy_t *p)
         free(p->wdir);
     }
     if (NULL != p->argv) {
-        pmix_argv_free(p->argv);
+        PMIX_ARGV_FREE_COMPAT(p->argv);
     }
     if (NULL != p->env) {
-        pmix_argv_free(p->env);
+        PMIX_ARGV_FREE_COMPAT(p->env);
     }
 }
 PMIX_CLASS_INSTANCE(prte_odls_spawn_caddy_t, pmix_object_t, sccon, scdes);

--- a/src/mca/oob/base/oob_base_stubs.c
+++ b/src/mca/oob/base/oob_base_stubs.c
@@ -324,7 +324,7 @@ static prte_oob_base_peer_t* process_uri(char *uri)
     }
 
     /* split the rest of the uri into component parts */
-    uris = pmix_argv_split(cptr, ';');
+    uris = PMIX_ARGV_SPLIT_COMPAT(cptr, ';');
 
     /* get the peer object for this process */
     pr = prte_oob_base_get_peer(&peer);
@@ -364,7 +364,7 @@ static prte_oob_base_peer_t* process_uri(char *uri)
             }
         }
     }
-    pmix_argv_free(uris);
+    PMIX_ARGV_FREE_COMPAT(uris);
     return pr;
 }
 

--- a/src/mca/oob/tcp/oob_tcp_component.c
+++ b/src/mca/oob/tcp/oob_tcp_component.c
@@ -167,22 +167,22 @@ static int tcp_component_close(void)
     PMIX_LIST_DESTRUCT(&prte_mca_oob_tcp_component.peers);
 
     if (NULL != prte_mca_oob_tcp_component.ipv4conns) {
-        pmix_argv_free(prte_mca_oob_tcp_component.ipv4conns);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.ipv4conns);
     }
     if (NULL != prte_mca_oob_tcp_component.ipv4ports) {
-        pmix_argv_free(prte_mca_oob_tcp_component.ipv4ports);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.ipv4ports);
     }
 
 #if PRTE_ENABLE_IPV6
     if (NULL != prte_mca_oob_tcp_component.ipv6conns) {
-        pmix_argv_free(prte_mca_oob_tcp_component.ipv6conns);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.ipv6conns);
     }
     if (NULL != prte_mca_oob_tcp_component.ipv6ports) {
-        pmix_argv_free(prte_mca_oob_tcp_component.ipv6ports);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.ipv6ports);
     }
 #endif
     if (NULL != prte_mca_oob_tcp_component.if_masks) {
-        pmix_argv_free(prte_mca_oob_tcp_component.if_masks);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.if_masks);
     }
     return PRTE_SUCCESS;
 }
@@ -236,7 +236,7 @@ static int tcp_component_register(void)
     if (NULL != static_port_string) {
         pmix_util_parse_range_options(static_port_string, &prte_mca_oob_tcp_component.tcp_static_ports);
         if (0 == strcmp(prte_mca_oob_tcp_component.tcp_static_ports[0], "-1")) {
-            pmix_argv_free(prte_mca_oob_tcp_component.tcp_static_ports);
+            PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.tcp_static_ports);
             prte_mca_oob_tcp_component.tcp_static_ports = NULL;
         }
     } else {
@@ -255,7 +255,7 @@ static int tcp_component_register(void)
         pmix_util_parse_range_options(static_port_string6,
                                       &prte_mca_oob_tcp_component.tcp6_static_ports);
         if (0 == strcmp(prte_mca_oob_tcp_component.tcp6_static_ports[0], "-1")) {
-            pmix_argv_free(prte_mca_oob_tcp_component.tcp6_static_ports);
+            PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.tcp6_static_ports);
             prte_mca_oob_tcp_component.tcp6_static_ports = NULL;
         }
     } else {
@@ -277,14 +277,14 @@ static int tcp_component_register(void)
     if (NULL != dyn_port_string) {
         /* can't have both static and dynamic ports! */
         if (prte_static_ports) {
-            char *err = pmix_argv_join(prte_mca_oob_tcp_component.tcp_static_ports, ',');
+            char *err = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.tcp_static_ports, ',');
             pmix_show_help("help-oob-tcp.txt", "static-and-dynamic", true, err, dyn_port_string);
             free(err);
             return PRTE_ERROR;
         }
         pmix_util_parse_range_options(dyn_port_string, &prte_mca_oob_tcp_component.tcp_dyn_ports);
         if (0 == strcmp(prte_mca_oob_tcp_component.tcp_dyn_ports[0], "-1")) {
-            pmix_argv_free(prte_mca_oob_tcp_component.tcp_dyn_ports);
+            PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.tcp_dyn_ports);
             prte_mca_oob_tcp_component.tcp_dyn_ports = NULL;
         }
     } else {
@@ -303,10 +303,10 @@ static int tcp_component_register(void)
         if (prte_static_ports) {
             char *err4 = NULL, *err6 = NULL;
             if (NULL != prte_mca_oob_tcp_component.tcp_static_ports) {
-                err4 = pmix_argv_join(prte_mca_oob_tcp_component.tcp_static_ports, ',');
+                err4 = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.tcp_static_ports, ',');
             }
             if (NULL != prte_mca_oob_tcp_component.tcp6_static_ports) {
-                err6 = pmix_argv_join(prte_mca_oob_tcp_component.tcp6_static_ports, ',');
+                err6 = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.tcp6_static_ports, ',');
             }
             pmix_show_help("help-oob-tcp.txt", "static-and-dynamic-ipv6", true,
                            (NULL == err4) ? "N/A" : err4, (NULL == err6) ? "N/A" : err6,
@@ -321,7 +321,7 @@ static int tcp_component_register(void)
         }
         pmix_util_parse_range_options(dyn_port_string6, &prte_mca_oob_tcp_component.tcp6_dyn_ports);
         if (0 == strcmp(prte_mca_oob_tcp_component.tcp6_dyn_ports[0], "-1")) {
-            pmix_argv_free(prte_mca_oob_tcp_component.tcp6_dyn_ports);
+            PMIX_ARGV_FREE_COMPAT(prte_mca_oob_tcp_component.tcp6_dyn_ports);
             prte_mca_oob_tcp_component.tcp6_dyn_ports = NULL;
         }
     } else {
@@ -437,7 +437,7 @@ static int component_available(void)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                 pmix_net_get_hostname((struct sockaddr *) &my_ss),
                                 (AF_INET == my_ss.ss_family) ? "V4" : "V6");
-            pmix_argv_append_nosize(&prte_mca_oob_tcp_component.ipv4conns,
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_oob_tcp_component.ipv4conns,
                                     pmix_net_get_hostname((struct sockaddr *) &my_ss));
         } else if (AF_INET6 == my_ss.ss_family) {
 #if PRTE_ENABLE_IPV6
@@ -446,7 +446,7 @@ static int component_available(void)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                 pmix_net_get_hostname((struct sockaddr *) &my_ss),
                                 (AF_INET == my_ss.ss_family) ? "V4" : "V6");
-            pmix_argv_append_nosize(&prte_mca_oob_tcp_component.ipv6conns,
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_oob_tcp_component.ipv6conns,
                                     pmix_net_get_hostname((struct sockaddr *) &my_ss));
 #endif // PRTE_ENABLE_IPV6
         } else {
@@ -478,13 +478,13 @@ static int component_available(void)
         copied_interface->ifmtu = selected_interface->ifmtu;
         /* Add the if_mask to the list */
         sprintf(string, "%d", selected_interface->if_mask);
-        pmix_argv_append_nosize(&prte_mca_oob_tcp_component.if_masks, string);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_oob_tcp_component.if_masks, string);
         pmix_list_append(&prte_mca_oob_tcp_component.local_ifs, &(copied_interface->super));
     }
 
-    if (0 == pmix_argv_count(prte_mca_oob_tcp_component.ipv4conns)
+    if (0 == PMIX_ARGV_COUNT_COMPAT(prte_mca_oob_tcp_component.ipv4conns)
 #if PRTE_ENABLE_IPV6
-        && 0 == pmix_argv_count(prte_mca_oob_tcp_component.ipv6conns)
+        && 0 == PMIX_ARGV_COUNT_COMPAT(prte_mca_oob_tcp_component.ipv6conns)
 #endif
     ) {
         return PRTE_ERR_NOT_AVAILABLE;
@@ -569,9 +569,9 @@ static char *component_get_addr(void)
 
     if (!prte_mca_oob_tcp_component.disable_ipv4_family &&
         NULL != prte_mca_oob_tcp_component.ipv4conns) {
-        tmp = pmix_argv_join(prte_mca_oob_tcp_component.ipv4conns, ',');
-        tp = pmix_argv_join(prte_mca_oob_tcp_component.ipv4ports, ',');
-        tm = pmix_argv_join(prte_mca_oob_tcp_component.if_masks, ',');
+        tmp = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.ipv4conns, ',');
+        tp = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.ipv4ports, ',');
+        tm = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.if_masks, ',');
         pmix_asprintf(&cptr, "tcp://%s:%s:%s", tmp, tp, tm);
         free(tmp);
         free(tp);
@@ -592,9 +592,9 @@ static char *component_get_addr(void)
          * an implementation may use an optional version flag to indicate such a format
          * explicitly rather than rely on heuristic determination.
          */
-        tmp = pmix_argv_join(prte_mca_oob_tcp_component.ipv6conns, ',');
-        tp = pmix_argv_join(prte_mca_oob_tcp_component.ipv6ports, ',');
-        tm = pmix_argv_join(prte_mca_oob_tcp_component.if_masks, ',');
+        tmp = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.ipv6conns, ',');
+        tp = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.ipv6ports, ',');
+        tm = PMIX_ARGV_JOIN_COMPAT(prte_mca_oob_tcp_component.if_masks, ',');
         if (NULL == cptr) {
             /* no ipv4 stuff */
             pmix_asprintf(&cptr, "tcp6://[%s]:%s:%s", tmp, tp, tm);
@@ -710,7 +710,7 @@ static int component_set_addr(pmix_proc_t *peer, char **uris)
         }
         *masks_string = '\0';
         masks_string++;
-        masks = pmix_argv_split(masks_string, ',');
+        masks = PMIX_ARGV_SPLIT_COMPAT(masks_string, ',');
 
         /* separate the ports from the network addrs */
         ports = strrchr(tcpuri, ':');
@@ -738,7 +738,7 @@ static int component_set_addr(pmix_proc_t *peer, char **uris)
             }
         }
 #endif // PRTE_ENABLE_IPV6
-        addrs = pmix_argv_split(hptr, ',');
+        addrs = PMIX_ARGV_SPLIT_COMPAT(hptr, ',');
 
         /* cycle across the provided addrs */
         for (j = 0; NULL != addrs[j]; j++) {
@@ -802,7 +802,7 @@ static int component_set_addr(pmix_proc_t *peer, char **uris)
 
             found = true;
         }
-        pmix_argv_free(addrs);
+        PMIX_ARGV_FREE_COMPAT(addrs);
         free(tcpuri);
     }
     if (found) {

--- a/src/mca/oob/tcp/oob_tcp_listener.c
+++ b/src/mca/oob/tcp/oob_tcp_listener.c
@@ -196,16 +196,16 @@ static int create_listen(void)
         /* if static ports were provided, take the
          * first entry in the list
          */
-        pmix_argv_append_nosize(&ports, prte_mca_oob_tcp_component.tcp_static_ports[0]);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_mca_oob_tcp_component.tcp_static_ports[0]);
         /* flag that we are using static ports */
         prte_static_ports = true;
     } else if (NULL != prte_mca_oob_tcp_component.tcp_dyn_ports) {
         /* take the entire range */
-        ports = pmix_argv_copy(prte_mca_oob_tcp_component.tcp_dyn_ports);
+        ports = PMIX_ARGV_COPY_COMPAT(prte_mca_oob_tcp_component.tcp_dyn_ports);
         prte_static_ports = false;
     } else {
         /* flag the system to dynamically take any available port */
-        pmix_argv_append_nosize(&ports, "0");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
         prte_static_ports = false;
     }
 
@@ -225,7 +225,7 @@ static int create_listen(void)
      * one socket, but that prun and daemons will have multiple
      * sockets to support more flexible wireup protocols
      */
-    for (i = 0; i < pmix_argv_count(ports); i++) {
+    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ports); i++) {
         pmix_output_verbose(5, prte_oob_base_framework.framework_output,
                             "%s attempting to bind to IPv4 port %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ports[i]);
@@ -243,7 +243,7 @@ static int create_listen(void)
                 pmix_output(0, "prte_mca_oob_tcp_component_init: socket() failed: %s (%d)",
                             strerror(prte_socket_errno), prte_socket_errno);
             }
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERR_IN_ERRNO;
         }
 
@@ -259,7 +259,7 @@ static int create_listen(void)
                         "SO_REUSEADDR option (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -271,7 +271,7 @@ static int create_listen(void)
                         "listening socket to CLOEXEC (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -283,7 +283,7 @@ static int create_listen(void)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) ntohs(port),
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
         /* resolve assigned port */
@@ -291,7 +291,7 @@ static int create_listen(void)
             pmix_output(0, "prte_oob_tcp_create_listen: getsockname(): %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -300,7 +300,7 @@ static int create_listen(void)
             pmix_output(0, "prte_mca_oob_tcp_component_init: listen(): %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -309,7 +309,7 @@ static int create_listen(void)
             pmix_output(0, "prte_mca_oob_tcp_component_init: fcntl(F_GETFL) failed: %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
         flags |= O_NONBLOCK;
@@ -317,7 +317,7 @@ static int create_listen(void)
             pmix_output(0, "prte_mca_oob_tcp_component_init: fcntl(F_SETFL) failed: %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -332,7 +332,7 @@ static int create_listen(void)
         pmix_list_append(&prte_mca_oob_tcp_component.listeners, &conn->item);
         /* and to our ports */
         pmix_asprintf(&tconn, "%d", ntohs(((struct sockaddr_in *) &inaddr)->sin_port));
-        pmix_argv_append_nosize(&prte_mca_oob_tcp_component.ipv4ports, tconn);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_oob_tcp_component.ipv4ports, tconn);
         free(tconn);
         if (OOB_TCP_DEBUG_CONNECT
             <= pmix_output_get_verbosity(prte_oob_base_framework.framework_output)) {
@@ -346,7 +346,7 @@ static int create_listen(void)
         }
     }
     /* done with this, so release it */
-    pmix_argv_free(ports);
+    PMIX_ARGV_FREE_COMPAT(ports);
 
     if (0 == pmix_list_get_size(&prte_mca_oob_tcp_component.listeners)) {
         /* cleanup */
@@ -389,16 +389,16 @@ static int create_listen6(void)
             /* if static ports were provided, take the
              * first entry in the list
              */
-            pmix_argv_append_nosize(&ports, prte_mca_oob_tcp_component.tcp6_static_ports[0]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_mca_oob_tcp_component.tcp6_static_ports[0]);
             /* flag that we are using static ports */
             prte_static_ports = true;
         } else if (NULL != prte_mca_oob_tcp_component.tcp6_dyn_ports) {
             /* take the entire range */
-            ports = pmix_argv_copy(prte_mca_oob_tcp_component.tcp6_dyn_ports);
+            ports = PMIX_ARGV_COPY_COMPAT(prte_mca_oob_tcp_component.tcp6_dyn_ports);
             prte_static_ports = false;
         } else {
             /* flag the system to dynamically take any available port */
-            pmix_argv_append_nosize(&ports, "0");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
             prte_static_ports = false;
         }
     } else {
@@ -406,16 +406,16 @@ static int create_listen6(void)
             /* if static ports were provided, take the
              * first entry in the list
              */
-            pmix_argv_append_nosize(&ports, prte_mca_oob_tcp_component.tcp6_static_ports[0]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_mca_oob_tcp_component.tcp6_static_ports[0]);
             /* flag that we are using static ports */
             prte_static_ports = true;
         } else if (NULL != prte_mca_oob_tcp_component.tcp6_dyn_ports) {
             /* take the entire range */
-            ports = pmix_argv_copy(prte_mca_oob_tcp_component.tcp6_dyn_ports);
+            ports = PMIX_ARGV_COPY_COMPAT(prte_mca_oob_tcp_component.tcp6_dyn_ports);
             prte_static_ports = false;
         } else {
             /* flag the system to dynamically take any available port */
-            pmix_argv_append_nosize(&ports, "0");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
             prte_static_ports = false;
         }
     }
@@ -436,7 +436,7 @@ static int create_listen6(void)
      * one socket, but that prun and daemons will have multiple
      * sockets to support more flexible wireup protocols
      */
-    for (i = 0; i < pmix_argv_count(ports); i++) {
+    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ports); i++) {
         pmix_output_verbose(5, prte_oob_base_framework.framework_output,
                             "%s attempting to bind to IPv6 port %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ports[i]);
@@ -464,7 +464,7 @@ static int create_listen6(void)
                         "listening socket to CLOEXEC (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -480,7 +480,7 @@ static int create_listen6(void)
                         "SO_REUSEADDR option (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
 
@@ -492,7 +492,7 @@ static int create_listen6(void)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) ntohs(port),
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            pmix_argv_free(ports);
+            PMIX_ARGV_FREE_COMPAT(ports);
             return PRTE_ERROR;
         }
         /* resolve assigned port */
@@ -531,7 +531,7 @@ static int create_listen6(void)
         pmix_list_append(&prte_mca_oob_tcp_component.listeners, &conn->item);
         /* and to our ports */
         pmix_asprintf(&tconn, "%d", ntohs(((struct sockaddr_in6 *) &inaddr)->sin6_port));
-        pmix_argv_append_nosize(&prte_mca_oob_tcp_component.ipv6ports, tconn);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_oob_tcp_component.ipv6ports, tconn);
         free(tconn);
         if (OOB_TCP_DEBUG_CONNECT
             <= pmix_output_get_verbosity(prte_oob_base_framework.framework_output)) {
@@ -547,12 +547,12 @@ static int create_listen6(void)
     if (0 == pmix_list_get_size(&prte_mca_oob_tcp_component.listeners)) {
         /* cleanup */
         CLOSE_THE_SOCKET(sd);
-        pmix_argv_free(ports);
+        PMIX_ARGV_FREE_COMPAT(ports);
         return PRTE_ERR_SOCKET_NOT_AVAILABLE;
     }
 
     /* done with this, so release it */
-    pmix_argv_free(ports);
+    PMIX_ARGV_FREE_COMPAT(ports);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -255,12 +255,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* Append user defined arguments to aprun */
     if (NULL != prte_mca_plm_alps_component.custom_args) {
-        custom_strings = pmix_argv_split(prte_mca_plm_alps_component.custom_args, ' ');
-        num_args = pmix_argv_count(custom_strings);
+        custom_strings = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_alps_component.custom_args, ' ');
+        num_args = PMIX_ARGV_COUNT_COMPAT(custom_strings);
         for (i = 0; i < num_args; ++i) {
             pmix_argv_append(&argc, &argv, custom_strings[i]);
         }
-        pmix_argv_free(custom_strings);
+        PMIX_ARGV_FREE_COMPAT(custom_strings);
     }
 
     /* number of processors needed */
@@ -313,13 +313,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
              */
             pmix_argv_append(&nodelist_argc, &nodelist_argv, node->name);
         }
-        if (0 == pmix_argv_count(nodelist_argv)) {
+        if (0 == PMIX_ARGV_COUNT_COMPAT(nodelist_argv)) {
             pmix_show_help("help-plm-alps.txt", "no-hosts-in-list", true);
             rc = PRTE_ERR_FAILED_TO_START;
             goto cleanup;
         }
-        nodelist_flat = pmix_argv_join(nodelist_argv, ',');
-        pmix_argv_free(nodelist_argv);
+        nodelist_flat = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, ',');
+        PMIX_ARGV_FREE_COMPAT(nodelist_argv);
 
         pmix_argv_append(&argc, &argv, "-L");
         pmix_argv_append(&argc, &argv, nodelist_flat);
@@ -350,7 +350,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     free(vpid_string);
 
     if (prte_mca_plm_alps_component.debug) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         if (NULL != param) {
             pmix_output(0, "plm:alps: final top-level argv:");
             pmix_output(0, "plm:alps:     %s", param);
@@ -398,10 +398,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_wrap_args(argv);
 
     /* setup environment */
-    env = pmix_argv_copy(prte_launch_environ);
+    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:alps: final top-level argv:\n\t%s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (NULL == param) ? "NULL" : param));
@@ -424,10 +424,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
 cleanup:
     if (NULL != argv) {
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
     }
     if (NULL != env) {
-        pmix_argv_free(env);
+        PMIX_ARGV_FREE_COMPAT(env);
     }
 
     /* check for failed launch - if so, force terminate */
@@ -584,7 +584,7 @@ static int plm_alps_start_proc(int argc, char **argv, char **env, char *prefix)
             } else {
                 pmix_asprintf(&newenv, "%s/%s", prefix, bin_base);
             }
-            pmix_setenv("PATH", newenv, true, &env);
+            PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
             if (prte_mca_plm_alps_component.debug) {
                 pmix_output(0, "plm:alps: reset PATH: %s", newenv);
             }
@@ -597,7 +597,7 @@ static int plm_alps_start_proc(int argc, char **argv, char **env, char *prefix)
             } else {
                 pmix_asprintf(&newenv, "%s/%s", prefix, lib_base);
             }
-            pmix_setenv("LD_LIBRARY_PATH", newenv, true, &env);
+            PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
             if (prte_mca_plm_alps_component.debug) {
                 pmix_output(0, "plm:alps: reset LD_LIBRARY_PATH: %s", newenv);
             }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -377,14 +377,14 @@ static void stack_trace_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t
         pmix_asprintf(&st, "STACK TRACE FOR PROC %s (%s, PID %lu)\n",
                       PRTE_NAME_PRINT(&name), hostname,
                       (unsigned long) pid);
-        pmix_argv_append_nosize(&jdata->traces, st);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->traces, st);
         free(hostname);
         free(st);
         /* unpack the stack_trace until complete */
         cnt = 1;
         while (PRTE_SUCCESS == (rc = PMIx_Data_unpack(NULL, &blob, &st, &cnt, PMIX_STRING))) {
             pmix_asprintf(&st2, "\t%s", st); // has its own newline
-            pmix_argv_append_nosize(&jdata->traces, st2);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->traces, st2);
             free(st);
             free(st2);
             cnt = 1;
@@ -907,7 +907,7 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
                 free(name);
             }
             /* pass the argv from each app */
-            name = pmix_argv_join(app->argv, ' ');
+            name = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
             PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_APP_ARGV, name, PMIX_STRING);
             free(name);
         }
@@ -1392,7 +1392,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             NULL != (ptr = strchr(nodename, '.'))) {
             /* retain the non-fqdn name as an alias */
             *ptr = '\0';
-            pmix_argv_append_unique_nosize(&daemon->node->aliases, nodename);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&daemon->node->aliases, nodename);
             *ptr = '.';
         }
 
@@ -1414,7 +1414,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
          * and apps may refer to the host by that name
          */
         if (0 != strcmp(nodename, daemon->node->name)) {
-            pmix_argv_append_unique_nosize(&daemon->node->aliases, daemon->node->name);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&daemon->node->aliases, daemon->node->name);
             free(daemon->node->name);
             daemon->node->name = strdup(nodename);
         }
@@ -1435,7 +1435,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                 prted_failed_launch = true;
                 goto CLEANUP;
             }
-            pmix_argv_append_unique_nosize(&daemon->node->aliases, alias);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&daemon->node->aliases, alias);
             free(alias);
         }
 
@@ -1688,7 +1688,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                         goto CLEANUP;
                     }
                     /* track that we requested it */
-                    pmix_argv_append_nosize(&prte_plm_globals.cache, dptr->node->topology->sig);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_plm_globals.cache, dptr->node->topology->sig);
                 }
             }
             /* transfer back any cached items */
@@ -1773,7 +1773,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                     goto CLEANUP;
                 }
                 /* record that it was sent */
-                pmix_argv_append_nosize(&prte_plm_globals.cache, daemon->node->topology->sig);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_plm_globals.cache, daemon->node->topology->sig);
             }
             /* we will count this node as completed
              * when we get the full topology back */
@@ -1906,14 +1906,14 @@ int prte_plm_base_setup_prted_cmd(int *argc, char ***argv)
      */
     loc = 0;
     /* split the command apart in case it is multi-word */
-    tmpv = pmix_argv_split(prte_launch_agent, ' ');
+    tmpv = PMIX_ARGV_SPLIT_COMPAT(prte_launch_agent, ' ');
     for (i = 0; NULL != tmpv && NULL != tmpv[i]; ++i) {
         if (0 == strcmp(tmpv[i], "prted")) {
             loc = i;
         }
         pmix_argv_append(argc, argv, tmpv[i]);
     }
-    pmix_argv_free(tmpv);
+    PMIX_ARGV_FREE_COMPAT(tmpv);
 
     return loc;
 }
@@ -2003,7 +2003,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     for (i=0; NULL != environ[i]; i++) {
         if (0 == strncmp(environ[i], "PMIX_MCA_", offset) ||
             0 == strncmp(environ[i], "PRTE_MCA_", offset)) {
-            tmpv = pmix_argv_split(environ[i], '=');
+            tmpv = PMIX_ARGV_SPLIT_COMPAT(environ[i], '=');
             /* check for duplicate */
             ignore = false;
             for (j = 0; j < *argc; j++) {
@@ -2022,7 +2022,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
                 pmix_argv_append(argc, argv, &tmpv[0][offset]);
                 pmix_argv_append(argc, argv, tmpv[1]);
             }
-            pmix_argv_free(tmpv);
+            PMIX_ARGV_FREE_COMPAT(tmpv);
         }
     }
 
@@ -2030,7 +2030,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
      * being sure to "purge" any that would cause problems
      * on backend nodes and ignoring all duplicates
      */
-    cnt = pmix_argv_count(prted_cmd_line);
+    cnt = PMIX_ARGV_COUNT_COMPAT(prted_cmd_line);
     for (i = 0; i < cnt; i += 3) {
         /* if the specified option is more than one word, we don't
          * have a generic way of passing it as some environments ignore
@@ -2608,7 +2608,7 @@ process:
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
-        PMIX_LOAD_NSPACE(&proc->name, PRTE_PROC_MY_NAME->nspace);
+        PMIX_LOAD_NSPACE(proc->name.nspace, PRTE_PROC_MY_NAME->nspace);
         if (PMIX_RANK_VALID - 1 <= daemons->num_procs) {
             /* no more daemons available */
             pmix_show_help("help-prte-rmaps-base.txt", "out-of-vpids", true);

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -211,9 +211,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
 
         /* assign a schizo module */
         if (NULL == jdata->personality) {
-            pmix_argv_append_nosize(&jdata->personality, "prte");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->personality, "prte");
         }
-        tmp = pmix_argv_join(jdata->personality, ',');
+        tmp = PMIX_ARGV_JOIN_COMPAT(jdata->personality, ',');
         jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(tmp);
         if (NULL == jdata->schizo) {
             pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, tmp);
@@ -278,7 +278,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
                     continue;
                 }
                 env = pmix_environ_merge(prte_forwarded_envars, app->env);
-                pmix_argv_free(app->env);
+                PMIX_ARGV_FREE_COMPAT(app->env);
                 app->env = env;
             }
         }

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -290,7 +290,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_wrap_args(argv);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         if (NULL != param) {
             pmix_output(0, "plm:lsf: final top-level argv:");
             pmix_output(0, "plm:lsf:     %s", param);
@@ -341,7 +341,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     }
 
     /* setup environment */
-    env = pmix_argv_copy(prte_launch_environ);
+    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
 
     /* lsb_launch tampers with SIGCHLD.
      * After the call to lsb_launch, the signal handler for SIGCHLD is NULL.
@@ -359,9 +359,9 @@ static void launch_daemons(int fd, short args, void *cbdata)
     if ((rc = lsb_launch(nodelist_argv, argv, LSF_DJOB_REPLACE_ENV | LSF_DJOB_NOWAIT, env)) < 0) {
         PRTE_ERROR_LOG(PRTE_ERR_FAILED_TO_START);
         char *flattened_nodelist = NULL;
-        flattened_nodelist = pmix_argv_join(nodelist_argv, '\n');
+        flattened_nodelist = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, '\n');
         pmix_show_help("help-plm-lsf.txt", "lsb_launch-failed", true, rc, lsberrno, lsb_sysmsg(),
-                       pmix_argv_count(nodelist_argv), flattened_nodelist);
+                       PMIX_ARGV_COUNT_COMPAT(nodelist_argv), flattened_nodelist);
         free(flattened_nodelist);
         rc = PRTE_ERR_FAILED_TO_START;
         prte_wait_enable(); /* re-enable our SIGCHLD handler */
@@ -378,10 +378,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
 cleanup:
     if (NULL != argv) {
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
     }
     if (NULL != env) {
-        pmix_argv_free(env);
+        PMIX_ARGV_FREE_COMPAT(env);
     }
 
     /* check for failed launch - if so, force terminate */

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -296,12 +296,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* Append user defined arguments to srun */
     if (NULL != prte_mca_plm_slurm_component.custom_args) {
-        custom_strings = pmix_argv_split(prte_mca_plm_slurm_component.custom_args, ' ');
-        num_args = pmix_argv_count(custom_strings);
+        custom_strings = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_slurm_component.custom_args, ' ');
+        num_args = PMIX_ARGV_COUNT_COMPAT(custom_strings);
         for (i = 0; i < num_args; ++i) {
             pmix_argv_append(&argc, &argv, custom_strings[i]);
         }
-        pmix_argv_free(custom_strings);
+        PMIX_ARGV_FREE_COMPAT(custom_strings);
     }
 
     /* create nodelist */
@@ -321,15 +321,15 @@ static void launch_daemons(int fd, short args, void *cbdata)
         /* otherwise, add it to the list of nodes upon which
          * we need to launch a daemon
          */
-        pmix_argv_append_nosize(&nodelist_argv, node->name);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nodelist_argv, node->name);
     }
-    if (0 == pmix_argv_count(nodelist_argv)) {
+    if (0 == PMIX_ARGV_COUNT_COMPAT(nodelist_argv)) {
         pmix_show_help("help-plm-slurm.txt", "no-hosts-in-list", true);
         rc = PRTE_ERR_FAILED_TO_START;
         goto cleanup;
     }
-    nodelist_flat = pmix_argv_join(nodelist_argv, ',');
-    pmix_argv_free(nodelist_argv);
+    nodelist_flat = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, ',');
+    PMIX_ARGV_FREE_COMPAT(nodelist_argv);
 
     /* if we are using all allocated nodes, then srun doesn't
      * require any further arguments
@@ -424,7 +424,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_wrap_args(argv);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         pmix_output(prte_plm_base_framework.framework_output,
                     "%s plm:slurm: final top-level argv:\n\t%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                     (NULL == param) ? "NULL" : param);
@@ -447,7 +447,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
 cleanup:
     if (NULL != argv) {
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
     }
     if (NULL != cur_prefix) {
         free(cur_prefix);
@@ -668,7 +668,7 @@ static int plm_slurm_start_proc(int argc, char **argv, char *prefix)
         for (n=0; NULL != environ[n]; n++) {
             if (0 == strncmp(environ[n], "PMIX_", 5) ||
                 0 == strncmp(environ[n], "PRTE_", 5)) {
-                pmix_argv_append_nosize(&tmp, environ[n]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, environ[n]);
             }
         }
         if (NULL != tmp) {
@@ -677,7 +677,7 @@ static int plm_slurm_start_proc(int argc, char **argv, char *prefix)
                 *p = '\0';
                 unsetenv(tmp[n]);
             }
-            pmix_argv_free(tmp);
+            PMIX_ARGV_FREE_COMPAT(tmp);
         }
 
         /* Figure out the basenames for the libdir and bindir.  There

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -348,9 +348,9 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
         pmix_string_copy(cwd, path, PRTE_PATH_MAX);
     }
     if (NULL == agent_list) {
-        lines = pmix_argv_split(prte_mca_plm_ssh_component.agent, ':');
+        lines = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_ssh_component.agent, ':');
     } else {
-        lines = pmix_argv_split(agent_list, ':');
+        lines = PMIX_ARGV_SPLIT_COMPAT(agent_list, ':');
     }
     for (i = 0; NULL != lines[i]; ++i) {
         line = lines[i];
@@ -367,23 +367,23 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
         }
 
         /* Split it */
-        tokens = pmix_argv_split(line, ' ');
+        tokens = PMIX_ARGV_SPLIT_COMPAT(line, ' ');
 
         /* Look for the first token in the PATH */
         tmp = pmix_path_findv(tokens[0], X_OK, environ, cwd);
         if (NULL != tmp) {
             free(tokens[0]);
             tokens[0] = tmp;
-            pmix_argv_free(lines);
+            PMIX_ARGV_FREE_COMPAT(lines);
             return tokens;
         }
 
         /* Didn't find it */
-        pmix_argv_free(tokens);
+        PMIX_ARGV_FREE_COMPAT(tokens);
     }
 
     /* Doh -- didn't find anything */
-    pmix_argv_free(lines);
+    PMIX_ARGV_FREE_COMPAT(lines);
     return NULL;
 }
 
@@ -422,7 +422,7 @@ static int ssh_launch_agent_lookup(const char *agent_list, char *path)
     if (0 == strcmp(bname, "ssh")) {
         /* if xterm option was given, add '-X', ensuring we don't do it twice */
         if (NULL != prte_xterm) {
-            pmix_argv_append_unique_nosize(&prte_mca_plm_ssh_component.agent_argv, "-X");
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_mca_plm_ssh_component.agent_argv, "-X");
         } else if (0 >= pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
             /* if debug was not specified, and the user didn't explicitly
              * specify X11 forwarding/non-forwarding, add "-x" if it
@@ -434,7 +434,7 @@ static int ssh_launch_agent_lookup(const char *agent_list, char *path)
                 }
             }
             if (NULL == prte_mca_plm_ssh_component.agent_argv[i]) {
-                pmix_argv_append_nosize(&prte_mca_plm_ssh_component.agent_argv, "-x");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_plm_ssh_component.agent_argv, "-x");
             }
         }
     }

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -130,7 +130,7 @@ static void caddy_const(prte_plm_ssh_caddy_t *ptr)
 static void caddy_dest(prte_plm_ssh_caddy_t *ptr)
 {
     if (NULL != ptr->argv) {
-        pmix_argv_free(ptr->argv);
+        PMIX_ARGV_FREE_COMPAT(ptr->argv);
     }
     if (NULL != ptr->daemon) {
         PMIX_RELEASE(ptr->daemon);
@@ -192,14 +192,14 @@ static int ssh_init(void)
         }
         free(tmp);
         /* automatically add -inherit and grid engine PE related flags */
-        pmix_argv_append_nosize(&ssh_agent_argv, "-inherit");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-inherit");
         /* Don't use the "-noshell" flag as qrsh would have a problem
          * swallowing a long command */
-        pmix_argv_append_nosize(&ssh_agent_argv, "-nostdin");
-        pmix_argv_append_nosize(&ssh_agent_argv, "-V");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-nostdin");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-V");
         if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-            pmix_argv_append_nosize(&ssh_agent_argv, "-verbose");
-            tmp = pmix_argv_join(ssh_agent_argv, ' ');
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-verbose");
+            tmp = PMIX_ARGV_JOIN_COMPAT(ssh_agent_argv, ' ');
             pmix_output_verbose(1, prte_plm_base_framework.framework_output,
                                 "%s plm:ssh: using \"%s\" for launching\n",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), tmp);
@@ -384,16 +384,16 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     /*
      * Build argv array
      */
-    argv = pmix_argv_copy(ssh_agent_argv);
-    argc = pmix_argv_count(argv);
+    argv = PMIX_ARGV_COPY_COMPAT(ssh_agent_argv);
+    argc = PMIX_ARGV_COUNT_COMPAT(argv);
     /* if any ssh args were provided, now is the time to add them */
     if (NULL != prte_mca_plm_ssh_component.ssh_args) {
         char **ssh_argv;
-        ssh_argv = pmix_argv_split(prte_mca_plm_ssh_component.ssh_args, ' ');
+        ssh_argv = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_ssh_component.ssh_args, ' ');
         for (i = 0; NULL != ssh_argv[i]; i++) {
             pmix_argv_append(&argc, &argv, ssh_argv[i]);
         }
-        pmix_argv_free(ssh_argv);
+        PMIX_ARGV_FREE_COMPAT(ssh_argv);
     }
     *node_name_index1 = argc;
     pmix_argv_append(&argc, &argv, "<template>");
@@ -443,21 +443,21 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
          * However, we don't need/want a prefix as nothing precedes the orted
          * cmd itself
          */
-        orted_cmd = pmix_argv_join(orted_argv, ' ');
+        orted_cmd = PMIX_ARGV_JOIN_COMPAT(orted_argv, ' ');
         orted_prefix = NULL;
     } else {
         /* okay, so the "orted" cmd is somewhere in this array, with
          * something preceding it and perhaps things following it.
          */
         orted_prefix = pmix_argv_join_range(orted_argv, 0, orted_index, ' ');
-        orted_cmd = pmix_argv_join_range(orted_argv, orted_index, pmix_argv_count(orted_argv), ' ');
+        orted_cmd = pmix_argv_join_range(orted_argv, orted_index, PMIX_ARGV_COUNT_COMPAT(orted_argv), ' ');
     }
-    pmix_argv_free(orted_argv); /* done with this */
+    PMIX_ARGV_FREE_COMPAT(orted_argv); /* done with this */
 
     /* if they asked us to change directory, do so */
     if (NULL != prte_mca_plm_ssh_component.chdir) {
         pmix_asprintf(&tmp, "cd %s", prte_mca_plm_ssh_component.chdir);
-        pmix_argv_append_nosize(&final_argv, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
         free(tmp);
     }
 
@@ -469,13 +469,13 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             PRTE_PLM_SSH_SHELL_ZSH == remote_shell ||
             PRTE_PLM_SSH_SHELL_BASH == remote_shell) {
             pmix_asprintf(&tmp, "PRTE_PREFIX=%s", prefix_dir);
-            pmix_argv_append_nosize(&final_argv, tmp);
-            pmix_argv_append_nosize(&final_argv, "export PRTE_PREFIX");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export PRTE_PREFIX");
             free(tmp);
             if (NULL != (param = getenv("PMIX_PREFIX"))) {
                 pmix_asprintf(&tmp, "PMIX_PREFIX=%s", param);
-                pmix_argv_append_nosize(&final_argv, tmp);
-                pmix_argv_append_nosize(&final_argv, "export PMIX_PREFIX");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export PMIX_PREFIX");
                 free(tmp);
                 pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s/%s:%s/%s:$LD_LIBRARY_PATH",
                               prefix_dir, value, param, value2);
@@ -483,8 +483,8 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s/%s:%s:$LD_LIBRARY_PATH",
                               prefix_dir, value, pmix_pinstall_dirs.libdir);
             }
-            pmix_argv_append_nosize(&final_argv, tmp);
-            pmix_argv_append_nosize(&final_argv, "export LD_LIBRARY_PATH");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export LD_LIBRARY_PATH");
             free(tmp);
             if (NULL != param) {
                 pmix_asprintf(&tmp, "DYLD_LIBRARY_PATH=%s/%s:%s/%s:$DYLD_LIBRARY_PATH",
@@ -493,8 +493,8 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "DYLD_LIBRARY_PATH=%s/%s:%s:$DYLD_LIBRARY_PATH",
                               prefix_dir, value, pmix_pinstall_dirs.libdir);
             }
-            pmix_argv_append_nosize(&final_argv, tmp);
-            pmix_argv_append_nosize(&final_argv, "export DYLD_LIBRARY_PATH");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export DYLD_LIBRARY_PATH");
             free(tmp);
         } else {
             /* [t]csh is a bit more challenging -- we
@@ -510,14 +510,14 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
              * we have to insert the orted_prefix in the right place
              */
             pmix_asprintf(&tmp, "setenv PRTE_PREFIX %s", prefix_dir);
-            pmix_argv_append_nosize(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
             free(tmp);
             if (NULL != (param = getenv("PMIX_PREFIX"))) {
                 pmix_asprintf(&tmp, "setenv PMIX_PREFIX %s", param);
-                pmix_argv_append_nosize(&final_argv, tmp);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
                 free(tmp);
             }
-            pmix_argv_append_nosize(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
             if (NULL != param) {
                 pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s/%s:%s/%s",
                               prefix_dir, value, param, value2);
@@ -525,7 +525,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s/%s:%s",
                               prefix_dir, value, pmix_pinstall_dirs.libdir);
             }
-            pmix_argv_append_nosize(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
             free(tmp);
             if (NULL != param) {
                 pmix_asprintf(&tmp, "if ( $?PRTE_have_llp == 1 ) setenv LD_LIBRARY_PATH %s/%s:%s/%s:$LD_LIBRARY_PATH",
@@ -534,7 +534,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "if ( $?PRTE_have_llp == 1 ) setenv LD_LIBRARY_PATH %s/%s:%s:$LD_LIBRARY_PATH",
                               prefix_dir, value, pmix_pinstall_dirs.libdir);
             }
-            pmix_argv_append_nosize(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
             free(tmp);
         }
         free(value);
@@ -550,12 +550,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             PRTE_PLM_SSH_SHELL_ZSH == remote_shell ||
             PRTE_PLM_SSH_SHELL_BASH == remote_shell) {
             pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            pmix_argv_append_nosize(&final_argv, tmp);
-            pmix_argv_append_nosize(&final_argv, "export LD_LIBRARY_PATH");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export LD_LIBRARY_PATH");
             free(tmp);
             pmix_asprintf(&tmp, "DYLD_LIBRARY_PATH=%s:$DYLD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            pmix_argv_append_nosize(&final_argv, tmp);
-            pmix_argv_append_nosize(&final_argv, "export DYLD_LIBRARY_PATH");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export DYLD_LIBRARY_PATH");
             free(tmp);
         } else {
             /* [t]csh is a bit more challenging -- we
@@ -570,12 +570,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
              * assemble the cmd with the orted_cmd at the end. Otherwise,
              * we have to insert the orted_prefix in the right place
              */
-            pmix_argv_append_nosize(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
             pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s", prte_mca_plm_ssh_component.pass_libpath);
-            pmix_argv_append_nosize(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
             free(tmp);
             pmix_asprintf(&tmp, "if ( $?PRTE_have_llp == 1 ) setenv LD_LIBRARY_PATH %s:$LD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            pmix_argv_append_nosize(&final_argv, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
             free(tmp);
         }
     }
@@ -611,12 +611,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     } else {
         tmp = strdup(full_orted_cmd);
     }
-    pmix_argv_append_nosize(&final_argv, tmp);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
     free(full_orted_cmd);
 
     /* now add the final cmd to the argv array */
-    final_cmd = pmix_argv_join(final_argv, ';');
-    pmix_argv_free(final_argv);
+    final_cmd = PMIX_ARGV_JOIN_COMPAT(final_argv, ';');
+    PMIX_ARGV_FREE_COMPAT(final_argv);
     pmix_argv_append(&argc, &argv, final_cmd);
     free(final_cmd); /* done with this */
 
@@ -660,7 +660,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     /* protect the params */
     prte_plm_base_wrap_args(argv);
 
-    value = pmix_argv_join(argv, ' ');
+    value = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
     if (sysconf(_SC_ARG_MAX) < (int) strlen(value)) {
         pmix_show_help("help-plm-ssh.txt", "cmd-line-too-long", true, strlen(value),
                        sysconf(_SC_ARG_MAX));
@@ -674,7 +674,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     }
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         pmix_output(prte_plm_base_framework.framework_output,
                     "%s plm:ssh: final template argv:\n\t%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                     (NULL == param) ? "NULL" : param);
@@ -700,7 +700,7 @@ static void ssh_child(int argc, char **argv)
     PRTE_HIDE_UNUSED_PARAMS(argc);
 
     /* setup environment */
-    env = pmix_argv_copy(prte_launch_environ);
+    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
 
     /* We don't need to sense an oversubscribed condition and set the sched_yield
      * for the node as we are only launching the daemons at this time. The daemons
@@ -748,7 +748,7 @@ static void ssh_child(int argc, char **argv)
     sigprocmask(SIG_UNBLOCK, &sigs, 0);
 
     /* exec the daemon */
-    var = pmix_argv_join(argv, ' ');
+    var = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
     PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                          "%s plm:ssh: executing: (%s) [%s]", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          exec_path, (NULL == var) ? "NULL" : var));
@@ -840,7 +840,7 @@ static int remote_spawn(void)
         /* we are in an event, so no need to protect the list */
         caddy = PMIX_NEW(prte_plm_ssh_caddy_t);
         caddy->argc = argc;
-        caddy->argv = pmix_argv_copy(argv);
+        caddy->argv = PMIX_ARGV_COPY_COMPAT(argv);
         /* fake a proc structure for the new daemon - will be released
          * upon startup
          */
@@ -864,7 +864,7 @@ static int remote_spawn(void)
 
 cleanup:
     if (NULL != argv) {
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
     }
 
     /* check for failed launch */
@@ -1228,7 +1228,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         /* we are in an event, so no need to protect the list */
         caddy = PMIX_NEW(prte_plm_ssh_caddy_t);
         caddy->argc = argc;
-        caddy->argv = pmix_argv_copy(argv);
+        caddy->argv = PMIX_ARGV_COPY_COMPAT(argv);
         /* insert the alternate port if any */
         portptr = &port;
         if (prte_get_attribute(&node->attributes, PRTE_NODE_PORT, (void **) &portptr, PMIX_INT)) {
@@ -1261,7 +1261,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * function determine they are all alive and trigger the next stage
      */
     PMIX_RELEASE(state);
-    pmix_argv_free(argv);
+    PMIX_ARGV_FREE_COMPAT(argv);
     return;
 
 cleanup:
@@ -1327,8 +1327,8 @@ static int ssh_finalize(void)
     }
     free(prte_mca_plm_ssh_component.agent_path);
     free(ssh_agent_path);
-    pmix_argv_free(prte_mca_plm_ssh_component.agent_argv);
-    pmix_argv_free(ssh_agent_argv);
+    PMIX_ARGV_FREE_COMPAT(prte_mca_plm_ssh_component.agent_argv);
+    PMIX_ARGV_FREE_COMPAT(ssh_agent_argv);
 
     return rc;
 }
@@ -1390,7 +1390,7 @@ static int launch_agent_setup(const char *agent, char *path)
                          (NULL == path) ? "NULL" : path));
     ssh_agent_argv = prte_plm_ssh_search(agent, path);
 
-    if (0 == pmix_argv_count(ssh_agent_argv)) {
+    if (0 == PMIX_ARGV_COUNT_COMPAT(ssh_agent_argv)) {
         /* nothing was found */
         return PRTE_ERR_NOT_FOUND;
     }
@@ -1400,7 +1400,7 @@ static int launch_agent_setup(const char *agent, char *path)
 
     if (NULL == ssh_agent_path) {
         /* not an error - just report not found */
-        pmix_argv_free(ssh_agent_argv);
+        PMIX_ARGV_FREE_COMPAT(ssh_agent_argv);
         return PRTE_ERR_NOT_FOUND;
     }
 
@@ -1408,7 +1408,7 @@ static int launch_agent_setup(const char *agent, char *path)
     if (NULL != bname && 0 == strcmp(bname, "ssh")) {
         /* if xterm option was given, add '-X', ensuring we don't do it twice */
         if (NULL != prte_xterm) {
-            pmix_argv_append_unique_nosize(&ssh_agent_argv, "-X");
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&ssh_agent_argv, "-X");
         } else if (0 >= pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
             /* if debug was not specified, and the user didn't explicitly
              * specify X11 forwarding/non-forwarding, add "-x" if it
@@ -1420,7 +1420,7 @@ static int launch_agent_setup(const char *agent, char *path)
                 }
             }
             if (NULL == ssh_agent_argv[i]) {
-                pmix_argv_append_nosize(&ssh_agent_argv, "-x");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-x");
             }
         }
     }
@@ -1467,8 +1467,8 @@ static int ssh_probe(char *nodename, prte_plm_ssh_shell_t *shell)
             exit(01);
         }
         /* Build argv array */
-        argv = pmix_argv_copy(prte_mca_plm_ssh_component.agent_argv);
-        argc = pmix_argv_count(prte_mca_plm_ssh_component.agent_argv);
+        argv = PMIX_ARGV_COPY_COMPAT(prte_mca_plm_ssh_component.agent_argv);
+        argc = PMIX_ARGV_COUNT_COMPAT(prte_mca_plm_ssh_component.agent_argv);
         pmix_argv_append(&argc, &argv, nodename);
         pmix_argv_append(&argc, &argv, "echo $SHELL");
 
@@ -1606,14 +1606,14 @@ static int setup_shell(prte_plm_ssh_shell_t *sshell, prte_plm_ssh_shell_t *lshel
     if (PRTE_PLM_SSH_SHELL_SH == remote_shell || PRTE_PLM_SSH_SHELL_KSH == remote_shell) {
         int i;
         char **tmp;
-        tmp = pmix_argv_split("( test ! -r ./.profile || . ./.profile;", ' ');
+        tmp = PMIX_ARGV_SPLIT_COMPAT("( test ! -r ./.profile || . ./.profile;", ' ');
         if (NULL == tmp) {
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         for (i = 0; NULL != tmp[i]; ++i) {
             pmix_argv_append(argc, argv, tmp[i]);
         }
-        pmix_argv_free(tmp);
+        PMIX_ARGV_FREE_COMPAT(tmp);
     }
 
     /* pass results back */

--- a/src/mca/plm/tm/plm_tm_component.c
+++ b/src/mca/plm/tm/plm_tm_component.c
@@ -103,7 +103,7 @@ static int plm_tm_open(void)
 static int plm_tm_close(void)
 {
     if (NULL != prte_mca_plm_tm_component.checked_paths) {
-        pmix_argv_free(prte_mca_plm_tm_component.checked_paths);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_plm_tm_component.checked_paths);
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -256,7 +256,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_prted_append_basic_args(&argc, &argv, "tm", &proc_vpid_index);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = pmix_argv_join(argv, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:tm: final top-level argv:\n\t%s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (NULL == param) ? "NULL" : param));
@@ -286,16 +286,16 @@ static void launch_daemons(int fd, short args, void *cbdata)
     bin_base = pmix_basename(prte_install_dirs.bindir);
 
     /* setup environment */
-    env = pmix_argv_copy(prte_launch_environ);
+    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
 
     /* enable local launch by the orteds */
-    pmix_setenv("PRTE_MCA_plm", "ssh", true, &env);
+    PMIX_SETENV_COMPAT("PRTE_MCA_plm", "ssh", true, &env);
 
     /* add our umask -- see big note in orted.c */
     current_umask = umask(0);
     umask(current_umask);
     pmix_asprintf(&var, "0%o", current_umask);
-    pmix_setenv("PRTE_DAEMON_UMASK_VALUE", var, true, &env);
+    PMIX_SETENV_COMPAT("PRTE_DAEMON_UMASK_VALUE", var, true, &env);
     free(var);
 
     /* If we have a prefix, then modify the PATH and
@@ -322,7 +322,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
                 PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                      "%s plm:tm: resetting PATH: %s",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
-                pmix_setenv("PATH", newenv, true, &env);
+                PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
                 free(newenv);
             }
 
@@ -332,7 +332,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
                 PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                      "%s plm:tm: resetting LD_LIBRARY_PATH: %s",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
-                pmix_setenv("LD_LIBRARY_PATH", newenv, true, &env);
+                PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
                 free(newenv);
             }
         }
@@ -368,7 +368,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
         /* exec the daemon */
         if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-            param = pmix_argv_join(argv, ' ');
+            param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
             PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                  "%s plm:tm: executing:\n\t%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  (NULL == param) ? "NULL" : param));

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_component.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_component.c
@@ -79,7 +79,7 @@ static int dlopen_component_register(void)
         return ret;
     }
     prte_mca_prtedl_dlopen_component.filename_suffixes
-        = pmix_argv_split(prte_mca_prtedl_dlopen_component.filename_suffixes_mca_storage, ',');
+        = PMIX_ARGV_SPLIT_COMPAT(prte_mca_prtedl_dlopen_component.filename_suffixes_mca_storage, ',');
 
     return PRTE_SUCCESS;
 }
@@ -92,7 +92,7 @@ static int dlopen_component_open(void)
 static int dlopen_component_close(void)
 {
     if (NULL != prte_mca_prtedl_dlopen_component.filename_suffixes) {
-        pmix_argv_free(prte_mca_prtedl_dlopen_component.filename_suffixes);
+        PMIX_ARGV_FREE_COMPAT(prte_mca_prtedl_dlopen_component.filename_suffixes);
         prte_mca_prtedl_dlopen_component.filename_suffixes = NULL;
     }
 

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
@@ -169,7 +169,7 @@ static int dlopen_foreachfile(const char *search_path,
     char **dirs = NULL;
     char **good_files = NULL;
 
-    dirs = pmix_argv_split(search_path, PRTE_ENV_SEP);
+    dirs = PMIX_ARGV_SPLIT_COMPAT(search_path, PRTE_ENV_SEP);
     for (int i = 0; NULL != dirs && NULL != dirs[i]; ++i) {
 
         dp = opendir(dirs[i]);
@@ -227,7 +227,7 @@ static int dlopen_foreachfile(const char *search_path,
             }
 
             if (!found) {
-                pmix_argv_append_nosize(&good_files, abs_name);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&good_files, abs_name);
             }
             free(abs_name);
         }
@@ -252,10 +252,10 @@ error:
         closedir(dp);
     }
     if (NULL != dirs) {
-        pmix_argv_free(dirs);
+        PMIX_ARGV_FREE_COMPAT(dirs);
     }
     if (NULL != good_files) {
-        pmix_argv_free(good_files);
+        PMIX_ARGV_FREE_COMPAT(good_files);
     }
 
     return ret;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -65,28 +65,28 @@ char *prte_ras_base_flag_string(prte_node_t *node)
     }
 
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
-        pmix_argv_append_nosize(&t2, "DAEMON_LAUNCHED");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "DAEMON_LAUNCHED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_LOC_VERIFIED)) {
-        pmix_argv_append_nosize(&t2, "LOCATION_VERIFIED");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "LOCATION_VERIFIED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
-        pmix_argv_append_nosize(&t2, "OVERSUBSCRIBED");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "OVERSUBSCRIBED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_MAPPED)) {
-        pmix_argv_append_nosize(&t2, "MAPPED");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "MAPPED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
-        pmix_argv_append_nosize(&t2, "SLOTS_GIVEN");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "SLOTS_GIVEN");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_NON_USABLE)) {
-        pmix_argv_append_nosize(&t2, "NONUSABLE");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "NONUSABLE");
     }
     if (NULL != t2) {
-        t3 = pmix_argv_join(t2, ':');
+        t3 = PMIX_ARGV_JOIN_COMPAT(t2, ':');
         pmix_asprintf(&tmp, "Flags: %s", t3);
         free(t3);
-        pmix_argv_free(t2);
+        PMIX_ARGV_FREE_COMPAT(t2);
     } else {
         tmp = strdup("Flags: NONE");
     }
@@ -127,7 +127,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
             flgs = prte_ras_base_flag_string(alloc);
             /* build the aliases string */
             if (NULL != alloc->aliases) {
-                aliases = pmix_argv_join(alloc->aliases, ',');
+                aliases = PMIX_ARGV_JOIN_COMPAT(alloc->aliases, ',');
             } else {
                 aliases = NULL;
             }
@@ -274,11 +274,11 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                 if (prte_keep_fqdn_hostnames) {
                     /* retain the non-fqdn name as an alias */
                     *ptr = '\0';
-                    pmix_argv_append_unique_nosize(&node->aliases, node->name);
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node->name);
                     *ptr = '.';
                 } else {
                     /* add the fqdn name as an alias */
-                    pmix_argv_append_unique_nosize(&node->aliases, node->name);
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node->name);
                     /* retain the non-fqdn name as the node's name */
                     *ptr = '\0';
                 }
@@ -420,11 +420,11 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), hosts));
 
             /* hostfile was specified - parse it and add it to the list */
-            hostlist = pmix_argv_split(hosts, ',');
+            hostlist = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
             free(hosts);
             for (j=0; NULL != hostlist[j]; j++) {
                 if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&nodes, hostlist[j]))) {
-                    pmix_argv_free(hostlist);
+                    PMIX_ARGV_FREE_COMPAT(hostlist);
                     PMIX_DESTRUCT(&nodes);
                     /* set an error event */
                     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
@@ -432,7 +432,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                     return;
                 }
             }
-            pmix_argv_free(hostlist);
+            PMIX_ARGV_FREE_COMPAT(hostlist);
         }
     }
 
@@ -553,7 +553,7 @@ next_state:
     jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO, (void**)&hosts, PMIX_STRING)) {
-        hostlist = pmix_argv_split(hosts, ',');
+        hostlist = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
         free(hosts);
         for (j=0; NULL != hostlist[j]; j++) {
             node = prte_node_match(NULL, hostlist[j]);
@@ -569,7 +569,7 @@ next_state:
             pmix_output(prte_clean_output,
                         "=================================================================\n");
         }
-        pmix_argv_free(hostlist);
+        PMIX_ARGV_FREE_COMPAT(hostlist);
     }
 
     /* set the job state to the next position */

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -148,7 +148,7 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 PRTE_FLAG_UNSET(hnp_node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             }
             /* if the node name is different, store it as an alias */
-            pmix_argv_append_unique_nosize(&hnp_node->aliases, node->name);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->name);
             if (NULL != node->rawname) {
                 if (NULL != hnp_node->rawname) {
                     free(hnp_node->rawname);

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -102,7 +102,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     }
 
     /* release the nodelist from lsf */
-    pmix_argv_free(nodelist);
+    PMIX_ARGV_FREE_COMPAT(nodelist);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -56,21 +56,21 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     bool use_hwthread_cpus = false;
     hwloc_cpuset_t available;
 
-    node_cnt = pmix_argv_split(prte_mca_ras_simulator_component.num_nodes, ',');
+    node_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.num_nodes, ',');
     if (NULL != prte_mca_ras_simulator_component.slots) {
-        slot_cnt = pmix_argv_split(prte_mca_ras_simulator_component.slots, ',');
+        slot_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.slots, ',');
         /* backfile the slot_cnt so every topology has a cnt */
-        tmp = slot_cnt[pmix_argv_count(slot_cnt) - 1];
-        for (n = pmix_argv_count(slot_cnt); n < pmix_argv_count(node_cnt); n++) {
-            pmix_argv_append_nosize(&slot_cnt, tmp);
+        tmp = slot_cnt[PMIX_ARGV_COUNT_COMPAT(slot_cnt) - 1];
+        for (n = PMIX_ARGV_COUNT_COMPAT(slot_cnt); n < PMIX_ARGV_COUNT_COMPAT(node_cnt); n++) {
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&slot_cnt, tmp);
         }
     }
     if (NULL != prte_mca_ras_simulator_component.slots_max) {
-        max_slot_cnt = pmix_argv_split(prte_mca_ras_simulator_component.slots_max, ',');
+        max_slot_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.slots_max, ',');
         /* backfill the max_slot_cnt as reqd */
-        tmp = max_slot_cnt[pmix_argv_count(slot_cnt) - 1];
-        for (n = pmix_argv_count(max_slot_cnt); n < pmix_argv_count(max_slot_cnt); n++) {
-            pmix_argv_append_nosize(&max_slot_cnt, tmp);
+        tmp = max_slot_cnt[PMIX_ARGV_COUNT_COMPAT(slot_cnt) - 1];
+        for (n = PMIX_ARGV_COUNT_COMPAT(max_slot_cnt); n < PMIX_ARGV_COUNT_COMPAT(max_slot_cnt); n++) {
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&max_slot_cnt, tmp);
         }
     }
 
@@ -148,13 +148,13 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     prte_num_allocated_nodes = pmix_list_get_size(nodes);
 
     if (NULL != max_slot_cnt) {
-        pmix_argv_free(max_slot_cnt);
+        PMIX_ARGV_FREE_COMPAT(max_slot_cnt);
     }
     if (NULL != slot_cnt) {
-        pmix_argv_free(slot_cnt);
+        PMIX_ARGV_FREE_COMPAT(slot_cnt);
     }
     if (NULL != node_cnt) {
-        pmix_argv_free(node_cnt);
+        PMIX_ARGV_FREE_COMPAT(node_cnt);
     }
     if (NULL != job_cpuset) {
         free(job_cpuset);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -474,7 +474,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
                                  "%s ras:slurm:allocate:discover: found node %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), base));
 
-            if (PRTE_SUCCESS != (ret = pmix_argv_append_nosize(&names, base))) {
+            if (PRTE_SUCCESS != (ret = PMIX_ARGV_APPEND_NOSIZE_COMPAT(&names, base))) {
                 PRTE_ERROR_LOG(ret);
                 free(orig);
                 return ret;
@@ -486,7 +486,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
 
     free(orig);
 
-    num_nodes = pmix_argv_count(names);
+    num_nodes = PMIX_ARGV_COUNT_COMPAT(names);
 
     /* Find the number of slots per node */
 
@@ -572,7 +572,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         pmix_list_append(nodelist, &node->super);
     }
     free(slots);
-    pmix_argv_free(names);
+    PMIX_ARGV_FREE_COMPAT(names);
 
     /* All done */
     return ret;
@@ -718,7 +718,7 @@ static int prte_ras_slurm_parse_range(char *base, char *range, char ***names)
             str[j] = '\0';
         }
         strcat(str, temp1);
-        ret = pmix_argv_append_nosize(names, str);
+        ret = PMIX_ARGV_APPEND_NOSIZE_COMPAT(names, str);
         if (PRTE_SUCCESS != ret) {
             PRTE_ERROR_LOG(ret);
             free(str);
@@ -789,7 +789,7 @@ static void recv_data(int fd, short args, void *cbdata)
     }
 
     /* break the message into its component parts, separated by colons */
-    alloc = pmix_argv_split(recv_msg, ':');
+    alloc = PMIX_ARGV_SPLIT_COMPAT(recv_msg, ':');
 
     /* the first section contains the PRTE jobid for this allocation */
     tpn = strchr(alloc[0], '=');
@@ -810,7 +810,7 @@ static void recv_data(int fd, short args, void *cbdata)
     if (NULL == jtrk) {
         pmix_show_help("help-ras-slurm.txt", "slurm-dyn-alloc-failed", true, "NO JOB TRACKER");
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_ALLOC_FAILED);
-        pmix_argv_free(alloc);
+        PMIX_ARGV_FREE_COMPAT(alloc);
         return;
     }
 
@@ -830,7 +830,7 @@ static void recv_data(int fd, short args, void *cbdata)
         if (PRTE_SUCCESS != parse_alloc_msg(alloc[i], &idx, &sjob, &nodelist, &tpn)) {
             pmix_show_help("help-ras-slurm.txt", "slurm-dyn-alloc-failed", true, jtrk->cmd);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-            pmix_argv_free(alloc);
+            PMIX_ARGV_FREE_COMPAT(alloc);
             if (NULL != nodelist) {
                 free(nodelist);
             }
@@ -842,7 +842,7 @@ static void recv_data(int fd, short args, void *cbdata)
         if (idx < 0) {
             pmix_show_help("help-ras-slurm.txt", "slurm-dyn-alloc-failed", true, jtrk->cmd);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-            pmix_argv_free(alloc);
+            PMIX_ARGV_FREE_COMPAT(alloc);
             free(nodelist);
             free(tpn);
             return;
@@ -850,7 +850,7 @@ static void recv_data(int fd, short args, void *cbdata)
         if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, idx))) {
             pmix_show_help("help-ras-slurm.txt", "slurm-dyn-alloc-failed", true, jtrk->cmd);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-            pmix_argv_free(alloc);
+            PMIX_ARGV_FREE_COMPAT(alloc);
             free(nodelist);
             free(tpn);
             return;
@@ -868,7 +868,7 @@ static void recv_data(int fd, short args, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_ras_slurm_discover(nodelist, tpn, &ndtmp))) {
             PRTE_ERROR_LOG(rc);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-            pmix_argv_free(alloc);
+            PMIX_ARGV_FREE_COMPAT(alloc);
             free(nodelist);
             free(tpn);
             return;
@@ -878,7 +878,7 @@ static void recv_data(int fd, short args, void *cbdata)
          */
         while (NULL != (item = pmix_list_remove_first(&ndtmp))) {
             nd = (prte_node_t *) item;
-            pmix_argv_append_nosize(&dash_host, nd->name);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&dash_host, nd->name);
             /* check for duplicates */
             found = false;
             for (itm = pmix_list_get_first(&nds); itm != pmix_list_get_end(&nds);
@@ -901,23 +901,23 @@ static void recv_data(int fd, short args, void *cbdata)
         free(tpn);
     }
     /* cleanup */
-    pmix_argv_free(alloc);
+    PMIX_ARGV_FREE_COMPAT(alloc);
     PMIX_DESTRUCT(&ndtmp);
     if (NULL != dash_host) {
-        tpn = pmix_argv_join(dash_host, ',');
+        tpn = PMIX_ARGV_JOIN_COMPAT(dash_host, ',');
         for (idx = 0; idx < jdata->apps->size; idx++) {
             if (NULL
                 == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, idx))) {
                 pmix_show_help("help-ras-slurm.txt", "slurm-dyn-alloc-failed", true, jtrk->cmd);
                 PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-                pmix_argv_free(dash_host);
+                PMIX_ARGV_FREE_COMPAT(dash_host);
                 free(tpn);
                 return;
             }
             prte_set_attribute(&app->attributes, PRTE_APP_DASH_HOST, PRTE_ATTR_LOCAL, (void *) tpn,
                                PMIX_STRING);
         }
-        pmix_argv_free(dash_host);
+        PMIX_ARGV_FREE_COMPAT(dash_host);
         free(tpn);
     }
 
@@ -989,10 +989,10 @@ static int dyn_allocate(prte_job_t *jdata)
      * want to provide a param to adjust the timeout value
      */
     /* construct the cmd string */
-    pmix_argv_append_nosize(&cmd, "allocate");
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, "allocate");
     /* add the jobid */
     pmix_asprintf(&tmp, "jobid=%s", jdata->nspace);
-    pmix_argv_append_nosize(&cmd, tmp);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
     free(tmp);
     /* if we want the allocation for all apps in one shot,
      * then tell slurm
@@ -1002,15 +1002,15 @@ static int dyn_allocate(prte_job_t *jdata)
      */
 #if 0
     if (!prte_mca_ras_slurm_component.rolling_alloc) {
-        pmix_argv_append_nosize(&cmd, "return=all");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, "return=all");
     }
 #else
-    pmix_argv_append_nosize(&cmd, "return=all");
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, "return=all");
 #endif
 
     /* pass the timeout */
     pmix_asprintf(&tmp, "timeout=%d", prte_mca_ras_slurm_component.timeout);
-    pmix_argv_append_nosize(&cmd, tmp);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
     free(tmp);
 
     /* for each app, add its allocation request info */
@@ -1021,17 +1021,17 @@ static int dyn_allocate(prte_job_t *jdata)
         }
         /* add the app id, preceded by a colon separator */
         pmix_asprintf(&tmp, ": app=%d", (int) app->idx);
-        pmix_argv_append_nosize(&cmd, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
         free(tmp);
         /* add the number of process "slots" we need */
         pmix_asprintf(&tmp, "np=%d", app->num_procs);
-        pmix_argv_append_nosize(&cmd, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
         free(tmp);
         /* if we were given a minimum number of nodes, pass it along */
         if (prte_get_attribute(&app->attributes, PRTE_APP_MIN_NODES, (void **) &i64ptr,
                                PMIX_INT64)) {
             pmix_asprintf(&tmp, "N=%ld", (long int) i64);
-            pmix_argv_append_nosize(&cmd, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
             free(tmp);
         }
         /* add the list of nodes, if one was given, ensuring
@@ -1040,21 +1040,21 @@ static int dyn_allocate(prte_job_t *jdata)
         node_list = get_node_list(app);
         if (NULL != node_list) {
             pmix_asprintf(&tmp, "node_list=%s", node_list);
-            pmix_argv_append_nosize(&cmd, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, tmp);
             free(node_list);
             free(tmp);
         }
         /* add the mandatory/optional flag */
         if (prte_get_attribute(&app->attributes, PRTE_APP_MANDATORY, NULL, PMIX_BOOL)) {
-            pmix_argv_append_nosize(&cmd, "flag=mandatory");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, "flag=mandatory");
         } else {
-            pmix_argv_append_nosize(&cmd, "flag=optional");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cmd, "flag=optional");
         }
     }
 
     /* assemble it into the final cmd to be sent */
-    cmd_str = pmix_argv_join(cmd, ' ');
-    pmix_argv_free(cmd);
+    cmd_str = PMIX_ARGV_JOIN_COMPAT(cmd, ' ');
+    PMIX_ARGV_FREE_COMPAT(cmd);
 
     /* start a timer - if the response to our request doesn't appear
      * in the defined time, then we will error out as Slurm isn't
@@ -1134,18 +1134,18 @@ static char *get_node_list(prte_app_context_t *app)
     if (!prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void **) &dh, PMIX_STRING)) {
         return NULL;
     }
-    dash_host = pmix_argv_split(dh, ',');
+    dash_host = PMIX_ARGV_SPLIT_COMPAT(dh, ',');
     free(dh);
     for (j = 0; NULL != dash_host[j]; j++) {
-        pmix_argv_append_unique_nosize(&total_host, dash_host[j]);
+        PMIX_ARGV_APPEND_UNIQUE_COMPAT(&total_host, dash_host[j]);
     }
-    pmix_argv_free(dash_host);
+    PMIX_ARGV_FREE_COMPAT(dash_host);
     if (NULL == total_host) {
         return NULL;
     }
 
-    nodes = pmix_argv_join(total_host, ',');
-    pmix_argv_free(total_host);
+    nodes = PMIX_ARGV_JOIN_COMPAT(total_host, ',');
+    PMIX_ARGV_FREE_COMPAT(total_host);
     return nodes;
 }
 

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -184,7 +184,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
         /* not enough cpus were specified */
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
-    cpus = pmix_argv_split(options->cpuset, ',');
+    cpus = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
     /* take the first one */
     idx = strtoul(cpus[0], NULL, 10);
     if (options->use_hwthreads) {
@@ -211,7 +211,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
 #endif
         obj = hwloc_get_obj_inside_cpuset_by_type(node->topology->topo, tset, type, idx);
         if (NULL == obj) {
-            pmix_argv_free(cpus);
+            PMIX_ARGV_FREE_COMPAT(cpus);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
 #if HWLOC_API_VERSION < 0x20000
@@ -232,9 +232,9 @@ static int bind_to_cpuset(prte_job_t *jdata,
     if (NULL == cpus[1]) {
         options->cpuset = NULL;
     } else {
-        options->cpuset = pmix_argv_join(&cpus[1], ',');
+        options->cpuset = PMIX_ARGV_JOIN_COMPAT(&cpus[1], ',');
     }
-    pmix_argv_free(cpus);
+    PMIX_ARGV_FREE_COMPAT(cpus);
 
     /* mark that we used ONE of these cpus - we do this each time we
      * the cpuset is assigned to a proc. When all the cpus in the

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -185,7 +185,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
         return PRTE_SUCCESS;
     }
 
-    ck2 = pmix_argv_split(ck, ':');
+    ck2 = PMIX_ARGV_SPLIT_COMPAT(ck, ':');
     for (i = 0; NULL != ck2[i]; i++) {
         if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_SPAN)) {
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_SPAN);
@@ -196,7 +196,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             PRTE_UNSET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_OVERSUBSCRIBE);
@@ -208,7 +208,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_OVERSUBSCRIBE);
@@ -238,7 +238,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* missing the value or value is invalid */
                 pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                "PE", ck2[i]);
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL,
@@ -249,7 +249,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -265,7 +265,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -280,7 +280,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             if (core_cpus_given) {
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -295,7 +295,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             if (hwthread_cpus_given) {
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -311,7 +311,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* missing the value */
                 pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true, "mapping policy",
                                "FILE", ck2[i]);
-                pmix_argv_free(ck2);
+                PMIX_ARGV_FREE_COMPAT(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -323,11 +323,11 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
 
         } else {
             /* unrecognized modifier */
-            pmix_argv_free(ck2);
+            PMIX_ARGV_FREE_COMPAT(ck2);
             return PRTE_ERR_BAD_PARAM;
         }
     }
-    pmix_argv_free(ck2);
+    PMIX_ARGV_FREE_COMPAT(ck2);
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -785,15 +785,15 @@ void prte_rmaps_base_report_bindings(prte_job_t *jdata,
                           proc->node->name, tmp);
             free(tmp);
         }
-        pmix_argv_append_nosize(&cache, out);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, out);
         free(out);
     }
     if (NULL == cache) {
         out = strdup("Error: job has no procs");
     } else {
         /* add a blank line with \n on it so IOF will output the last line */
-        pmix_argv_append_nosize(&cache, "");
-        out = pmix_argv_join(cache, '\n');
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, "");
+        out = PMIX_ARGV_JOIN_COMPAT(cache, '\n');
     }
     PMIX_LOAD_PROCID(&source, jdata->nspace, PMIX_RANK_WILDCARD);
     prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, out);

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -168,23 +168,23 @@ char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping)
     }
 
     if (PRTE_MAPPING_NO_USE_LOCAL & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        pmix_argv_append_nosize(&qls, "NO_USE_LOCAL");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "NO_USE_LOCAL");
     }
     if (PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        pmix_argv_append_nosize(&qls, "NOOVERSUBSCRIBE");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "NOOVERSUBSCRIBE");
     } else if (PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        pmix_argv_append_nosize(&qls, "OVERSUBSCRIBE");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "OVERSUBSCRIBE");
     }
     if (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        pmix_argv_append_nosize(&qls, "SPAN");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "SPAN");
     }
     if (PRTE_MAPPING_ORDERED & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        pmix_argv_append_nosize(&qls, "ORDERED");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "ORDERED");
     }
 
     if (NULL != qls) {
-        tmp = pmix_argv_join(qls, ':');
-        pmix_argv_free(qls);
+        tmp = PMIX_ARGV_JOIN_COMPAT(qls, ':');
+        PMIX_ARGV_FREE_COMPAT(qls);
         pmix_asprintf(&mymap, "%s:%s", map, tmp);
         free(tmp);
     } else {

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -104,11 +104,11 @@ static int ppr_mapper(prte_job_t *jdata,
     jdata->map->last_mapper = strdup(c->pmix_mca_component_name);
 
         /* split on the colon */
-    ck = pmix_argv_split(jobppr, ':');
-    if (2 != pmix_argv_count(ck)) {
+    ck = PMIX_ARGV_SPLIT_COMPAT(jobppr, ':');
+    if (2 != PMIX_ARGV_COUNT_COMPAT(ck)) {
         /* must provide a specification */
         pmix_show_help("help-prte-rmaps-ppr.txt", "invalid-ppr", true, jobppr);
-        pmix_argv_free(ck);
+        PMIX_ARGV_FREE_COMPAT(ck);
         free(jobppr);
         return PRTE_ERR_SILENT;
     }
@@ -145,11 +145,11 @@ static int ppr_mapper(prte_job_t *jdata,
         /* unknown spec */
         pmix_show_help("help-prte-rmaps-ppr.txt", "unrecognized-ppr-option", true, ck[1],
                        jobppr);
-        pmix_argv_free(ck);
+        PMIX_ARGV_FREE_COMPAT(ck);
         free(jobppr);
         return PRTE_ERR_SILENT;
     }
-    pmix_argv_free(ck);
+    PMIX_ARGV_FREE_COMPAT(ck);
 
     /* if nothing was given, that's an error */
     if (0 == mapping) {

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -570,8 +570,8 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                 } else {
                     value = prte_rmaps_rank_file_value.sval;
                 }
-                argv = pmix_argv_split(value, '@');
-                cnt = pmix_argv_count(argv);
+                argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
+                cnt = PMIX_ARGV_COUNT_COMPAT(argv);
                 if (NULL != node_name) {
                     free(node_name);
                 }
@@ -583,11 +583,11 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                     pmix_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                     rc = PRTE_ERR_BAD_PARAM;
                     PRTE_ERROR_LOG(rc);
-                    pmix_argv_free(argv);
+                    PMIX_ARGV_FREE_COMPAT(argv);
                     node_name = NULL;
                     goto unlock;
                 }
-                pmix_argv_free(argv);
+                PMIX_ARGV_FREE_COMPAT(argv);
 
                 // Strip off the FQDN if present, ignore IP addresses
                 if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(node_name)) {
@@ -843,7 +843,7 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
         pmix_output_verbose(20, prte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rf: (lsf) Convert Physical CPUSET from <%s>", sep);
         my_topo = (prte_topology_t *) pmix_pointer_array_get_item(prte_node_topologies, 0);
-        cpus = pmix_argv_split(sep, ',');
+        cpus = PMIX_ARGV_SPLIT_COMPAT(sep, ',');
         for(i = 0; NULL != cpus[i]; ++i) {
             // assume HNP has the same topology as other nodes
             obj = hwloc_get_pu_obj_by_os_index(my_topo->topo, strtol(cpus[i], NULL, 10)) ;
@@ -853,8 +853,8 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
             cpus[i] = (char*)malloc(sizeof(char) * 10);
             sprintf(cpus[i], "%d", obj->logical_index);
         }
-        sep = pmix_argv_join(cpus, ',');
-        pmix_argv_free(cpus);
+        sep = PMIX_ARGV_JOIN_COMPAT(cpus, ',');
+        PMIX_ARGV_FREE_COMPAT(cpus);
         pmix_output_verbose(20, prte_rmaps_base_framework.framework_output,
                             "mca:rmaps:rf: (lsf) Convert Physical CPUSET to   <%s>", sep);
 

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -131,9 +131,9 @@ static int prte_rmaps_rr_map(prte_job_t *jdata,
 
         if (0 == app->num_procs) {
             if (NULL != options->cpuset && !options->overload) {
-                tmp = pmix_argv_split(options->cpuset, ',');
-                app->num_procs = pmix_argv_count(tmp);
-                pmix_argv_free(tmp);
+                tmp = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
+                app->num_procs = PMIX_ARGV_COUNT_COMPAT(tmp);
+                PMIX_ARGV_FREE_COMPAT(tmp);
             } else {
                 /* set the num_procs to equal the number of slots on these
                  * mapped nodes, taking into account the number of cpus/rank

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -398,9 +398,9 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
     }
 
     nprocs_mapped = 0;
-    tmp = pmix_argv_split(options->cpuset, ',');
-    ntomap = pmix_argv_count(tmp);
-    pmix_argv_free(tmp);
+    tmp = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
+    ntomap = PMIX_ARGV_COUNT_COMPAT(tmp);
+    PMIX_ARGV_FREE_COMPAT(tmp);
     if (NULL != options->cpuset) {
         savecpuset = strdup(options->cpuset);
     }

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -116,7 +116,7 @@ bool prte_schizo_base_check_qualifiers(char *directive,
             return true;
         }
     }
-    v = pmix_argv_join(valid, ',');
+    v = PMIX_ARGV_JOIN_COMPAT(valid, ',');
     pmix_show_help("help-prte-rmaps-base.txt",
                    "unrecognized-qualifier", true,
                    directive, qual, v);
@@ -147,14 +147,14 @@ bool prte_schizo_base_check_directives(char *directive,
 
     /* if it starts with a ':', then these are just qualifiers */
     if (':' == dir[0]) {
-        qls = pmix_argv_split(&dir[1], ':');
+        qls = PMIX_ARGV_SPLIT_COMPAT(&dir[1], ':');
         for (m=0; NULL != qls[m]; m++) {
             if (!prte_schizo_base_check_qualifiers(directive, quals, qls[m])) {
-                pmix_argv_free(qls);
+                PMIX_ARGV_FREE_COMPAT(qls);
                 return false;
             }
         }
-        pmix_argv_free(qls);
+        PMIX_ARGV_FREE_COMPAT(qls);
         return true;
     }
 
@@ -165,7 +165,7 @@ bool prte_schizo_base_check_directives(char *directive,
         return true;
     }
 
-    args = pmix_argv_split(dir, ':');
+    args = PMIX_ARGV_SPLIT_COMPAT(dir, ':');
     /* remove any '=' in the directive */
     if (NULL != (v = strchr(args[0], '='))) {
         *v = '\0';
@@ -188,7 +188,7 @@ bool prte_schizo_base_check_directives(char *directive,
                                        "unrecognized-qualifier", true,
                                        directive, dir, v);
                         free(v);
-                        pmix_argv_free(args);
+                        PMIX_ARGV_FREE_COMPAT(args);
                         return false;
                     }
                     found = false;
@@ -199,45 +199,45 @@ bool prte_schizo_base_check_directives(char *directive,
                         }
                     }
                     if (!found) {
-                        v = pmix_argv_join(pproptions, ':');
+                        v = PMIX_ARGV_JOIN_COMPAT(pproptions, ':');
                         pmix_asprintf(&q, "ppr:%s:[%s]", args[1], v);
                         free(v);
                         pmix_show_help("help-prte-rmaps-base.txt",
                                        "unrecognized-qualifier", true,
                                        directive, dir, q);
                         free(q);
-                        pmix_argv_free(args);
+                        PMIX_ARGV_FREE_COMPAT(args);
                         return false;
                     }
                     if (NULL != args[3]) {
-                        qls = pmix_argv_split(args[3], ':');
+                        qls = PMIX_ARGV_SPLIT_COMPAT(args[3], ':');
                     } else {
-                        pmix_argv_free(args);
+                        PMIX_ARGV_FREE_COMPAT(args);
                         return true;
                     }
                 } else {
-                    qls = pmix_argv_split(args[1], ':');
+                    qls = PMIX_ARGV_SPLIT_COMPAT(args[1], ':');
                 }
                for (m=0; NULL != qls[m]; m++) {
                     if (!prte_schizo_base_check_qualifiers(directive, quals, qls[m])) {
-                        pmix_argv_free(qls);
-                        pmix_argv_free(args);
+                        PMIX_ARGV_FREE_COMPAT(qls);
+                        PMIX_ARGV_FREE_COMPAT(args);
                         return false;
                     }
                 }
-                pmix_argv_free(qls);
-                pmix_argv_free(args);
+                PMIX_ARGV_FREE_COMPAT(qls);
+                PMIX_ARGV_FREE_COMPAT(args);
                 return true;
             }
-            pmix_argv_free(args);
+            PMIX_ARGV_FREE_COMPAT(args);
             return true;
         }
     }
-    v = pmix_argv_join(valid, ':');
+    v = PMIX_ARGV_JOIN_COMPAT(valid, ':');
     pmix_show_help("help-prte-rmaps-base.txt",
                    "unrecognized-directive", true,
                    directive, dir, v);
-    pmix_argv_free(args);
+    PMIX_ARGV_FREE_COMPAT(args);
     return false;
 }
 
@@ -280,9 +280,9 @@ static int check_ndirs(pmix_cli_item_t *opt)
 
     for (n=0; NULL != limits[n]; n++) {
         if (0 == strcmp(opt->key, limits[n])) {
-            count = pmix_argv_count(opt->values);
+            count = PMIX_ARGV_COUNT_COMPAT(opt->values);
             if (1 > count) {
-                param = pmix_argv_join(opt->values, ' ');
+                param = PMIX_ARGV_JOIN_COMPAT(opt->values, ' ');
                 pmix_show_help("help-schizo-base.txt", "too-many-instances", true,
                                param, opt->key, count, 1);
                 return PRTE_ERR_SILENT;
@@ -481,35 +481,35 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     /* the following have multiple directives */
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
-        vtmp = pmix_argv_split(opt->values[0], ',');
+        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_OUTPUT, outputs, outquals, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        pmix_argv_free(vtmp);
+        PMIX_ARGV_FREE_COMPAT(vtmp);
     }
 
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_DISPLAY);
     if (NULL != opt) {
-        vtmp = pmix_argv_split(opt->values[0], ',');
+        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_DISPLAY, displays, NULL, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        pmix_argv_free(vtmp);
+        PMIX_ARGV_FREE_COMPAT(vtmp);
     }
 
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_RTOS);
     if (NULL != opt) {
-        vtmp = pmix_argv_split(opt->values[0], ',');
+        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_RTOS, rtos, NULL, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        pmix_argv_free(vtmp);
+        PMIX_ARGV_FREE_COMPAT(vtmp);
     }
 
     // check too many values given to a single command line option
@@ -530,14 +530,14 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
     char **targv, *ptr;
 
     for (n=0; NULL != opt->values[n]; n++) {
-        targv = pmix_argv_split(opt->values[n], ',');
-        for (idx = 0; idx < pmix_argv_count(targv); idx++) {
+        targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[n], ',');
+        for (idx = 0; idx < PMIX_ARGV_COUNT_COMPAT(targv); idx++) {
 
             if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_ALLOC)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_ALLOCATION, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -545,7 +545,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -553,7 +553,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -561,7 +561,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_REPORT_BINDINGS, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -571,7 +571,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     /* missing the value or value is invalid */
                     pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                    "display", "TOPO", targv[idx]);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return PRTE_ERR_FATAL;
                 }
                 ++ptr;
@@ -579,18 +579,18 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     /* missing the value or value is invalid */
                     pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                    "display", "TOPO", targv[idx]);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return PRTE_ERR_FATAL;
                 }
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_TOPOLOGY, ptr, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
             }
         }
-        pmix_argv_free(targv);
+        PMIX_ARGV_FREE_COMPAT(targv);
     }
 
     return PRTE_SUCCESS;
@@ -605,7 +605,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
     pmix_status_t ret;
 
     for (n=0; NULL != opt->values[n]; n++) {
-        targv = pmix_argv_split(opt->values[0], ',');
+        targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
         for (idx = 0; NULL != targv[idx]; idx++) {
             /* check for qualifiers */
             cptr = strchr(targv[idx], ':');
@@ -613,15 +613,15 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 *cptr = '\0';
                 ++cptr;
                 /* could be multiple qualifiers, so separate them */
-                options = pmix_argv_split(cptr, ',');
+                options = PMIX_ARGV_SPLIT_COMPAT(cptr, ',');
                 for (m=0; NULL != options[m]; m++) {
 
                     if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_NOCOPY)) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            pmix_argv_free(targv);
-                            pmix_argv_free(options);
+                            PMIX_ARGV_FREE_COMPAT(targv);
+                            PMIX_ARGV_FREE_COMPAT(options);
                             return ret;
                         }
 
@@ -629,8 +629,8 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            pmix_argv_free(targv);
-                            pmix_argv_free(options);
+                            PMIX_ARGV_FREE_COMPAT(targv);
+                            PMIX_ARGV_FREE_COMPAT(options);
                             return ret;
                         }
 
@@ -639,12 +639,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     }
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
-                        pmix_argv_free(targv);
-                        pmix_argv_free(options);
+                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIX_ARGV_FREE_COMPAT(options);
                         return ret;
                     }
                 }
-                pmix_argv_free(options);
+                PMIX_ARGV_FREE_COMPAT(options);
             }
             if (0 == strlen(targv[idx])) {
                 // only qualifiers were given
@@ -659,7 +659,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -667,7 +667,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -675,7 +675,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -683,7 +683,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -691,7 +691,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -699,7 +699,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -707,7 +707,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -716,12 +716,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "directory", "directory");
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return PRTE_ERR_FATAL;
                 }
                 if (NULL != outfile) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, ptr);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     free(outfile);
                     return PRTE_ERR_FATAL;
                 }
@@ -732,7 +732,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        pmix_argv_free(targv);
+                        PMIX_ARGV_FREE_COMPAT(targv);
                         return PRTE_ERR_FATAL;
                     }
                     outdir = pmix_os_path(false, cwd, ptr, NULL);
@@ -742,7 +742,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
 
@@ -751,12 +751,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "filename", "filename");
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return PRTE_ERR_FATAL;
                 }
                 if (NULL != outdir) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, ptr, outdir);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return PRTE_ERR_FATAL;
                 }
                 /* If the given filename isn't an absolute path, then
@@ -766,7 +766,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        pmix_argv_free(targv);
+                        PMIX_ARGV_FREE_COMPAT(targv);
                         return PRTE_ERR_FATAL;
                     }
                     outfile = pmix_os_path(false, cwd, ptr, NULL);
@@ -776,12 +776,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    pmix_argv_free(targv);
+                    PMIX_ARGV_FREE_COMPAT(targv);
                     return ret;
                 }
             }
         }
-        pmix_argv_free(targv);
+        PMIX_ARGV_FREE_COMPAT(targv);
     }
     if (NULL != outdir) {
         free(outdir);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -95,8 +95,8 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
         // does it already have a value?
         if (NULL == opt->values) {
             // technically this should never happen, but...
-            pmix_argv_append_nosize(&opt->values, directive);
-        } else if (1 < pmix_argv_count(opt->values)) {
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, directive);
+        } else if (1 < PMIX_ARGV_COUNT_COMPAT(opt->values)) {
             // cannot use this function
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
@@ -113,7 +113,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
                 // do we allow multiple directives?
                 if (!check_multi(target)) {
                     // report the error
-                    tmp = pmix_argv_join(opt->values, ',');
+                    tmp = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
                     ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-directives",
                                                 true, target, tmp, deprecated, directive);
                     free(tmp);
@@ -141,7 +141,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
         // add the new option
         opt = PMIX_NEW(pmix_cli_item_t);
         opt->key = strdup(target);
-        pmix_argv_append_nosize(&opt->values, directive);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, directive);
         pmix_list_append(&results->instances, &opt->super);
     }
 
@@ -172,9 +172,9 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
         if (NULL == opt->values) {
             // technically this should never happen, but...
             pmix_asprintf(&tmp, ":%s", qualifier);
-            pmix_argv_append_nosize(&opt->values, tmp);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, tmp);
             free(tmp);
-        } else if (1 < pmix_argv_count(opt->values)) {
+        } else if (1 < PMIX_ARGV_COUNT_COMPAT(opt->values)) {
             // cannot use this function
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
@@ -191,7 +191,7 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
         opt = PMIX_NEW(pmix_cli_item_t);
         opt->key = strdup(target);
         pmix_asprintf(&tmp, ":%s", qualifier);
-        pmix_argv_append_nosize(&opt->values, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, tmp);
         free(tmp);
         pmix_list_append(&results->instances, &opt->super);
     }
@@ -274,14 +274,14 @@ bool prte_schizo_base_check_prte_param(char *param)
     char **tmp;
     size_t n;
 
-    tmp = pmix_argv_split(param, '_');
+    tmp = PMIX_ARGV_SPLIT_COMPAT(param, '_');
     for (n=0; NULL != prte_frameworks[n]; n++) {
         if (0 == strncmp(tmp[0], prte_frameworks[n], strlen(prte_frameworks[n]))) {
-            pmix_argv_free(tmp);
+            PMIX_ARGV_FREE_COMPAT(tmp);
             return true;
         }
     }
-    pmix_argv_free(tmp);
+    PMIX_ARGV_FREE_COMPAT(tmp);
     return false;
 }
 
@@ -308,9 +308,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                 setenv(param, p2, true);
                 free(param);
             } else {
-                pmix_argv_append_nosize(target, "--prtemca");
-                pmix_argv_append_nosize(target, p1);
-                pmix_argv_append_nosize(target, p2);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
             }
             free(p1);
             free(p2);
@@ -369,9 +369,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                     pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                         "%s schizo:prte:parse_cli adding %s to target",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), p1);
-                    pmix_argv_append_nosize(target, "--prtemca");
-                    pmix_argv_append_nosize(target, p1);
-                    pmix_argv_append_nosize(target, p2);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
                 }
                 i += 2;
             }
@@ -412,14 +412,14 @@ bool prte_schizo_base_check_pmix_param(char *param)
     char **tmp;
     size_t n;
 
-    tmp = pmix_argv_split(param, '_');
+    tmp = PMIX_ARGV_SPLIT_COMPAT(param, '_');
     for (n=0; NULL != pmix_frameworks[n]; n++) {
         if (0 == strncmp(tmp[0], pmix_frameworks[n], strlen(pmix_frameworks[n]))) {
-            pmix_argv_free(tmp);
+            PMIX_ARGV_FREE_COMPAT(tmp);
             return true;
         }
     }
-    pmix_argv_free(tmp);
+    PMIX_ARGV_FREE_COMPAT(tmp);
     return false;
 }
 
@@ -448,9 +448,9 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                 setenv(param, p2, true);
                 free(param);
             } else {
-                pmix_argv_append_nosize(target, argv[i]);
-                pmix_argv_append_nosize(target, p1);
-                pmix_argv_append_nosize(target, p2);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, argv[i]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
             }
             free(p1);
             free(p2);
@@ -506,9 +506,9 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                     setenv(param, p2, true);
                     free(param);
                 } else {
-                    pmix_argv_append_nosize(target, "--pmixmca");
-                    pmix_argv_append_nosize(target, p1);
-                    pmix_argv_append_nosize(target, p2);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--pmixmca");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
                 }
             }
             free(p1);

--- a/src/mca/schizo/hydra/schizo_hydra.c
+++ b/src/mca/schizo/hydra/schizo_hydra.c
@@ -708,16 +708,16 @@ static int parse_cli(int argc, int start, char **argv, char ***target)
                 && NULL == strcasestr(argv[i + 1], "noinherit")) {
                 if (NULL == target) {
                     /* push it into our environment */
-                    pmix_setenv("PRTE_MCA_rmaps_default_inherit", "1", true, &environ);
-                    pmix_setenv("PRTE_MCA_rmaps_default_mapping_policy", argv[i + 1], true,
+                    PMIX_SETENV_COMPAT("PRTE_MCA_rmaps_default_inherit", "1", true, &environ);
+                    PMIX_SETENV_COMPAT("PRTE_MCA_rmaps_default_mapping_policy", argv[i + 1], true,
                                 &environ);
                 } else {
-                    pmix_argv_append_nosize(target, "--prtemca");
-                    pmix_argv_append_nosize(target, "rmaps_default_inherit");
-                    pmix_argv_append_nosize(target, "1");
-                    pmix_argv_append_nosize(target, "--prtemca");
-                    pmix_argv_append_nosize(target, "rmaps_default_mapping_policy");
-                    pmix_argv_append_nosize(target, argv[i + 1]);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "rmaps_default_inherit");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "1");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "rmaps_default_mapping_policy");
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, argv[i + 1]);
                 }
             }
              break;
@@ -751,7 +751,7 @@ static int parse_env(prte_cmd_line_t *cmd_line, char **srcenv, char ***dstenv, b
             /* next value on the list is the value */
             pval = pmix_cmd_line_get_param(cmd_line, "genv", i, 1);
             p2 = prte_schizo_base_strip_quotes(pval->value.data.string);
-            pmix_setenv(p1, p2, true, dstenv);
+            PMIX_SETENV_COMPAT(p1, p2, true, dstenv);
             free(p1);
             free(p2);
         }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -413,7 +413,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     char **pargv;
 
     /* backup the argv */
-    pargv = pmix_argv_copy(argv);
+    pargv = PMIX_ARGV_COPY_COMPAT(argv);
 
     char **caught_single_dashes = NULL;
     int  *caught_positions = NULL;
@@ -467,7 +467,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     rc = pmix_cmd_line_parse(pargv, ompishorts, ompioptions, NULL,
                              results, "help-schizo-ompi.txt");
     if (PMIX_SUCCESS != rc) {
-        pmix_argv_free(pargv);
+        PMIX_ARGV_FREE_COMPAT(pargv);
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             /* pmix cmd line interpreter output result
              * successfully - usually means version or
@@ -540,7 +540,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         free(caught_positions);
     }
 
-    pmix_argv_free(pargv);
+    PMIX_ARGV_FREE_COMPAT(pargv);
     /* check for deprecated options - warn and convert them */
     rc = convert_deprecated_cli(results, silent);
     if (PRTE_SUCCESS != rc) {
@@ -573,8 +573,8 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
             if (0 == strcmp(results->tail[0], argv[n])) {
                 /* this starts the tail - replace the rest of the
                  * tail with the original argv */
-                pmix_argv_free(results->tail);
-                results->tail = pmix_argv_copy(&argv[n]);
+                PMIX_ARGV_FREE_COMPAT(results->tail);
+                results->tail = PMIX_ARGV_COPY_COMPAT(&argv[n]);
                 break;
             }
         }
@@ -1024,8 +1024,8 @@ static int check_cache(char ***c1, char ***c2, char *p1, char *p2)
 
     if (PRTE_SUCCESS == rc) {
         /* add them to the cache */
-        pmix_argv_append_nosize(c1, p1);
-        pmix_argv_append_nosize(c2, p2);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(c1, p1);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(c2, p2);
     }
     return rc;
 }
@@ -1135,7 +1135,7 @@ static int process_env_list(const char *env_list, char ***xparams, char ***xvals
     char **tokens;
     int rc = PRTE_SUCCESS;
 
-    tokens = pmix_argv_split(env_list, (int) sep);
+    tokens = PMIX_ARGV_SPLIT_COMPAT(env_list, (int) sep);
     if (NULL == tokens) {
         return PRTE_SUCCESS;
     }
@@ -1151,7 +1151,7 @@ static int process_env_list(const char *env_list, char ***xparams, char ***xvals
         }
     }
 
-    pmix_argv_free(tokens);
+    PMIX_ARGV_FREE_COMPAT(tokens);
     return rc;
 }
 
@@ -1163,7 +1163,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
     char **cache = NULL, **cachevals = NULL;
     char **xparams = NULL, **xvals = NULL;
 
-    tmp = pmix_argv_split(filename, sep);
+    tmp = PMIX_ARGV_SPLIT_COMPAT(filename, sep);
     if (NULL == tmp) {
         return PRTE_SUCCESS;
     }
@@ -1180,22 +1180,22 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 fp = fopen(p1, "r");
                 if (NULL == fp) {
                     pmix_show_help("help-schizo-base.txt", "missing-param-file-def", true, tmp[i], p1);;
-                    pmix_argv_free(tmp);
-                    pmix_argv_free(cache);
-                    pmix_argv_free(cachevals);
-                    pmix_argv_free(xparams);
-                    pmix_argv_free(xvals);
+                    PMIX_ARGV_FREE_COMPAT(tmp);
+                    PMIX_ARGV_FREE_COMPAT(cache);
+                    PMIX_ARGV_FREE_COMPAT(cachevals);
+                    PMIX_ARGV_FREE_COMPAT(xparams);
+                    PMIX_ARGV_FREE_COMPAT(xvals);
                     free(p1);
                     return PRTE_ERR_NOT_FOUND;
                 }
                 free(p1);
             } else {
                 pmix_show_help("help-schizo-base.txt", "missing-param-file", true, tmp[i]);;
-                pmix_argv_free(tmp);
-                pmix_argv_free(cache);
-                pmix_argv_free(cachevals);
-                pmix_argv_free(xparams);
-                pmix_argv_free(xvals);
+                PMIX_ARGV_FREE_COMPAT(tmp);
+                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIX_ARGV_FREE_COMPAT(cachevals);
+                PMIX_ARGV_FREE_COMPAT(xparams);
+                PMIX_ARGV_FREE_COMPAT(xvals);
                 return PRTE_ERR_NOT_FOUND;
             }
         }
@@ -1203,15 +1203,15 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
             if ('\0' == line[0]) {
                 continue; /* skip empty lines */
             }
-            opts = pmix_argv_split_with_empty(line, ' ');
+            opts = PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(line, ' ');
             if (NULL == opts) {
                 pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i], line);
                 free(line);
-                pmix_argv_free(tmp);
-                pmix_argv_free(cache);
-                pmix_argv_free(cachevals);
-                pmix_argv_free(xparams);
-                pmix_argv_free(xvals);
+                PMIX_ARGV_FREE_COMPAT(tmp);
+                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIX_ARGV_FREE_COMPAT(cachevals);
+                PMIX_ARGV_FREE_COMPAT(xparams);
+                PMIX_ARGV_FREE_COMPAT(xvals);
                 fclose(fp);
                 return PRTE_ERR_BAD_PARAM;
             }
@@ -1226,12 +1226,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1244,12 +1244,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                             pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                            line);
                             free(line);
-                            pmix_argv_free(tmp);
-                            pmix_argv_free(opts);
-                            pmix_argv_free(cache);
-                            pmix_argv_free(cachevals);
-                            pmix_argv_free(xparams);
-                            pmix_argv_free(xvals);
+                            PMIX_ARGV_FREE_COMPAT(tmp);
+                            PMIX_ARGV_FREE_COMPAT(opts);
+                            PMIX_ARGV_FREE_COMPAT(cache);
+                            PMIX_ARGV_FREE_COMPAT(cachevals);
+                            PMIX_ARGV_FREE_COMPAT(xparams);
+                            PMIX_ARGV_FREE_COMPAT(xvals);
                             fclose(fp);
                             return PRTE_ERR_BAD_PARAM;
                         }
@@ -1264,12 +1264,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     free(p1);
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         free(line);
                         return rc;
                     }
@@ -1279,12 +1279,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1301,12 +1301,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     free(p2);
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         free(line);
                         return rc;
                     }
@@ -1318,12 +1318,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1331,12 +1331,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     rc = process_env_list(p1, &xparams, &xvals, ';');
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         free(line);
                         return rc;
                     }
@@ -1346,12 +1346,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         fclose(fp);
-                        pmix_argv_free(tmp);
-                        pmix_argv_free(opts);
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(tmp);
+                        PMIX_ARGV_FREE_COMPAT(opts);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         free(line);
                         return rc;
                     }
@@ -1362,30 +1362,30 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
         fclose(fp);
     }
 
-    pmix_argv_free(tmp);
+    PMIX_ARGV_FREE_COMPAT(tmp);
 
     if (NULL != cache) {
         /* add the results into dstenv */
         for (i = 0; NULL != cache[i]; i++) {
             if (0 != strncmp(cache[i], "OMPI_MCA_", strlen("OMPI_MCA_"))) {
                 pmix_asprintf(&p1, "OMPI_MCA_%s", cache[i]);
-                pmix_setenv(p1, cachevals[i], true, dstenv);
+                PMIX_SETENV_COMPAT(p1, cachevals[i], true, dstenv);
                 free(p1);
             } else {
-                pmix_setenv(cache[i], cachevals[i], true, dstenv);
+                PMIX_SETENV_COMPAT(cache[i], cachevals[i], true, dstenv);
             }
         }
-        pmix_argv_free(cache);
-        pmix_argv_free(cachevals);
+        PMIX_ARGV_FREE_COMPAT(cache);
+        PMIX_ARGV_FREE_COMPAT(cachevals);
     }
 
     /* add the -x values */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            pmix_setenv(xparams[i], xvals[i], true, dstenv);
+            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
         }
-        pmix_argv_free(xparams);
-        pmix_argv_free(xvals);
+        PMIX_ARGV_FREE_COMPAT(xparams);
+        PMIX_ARGV_FREE_COMPAT(xvals);
     }
 
     return PRTE_SUCCESS;
@@ -1460,7 +1460,7 @@ static void setup_ompi_frameworks(void)
 
     // If we found the env variable, it will be a comma-delimited list
     // of values.  Split it into an argv-style array.
-    char **tmp = pmix_argv_split(env, ',');
+    char **tmp = PMIX_ARGV_SPLIT_COMPAT(env, ',');
     if (NULL != tmp) {
         ompi_frameworks = tmp;
     }
@@ -1507,26 +1507,26 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != env_set_flag) {
         rc = process_env_list(env_set_flag, &xparams, &xvals, ';');
         if (PRTE_SUCCESS != rc) {
-            pmix_argv_free(xparams);
-            pmix_argv_free(xvals);
+            PMIX_ARGV_FREE_COMPAT(xparams);
+            PMIX_ARGV_FREE_COMPAT(xvals);
             return rc;
         }
     }
     /* process the resulting cache into the dstenv */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            pmix_setenv(xparams[i], xvals[i], true, dstenv);
+            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
         }
-        pmix_argv_free(xparams);
+        PMIX_ARGV_FREE_COMPAT(xparams);
         xparams = NULL;
-        pmix_argv_free(xvals);
+        PMIX_ARGV_FREE_COMPAT(xvals);
         xvals = NULL;
     }
 
     /* now process any tune file specification - the tune file processor
      * will police itself for duplicate values */
     if (NULL != (opt = pmix_cmd_line_get_param(results, "tune"))) {
-        p1 = pmix_argv_join(opt->values, ',');
+        p1 = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
         rc = process_tune_files(p1, dstenv, ',');
         free(p1);
         if (PRTE_SUCCESS != rc) {
@@ -1537,19 +1537,19 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != (opt = pmix_cmd_line_get_param(results, "initial-errhandler"))) {
         rc = check_cache(&cache, &cachevals, "mpi_initial_errhandler", opt->values[0]);
         if (PRTE_SUCCESS != rc) {
-            pmix_argv_free(cache);
-            pmix_argv_free(cachevals);
+            PMIX_ARGV_FREE_COMPAT(cache);
+            PMIX_ARGV_FREE_COMPAT(cachevals);
             return rc;
         }
     }
 
     if (pmix_cmd_line_is_taken(results, "display-comm") &&
         pmix_cmd_line_is_taken(results, "display-comm-finalize")) {
-        pmix_setenv("OMPI_MCA_ompi_display_comm", "mpi_init,mpi_finalize", true, dstenv);
+        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_init,mpi_finalize", true, dstenv);
     } else if (pmix_cmd_line_is_taken(results, "display-comm")) {
-        pmix_setenv("OMPI_MCA_ompi_display_comm", "mpi_init", true, dstenv);
+        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_init", true, dstenv);
     } else if (pmix_cmd_line_is_taken(results, "display-comm-finalize")) {
-        pmix_setenv("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
+        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
     }
 
     /* --stream-buffering will be deprecated starting with Open MPI v5 */
@@ -1565,7 +1565,7 @@ static int parse_env(char **srcenv, char ***dstenv,
             /* bad value */
             pmix_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
         }
-        pmix_setenv("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
+        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
     }
 
     /* now look for any "--mca" options - note that it is an error
@@ -1582,13 +1582,13 @@ static int parse_env(char **srcenv, char ***dstenv,
             p1 = opt->values[i];
             /* treat mca_base_env_list as a special case */
             if (0 == strcmp(p1, "mca_base_env_list")) {
-                pmix_argv_append_nosize(&envlist, p3);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
                 continue;
             }
             rc = check_cache(&cache, &cachevals, p1, p3);
             if (PRTE_SUCCESS != rc) {
-                pmix_argv_free(cache);
-                pmix_argv_free(cachevals);
+                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIX_ARGV_FREE_COMPAT(cachevals);
                 return rc;
             }
         }
@@ -1604,13 +1604,13 @@ static int parse_env(char **srcenv, char ***dstenv,
             p1 = opt->values[i];
             /* treat mca_base_env_list as a special case */
             if (0 == strcmp(p1, "mca_base_env_list")) {
-                pmix_argv_append_nosize(&envlist, p3);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
                 continue;
             }
             rc = check_cache(&cache, &cachevals, p1, p3);
             if (PRTE_SUCCESS != rc) {
-                pmix_argv_free(cache);
-                pmix_argv_free(cachevals);
+                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIX_ARGV_FREE_COMPAT(cachevals);
                 return rc;
             }
         }
@@ -1628,14 +1628,14 @@ static int parse_env(char **srcenv, char ***dstenv,
             if (check_generic(p1)) {
                 /* treat mca_base_env_list as a special case */
                 if (0 == strcmp(p1, "mca_base_env_list")) {
-                    pmix_argv_append_nosize(&envlist, p3);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
                     continue;
                 }
                 rc = check_cache(&cache, &cachevals, p1, p3);
                 if (PRTE_SUCCESS != rc) {
-                    pmix_argv_free(cache);
-                    pmix_argv_free(cachevals);
-                    pmix_argv_free(envlist);
+                    PMIX_ARGV_FREE_COMPAT(cache);
+                    PMIX_ARGV_FREE_COMPAT(cachevals);
+                    PMIX_ARGV_FREE_COMPAT(envlist);
                     return rc;
                 }
             }
@@ -1654,14 +1654,14 @@ static int parse_env(char **srcenv, char ***dstenv,
             if (check_generic(p1)) {
                 /* treat mca_base_env_list as a special case */
                 if (0 == strcmp(p1, "mca_base_env_list")) {
-                    pmix_argv_append_nosize(&envlist, p3);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
                     continue;
                 }
                 rc = check_cache(&cache, &cachevals, p1, p3);
                 if (PRTE_SUCCESS != rc) {
-                    pmix_argv_free(cache);
-                    pmix_argv_free(cachevals);
-                    pmix_argv_free(envlist);
+                    PMIX_ARGV_FREE_COMPAT(cache);
+                    PMIX_ARGV_FREE_COMPAT(cachevals);
+                    PMIX_ARGV_FREE_COMPAT(envlist);
                     return rc;
                 }
             }
@@ -1671,7 +1671,7 @@ static int parse_env(char **srcenv, char ***dstenv,
     /* if we got any env lists, process them here */
     if (NULL != envlist) {
         for (i = 0; NULL != envlist[i]; i++) {
-            envtgt = pmix_argv_split(envlist[i], ';');
+            envtgt = PMIX_ARGV_SPLIT_COMPAT(envlist[i], ';');
             for (j = 0; NULL != envtgt[j]; j++) {
                 if (NULL == (p2 = strchr(envtgt[j], '='))) {
                     p1 = getenv(envtgt[j]);
@@ -1687,28 +1687,28 @@ static int parse_env(char **srcenv, char ***dstenv,
                     }
                     free(p1);
                     if (PRTE_SUCCESS != rc) {
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(envtgt);
-                        pmix_argv_free(envlist);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(envtgt);
+                        PMIX_ARGV_FREE_COMPAT(envlist);
                         return rc;
                     }
                 } else {
                     *p2 = '\0';
                     rc = check_cache(&xparams, &xvals, envtgt[j], p2 + 1);
                     if (PRTE_SUCCESS != rc) {
-                        pmix_argv_free(cache);
-                        pmix_argv_free(cachevals);
-                        pmix_argv_free(envtgt);
-                        pmix_argv_free(envlist);
+                        PMIX_ARGV_FREE_COMPAT(cache);
+                        PMIX_ARGV_FREE_COMPAT(cachevals);
+                        PMIX_ARGV_FREE_COMPAT(envtgt);
+                        PMIX_ARGV_FREE_COMPAT(envlist);
                         return rc;
                     }
                 }
             }
-            pmix_argv_free(envtgt);
+            PMIX_ARGV_FREE_COMPAT(envtgt);
         }
     }
-    pmix_argv_free(envlist);
+    PMIX_ARGV_FREE_COMPAT(envlist);
 
     /* now look for -x options - not allowed to conflict with a -mca option */
     if (NULL != (opt = pmix_cmd_line_get_param(results, "x"))) {
@@ -1728,15 +1728,15 @@ static int parse_env(char **srcenv, char ***dstenv,
             /* not allowed to duplicate anything from an MCA param on the cmd line */
             rc = check_cache_noadd(&cache, &cachevals, p1, p2);
             if (PRTE_SUCCESS != rc) {
-                pmix_argv_free(cache);
-                pmix_argv_free(cachevals);
-                pmix_argv_free(xparams);
-                pmix_argv_free(xvals);
+                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIX_ARGV_FREE_COMPAT(cachevals);
+                PMIX_ARGV_FREE_COMPAT(xparams);
+                PMIX_ARGV_FREE_COMPAT(xvals);
                 return rc;
             }
             /* cache this for later inclusion */
-            pmix_argv_append_nosize(&xparams, p1);
-            pmix_argv_append_nosize(&xvals, p2);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xparams, p1);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xvals, p2);
         }
     }
 
@@ -1745,23 +1745,23 @@ static int parse_env(char **srcenv, char ***dstenv,
         for (i = 0; NULL != cache[i]; i++) {
             if (0 != strncmp(cache[i], "OMPI_MCA_", strlen("OMPI_MCA_"))) {
                 pmix_asprintf(&p1, "OMPI_MCA_%s", cache[i]);
-                pmix_setenv(p1, cachevals[i], true, dstenv);
+                PMIX_SETENV_COMPAT(p1, cachevals[i], true, dstenv);
                 free(p1);
             } else {
-                pmix_setenv(cache[i], cachevals[i], true, dstenv);
+                PMIX_SETENV_COMPAT(cache[i], cachevals[i], true, dstenv);
             }
         }
     }
-    pmix_argv_free(cache);
-    pmix_argv_free(cachevals);
+    PMIX_ARGV_FREE_COMPAT(cache);
+    PMIX_ARGV_FREE_COMPAT(cachevals);
 
     /* add the -x values */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            pmix_setenv(xparams[i], xvals[i], true, dstenv);
+            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
         }
-        pmix_argv_free(xparams);
-        pmix_argv_free(xvals);
+        PMIX_ARGV_FREE_COMPAT(xparams);
+        PMIX_ARGV_FREE_COMPAT(xvals);
     }
 
     return PRTE_SUCCESS;
@@ -1858,7 +1858,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     int i;
 
     /* flag that we started this job */
-    pmix_setenv("PRTE_LAUNCHED", "1", true, &app->env);
+    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
 
     /* now process any envar attributes - we begin with the job-level
      * ones as the app-specific ones can override them. We have to
@@ -1867,9 +1867,9 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
     {
         if (PRTE_JOB_SET_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
         } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
         } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
             pmix_unsetenv(attr->data.data.string, &app->env);
         } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
@@ -1885,7 +1885,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1895,7 +1895,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
@@ -1911,7 +1911,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1921,7 +1921,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         }
@@ -1931,9 +1931,9 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
     {
         if (PRTE_APP_SET_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
         } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
         } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
             pmix_unsetenv(attr->data.data.string, &app->env);
         } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
@@ -1949,7 +1949,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1959,7 +1959,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
@@ -1975,7 +1975,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1985,7 +1985,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         }

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -943,8 +943,8 @@ static int parse_env(char **srcenv, char ***dstenv,
                         pmix_show_help("help-schizo-base.txt", "duplicate-mca-value", true, p1, p2,
                                        value);
                         free(param);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         return PRTE_ERR_BAD_PARAM;
                     }
                 }
@@ -958,26 +958,26 @@ static int parse_env(char **srcenv, char ***dstenv,
                         /* this is an error - different values */
                         pmix_show_help("help-schizo-base.txt", "duplicate-mca-value", true, p1, p2,
                                        xvals[i]);
-                        pmix_argv_free(xparams);
-                        pmix_argv_free(xvals);
+                        PMIX_ARGV_FREE_COMPAT(xparams);
+                        PMIX_ARGV_FREE_COMPAT(xvals);
                         return PRTE_ERR_BAD_PARAM;
                     }
                 }
             }
 
             /* cache this for later inclusion - do not modify dstenv in this loop */
-            pmix_argv_append_nosize(&xparams, p1);
-            pmix_argv_append_nosize(&xvals, p2);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xparams, p1);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xvals, p2);
         }
     }
 
     /* add the -x values */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            pmix_setenv(xparams[i], xvals[i], true, dstenv);
+            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
         }
-        pmix_argv_free(xparams);
-        pmix_argv_free(xvals);
+        PMIX_ARGV_FREE_COMPAT(xparams);
+        PMIX_ARGV_FREE_COMPAT(xvals);
     }
 
     return PRTE_SUCCESS;
@@ -991,7 +991,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     int i;
 
     /* flag that we started this job */
-    pmix_setenv("PRTE_LAUNCHED", "1", true, &app->env);
+    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
 
     /* now process any envar attributes - we begin with the job-level
      * ones as the app-specific ones can override them. We have to
@@ -1000,9 +1000,9 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
     {
         if (PRTE_JOB_SET_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
         } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
         } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
             pmix_unsetenv(attr->data.data.string, &app->env);
         } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
@@ -1018,7 +1018,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1028,7 +1028,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
@@ -1044,7 +1044,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1054,7 +1054,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         }
@@ -1064,9 +1064,9 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
     {
         if (PRTE_APP_SET_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
         } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
         } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
             pmix_unsetenv(attr->data.data.string, &app->env);
         } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
@@ -1082,7 +1082,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1092,7 +1092,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
@@ -1108,7 +1108,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    pmix_setenv(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -1118,7 +1118,7 @@ static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                pmix_setenv(attr->data.data.envar.envar, attr->data.data.envar.value, true,
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
                             &app->env);
             }
         }

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -952,13 +952,13 @@ void prte_state_base_check_fds(prte_job_t *jdata)
         }
         /* construct the list of capabilities */
         if (fdflags & FD_CLOEXEC) {
-            pmix_argv_append_nosize(&list, "cloexec");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "cloexec");
         }
         if (flflags & O_APPEND) {
-            pmix_argv_append_nosize(&list, "append");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "append");
         }
         if (flflags & O_NONBLOCK) {
-            pmix_argv_append_nosize(&list, "nonblock");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "nonblock");
         }
         /* from the man page:
          *  Unlike the other values that can be specified in flags,
@@ -967,22 +967,22 @@ void prte_state_base_check_fds(prte_job_t *jdata)
          * the low order two bits of flags, and defined respectively
          * as 0, 1, and 2. */
         if (O_RDONLY == (flflags & 3)) {
-            pmix_argv_append_nosize(&list, "rdonly");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdonly");
         } else if (O_WRONLY == (flflags & 3)) {
-            pmix_argv_append_nosize(&list, "wronly");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "wronly");
         } else {
-            pmix_argv_append_nosize(&list, "rdwr");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdwr");
         }
         if (flk && F_UNLCK != fl.l_type) {
             if (F_WRLCK == fl.l_type) {
-                pmix_argv_append_nosize(&list, "wrlock");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "wrlock");
             } else {
-                pmix_argv_append_nosize(&list, "rdlock");
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdlock");
             }
         }
         if (NULL != list) {
-            status = pmix_argv_join(list, ' ');
-            pmix_argv_free(list);
+            status = PMIX_ARGV_JOIN_COMPAT(list, ' ');
+            PMIX_ARGV_FREE_COMPAT(list);
             list = NULL;
             if (NULL == result) {
                 pmix_asprintf(&result, "    %d\t(%s)\t%s\n", i, info, status);

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -188,7 +188,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
         }
 
     } else {
-        options = pmix_argv_split(spec, ',');
+        options = PMIX_ARGV_SPLIT_COMPAT(spec, ',');
         for (n=0; NULL != options[n]; n++) {
             /* see if there is an '=' */
             ptr = strchr(options[n], '=');
@@ -199,7 +199,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                     /* missing the value */
                     pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
-                    pmix_argv_free(options);
+                    PMIX_ARGV_FREE_COMPAT(options);
                     return PRTE_ERR_BAD_PARAM;
                 }
             }
@@ -252,7 +252,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                     /* missing the value */
                     pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
-                    pmix_argv_free(options);
+                    PMIX_ARGV_FREE_COMPAT(options);
                     return PRTE_ERR_BAD_PARAM;
                 }
                 i32 = strtol(ptr, NULL, 10);
@@ -344,7 +344,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 return PRTE_ERR_SILENT;
             }
         }
-        pmix_argv_free(options);
+        PMIX_ARGV_FREE_COMPAT(options);
     }
     /* if notify-error is set but neither recovery nor continuous were specified,
      * then notifications will not be given as we will terminate the job upon

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -452,7 +452,7 @@ static void ready_for_debug(int fd, short args, void *cbdata)
            free(name);
         }
         /* pass the argv from each app */
-        name = pmix_argv_join(app->argv, ' ');
+        name = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
         PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_APP_ARGV, name, PMIX_STRING);
         free(name);
     }

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -277,6 +277,78 @@ PRTE_EXPORT int prte_pmix_register_cleanup(char *path, bool directory, bool igno
     PMIX_MCA_BASE_VERSION_2_1_0("prte", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION, \
                                 PRTE_RELEASE_VERSION, type, type_major, type_minor, type_release)
 
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        pmix_argv_join(a, b)
+#else
+#define PMIX_ARGV_JOIN_COMPAT(a, b) \
+        PMIx_Argv_join(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        pmix_argv_split(a, b)
+#else
+#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
+        PMIx_Argv_split(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        pmix_argv_split_with_empty(a, b)
+#else
+#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
+        PMIx_Argv_split_with_empty(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        pmix_argv_count(a)
+#else
+#define PMIX_ARGV_COUNT_COMPAT(a) \
+        PMIx_Argv_count(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        pmix_argv_free(a)
+#else
+#define PMIX_ARGV_FREE_COMPAT(a) \
+        PMIx_Argv_free(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        pmix_argv_append_unique_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
+        PMIx_Argv_append_unique_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        pmix_argv_append_nosize(a, b)
+#else
+#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
+        PMIx_Argv_append_nosize(a, b)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        pmix_argv_copy(a)
+#else
+#define PMIX_ARGV_COPY_COMPAT(a) \
+        PMIx_Argv_copy(a)
+#endif
+
+#if PMIX_NUMERIC_VERSION < 0x00040203
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        pmix_setenv(a, b, c, d)
+#else
+#define PMIX_SETENV_COMPAT(a, b, c, d) \
+        PMIx_Setenv(a, b, c, d)
+#endif
+
 END_C_DECLS
 
 #endif

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -115,7 +115,9 @@ static pmix_server_module_t pmix_server = {
     .push_stdin = pmix_server_stdin_fn,
     .group = pmix_server_group_fn,
     .allocate = pmix_server_alloc_fn,
+#if PMIX_NUMERIC_VERSION >= 0x00050000
     .session_control = pmix_server_session_ctrl_fn
+#endif
 };
 
 typedef struct {
@@ -427,7 +429,7 @@ void pmix_server_register_params(void)
                                       &generate_dist);
     prte_pmix_server_globals.generate_dist = 0;
     if (NULL != generate_dist) {
-        tmp = pmix_argv_split(generate_dist, ',');
+        tmp = PMIX_ARGV_SPLIT_COMPAT(generate_dist, ',');
         for (i=0; NULL != tmp[i]; i++) {
             if (0 == strcasecmp(tmp[i], "fabric")) {
                 prte_pmix_server_globals.generate_dist |= PMIX_DEVTYPE_OPENFABRICS;
@@ -863,7 +865,7 @@ int pmix_server_init(void)
 
     // check for aliases
     if (NULL != prte_process_info.aliases) {
-        tmp = pmix_argv_join(prte_process_info.aliases, ',');
+        tmp = PMIX_ARGV_JOIN_COMPAT(prte_process_info.aliases, ',');
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_HOSTNAME_ALIASES, tmp, PMIX_STRING);
         free(tmp);
         if (PMIX_SUCCESS != rc) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -224,7 +224,7 @@ static void interim(int sd, short args, void *cbdata)
      * option parsing */
     for (n=0; n < cd->ninfo; n++) {
         if (PMIX_CHECK_KEY(&cd->info[n], PMIX_PERSONALITY)) {
-            jdata->personality = pmix_argv_split(cd->info[n].value.data.string, ',');
+            jdata->personality = PMIX_ARGV_SPLIT_COMPAT(cd->info[n].value.data.string, ',');
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(cd->info[n].value.data.string);
             pmix_server_cache_job_info(jdata, &cd->info[n]);
             break;
@@ -252,10 +252,10 @@ static void interim(int sd, short args, void *cbdata)
             app->app = strdup(papp->argv[0]);
         }
         if (NULL != papp->argv) {
-            app->argv = pmix_argv_copy(papp->argv);
+            app->argv = PMIX_ARGV_COPY_COMPAT(papp->argv);
         }
         if (NULL != papp->env) {
-            app->env = pmix_argv_copy(papp->env);
+            app->env = PMIX_ARGV_COPY_COMPAT(papp->env);
         }
         if (NULL != papp->cwd) {
             app->cwd = strdup(papp->cwd);
@@ -1073,7 +1073,7 @@ static void _cnct(int sd, short args, void *cbdata)
             }
             /* ask the global data server for the data - if we get it,
              * then we can complete the request */
-            pmix_argv_append_nosize(&keys, cd->procs[n].nspace);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&keys, cd->procs[n].nspace);
             /* we have to add the user's id to the directives */
             cd->ndirs = 1;
             PMIX_INFO_CREATE(cd->directives, cd->ndirs);
@@ -1082,11 +1082,11 @@ static void _cnct(int sd, short args, void *cbdata)
             if (PRTE_SUCCESS
                 != (rc = pmix_server_lookup_fn(&cd->procs[n], keys, cd->directives, cd->ndirs,
                                                _cnlk, cd))) {
-                pmix_argv_free(keys);
+                PMIX_ARGV_FREE_COMPAT(keys);
                 PMIX_INFO_FREE(cd->directives, cd->ndirs);
                 goto release;
             }
-            pmix_argv_free(keys);
+            PMIX_ARGV_FREE_COMPAT(keys);
             /* the callback function on this lookup will return us to this
              * routine so we can continue the process */
             return;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -858,10 +858,10 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_p
             }
             /* pack the target jobid */
             if (NULL == targets) {
-                PMIX_LOAD_NSPACE(&jobid, NULL);
+                PMIX_LOAD_NSPACE(jobid, NULL);
             } else {
                 proct = (pmix_proc_t *) &targets[0];
-                PMIX_LOAD_NSPACE(&jobid, proct->nspace);
+                PMIX_LOAD_NSPACE(jobid, proct->nspace);
             }
             rc = PMIx_Data_pack(NULL, cmd, &jobid, 1, PMIX_PROC_NSPACE);
             if (PMIX_SUCCESS != rc) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -353,11 +353,13 @@ PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 
+#if PMIX_NUMERIC_VERSION >= 0x00050000
 PRTE_EXPORT extern pmix_status_t
 pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                             uint32_t sessionID,
                             const pmix_info_t directives[], size_t ndirs,
                             pmix_info_cbfunc_t cbfunc, void *cbdata);
+#endif
 
 /* exposed shared variables */
 typedef struct {

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -291,7 +291,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     size_t m, n;
     pmix_status_t rc;
 
-    if (NULL == keys || 0 == pmix_argv_count(keys)) {
+    if (NULL == keys || 0 == PMIX_ARGV_COUNT_COMPAT(keys)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -326,7 +326,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     }
 
     /* pack the number of keys */
-    n = pmix_argv_count(keys);
+    n = PMIX_ARGV_COUNT_COMPAT(keys);
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, &req->msg, &n, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
@@ -408,7 +408,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
     }
 
     /* pack the number of keys */
-    n = pmix_argv_count(keys);
+    n = PMIX_ARGV_COUNT_COMPAT(keys);
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, &req->msg, &n, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -207,13 +207,13 @@ static void _query(int sd, short args, void *cbdata)
                     }
                     /* don't show the requestor's job */
                     if (!PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
-                        pmix_argv_append_nosize(&nspaces, jdata->nspace);
+                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nspaces, jdata->nspace);
                     }
                 }
                 /* join the results into a single comma-delimited string */
                 kv = PMIX_NEW(prte_info_item_t);
-                tmp = pmix_argv_join(nspaces, ',');
-                pmix_argv_free(nspaces);
+                tmp = PMIX_ARGV_JOIN_COMPAT(nspaces, ',');
+                PMIX_ARGV_FREE_COMPAT(nspaces);
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_NAMESPACES, tmp, PMIX_STRING);
                 free(tmp);
                 pmix_list_append(&results, &kv->super);
@@ -244,7 +244,7 @@ static void _query(int sd, short args, void *cbdata)
                             ret = PMIX_ERR_NOT_FOUND;
                             goto done;
                         }
-                        cmdline = pmix_argv_join(app->argv, ' ');
+                        cmdline = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
                         PMIX_INFO_LOAD(&info[1], PMIX_CMD_LINE, cmdline, PMIX_STRING);
                         free(cmdline);
                     }
@@ -268,37 +268,37 @@ static void _query(int sd, short args, void *cbdata)
 
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_SPAWN_SUPPORT)) {
                 ans = NULL;
-                pmix_argv_append_nosize(&ans, PMIX_HOST);
-                pmix_argv_append_nosize(&ans, PMIX_HOSTFILE);
-                pmix_argv_append_nosize(&ans, PMIX_ADD_HOST);
-                pmix_argv_append_nosize(&ans, PMIX_ADD_HOSTFILE);
-                pmix_argv_append_nosize(&ans, PMIX_PREFIX);
-                pmix_argv_append_nosize(&ans, PMIX_WDIR);
-                pmix_argv_append_nosize(&ans, PMIX_MAPPER);
-                pmix_argv_append_nosize(&ans, PMIX_PPR);
-                pmix_argv_append_nosize(&ans, PMIX_MAPBY);
-                pmix_argv_append_nosize(&ans, PMIX_RANKBY);
-                pmix_argv_append_nosize(&ans, PMIX_BINDTO);
-                pmix_argv_append_nosize(&ans, PMIX_COSPAWN_APP);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_HOST);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_HOSTFILE);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_ADD_HOST);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_ADD_HOSTFILE);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_PREFIX);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_WDIR);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_MAPPER);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_PPR);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_MAPBY);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_RANKBY);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_BINDTO);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_COSPAWN_APP);
                 /* create the return kv */
                 kv = PMIX_NEW(prte_info_item_t);
-                tmp = pmix_argv_join(ans, ',');
-                pmix_argv_free(ans);
+                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
+                PMIX_ARGV_FREE_COMPAT(ans);
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_SPAWN_SUPPORT, tmp, PMIX_STRING);
                 free(tmp);
                 pmix_list_append(&results, &kv->super);
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_DEBUG_SUPPORT)) {
                 ans = NULL;
-                pmix_argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_INIT);
-                pmix_argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_APP);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_IN_INIT);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_IN_APP);
 #if PRTE_HAVE_STOP_ON_EXEC
-                pmix_argv_append_nosize(&ans, PMIX_DEBUG_STOP_ON_EXEC);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_ON_EXEC);
 #endif
-                pmix_argv_append_nosize(&ans, PMIX_DEBUG_TARGET);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_TARGET);
                 /* create the return kv */
                 kv = PMIX_NEW(prte_info_item_t);
-                tmp = pmix_argv_join(ans, ',');
-                pmix_argv_free(ans);
+                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
+                PMIX_ARGV_FREE_COMPAT(ans);
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_DEBUG_SUPPORT, tmp, PMIX_STRING);
                 free(tmp);
                 pmix_list_append(&results, &kv->super);
@@ -515,14 +515,14 @@ static void _query(int sd, short args, void *cbdata)
                 ans = NULL;
                 PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, pmix_server_pset_t)
                 {
-                    pmix_argv_append_nosize(&ans, ps->name);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
                 }
                 if (NULL == ans) {
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 } else {
-                    tmp = pmix_argv_join(ans, ',');
-                    pmix_argv_free(ans);
+                    tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
+                    PMIX_ARGV_FREE_COMPAT(ans);
                     ans = NULL;
                     kv = PMIX_NEW(prte_info_item_t);
                     PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
@@ -583,10 +583,10 @@ static void _query(int sd, short args, void *cbdata)
                 ans = NULL;
                 PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, pmix_server_pset_t)
                 {
-                    pmix_argv_append_nosize(&ans, ps->name);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
                 }
-                tmp = pmix_argv_join(ans, ',');
-                pmix_argv_free(ans);
+                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
+                PMIX_ARGV_FREE_COMPAT(ans);
                 ans = NULL;
                 kv = PMIX_NEW(prte_info_item_t);
                 PMIX_INFO_LOAD(&kv->info, PMIX_QUERY_GROUP_NAMES, tmp, PMIX_STRING);
@@ -626,6 +626,7 @@ static void _query(int sd, short args, void *cbdata)
                     PMIX_LOAD_PROCID(&proc[k], grp->members[k].nspace, grp->members[k].rank);
                 }
 
+#if PMIX_NUMERIC_VERSION >= 0x00050000
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_ALLOCATION)) {
                 /* collect all the node info */
                 void *nodelist, *nodeinfolist;
@@ -645,7 +646,7 @@ static void _query(int sd, short args, void *cbdata)
                     PMIX_INFO_LIST_ADD(rc, nodeinfolist, PMIX_HOSTNAME, node->name, PMIX_STRING);
                     /* add any aliases */
                     if (NULL != node->aliases) {
-                        str = pmix_argv_join(node->aliases, ',');
+                        str = PMIX_ARGV_JOIN_COMPAT(node->aliases, ',');
                         PMIX_INFO_LIST_ADD(rc, nodeinfolist, PMIX_HOSTNAME_ALIASES, str, PMIX_STRING);
                         free(str);
                     }
@@ -690,6 +691,7 @@ static void _query(int sd, short args, void *cbdata)
                 kv->info.value.type = PMIX_DATA_ARRAY;
                 kv->info.value.data.darray = darray;
                 pmix_list_append(&results, &kv->super);
+#endif
             } else {
                 fprintf(stderr, "Query for unrecognized attribute: %s\n", q->keys[n]);
             }

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -163,12 +163,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             tmp = NULL;
             vpid = PMIX_RANK_VALID;
             ui32 = 0;
-            pmix_argv_append_nosize(&list, node->name);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, node->name);
             /* assemble all the ranks for this job that are on this node */
             for (k = 0; k < node->procs->size; k++) {
                 if (NULL != (pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, k))) {
                     if (PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
-                        pmix_argv_append_nosize(&micro, PRTE_VPID_PRINT(pptr->name.rank));
+                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&micro, PRTE_VPID_PRINT(pptr->name.rank));
                         if (pptr->name.rank < vpid) {
                             vpid = pptr->name.rank;
                         }
@@ -194,9 +194,9 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             }
             /* assemble the rank/node map */
             if (NULL != micro) {
-                tmp = pmix_argv_join(micro, ',');
-                pmix_argv_free(micro);
-                pmix_argv_append_nosize(&procs, tmp);
+                tmp = PMIX_ARGV_JOIN_COMPAT(micro, ',');
+                PMIX_ARGV_FREE_COMPAT(micro);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&procs, tmp);
             }
             /* construct the node info array */
             PMIX_INFO_LIST_START(iarray);
@@ -204,7 +204,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_HOSTNAME, node->name, PMIX_STRING);
             /* add any aliases */
             if (NULL != node->aliases) {
-                regex = pmix_argv_join(node->aliases, ',');
+                regex = PMIX_ARGV_JOIN_COMPAT(node->aliases, ',');
                 PMIX_INFO_LIST_ADD(ret, iarray, PMIX_HOSTNAME_ALIASES, regex, PMIX_STRING);
                 free(regex);
             }
@@ -234,8 +234,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     }
     /* let the PMIx server generate the nodemap regex */
     if (NULL != list) {
-        tmp = pmix_argv_join(list, ',');
-        pmix_argv_free(list);
+        tmp = PMIX_ARGV_JOIN_COMPAT(list, ',');
+        PMIX_ARGV_FREE_COMPAT(list);
         list = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -251,8 +251,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
 
     /* let the PMIx server generate the procmap regex */
     if (NULL != procs) {
-        tmp = pmix_argv_join(procs, ';');
-        pmix_argv_free(procs);
+        tmp = PMIX_ARGV_JOIN_COMPAT(procs, ';');
+        PMIX_ARGV_FREE_COMPAT(procs);
         procs = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -382,7 +382,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         /* add the wdir */
         PMIX_INFO_LIST_ADD(ret, iarray, PMIX_WDIR, app->cwd, PMIX_STRING);
         /* add the argv */
-        tmp = pmix_argv_join(app->argv, ' ');
+        tmp = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
         PMIX_INFO_LIST_ADD(ret, iarray, PMIX_APP_ARGV, tmp, PMIX_STRING);
         free(tmp);
         /* add the pset name */

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -25,6 +25,8 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
+#if PMIX_NUMERIC_VERSION >= 0x00050000
+
 pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                                           uint32_t sessionID,
                                           const pmix_info_t directives[], size_t ndirs,
@@ -37,3 +39,5 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
 
     return PMIX_ERR_NOT_SUPPORTED;
 }
+
+#endif

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -122,7 +122,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     }
     /* Setup application context */
     app = PMIX_NEW(prte_pmix_app_t);
-    app->app.argv = pmix_argv_copy(results.tail);
+    app->app.argv = PMIX_ARGV_COPY_COMPAT(results.tail);
     app->app.cmd = strdup(app->app.argv[0]);
 
     /* see if we are to forward the environment */
@@ -139,7 +139,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
         }
     }
     if (fwd) {
-        app->app.env = pmix_argv_copy(environ);
+        app->app.env = PMIX_ARGV_COPY_COMPAT(environ);
     }
 
     /* get the cwd - we may need it in several places */
@@ -194,13 +194,13 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     /* Did the user specify a hostfile? */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOSTFILE);
     if (NULL != opt) {
-        tval = pmix_argv_join(opt->values, ',');
+        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_HOSTFILE,
                            tval, PMIX_STRING);
         free(tval);
         if (NULL != hostfiles) {
             for (i=0; NULL != opt->values[i]; i++) {
-                pmix_argv_append_nosize(hostfiles, opt->values[i]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(hostfiles, opt->values[i]);
             }
         }
     }
@@ -208,12 +208,12 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     /* Did the user specify any hosts? */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOST);
     if (NULL != opt) {
-        tval = pmix_argv_join(opt->values, ',');
+        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_HOST, tval, PMIX_STRING);
         free(tval);
         if (NULL != hosts) {
             for (i=0; NULL != opt->values[i]; i++) {
-                pmix_argv_append_nosize(hosts, opt->values[i]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(hosts, opt->values[i]);
             }
         }
     }
@@ -304,7 +304,7 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
 
     /* Make the apps */
     temp_argv = NULL;
-    pmix_argv_append_nosize(&temp_argv, argv[0]);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[0]);
 
     /* NOTE: This bogus env variable is necessary in the calls to
      create_app(), below.  See comment immediately before the
@@ -314,9 +314,9 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     for (i = 1; NULL != argv[i]; ++i) {
         if (0 == strcmp(argv[i], ":")) {
             /* Make an app with this argv */
-            if (pmix_argv_count(temp_argv) > 1) {
+            if (PMIX_ARGV_COUNT_COMPAT(temp_argv) > 1) {
                 if (NULL != env) {
-                    pmix_argv_free(env);
+                    PMIX_ARGV_FREE_COMPAT(env);
                     env = NULL;
                 }
                 app = NULL;
@@ -325,7 +325,7 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                 if (PRTE_SUCCESS != rc) {
                     /* Assume that the error message has already been
                      printed; */
-                    pmix_argv_free(temp_argv);
+                    PMIX_ARGV_FREE_COMPAT(temp_argv);
                     return rc;
                 }
                 if (made_app) {
@@ -333,16 +333,16 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                 }
 
                 /* Reset the temps */
-                pmix_argv_free(temp_argv);
+                PMIX_ARGV_FREE_COMPAT(temp_argv);
                 temp_argv = NULL;
-                pmix_argv_append_nosize(&temp_argv, argv[0]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[0]);
             }
         } else {
-            pmix_argv_append_nosize(&temp_argv, argv[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[i]);
         }
     }
 
-    if (pmix_argv_count(temp_argv) > 1) {
+    if (PMIX_ARGV_COUNT_COMPAT(temp_argv) > 1) {
         app = NULL;
         rc = create_app(schizo, temp_argv, jdata, &app, &made_app, &env,
                         hostfiles, hosts);
@@ -354,9 +354,9 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
         }
     }
     if (NULL != env) {
-        pmix_argv_free(env);
+        PMIX_ARGV_FREE_COMPAT(env);
     }
-    pmix_argv_free(temp_argv);
+    PMIX_ARGV_FREE_COMPAT(temp_argv);
 
     /* All done */
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -739,8 +739,8 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
     {
         papps[n].cmd = strdup(app->app.cmd);
-        papps[n].argv = pmix_argv_copy(app->app.argv);
-        papps[n].env = pmix_argv_copy(app->app.env);
+        papps[n].argv = PMIX_ARGV_COPY_COMPAT(app->app.argv);
+        papps[n].env = PMIX_ARGV_COPY_COMPAT(app->app.env);
         papps[n].cwd = strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);

--- a/src/rml/rml_base_contact.c
+++ b/src/rml/rml_base_contact.c
@@ -57,7 +57,7 @@ int prte_rml_parse_uris(const char *uri, pmix_proc_t *peer, char ***uris)
 
     if (NULL != uris) {
         /* parse the remainder of the string into an array of uris */
-        *uris = pmix_argv_split(ptr, ';');
+        *uris = PMIX_ARGV_SPLIT_COMPAT(ptr, ';');
     }
     free(cinfo);
     return PRTE_SUCCESS;

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -96,8 +96,8 @@ int prte_app_copy(prte_app_context_t **dest, prte_app_context_t *src)
         (*dest)->app = strdup(src->app);
     }
     (*dest)->num_procs = src->num_procs;
-    (*dest)->argv = pmix_argv_copy(src->argv);
-    (*dest)->env = pmix_argv_copy(src->env);
+    (*dest)->argv = PMIX_ARGV_COPY_COMPAT(src->argv);
+    (*dest)->env = PMIX_ARGV_COPY_COMPAT(src->env);
     if (NULL != src->cwd) {
         (*dest)->cwd = strdup(src->cwd);
     }

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -126,7 +126,7 @@ int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job)
     }
 
     /* pack the personality */
-    count = pmix_argv_count(job->personality);
+    count = PMIX_ARGV_COUNT_COMPAT(job->personality);
     rc = PMIx_Data_pack(NULL, bkt, (void *) &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -470,7 +470,7 @@ int prte_app_pack(pmix_data_buffer_t *bkt, prte_app_context_t *app)
     }
 
     /* pack the number of entries in the argv array */
-    count = pmix_argv_count(app->argv);
+    count = PMIX_ARGV_COUNT_COMPAT(app->argv);
     rc = PMIx_Data_pack(NULL, bkt, &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -487,7 +487,7 @@ int prte_app_pack(pmix_data_buffer_t *bkt, prte_app_context_t *app)
     }
 
     /* pack the number of entries in the enviro array */
-    count = pmix_argv_count(app->env);
+    count = PMIX_ARGV_COUNT_COMPAT(app->env);
     rc = PMIx_Data_pack(NULL, bkt, &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -51,7 +51,7 @@ void prte_job_print(char **output, prte_job_t *src)
     /* set default result */
     *output = NULL;
 
-    tmp2 = pmix_argv_join(src->personality, ',');
+    tmp2 = PMIX_ARGV_JOIN_COMPAT(src->personality, ',');
     pmix_asprintf(&tmp,
                   "\nData for job: %s\tPersonality: %s\tRecovery: %s\n\tNum apps: %ld\tStdin "
                   "target: %s\tState: %s\tAbort: %s",
@@ -328,14 +328,14 @@ void prte_app_print(char **output, prte_job_t *jdata, prte_app_context_t *src)
                   (unsigned long) src->idx, (NULL == src->app) ? "NULL" : src->app,
                   (unsigned long) src->num_procs, PRTE_VPID_PRINT(src->first_rank));
 
-    count = pmix_argv_count(src->argv);
+    count = PMIX_ARGV_COUNT_COMPAT(src->argv);
     for (i = 0; i < count; i++) {
         pmix_asprintf(&tmp2, "%s\n\tArgv[%d]: %s", tmp, i, src->argv[i]);
         free(tmp);
         tmp = tmp2;
     }
 
-    count = pmix_argv_count(src->env);
+    count = PMIX_ARGV_COUNT_COMPAT(src->env);
     for (i = 0; i < count; i++) {
         pmix_asprintf(&tmp2, "%s\n\tEnv[%lu]: %s", tmp, (unsigned long) i, src->env[i]);
         free(tmp);

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -150,7 +150,7 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
             PMIX_RELEASE(jptr);
             return prte_pmix_convert_status(rc);
         }
-        pmix_argv_append_nosize(&jptr->personality, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jptr->personality, tmp);
         free(tmp);
     }
 
@@ -561,7 +561,7 @@ int prte_app_unpack(pmix_data_buffer_t *bkt, prte_app_context_t **ap)
             PMIX_RELEASE(app);
             return prte_pmix_convert_status(rc);
         }
-        pmix_argv_append_nosize(&app->argv, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->argv, tmp);
         free(tmp);
     }
 
@@ -581,7 +581,7 @@ int prte_app_unpack(pmix_data_buffer_t *bkt, prte_app_context_t **ap)
             PMIX_RELEASE(app);
             return prte_pmix_convert_status(rc);
         }
-        pmix_argv_append_nosize(&app->env, tmp);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->env, tmp);
         free(tmp);
     }
 

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -106,7 +106,7 @@ static void rqcon(prte_data_req_t *p)
 }
 static void rqdes(prte_data_req_t *p)
 {
-    pmix_argv_free(p->keys);
+    PMIX_ARGV_FREE_COMPAT(p->keys);
     PMIX_LIST_DESTRUCT(&p->answers);
 }
 static PMIX_CLASS_INSTANCE(prte_data_req_t, pmix_list_item_t, rqcon, rqdes);
@@ -385,7 +385,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
                     goto SEND_ERROR;
                 }
                 /* if we found all of the requested keys, then indicate so */
-                if (n == (size_t) pmix_argv_count(req->keys)) {
+                if (n == (size_t) PMIX_ARGV_COUNT_COMPAT(req->keys)) {
                     i = PRTE_SUCCESS;
                 } else {
                     i = (uint32_t) PRTE_ERR_PARTIAL_SUCCESS;
@@ -495,10 +495,10 @@ void prte_data_server(int status, pmix_proc_t *sender,
             if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(NULL, buffer, &str, &count, PMIX_STRING))) {
                 PMIX_ERROR_LOG(ret);
                 rc = PRTE_ERR_UNPACK_FAILURE;
-                pmix_argv_free(keys);
+                PMIX_ARGV_FREE_COMPAT(keys);
                 goto SEND_ERROR;
             }
-            pmix_argv_append_nosize(&keys, str);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&keys, str);
             free(str);
         }
 
@@ -592,7 +592,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
                 PMIX_ERROR_LOG(ret);
                 rc = PRTE_ERR_PACK_FAILURE;
                 PMIX_LIST_DESTRUCT(&answers);
-                pmix_argv_free(keys);
+                PMIX_ARGV_FREE_COMPAT(keys);
                 goto SEND_ERROR;
             }
             /* loop thru and pack the individual responses - this is somewhat less
@@ -607,7 +607,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
                     PMIX_ERROR_LOG(ret);
                     rc = PRTE_ERR_PACK_FAILURE;
                     PMIX_LIST_DESTRUCT(&answers);
-                    pmix_argv_free(keys);
+                    PMIX_ARGV_FREE_COMPAT(keys);
                     goto SEND_ERROR;
                 }
                 if (PMIX_SUCCESS
@@ -615,7 +615,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
                     PMIX_ERROR_LOG(ret);
                     rc = PRTE_ERR_PACK_FAILURE;
                     PMIX_LIST_DESTRUCT(&answers);
-                    pmix_argv_free(keys);
+                    PMIX_ARGV_FREE_COMPAT(keys);
                     goto SEND_ERROR;
                 }
                 if (PMIX_PERSIST_FIRST_READ == rinfo->persistence) {
@@ -629,13 +629,13 @@ void prte_data_server(int status, pmix_proc_t *sender,
         }
         PMIX_LIST_DESTRUCT(&answers);
 
-        if (nanswers == (size_t) pmix_argv_count(keys)) {
+        if (nanswers == (size_t) PMIX_ARGV_COUNT_COMPAT(keys)) {
             rc = PRTE_SUCCESS;
         } else {
             pmix_output_verbose(1, prte_data_server_output,
                                 "%s data server:lookup: at least some data not found %d vs %d",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nanswers,
-                                (int) pmix_argv_count(keys));
+                                (int) PMIX_ARGV_COUNT_COMPAT(keys));
 
             /* if we were told to wait for the data, then queue this up
              * for later processing */
@@ -660,14 +660,14 @@ void prte_data_server(int status, pmix_proc_t *sender,
             if (0 == nanswers) {
                 /* nothing was found - indicate that situation */
                 rc = PRTE_ERR_NOT_FOUND;
-                pmix_argv_free(keys);
+                PMIX_ARGV_FREE_COMPAT(keys);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 goto SEND_ERROR;
             } else {
                 rc = PRTE_ERR_PARTIAL_SUCCESS;
             }
         }
-        pmix_argv_free(keys);
+        PMIX_ARGV_FREE_COMPAT(keys);
         pmix_output_verbose(1, prte_data_server_output, "%s data server:lookup: data found",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         /* pack the status */
@@ -723,10 +723,10 @@ void prte_data_server(int status, pmix_proc_t *sender,
             if (PMIX_SUCCESS != (ret = PMIx_Data_unpack(NULL, buffer, &str, &count, PMIX_STRING))) {
                 PMIX_ERROR_LOG(ret);
                 rc = PRTE_ERR_UNPACK_FAILURE;
-                pmix_argv_free(keys);
+                PMIX_ARGV_FREE_COMPAT(keys);
                 goto SEND_ERROR;
             }
-            pmix_argv_append_nosize(&keys, str);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&keys, str);
             free(str);
         }
 
@@ -801,7 +801,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
                 }
             }
         }
-        pmix_argv_free(keys);
+        PMIX_ARGV_FREE_COMPAT(keys);
 
         /* tell the sender this succeeded */
         ret = PRTE_SUCCESS;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -438,12 +438,12 @@ static void prte_app_context_destructor(prte_app_context_t *app_context)
 
     /* argv and env lists created by util/argv copy functions */
     if (NULL != app_context->argv) {
-        pmix_argv_free(app_context->argv);
+        PMIX_ARGV_FREE_COMPAT(app_context->argv);
         app_context->argv = NULL;
     }
 
     if (NULL != app_context->env) {
-        pmix_argv_free(app_context->env);
+        PMIX_ARGV_FREE_COMPAT(app_context->env);
         app_context->env = NULL;
     }
 
@@ -522,7 +522,7 @@ static void prte_job_destruct(prte_job_t *job)
     }
 
     if (NULL != job->personality) {
-        pmix_argv_free(job->personality);
+        PMIX_ARGV_FREE_COMPAT(job->personality);
     }
     for (n = 0; n < job->apps->size; n++) {
         if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(job->apps, n))) {
@@ -590,7 +590,7 @@ static void prte_job_destruct(prte_job_t *job)
         pmix_pointer_array_set_item(prte_job_data, job->index, NULL);
     }
     if (NULL != job->traces) {
-        pmix_argv_free(job->traces);
+        PMIX_ARGV_FREE_COMPAT(job->traces);
     }
     PMIX_DESTRUCT(&job->cli);
 }
@@ -640,7 +640,7 @@ static void prte_node_destruct(prte_node_t *node)
         node->rawname = NULL;
     }
     if (NULL != node->aliases) {
-        pmix_argv_free(node->aliases);
+        PMIX_ARGV_FREE_COMPAT(node->aliases);
         node->aliases = NULL;
     }
     if (NULL != node->daemon) {

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -264,7 +264,7 @@ static int start_progress_engine(prte_progress_tracker_t *trk)
     if (NULL != prte_progress_thread_cpus) {
         CPU_ZERO(&cpuset);
         // comma-delimited list of cpu ranges
-        ranges = pmix_argv_split(prte_progress_thread_cpus, ',');
+        ranges = PMIX_ARGV_SPLIT_COMPAT(prte_progress_thread_cpus, ',');
         for (n=0; NULL != ranges[n]; n++) {
             // look for '-'
             start = strtoul(ranges[n], &dash, 10);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
     for (i=0; NULL != environ[i]; i++) {
         if (0 != strncmp(environ[i], "PMIX_", 5) &&
             0 != strncmp(environ[i], "PRTE_", 5)) {
-            pmix_argv_append_nosize(&prte_launch_environ, environ[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_launch_environ, environ[i]);
         }
     }
 
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
     /* if we were given a keepalive pipe, set up to monitor it now */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_KEEPALIVE);
     if (NULL != opt) {
-        pmix_setenv("PMIX_KEEPALIVE_PIPE", opt->values[0], true, &environ);
+        PMIX_SETENV_COMPAT("PMIX_KEEPALIVE_PIPE", opt->values[0], true, &environ);
     }
 
     /* check for debug options */
@@ -518,10 +518,10 @@ int main(int argc, char *argv[])
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYSTEM_SERVER)) {
         /* we should act as system-level PMIx server */
-        pmix_setenv("PRTE_MCA_pmix_system_server", "1", true, &environ);
+        PMIX_SETENV_COMPAT("PRTE_MCA_pmix_system_server", "1", true, &environ);
     }
     /* always act as session-level PMIx server */
-    pmix_setenv("PRTE_MCA_pmix_session_server", "1", true, &environ);
+    PMIX_SETENV_COMPAT("PRTE_MCA_pmix_session_server", "1", true, &environ);
     /* if we were asked to report a uri, set the MCA param to do so */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_REPORT_URI);
     if (NULL != opt) {
@@ -761,7 +761,7 @@ int main(int argc, char *argv[])
     if (prte_persistent) {
         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOSTFILE);
         if (NULL != opt) {
-            tpath = pmix_argv_join(opt->values, ',');
+            tpath = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_HOSTFILE,
                                PRTE_ATTR_GLOBAL, tpath, PMIX_STRING);
             free(tpath);
@@ -771,7 +771,7 @@ int main(int argc, char *argv[])
         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOST);
         if (NULL != opt) {
             char *tval;
-            tval = pmix_argv_join(opt->values, ',');
+            tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_DASH_HOST,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
@@ -780,19 +780,19 @@ int main(int argc, char *argv[])
         /* the directives might be in the app(s) */
         if (NULL != hostfiles) {
             char *tval;
-            tval = pmix_argv_join(hostfiles, ',');
+            tval = PMIX_ARGV_JOIN_COMPAT(hostfiles, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_HOSTFILE,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
-            pmix_argv_free(hostfiles);
+            PMIX_ARGV_FREE_COMPAT(hostfiles);
         }
         if (NULL != hosts) {
             char *tval;
-            tval = pmix_argv_join(hosts, ',');
+            tval = PMIX_ARGV_JOIN_COMPAT(hosts, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_DASH_HOST,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
-            pmix_argv_free(hosts);
+            PMIX_ARGV_FREE_COMPAT(hosts);
         }
     }
 
@@ -1063,8 +1063,8 @@ int main(int argc, char *argv[])
     PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
     {
         papps[n].cmd = strdup(app->app.cmd);
-        papps[n].argv = pmix_argv_copy(app->app.argv);
-        papps[n].env = pmix_argv_copy(app->app.env);
+        papps[n].argv = PMIX_ARGV_COPY_COMPAT(app->app.argv);
+        papps[n].env = PMIX_ARGV_COPY_COMPAT(app->app.env);
         papps[n].cwd = strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);
@@ -1314,7 +1314,7 @@ static int prep_singleton(const char *name)
     app = PMIX_NEW(prte_app_context_t);
     app->app = strdup(jdata->nspace);
     app->num_procs = 1;
-    pmix_argv_append_nosize(&app->argv, app->app);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->argv, app->app);
     getcwd(cwd, sizeof(cwd));
     app->cwd = strdup(cwd);
     pmix_pointer_array_set_item(jdata->apps, 0, app);

--- a/src/tools/prte_info/param.c
+++ b/src/tools/prte_info/param.c
@@ -98,7 +98,7 @@ void prte_info_do_params(bool want_all_in, bool want_internal)
          */
         if (NULL != opt) {
             /* split the arguments at the colon */
-            args = pmix_argv_split(opt->values[0], ':');
+            args = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ':');
             if (0 == strcmp(args[0], "all")) {
                 want_all = true;
             }
@@ -117,7 +117,7 @@ void prte_info_do_params(bool want_all_in, bool want_internal)
         if (NULL != opt && NULL != args) {
             type = args[0];
             if (NULL != args[1]) {
-                tmp = pmix_argv_split(args[1], ',');
+                tmp = PMIX_ARGV_SPLIT_COMPAT(args[1], ',');
 
                 for (j=0; NULL != tmp[j]; j++) {
                     for (found = false, i = 0; i < mca_types.size; ++i) {
@@ -138,14 +138,14 @@ void prte_info_do_params(bool want_all_in, bool want_internal)
 
                     prte_info_show_mca_params(type, tmp[j], want_internal);
                 }
-                pmix_argv_free(tmp);
+                PMIX_ARGV_FREE_COMPAT(tmp);
             } else {
                 prte_info_show_mca_params(type, "*", want_internal);
             }
         }
     }
     if (NULL != args) {
-        pmix_argv_free(args);
+        PMIX_ARGV_FREE_COMPAT(args);
     }
 }
 

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
     }
     // we do NOT accept arguments other than our own
     if (NULL != prte_info_cmd_line.tail) {
-        str = pmix_argv_join(prte_info_cmd_line.tail, ' ');
+        str = PMIX_ARGV_JOIN_COMPAT(prte_info_cmd_line.tail, ' ');
         ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
                                     prte_tool_basename, str, prte_tool_basename);
         free(str);

--- a/src/tools/prte_info/version.c
+++ b/src/tools/prte_info/version.c
@@ -114,7 +114,7 @@ void prte_info_do_version(bool want_all)
     } else {
         opt = pmix_cmd_line_get_param(&prte_info_cmd_line, "show-version");
         if (NULL != opt) {
-            tmp = pmix_argv_split(opt->values[0], ':');
+            tmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ':');
             arg1 = tmp[0];
             if (NULL == tmp[1]) {
                 scope = (char*)prte_info_ver_all;
@@ -147,7 +147,7 @@ void prte_info_do_version(bool want_all)
                 prte_info_show_component_version(arg1, prte_info_component_all, scope,
                                                  prte_info_ver_all);
             }
-            pmix_argv_free(tmp);
+            PMIX_ARGV_FREE_COMPAT(tmp);
         }
     }
 }

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
     for (i=0; NULL != environ[i]; i++) {
         if (0 != strncmp(environ[i], "PMIX_", 5) &&
             0 != strncmp(environ[i], "PRTE_", 5)) {
-            pmix_argv_append_nosize(&prte_launch_environ, environ[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_launch_environ, environ[i]);
         }
     }
 
@@ -336,7 +336,7 @@ int main(int argc, char *argv[])
 #endif
 
     /* ensure we silence any compression warnings */
-    pmix_setenv("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
+    PMIX_SETENV_COMPAT("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
 
     if (PRTE_SUCCESS != (ret = prte_init(&argc, &argv, PRTE_PROC_DAEMON))) {
         PRTE_ERROR_LOG(ret);
@@ -385,7 +385,7 @@ int main(int argc, char *argv[])
             /* cleanup */
             hwloc_bitmap_free(ours);
             hwloc_bitmap_free(res);
-            pmix_argv_free(cores);
+            PMIX_ARGV_FREE_COMPAT(cores);
         }
     }
 
@@ -550,15 +550,15 @@ int main(int argc, char *argv[])
         if (0 != strcmp(prte_process_info.aliases[n], "localhost")
             && 0 != strcmp(prte_process_info.aliases[n], "127.0.0.1")
             && 0 != strcmp(prte_process_info.aliases[n], prte_process_info.nodename)) {
-            pmix_argv_append_nosize(&nonlocal, prte_process_info.aliases[n]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nonlocal, prte_process_info.aliases[n]);
         }
     }
-    naliases = pmix_argv_count(nonlocal);
+    naliases = PMIX_ARGV_COUNT_COMPAT(nonlocal);
     prc = PMIx_Data_pack(NULL, buffer, &naliases, 1, PMIX_UINT8);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(buffer);
-        pmix_argv_free(nonlocal);
+        PMIX_ARGV_FREE_COMPAT(nonlocal);
         goto DONE;
     }
     for (ni = 0; ni < naliases; ni++) {
@@ -566,11 +566,11 @@ int main(int argc, char *argv[])
         if (PMIX_SUCCESS != prc) {
             PMIX_ERROR_LOG(prc);
             PMIX_DATA_BUFFER_RELEASE(buffer);
-            pmix_argv_free(nonlocal);
+            PMIX_ARGV_FREE_COMPAT(nonlocal);
             goto DONE;
         }
     }
-    pmix_argv_free(nonlocal);
+    PMIX_ARGV_FREE_COMPAT(nonlocal);
 
     prc = PMIx_Data_pack(NULL, buffer, &prte_topo_signature, 1, PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
@@ -727,9 +727,9 @@ int main(int argc, char *argv[])
                     }
                 }
                 if (!ignore) {
-                    pmix_argv_append_nosize(&prted_cmd_line, "--"PRTE_CLI_PRTEMCA);
-                    pmix_argv_append_nosize(&prted_cmd_line, opt->values[i]);
-                    pmix_argv_append_nosize(&prted_cmd_line, t);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, "--"PRTE_CLI_PRTEMCA);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, opt->values[i]);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, t);
                 }
                 --t;
                 *t = '=';
@@ -742,9 +742,9 @@ int main(int argc, char *argv[])
                 char *t = strchr(opt->values[i], '=');
                 *t = '\0';
                 ++t;
-                pmix_argv_append_nosize(&prted_cmd_line, "--"PRTE_CLI_PMIXMCA);
-                pmix_argv_append_nosize(&prted_cmd_line, opt->values[i]);
-                pmix_argv_append_nosize(&prted_cmd_line, t);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, "--"PRTE_CLI_PMIXMCA);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, opt->values[i]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, t);
                 --t;
                 *t = '=';
             }

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
 
     // we do NOT accept arguments other than our own
     if (NULL != results.tail) {
-        param = pmix_argv_join(results.tail, ' ');
+        param = PMIX_ARGV_JOIN_COMPAT(results.tail, ' ');
         ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
                                     prte_tool_basename, param, prte_tool_basename);
         if (NULL != ptr) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -18,6 +18,7 @@
 #include "constants.h"
 #include "types.h"
 
+#include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_printf.h"
@@ -204,11 +205,11 @@ char *prte_attr_print_list(pmix_list_t *attributes)
 
     PMIX_LIST_FOREACH(attr, attributes, prte_attribute_t)
     {
-        pmix_argv_append_nosize(&cache, prte_attr_key_to_str(attr->key));
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, prte_attr_key_to_str(attr->key));
     }
     if (NULL != cache) {
-        out1 = pmix_argv_join(cache, '\n');
-        pmix_argv_free(cache);
+        out1 = PMIX_ARGV_JOIN_COMPAT(cache, '\n');
+        PMIX_ARGV_FREE_COMPAT(cache);
     } else {
         out1 = NULL;
     }

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -71,7 +71,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
     int slots = 0;
     int n;
 
-    specs = pmix_argv_split(hosts, ',');
+    specs = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
 
     /* see if this node appears in the list */
     for (n = 0; NULL != specs[n]; n++) {
@@ -94,7 +94,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
             }
         }
     }
-    pmix_argv_free(specs);
+    PMIX_ARGV_FREE_COMPAT(specs);
     return slots;
 }
 
@@ -123,7 +123,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                          hosts));
 
     PMIX_CONSTRUCT(&adds, pmix_list_t);
-    host_argv = pmix_argv_split(hosts, ',');
+    host_argv = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
     if (0 < pmix_list_get_size(nodes)) {
         needcheck = true;
     } else {
@@ -131,24 +131,24 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
     }
 
     /* Accumulate all of the host name mappings */
-    for (j = 0; j < pmix_argv_count(host_argv); ++j) {
-        mini_map = pmix_argv_split(host_argv[j], ',');
+    for (j = 0; j < PMIX_ARGV_COUNT_COMPAT(host_argv); ++j) {
+        mini_map = PMIX_ARGV_SPLIT_COMPAT(host_argv[j], ',');
 
         if (mapped_nodes == NULL) {
             mapped_nodes = mini_map;
         } else {
             for (k = 0; NULL != mini_map[k]; ++k) {
-                rc = pmix_argv_append_nosize(&mapped_nodes, mini_map[k]);
+                rc = PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mapped_nodes, mini_map[k]);
                 if (PRTE_SUCCESS != rc) {
-                    pmix_argv_free(host_argv);
-                    pmix_argv_free(mini_map);
+                    PMIX_ARGV_FREE_COMPAT(host_argv);
+                    PMIX_ARGV_FREE_COMPAT(mini_map);
                     goto cleanup;
                 }
             }
-            pmix_argv_free(mini_map);
+            PMIX_ARGV_FREE_COMPAT(mini_map);
         }
     }
-    pmix_argv_free(host_argv);
+    PMIX_ARGV_FREE_COMPAT(host_argv);
     mini_map = NULL;
 
     /* Did we find anything? If not, then do nothing */
@@ -181,7 +181,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                         if (NULL
                             != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, k))) {
                             if (0 == node->num_procs) {
-                                pmix_argv_append_nosize(&mini_map, node->name);
+                                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, node->name);
                                 --j;
                             }
                         }
@@ -224,7 +224,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                         goto cleanup;
                     }
                     /* add this node to the list */
-                    pmix_argv_append_nosize(&mini_map, node->name);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, node->name);
                 } else {
                     /* invalid relative node syntax */
                     pmix_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
@@ -235,7 +235,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             }
         } else {
             /* just one node was given */
-            pmix_argv_append_nosize(&mini_map, mapped_nodes[i]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, mapped_nodes[i]);
         }
     }
     if (NULL == mini_map) {
@@ -317,7 +317,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             /* if we didn't find it, add it to the list */
             node = PMIX_NEW(prte_node_t);
             if (NULL == node) {
-                pmix_argv_free(mapped_nodes);
+                PMIX_ARGV_FREE_COMPAT(mapped_nodes);
                 if (NULL != shortname) {
                     free(shortname);
                 }
@@ -355,11 +355,11 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         }
         if (0 != strcmp(node->name, mini_map[i])) {
             // add the mini_map name to the list of aliases
-            pmix_argv_append_unique_nosize(&node->aliases, mini_map[i]);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, mini_map[i]);
         }
         // ensure the non-fqdn version is saved
         if (NULL != shortname && 0 != strcmp(shortname, node->name)) {
-            pmix_argv_append_unique_nosize(&node->aliases, shortname);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, shortname);
         }
         if (NULL != shortname) {
             free(shortname);
@@ -368,7 +368,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             free(rawname);
         }
     }
-    pmix_argv_free(mini_map);
+    PMIX_ARGV_FREE_COMPAT(mini_map);
 
     /* transfer across all unique nodes */
     while (NULL != (item = pmix_list_remove_first(&adds))) {
@@ -429,7 +429,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
 
 cleanup:
     if (NULL != mapped_nodes) {
-        pmix_argv_free(mapped_nodes);
+        PMIX_ARGV_FREE_COMPAT(mapped_nodes);
     }
     PMIX_LIST_DESTRUCT(&adds);
 
@@ -449,11 +449,11 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
     prte_node_t *node;
     char **host_argv = NULL;
 
-    host_argv = pmix_argv_split(hosts, ',');
+    host_argv = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
 
     /* Accumulate all of the host name mappings */
-    for (j = 0; j < pmix_argv_count(host_argv); ++j) {
-        mini_map = pmix_argv_split(host_argv[j], ',');
+    for (j = 0; j < PMIX_ARGV_COUNT_COMPAT(host_argv); ++j) {
+        mini_map = PMIX_ARGV_SPLIT_COMPAT(host_argv[j], ',');
 
         for (k = 0; NULL != mini_map[k]; ++k) {
             if ('+' == mini_map[k][0]) {
@@ -465,10 +465,10 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                     if (NULL != (cptr = strchr(mini_map[k], ':'))) {
                         /* the colon indicates a specific # are requested */
                         *cptr = '*';
-                        pmix_argv_append_nosize(mapped_nodes, cptr);
+                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, cptr);
                     } else {
                         /* add a marker to the list */
-                        pmix_argv_append_nosize(mapped_nodes, "*");
+                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, "*");
                     }
                 } else if ('n' == mini_map[k][1] || 'N' == mini_map[k][1]) {
                     /* they want a specific relative node #, so
@@ -500,7 +500,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                         goto cleanup;
                     }
                     /* add this node to the list */
-                    pmix_argv_append_nosize(mapped_nodes, node->name);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, node->name);
                 } else {
                     /* invalid relative node syntax */
                     pmix_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
@@ -515,22 +515,22 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                 }
                 /* check for local alias */
                 if (prte_check_host_is_local(mini_map[k])) {
-                    pmix_argv_append_nosize(mapped_nodes, prte_process_info.nodename);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, prte_process_info.nodename);
                 } else {
-                    pmix_argv_append_nosize(mapped_nodes, mini_map[k]);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, mini_map[k]);
                 }
             }
         }
-        pmix_argv_free(mini_map);
+        PMIX_ARGV_FREE_COMPAT(mini_map);
         mini_map = NULL;
     }
 
 cleanup:
     if (NULL != host_argv) {
-        pmix_argv_free(host_argv);
+        PMIX_ARGV_FREE_COMPAT(host_argv);
     }
     if (NULL != mini_map) {
-        pmix_argv_free(mini_map);
+        PMIX_ARGV_FREE_COMPAT(mini_map);
     }
     return rc;
 }
@@ -570,7 +570,7 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
      * nodes list ONCE.
      */
 
-    len_mapped_node = pmix_argv_count(mapped_nodes);
+    len_mapped_node = PMIX_ARGV_COUNT_COMPAT(mapped_nodes);
     /* setup a working list so we can put the final list
      * of nodes in order. This way, if the user specifies a
      * set of nodes, we will use them in the order in which
@@ -743,6 +743,6 @@ int prte_util_get_ordered_dash_host_list(pmix_list_t *nodes, char *hosts)
     }
 
     /* cleanup */
-    pmix_argv_free(mapped_nodes);
+    PMIX_ARGV_FREE_COMPAT(mapped_nodes);
     return rc;
 }

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -127,9 +127,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         } else {
             value = prte_util_hostfile_value.sval;
         }
-        argv = pmix_argv_split(value, '@');
+        argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
 
-        cnt = pmix_argv_count(argv);
+        cnt = PMIX_ARGV_COUNT_COMPAT(argv);
         if (1 == cnt) {
             node_name = strdup(argv[0]);
         } else if (2 == cnt) {
@@ -138,7 +138,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         } else {
             pmix_output(0, "WARNING: Unhandled user@host-combination\n"); /* XXX */
         }
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
 
         // Strip off the FQDN if present, ignore IP addresses
         if (!pmix_net_isaddr(node_name)) {
@@ -189,18 +189,18 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                 }
                 if (NULL != alias && 0 != strcmp(alias, node->name)) {
                     // new node object, so alias must be unique
-                    pmix_argv_append_nosize(&node->aliases, alias);
+                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
                 }
                 pmix_list_append(exclude, &node->super);
             } else {
                 /* the node name may not match the prior entry, so ensure we
                  * keep it if necessary */
                 if (0 != strcmp(node_name, node->name)) {
-                    pmix_argv_append_unique_nosize(&node->aliases, node_name);
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
                 }
                 free(node_name);
                 if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                    pmix_argv_append_unique_nosize(&node->aliases, alias);
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
                 }
             }
             if (NULL != alias) {
@@ -234,7 +234,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             }
             if (NULL != alias && 0 != strcmp(alias, node->name)) {
                 // new node object, so alias must be unique
-                pmix_argv_append_nosize(&node->aliases, alias);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
             }
             pmix_list_append(updates, &node->super);
         } else {
@@ -244,11 +244,11 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             /* the node name may not match the prior entry, so ensure we
              * keep it if necessary */
             if (0 != strcmp(node_name, node->name)) {
-                pmix_argv_append_unique_nosize(&node->aliases, node_name);
+                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
             }
             free(node_name);
             if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                pmix_argv_append_unique_nosize(&node->aliases, alias);
+                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
             }
         }
     } else if (PRTE_HOSTFILE_RELATIVE == token) {
@@ -273,7 +273,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         }
         if (NULL != alias && 0 != strcmp(alias, node->name)) {
             // new node object, so alias must be unique
-            pmix_argv_append_nosize(&node->aliases, alias);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
             free(alias);
         }
         pmix_list_append(updates, &node->super);
@@ -298,9 +298,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             value = prte_util_hostfile_value.sval;
         }
 
-        argv = pmix_argv_split(value, '@');
+        argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
 
-        cnt = pmix_argv_count(argv);
+        cnt = PMIX_ARGV_COUNT_COMPAT(argv);
         if (1 == cnt) {
             node_name = strdup(argv[0]);
         } else if (2 == cnt) {
@@ -309,7 +309,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         } else {
             pmix_output(0, "WARNING: Unhandled user@host-combination\n"); /* XXX */
         }
-        pmix_argv_free(argv);
+        PMIX_ARGV_FREE_COMPAT(argv);
 
         // Strip off the FQDN if present, ignore IP addresses
         if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(node_name)) {
@@ -336,11 +336,11 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             /* the node name may not match the prior entry, so ensure we
              * keep it if necessary */
             if (0 != strcmp(node_name, node->name)) {
-                pmix_argv_append_unique_nosize(&node->aliases, node_name);
+                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
             }
         }
         if (NULL != alias) {
-            pmix_argv_append_unique_nosize(&node->aliases, alias);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
             free(alias);
             node->rawname = strdup(node_name);
         }
@@ -615,11 +615,11 @@ int prte_util_add_hostfile_nodes(pmix_list_t *nodes, char *hostfile)
         }
         if (found) {
             /* add this node name as alias */
-            pmix_argv_append_unique_nosize(&node->aliases, nd->name);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, nd->name);
             /* ensure all other aliases are also transferred */
             if (NULL != nd->aliases) {
                 for (i=0; NULL != nd->aliases[i]; i++) {
-                    pmix_argv_append_unique_nosize(&node->aliases, nd->aliases[i]);
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, nd->aliases[i]);
                 }
             }
            PMIX_RELEASE(item);

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -87,18 +87,18 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
             continue;
         }
         /* add the hostname to the argv */
-        pmix_argv_append_nosize(&names, nptr->name);
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&names, nptr->name);
         als = NULL;
         if (NULL != nptr->aliases) {
             for (m=0; NULL != nptr->aliases[m]; m++) {
-                pmix_argv_append_nosize(&als, nptr->aliases[m]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&als, nptr->aliases[m]);
             }
-            raw = pmix_argv_join(als, ',');
-            pmix_argv_free(als);
-            pmix_argv_append_nosize(&aliases, raw);
+            raw = PMIX_ARGV_JOIN_COMPAT(als, ',');
+            PMIX_ARGV_FREE_COMPAT(als);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&aliases, raw);
             free(raw);
         } else {
-            pmix_argv_append_nosize(&aliases, "PRTENONE");
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&aliases, "PRTENONE");
         }
         /* store the vpid */
         if (NULL == nptr->daemon) {
@@ -117,8 +117,8 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     }
 
     /* construct the string of node names for compression */
-    raw = pmix_argv_join(names, ',');
-    pmix_argv_free(names);
+    raw = PMIX_ARGV_JOIN_COMPAT(names, ',');
+    PMIX_ARGV_FREE_COMPAT(names);
     if (PMIx_Data_compress((uint8_t *) raw, strlen(raw) + 1, (uint8_t **) &bo.bytes, &sz)) {
         /* mark that this was compressed */
         compressed = true;
@@ -149,8 +149,8 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     free(bo.bytes);
 
     /* construct the string of aliases for compression */
-    raw = pmix_argv_join(aliases, ';');
-    pmix_argv_free(aliases);
+    raw = PMIX_ARGV_JOIN_COMPAT(aliases, ';');
+    PMIX_ARGV_FREE_COMPAT(aliases);
     if (PMIx_Data_compress((uint8_t *) raw, strlen(raw) + 1, (uint8_t **) &bo.bytes, &sz)) {
         /* mark that this was compressed */
         compressed = true;
@@ -282,7 +282,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pbo.size = 0;
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    names = pmix_argv_split(raw, ',');
+    names = PMIX_ARGV_SPLIT_COMPAT(raw, ',');
     free(raw);
 
     /* unpack compression flag for node aliases */
@@ -315,7 +315,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pbo.size = 0;
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    aliases = pmix_argv_split(raw, ';');
+    aliases = PMIX_ARGV_SPLIT_COMPAT(raw, ';');
     free(raw);
 
     /* unpack compression flag for daemon vpids */
@@ -380,9 +380,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
             }
             if (0 != strcmp(aliases[n], "PRTENONE")) {
                 if (NULL != nd->aliases) {
-                    pmix_argv_free(nd->aliases);
+                    PMIX_ARGV_FREE_COMPAT(nd->aliases);
                 }
-                nd->aliases = pmix_argv_split(aliases[n], ',');
+                nd->aliases = PMIX_ARGV_SPLIT_COMPAT(aliases[n], ',');
             }
             continue;
         }
@@ -393,7 +393,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pmix_pointer_array_set_item(prte_node_pool, n, nd);
         /* add any aliases */
         if (0 != strcmp(aliases[n], "PRTENONE")) {
-            nd->aliases = pmix_argv_split(aliases[n], ',');
+            nd->aliases = PMIX_ARGV_SPLIT_COMPAT(aliases[n], ',');
         }
         /* set the topology - always default to homogeneous
          * as that is the most common scenario */
@@ -427,7 +427,7 @@ cleanup:
         free(vpid);
     }
     if (NULL != names) {
-        pmix_argv_free(names);
+        PMIX_ARGV_FREE_COMPAT(names);
     }
     return rc;
 }

--- a/src/util/parse_options.c
+++ b/src/util/parse_options.c
@@ -65,11 +65,11 @@ void pmix_util_parse_range_options(char *inp, char ***output)
     }
 
     /* split on commas */
-    r1 = pmix_argv_split(input, ',');
+    r1 = PMIX_ARGV_SPLIT_COMPAT(input, ',');
     /* for each resulting element, check for range */
-    for (i = 0; i < pmix_argv_count(r1); i++) {
-        r2 = pmix_argv_split(r1[i], '-');
-        if (1 < pmix_argv_count(r2)) {
+    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(r1); i++) {
+        r2 = PMIX_ARGV_SPLIT_COMPAT(r1[i], '-');
+        if (1 < PMIX_ARGV_COUNT_COMPAT(r2)) {
             /* given range - get start and end */
             start = strtol(r2[0], NULL, 10);
             end = strtol(r2[1], NULL, 10);
@@ -79,10 +79,10 @@ void pmix_util_parse_range_options(char *inp, char ***output)
              */
             vint = strtol(r1[i], NULL, 10);
             if (-1 == vint) {
-                pmix_argv_free(*output);
+                PMIX_ARGV_FREE_COMPAT(*output);
                 *output = NULL;
-                pmix_argv_append_nosize(output, "-1");
-                pmix_argv_free(r2);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, "-1");
+                PMIX_ARGV_FREE_COMPAT(r2);
                 goto cleanup;
             }
             start = strtol(r2[0], NULL, 10);
@@ -90,17 +90,17 @@ void pmix_util_parse_range_options(char *inp, char ***output)
         }
         for (n = start; n <= end; n++) {
             snprintf(nstr, 32, "%d", n);
-            pmix_argv_append_nosize(output, nstr);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, nstr);
         }
-        pmix_argv_free(r2);
+        PMIX_ARGV_FREE_COMPAT(r2);
     }
 
 cleanup:
     if (bang_option) {
-        pmix_argv_append_nosize(output, "BANG");
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, "BANG");
     }
     free(input);
-    pmix_argv_free(r1);
+    PMIX_ARGV_FREE_COMPAT(r1);
 }
 
 void prte_util_get_ranges(char *inp, char ***startpts, char ***endpts)
@@ -118,28 +118,28 @@ void prte_util_get_ranges(char *inp, char ***startpts, char ***endpts)
     input = strdup(inp);
 
     /* split on commas */
-    r1 = pmix_argv_split(input, ',');
+    r1 = PMIX_ARGV_SPLIT_COMPAT(input, ',');
     /* for each resulting element, check for range */
-    for (i = 0; i < pmix_argv_count(r1); i++) {
-        r2 = pmix_argv_split(r1[i], '-');
-        if (2 == pmix_argv_count(r2)) {
+    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(r1); i++) {
+        r2 = PMIX_ARGV_SPLIT_COMPAT(r1[i], '-');
+        if (2 == PMIX_ARGV_COUNT_COMPAT(r2)) {
             /* given range - get start and end */
-            pmix_argv_append_nosize(startpts, r2[0]);
-            pmix_argv_append_nosize(endpts, r2[1]);
-        } else if (1 == pmix_argv_count(r2)) {
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(startpts, r2[0]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(endpts, r2[1]);
+        } else if (1 == PMIX_ARGV_COUNT_COMPAT(r2)) {
             /* only one value provided, so it is both the start
              * and the end
              */
-            pmix_argv_append_nosize(startpts, r2[0]);
-            pmix_argv_append_nosize(endpts, r2[0]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(startpts, r2[0]);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(endpts, r2[0]);
         } else {
             /* no idea how to parse this */
             pmix_output(0, "%s Unknown parse error on string: %s(%s)",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), inp, r1[i]);
         }
-        pmix_argv_free(r2);
+        PMIX_ARGV_FREE_COMPAT(r2);
     }
 
     free(input);
-    pmix_argv_free(r1);
+    PMIX_ARGV_FREE_COMPAT(r1);
 }

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -108,7 +108,7 @@ void prte_setup_hostname(void)
      * the names exchanged in the modex match the names found locally
      */
     if (NULL != prte_strip_prefix && !pmix_net_isaddr(hostname)) {
-        prefixes = pmix_argv_split(prte_strip_prefix, ',');
+        prefixes = PMIX_ARGV_SPLIT_COMPAT(prte_strip_prefix, ',');
         match = false;
         for (i = 0; NULL != prefixes[i]; i++) {
             if (0 == strncmp(hostname, prefixes[i], strlen(prefixes[i]))) {
@@ -125,7 +125,7 @@ void prte_setup_hostname(void)
                     prte_process_info.nodename = strdup(&hostname[idx]);
                 }
                 /* add this to our list of aliases */
-                pmix_argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
+                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
                 match = true;
                 break;
             }
@@ -134,7 +134,7 @@ void prte_setup_hostname(void)
         if (!match) {
             prte_process_info.nodename = strdup(hostname);
         }
-        pmix_argv_free(prefixes);
+        PMIX_ARGV_FREE_COMPAT(prefixes);
     } else {
         prte_process_info.nodename = strdup(hostname);
     }
@@ -145,11 +145,11 @@ void prte_setup_hostname(void)
         if (prte_keep_fqdn_hostnames) {
             /* retain the non-fqdn name as an alias */
             *ptr = '\0';
-            pmix_argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
             *ptr = '.';
         } else {
             /* add the fqdn name as an alias */
-            pmix_argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
+            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
             /* retain the non-fqdn name as the node's name */
             *ptr = '\0';
         }
@@ -177,7 +177,7 @@ bool prte_check_host_is_local(const char *name)
     if (!prte_do_not_resolve) {
         if (pmix_ifislocal(name)) {
             /* add to our aliases */
-            pmix_argv_append_nosize(&prte_process_info.aliases, name);
+            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_process_info.aliases, name);
             return true;
         }
     }
@@ -291,7 +291,7 @@ int prte_proc_info_finalize(void)
 
     prte_process_info.proc_type = PRTE_PROC_TYPE_NONE;
 
-    pmix_argv_free(prte_process_info.aliases);
+    PMIX_ARGV_FREE_COMPAT(prte_process_info.aliases);
 
     init = false;
     return PRTE_SUCCESS;

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -282,8 +282,8 @@ int prte_session_setup_base(pmix_proc_t *proc)
         /* break the string into tokens - it should be
          * separated by ','
          */
-        list = pmix_argv_split(prte_prohibited_session_dirs, ',');
-        len = pmix_argv_count(list);
+        list = PMIX_ARGV_SPLIT_COMPAT(prte_prohibited_session_dirs, ',');
+        len = PMIX_ARGV_COUNT_COMPAT(list);
         /* cycle through the list */
         for (i = 0; i < len; i++) {
             /* check if prefix matches */
@@ -291,11 +291,11 @@ int prte_session_setup_base(pmix_proc_t *proc)
                 /* this is a prohibited location */
                 pmix_show_help("help-prte-runtime.txt", "prte:session:dir:prohibited", true,
                                prte_process_info.tmpdir_base, prte_prohibited_session_dirs);
-                pmix_argv_free(list);
+                PMIX_ARGV_FREE_COMPAT(list);
                 return PRTE_ERR_FATAL;
             }
         }
-        pmix_argv_free(list); /* done with this */
+        PMIX_ARGV_FREE_COMPAT(list); /* done with this */
     }
     return PRTE_SUCCESS;
 }

--- a/src/util/sys_limits.c
+++ b/src/util/sys_limits.c
@@ -118,15 +118,15 @@ int prte_util_init_sys_limits(char **errmsg)
     }
 
     /* parse the requested limits to set */
-    lims = pmix_argv_split(prte_set_max_sys_limits, ',');
+    lims = PMIX_ARGV_SPLIT_COMPAT(prte_set_max_sys_limits, ',');
     if (NULL == lims) {
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
     /* each limit is expressed as a "param:value" pair */
     for (i = 0; NULL != lims[i]; i++) {
-        lim = pmix_argv_split(lims[i], ':');
-        if (1 == pmix_argv_count(lim)) {
+        lim = PMIX_ARGV_SPLIT_COMPAT(lims[i], ':');
+        if (1 == PMIX_ARGV_COUNT_COMPAT(lim)) {
             setlim = "max";
         } else {
             setlim = lim[1];
@@ -224,7 +224,7 @@ int prte_util_init_sys_limits(char **errmsg)
                                             lim[0], setlim);
             goto out;
         }
-        pmix_argv_free(lim);
+        PMIX_ARGV_FREE_COMPAT(lim);
         lim = NULL;
     }
 
@@ -234,9 +234,9 @@ int prte_util_init_sys_limits(char **errmsg)
     rc = PRTE_SUCCESS;
 
 out:
-    pmix_argv_free(lims);
+    PMIX_ARGV_FREE_COMPAT(lims);
     if (NULL != lim) {
-        pmix_argv_free(lim);
+        PMIX_ARGV_FREE_COMPAT(lim);
     }
 
     return rc;


### PR DESCRIPTION
Macros have been converted to functions, which is contrary to what is in earlier releases such as v4.2.2. Introduce compatibility macros to switch between the two forms so we remain compatible across the PMIx versions.

Signed-off-by: Ralph Castain <rhc@pmix.org>