### PR TITLE
Remove antiquated code that can cause problems

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -169,11 +169,6 @@ hwloc_cpuset_t prte_hwloc_base_setup_summary(hwloc_topology_t topo)
     hwloc_cpuset_t avail = NULL;
 
     avail = hwloc_bitmap_alloc();
-    /* get the cpus we are bound to */
-    if (!prte_hwloc_synthetic_topo &&
-        0 <= hwloc_get_cpubind(topo, avail, HWLOC_CPUBIND_PROCESS)) {
-        return avail;
-    }
 
     /* get the root available cpuset */
 #if HWLOC_API_VERSION < 0x20000


### PR DESCRIPTION
Now that hwloc is providing better definition of
"allowed" cpus, we no longer want/need to be
doing an explicit read of the local affinity.
This was incorrectly being applied to all
daemons because we assumed that any externally
applied binding (e.g., cgroup) would apply to
all locations - mpirun as well as compute
nodes. Sometimes isn't true, so just avoid
the complications.

Fixes https://github.com/open-mpi/ompi/issues/11371
Signed-off-by: Ralph Castain <rhc@pmix.org>