### PR TITLE
Put the HTML configurator in docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,8 +153,6 @@ src/include/version.h
 src/include/frameworks.h
 src/include/prte_config.h
 
-src/etc/prte-configurator.html
-
 src/mca/rmaps/rank_file/rmaps_rank_file_lex.c
 src/mca/rmaps/rank_file/rankfile_lex.c
 

--- a/.gitignore
+++ b/.gitignore
@@ -103,8 +103,6 @@ config/ext_no_configure_components.m4
 config/ext_m4_config_include.m4
 config/mca_library_paths.txt
 
-docs/configuration.rst
-
 include/prte_version.h
 contrib/docker/tmp
 

--- a/configure.ac
+++ b/configure.ac
@@ -992,7 +992,6 @@ AC_CONFIG_FILES([
     include/prte_version.h
     docs/Makefile
     docs/configuration.rst
-    src/etc/prte-configurator.html
 ])
 
 PRTE_CONFIG_FILES

--- a/configure.ac
+++ b/configure.ac
@@ -991,7 +991,6 @@ AC_CONFIG_FILES([
     include/Makefile
     include/prte_version.h
     docs/Makefile
-    docs/configuration.rst
 ])
 
 PRTE_CONFIG_FILES

--- a/docs/_templates/configurator.html
+++ b/docs/_templates/configurator.html
@@ -1,3 +1,6 @@
+{% extends "layout.html" %}
+{% set title = 'PRRTE DVM Configuration Tool' %}
+{% block body %}
 <!--
 Copyright (C) 2023      Nanook Consulting. All rights reserved
 
@@ -12,10 +15,6 @@ FOR A PARTICULAR PURPOSE. See the full license statement at
 <https://docs.prrte.org/en/latest/license.html> for details.
 
 -->
-<!DOCTYPE html>
-<html lang="en-US">
-<head>
-<title>PRRTE DVM Configuration Tool</title>
 <SCRIPT type="text/javascript">
 <!--
 function get_field(name,form)
@@ -124,10 +123,8 @@ function displayfile()
 -->
 </SCRIPT>
 <!-- <div style='visibility:hidden;text-align:left;background:#ccc;border:1px solid black;position: absolute;left:100;z-index:1;padding:5;' id='out_box'></div> -->
-</head>
-<body>
 <form name=config>
-<H1>PRRTE Version @PRTE_MAJOR_VERSION@.@PRTE_MINOR_VERSION@ DVM Configuration Tool</H1>
+<H1>PRRTE Version v{{ release }} DVM Configuration Tool</H1>
 <P>This configuration tool is intended to help system administrators create
 a PRRTE configuration file that sets important configuration parameters.</P>
 
@@ -160,7 +157,7 @@ must be stored as <I>/prrte/etc/prte.conf</I> so that all prted daemons can find
 </P>
 
 <H2>Supported Options</H2>
-The following options are supported by PRRTE v@PRTE_MAJOR_VERSION@.@PRTE_MINOR_VERSION@.
+The following options are supported by PRRTE v{{ release }}.
 
 <H3>Bootstrap Options</H3>
 
@@ -191,7 +188,7 @@ on the remaining system nodes.
 
 <b>PRTEDPort</b>: <input type="text" name="prted_port" value="7818">
 <BR>
-`The TCP port upon which each
+The TCP port upon which each
 <I>prted</I> daemon will be listening for connections from its peer daemons
 on the other system nodes.
 <BR>
@@ -287,9 +284,4 @@ to this field. The log filename is formatted as <I>prted-<hostname>-log</I>.
 <input type=button value="Submit" onClick="javascript:displayfile()">
 <input type=reset value="Reset Form">
 </form>
-<hr>
-<p>
-<a href="disclaimer.html" target="_blank" class="privacy">Legal Notices</a><br>
-Last modified 17 June 2020</p>
-</body>
-</html>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,6 +136,10 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
 
+html_additional_pages = {
+    'configurator' : 'configurator.html',
+}
+
 # -- Options for MAN output -------------------------------------------------
 
 import os

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,10 +3,10 @@ PRRTE DVM Configuration
 
 The PMIx Reference RunTime Environment (PRRTE) can be instantiated
 as a Distributed Virtual Machine (DVM) in two ways. First, the
-`prte` command can be executed at a shell prompt. This will discover
+``prte`` command can be executed at a shell prompt. This will discover
 the available resources (either from hostfile or as allocated by a
-resource manager) and start a PRRTE shepherd daemon (`prted`) on each
-of the indicated nodes.
+resource manager) and start a PRRTE shepherd daemon (:ref:`prted(1)
+<man1-prted>`) on each of the indicated nodes.
 
 The other method, however, is to bootstrap the DVM at time of cluster
 startup. Bootstrapping PRRTE allows the DVM to serve as the system-level
@@ -24,8 +24,8 @@ system-level prolog and epilog scripts for each session, and other
 PRRTE features.
 
 The configuration file can be manually created or can be created using
-the PRRTE configuration tool ``<install-location>/etc/prte-configurator.html``
-running in the browser of your choice. Manual creation can best be done
+the :doc:`PRRTE configuration tool </configurator>`
+Manual creation can best be done
 by editing the example configuration file (``<source-location>/src/etc/prte.conf``).
 This file contains all the supported configuration options, with all
 entries commented out. Simply uncomment the options of interest and
@@ -35,18 +35,18 @@ final ``<install-location>/etc`` when ``make install`` is performed.
 The configuration tool also contains all the supported options in an
 easy-to-use form. Once you have filled out the desired entries, the
 "submit" button will show the resulting configuration file on the
-browser window - a simple "copy/paste" operation into your target
+browser window |mdash| a simple "copy/paste" operation into your target
 configuration file will yield the final result.
 
 Configuration Options
 ---------------------
 
-The following options are supported by PRRTE v@PRTE_MAJOR_VERSION@.@PRTE_MINOR_VERSION@.
+The following options are supported by PRRTE |prte_ver|.
 While we make every effort to maintain compatibility with prior versions,
 we recommend that you check options when installing new versions to
 see what may have changed and/or been added. We also recommend that
-you use the prte-configurator.html for the version you are using to
-ensure that it is fully compatible.
+you use the :doc:`PRRTE DVM configurator </configurator>` for the
+version you are using to ensure that it is fully compatible.
 
 Bootstrap Options
 ^^^^^^^^^^^^^^^^^
@@ -122,4 +122,3 @@ be written. If a relative path is provided,
 then the directory will be created under the ``DVMTempDir`` location. The
 path defaults to the specified SessionTmpDir in the absence of any input
 to this field. The log filename is formatted as ``prted-<hostname>-log<``.
-

--- a/docs/configurator.rst
+++ b/docs/configurator.rst
@@ -1,0 +1,11 @@
+PRRTE DVM Configuration Tool
+============================
+
+.. This rst file exists solely so that Sphinx generates a document
+   named "configurator" that can be referenced by the top-level TOC.
+   In the rendered HTML tree, this file will be overwritten by the
+   _templates/configurator.html templated file.
+
+   Note, however, that even though the entire contents of this file at
+   effectively ignored, this file *does* need to have a valid title so
+   that it can be rendered in the TOC.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Table of contents
    getting-help
    install
    configuration
+   configurator
    resilience
    developers/index
    contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ The project is formally referred to in documentation by "PRRTE", and
 the GitHub repository is ``prrte``.
 
 However, we have found that most users do not like typing the two
-consecutive `r`s in the name. Hence, all of the internal API symbols,
+consecutive ``r`` letters in the name. Hence, all of the internal API symbols,
 environment variables, MCA frameworks, and CLI executables all use the
 abbreviated ``prte`` (one ``r``, not two) for convenience.
 

--- a/src/etc/Makefile.am
+++ b/src/etc/Makefile.am
@@ -9,7 +9,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008-2023 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
@@ -19,7 +19,7 @@
 # $HEADER$
 #
 
-prte_config_files = prte-configurator.html prte.conf
+prte_config_files = prte.conf
 prte_file_from_platform = @PRTE_PARAM_FROM_PLATFORM@
 prte_mca_param_file = @PRTE_DEFAULT_MCA_PARAM_CONF@
 
@@ -52,14 +52,6 @@ install-data-local:
         echo "******************************* WARNING ************************************"; \
     else \
         $(INSTALL_DATA) $(srcdir)/prte-default-hostfile $(DESTDIR)$(sysconfdir)/; \
-    fi; \
-	if test -f $(DESTDIR)$(sysconfdir)/prte-configurator.html; then \
-        echo "******************************* WARNING ************************************"; \
-        echo "*** Not installing new prte-configurator.html over existing file in:"; \
-        echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
-        echo "******************************* WARNING ************************************"; \
-    else \
-        $(INSTALL_DATA) $(srcdir)/prte-configurator.html $(DESTDIR)$(sysconfdir)/; \
     fi; \
 	if test -f $(DESTDIR)$(sysconfdir)/prte.conf; then \
         echo "******************************* WARNING ************************************"; \

--- a/src/etc/Makefile.am
+++ b/src/etc/Makefile.am
@@ -25,6 +25,10 @@ prte_mca_param_file = @PRTE_DEFAULT_MCA_PARAM_CONF@
 
 EXTRA_DIST = $(prte_config_files) prte-mca-params.conf prte-default-hostfile
 
+# Note that prte-mca-params.conf is "special" -- we do not list it
+# here.
+prte_install_hook_files = $(prte_config_files) prte-default-hostfile
+
 # Steal a little trickery from a generated Makefile to only install
 # files if they do not already exist at the target.  Be sure to read
 # thread starting here
@@ -32,35 +36,31 @@ EXTRA_DIST = $(prte_config_files) prte-mca-params.conf prte-default-hostfile
 # details why the mkdir is in install-data-local.
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(sysconfdir); \
-    if test "$(prte_file_from_platform)" = "yes"; then \
+	@ $(MKDIR_P) $(DESTDIR)$(sysconfdir); \
+	if test "$(prte_file_from_platform)" = "yes"; then \
 	    $(INSTALL_DATA) $(prte_mca_param_file) $(DESTDIR)$(sysconfdir)/prte-mca-params.conf; \
 	else \
-		if test -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf; then \
-	        echo "******************************* WARNING ************************************"; \
-	        echo "*** Not installing new prte-mca-params.conf over existing file in:"; \
-	        echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
-	        echo "******************************* WARNING ************************************"; \
+	    if test -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf; then \
+		echo "******************************* WARNING ************************************"; \
+		echo "*** Not installing new prte-mca-params.conf over existing file in:"; \
+		echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
+		echo "******************************* WARNING ************************************"; \
 	    else \
-	        $(INSTALL_DATA) $(srcdir)/prte-mca-params.conf $(DESTDIR)$(sysconfdir)/; \
+		echo installing prte-mca-params.conf to $(DESTDIR)$(sysconfdir)/; \
+		$(INSTALL_DATA) $(srcdir)/prte-mca-params.conf $(DESTDIR)$(sysconfdir)/; \
 	    fi; \
-	fi; \
-	if test -f $(DESTDIR)$(sysconfdir)/prte-default-hostfile; then \
-        echo "******************************* WARNING ************************************"; \
-        echo "*** Not installing new prte-default-hostfile over existing file in:"; \
-        echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
-        echo "******************************* WARNING ************************************"; \
-    else \
-        $(INSTALL_DATA) $(srcdir)/prte-default-hostfile $(DESTDIR)$(sysconfdir)/; \
-    fi; \
-	if test -f $(DESTDIR)$(sysconfdir)/prte.conf; then \
-        echo "******************************* WARNING ************************************"; \
-        echo "*** Not installing new prte.conf over existing file in:"; \
-        echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
-        echo "******************************* WARNING ************************************"; \
-    else \
-        $(INSTALL_DATA) $(srcdir)/prte.conf $(DESTDIR)$(sysconfdir)/; \
-    fi;
+	fi
+	@ for file in $(prte_install_hook_files); do \
+	    if test -f $(DESTDIR)$(sysconfdir)/$$file; then \
+		echo "******************************* WARNING ************************************"; \
+		echo "*** Not installing new $$file over existing file in:"; \
+		echo "***   $(DESTDIR)$(sysconfdir)/$$file"; \
+		echo "******************************* WARNING ************************************"; \
+	    else \
+		echo installing $$file to $(DESTDIR)$(sysconfdir)/; \
+		$(INSTALL_DATA) $(srcdir)/$$file $(DESTDIR)$(sysconfdir)/; \
+	    fi; \
+	done
 
 
 # Only remove if exactly the same as what in our tree
@@ -68,7 +68,7 @@ install-data-local:
 #    the return of the evaluted command is 0 (as opposed to non-zero
 #    as used by everyone else)
 uninstall-local:
-	@ p="$(prte_config_files)"; \
+	@ p="$(prte_install_hook_files)"; \
 	for file in $$p; do \
 	  if test -f "$(DESTDIR)$(sysconfdir)/$$file"; then \
 	  	if test -f "$$file"; then d=; else d="$(srcdir)/"; fi; \
@@ -78,22 +78,3 @@ uninstall-local:
 	    fi ; \
 	  fi ; \
 	done
-	@ if test -f "$(DESTDIR)$(sysconfdir)/prte-default-hostfile"; then \
-		if diff "$(DESTDIR)$(sysconfdir)/prte-default-hostfile" "$(srcdir)/prte-default-hostfile" > /dev/null 2>&1 ; then \
-	      echo "rm -f $(DESTDIR)$(sysconfdir)/prte-default-hostfile" ; \
-	      rm -f "$(DESTDIR)$(sysconfdir)/prte-default-hostfile" ; \
-	    fi ; \
-	fi ;
-	@ if test -f "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf"; then \
-    	if test "$(prte_file_from_platform)" = "yes"; then \
-    		if diff "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" "$(prte_mca_param_file)" > /dev/null 2>&1 ; then \
-	      		echo "rm -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
-	      		rm -f "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
-	    	fi ; \
-	    else \
-			if diff "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" "$(srcdir)/prte-mca-params.conf" > /dev/null 2>&1 ; then \
-		      echo "rm -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
-		      rm -f "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
-		    fi ; \
-		fi; \
-	fi ;


### PR DESCRIPTION
@rhc54 This PR shows how to move your configurator HTML file into the Sphinx tree so that it's just part of the PRTE RTD/HTML docs, just like all the rest.  You will probably want to edit this -- I think there might now be some duplicated content between configuration.rst and _templates/configurator.html, and I pretty arbitrarily chose where to put the configurator in the overall doc.  This exercise was mainly showing that you can take an HTML template page (with javascript) and put it in the Sphinx docs -- you will likely want to tweak it to your tastes.

For these reasons, I created this PR in draft mode.  Feel free to fix up this PR how you like it and then merge it.

I also changed it to not have configure generate configuration.rst -- it just uses the Sphinx macro (defined in conf.py) `|prte_ver|`, instead.

Finally, I also included a few other minor cleanups and cross-references here (nothing comprehensive -- just stuff I noticed while working on the configurator stuff).