### PR TITLE
Multiple commits

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     char *tmp;
     pmix_proc_t proc;
-    uint32_t nprocs, n;
+    uint32_t nprocs, n, sid;
     pmix_info_t *info;
     bool flag;
     mylock_t mylock;
@@ -212,6 +212,29 @@ int main(int argc, char **argv)
     PMIX_VALUE_GET_NUMBER(rc, val, nprocs, uint32_t);
     PMIX_VALUE_RELEASE(val);
     fprintf(stderr, "Client %s:%d num procs %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* get out sessionID */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_SESSION_ID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get sessionID failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        PMIX_VALUE_GET_NUMBER(rc, val, sid, uint32_t);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Session ID was not a number: %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+        fprintf(stderr, "Client %s:%d sessionID %u\n", myproc.nspace, myproc.rank, sid);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    /* get out jobID */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOBID, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get jobID failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client %s:%d jobID %s\n", myproc.nspace, myproc.rank, val->data.string);
+        PMIX_VALUE_RELEASE(val);
+    }
 
     /* get the number of local procs in our job */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_SIZE, NULL, 0, &val))) {

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1697,6 +1697,14 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
         goto reply;
     }
 
+    /* unpack the number of info */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto reply;
+    }
+
     if (0 == cmd) {
         /* allocation request - unpack the directive */
         cnt = 1;

--- a/src/tools/prte_info/Makefile.am
+++ b/src/tools/prte_info/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -34,9 +34,6 @@ AM_CFLAGS = \
             -DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
             -DPRTE_BUILD_LIBS="\"@LIBS@\"" \
             -DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
-            -DPRTE_WRAPPER_EXTRA_CFLAGS="\"@PRTE_WRAPPER_EXTRA_CFLAGS@\"" \
-            -DPRTE_WRAPPER_EXTRA_LDFLAGS="\"@PRTE_WRAPPER_EXTRA_LDFLAGS@\"" \
-            -DPRTE_WRAPPER_EXTRA_LIBS="\"@PRTE_WRAPPER_EXTRA_LIBS@\"" \
             -DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
             -DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
             -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""

--- a/src/tools/prte_info/param.c
+++ b/src/tools/prte_info/param.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2018      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -401,11 +401,6 @@ void prte_info_do_config(bool want_all)
         prte_info_out("Build LDFLAGS", "option:build:ldflags", PRTE_BUILD_LDFLAGS);
         prte_info_out("Build LIBS", "option:build:libs", PRTE_BUILD_LIBS);
 
-        prte_info_out("Wrapper extra CFLAGS", "option:wrapper:extra_cflags",
-                      PRTE_WRAPPER_EXTRA_CFLAGS);
-        prte_info_out("Wrapper extra LDFLAGS", "option:wrapper:extra_ldflags",
-                      PRTE_WRAPPER_EXTRA_LDFLAGS);
-        prte_info_out("Wrapper extra LIBS", "option:wrapper:extra_libs", PRTE_WRAPPER_EXTRA_LIBS);
     }
 
     prte_info_out("Internal debug support", "option:debug", debug);


### PR DESCRIPTION
[Remove wrapper definitions](https://github.com/openpmix/prrte/commit/364fd496622e2c9e627db9539a720010af657cfc)

The wrapper is defined in PMIx, not here, so there
is no way to show wrapper extra flags.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5119d629fc503760c8fab26e2363f93140a8ea2b)

[Extend example to check for sessionID and jobID](https://github.com/openpmix/prrte/commit/0e404f67572630bb811c17ae313a745d49db2819)

Verify that we can PMIx_Get the PMIX_SESSION_ID and
PMIX_JOBID values.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7194a18a844e281372a133cb79bb64adc466e30e)

bot:notacherrypick