### PR TITLE
Provide size estimates for collective operations that return data

### DIFF
--- a/src/mca/grpcomm/base/base.h
+++ b/src/mca/grpcomm/base/base.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,12 +82,13 @@ PRTE_EXPORT extern prte_grpcomm_base_t prte_grpcomm_base;
 PRTE_EXPORT int prte_grpcomm_API_xcast(prte_grpcomm_signature_t *sig, prte_rml_tag_t tag,
                                        pmix_data_buffer_t *buf);
 
-PRTE_EXPORT int prte_grpcomm_API_allgather(prte_grpcomm_signature_t *sig, pmix_data_buffer_t *buf,
-                                           int mode, pmix_status_t local_status,
-                                           prte_grpcomm_cbfunc_t cbfunc, void *cbdata);
+PRTE_EXPORT int prte_grpcomm_API_allgather(prte_pmix_mdx_caddy_t *cd);
 
 PRTE_EXPORT prte_grpcomm_coll_t *prte_grpcomm_base_get_tracker(prte_grpcomm_signature_t *sig,
                                                                bool create);
+
+PRTE_EXPORT int prte_pack_ctrl_options(pmix_byte_object_t *bo,
+                                       const pmix_info_t *info, size_t ninfo);
 
 END_C_DECLS
 #endif

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,6 +144,9 @@ static void ccon(prte_grpcomm_coll_t *p)
     p->ndmns = 0;
     p->nexpected = 0;
     p->nreported = 0;
+    p->assignID = false;
+    p->timeout = 0;
+    p->memsize = 0;
     p->cbfunc = NULL;
     p->cbdata = NULL;
     p->buffers = NULL;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1609,7 +1609,9 @@ static void opcon(prte_pmix_server_op_caddy_t *p)
     p->cbdata = NULL;
     p->server_object = NULL;
 }
-PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t, pmix_object_t, opcon, NULL);
+PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t,
+                    pmix_object_t,
+                    opcon, NULL);
 
 static void rqcon(pmix_server_req_t *p)
 {
@@ -1657,17 +1659,22 @@ static void rqdes(pmix_server_req_t *p)
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->msg);
 }
-PMIX_CLASS_INSTANCE(pmix_server_req_t, pmix_object_t, rqcon, rqdes);
+PMIX_CLASS_INSTANCE(pmix_server_req_t,
+                    pmix_object_t,
+                    rqcon, rqdes);
 
 static void mdcon(prte_pmix_mdx_caddy_t *p)
 {
     p->sig = NULL;
     p->buf = NULL;
-    p->cbfunc = NULL;
-    p->mode = 0;
+    PMIX_BYTE_OBJECT_CONSTRUCT(&p->ctrls);
     p->info = NULL;
     p->ninfo = 0;
     p->cbdata = NULL;
+    p->grpcbfunc = NULL;
+    p->mdxcbfunc = NULL;
+    p->infocbfunc = NULL;
+    p->opcbfunc = NULL;
 }
 static void mddes(prte_pmix_mdx_caddy_t *p)
 {
@@ -1677,8 +1684,11 @@ static void mddes(prte_pmix_mdx_caddy_t *p)
     if (NULL != p->buf) {
         PMIX_DATA_BUFFER_RELEASE(p->buf);
     }
+    PMIX_BYTE_OBJECT_DESTRUCT(&p->ctrls);
 }
-PMIX_CLASS_INSTANCE(prte_pmix_mdx_caddy_t, pmix_object_t, mdcon, mddes);
+PMIX_CLASS_INSTANCE(prte_pmix_mdx_caddy_t,
+                    pmix_object_t,
+                    mdcon, mddes);
 
 static void pscon(pmix_server_pset_t *p)
 {
@@ -1695,7 +1705,9 @@ static void psdes(pmix_server_pset_t *p)
         free(p->members);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_server_pset_t, pmix_list_item_t, pscon, psdes);
+PMIX_CLASS_INSTANCE(pmix_server_pset_t,
+                    pmix_list_item_t,
+                    pscon, psdes);
 
 static void tlcon(prte_pmix_tool_t *p)
 {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,7 +49,6 @@
 #include "src/util/proc_info.h"
 #include "types.h"
 
-#include "src/mca/grpcomm/base/base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/threads/pmix_threads.h"
 
@@ -145,20 +144,6 @@ typedef struct {
     void *cbdata;
 } prte_pmix_server_op_caddy_t;
 PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
-
-typedef struct {
-    pmix_object_t super;
-    prte_grpcomm_signature_t *sig;
-    pmix_data_buffer_t *buf;
-    pmix_modex_cbfunc_t cbfunc;
-    pmix_info_cbfunc_t infocbfunc;
-    pmix_op_cbfunc_t opcbfunc;
-    int mode;
-    pmix_info_t *info;
-    size_t ninfo;
-    void *cbdata;
-} prte_pmix_mdx_caddy_t;
-PMIX_CLASS_DECLARATION(prte_pmix_mdx_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;


### PR DESCRIPTION
Generalize the grpcomm allgather operation to support any number of directives, not just "assign a context ID". Update the group, modex, and connect operations to take this into account.

Signed-off-by: Ralph Castain <rhc@pmix.org>