### PR TITLE
Correctly identify the source prte-mca-params.conf file

### DIFF
--- a/src/etc/Makefile.am
+++ b/src/etc/Makefile.am
@@ -85,7 +85,7 @@ uninstall-local:
 	    fi ; \
 	else \
 	    if test -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf; then \
-		    if diff "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" "$srcdir/prte-mca-params.conf"> /dev/null 2>&1 ; then \
+		    if diff "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" "$(srcdir)/prte-mca-params.conf"> /dev/null 2>&1 ; then \
 		      echo "rm -f $(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
 		      rm -f "$(DESTDIR)$(sysconfdir)/prte-mca-params.conf" ; \
 		    fi ; \


### PR DESCRIPTION
When we aren't using a platform file, need to correctly identify the source prte-mca-params.conf file.

Signed-off-by: Ralph Castain <rhc@pmix.org>