### PR TITLE
Multiple commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ test/cmspawn
 test/qspawn
 test/filegen
 test/iostress
+test/spawn_multiple
 
 docs/_build
 docs/_static

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -378,6 +378,11 @@ PRTE_EXPORT int prte_hwloc_base_open(void);
 PRTE_EXPORT void prte_hwloc_base_close(void);
 PRTE_EXPORT int prte_hwloc_base_register(void);
 PRTE_EXPORT int prte_hwloc_print(char **output, char *prefix, hwloc_topology_t src);
+
+PRTE_EXPORT void prte_hwloc_build_map(hwloc_topology_t topo,
+                                      hwloc_cpuset_t avail,
+                                      bool use_hwthread_cpus,
+                                      hwloc_bitmap_t coreset);
 
 END_C_DECLS
 

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1192,8 +1192,10 @@ char *prte_hwloc_base_print_binding(prte_binding_policy_t binding)
     return ret;
 }
 
-static void build_map(hwloc_topology_t topo, hwloc_cpuset_t avail, bool use_hwthread_cpus,
-                      hwloc_bitmap_t coreset)
+void prte_hwloc_build_map(hwloc_topology_t topo,
+                          hwloc_cpuset_t avail,
+                          bool use_hwthread_cpus,
+                          hwloc_bitmap_t coreset)
 {
     unsigned k, obj_index, core_index;
     hwloc_obj_t pu, core;
@@ -1289,7 +1291,7 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
             hwloc_bitmap_list_snprintf(tmp, 2048, avail);
             snprintf(ans, 4096, "package[%d][hwt:%s]", n, tmp);
         } else {
-            build_map(topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
+            prte_hwloc_build_map(topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
             /* now print out the string */
             hwloc_bitmap_list_snprintf(tmp, 2048, coreset);
             snprintf(ans, 4096, "package[%d][core:%s]", n, tmp);

--- a/src/mca/grpcomm/base/base.h
+++ b/src/mca/grpcomm/base/base.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -82,12 +82,13 @@ PRTE_EXPORT extern prte_grpcomm_base_t prte_grpcomm_base;
 PRTE_EXPORT int prte_grpcomm_API_xcast(prte_grpcomm_signature_t *sig, prte_rml_tag_t tag,
                                        pmix_data_buffer_t *buf);
 
-PRTE_EXPORT int prte_grpcomm_API_allgather(prte_grpcomm_signature_t *sig, pmix_data_buffer_t *buf,
-                                           int mode, pmix_status_t local_status,
-                                           prte_grpcomm_cbfunc_t cbfunc, void *cbdata);
+PRTE_EXPORT int prte_grpcomm_API_allgather(prte_pmix_mdx_caddy_t *cd);
 
 PRTE_EXPORT prte_grpcomm_coll_t *prte_grpcomm_base_get_tracker(prte_grpcomm_signature_t *sig,
                                                                bool create);
+
+PRTE_EXPORT int prte_pack_ctrl_options(pmix_byte_object_t *bo,
+                                       const pmix_info_t *info, size_t ninfo);
 
 END_C_DECLS
 #endif

--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,6 +144,9 @@ static void ccon(prte_grpcomm_coll_t *p)
     p->ndmns = 0;
     p->nexpected = 0;
     p->nreported = 0;
+    p->assignID = false;
+    p->timeout = 0;
+    p->memsize = 0;
     p->cbfunc = NULL;
     p->cbdata = NULL;
     p->buffers = NULL;

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -13,7 +13,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +63,8 @@ typedef struct prte_ras_base_t {
 PRTE_EXPORT extern prte_ras_base_t prte_ras_base;
 
 PRTE_EXPORT void prte_ras_base_display_alloc(prte_job_t *jdata);
+
+PRTE_EXPORT void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist);
 
 PRTE_EXPORT void prte_ras_base_allocate(int fd, short args, void *cbdata);
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -435,10 +435,31 @@ ranking:
             PRTE_HWLOC_MAKE_OBJ_CACHE(1, options.maptype, options.cmaplvl);
             break;
         case PRTE_MAPPING_BYCORE:
+            if (1 < options.cpus_per_rank &&
+                !options.use_hwthreads) {
+                /* we cannot support this operation as there is only one
+                 * cpu in a core */
+                pmix_show_help("help-prte-rmaps-base.txt", "mapping-too-low", true,
+                               options.cpus_per_rank, 1,
+                               prte_rmaps_base_print_mapping(options.map));
+                jdata->exit_code = PRTE_ERR_SILENT;
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                goto cleanup;
+            }
             options.mapdepth = PRTE_BIND_TO_CORE;
             options.maptype = HWLOC_OBJ_CORE;
             break;
         case PRTE_MAPPING_BYHWTHREAD:
+            if (1 < options.cpus_per_rank) {
+                /* we cannot support this operation as there is only one
+                 * cpu in a core */
+                pmix_show_help("help-prte-rmaps-base.txt", "mapping-too-low", true,
+                               options.cpus_per_rank, 1,
+                               prte_rmaps_base_print_mapping(options.map));
+                jdata->exit_code = PRTE_ERR_SILENT;
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                goto cleanup;
+            }
             options.mapdepth = PRTE_BIND_TO_HWTHREAD;
             options.maptype = HWLOC_OBJ_PU;
             break;

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      UT-Battelle, LLC. All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -319,6 +319,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
         options.use_hwthreads = true;
+    }
+
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS, (void*)&tmp, PMIX_STRING)) {
+        prte_ras_base_display_cpus(jdata, tmp);
+        free(tmp);
     }
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -143,8 +143,8 @@ pass:
         for (i = 0; i < options->nprocs && nprocs_mapped < app->num_procs; i++) {
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto errout;
+                /* move on to the next node */
+                break;
             }
             nprocs_mapped++;
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
@@ -304,8 +304,8 @@ pass:
         for (j=0; j < options->nprocs && nprocs_mapped < app->num_procs; j++) {
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto errout;
+                /* move to next node */
+                break;
             }
             nprocs_mapped++;
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,6 +31,9 @@ Supported values include:
 
 -   TOPO=LIST displays the topology of each node in the comma-delimited list
     that is allocated to the job
+
+-   CPUS[=LIST] displays the comma-delimited ranges of available CPUs on
+    the provided comma-delimited list of nodes (defaults to all nodes)
 
 No qualifiers are defined for this directive.
 #

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -707,3 +707,15 @@ Examples:
   <command> --dvm pid:file:prte_pid.txt --np 4 ./a.out
 
   <command> --dvm search --np 4 ./a.out
+#
+# NON-SUPPORTING PMIX
+#
+[non-supporting-pmix]
+The given command line directive is technically valid, but the underlying
+PMIx version being employed lacks the necessary attribute definitions to
+support it.
+
+  Directive:  %s
+  Option:     %s
+
+We are therefore unable to satisfy this request.

--- a/src/mca/schizo/base/help-schizo-cli.txt
+++ b/src/mca/schizo/base/help-schizo-cli.txt
@@ -29,13 +29,20 @@ Supported values include:
     processes in this job that includes local and node ranks, assigned
     bindings, and other data
 
--   TOPO=LIST displays the topology of each node in the comma-delimited list
+-   TOPO=LIST displays the topology of each node in the semicolon-delimited list
     that is allocated to the job
 
--   CPUS[=LIST] displays the comma-delimited ranges of available CPUs on
-    the provided comma-delimited list of nodes (defaults to all nodes)
+-   CPUS[=LIST] displays the available CPUs on the provided semicolon-delimited
+    list of nodes (defaults to all nodes)
 
-No qualifiers are defined for this directive.
+The display command line directive can include qualifiers by adding a colon (:)
+and any combination of one or more of the following (delimited by colons):
+
+-   PARSEABLE directs that the output be provided in a format that is easily
+    parsed by machines. Note that PARSABLE is also accepted as a typical
+    spelling for the qualifier.
+
+Provided qualifiers will apply to ALL of the display directives.
 #
 #  OUTPUT
 #

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -387,6 +387,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_BIND,
         PRTE_CLI_MAPDEV,
         PRTE_CLI_TOPO,
+        PRTE_CLI_CPUS,
         NULL
     };
 
@@ -578,22 +579,36 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_TOPO)) {
                 ptr = strchr(targv[idx], '=');
-                if (NULL == ptr) {
-                    /* missing the value or value is invalid */
-                    pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                   "display", "TOPO", targv[idx]);
-                    PMIX_ARGV_FREE_COMPAT(targv);
-                    return PRTE_ERR_FATAL;
-                }
-                ++ptr;
-                if ('\0' == *ptr) {
-                    /* missing the value or value is invalid */
-                    pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                   "display", "TOPO", targv[idx]);
-                    PMIX_ARGV_FREE_COMPAT(targv);
-                    return PRTE_ERR_FATAL;
+                ptr = strchr(targv[idx], '=');
+                if (NULL != ptr) {
+                    ++ptr;
+                    if ('\0' == *ptr) {
+                        /* missing the value or value is invalid */
+                        pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                                       "display", "PROCESSORS", targv[idx]);
+                        PMIX_ARGV_FREE_COMPAT(targv);
+                        return PRTE_ERR_FATAL;
+                    }
                 }
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_TOPOLOGY, ptr, PMIX_STRING);
+                if (PMIX_SUCCESS != ret) {
+                    PMIX_ERROR_LOG(ret);
+                    PMIX_ARGV_FREE_COMPAT(targv);
+                    return ret;
+                }
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_CPUS)) {
+                ptr = strchr(targv[idx], '=');
+                if (NULL != ptr) {
+                    ++ptr;
+                    if ('\0' == *ptr) {
+                        /* missing the value or value is invalid */
+                        pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                                       "display", "PROCESSORS", targv[idx]);
+                        PMIX_ARGV_FREE_COMPAT(targv);
+                        return PRTE_ERR_FATAL;
+                    }
+                }
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PROCESSORS, ptr, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_ARGV_FREE_COMPAT(targv);

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -608,7 +608,14 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         return PRTE_ERR_FATAL;
                     }
                 }
+#ifdef PMIX_DISPLAY_PROCESSORS
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PROCESSORS, ptr, PMIX_STRING);
+#else
+                pmix_show_help("help-prte-rmaps-base.txt", "non-supporting-pmix", true,
+                               "display", targv[idx]);
+                PMIX_ARGV_FREE_COMPAT(targv);
+                return PRTE_ERR_FATAL;
+#endif
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_ARGV_FREE_COMPAT(targv);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -86,7 +86,8 @@ prte_schizo_base_module_t prte_schizo_ompi_module = {
     .allow_run_as_root = allow_run_as_root,
     .set_default_ranking = set_default_ranking,
     .job_info = job_info,
-    .set_default_rto = set_default_rto
+    .set_default_rto = set_default_rto,
+    .check_sanity = prte_schizo_base_sanity
 };
 
 static struct option ompioptions[] = {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,7 +77,8 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
     .job_info = job_info,
-    .set_default_rto = set_default_rto
+    .set_default_rto = set_default_rto,
+    .check_sanity = prte_schizo_base_sanity
 };
 
 static struct option prteoptions[] = {

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -5,7 +5,7 @@
  *                         reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -114,6 +114,9 @@ typedef void (*prte_schizo_base_module_finalize_fn_t)(void);
 typedef void (*prte_schizo_base_module_job_info_fn_t)(pmix_cli_result_t *results,
                                                       void *jobinfo);
 
+/* give the component a chance to validate directives and their values */
+typedef int (*prte_schizo_base_module_check_sanity_fn_t)(pmix_cli_result_t *cmd_line);
+
 /*
  * schizo module version 1.3.0
  */
@@ -131,6 +134,7 @@ typedef struct {
     prte_schizo_base_module_setup_app_fn_t              setup_app;
     prte_schizo_base_module_setup_fork_fn_t             setup_fork;
     prte_schizo_base_module_job_info_fn_t               job_info;
+    prte_schizo_base_module_check_sanity_fn_t           check_sanity;
     prte_schizo_base_module_finalize_fn_t               finalize;
 } prte_schizo_base_module_t;
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -425,7 +425,7 @@ void pmix_server_register_params(void)
     /* whether or not to drop a system-level tool rendezvous point */
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "generate_distances",
                                       "Device types whose distances are to be provided (default=none, options=fabric,gpu,network",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &generate_dist);
     prte_pmix_server_globals.generate_dist = 0;
     if (NULL != generate_dist) {

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -368,7 +368,7 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
 static void _mdxresp(int sd, short args, void *cbdata);
 static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata);
 
-static char *generate_dist = NULL;
+static char *generate_dist = "fabric,gpu,network";
 void pmix_server_register_params(void)
 {
     char **tmp;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1607,7 +1607,9 @@ static void opcon(prte_pmix_server_op_caddy_t *p)
     p->cbdata = NULL;
     p->server_object = NULL;
 }
-PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t, pmix_object_t, opcon, NULL);
+PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t,
+                    pmix_object_t,
+                    opcon, NULL);
 
 static void rqcon(pmix_server_req_t *p)
 {
@@ -1655,17 +1657,22 @@ static void rqdes(pmix_server_req_t *p)
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->msg);
 }
-PMIX_CLASS_INSTANCE(pmix_server_req_t, pmix_object_t, rqcon, rqdes);
+PMIX_CLASS_INSTANCE(pmix_server_req_t,
+                    pmix_object_t,
+                    rqcon, rqdes);
 
 static void mdcon(prte_pmix_mdx_caddy_t *p)
 {
     p->sig = NULL;
     p->buf = NULL;
-    p->cbfunc = NULL;
-    p->mode = 0;
+    PMIX_BYTE_OBJECT_CONSTRUCT(&p->ctrls);
     p->info = NULL;
     p->ninfo = 0;
     p->cbdata = NULL;
+    p->grpcbfunc = NULL;
+    p->mdxcbfunc = NULL;
+    p->infocbfunc = NULL;
+    p->opcbfunc = NULL;
 }
 static void mddes(prte_pmix_mdx_caddy_t *p)
 {
@@ -1675,8 +1682,11 @@ static void mddes(prte_pmix_mdx_caddy_t *p)
     if (NULL != p->buf) {
         PMIX_DATA_BUFFER_RELEASE(p->buf);
     }
+    PMIX_BYTE_OBJECT_DESTRUCT(&p->ctrls);
 }
-PMIX_CLASS_INSTANCE(prte_pmix_mdx_caddy_t, pmix_object_t, mdcon, mddes);
+PMIX_CLASS_INSTANCE(prte_pmix_mdx_caddy_t,
+                    pmix_object_t,
+                    mdcon, mddes);
 
 static void pscon(pmix_server_pset_t *p)
 {
@@ -1693,7 +1703,9 @@ static void psdes(pmix_server_pset_t *p)
         free(p->members);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_server_pset_t, pmix_list_item_t, pscon, psdes);
+PMIX_CLASS_INSTANCE(pmix_server_pset_t,
+                    pmix_list_item_t,
+                    pscon, psdes);
 
 static void tlcon(prte_pmix_tool_t *p)
 {

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -350,6 +350,7 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_ALLOC_QUEUE",
                          "PMIX_ALLOC_PREEMPTIBLE",
                          NULL}},
+#if PMIX_NUMERIC_VERSION >= 0x00050000
     {.function = "PMIx_Session_control",
      .attrs = (char *[]){"PMIX_SESSION_CTRL_ID",
                          "PMIX_SESSION_APP",
@@ -361,6 +362,7 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_SESSION_SIGNAL",
                          "PMIX_SESSION_COMPLETE",
                          NULL}},
+#endif
     {.function = ""},
 };
 

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -408,6 +408,14 @@ static void interim(int sd, short args, void *cbdata)
                                PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
 #endif
 
+#ifdef PMIX_DISPLAY_PARSEABLE_OUTPUT
+            /***   DISPLAY PARSEABLE OUTPUT   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_PARSEABLE_OUTPUT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT,
+                               PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
+#endif
+
         /***   PPR (PROCS-PER-RESOURCE)   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_PPR)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -401,6 +401,13 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO,
                                PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
 
+#ifdef PMIX_DISPLAY_PROCESSORS
+            /***   DISPLAY PROCESSORS   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_PROCESSORS)) {
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS,
+                               PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
+#endif
+
         /***   PPR (PROCS-PER-RESOURCE)   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_PPR)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,7 +49,6 @@
 #include "src/util/proc_info.h"
 #include "types.h"
 
-#include "src/mca/grpcomm/base/base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/threads/pmix_threads.h"
 
@@ -145,20 +144,6 @@ typedef struct {
     void *cbdata;
 } prte_pmix_server_op_caddy_t;
 PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
-
-typedef struct {
-    pmix_object_t super;
-    prte_grpcomm_signature_t *sig;
-    pmix_data_buffer_t *buf;
-    pmix_modex_cbfunc_t cbfunc;
-    pmix_info_cbfunc_t infocbfunc;
-    pmix_op_cbfunc_t opcbfunc;
-    int mode;
-    pmix_info_t *info;
-    size_t ninfo;
-    void *cbdata;
-} prte_pmix_mdx_caddy_t;
-PMIX_CLASS_DECLARATION(prte_pmix_mdx_caddy_t);
 
 typedef struct {
     pmix_list_item_t super;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -507,6 +507,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                                             distances[f].mindist, distances[f].maxdist);
                             }
                         }
+                        darray.type = PMIX_DEVICE_DIST;
                         darray.array = distances;
                         darray.size = ndist;
                         PMIX_INFO_LIST_ADD(ret, pmap, PMIX_DEVICE_DISTANCES, &darray, PMIX_DATA_ARRAY);

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -37,7 +37,7 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
         }
         prte_pmix_server_globals.scheduler_set_as_server = true;
     }
-
+    return PMIX_SUCCESS;
 }
 
 #if PMIX_NUMERIC_VERSION >= 0x00050000
@@ -67,6 +67,7 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
         }
         prte_pmix_server_globals.scheduler_set_as_server = true;
     }
+    return PMIX_SUCCESS;
 
 }
 

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -108,7 +108,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
         return rc;
     }
     // sanity check the results
-    rc = prte_schizo_base_sanity(&results);
+    rc = schizo->check_sanity(&results);
     if (PRTE_SUCCESS != rc) {
         // sanity checker prints the reason
         PMIX_DESTRUCT(&results);

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -123,8 +123,8 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
     /* set default result */
     *output = NULL;
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         pmix_asprintf(&tmp, "<host name=\"%s\" slots=\"%d\" max_slots=\"%d\">\n",
                       (NULL == src->name) ? "UNKNOWN" : src->name, (int) src->slots,
                       (int) src->slots_max);
@@ -243,8 +243,8 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
         use_hwthread_cpus = false;
     }
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         if (0 == src->pid) {
             pmix_asprintf(output, "%s<process rank=\"%s\" status=\"%s\"/>\n", pfx2,
                           PRTE_VPID_PRINT(src->name.rank), prte_proc_state_to_str(src->state));
@@ -372,8 +372,8 @@ void prte_map_print(char **output, prte_job_t *jdata)
     /* set default result */
     *output = NULL;
 
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, NULL, PMIX_BOOL)) {
-        /* need to create the output in XML format */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+        /* need to create the output in parsable format */
         pmix_asprintf(&tmp, "<map>\n");
         /* loop through nodes */
         for (i = 0; i < src->nodes->size; i++) {

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
@@ -420,9 +420,9 @@ int main(int argc, char *argv[])
 
     /* decide if we are to use a persistent DVM, or act alone */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DVM);
-    if (NULL != opt && proxyrun) {
+    if (proxyrun && (NULL != opt || NULL != getenv("PRTEPROXY_USE_DVM"))) {
         /* use a persistent DVM - act like prun */
-        if (NULL != opt->values && NULL != opt->values[0]) {
+        if (NULL != opt && NULL != opt->values && NULL != opt->values[0]) {
             /* they provided a directive on how to find the DVM */
             if (0 == strncasecmp(opt->values[0], "file:", 5)) {
                 /* change the key to match what prun expects */

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -73,7 +73,7 @@ int prte_set_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                        pmix_data_type_t type)
 {
     prte_attribute_t *kv;
-    bool *bl;
+    bool *bl, bltrue = true;
     int rc;
 
     PMIX_LIST_FOREACH(kv, attributes, prte_attribute_t)
@@ -83,7 +83,11 @@ int prte_set_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                 return PRTE_ERR_TYPE_MISMATCH;
             }
             if (PMIX_BOOL == type) {
-                bl = (bool*)data;
+                if (NULL == data) {
+                    bl = &bltrue;
+                } else {
+                    bl = (bool*)data;
+                }
                 if (false == *bl) {
                     pmix_list_remove_item(attributes, &kv->super);
                     PMIX_RELEASE(kv);
@@ -487,6 +491,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "AUTORESTART";
         case PRTE_JOB_OUTPUT_PROCTABLE:
             return "OUTPUT PROCTABLE";
+        case PRTE_JOB_DISPLAY_PROCESSORS:
+            return "DISPLAY PROCESSORS";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -493,6 +493,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "OUTPUT PROCTABLE";
         case PRTE_JOB_DISPLAY_PROCESSORS:
             return "DISPLAY PROCESSORS";
+        case PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT:
+            return "DISPLAY PARSEABLE OUTPUT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -217,6 +217,7 @@ typedef uint16_t prte_job_flags_t;
                                                                        //         indicating stdout, '+' indicating stderr, else path
 #define PRTE_JOB_DISPLAY_PROCESSORS         (PRTE_JOB_START_KEY + 109) // char* - string displaying nodes whose avail CPUs
                                                                        //         are to be displayed
+#define PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT   (PRTE_JOB_START_KEY + 110) // bool - display output in machine parsable format
 
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -215,6 +215,9 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_AUTORESTART                (PRTE_JOB_START_KEY + 107) // bool - automatically restart failed processes
 #define PRTE_JOB_OUTPUT_PROCTABLE           (PRTE_JOB_START_KEY + 108) // char* - string specifying where the output is to go, with a '-'
                                                                        //         indicating stdout, '+' indicating stderr, else path
+#define PRTE_JOB_DISPLAY_PROCESSORS         (PRTE_JOB_START_KEY + 109) // char* - string displaying nodes whose avail CPUs
+                                                                       //         are to be displayed
+
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -189,6 +189,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_BIND       "bind"
 #define PRTE_CLI_MAPDEV     "map-devel"
 #define PRTE_CLI_TOPO       "topo="
+#define PRTE_CLI_CPUS       "cpus="
 
 // Runtime directives
 #define PRTE_CLI_ERROR_NZ           "error-nonzero-status"          // optional arg

--- a/test/spawn_multiple.c
+++ b/test/spawn_multiple.c
@@ -1,0 +1,51 @@
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+int main(int argc, char* argv[])
+{
+    pmix_proc_t myproc;
+    char hostname[1024];
+    pid_t pid;
+    pmix_value_t *val = NULL;
+    pmix_app_t apps[2];
+    pmix_nspace_t nspace;
+    pmix_status_t rc;
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    PMIx_Init(&myproc, NULL, 0);
+
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, NULL, 0, &val);
+    /* If we don't find it, then we're the parent */
+    if (PMIX_SUCCESS != rc) {
+        printf("Parent [pid %ld] about to spawn!\n", (long)pid);
+        PMIX_APP_CONSTRUCT(&apps[0]);
+        apps[0].cmd = strdup(argv[0]);
+        PMIX_ARGV_APPEND(rc, apps[0].argv, "This is job 1");
+        apps[0].maxprocs = 2;
+        PMIX_APP_CONSTRUCT(&apps[1]);
+        apps[1].cmd = strdup(argv[0]);
+        PMIX_ARGV_APPEND(rc, apps[1].argv, "This is job 2");
+        apps[1].maxprocs = 2;
+
+        rc = PMIx_Spawn(NULL, 0, apps, 2, nspace);
+        if (PMIX_SUCCESS != rc) {
+            printf("Child failed to spawn\n");
+            return rc;
+        }
+        printf("Parent done with spawn\n");
+    }
+    /* Otherwise, we're the child */
+    else {
+        printf("Hello from the child %s.%u on host %s pid %ld argv[1] = %s\n",
+               myproc.nspace, myproc.rank, hostname, (long)pid, argv[1]);
+    }
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}


### PR DESCRIPTION
[Add a spawn_multiple test](https://github.com/openpmix/prrte/commit/c9bd77a3bfdb866fb6c9cfb4990a3bc95ebb7ead)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a61250749f3590a96938bebe6cba4f6584ed8f06)

[Provide an estimate of the size of registration data](https://github.com/openpmix/prrte/commit/e252805f1310c53ba8a725e8d8efc2a10ae7f309)

If the PMIx version supports it, the size can be used
by the PMIx server to size shared memory segments.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1686e9bd5c1e7e1641a4cb110a55a3d577a8a1b3)

[Provide size estimates for collective operations that return data](https://github.com/openpmix/prrte/commit/be3388dc28b99126daa3195f3fc061013dffce53)

Generalize the grpcomm allgather operation to support any number
of directives, not just "assign a context ID". Update the group,
modex, and connect operations to take this into account.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3c03edcab60f4ac657f5cc369853f5c64ff85629)

[Add an option to display the available CPUs](https://github.com/openpmix/prrte/commit/b8063a6436c4982591d52823b32902718cf24eca)

Given an optional list of node names, display the
available CPUs for each of them. The current output
is definitely spartan and can use some prettying up,
but the hooks are here for someone to do so.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/32ad7b0a5e84825cb023b9aa0354c75cb55fecd8)

[Fix generate_dist type](https://github.com/openpmix/prrte/commit/bec8b92812efc9fe19c139c5a1e6ecea459f417f)

generate_dist is a char *. When registering the mca parameter, register it
as a string not a bool. The parameter allows the specification of which
objects to generate distances for. It's not an enable/disable variable.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e184691fe393672f366b8a6337280b0e5fd1db4b)

[Protect against missing attribute definition](https://github.com/openpmix/prrte/commit/e7e5515a6c2d8d5ca9df43d1643fd2655ea6c4ba)

Missed one place that needs to be protected against
earlier versions of PMIx that lack the PMIX_DISPLAY_PROCESSORS
attribute.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/d0fc2d9b2e237d75094db87dd5f1a62cb523a5cc)

[Set distances array type](https://github.com/openpmix/prrte/commit/5f618d3d6ef5706acfe297d7d87fcea832aabca8)

After gathering the distances they need to be stored.
Set the darray.type to PMIX_DEVICE_DIST before calling
PMIX_INFO_LIST_ADD() to ensure proper processing

Signed-off-by: Amir Shehata <shehataa@ornl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/40c54daf354074f8a3e4e6b7eee6ebfa54da6e4c)

[Add "parseable" display qualifier](https://github.com/openpmix/prrte/commit/932e23e8d125a8229056a0bff6712eea51127091)

When requesting display of info, allow specificying a
"parseable" qualifier to indicate that the output should
be provided in a format amenable to machine parsing.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/47021169cc230bf44fb308f36a732ddf3a6dfb25)

[Generate distances by default](https://github.com/openpmix/prrte/commit/77745e80f33f98927b6ffa3c360ca04cb641a753)

Turn on distance generation for fabric, gpu and network by default. This
reduces the configuration overhead when requiring distances and it doesn't
add much overhead.

Signed-off-by: Amir Shehata <shehataa@ornl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/43fbe98b9c621618d02d34c0f82a04dc824d110a)

[Show help message when mapping too low](https://github.com/openpmix/prrte/commit/7b0331be279355fe288efd2ea1df313fdd23be48)

If the user requests multiple cpus/rank, then error out
if they ask us to map-by cpu as there is only one cpu
under each cpu.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8cab391cd971a50bf72480322cea3b8150bd8a29)

[Fix round-robin by obj with multiple cpus/rank](https://github.com/openpmix/prrte/commit/6124fdac36cb26122bd7680d906eae3c1932a6f5)

We don't want the multiple cpus/rank to straddle
objects - the binding should fit entirely within
the target object. Ensure that any overflow causes
the placement algorithm to move to the next object.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ae907a1c268ceea2a4ce2c592661bb6bdeec58ba)

[Fix map-by slot and node for multiple cpus/rank](https://github.com/openpmix/prrte/commit/8f0ea489dbfca3b8c6845abccc5479881430c5f5)

Do not bind across the edge of packages.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/29318589d8155f1bb91acee13e2620796141b013)

bot:notacherrypick