### PR TITLE
Remove wrapper definitions

### DIFF
--- a/src/tools/prte_info/Makefile.am
+++ b/src/tools/prte_info/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,9 +34,6 @@ AM_CFLAGS = \
             -DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
             -DPRTE_BUILD_LIBS="\"@LIBS@\"" \
             -DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
-            -DPRTE_WRAPPER_EXTRA_CFLAGS="\"@PRTE_WRAPPER_EXTRA_CFLAGS@\"" \
-            -DPRTE_WRAPPER_EXTRA_LDFLAGS="\"@PRTE_WRAPPER_EXTRA_LDFLAGS@\"" \
-            -DPRTE_WRAPPER_EXTRA_LIBS="\"@PRTE_WRAPPER_EXTRA_LIBS@\"" \
             -DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
             -DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
             -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""

--- a/src/tools/prte_info/param.c
+++ b/src/tools/prte_info/param.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -401,11 +401,6 @@ void prte_info_do_config(bool want_all)
         prte_info_out("Build LDFLAGS", "option:build:ldflags", PRTE_BUILD_LDFLAGS);
         prte_info_out("Build LIBS", "option:build:libs", PRTE_BUILD_LIBS);
 
-        prte_info_out("Wrapper extra CFLAGS", "option:wrapper:extra_cflags",
-                      PRTE_WRAPPER_EXTRA_CFLAGS);
-        prte_info_out("Wrapper extra LDFLAGS", "option:wrapper:extra_ldflags",
-                      PRTE_WRAPPER_EXTRA_LDFLAGS);
-        prte_info_out("Wrapper extra LIBS", "option:wrapper:extra_libs", PRTE_WRAPPER_EXTRA_LIBS);
     }
 
     prte_info_out("Internal debug support", "option:debug", debug);


### PR DESCRIPTION
The wrapper is defined in PMIx, not here, so there is no way to show wrapper extra flags.