### PR TITLE
Protect against missing attribute definition

### DIFF
--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -707,3 +707,15 @@ Examples:
   <command> --dvm pid:file:prte_pid.txt --np 4 ./a.out
 
   <command> --dvm search --np 4 ./a.out
+#
+# NON-SUPPORTING PMIX
+#
+[non-supporting-pmix]
+The given command line directive is technically valid, but the underlying
+PMIx version being employed lacks the necessary attribute definitions to
+support it.
+
+  Directive:  %s
+  Option:     %s
+
+We are therefore unable to satisfy this request.

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -608,7 +608,14 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         return PRTE_ERR_FATAL;
                     }
                 }
+#ifdef PMIX_DISPLAY_PROCESSORS
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PROCESSORS, ptr, PMIX_STRING);
+#else
+                pmix_show_help("help-prte-rmaps-base.txt", "non-supporting-pmix", true,
+                               "display", targv[idx]);
+                PMIX_ARGV_FREE_COMPAT(targv);
+                return PRTE_ERR_FATAL;
+#endif
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_ARGV_FREE_COMPAT(targv);


### PR DESCRIPTION
Missed one place that needs to be protected against earlier versions of PMIx that lack the PMIX_DISPLAY_PROCESSORS attribute.

Signed-off-by: Ralph Castain <rhc@pmix.org>