### PR TITLE
Fix generate_dist type

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -427,7 +427,7 @@ void pmix_server_register_params(void)
     /* whether or not to drop a system-level tool rendezvous point */
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "generate_distances",
                                       "Device types whose distances are to be provided (default=none, options=fabric,gpu,network",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &generate_dist);
     prte_pmix_server_globals.generate_dist = 0;
     if (NULL != generate_dist) {


### PR DESCRIPTION
generate_dist is a char *. When registering the mca parameter, register it as a string not a bool. The parameter allows the specification of which objects to generate distances for. It's not an enable/disable variable.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>