### PR TITLE
Correct default binding for map-by node/slot

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -335,19 +335,26 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
                                 "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
             PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
         } else {
-            /* we are mapping by node or some other non-object method */
-            if (options->use_hwthreads) {
-                /* if we are using hwthread cpus, then bind to those */
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                PRTE_BIND_TO_HWTHREAD);
+            if (options->nprocs <= 2) {
+                /* we are mapping by node or some other non-object method */
+                if (options->use_hwthreads) {
+                    /* if we are using hwthread cpus, then bind to those */
+                    pmix_output_verbose(options->verbosity, options->stream,
+                                        "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
+                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                    PRTE_BIND_TO_HWTHREAD);
+                } else {
+                    /* otherwise bind to core */
+                    pmix_output_verbose(options->verbosity, options->stream,
+                                        "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
+                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                    PRTE_BIND_TO_CORE);
+                }
             } else {
-                /* otherwise bind to core */
                 pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                PRTE_BIND_TO_CORE);
+                                    "setdefaultbinding[%d] binding not given - using bynuma",
+                                    __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NUMA);
             }
         }
     }

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -334,6 +334,20 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
             pmix_output_verbose(options->verbosity, options->stream,
                                 "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
             PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
+        } else if (PRTE_MAPPING_PELIST == mpol) {
+            if (options->use_hwthreads) {
+                /* if we are using hwthread cpus, then bind to those */
+                pmix_output_verbose(options->verbosity, options->stream,
+                                    "setdefaultbinding[%d] binding not given - using byhwthread for pe-list", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_HWTHREAD);
+            } else {
+                /* otherwise bind to core */
+                pmix_output_verbose(options->verbosity, options->stream,
+                                    "setdefaultbinding[%d] binding not given - using bycore for pe-list", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_CORE);
+            }
         } else {
             if (options->nprocs <= 2) {
                 /* we are mapping by node or some other non-object method */

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -128,6 +128,36 @@ mapping operation.
   Binding policy:      %s
 
 #
+[span-packages-multiple]
+Your job failed to map because the resulting process placement
+would cause the process to be bound to CPUs in more than one
+package:
+
+  Mapping policy:  %s
+  Binding policy:  %s
+  CPUs/rank:       %d
+
+This configuration almost always results in a loss of performance
+that can significantly impact applications. Either alter the
+mapping, binding, and/or cpus/rank policies so that each process
+can fit into a single package, or consider using an alternative
+mapper that can handle this configuration (e.g., the rankfile mapper).
+#
+[span-packages-cpuset]
+Your job failed to map because the resulting process placement
+would cause the process to be bound to CPUs in more than one
+package:
+
+  Mapping policy:  %s
+  Binding policy:  %s
+  PE-LIST:         %s
+
+This configuration almost always results in a loss of performance
+that can significantly impact applications. Either alter the
+mapping, binding, and/or PE-LIST policies so that each process
+can fit into a single package, or consider using an alternative
+mapper that can handle this configuration (e.g., the rankfile mapper).
+#
 [unrecognized-policy]
 The specified %s directive is not recognized:
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -144,6 +144,7 @@ pass:
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
                 /* move on to the next node */
+                rc = PRTE_ERR_SILENT;
                 break;
             }
             nprocs_mapped++;
@@ -305,6 +306,7 @@ pass:
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
                 /* move to next node */
+                rc = PRTE_ERR_SILENT;
                 break;
             }
             nprocs_mapped++;
@@ -466,7 +468,7 @@ pass:
         for (i = 0; i < options->nprocs && nprocs_mapped < app->num_procs; i++) {
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                rc = PRTE_ERR_SILENT;
                 goto errout;
             }
             nprocs_mapped++;


### PR DESCRIPTION
[Correct default binding for map-by node/slot](https://github.com/openpmix/prrte/pull/1662/commits/b7d938775e3c7329245384eee4b9efc61ad53679)
If we are mapping to a non-object (i.e., node or slot) and the binding target was not specified, then set the default binding (if supported) to cpu for nprocs <= 2 and to NUMA for nprocs > 2.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Provide better error message for cross-package binding](https://github.com/openpmix/prrte/pull/1662/commits/8f58601bc4f407b14688efa1d7775f29a3fc7482)

Deal with mapping by something other than objects to detect
cross-package binding. Provide a better error message when
we encounter that situation.

Signed-off-by: Ralph Castain <rhc@pmix.org>