### PR TITLE
Begin wiring in the scheduler support

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -145,11 +145,11 @@ static void spawn(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(req);
 
     /* add this request to our tracker array */
-    req->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
     /* include the request room number for quick retrieval */
     prte_set_attribute(&req->jdata->attributes, PRTE_JOB_ROOM_NUM,
-                       PRTE_ATTR_GLOBAL, &req->room_num, PMIX_INT);
+                       PRTE_ATTR_GLOBAL, &req->local_index, PMIX_INT);
 
     /* construct a spawn message */
     PMIX_DATA_BUFFER_CREATE(buf);
@@ -159,7 +159,7 @@ static void spawn(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         goto callback;
     }
 
@@ -167,7 +167,7 @@ static void spawn(int sd, short args, void *cbdata)
     rc = prte_job_pack(buf, req->jdata);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
@@ -176,7 +176,7 @@ static void spawn(int sd, short args, void *cbdata)
     PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_PLM);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -619,14 +619,14 @@ static void _toolconn(int sd, short args, void *cbdata)
             free(tmp);
             prte_plm_globals.next_jobid++;
         } else {
-            cd->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
+            cd->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
             /* we need to send this to the HNP for a jobid */
             PMIX_DATA_BUFFER_CREATE(buf);
             rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
-            rc = PMIx_Data_pack(NULL, buf, &cd->room_num, 1, PMIX_INT);
+            rc = PMIx_Data_pack(NULL, buf, &cd->local_index, 1, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
@@ -636,7 +636,7 @@ static void _toolconn(int sd, short args, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 xrc = prte_pmix_convert_rc(rc);
-                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->room_num, NULL);
+                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->local_index, NULL);
                 PMIX_DATA_BUFFER_RELEASE(buf);
                 if (NULL != cd->toolcbfunc) {
                     cd->toolcbfunc(xrc, NULL, cd->cbdata);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,14 +157,14 @@ static void execute(int sd, short args, void *cbdata)
     }
 
     /* add this request to our tracker array */
-    req->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
     stored = true;
 
     /* setup the xfer */
     PMIX_DATA_BUFFER_CREATE(xfer);
 
     /* pack the room number */
-    rc = PMIx_Data_pack(NULL, xfer, &req->room_num, 1, PMIX_INT);
+    rc = PMIx_Data_pack(NULL, xfer, &req->local_index, 1, PMIX_INT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(xfer);
@@ -210,7 +210,7 @@ callback:
         req->lkcbfunc(rc, NULL, 0, req->cbdata);
     }
     if (stored) {
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     }
     PMIX_RELEASE(req);
 }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -11,33 +11,150 @@
 
 #include "src/pmix/pmix-internal.h"
 #include "src/prted/pmix/pmix_server_internal.h"
+#include "src/rml/rml.h"
+
+static void localrelease(void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+static void pass_request(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
+    pmix_server_req_t *req;
+    pmix_data_buffer_t *buf;
+    uint8_t command;
+    pmix_status_t rc;
+
+    /* create a request tracker for this operation */
+    req = PMIX_NEW(pmix_server_req_t);
+    if (0 < cd->allocdir) {
+        pmix_asprintf(&req->operation, "ALLOCATE: %u", cd->allocdir);
+        command = 0;
+    } else {
+        pmix_asprintf(&req->operation, "SESSIONCTRL: %u", cd->sessionID);
+        command = 1;
+    }
+    req->infocbfunc = cd->infocbfunc;
+    req->cbdata = cd->cbdata;
+    /* add this request to our local request tracker array */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+
+    /* construct a request message for the command */
+    rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    /* pack the local requestor ID */
+    rc = PMIx_Data_pack(NULL, buf, &req->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    /* pack the requestor */
+    rc = PMIx_Data_pack(NULL, buf, &cd->proc, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    if (0 == command) {
+        /* pack the allocation directive */
+        rc = PMIx_Data_pack(NULL, buf, &cd->allocdir, 1, PMIX_ALLOC_DIRECTIVE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    } else {
+        /* pack the sessionID */
+        rc = PMIx_Data_pack(NULL, buf, &cd->sessionID, 1, PMIX_UINT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    }
+
+    /* pack the number of info */
+    rc = PMIx_Data_pack(NULL, buf, &cd->ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+    if (0 < cd->ninfo) {
+        /* pack the info */
+        rc = PMIx_Data_pack(NULL, buf, cd->info, cd->ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    }
+
+    /* send this request to the DVM controller - might be us */
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        goto callback;
+    }
+    PMIX_RELEASE(cd);
+    return;
+
+callback:
+    PMIX_RELEASE(cd);
+    /* this section gets executed solely upon an error */
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+        return;
+    }
+    PMIX_RELEASE(req);
+}
 
 pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
                                    pmix_alloc_directive_t directive,
                                    const pmix_info_t data[], size_t ndata,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_status_t rc;
+    prte_pmix_server_op_caddy_t *cd;
 
-    /* if we are not the DVM controller, then send it there */
 
-    /* we are the DVM controller, so pass it down so PMIx can
-     * send it to the scheduler */
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s allocate upcalled on behalf of proc %s:%u with %" PRIsize_t " infos",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), client->nspace, client->rank, ndata);
 
-    if (!prte_pmix_server_globals.scheduler_connected) {
-        /* the scheduler has not attached to us - there is
-         * nothing we can do */
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-    /* if we have not yet set the scheduler as our server, do so */
-    if (!prte_pmix_server_globals.scheduler_set_as_server) {
-        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-        prte_pmix_server_globals.scheduler_set_as_server = true;
-    }
-    return PMIX_SUCCESS;
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    PMIX_LOAD_PROCID(&cd->proc, client->nspace, client->rank);
+    cd->allocdir = directive;
+    cd->info = (pmix_info_t *) data;
+    cd->ninfo = ndata;
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
+    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+    return PRTE_SUCCESS;
 }
 
 #if PMIX_NUMERIC_VERSION >= 0x00050000
@@ -47,28 +164,25 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                                           const pmix_info_t directives[], size_t ndirs,
                                           pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_status_t rc;
+    prte_pmix_server_op_caddy_t *cd;
 
-    /* if we are not the DVM controller, then send it there */
 
-    /* we are the DVM controller, so pass it down so PMIx can
-     * send it to the scheduler */
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl upcalled on behalf of proc %s:%u with %" PRIsize_t " directives",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), requestor->nspace, requestor->rank, ndirs);
 
-    if (!prte_pmix_server_globals.scheduler_connected) {
-        /* the scheduler has not attached to us - there is
-         * nothing we can do */
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-    /* if we have not yet set the scheduler as our server, do so */
-    if (!prte_pmix_server_globals.scheduler_set_as_server) {
-        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-        prte_pmix_server_globals.scheduler_set_as_server = true;
-    }
-    return PMIX_SUCCESS;
-
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    PMIX_LOAD_PROCID(&cd->proc, requestor->nspace, requestor->rank);
+    cd->sessionID = sessionID;
+    cd->info = (pmix_info_t *) directives;
+    cd->ninfo = ndirs;
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
+    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+    return PRTE_SUCCESS;
 }
 
 #endif

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -219,6 +219,10 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 
 /* error propagate  */
 #define PRTE_RML_TAG_PROPAGATE 71
+
+/* scheduler requests */
+#define PRTE_RML_TAG_SCHED 72
+
 
 #define PRTE_RML_TAG_MAX 100
 


### PR DESCRIPTION
Add in the transfer of scheduling requests to the DVM master for relay to the scheduler. Cleanup the request tracking system to move away from the hotel, running the timeout event directly in libevent for the specified timeout time.

Signed-off-by: Ralph Castain <rhc@pmix.org>