### PR TITLE
Add missing command line directives

### DIFF
--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -367,6 +367,8 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
 
     char *outputs[] = {
         PRTE_CLI_TAG,
+        PRTE_CLI_TAG_DET,
+        PRTE_CLI_TAG_FULL,
         PRTE_CLI_RANK,
         PRTE_CLI_TIMESTAMP,
         PRTE_CLI_XML,


### PR DESCRIPTION
Add a couple of missing directives to the
output category sanity checker.

Signed-off-by: Ralph Castain <rhc@pmix.org>