### PR TITLE
Check for and track scheduler attachment

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -164,3 +164,14 @@ command line option has more than one value:
 
 The resolution function cannot handle this scenario - please
 notify the developers
+#
+[binding-pe-conflict]
+The PE=<list> mapping directive cannot be combined with a
+binding directive as it already mandates that we bind to
+the specified cpu(s). The conflicting directives that were
+given are:
+
+  map-by:  %s
+  bind-to: %s
+
+Please resolve the conflict and try again.

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -520,6 +520,17 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         }
     }
 
+    // check for map-by - bind-to conflicts
+    opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_MAPBY);
+    newopt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_BINDTO);
+    if (NULL != opt && NULL != newopt) {
+        if (NULL != strcasestr(opt->values[0], "PE")) {
+            pmix_show_help("help-schizo-base.txt", "binding-pe-conflict", true,
+                           opt->values[0], newopt->values[0]);
+            return PRTE_ERR_SILENT;
+        }
+    }
+
     return PRTE_SUCCESS;
 }
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1616,6 +1616,7 @@ static void rqcon(pmix_server_req_t *p)
     p->key = NULL;
     p->flag = true;
     p->launcher = false;
+    p->scheduler = false;
     p->remote_room_num = -1;
     p->uid = 0;
     p->gid = 0;

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -384,6 +384,9 @@ typedef struct {
     bool pubsub_init;
     bool session_server;
     bool system_server;
+    bool scheduler_connected;
+    pmix_proc_t scheduler;
+    bool scheduler_set_as_server;
     char *report_uri;
     char *singleton;
     pmix_device_type_t generate_dist;

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -17,12 +17,27 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
                                    const pmix_info_t data[], size_t ndata,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
+    pmix_status_t rc;
+
     /* if we are not the DVM controller, then send it there */
 
     /* we are the DVM controller, so pass it down so PMIx can
      * send it to the scheduler */
 
-    return PMIX_ERR_NOT_SUPPORTED;
+    if (!prte_pmix_server_globals.scheduler_connected) {
+        /* the scheduler has not attached to us - there is
+         * nothing we can do */
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+    /* if we have not yet set the scheduler as our server, do so */
+    if (!prte_pmix_server_globals.scheduler_set_as_server) {
+        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        prte_pmix_server_globals.scheduler_set_as_server = true;
+    }
+
 }
 
 #if PMIX_NUMERIC_VERSION >= 0x00050000
@@ -32,12 +47,27 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                                           const pmix_info_t directives[], size_t ndirs,
                                           pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
+    pmix_status_t rc;
+
     /* if we are not the DVM controller, then send it there */
 
     /* we are the DVM controller, so pass it down so PMIx can
      * send it to the scheduler */
 
-    return PMIX_ERR_NOT_SUPPORTED;
+    if (!prte_pmix_server_globals.scheduler_connected) {
+        /* the scheduler has not attached to us - there is
+         * nothing we can do */
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+    /* if we have not yet set the scheduler as our server, do so */
+    if (!prte_pmix_server_globals.scheduler_set_as_server) {
+        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        prte_pmix_server_globals.scheduler_set_as_server = true;
+    }
+
 }
 
 #endif


### PR DESCRIPTION
Record that a scheduler has attached to us so
we know when scheduler-related requests can be
supported.

Signed-off-by: Ralph Castain <rhc@pmix.org>