### PR TITLE
Multiple commits

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=4.2.0,<=5.3.0
+sphinx>=4.2.0
 recommonmark
 docutils
-sphinx-rtd-theme<1.2.0
+sphinx-rtd-theme

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019-2022 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -38,7 +39,7 @@ static pmix_proc_t myproc;
 
 int main(int argc, char **argv)
 {
-    int rc;
+    int rc, np;
     pmix_value_t value;
     pmix_value_t *val = NULL;
     char tmp[1024];
@@ -144,7 +145,12 @@ int main(int argc, char **argv)
     }
     PMIX_ARGV_FREE(peers);
 
-    snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s",  myproc.nspace);
+    np = snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s",  myproc.nspace);
+    if (np >= PMIX_MAX_NSLEN) {
+        fprintf(stderr, "Client ns %s rank %d: snprintf failed\n", myproc.nspace, myproc.rank);
+        exit(0);
+    }
+
     PMIX_INFO_LOAD(&timeout, PMIX_TIMEOUT, &tlimit, PMIX_INT);
     /* get the committed data - ask for someone who doesn't exist as well */
     for (n = 0; n < nprocs; n++) {

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
                 rc);
-        exit(0);
+        exit(EXIT_FAILURE);
     }
 
     /* get our job size */
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
     np = snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s",  myproc.nspace);
     if (np >= PMIX_MAX_NSLEN) {
         fprintf(stderr, "Client ns %s rank %d: snprintf failed\n", myproc.nspace, myproc.rank);
-        exit(0);
+        exit(EXIT_FAILURE);
     }
 
     PMIX_INFO_LOAD(&timeout, PMIX_TIMEOUT, &tlimit, PMIX_INT);
@@ -242,7 +242,7 @@ done:
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank,
                 rc);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
@@ -255,5 +255,5 @@ done:
         }
     }
     fflush(stderr);
-    return (0);
+    return (EXIT_SUCCESS);
 }

--- a/examples/nodeid.c
+++ b/examples/nodeid.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,18 +78,18 @@ int main(int argc, char **argv)
         proc.rank = n;
         rc = PMIx_Get(&proc, PMIX_NODEID, NULL, 0, &val);
         if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "[%s:%u] PMIx_Get failed for nodeid on rank %u: %s\n",
+            fprintf(stderr, "[%s:%u] PMIx_Get failed for nodeid on rank %zd: %s\n",
                     myproc.nspace, myproc.rank, n, PMIx_Error_string(rc));
             break;
         }
         PMIX_VALUE_GET_NUMBER(rc, val, nodeid, uint32_t);
         if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "[%s:%u] Got bad nodeid for rank %u: %s\n",
+            fprintf(stderr, "[%s:%u] Got bad nodeid for rank %zd: %s\n",
                     myproc.nspace, myproc.rank, n, PMIx_Error_string(rc));
             goto done;
         }
         if (0 == myproc.rank) {
-            fprintf(stderr, "[%s:%u] Peer %u is running on node %u\n",
+            fprintf(stderr, "[%s:%u] Peer %zd is running on node %u\n",
                     myproc.nspace, myproc.rank, n, nodeid);
         }
         PMIX_VALUE_RELEASE(val);

--- a/examples/pset.c
+++ b/examples/pset.c
@@ -16,6 +16,7 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +77,7 @@ int main(int argc, char **argv)
                 myproc.nspace, myproc.rank, PMIx_Data_type_string(val->type));
         goto done;
     }
-    fprintf(stderr, "Client %s:%d PMIx_Get returned %d members\n", myproc.nspace, myproc.rank,
+    fprintf(stderr, "Client %s:%d PMIx_Get returned %zd members\n", myproc.nspace, myproc.rank,
             val->data.darray->size);
     pptr = (pmix_proc_t*)val->data.darray->array;
     for (n=0; n < val->data.darray->size; n++) {

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -335,19 +335,26 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
                                 "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
             PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
         } else {
-            /* we are mapping by node or some other non-object method */
-            if (options->use_hwthreads) {
-                /* if we are using hwthread cpus, then bind to those */
-                pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                PRTE_BIND_TO_HWTHREAD);
+            if (options->nprocs <= 2) {
+                /* we are mapping by node or some other non-object method */
+                if (options->use_hwthreads) {
+                    /* if we are using hwthread cpus, then bind to those */
+                    pmix_output_verbose(options->verbosity, options->stream,
+                                        "setdefaultbinding[%d] binding not given - using byhwthread", __LINE__);
+                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                    PRTE_BIND_TO_HWTHREAD);
+                } else {
+                    /* otherwise bind to core */
+                    pmix_output_verbose(options->verbosity, options->stream,
+                                        "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
+                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                    PRTE_BIND_TO_CORE);
+                }
             } else {
-                /* otherwise bind to core */
                 pmix_output_verbose(options->verbosity, options->stream,
-                                    "setdefaultbinding[%d] binding not given - using bycore", __LINE__);
-                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
-                                                PRTE_BIND_TO_CORE);
+                                    "setdefaultbinding[%d] binding not given - using bynuma",
+                                    __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NUMA);
             }
         }
     }

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -334,6 +334,20 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
             pmix_output_verbose(options->verbosity, options->stream,
                                 "setdefaultbinding[%d] binding not given - using bypackage", __LINE__);
             PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
+        } else if (PRTE_MAPPING_PELIST == mpol) {
+            if (options->use_hwthreads) {
+                /* if we are using hwthread cpus, then bind to those */
+                pmix_output_verbose(options->verbosity, options->stream,
+                                    "setdefaultbinding[%d] binding not given - using byhwthread for pe-list", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_HWTHREAD);
+            } else {
+                /* otherwise bind to core */
+                pmix_output_verbose(options->verbosity, options->stream,
+                                    "setdefaultbinding[%d] binding not given - using bycore for pe-list", __LINE__);
+                PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding,
+                                                PRTE_BIND_TO_CORE);
+            }
         } else {
             if (options->nprocs <= 2) {
                 /* we are mapping by node or some other non-object method */

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -169,11 +169,6 @@ hwloc_cpuset_t prte_hwloc_base_setup_summary(hwloc_topology_t topo)
     hwloc_cpuset_t avail = NULL;
 
     avail = hwloc_bitmap_alloc();
-    /* get the cpus we are bound to */
-    if (!prte_hwloc_synthetic_topo &&
-        0 <= hwloc_get_cpubind(topo, avail, HWLOC_CPUBIND_PROCESS)) {
-        return avail;
-    }
 
     /* get the root available cpuset */
 #if HWLOC_API_VERSION < 0x20000

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -274,20 +274,6 @@ static void allgather_recv(int status, pmix_proc_t *sender,
             /* update the info with the collected value */
             info[n].value.type = PMIX_STATUS;
             info[n].value.data.status = coll->status;
-#ifdef PMIX_SIZE_ESTIMATE
-        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SIZE_ESTIMATE)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, memsize, size_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_PROC_FREE(sig.signature, sig.sz);
-                PMIX_DATA_BUFFER_DESTRUCT(&ctrlbuf);
-                return;
-            }
-            coll->memsize += memsize;
-            /* update the info with the collected value */
-            info[n].value.type = PMIX_SIZE;
-            info[n].value.data.size = coll->memsize;
-#endif
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ASSIGN_CONTEXT_ID)) {
             assignID = PMIX_INFO_TRUE(&info[n]);
             if (assignID) {
@@ -346,18 +332,6 @@ static void allgather_recv(int status, pmix_proc_t *sender,
             }
             /* add some values to the payload in the bucket */
 
-#ifdef PMIX_SIZE_ESTIMATE
-            /* pack the memory size */
-            PMIX_INFO_LOAD(&infostat, PMIX_SIZE_ESTIMATE, &coll->memsize, PMIX_SIZE);
-            rc = PMIx_Data_pack(NULL, reply, &infostat, 1, PMIX_INFO);
-            PMIX_INFO_DESTRUCT(&infostat);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_PROC_FREE(sig.signature, sig.sz);
-                return;
-            }
-#endif
             /* if we were asked to provide a context id, do so */
             if (assignID) {
                 size_t sz;

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -128,6 +128,36 @@ mapping operation.
   Binding policy:      %s
 
 #
+[span-packages-multiple]
+Your job failed to map because the resulting process placement
+would cause the process to be bound to CPUs in more than one
+package:
+
+  Mapping policy:  %s
+  Binding policy:  %s
+  CPUs/rank:       %d
+
+This configuration almost always results in a loss of performance
+that can significantly impact applications. Either alter the
+mapping, binding, and/or cpus/rank policies so that each process
+can fit into a single package, or consider using an alternative
+mapper that can handle this configuration (e.g., the rankfile mapper).
+#
+[span-packages-cpuset]
+Your job failed to map because the resulting process placement
+would cause the process to be bound to CPUs in more than one
+package:
+
+  Mapping policy:  %s
+  Binding policy:  %s
+  PE-LIST:         %s
+
+This configuration almost always results in a loss of performance
+that can significantly impact applications. Either alter the
+mapping, binding, and/or PE-LIST policies so that each process
+can fit into a single package, or consider using an alternative
+mapper that can handle this configuration (e.g., the rankfile mapper).
+#
 [unrecognized-policy]
 The specified %s directive is not recognized:
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -144,6 +144,7 @@ pass:
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
                 /* move on to the next node */
+                rc = PRTE_ERR_SILENT;
                 break;
             }
             nprocs_mapped++;
@@ -305,6 +306,7 @@ pass:
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
                 /* move to next node */
+                rc = PRTE_ERR_SILENT;
                 break;
             }
             nprocs_mapped++;
@@ -466,7 +468,7 @@ pass:
         for (i = 0; i < options->nprocs && nprocs_mapped < app->num_procs; i++) {
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                rc = PRTE_ERR_SILENT;
                 goto errout;
             }
             nprocs_mapped++;

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -367,6 +367,8 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
 
     char *outputs[] = {
         PRTE_CLI_TAG,
+        PRTE_CLI_TAG_DET,
+        PRTE_CLI_TAG_FULL,
         PRTE_CLI_RANK,
         PRTE_CLI_TIMESTAMP,
         PRTE_CLI_XML,

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -981,9 +981,6 @@ static void connect_release(int status, pmix_data_buffer_t *buf, void *cbdata)
     uint32_t ctxid;
     bool first = true;
     char *payload;
-#ifdef PMIX_SIZE_ESTIMATE
-    size_t memsize = 0;
-#endif
 
     PMIX_ACQUIRE_OBJECT(md);
 
@@ -1002,15 +999,6 @@ static void connect_release(int status, pmix_data_buffer_t *buf, void *cbdata)
                     assignedID = true;
                     ++ninfo;
                 }
-#ifdef PMIX_SIZE_ESTIMATE
-            } else if (PMIX_CHECK_KEY(&infostat, PMIX_SIZE_ESTIMATE)) {
-                PMIX_VALUE_GET_NUMBER(rc, &infostat.value, memsize, size_t);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                } else {
-                    ++ninfo;
-                }
-#endif
             }
             /* save where we are */
             payload = buf->unpack_ptr;
@@ -1033,11 +1021,6 @@ static void connect_release(int status, pmix_data_buffer_t *buf, void *cbdata)
             PMIX_INFO_LOAD(&info[n], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_UINT32);
             ++n;
         }
-#ifdef PMIX_SIZE_ESTIMATE
-        if (0 < memsize) {
-            PMIX_INFO_LOAD(&info[n], PMIX_SIZE_ESTIMATE, &memsize, PMIX_SIZE);
-        }
-#endif
 
         /* there is a byte object for each proc in the connect operation */
         cnt = 1;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -937,10 +937,6 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
     pmix_info_t info;
     pmix_byte_object_t bo;
     int32_t byused;
-#ifdef PMIX_SIZE_ESTIMATE
-    bool gotestimate = false;
-    size_t memsize = 0;
-#endif
     char *payload;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -969,17 +965,6 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
             }
             assignedID = true;
             cd->ninfo++;
-#ifdef PMIX_SIZE_ESTIMATE
-        } else if (PMIX_CHECK_KEY(&info, PMIX_SIZE_ESTIMATE)) {
-            PMIX_VALUE_GET_NUMBER(rc, &info.value, memsize, size_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                cd->ninfo = 0;
-                goto complete;
-            }
-            gotestimate = true;
-            cd->ninfo++;
-#endif
         }
         /* save where we are */
         payload = buf->unpack_ptr;
@@ -1015,12 +1000,6 @@ static void group_release(int status, pmix_data_buffer_t *buf, void *cbdata)
     if (0 < cd->ninfo) {
         PMIX_INFO_CREATE(cd->info, cd->ninfo);
         n = 0;
-#ifdef PMIX_SIZE_ESTIMATE
-        if (gotestimate) {
-            PMIX_INFO_LOAD(&cd->info[n], PMIX_SIZE_ESTIMATE, &memsize, PMIX_SIZE);
-            ++n;
-        }
-#endif
         if (assignedID) {
             PMIX_INFO_LOAD(&cd->info[n], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_UINT32);
             ++n;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -608,30 +608,6 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     }
     PMIX_LIST_DESTRUCT(&local_procs);
 
-#ifdef PMIX_SIZE_ESTIMATE
-    /* determine the overall size of this payload */
-    iptr = PMIx_Info_list_get_info(info, NULL, &next);
-    size = 0;
-    while (1) {
-        ret = PMIx_Info_get_size(iptr, &sz);
-        if (PMIX_SUCCESS != ret) {
-            break;
-        }
-        size += sz;
-        if (NULL == next) {
-            break;
-        }
-        iptr = PMIx_Info_list_get_info(info, next, &next);
-    }
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        rc = prte_pmix_convert_status(ret);
-        PMIX_INFO_LIST_RELEASE(info);
-        return rc;
-    }
-    PMIX_INFO_LIST_PREPEND(ret, info, PMIX_SIZE_ESTIMATE, &size, PMIX_SIZE);
-#endif
-    
     /* register it */
     PMIX_INFO_LIST_CONVERT(ret, info, &darray);
     pinfo = (pmix_info_t*)darray.array;

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,6 +15,7 @@
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -37,8 +38,8 @@ TESTS = \
 	double-get \
 	get-nofence \
 	get-immediate \
-	attachtest/app.c \
-	attachtest/tool.c \
+	attachtest/app \
+	attachtest/tool \
 	abort \
 	simple_spawn \
 	hello \

--- a/test/connect.c
+++ b/test/connect.c
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     }
 
     /* try to get a remote value */
-    PMIX_LOAD_NSPACE(&remote, myproc.nspace);
+    PMIX_LOAD_NSPACE(remote.nspace, myproc.nspace);
     if (0 == myproc.rank) {
         remote.rank = 1;
     } else {

--- a/test/loop_spawn.c
+++ b/test/loop_spawn.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
                         "Usage: %s\n    Options:\n"
                         "        [-i N] [number of iterations]\n"
                         "        [-s] [Sync mode - wait for termination before spawning next child]\n"
-                        "        [-v] [Verbose]\n",
+                        "        [-v] [Verbose]\n"
                         "        [-r N] [Report progress every N iterations]\n",
                         argv[0]);
                 exit(1);
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
                         "Usage: %s\n    Options:\n"
                         "        [-i N] [number of iterations]\n"
                         "        [-s] [Sync mode - wait for termination before spawning next child]\n"
-                        "        [-v] [Verbose]\n",
+                        "        [-v] [Verbose]\n"
                         "        [-r N] [Report progress every N iterations]\n",
                         argv[0]);
                 exit(1);


### PR DESCRIPTION
[Correct default binding for map-by node/slot](https://github.com/openpmix/prrte/commit/b08832097f3f6b7cd0349b9302be5a5bfd5158da)

If we are mapping to a non-object (i.e., node or slot)
and the binding target was not specified, then set the
default binding (if supported) to cpu for nprocs <= 2
and to NUMA for nprocs > 2.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ec471d9b21c83be39290d6e50c9f88b71e6d86eb)

[Provide better error message for cross-package binding](https://github.com/openpmix/prrte/commit/100507d935c89bfe5d5bce025ca731797eafca77)

Deal with mapping by something other than objects to detect
cross-package binding. Provide a better error message when
we encounter that situation.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/081890acbb8485ed250ffd3b74fcecb3d0da8eb7)

[Add missing command line directives](https://github.com/openpmix/prrte/commit/f501c5c9b24783c983a6e7271742d79d21420fa7)

Add a couple of missing directives to the
output category sanity checker.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/c561a6095aaa256e32457ecee979dbfab371a16b)

[Fix minor issues found in tests.](https://github.com/openpmix/prrte/commit/aac077db33a0ef91251ac14046bbaef5d6658674)

* Don't accidentally remove source files in make clean
* Silence compiler warnings

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5d030c908178ac8100c0a48818d567ee00c810a0)

[Silence compiler warning in test/connect.](https://github.com/openpmix/prrte/commit/dc2bfed5f8e997d644015ad6b15a7781116555d4)

Co-authored-by: Ralph Castain <rhc@pmix.org>
Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/4f652de87846a319b14dfd3b0ac9dbe6017ab07e)

[Silence compiler warnings in examples.](https://github.com/openpmix/prrte/commit/8f1a61343753ad7df098cfd47855dcc65c9b6b83)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/83ddaf9f4091bb8245f1490cbec35e8a59f14ebc)

[Use exit macros in example dmodex.](https://github.com/openpmix/prrte/commit/8d1e5abd3569de733452a18a9bde5fc044624ab4)

* Use exit macros in example dmodex
* correct exit status in error paths

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/2b91998c4116ba8b46a3e9024c5ccf40787c522c)

[Remove antiquated code that can cause problems](https://github.com/openpmix/prrte/commit/f592a1a9b69f8b34a83f2e35f06f84f38163157f)

Now that hwloc is providing better definition of
"allowed" cpus, we no longer want/need to be
doing an explicit read of the local affinity.
This was incorrectly being applied to all
daemons because we assumed that any externally
applied binding (e.g., cgroup) would apply to
all locations - mpirun as well as compute
nodes. Sometimes isn't true, so just avoid
the complications.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5712e2e24fdcac24ec2b1db5d1fab6567ab60a4e)

[Update sphinx requirements](https://github.com/openpmix/prrte/commit/2739771d8e1b9ae7b3caffbd42b0574cf9418737)

Crossport of https://github.com/open-mpi/ompi/pull/11395

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8bb7fa1d1d371270fab4e5b6cee52f3c1deb8180)

@rhc54
[Remove the PMIX_SIZE_ESTIMATE support](https://github.com/openpmix/prrte/pull/1672/commits/d5cec235c9e202c1e146a25166d370c826478874)
[d5cec23](https://github.com/openpmix/prrte/pull/1672/commits/d5cec235c9e202c1e146a25166d370c826478874)

No longer required

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/rhc54/prrte/commit/10496e38a0b54722723ec83923f6311ec82d692b)
