### PR TITLE
Pass our event base for use by the PMIx library as an aux base

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -647,6 +647,13 @@ int pmix_server_init(void)
         return rc;
     }
 
+    /* give the server our event base to use for signal trapping */
+    PMIX_INFO_LIST_ADD(prc, ilist, PMIX_EXTERNAL_AUX_EVENT_BASE, prte_event_base, PMIX_POINTER);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_INFO_LIST_RELEASE(ilist);
+        return rc;
+    }
+
     /* if PMIx is version 4 or higher, then we can pass our
      * topology object down to the server library for its use
      * and for passing to any local clients */


### PR DESCRIPTION
Have the PMIx library use our event base for capturing signals to avoid confusion.

Signed-off-by: Ralph Castain <rhc@pmix.org>