### PR TITLE
Fix the routing for non-tree-spawn launch

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -507,8 +507,10 @@ static int rte_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     (void) pmix_mca_base_framework_close(&prte_iof_base_framework);
     (void) pmix_mca_base_framework_close(&prte_plm_base_framework);
-    /* make sure our local procs are dead */
-    prte_odls.kill_local_procs(NULL);
+    if (!prte_abnormal_term_ordered) {
+        /* make sure our local procs are dead */
+        prte_odls.kill_local_procs(NULL);
+    }
     (void) pmix_mca_base_framework_close(&prte_rtc_base_framework);
     (void) pmix_mca_base_framework_close(&prte_odls_base_framework);
     prte_rml_close();

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1336,9 +1336,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     idx = 1;
     while (PMIX_SUCCESS == (ret = PMIx_Data_unpack(NULL, buffer, &dname, &idx, PMIX_PROC))) {
 
-        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+        pmix_output_verboxe(5, prte_plm_base_framework.framework_output,
                              "%s plm:base:orted_report_launch from daemon %s",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname)));
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname));
 
         /* update state and record for this daemon contact info */
         daemon = (prte_proc_t *) pmix_pointer_array_get_item(jdatorted->procs, dname.rank);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1336,7 +1336,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     idx = 1;
     while (PMIX_SUCCESS == (ret = PMIx_Data_unpack(NULL, buffer, &dname, &idx, PMIX_PROC))) {
 
-        pmix_output_verboxe(5, prte_plm_base_framework.framework_output,
+        pmix_output_verbose(5, prte_plm_base_framework.framework_output,
                              "%s plm:base:orted_report_launch from daemon %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname));
 

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2022  Consulting.  All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -338,14 +338,13 @@ static void track_procs(int fd, short argc, void *cbdata)
     proc = &caddy->name;
     state = caddy->proc_state;
 
-    PMIX_OUTPUT_VERBOSE((5, prte_state_base_framework.framework_output,
+    pmix_output_verbose(5, prte_state_base_framework.framework_output,
                          "%s state:prted:track_procs called for proc %s state %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
-                         prte_proc_state_to_str(state)));
+                         prte_proc_state_to_str(state));
 
     /* get the job object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
-        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         goto cleanup;
     }
     if (PRTE_PROC_STATE_READY_FOR_DEBUG == state) {
@@ -492,10 +491,8 @@ static void track_procs(int fd, short argc, void *cbdata)
         if (prte_prteds_term_ordered &&
             0 == pmix_list_get_size(&prte_rml_base.children)) {
             for (i = 0; i < prte_local_children->size; i++) {
-                if (NULL
-                        != (pdata = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children,
-                                                                                i))
-                    && PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_ALIVE)) {
+                pdata = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+                if (NULL != pdata && PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_ALIVE)) {
                     /* at least one is still alive */
                     PMIX_OUTPUT_VERBOSE((5, prte_state_base_framework.framework_output,
                                          "%s state:prted all routes gone but proc %s still alive",

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,6 +47,7 @@ static int verbosity = 0;
 
 void prte_rml_register(void)
 {
+    int ret;
 
     prte_rml_base.max_retries = 3;
     pmix_mca_base_var_register("prte", "rml", "base", "max_retries",
@@ -74,10 +75,13 @@ void prte_rml_register(void)
         pmix_output_set_verbosity(prte_rml_base.routed_output, verbosity);
     }
 
-    pmix_mca_base_var_register("prte", "rml", "base", "radix",
-                               "Radix to be used for routing tree",
-                               PMIX_MCA_BASE_VAR_TYPE_INT,
-                               &prte_rml_base.radix);
+    ret = pmix_mca_base_var_register("prte", "rml", "base", "radix",
+                                     "Radix to be used for routing tree",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &prte_rml_base.radix);
+    pmix_mca_base_var_register_synonym(ret, "prte", "routed", "radix", NULL,
+                                       PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
 }
 
 void prte_rml_close(void)

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -211,6 +211,12 @@ void prte_rml_compute_routing_tree(void)
         PMIX_LIST_FOREACH(child, &prte_rml_base.children, prte_routed_tree_t)
         {
             d = (prte_proc_t *) pmix_pointer_array_get_item(dmns->procs, child->rank);
+            if (NULL == d || NULL == d->node || NULL == d->node->name) {
+                pmix_output(0, "%s: \tchild %d ",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            child->rank);
+                continue;
+            }
             pmix_output(0, "%s: \tchild %d node %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         child->rank, d->node->name);
             for (j = 0; j < (int) prte_process_info.num_daemons; j++) {

--- a/src/tools/prte_info/version.c
+++ b/src/tools/prte_info/version.c
@@ -192,9 +192,8 @@ void prte_info_show_component_version(const char *type_name, const char *compone
     /* Now that we have a valid type, find the right component list */
     components = NULL;
     for (j = 0; j < prte_component_map.size; j++) {
-        if (NULL
-            == (map = (prte_info_component_map_t *) pmix_pointer_array_get_item(&prte_component_map,
-                                                                                j))) {
+        map = (prte_info_component_map_t*) pmix_pointer_array_get_item(&prte_component_map, j);
+        if (NULL == map) {
             continue;
         }
         if (0 == strcmp(type_name, map->type)) {
@@ -216,6 +215,11 @@ void prte_info_show_component_version(const char *type_name, const char *compone
                 }
             }
         }
+    } else {
+        /* there are no components, but we still show their type */
+        pmix_asprintf(&pos, "MCA %s", type_name);
+        prte_info_out(pos, NULL, " no components");
+        free(pos);
     }
 }
 

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -702,12 +702,22 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* start by sending it to ourselves */
-    PRTE_RML_SEND(ret, PRTE_PROC_MY_NAME->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
-    if (PRTE_SUCCESS != ret) {
-        PRTE_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(buffer);
-        goto DONE;
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_TREE_SPAWN)) {
+        /* if we are tree-spawning, start by sending it to ourselves */
+        PRTE_RML_SEND(ret, PRTE_PROC_MY_NAME->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(buffer);
+            goto DONE;
+        }
+    } else {
+        /* send it to the HNP */
+        PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(buffer);
+            goto DONE;
+        }
     }
 
     /* if we are tree-spawning, then we need to capture the MCA params

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -421,6 +421,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         prte_process_info.num_daemons = daemons->num_procs;
         prte_rml_compute_routing_tree();
     }
+
+    /* update the routing tree */
+    prte_rml_compute_routing_tree();
 
 cleanup:
     if (NULL != vpid) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -419,10 +419,10 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     /* update num procs */
     if (prte_process_info.num_daemons != daemons->num_procs) {
         prte_process_info.num_daemons = daemons->num_procs;
+        /* update the routing tree */
+        prte_rml_compute_routing_tree();
     }
 
-    /* update the routing tree */
-    prte_rml_compute_routing_tree();
 
 cleanup:
     if (NULL != vpid) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -419,7 +419,6 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     /* update num procs */
     if (prte_process_info.num_daemons != daemons->num_procs) {
         prte_process_info.num_daemons = daemons->num_procs;
-        prte_rml_compute_routing_tree();
     }
 
     /* update the routing tree */


### PR DESCRIPTION
The prted should send directly back to the HNP in this scenario. Nidmap needs to update the routing tree when we update the map as the number of daemons may have changed.