### PR TITLE
Cleanup initial implementation of allocate and session ctrl

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -582,6 +582,8 @@ int pmix_server_init(void)
     pmix_pointer_array_init(&prte_pmix_server_globals.remote_reqs, 128, INT_MAX, 2);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.notifications, pmix_list_t);
     prte_pmix_server_globals.server = *PRTE_NAME_INVALID;
+    prte_pmix_server_globals.scheduler_connected = false;
+    prte_pmix_server_globals.scheduler_set_as_server = false;
 
     PMIX_INFO_LIST_START(ilist);
 
@@ -1690,14 +1692,6 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     /* unpack the source of the request */
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &source, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto reply;
-    }
-
-    /* unpack the number of info */
-    cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto reply;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -593,18 +593,20 @@ static void _toolconn(int sd, short args, void *cbdata)
 
     /* if this is the scheduler and we are not the DVM master, then
      * this is not allowed */
-    if (cd->scheduler && !PRTE_PROC_IS_MASTER) {
-        cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
-        PMIX_RELEASE(cd);
-        return;
-    } else {
-        /* mark that the scheduler has attached to us */
-        prte_pmix_server_globals.scheduler_connected = true;
-        PMIX_LOAD_PROCID(&prte_pmix_server_globals.scheduler,
-                         cd->target.nspace, cd->target.rank);
-        /* we cannot immediately set the scheduler to be our
-         * PMIx server as the PMIx library hasn't finished
-         * recording it */
+    if (cd->scheduler) {
+        if (!PRTE_PROC_IS_MASTER) {
+            cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+            PMIX_RELEASE(cd);
+            return;
+        } else {
+            /* mark that the scheduler has attached to us */
+            prte_pmix_server_globals.scheduler_connected = true;
+            PMIX_LOAD_PROCID(&prte_pmix_server_globals.scheduler,
+                             cd->target.nspace, cd->target.rank);
+            /* we cannot immediately set the scheduler to be our
+             * PMIx server as the PMIx library hasn't finished
+             * recording it */
+        }
     }
 
     /* if we are not the HNP or master, and the tool doesn't


### PR DESCRIPTION
Handle the upcalls ourselves if we are the DVM master. Cleanup the relay to the DVM master if needed.