### PR TITLE
Add an option to display the available CPUs

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -378,6 +378,11 @@ PRTE_EXPORT int prte_hwloc_base_open(void);
 PRTE_EXPORT void prte_hwloc_base_close(void);
 PRTE_EXPORT int prte_hwloc_base_register(void);
 PRTE_EXPORT int prte_hwloc_print(char **output, char *prefix, hwloc_topology_t src);
+
+PRTE_EXPORT void prte_hwloc_build_map(hwloc_topology_t topo,
+                                      hwloc_cpuset_t avail,
+                                      bool use_hwthread_cpus,
+                                      hwloc_bitmap_t coreset);
 
 END_C_DECLS
 

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1192,8 +1192,10 @@ char *prte_hwloc_base_print_binding(prte_binding_policy_t binding)
     return ret;
 }
 
-static void build_map(hwloc_topology_t topo, hwloc_cpuset_t avail, bool use_hwthread_cpus,
-                      hwloc_bitmap_t coreset)
+void prte_hwloc_build_map(hwloc_topology_t topo,
+                          hwloc_cpuset_t avail,
+                          bool use_hwthread_cpus,
+                          hwloc_bitmap_t coreset)
 {
     unsigned k, obj_index, core_index;
     hwloc_obj_t pu, core;
@@ -1289,7 +1291,7 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
             hwloc_bitmap_list_snprintf(tmp, 2048, avail);
             snprintf(ans, 4096, "package[%d][hwt:%s]", n, tmp);
         } else {
-            build_map(topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
+            prte_hwloc_build_map(topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
             /* now print out the string */
             hwloc_bitmap_list_snprintf(tmp, 2048, coreset);
             snprintf(ans, 4096, "package[%d][core:%s]", n, tmp);

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -13,7 +13,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +63,8 @@ typedef struct prte_ras_base_t {
 PRTE_EXPORT extern prte_ras_base_t prte_ras_base;
 
 PRTE_EXPORT void prte_ras_base_display_alloc(prte_job_t *jdata);
+
+PRTE_EXPORT void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist);
 
 PRTE_EXPORT void prte_ras_base_allocate(int fd, short args, void *cbdata);
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      UT-Battelle, LLC. All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -319,6 +319,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
         options.use_hwthreads = true;
+    }
+
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS, (void*)&tmp, PMIX_STRING)) {
+        prte_ras_base_display_cpus(jdata, tmp);
+        free(tmp);
     }
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +31,9 @@ Supported values include:
 
 -   TOPO=LIST displays the topology of each node in the comma-delimited list
     that is allocated to the job
+
+-   CPUS[=LIST] displays the comma-delimited ranges of available CPUs on
+    the provided comma-delimited list of nodes (defaults to all nodes)
 
 No qualifiers are defined for this directive.
 #

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -387,6 +387,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_BIND,
         PRTE_CLI_MAPDEV,
         PRTE_CLI_TOPO,
+        PRTE_CLI_CPUS,
         NULL
     };
 
@@ -578,22 +579,36 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_TOPO)) {
                 ptr = strchr(targv[idx], '=');
-                if (NULL == ptr) {
-                    /* missing the value or value is invalid */
-                    pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                   "display", "TOPO", targv[idx]);
-                    PMIX_ARGV_FREE_COMPAT(targv);
-                    return PRTE_ERR_FATAL;
-                }
-                ++ptr;
-                if ('\0' == *ptr) {
-                    /* missing the value or value is invalid */
-                    pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                   "display", "TOPO", targv[idx]);
-                    PMIX_ARGV_FREE_COMPAT(targv);
-                    return PRTE_ERR_FATAL;
+                ptr = strchr(targv[idx], '=');
+                if (NULL != ptr) {
+                    ++ptr;
+                    if ('\0' == *ptr) {
+                        /* missing the value or value is invalid */
+                        pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                                       "display", "PROCESSORS", targv[idx]);
+                        PMIX_ARGV_FREE_COMPAT(targv);
+                        return PRTE_ERR_FATAL;
+                    }
                 }
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_TOPOLOGY, ptr, PMIX_STRING);
+                if (PMIX_SUCCESS != ret) {
+                    PMIX_ERROR_LOG(ret);
+                    PMIX_ARGV_FREE_COMPAT(targv);
+                    return ret;
+                }
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_CPUS)) {
+                ptr = strchr(targv[idx], '=');
+                if (NULL != ptr) {
+                    ++ptr;
+                    if ('\0' == *ptr) {
+                        /* missing the value or value is invalid */
+                        pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                                       "display", "PROCESSORS", targv[idx]);
+                        PMIX_ARGV_FREE_COMPAT(targv);
+                        return PRTE_ERR_FATAL;
+                    }
+                }
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PROCESSORS, ptr, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_ARGV_FREE_COMPAT(targv);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -401,6 +401,13 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO,
                                PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
 
+#ifdef PMIX_DISPLAY_PROCESSORS
+            /***   DISPLAY PROCESSORS   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_PROCESSORS)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS,
+                               PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
+#endif
+
         /***   PPR (PROCS-PER-RESOURCE)   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_PPR)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -73,7 +73,7 @@ int prte_set_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                        pmix_data_type_t type)
 {
     prte_attribute_t *kv;
-    bool *bl;
+    bool *bl, bltrue = true;
     int rc;
 
     PMIX_LIST_FOREACH(kv, attributes, prte_attribute_t)
@@ -83,7 +83,11 @@ int prte_set_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                 return PRTE_ERR_TYPE_MISMATCH;
             }
             if (PMIX_BOOL == type) {
-                bl = (bool*)data;
+                if (NULL == data) {
+                    bl = &bltrue;
+                } else {
+                    bl = (bool*)data;
+                }
                 if (false == *bl) {
                     pmix_list_remove_item(attributes, &kv->super);
                     PMIX_RELEASE(kv);
@@ -487,6 +491,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "AUTORESTART";
         case PRTE_JOB_OUTPUT_PROCTABLE:
             return "OUTPUT PROCTABLE";
+        case PRTE_JOB_DISPLAY_PROCESSORS:
+            return "DISPLAY PROCESSORS";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -215,6 +215,9 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_AUTORESTART                (PRTE_JOB_START_KEY + 107) // bool - automatically restart failed processes
 #define PRTE_JOB_OUTPUT_PROCTABLE           (PRTE_JOB_START_KEY + 108) // char* - string specifying where the output is to go, with a '-'
                                                                        //         indicating stdout, '+' indicating stderr, else path
+#define PRTE_JOB_DISPLAY_PROCESSORS         (PRTE_JOB_START_KEY + 109) // char* - string displaying nodes whose avail CPUs
+                                                                       //         are to be displayed
+
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -189,6 +189,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_BIND       "bind"
 #define PRTE_CLI_MAPDEV     "map-devel"
 #define PRTE_CLI_TOPO       "topo="
+#define PRTE_CLI_CPUS       "cpus="
 
 // Runtime directives
 #define PRTE_CLI_ERROR_NZ           "error-nonzero-status"          // optional arg


### PR DESCRIPTION
Given an optional list of node names, display the
available CPUs for each of them. The current output is definitely spartan and can use some prettying up, but the hooks are here for someone to do so.

Signed-off-by: Ralph Castain <rhc@pmix.org>