### PR TITLE
Add "parseable" display qualifier

### DIFF
--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -29,13 +29,20 @@ Supported values include:
     processes in this job that includes local and node ranks, assigned
     bindings, and other data
 
--   TOPO=LIST displays the topology of each node in the comma-delimited list
+-   TOPO=LIST displays the topology of each node in the semicolon-delimited list
     that is allocated to the job
 
--   CPUS[=LIST] displays the comma-delimited ranges of available CPUs on
-    the provided comma-delimited list of nodes (defaults to all nodes)
+-   CPUS[=LIST] displays the available CPUs on the provided semicolon-delimited
+    list of nodes (defaults to all nodes)
 
-No qualifiers are defined for this directive.
+The display command line directive can include qualifiers by adding a colon (:)
+and any combination of one or more of the following (delimited by colons):
+
+-   PARSEABLE directs that the output be provided in a format that is easily
+    parsed by machines. Note that PARSABLE is also accepted as a typical
+    spelling for the qualifier.
+
+Provided qualifiers will apply to ALL of the display directives.
 #
 #  OUTPUT
 #

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -408,6 +408,14 @@ static void interim(int sd, short args, void *cbdata)
                                PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
 #endif
 
+#ifdef PMIX_DISPLAY_PARSEABLE_OUTPUT
+            /***   DISPLAY PARSEABLE OUTPUT   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_PARSEABLE_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT,
+                               PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
+#endif
+
         /***   PPR (PROCS-PER-RESOURCE)   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_PPR)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -123,8 +123,8 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
     /* set default result */
     *output = NULL;
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         pmix_asprintf(&tmp, "<host name=\"%s\" slots=\"%d\" max_slots=\"%d\">\n",
                       (NULL == src->name) ? "UNKNOWN" : src->name, (int) src->slots,
                       (int) src->slots_max);
@@ -243,8 +243,8 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
         use_hwthread_cpus = false;
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         if (0 == src->pid) {
             pmix_asprintf(output, "%s<process rank=\"%s\" status=\"%s\"/>\n", pfx2,
                           PRTE_VPID_PRINT(src->name.rank), prte_proc_state_to_str(src->state));
@@ -372,8 +372,8 @@ void prte_map_print(char **output, prte_job_t *jdata)
     /* set default result */
     *output = NULL;
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         pmix_asprintf(&tmp, "<map>\n");
         /* loop through nodes */
         for (i = 0; i < src->nodes->size; i++) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -493,6 +493,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "OUTPUT PROCTABLE";
         case PRTE_JOB_DISPLAY_PROCESSORS:
             return "DISPLAY PROCESSORS";
+        case PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT:
+            return "DISPLAY PARSEABLE OUTPUT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -217,6 +217,7 @@ typedef uint16_t prte_job_flags_t;
                                                                        //         indicating stdout, '+' indicating stderr, else path
 #define PRTE_JOB_DISPLAY_PROCESSORS         (PRTE_JOB_START_KEY + 109) // char* - string displaying nodes whose avail CPUs
                                                                        //         are to be displayed
+#define PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT   (PRTE_JOB_START_KEY + 110) // bool - display output in machine parsable format
 
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)


### PR DESCRIPTION
When requesting display of info, allow specificying a "parseable" qualifier to indicate that the output should be provided in a format amenable to machine parsing.

Signed-off-by: Ralph Castain <rhc@pmix.org>