### PR TITLE
plm/ess: add support for HPE Cray PALS launcher

### DIFF
--- a/config/prte_check_pals.m4
+++ b/config/prte_check_pals.m4
@@ -1,0 +1,58 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2019      Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2020-2023 Triad National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# PRTE_CHECK_PALS(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+AC_DEFUN([PRTE_CHECK_PALS],[
+
+    AC_ARG_WITH([pals],
+                [AS_HELP_STRING([--with-pals(=DIR|yes|no)],
+                [Build with PALS (HPE/Cray) application launcher (default: auto)])],[],with_pals=auto)
+
+    AC_MSG_CHECKING([for HPE PALS support])
+
+dnl  We do not currently use libpals.so but this is a good sentinel for the pals runtime being installed 
+dnl  so we check this way for presence of HPE/Cray PALS system
+    AS_IF([test "$with_pals" != "no"],
+          [OAC_CHECK_PACKAGE([libpals],
+                             [$1],
+                             [pals.h],
+                             [pals],
+                             [pals_get_apid],
+                             [prte_check_pals_happy="yes"],
+                             [prte_check_pals_happy="no"])
+              ])
+
+   AC_MSG_RESULT([prte_check_pals_happy = $prte_check_pals_happy $with_pals])
+
+   AS_IF([test "$prte_check_pals_happy" = "yes"],
+         [$2],
+         [AS_IF([test ! -z "$with_pals" && test "$with_pals" != "no" && test "$with_pals" != "auto"],
+               [AC_MSG_ERROR([PALS support requested but not found.  Aborting])])
+         $3])
+])

--- a/src/mca/ess/pals/Makefile.am
+++ b/src/mca/ess/pals/Makefile.am
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        ess_pals.h \
+        ess_pals_component.c \
+        ess_pals_module.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_ess_pals_DSO
+component_noinst =
+component_install = prte_mca_ess_pals.la
+else
+component_noinst = libprtemca_ess_pals.la
+component_install =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+prte_mca_ess_pals_la_SOURCES = $(sources)
+prte_mca_ess_pals_la_LDFLAGS = -module -avoid-version
+prte_mca_ess_pals_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libprtemca_ess_pals_la_SOURCES =$(sources)
+libprtemca_ess_pals_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ess/pals/configure.m4
+++ b/src/mca/ess/pals/configure.m4
@@ -1,0 +1,43 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011      Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_ess_pals_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_prte_ess_pals_CONFIG],[
+    AC_CONFIG_FILES([src/mca/ess/pals/Makefile])
+
+    PRTE_CHECK_PALS([ess_pals], [ess_pals_good=1], [ess_pals_good=0])
+
+    # if check worked, set wrapper flags if so.
+    # Evaluate succeed / fail
+    AS_IF([test "$ess_pals_good" = "1"],
+          [$1],
+          [$2])
+
+    # set build flags to use in makefile
+    AC_SUBST([ess_pals_CPPFLAGS])
+    AC_SUBST([ess_pals_LDFLAGS])
+    AC_SUBST([ess_pals_LIBS])
+])dnl

--- a/src/mca/ess/pals/ess_pals.h
+++ b/src/mca/ess/pals/ess_pals.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_ESS_PALS_H
+#define PRTE_ESS_PALS_H
+
+BEGIN_C_DECLS
+
+PRTE_MODULE_EXPORT extern prte_ess_base_component_t prte_mca_ess_pals_component;
+
+/*
+ * Module open / close
+ */
+int prte_mca_ess_pals_component_open(void);
+int prte_mca_ess_pals_component_close(void);
+int prte_mca_ess_pals_component_query(pmix_mca_base_module_t **module, int *priority);
+
+END_C_DECLS
+
+#endif /* PRTE_ESS_PALS_H */

--- a/src/mca/ess/pals/ess_pals_component.c
+++ b/src/mca/ess/pals/ess_pals_component.c
@@ -1,0 +1,94 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/util/proc_info.h"
+
+#include "src/mca/ess/ess.h"
+#include "src/mca/ess/pals/ess_pals.h"
+
+extern prte_ess_base_module_t prte_ess_pals_module;
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+prte_ess_base_component_t prte_mca_ess_pals_component = {
+    PRTE_ESS_BASE_VERSION_3_0_0,
+
+    /* Component name and version */
+    .pmix_mca_component_name = "pals",
+    PMIX_MCA_BASE_MAKE_VERSION(component,
+                               PRTE_MAJOR_VERSION,
+                               PRTE_MINOR_VERSION,
+                               PMIX_RELEASE_VERSION),
+
+    /* Component open and close functions */
+    .pmix_mca_open_component = prte_mca_ess_pals_component_open,
+    .pmix_mca_close_component = prte_mca_ess_pals_component_close,
+    .pmix_mca_query_component = prte_mca_ess_pals_component_query,
+};
+
+int prte_mca_ess_pals_component_open(void)
+{
+    return PRTE_SUCCESS;
+}
+
+int prte_mca_ess_pals_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    /* Were we lauched by the PALS aprun launcher? Were
+     * we given a path back to the HNP? If the
+     * answer to both is "yes", then we were launched
+     * by the PALS variant of aprun, so make ourselves available
+     */
+
+    if (PRTE_PROC_IS_DAEMON && NULL != getenv("PALS_APID")
+        && NULL != prte_process_info.my_hnp_uri) {
+        *priority = 50;
+        *module = (pmix_mca_base_module_t *) &prte_ess_pals_module;
+        return PRTE_SUCCESS;
+    }
+
+    /* Sadly, no */
+    *priority = -1;
+    *module = NULL;
+    return PRTE_ERROR;
+}
+
+int prte_mca_ess_pals_component_close(void)
+{
+    return PRTE_SUCCESS;
+}

--- a/src/mca/ess/pals/ess_pals_module.c
+++ b/src/mca/ess/pals/ess_pals_module.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif /* HAVE_UNISTD_H */
+#include <ctype.h>
+#include <string.h>
+
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_environ.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/rml/rml.h"
+#include "src/pmix/pmix-internal.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+#include "src/util/proc_info.h"
+#include "src/util/pmix_show_help.h"
+
+#include "src/mca/ess/base/base.h"
+#include "src/mca/ess/ess.h"
+#include "src/mca/ess/pals/ess_pals.h"
+
+static int pals_set_name(void);
+
+static int rte_init(int argc, char **argv);
+static int rte_finalize(void);
+
+prte_ess_base_module_t prte_ess_pals_module = {.init = rte_init,
+                                                .finalize = rte_finalize,
+                                                .abort = NULL};
+
+static int rte_init(int argc, char **argv)
+{
+    int ret;
+    char *error = NULL;
+    PRTE_HIDE_UNUSED_PARAMS(argc, argv);
+
+    /* run the prolog */
+    if (PRTE_SUCCESS != (ret = prte_ess_base_std_prolog())) {
+        error = "prte_ess_base_std_prolog";
+        goto error;
+    }
+
+    /* Start by getting a unique name */
+    pals_set_name();
+
+    if (PRTE_SUCCESS != (ret = prte_ess_base_prted_setup())) {
+        PRTE_ERROR_LOG(ret);
+        error = "prte_ess_base_prted_setup";
+        goto error;
+    }
+    return PRTE_SUCCESS;
+
+error:
+    if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
+        pmix_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+                       PRTE_ERROR_NAME(ret), ret);
+    }
+
+    return ret;
+}
+
+static int rte_finalize(void)
+{
+    int ret;
+
+    if (PRTE_SUCCESS != (ret = prte_ess_base_prted_finalize())) {
+        PRTE_ERROR_LOG(ret);
+    }
+
+    return ret;
+}
+
+static int pals_set_name(void)
+{
+    int pals_nodeid;
+    pmix_rank_t vpid;
+    char *tmp;
+
+    PMIX_OUTPUT_VERBOSE((1, prte_ess_base_framework.framework_output, "ess:pals setting name"));
+
+    if (NULL == prte_ess_base_nspace) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, prte_ess_base_nspace);
+
+    if (NULL == prte_ess_base_vpid) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+    vpid = strtoul(prte_ess_base_vpid, NULL, 10);
+
+    if (NULL != getenv("PALS_NODEID")) {
+        /* fix up the vpid and make it the "real" vpid */
+        pals_nodeid = atoi(getenv("PALS_NODEID"));
+        PRTE_PROC_MY_NAME->rank = vpid + pals_nodeid;
+    } else {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_ess_base_framework.framework_output, "ess:pals set name to %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+
+    /* get the num procs as provided in the cmd line param */
+    prte_process_info.num_daemons = prte_ess_base_num_procs;
+
+    return PRTE_SUCCESS;
+}

--- a/src/mca/plm/pals/Makefile.am
+++ b/src/mca/plm/pals/Makefile.am
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+#                         reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        plm_pals.h \
+        plm_pals_component.c \
+        plm_pals_module.c
+
+dist_prtedata_DATA = help-plm-pals.txt
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_plm_pals_DSO
+component_noinst =
+component_install = prte_mca_plm_pals.la
+else
+component_noinst = libprtemca_plm_pals.la
+component_install =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+prte_mca_plm_pals_la_SOURCES = $(sources)
+prte_mca_plm_pals_la_CPPFLAGS = $(plm_pals_CPPFLAGS)
+prte_mca_plm_pals_la_LDFLAGS = -module -avoid-version $(plm_pals_LDFLAGS)
+prte_mca_plm_pals_la_LIBADD = $(plm_pals_LIBS) \
+    $(top_builddir)/src/libprrte.la   \
+    $(PRTE_TOP_BUILDDIR)/src/mca/common/pals/libmca_common_pals.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libprtemca_plm_pals_la_SOURCES =$(sources)
+libprtemca_plm_pals_la_CPPFLAGS = $(plm_pals_CPPFLAGS)
+libprtemca_plm_pals_la_LDFLAGS = -module -avoid-version $(plm_pals_LDFLAGS)
+libprtemca_plm_pals_la_LIBADD = $(plm_pals_LIBS)

--- a/src/mca/plm/pals/configure.m4
+++ b/src/mca/plm/pals/configure.m4
@@ -1,0 +1,39 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennplmee and The University
+#                         of Tennplmee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_plm_pals_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_prte_plm_pals_CONFIG],[
+    AC_CONFIG_FILES([src/mca/plm/pals/Makefile])
+
+    PRTE_CHECK_PALS([plm_pals], [plm_pals_good=1], [plm_pals_good=0])
+
+    # if check worked, set wrapper flags if so.
+    # Evaluate succeed / fail
+    AS_IF([test "$plm_pals_good" = "1"],
+          [$1],
+          [$2])
+])dnl

--- a/src/mca/plm/pals/help-plm-pals.txt
+++ b/src/mca/plm/pals/help-plm-pals.txt
@@ -1,0 +1,45 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2023      Triad National Security, LLC. All rights
+#                         reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+[multiple-prefixes]
+The PALS process starter for PRTE does not support multiple
+different --prefix options to mpirun.  You can specify at most one
+unique value for the --prefix option (in any of the application
+contexts); it will be applied to all the application contexts of your
+parallel job.
+
+Put simply, you must have PRTE installed in the same location on
+all of your PALS nodes.
+
+Multiple different --prefix options were specified to mpirun.  This is
+a fatal error for the PALS process starter in PRTE.
+
+The first two prefix values supplied were:
+    %s
+and %s
+#
+[no-hosts-in-list]
+The PALS process starter for PRTE didn't find any hosts in
+the map for this application. This can be caused by a lack of
+an allocation, or by an error in the PRTE code. Please check
+to ensure you have a PALS allocation. If you do, then please pass
+the error to the PRTE user's mailing list for assistance.

--- a/src/mca/plm/pals/owner.txt
+++ b/src/mca/plm/pals/owner.txt
@@ -1,0 +1,7 @@
+#
+# owner/status file
+# owner: institution that is responsible for this package
+# status: e.g. active, maintenance, unmaintained
+#
+owner: LANL
+status: maintenance

--- a/src/mca/plm/pals/plm_pals.h
+++ b/src/mca/plm/pals/plm_pals.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_PLM_PALS_EXPORT_H
+#define PRTE_PLM_PALS_EXPORT_H
+
+#include "prte_config.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/plm/plm.h"
+
+BEGIN_C_DECLS
+
+struct prte_mca_plm_pals_component_t {
+    prte_plm_base_component_t super;
+    int priority;
+    bool debug;
+    char *aprun_cmd;
+    char *custom_args;
+};
+typedef struct prte_mca_plm_pals_component_t prte_mca_plm_pals_component_t;
+
+/*
+ * Globally exported variable
+ */
+
+PRTE_MODULE_EXPORT extern prte_mca_plm_pals_component_t prte_mca_plm_pals_component;
+PRTE_EXPORT extern prte_plm_base_module_t prte_plm_pals_module;
+
+END_C_DECLS
+
+#endif /* PRTE_PLM_PALS_EXPORT_H */

--- a/src/mca/plm/pals/plm_pals_component.c
+++ b/src/mca/plm/pals/plm_pals_component.c
@@ -1,0 +1,134 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/mca/base/pmix_mca_base_var.h"
+
+#include "src/runtime/prte_globals.h"
+
+#include "plm_pals.h"
+#include "src/mca/plm/base/base.h"
+#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/plm.h"
+
+/*
+ * Public string showing the plm ompi_pals component version number
+ */
+const char *prte_mca_plm_pals_component_version_string
+    = "PRTE pals plm MCA component version " PRTE_VERSION;
+
+/*
+ * Local functions
+ */
+static int plm_pals_register(void);
+static int plm_pals_open(void);
+static int plm_pals_close(void);
+static int prte_mca_plm_pals_component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+
+prte_mca_plm_pals_component_t prte_mca_plm_pals_component = {
+    .super = {
+        PRTE_PLM_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "pals",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = plm_pals_open,
+        .pmix_mca_close_component = plm_pals_close,
+        .pmix_mca_query_component = prte_mca_plm_pals_component_query,
+        .pmix_mca_register_component_params = plm_pals_register,
+    }
+};
+
+static int plm_pals_register(void)
+{
+    pmix_mca_base_component_t *comp = &prte_mca_plm_pals_component.super;
+
+    prte_mca_plm_pals_component.debug = false;
+    (void) pmix_mca_base_component_var_register(comp, "debug", "Enable debugging of pals plm",
+                                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                                &prte_mca_plm_pals_component.debug);
+
+    if (prte_mca_plm_pals_component.debug == 0) {
+        prte_mca_plm_pals_component.debug = prte_debug_flag;
+    }
+
+    prte_mca_plm_pals_component.priority = 100;
+    (void) pmix_mca_base_component_var_register(comp, "priority", "Default selection priority",
+                                                PMIX_MCA_BASE_VAR_TYPE_INT,
+                                                &prte_mca_plm_pals_component.priority);
+
+    prte_mca_plm_pals_component.aprun_cmd = "aprun";
+    (void) pmix_mca_base_component_var_register(comp, "aprun", "Command to run instead of aprun",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_plm_pals_component.aprun_cmd);
+
+    prte_mca_plm_pals_component.custom_args = NULL;
+    (void) pmix_mca_base_component_var_register(comp, "args", "Custom arguments to aprun",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_plm_pals_component.custom_args);
+    return PRTE_SUCCESS;
+}
+
+static int plm_pals_open(void)
+{
+    return PRTE_SUCCESS;
+}
+
+static int prte_mca_plm_pals_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = prte_mca_plm_pals_component.priority;
+    *module = (pmix_mca_base_module_t *) &prte_plm_pals_module;
+    PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                         "%s plm:pals: available for selection",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+
+    return PRTE_SUCCESS;
+}
+
+static int plm_pals_close(void)
+{
+    return PRTE_SUCCESS;
+}

--- a/src/mca/plm/pals/plm_pals_module.c
+++ b/src/mca/plm/pals/plm_pals_module.c
@@ -1,0 +1,640 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2007-2015 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights
+ *                         reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include <sys/types.h>
+#ifdef HAVE_UNISTD_H
+#    include <unistd.h>
+#endif
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_SYS_TYPES_H
+#    include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#    include <sys/time.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#    include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#endif
+
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/prteinstalldirs/prteinstalldirs.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_basename.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_path.h"
+#include "src/util/pmix_environ.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/rmaps/rmaps.h"
+#include "src/mca/schizo/schizo.h"
+#include "src/mca/state/state.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_wait.h"
+#include "src/threads/pmix_threads.h"
+#include "src/util/name_fns.h"
+#include "src/util/pmix_show_help.h"
+
+#include "plm_pals.h"
+#include "src/mca/plm/base/base.h"
+#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/plm.h"
+
+/*
+ * Local functions
+ */
+static int plm_pals_init(void);
+static int plm_pals_launch_job(prte_job_t *jdata);
+static int plm_pals_terminate_orteds(void);
+static int plm_pals_signal_job(pmix_nspace_t jobid, int32_t signal);
+static int plm_pals_finalize(void);
+
+static int plm_pals_start_proc(int argc, char **argv, char **env, char *prefix);
+
+/*
+ * Global variable
+ */
+prte_plm_base_module_t prte_plm_pals_module = {
+    .init = plm_pals_init,
+    .set_hnp_name = prte_plm_base_set_hnp_name,
+    .spawn = plm_pals_launch_job,
+    .terminate_job = prte_plm_base_prted_terminate_job,
+    .terminate_orteds = plm_pals_terminate_orteds,
+    .terminate_procs = prte_plm_base_prted_kill_local_procs,
+    .signal_job = plm_pals_signal_job,
+    .finalize = plm_pals_finalize
+};
+
+/*
+ * Local variables
+ */
+static prte_proc_t *palsrun = NULL;
+static bool failed_launch;
+static void launch_daemons(int fd, short args, void *cbdata);
+
+/**
+ * Init the module
+ */
+static int plm_pals_init(void)
+{
+    int rc;
+    prte_job_t *daemons;
+
+    if (PRTE_SUCCESS != (rc = prte_plm_base_comm_start())) {
+        PRTE_ERROR_LOG(rc);
+	fprintf(stderr, "OOPS prte_plm_base_comm_start returned error\n");
+        return rc;
+    }
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (prte_get_attribute(&daemons->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+        /* must map daemons since we won't be launching them */
+        prte_plm_globals.daemon_nodes_assigned_at_launch = true;
+    } else {
+        /* we do NOT assign daemons to nodes at launch - we will
+         * determine that mapping when the daemon
+         * calls back. This is required because pals does
+         * its own mapping of proc-to-node, and we cannot know
+         * in advance which daemon will wind up on which node
+         */
+        prte_plm_globals.daemon_nodes_assigned_at_launch = false;
+    }
+
+    /* point to our launch command */
+    if (PRTE_SUCCESS
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
+                                          PRTE_SYS_PRI))) {
+        PRTE_ERROR_LOG(rc);
+        return rc;
+    }
+
+    return rc;
+}
+
+/* When working in this function, ALWAYS jump to "cleanup" if
+ * you encounter an error so that prun will be woken up and
+ * the job can cleanly terminate
+ */
+static int plm_pals_launch_job(prte_job_t *jdata)
+{
+
+    if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_RESTART)) {
+        /* this is a restart situation - skip to the mapping stage */
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP);
+    } else {
+        /* new job - set it up */
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_INIT);
+    }
+    return PRTE_SUCCESS;
+}
+
+static void launch_daemons(int fd, short args, void *cbdata)
+{
+    prte_job_map_t *map;
+    char *param;
+    char **argv = NULL;
+    int argc;
+    int rc;
+    char *tmp;
+    char **env = NULL;
+    char *nodelist_flat;
+    char **nodelist_argv;
+    int nodelist_argc;
+    char *vpid_string;
+    char **custom_strings;
+    int num_args, i;
+    char *cur_prefix;
+    int proc_vpid_index;
+    prte_app_context_t *app;
+    prte_node_t *node;
+    int32_t nnode;
+    prte_job_t *daemons;
+    prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
+
+    PMIX_ACQUIRE_OBJECT(state);
+
+    /* start by setting up the virtual machine */
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (PRTE_SUCCESS != (rc = prte_plm_base_setup_virtual_machine(state->jdata))) {
+        PRTE_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    /* if we don't want to launch, then don't attempt to
+     * launch the daemons - the user really wants to just
+     * look at the proposed process map
+     */
+    if (prte_get_attribute(&daemons->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+        /* set the state to indicate the daemons reported - this
+         * will trigger the daemons_reported event and cause the
+         * job to move to the following step
+         */
+        state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
+        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
+        PMIX_RELEASE(state);
+        return;
+    }
+
+    /* Get the map for this job */
+    if (NULL == (map = daemons->map)) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        rc = PRTE_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    if (0 == map->num_new_daemons) {
+        /* set the state to indicate the daemons reported - this
+         * will trigger the daemons_reported event and cause the
+         * job to move to the following step
+         */
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "%s plm:pals: no new daemons to launch",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
+        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
+        PMIX_RELEASE(state);
+        return;
+    }
+
+    /*
+     * start building argv array
+     */
+    argv = NULL;
+    argc = 0;
+
+    /*
+     * ALPS aprun  OPTIONS
+     */
+
+    /* protect against launchers that forward the entire environment */
+    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
+    }
+    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
+        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
+    }
+
+    /* add the aprun command */
+    pmix_argv_append(&argc, &argv, prte_mca_plm_pals_component.aprun_cmd);
+
+    /* Append user defined arguments to aprun */
+    if (NULL != prte_mca_plm_pals_component.custom_args) {
+        custom_strings = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_pals_component.custom_args, ' ');
+        num_args = PMIX_ARGV_COUNT_COMPAT(custom_strings);
+        for (i = 0; i < num_args; ++i) {
+            pmix_argv_append(&argc, &argv, custom_strings[i]);
+        }
+        PMIX_ARGV_FREE_COMPAT(custom_strings);
+    }
+
+    /* number of processors needed */
+    pmix_argv_append(&argc, &argv, "-n");
+    pmix_asprintf(&tmp, "%lu", (unsigned long) map->num_new_daemons);
+    pmix_argv_append(&argc, &argv, tmp);
+    free(tmp);
+    pmix_argv_append(&argc, &argv, "-N");
+    pmix_argv_append(&argc, &argv, "1");
+    pmix_argv_append(&argc, &argv, "--cc");
+    pmix_argv_append(&argc, &argv, "none");
+
+    /* if we are using all allocated nodes, then pals
+     * doesn't need a nodelist, or if running without a batch scheduler
+     */
+#if 0
+    if ((map->num_new_daemons < prte_num_allocated_nodes) || (prte_num_allocated_nodes == 0)) {
+        /* create nodelist */
+        nodelist_argv = NULL;
+        nodelist_argc = 0;
+
+        for (nnode = 0; nnode < map->nodes->size; nnode++) {
+            if (NULL == (node = (prte_node_t *) pmix_pointer_array_get_item(map->nodes, nnode))) {
+                continue;
+            }
+
+            /* if the daemon already exists on this node, then
+             * don't include it
+             */
+            if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
+                continue;
+            }
+
+            /* otherwise, add it to the list of nodes upon which
+             * we need to launch a daemon
+             */
+            pmix_argv_append(&nodelist_argc, &nodelist_argv, node->name);
+        }
+        if (0 == PMIX_ARGV_COUNT_COMPAT(nodelist_argv)) {
+            pmix_show_help("help-plm-pals.txt", "no-hosts-in-list", true);
+            rc = PRTE_ERR_FAILED_TO_START;
+            goto cleanup;
+        }
+        nodelist_flat = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, ',');
+        PMIX_ARGV_FREE_COMPAT(nodelist_argv);
+
+        pmix_argv_append(&argc, &argv, "-L");
+        pmix_argv_append(&argc, &argv, nodelist_flat);
+        free(nodelist_flat);
+    }
+#endif
+
+    /*
+     * PRTED OPTIONS
+     */
+
+    /* add the daemon command (as specified by user) */
+    prte_plm_base_setup_prted_cmd(&argc, &argv);
+
+    /* Add basic orted command line options, including debug flags */
+    prte_plm_base_prted_append_basic_args(&argc, &argv, "pals", &proc_vpid_index);
+
+    /* tell the new daemons the base of the name list so they can compute
+     * their own name on the other end
+     */
+    rc = prte_util_convert_vpid_to_string(&vpid_string, map->daemon_vpid_start);
+    if (PRTE_SUCCESS != rc) {
+        pmix_output(0, "plm_pals: unable to create process name");
+        goto cleanup;
+    }
+
+    free(argv[proc_vpid_index]);
+    argv[proc_vpid_index] = strdup(vpid_string);
+    free(vpid_string);
+
+    if (prte_mca_plm_pals_component.debug) {
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        if (NULL != param) {
+            pmix_output(0, "plm:pals: final top-level argv:");
+            pmix_output(0, "plm:pals:     %s", param);
+            free(param);
+        }
+    }
+
+    /* Copy the prefix-directory specified in the
+       corresponding app_context.  If there are multiple,
+       different prefix's in the app context, complain (i.e., only
+       allow one --prefix option for the entire pals run -- we
+       don't support different --prefix'es for different nodes in
+       the ALPS plm) */
+    cur_prefix = NULL;
+    for (i = 0; i < state->jdata->apps->size; i++) {
+        char *app_prefix_dir = NULL;
+        if (NULL
+            == (app = (prte_app_context_t *) pmix_pointer_array_get_item(state->jdata->apps, i))) {
+            continue;
+        }
+        prte_get_attribute(&app->attributes, PRTE_APP_PREFIX_DIR, (void **) &app_prefix_dir,
+                           PMIX_STRING);
+        /* Check for already set cur_prefix_dir -- if different,
+           complain */
+        if (NULL != app_prefix_dir) {
+            if (NULL != cur_prefix && 0 != strcmp(cur_prefix, app_prefix_dir)) {
+                pmix_show_help("help-plm-pals.txt", "multiple-prefixes", true, cur_prefix,
+                               app_prefix_dir);
+                goto cleanup;
+            }
+
+            /* If not yet set, copy it; iff set, then it's the
+               same anyway */
+            if (NULL == cur_prefix) {
+                cur_prefix = strdup(app_prefix_dir);
+                if (prte_mca_plm_pals_component.debug) {
+                    pmix_output(0, "plm:pals: Set prefix:%s", cur_prefix);
+                }
+            }
+            free(app_prefix_dir);
+        }
+    }
+
+    /* protect the args in case someone has a script wrapper around aprun */
+    prte_plm_base_wrap_args(argv);
+
+    /* setup environment */
+    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
+
+    if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
+        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "%s plm:pals: final top-level argv:\n\t%s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (NULL == param) ? "NULL" : param));
+        if (NULL != param)
+            free(param);
+    }
+
+    /* exec the daemon(s) */
+    if (PRTE_SUCCESS != (rc = plm_pals_start_proc(argc, argv, env, cur_prefix))) {
+        PRTE_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    /* indicate that the daemons for this job were launched */
+    state->jdata->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
+    daemons->state = PRTE_JOB_STATE_DAEMONS_LAUNCHED;
+
+    /* flag that launch was successful, so far as we currently know */
+    failed_launch = false;
+
+cleanup:
+    if (NULL != argv) {
+        PMIX_ARGV_FREE_COMPAT(argv);
+    }
+    if (NULL != env) {
+        PMIX_ARGV_FREE_COMPAT(env);
+    }
+
+    /* check for failed launch - if so, force terminate */
+    if (failed_launch) {
+        PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_START);
+    }
+
+    /* cleanup the caddy */
+    PMIX_RELEASE(state);
+}
+
+/**
+ * Terminate the orteds for a given job
+ */
+static int plm_pals_terminate_orteds(void)
+{
+    int rc;
+    prte_job_t *jdata;
+
+    PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
+                         "%s plm:pals: terminating orteds", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+
+    /* deregister the waitpid callback to ensure we don't make it look like
+     * pals failed when it didn't. Since the pals may have already completed,
+     * do NOT ERROR_LOG any return code to avoid confusing, duplicate error
+     * messages
+     */
+    if (NULL != palsrun) {
+        prte_wait_cb_cancel(palsrun);
+    }
+
+    /* now tell them to die */
+    if (PRTE_SUCCESS != (rc = prte_plm_base_prted_exit(PRTE_DAEMON_EXIT_CMD))) {
+        PRTE_ERROR_LOG(rc);
+    }
+
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+
+    PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
+                         "%s plm:pals: terminated orteds", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+    return rc;
+}
+
+/**
+ * Signal all the processes in the child pals by sending the signal directly to it
+ */
+static int plm_pals_signal_job(pmix_nspace_t jobid, int32_t signal)
+{
+    if (NULL != palsrun && 0 != palsrun->pid) {
+        kill(palsrun->pid, (int) signal);
+    }
+    return PRTE_SUCCESS;
+}
+
+static int plm_pals_finalize(void)
+{
+    int rc;
+
+    if (NULL != palsrun) {
+        PMIX_RELEASE(palsrun);
+    }
+
+    /* cleanup any pending recvs */
+    if (PRTE_SUCCESS != (rc = prte_plm_base_comm_stop())) {
+        PRTE_ERROR_LOG(rc);
+    }
+
+    return PRTE_SUCCESS;
+}
+
+static void pals_wait_cb(int sd, short args, void *cbdata)
+{
+    prte_wait_tracker_t *t2 = (prte_wait_tracker_t *) cbdata;
+    prte_proc_t *proc = t2->child;
+    prte_job_t *jdata;
+
+    /* According to the ALPS folks, pals always returns the highest exit
+       code of our remote processes. Thus, a non-zero exit status doesn't
+       necessarily mean that pals failed - it could be that an orted returned
+       a non-zero exit status. Of course, that means the orted failed(!), so
+       the end result is the same - the job didn't start.
+
+       As a result, we really can't do much with the exit status itself - it
+       could be something in errno (if pals itself failed), or it could be
+       something returned by an orted, or it could be something returned by
+       the OS (e.g., couldn't find the orted binary). Somebody is welcome
+       to sort out all the options and pretty-print a better error message. For
+       now, though, the only thing that really matters is that
+       pals failed. Report the error and make sure that prun
+       wakes up - otherwise, do nothing!
+    */
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+
+    if (0 != proc->exit_code) {
+        if (failed_launch) {
+            /* report that the daemon has failed so we break out of the daemon
+             * callback receive and exit
+             */
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FAILED_TO_START);
+        } else {
+            /* an orted must have died unexpectedly after launch - report
+             * that the daemon has failed so we exit
+             */
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ABORTED);
+        }
+    }
+    PMIX_RELEASE(t2);
+}
+
+static int plm_pals_start_proc(int argc, char **argv, char **env, char *prefix)
+{
+    int fd;
+    pid_t pals_pid;
+    char *exec_argv = pmix_path_findv(argv[0], 0, env, NULL);
+
+    if (NULL == exec_argv) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    pals_pid = fork();
+    if (-1 == pals_pid) {
+        PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_CHILDREN);
+        return PRTE_ERR_SYS_LIMITS_CHILDREN;
+    }
+
+    palsrun = PMIX_NEW(prte_proc_t);
+    palsrun->pid = pals_pid;
+    /* be sure to mark it as alive so we don't instantly fire */
+    PRTE_FLAG_SET(palsrun, PRTE_PROC_FLAG_ALIVE);
+    /* setup the waitpid so we can find out if pals succeeds! */
+    prte_wait_cb(palsrun, pals_wait_cb, prte_event_base, NULL);
+
+    if (0 == pals_pid) { /* child */
+        char *bin_base = NULL, *lib_base = NULL;
+
+        /* Figure out the basenames for the libdir and bindir.  There
+           is a lengthy comment about this in plm_rsh_module.c
+           explaining all the rationale for how / why we're doing
+           this. */
+
+        lib_base = pmix_basename(prte_install_dirs.libdir);
+        bin_base = pmix_basename(prte_install_dirs.bindir);
+
+        /* If we have a prefix, then modify the PATH and
+           LD_LIBRARY_PATH environment variables.  */
+        if (NULL != prefix) {
+            char *oldenv, *newenv;
+
+            /* Reset PATH */
+            oldenv = getenv("PATH");
+            if (NULL != oldenv) {
+                pmix_asprintf(&newenv, "%s/%s:%s", prefix, bin_base, oldenv);
+            } else {
+                pmix_asprintf(&newenv, "%s/%s", prefix, bin_base);
+            }
+            PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
+            if (prte_mca_plm_pals_component.debug) {
+                pmix_output(0, "plm:pals: reset PATH: %s", newenv);
+            }
+            free(newenv);
+
+            /* Reset LD_LIBRARY_PATH */
+            oldenv = getenv("LD_LIBRARY_PATH");
+            if (NULL != oldenv) {
+                pmix_asprintf(&newenv, "%s/%s:%s", prefix, lib_base, oldenv);
+            } else {
+                pmix_asprintf(&newenv, "%s/%s", prefix, lib_base);
+            }
+            PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+            if (prte_mca_plm_pals_component.debug) {
+                pmix_output(0, "plm:pals: reset LD_LIBRARY_PATH: %s", newenv);
+            }
+            free(newenv);
+        }
+
+        fd = open("/dev/null", O_CREAT | O_WRONLY | O_TRUNC, 0666);
+        if (fd > 0) {
+            dup2(fd, 0);
+        }
+
+        /* When not in debug mode and --debug-daemons was not passed,
+         * tie stdout/stderr to dev null so we don't see messages from orted */
+        if (0 == prte_mca_plm_pals_component.debug && !prte_debug_daemons_flag) {
+            if (fd >= 0) {
+                if (fd != 1) {
+                    dup2(fd, 1);
+                }
+                if (fd != 2) {
+                    dup2(fd, 2);
+                }
+            }
+        }
+
+        if (fd > 2) {
+            close(fd);
+        }
+
+        /* get the pals process out of prun's process group so that
+           signals sent from the shell (like those resulting from
+           cntl-c) don't get sent to pals */
+        setpgid(0, 0);
+
+        execve(exec_argv, argv, env);
+
+        pmix_output(0, "plm:pals:start_proc: exec failed");
+        /* don't return - need to exit - returning would be bad -
+           we're not in the calling process anymore */
+        exit(1);
+    } else { /* parent */
+        /* just in case, make sure that the pals process is not in our
+        process group any more.  Stevens says always do this on both
+        sides of the fork... */
+        setpgid(pals_pid, pals_pid);
+
+        free(exec_argv);
+    }
+
+    return PRTE_SUCCESS;
+}


### PR DESCRIPTION
This PR adds HPE Cray PALS launcher and ess components.

This allows for launching processes to be childern of the palsd daemon.  This daemon sets a bunch of SS11 related environment variables:

SLINGSHOT_DEVICES - The set of Slingshot devices configured for us

SLINGSHOT_SVC_IDS - The Slingshot Service ID for each corresponding device

SLINGSHOT_VNIS - The Slingshot security tokens they can use

SLINGSHOT_TCS - The Slingshot Traffic Classes they can use

that will eventually be useful if we want prrte/openpmix clients to be able to use the CXI provider when VNI enforcement is enabled.

This env variables are not visible to a process that just gets started via ssh or other mechanism on a compute node.

Related to #1628

Signed-off-by: Howard Pritchard <howardp@uan-0002.head.cm.americas.sgi.com>