### PR TITLE
Ensure cmd line errors provide error messages

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -175,3 +175,11 @@ given are:
   bind-to: %s
 
 Please resolve the conflict and try again.
+#
+[missing-values]
+The provided command line option requires passing two
+values:
+
+  Option:  %s <MCA param name> <param value>
+
+Please provide the missing values and try again.

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -295,7 +295,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--prtemca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                return PRTE_ERR_FATAL;
+                pmix_show_help("help-schizo-base.txt", "missing-values", true,
+                               "--prtemca");
+                return PRTE_ERR_SILENT;
             }
             p1 = prte_schizo_base_strip_quotes(argv[i + 1]);
             p2 = prte_schizo_base_strip_quotes(argv[i + 2]);
@@ -320,7 +322,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--mca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                return PRTE_ERR_FATAL;
+                pmix_show_help("help-schizo-base.txt", "missing-values", true,
+                               "--mca");
+                return PRTE_ERR_SILENT;
             }
             p1 = prte_schizo_base_strip_quotes(argv[i + 1]);
             p2 = prte_schizo_base_strip_quotes(argv[i + 2]);
@@ -434,7 +438,9 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--pmixmca", argv[i]) || 0 == strcmp("--gpmixmca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                return PRTE_ERR_FATAL;
+                pmix_show_help("help-schizo-base.txt", "missing-values", true,
+                               "--pmixmca");
+                return PRTE_ERR_SILENT;
             }
             /* strip any quotes around the args */
             p1 = prte_schizo_base_strip_quotes(argv[i + 1]);

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -106,6 +106,7 @@ pmix_proc_t prte_name_invalid = {{0}, PMIX_RANK_INVALID};
 pmix_nspace_t prte_nspace_wildcard = {0};
 
 static bool util_initialized = false;
+static bool min_initialized = false;
 
 #if PRTE_CC_USE_PRAGMA_IDENT
 #    pragma ident PRTE_IDENT_STRING
@@ -126,16 +127,15 @@ static bool check_exist(char *path)
     return false;
 }
 
-int prte_init_util(prte_proc_type_t flags)
+int prte_init_minimum(void)
 {
     int ret;
-    char *error = NULL;
     char *path = NULL;
 
-    if (util_initialized) {
+    if (min_initialized) {
         return PRTE_SUCCESS;
     }
-    util_initialized = true;
+    min_initialized = true;
 
     /* carry across the toolname */
     pmix_tool_basename = prte_tool_basename;
@@ -165,6 +165,25 @@ int prte_init_util(prte_proc_type_t flags)
     ret = pmix_show_help_add_dir(prte_install_dirs.prtedatadir);
     if (PMIX_SUCCESS != ret) {
         return prte_pmix_convert_status(ret);
+    }
+
+    return PRTE_SUCCESS;
+}
+
+int prte_init_util(prte_proc_type_t flags)
+{
+    int ret;
+    char *error = NULL;
+    char *path = NULL;
+
+    if (util_initialized) {
+        return PRTE_SUCCESS;
+    }
+    util_initialized = true;
+
+    ret = prte_init_minimum();
+    if (PRTE_SUCCESS != ret) {
+        return ret;
     }
 
     /* ensure we know the type of proc for when we finalize */

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,7 @@ PRTE_EXPORT extern int prte_cache_line_size;
  */
 PRTE_EXPORT int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags);
 PRTE_EXPORT int prte_init_util(prte_proc_type_t flags);
+PRTE_EXPORT int prte_init_minimum(void);
 
 /**
  * Initialize parameters for PRTE.

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
@@ -287,6 +287,11 @@ int main(int argc, char *argv[])
             0 != strncmp(environ[i], "PRTE_", 5)) {
             PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_launch_environ, environ[i]);
         }
+    }
+
+    rc = prte_init_minimum();
+    if (PRTE_SUCCESS != rc) {
+        return rc;
     }
 
     /* because we have to use the schizo framework and init our hostname

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -152,14 +152,17 @@ int main(int argc, char *argv[])
     // we do NOT accept arguments other than our own
     if (NULL != prte_info_cmd_line.tail) {
         str = PMIX_ARGV_JOIN_COMPAT(prte_info_cmd_line.tail, ' ');
-        ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
-                                    prte_tool_basename, str, prte_tool_basename);
-        free(str);
-        if (NULL != ptr) {
-            printf("%s", ptr);
-            free(ptr);
+        if (0 != strcmp(str, argv[0])) {
+            ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
+                                        prte_tool_basename, str, prte_tool_basename);
+            free(str);
+            if (NULL != ptr) {
+                printf("%s", ptr);
+                free(ptr);
+            }
+            return -1;
         }
-        return -1;
+        free(str);
     }
 
     /* setup the mca_types array */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -235,6 +235,11 @@ int main(int argc, char *argv[])
         }
     }
 
+    ret = prte_init_minimum();
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
+
     /* we always need the prrte and pmix params */
     ret = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
     if (PRTE_SUCCESS != ret) {

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -121,6 +121,11 @@ int prun(int argc, char *argv[])
     pargc = argc;
     pargv = pmix_argv_copy_strip(argv);  // strip any quoted arguments
     gethostname(hostname, sizeof(hostname));
+
+    rc = prte_init_minimum();
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
 
     /* because we have to use the schizo framework and init our hostname
      * prior to parsing the incoming argv for cmd line options, do a hacky

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -246,6 +246,11 @@ int main(int argc, char *argv[])
     gethostname(hostname, sizeof(hostname));
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
 
+    rc = prte_init_minimum();
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
     /* we always need the prrte and pmix params */
     rc = prte_schizo_base_parse_prte(argc, 0, argv, NULL);
     if (PRTE_SUCCESS != rc) {
@@ -307,13 +312,16 @@ int main(int argc, char *argv[])
     // we do NOT accept arguments other than our own
     if (NULL != results.tail) {
         param = PMIX_ARGV_JOIN_COMPAT(results.tail, ' ');
-        ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
-                                    prte_tool_basename, param, prte_tool_basename);
-        if (NULL != ptr) {
-            printf("%s", ptr);
-            free(ptr);
+        if (0 != strcmp(param, argv[0])) {
+            ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
+                                        prte_tool_basename, param, prte_tool_basename);
+            if (NULL != ptr) {
+                printf("%s", ptr);
+                free(ptr);
+            }
+            return -1;
         }
-        return -1;
+        free(param);
     }
 
     /* setup options */


### PR DESCRIPTION
If someone provides an empty "--mca" of some flavor, ensure we print out some kind of error message instead of just returning an error code.

Signed-off-by: Ralph Castain <rhc@pmix.org>