### PR TITLE
Properly handle overload-allowed

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -14,7 +14,7 @@
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -154,6 +154,17 @@ processes than cpus on a resource:
    Node:        %s
    #processes:  %d
    #cpus:       %d
+
+You can override this protection by adding the "overload-allowed"
+option to your binding directive.
+#
+[allocation-overload]
+A request was made to bind to that would result in binding more
+processes than cpus available in your allocation:
+
+   Application:     %s
+   #processes:      %d
+   Binding policy:  %s
 
 You can override this protection by adding the "overload-allowed"
 option to your binding directive.

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -158,10 +158,17 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
                                                   type, 0);
 #if HWLOC_API_VERSION < 0x20000
     hwloc_bitmap_andnot(node->available, node->available, tmp_obj->allowed_cpuset);
+    if (hwloc_bitmap_empty(node->available) && options->overload) {
+        /* reset the availability */
+        hwloc_bitmap_copy(node->available, node->jobcache);
+    }
     hwloc_bitmap_andnot(options->target, options->target, tmp_obj->allowed_cpuset);
 #else
     hwloc_bitmap_andnot(node->available, node->available, tmp_obj->cpuset);
-//    hwloc_bitmap_andnot(options->target, options->target, tmp_obj->cpuset);
+    if (hwloc_bitmap_iszero(node->available) && options->overload) {
+        /* reset the availability */
+        hwloc_bitmap_copy(node->available, node->jobcache);
+    }
 #endif
     return PRTE_SUCCESS;
 }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -438,7 +438,10 @@ complete:
                 /* cannot use this node - should never happen */
                 pmix_list_remove_item(allocated_nodes, &node->super);
                 PMIX_RELEASE(node);
+                continue;
             }
+            /* cache the available CPUs for later */
+            hwloc_bitmap_copy(node->jobcache, node->available);
         }
     } else {
         num_slots = 0;
@@ -502,6 +505,8 @@ complete:
                                      "%s node %s has %d slots available",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name, s));
                 num_slots += s;
+                /* cache the available CPUs for later */
+                hwloc_bitmap_copy(node->jobcache, node->available);
                 continue;
             }
             if (!(PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(policy))) {
@@ -512,6 +517,8 @@ complete:
                 PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
                                      "%s node %s is fully used, but available for oversubscription",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
+                /* cache the available CPUs for later */
+                hwloc_bitmap_copy(node->jobcache, node->available);
             } else {
                 PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
                                      "%s node %s is fully used and not available for oversubscription: SLOTS %d INUSE %d",
@@ -520,6 +527,7 @@ complete:
                 /* if we cannot use it, remove it from list */
                 pmix_list_remove_item(allocated_nodes, &node->super);
                 PMIX_RELEASE(node); /* "un-retain" it */
+                continue;
             }
         }
     }

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -608,6 +608,7 @@ static void prte_node_construct(prte_node_t *node)
     node->aliases = NULL;
     node->daemon = NULL;
     node->available = NULL;
+    node->jobcache = hwloc_bitmap_alloc();
 
     node->num_procs = 0;
     node->procs = PMIX_NEW(pmix_pointer_array_t);
@@ -650,6 +651,9 @@ static void prte_node_destruct(prte_node_t *node)
     }
     if (NULL != node->available) {
         hwloc_bitmap_free(node->available);
+    }
+    if (NULL != node->jobcache) {
+        hwloc_bitmap_free(node->jobcache);
     }
     for (i = 0; i < node->procs->size; i++) {
         if (NULL != (proc = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, i))) {

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -270,6 +270,8 @@ typedef struct {
     struct prte_proc_t *daemon;
     /* track the unassigned cpus */
     hwloc_cpuset_t available;
+    /* cache the cpuset prior to mapping a job for easy reset */
+    hwloc_cpuset_t jobcache;
     /** number of procs on this node */
     prte_node_rank_t num_procs;
     /* array of pointers to procs on this node */


### PR DESCRIPTION
When we run out of cpus while binding, we need to check if overload is allowed. If it is, we have to reset the available cpus for reuse - otherwise, we error out as no cpus are shown as available. Ensure we only make the cpus used for that job available for reuse so we don't step on those being used by other jobs.

Signed-off-by: Ralph Castain <rhc@pmix.org>