### PR TITLE
Don't error out on binding if not required

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -118,8 +118,12 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
     }
     if (NULL == trg_obj) {
         /* there aren't any appropriate targets under this object */
-        pmix_show_help("help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
-        return PRTE_ERR_SILENT;
+        if (PRTE_BINDING_REQUIRED(jdata->map->binding)) {
+            pmix_show_help("help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
+            return PRTE_ERR_SILENT;
+        } else {
+            return PRTE_SUCCESS;
+        }
     }
 
 #if HWLOC_API_VERSION < 0x20000

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -534,7 +534,7 @@ int main(int argc, char *argv[])
         setenv("PRTE_MCA_prte_launch_agent", opt->values[0], true); // cmd line overrides all
     }
 
-    /* if we are supporting a singleton, push its ID into the environ
+    /* if we are supporting a singleton, cache its ID
      * so it can get picked up and registered by server init */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_SINGLETON);
     if (NULL != opt) {


### PR DESCRIPTION
Since we default binding to the mapping object, we need to protect against false errors when binding to such an object isn't supported (e.g., on a Mac).

Signed-off-by: Ralph Castain <rhc@pmix.org>