### PR TITLE
Set distances array type

### DIFF
--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -507,6 +507,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                                             distances[f].mindist, distances[f].maxdist);
                             }
                         }
+                        darray.type = PMIX_DEVICE_DIST;
                         darray.array = distances;
                         darray.size = ndist;
                         PMIX_INFO_LIST_ADD(ret, pmap, PMIX_DEVICE_DISTANCES, &darray, PMIX_DATA_ARRAY);


### PR DESCRIPTION
After gathering the distances they need to be stored. Set the darray.type to PMIX_DEVICE_DIST before calling PMIX_INFO_LIST_ADD() to ensure proper processing

Signed-off-by: Amir Shehata <shehataa@ornl.gov>