### PR TITLE
Cleanup a couple of things

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -350,6 +350,7 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_ALLOC_QUEUE",
                          "PMIX_ALLOC_PREEMPTIBLE",
                          NULL}},
+#if PMIX_NUMERIC_VERSION >= 0x00050000
     {.function = "PMIx_Session_control",
      .attrs = (char *[]){"PMIX_SESSION_CTRL_ID",
                          "PMIX_SESSION_APP",
@@ -361,6 +362,7 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_SESSION_SIGNAL",
                          "PMIX_SESSION_COMPLETE",
                          NULL}},
+#endif
     {.function = ""},
 };
 

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -50,7 +50,6 @@ prte_LDADD = \
 
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f prterun$(EXEEXT); $(LN_S) prte$(EXEEXT) prterun$(EXEEXT))
-	(cd $(DESTDIR)$(bindir); rm -f srun$(EXEEXT); $(LN_S) prte$(EXEEXT) srun$(EXEEXT))
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/prterun$(EXEEXT)


### PR DESCRIPTION
Don't install the experimental "srun" cmd link as that will create problems for the slurm plm plugin on slurm machines.

supported attribute array.

Signed-off-by: Ralph Castain <rhc@pmix.org>