### PR TITLE
Generate distances by default

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -370,7 +370,7 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
 static void _mdxresp(int sd, short args, void *cbdata);
 static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata);
 
-static char *generate_dist = NULL;
+static char *generate_dist = "fabric,gpu,network";
 void pmix_server_register_params(void)
 {
     char **tmp;


### PR DESCRIPTION
Turn on distance generation for fabric, gpu and network by default. This reduces the configuration overhead when requiring distances and it doesn't add much overhead.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>