### PR TITLE
Extend example to check for sessionID and jobID

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     char *tmp;
     pmix_proc_t proc;
-    uint32_t nprocs, n;
+    uint32_t nprocs, n, sid;
     pmix_info_t *info;
     bool flag;
     mylock_t mylock;
@@ -212,6 +212,29 @@ int main(int argc, char **argv)
     PMIX_VALUE_GET_NUMBER(rc, val, nprocs, uint32_t);
     PMIX_VALUE_RELEASE(val);
     fprintf(stderr, "Client %s:%d num procs %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* get out sessionID */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_SESSION_ID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get sessionID failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        PMIX_VALUE_GET_NUMBER(rc, val, sid, uint32_t);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Session ID was not a number: %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client %s:%d sessionID %u\n", myproc.nspace, myproc.rank, sid);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    /* get out jobID */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOBID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get jobID failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client %s:%d jobID %s\n", myproc.nspace, myproc.rank, val->data.string);
+        PMIX_VALUE_RELEASE(val);
+    }
 
     /* get the number of local procs in our job */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1765,8 +1765,12 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
         rc = PMIx_Allocation_request_nb(allocdir, info, ninfo,
                                         req->infocbfunc, req);
     } else {
+#if PMIX_NUMERIC_VERSION < 0x00050000
+        rc = PMIX_ERR_NOT_SUPPORTED;
+#else
         rc = PMIx_Session_control(sessionID, info, ninfo,
                                   req->infocbfunc, req);
+#endif
     }
     if (PMIX_SUCCESS != rc) {
         if (NULL != info) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -38,6 +38,7 @@
 
 #include "prte_stdint.h"
 #include "src/hwloc/hwloc-internal.h"
+#include "src/include/hash_string.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/error.h"
@@ -112,6 +113,16 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         return rc;
     }
     PMIX_INFO_LIST_ADD(ret, info, PMIX_SERVER_RANK, &prte_process_info.myproc.rank, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_INFO_LIST_RELEASE(info);
+        rc = prte_pmix_convert_status(ret);
+        return rc;
+    }
+
+    /* pass the session ID - just a 32-bit hash of our nspace for now */
+    PRTE_HASH_STR(prte_process_info.myproc.nspace, ui32);
+    PMIX_INFO_LIST_ADD(ret, info, PMIX_SESSION_ID, &ui32, PMIX_UINT32);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(info);


### PR DESCRIPTION
Verify that we can PMIx_Get the PMIX_SESSION_ID and PMIX_JOBID values.