### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -507,8 +507,10 @@ static int rte_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     (void) pmix_mca_base_framework_close(&prte_iof_base_framework);
     (void) pmix_mca_base_framework_close(&prte_plm_base_framework);
-    /* make sure our local procs are dead */
-    prte_odls.kill_local_procs(NULL);
+    if (!prte_abnormal_term_ordered) {
+        /* make sure our local procs are dead */
+        prte_odls.kill_local_procs(NULL);
+    }
     (void) pmix_mca_base_framework_close(&prte_rtc_base_framework);
     (void) pmix_mca_base_framework_close(&prte_odls_base_framework);
     prte_rml_close();

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1336,9 +1336,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     idx = 1;
     while (PMIX_SUCCESS == (ret = PMIx_Data_unpack(NULL, buffer, &dname, &idx, PMIX_PROC))) {
 
-        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+        pmix_output_verboxe(5, prte_plm_base_framework.framework_output,
                              "%s plm:base:orted_report_launch from daemon %s",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname)));
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname));
 
         /* update state and record for this daemon contact info */
         daemon = (prte_proc_t *) pmix_pointer_array_get_item(jdatorted->procs, dname.rank);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1336,7 +1336,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     idx = 1;
     while (PMIX_SUCCESS == (ret = PMIx_Data_unpack(NULL, buffer, &dname, &idx, PMIX_PROC))) {
 
-        pmix_output_verboxe(5, prte_plm_base_framework.framework_output,
+        pmix_output_verbose(5, prte_plm_base_framework.framework_output,
                              "%s plm:base:orted_report_launch from daemon %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname));
 

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2022  Consulting.  All rights reserved.
- * Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -338,14 +338,13 @@ static void track_procs(int fd, short argc, void *cbdata)
     proc = &caddy->name;
     state = caddy->proc_state;
 
-    PMIX_OUTPUT_VERBOSE((5, prte_state_base_framework.framework_output,
+    pmix_output_verbose(5, prte_state_base_framework.framework_output,
                          "%s state:prted:track_procs called for proc %s state %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
-                         prte_proc_state_to_str(state)));
+                         prte_proc_state_to_str(state));
 
     /* get the job object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
-        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         goto cleanup;
     }
     if (PRTE_PROC_STATE_READY_FOR_DEBUG == state) {
@@ -492,10 +491,8 @@ static void track_procs(int fd, short argc, void *cbdata)
         if (prte_prteds_term_ordered &&
             0 == pmix_list_get_size(&prte_rml_base.children)) {
             for (i = 0; i < prte_local_children->size; i++) {
-                if (NULL
-                        != (pdata = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children,
-                                                                                i))
-                    && PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_ALIVE)) {
+                pdata = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+                if (NULL != pdata && PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_ALIVE)) {
                     /* at least one is still alive */
                     PMIX_OUTPUT_VERBOSE((5, prte_state_base_framework.framework_output,
                                          "%s state:prted all routes gone but proc %s still alive",

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,7 +18,8 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -373,7 +374,6 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
 static char *generate_dist = "fabric,gpu,network";
 void pmix_server_register_params(void)
 {
-    char **tmp;
     int i;
 
     /* register a verbosity */
@@ -431,7 +431,7 @@ void pmix_server_register_params(void)
                                       &generate_dist);
     prte_pmix_server_globals.generate_dist = 0;
     if (NULL != generate_dist) {
-        tmp = PMIX_ARGV_SPLIT_COMPAT(generate_dist, ',');
+        char **tmp = PMIX_ARGV_SPLIT_COMPAT(generate_dist, ',');
         for (i=0; NULL != tmp[i]; i++) {
             if (0 == strcasecmp(tmp[i], "fabric")) {
                 prte_pmix_server_globals.generate_dist |= PMIX_DEVTYPE_OPENFABRICS;
@@ -441,6 +441,7 @@ void pmix_server_register_params(void)
                 prte_pmix_server_globals.generate_dist |= PMIX_DEVTYPE_NETWORK;
             }
         }
+        PMIX_ARGV_FREE_COMPAT(tmp);
     }
 
 }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -87,6 +87,8 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender, pmix_data_buf
                                   prte_rml_tag_t tg, void *cbdata);
 static void pmix_server_log(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                             prte_rml_tag_t tg, void *cbdata);
+static void pmix_server_sched(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+                              prte_rml_tag_t tg, void *cbdata);
 
 #define PRTE_PMIX_SERVER_MIN_ROOMS 4096
 
@@ -387,19 +389,6 @@ void pmix_server_register_params(void)
         pmix_output_set_verbosity(prte_pmix_server_globals.output,
                                   prte_pmix_server_globals.verbosity);
     }
-    /* specify the size of the hotel */
-    prte_pmix_server_globals.num_rooms = -1;
-    (void)
-        pmix_mca_base_var_register("prte", "pmix", NULL, "server_max_reqs",
-                                   "Maximum number of backlogged PMIx server direct modex requests",
-                                   PMIX_MCA_BASE_VAR_TYPE_INT,
-                                   &prte_pmix_server_globals.num_rooms);
-    /* specify the timeout for the hotel */
-    prte_pmix_server_globals.timeout = 2;
-    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "server_max_wait",
-                                      "Maximum time (in seconds) the PMIx server should wait to service direct modex requests",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_pmix_server_globals.timeout);
 
     /* whether or not to wait for the universal server */
     prte_pmix_server_globals.wait_for_server = false;
@@ -446,80 +435,32 @@ void pmix_server_register_params(void)
 
 }
 
-static void eviction_cbfunc(struct pmix_hotel_t *hotel,
-                            int room_num, void *occupant)
+static void timeout_cbfunc(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) occupant;
-    bool timeout = false;
-    int rc = PRTE_ERR_TIMEOUT;
-    pmix_value_t *pval = NULL;
-    pmix_status_t prc;
-    PRTE_HIDE_UNUSED_PARAMS(hotel);
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "EVICTION FROM ROOM %d", room_num);
+                        "REQUEST TIMED OUT - LOCAL REFID %d REMOTE REFID %d",
+                        req->local_index, req->remote_index);
 
-    /* decrement the request timeout */
-    req->timeout -= prte_pmix_server_globals.timeout;
-    if (req->timeout > 0) {
-        req->timeout -= prte_pmix_server_globals.timeout;
-    }
-    if (0 >= req->timeout) {
-        timeout = true;
-    }
-    if (!timeout) {
-        /* see if this is a dmdx request waiting for a key to arrive */
-        if (NULL != req->key) {
-            pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                "%s server:evict timeout - checking for key %s from proc %s:%u",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key, req->tproc.nspace,
-                                req->tproc.rank);
-
-            /* see if the key has arrived */
-            if (PMIX_SUCCESS == PMIx_Get(&req->tproc, req->key, req->info, req->ninfo, &pval)) {
-                pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                    "%s server:evict key %s found - retrieving payload",
-                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
-                /* it has - ask our local pmix server for the data */
-                PMIX_VALUE_RELEASE(pval);
-                /* check us back into hotel so the modex_resp function can safely remove us */
-                prc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-                if(PMIX_SUCCESS != prc) {
-                  goto error_condition;
-                }
-                prc = PMIx_server_dmodex_request(&req->tproc, modex_resp, req);
-                if (PMIX_SUCCESS != prc) {
-                    PMIX_ERROR_LOG(prc);
-                    send_error(rc, &req->tproc, &req->proxy, req->remote_room_num);
-                    pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
-                    PMIX_RELEASE(req);
-                }
-                return;
-            }
-            /* if not, then we continue to wait */
-            pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                "%s server:evict key %s not found - returning to hotel",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
-        }
-        /* not done yet - check us back in */
-        prc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-        if (PMIX_SUCCESS == prc) {
-            pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                "%s server:evict checked back in to room %d",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->room_num);
-            return;
-        }
-        /* fall thru and return an error so the caller doesn't hang */
-    } else {
-        pmix_show_help("help-prted.txt", "timedout", true, req->operation);
-    }
-
-    error_condition:
+    /* mark that we timed out */
+    req->timed_out = true;
 
     /* don't let the caller hang */
-    if (0 <= req->remote_room_num) {
-        send_error(rc, &req->tproc, &req->proxy, req->remote_room_num);
-    } else if (NULL != req->opcbfunc) {
+    if (0 <= req->remote_index) {
+        /* this was a remote request */
+        send_error(PMIX_ERR_TIMEOUT, &req->tproc, &req->proxy, req->remote_index);
+        /* note: we cannot release the req object because whomever
+         * we gave it to (host or PMIx server library) is still
+         * using it. We'll take care of it once the current holder
+         * returns.
+         */
+        return;
+    }
+
+    /* this was a local request */
+    if (NULL != req->opcbfunc) {
         req->opcbfunc(PMIX_ERR_TIMEOUT, req->cbdata);
     } else if (NULL != req->mdxcbfunc) {
         req->mdxcbfunc(PMIX_ERR_TIMEOUT, NULL, 0, req->cbdata, NULL, NULL);
@@ -528,7 +469,11 @@ static void eviction_cbfunc(struct pmix_hotel_t *hotel,
     } else if (NULL != req->lkcbfunc) {
         req->lkcbfunc(PMIX_ERR_TIMEOUT, NULL, 0, req->cbdata);
     }
-    PMIX_RELEASE(req);
+    /* note: we cannot release the req object because whomever
+     * we gave it to (host or PMIx server library) is still
+     * using it. We'll take care of it once the current holder
+     * returns.
+     */
 }
 
 /* NOTE: this function must be called from within an event! */
@@ -537,12 +482,27 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
     int n;
     pmix_server_req_t *req;
 
-    for (n = 0; n < prte_pmix_server_globals.reqs.num_rooms; n++) {
-        pmix_hotel_knock(&prte_pmix_server_globals.reqs, n, (void **) &req);
+    for (n = 0; n < prte_pmix_server_globals.remote_reqs.size; n++) {
+        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, n);
         if (NULL != req) {
-            if (0 == strncmp(req->tproc.nspace, pname->nspace, PMIX_MAX_NSLEN) &&
-                PMIX_CHECK_RANK(req->tproc.rank, pname->rank)) {
-                pmix_hotel_checkout(&prte_pmix_server_globals.reqs, n);
+            if (!PMIX_CHECK_NSPACE(req->tproc.nspace, pname->nspace) ||
+                !PMIX_CHECK_RANK(req->tproc.rank, pname->rank)) {
+                continue;
+            }
+            /* delete the timeout event, if active */
+            if (req->event_active) {
+                prte_event_del(&req->ev);
+            }
+            /* delete the cycle event, if active */
+            if (req->cycle_active) {
+                prte_event_del(&req->cycle);
+            }
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, n, NULL);
+            if (!req->inprogress) {
+                /* if the request is in progress, then someone (host or PMIx server
+                 * library) has the req object - so we cannot release it yet.
+                 * We'll take care of it once the current holder returns.
+                 * If that isn't the case, then release it */
                 PMIX_RELEASE(req);
             }
         }
@@ -613,31 +573,13 @@ int pmix_server_init(void)
     prte_pmix_server_globals.initialized = true;
 
     /* setup the server's state variables */
-    PMIX_CONSTRUCT(&prte_pmix_server_globals.reqs, pmix_hotel_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.psets, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.tools, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.local_reqs, pmix_pointer_array_t);
     pmix_pointer_array_init(&prte_pmix_server_globals.local_reqs, 128, INT_MAX, 2);
-
-    /* by the time we init the server, we should know how many nodes we
-     * have in our environment - with the exception of mpirun. If the
-     * user specified the size of the hotel, then use that value. Otherwise,
-     * set the value to something large to avoid running out of rooms on
-     * large machines */
-    if (-1 == prte_pmix_server_globals.num_rooms) {
-        prte_pmix_server_globals.num_rooms = prte_process_info.num_daemons * 2;
-        if (prte_pmix_server_globals.num_rooms < PRTE_PMIX_SERVER_MIN_ROOMS) {
-            prte_pmix_server_globals.num_rooms = PRTE_PMIX_SERVER_MIN_ROOMS;
-        }
-    }
-    rc = pmix_hotel_init(&prte_pmix_server_globals.reqs, prte_pmix_server_globals.num_rooms,
-                         prte_event_base, prte_pmix_server_globals.timeout,
-                         eviction_cbfunc);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.remote_reqs, pmix_pointer_array_t);
+    pmix_pointer_array_init(&prte_pmix_server_globals.remote_reqs, 128, INT_MAX, 2);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.notifications, pmix_list_t);
     prte_pmix_server_globals.server = *PRTE_NAME_INVALID;
     prte_pmix_server_globals.scheduler_connected = false;
@@ -755,15 +697,8 @@ int pmix_server_init(void)
                            &prte_bind_progress_thread_reqd, PMIX_BOOL);
     }
 
-    /* if we are the MASTER, then we are the scheduler
-     * as well as a gateway */
+    /* if we are the MASTER, then we are the gateway */
     if (PRTE_PROC_IS_MASTER) {
-        PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
-        if (PMIX_SUCCESS != prc) {
-            PMIX_INFO_LIST_RELEASE(ilist);
-            rc = prte_pmix_convert_status(prc);
-            return rc;
-        }
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_GATEWAY, NULL, PMIX_BOOL);
         if (PMIX_SUCCESS != prc) {
             PMIX_INFO_LIST_RELEASE(ilist);
@@ -945,6 +880,9 @@ void pmix_server_start(void)
         /* setup recv for logging requests */
         PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LOGGING,
                       PRTE_RML_PERSISTENT, pmix_server_log, NULL);
+        /* setup recv for scheduler requests */
+        PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED,
+                      PRTE_RML_PERSISTENT, pmix_server_sched, NULL);
     }
 }
 
@@ -964,8 +902,9 @@ void pmix_server_finalize(void)
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LAUNCH_RESP);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DATA_CLIENT);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_NOTIFICATION);
-    if (PRTE_PROC_IS_MASTER || PRTE_PROC_IS_MASTER) {
+    if (PRTE_PROC_IS_MASTER) {
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LOGGING);
+        PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED);
     }
 
     /* finalize our local data server */
@@ -973,14 +912,20 @@ void pmix_server_finalize(void)
 
     /* cleanup collectives */
     pmix_server_req_t *cd;
-    for (int i = 0; i < prte_pmix_server_globals.num_rooms; i++) {
-      pmix_hotel_checkout_and_return_occupant(&prte_pmix_server_globals.reqs, i, (void **) &cd);
+    for (int i = 0; i < prte_pmix_server_globals.local_reqs.size; i++) {
+      cd = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, i);
+      if (NULL != cd) {
+          PMIX_RELEASE(cd);
+      }
+    }
+    for (int i = 0; i < prte_pmix_server_globals.remote_reqs.size; i++) {
+      cd = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, i);
       if (NULL != cd) {
           PMIX_RELEASE(cd);
       }
     }
 
-    PMIX_DESTRUCT(&prte_pmix_server_globals.reqs);
+    PMIX_DESTRUCT(&prte_pmix_server_globals.remote_reqs);
     PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
@@ -990,7 +935,7 @@ void pmix_server_finalize(void)
     prte_pmix_server_globals.initialized = false;
 }
 
-static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int remote_room)
+static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int remote_index)
 {
     pmix_data_buffer_t *reply;
     pmix_status_t prc, pstatus;
@@ -1010,8 +955,8 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
         return;
     }
 
-    /* pack the remote daemon's request room number */
-    if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, reply, &remote_room, 1, PMIX_INT))) {
+    /* pack the remote daemon's request index */
+    if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, reply, &remote_index, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
@@ -1039,8 +984,8 @@ static void _mdxresp(int sd, short args, void *cbdata)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         req->tproc.nspace, req->tproc.rank);
 
-    /* check us out of the hotel */
-    pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
+    /* remove us from the pending array */
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
 
     /* pack the status */
     PMIX_DATA_BUFFER_CREATE(reply);
@@ -1056,8 +1001,8 @@ static void _mdxresp(int sd, short args, void *cbdata)
         goto error;
     }
 
-    /* pack the remote daemon's request room number */
-    if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, reply, &req->remote_room_num, 1, PMIX_INT))) {
+    /* pack the remote daemon's request index */
+    if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, reply, &req->remote_index, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         goto error;
@@ -1091,6 +1036,7 @@ error:
     PMIX_RELEASE(req);
     return;
 }
+
 /* the modex_resp function takes place in the local PMIx server's
  * progress thread - we must therefore thread-shift it so we can
  * access our global data */
@@ -1100,6 +1046,17 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
 
     PMIX_ACQUIRE_OBJECT(req);
 
+    /* clear any timeout event */
+    if (req->event_active) {
+        prte_event_del(&req->ev);
+        req->event_active = false;
+    }
+    if (req->cycle_active) {
+        prte_event_del(&req->cycle);
+        req->cycle_active = false;
+    }
+
+    req->inprogress = false; // we are done processing this request
     req->pstatus = status;
     if (PMIX_SUCCESS == status && NULL != data) {
         /* we need to preserve the data as the caller
@@ -1116,12 +1073,96 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 }
+
+static void dmdx_check(int sd, short args, void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_job_t *jdata;
+    prte_proc_t *proc;
+    struct timeval tv = {2, 0};
+    pmix_value_t *pval = NULL;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* do we know about this job? */
+    jdata = prte_get_job_data_object(req->tproc.nspace);
+    if (NULL == jdata) {
+        /* wait some more */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s dmdx:recv dmdx_check cannot find job object - delaying",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+        PMIX_POST_OBJECT(req);
+        prte_event_evtimer_add(&req->cycle, &tv);
+        return;
+    }
+
+    /* we know about this job - look for the proc */
+    proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, req->tproc.rank);
+    if (NULL == proc) {
+        /* this is truly an error, so notify the sender */
+        send_error(PRTE_ERR_NOT_FOUND, &req->tproc, &req->proxy, req->remote_index);
+        if (req->event_active) {
+            /* delete the timeout event */
+            prte_event_del(&req->ev);
+        }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        PMIX_RELEASE(req);
+        return;
+    }
+    if (!PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_LOCAL)) {
+        /* send back an error - they obviously have made a mistake */
+        send_error(PRTE_ERR_NOT_FOUND, &req->tproc, &req->proxy, req->remote_index);
+        if (req->event_active) {
+            /* delete the timeout event */
+            prte_event_del(&req->ev);
+        }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        PMIX_RELEASE(req);
+        return;
+    }
+
+    if (NULL != req->key) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s dmdx:check for key %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
+        /* see if we have it */
+        if (PMIX_SUCCESS != PMIx_Get(&req->tproc, req->key, req->info, req->ninfo, &pval)) {
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s dmdx:recv key %s not found - resetting wait",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->key);
+            PMIX_POST_OBJECT(req);
+            prte_event_evtimer_add(&req->cycle, &tv);
+            return;
+        }
+        PMIX_VALUE_RELEASE(pval);
+        /* we do have it, so fetch payload */
+    }
+
+    /* ask our local PMIx server for the data */
+    req->inprogress = true;
+    rc = PMIx_server_dmodex_request(&req->tproc, modex_resp, req);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        req->inprogress = false;
+        send_error(rc, &req->tproc, &req->proxy, req->remote_index);
+        if (req->event_active) {
+            /* delete the timeout event */
+            prte_event_del(&req->ev);
+        }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        PMIX_RELEASE(req);
+        return;
+    }
+    return;
+}
+
 static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
                                   pmix_data_buffer_t *buffer,
                                   prte_rml_tag_t tg, void *cbdata)
 {
-    int rc, room_num;
-    int32_t cnt;
+    int rc, index;
+    int32_t cnt, timeout = 0;
+    struct timeval tv = {0, 0};
     prte_job_t *jdata;
     prte_proc_t *proc;
     pmix_server_req_t *req;
@@ -1143,9 +1184,9 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
                         "%s dmdx:recv processing request from proc %s for proc %s:%u",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender), pproc.nspace,
                         pproc.rank);
-    /* and the remote daemon's tracking room number */
+    /* and the remote daemon's tracking index */
     cnt = 1;
-    if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &room_num, &cnt, PMIX_INT))) {
+    if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &index, &cnt, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
         return;
     }
@@ -1169,19 +1210,31 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         for (sz = 0; sz < ninfo; sz++) {
             if (PMIX_CHECK_KEY(&info[sz], PMIX_REQUIRED_KEY)) {
                 key = info[sz].value.data.string;
-                break;
+                continue;
+            }
+            if (PMIX_CHECK_KEY(&info[sz], PMIX_TIMEOUT)) {
+                PMIX_VALUE_GET_NUMBER(prc, &info[sz].value, timeout, int32_t);
+                if (PMIX_SUCCESS != prc) {
+                    PMIX_ERROR_LOG(prc);
+                    if (NULL != info) {
+                        PMIX_INFO_FREE(info, ninfo);
+                    }
+                    return;
+                }
+                continue;
             }
         }
     }
 
-    /* is this proc one of mine? */
-    if (NULL == (jdata = prte_get_job_data_object(pproc.nspace))) {
+    /* do we know about this job? */
+    jdata = prte_get_job_data_object(pproc.nspace);
+    if (NULL == jdata) {
         /* not having the jdata means that we haven't unpacked the
          * the launch message for this job yet - this is a race
          * condition, so just log the request and we will fill
          * it later */
         pmix_output_verbose(2, prte_pmix_server_globals.output,
-                            "%s dmdx:recv request no job - checking into hotel",
+                            "%s dmdx:recv request cannot find job object - delaying",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         req = PMIX_NEW(pmix_server_req_t);
         pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
@@ -1192,28 +1245,42 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         if (NULL != key) {
             req->key = strdup(key);
         }
-        req->remote_room_num = room_num;
-        /* adjust the timeout to reflect the size of the job as it can take some
-         * amount of time to start the job */
-        PRTE_ADJUST_TIMEOUT(req);
-        rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-        if (PMIX_SUCCESS != rc) {
-            pmix_show_help("help-prted.txt", "noroom", true, req->operation,
-                           prte_pmix_server_globals.num_rooms);
-            PMIX_RELEASE(req);
-            rc = prte_pmix_convert_status(rc);
-            send_error(rc, &pproc, sender, room_num);
+        /* store THEIR index to the request */
+        req->remote_index = index;
+        /* store it in my remote reqs, assigning the index in that array
+         * to the req->local_index as this is MY index to the request */
+        req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.remote_reqs, req);
+
+        /* setup the cycle timer so we periodically wake up and try again */
+        prte_event_evtimer_set(prte_event_base, &req->cycle, dmdx_check, req);
+        prte_event_set_priority(&req->cycle, PRTE_MSG_PRI);
+        req->cycle_active = true;
+        PMIX_POST_OBJECT(req);
+        tv.tv_sec = 2;
+        prte_event_evtimer_add(&req->cycle, &tv);
+
+        /* if they asked for a timeout, then set that too */
+        if (0 < timeout) {
+            prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
+            prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
+            req->event_active = true;
+            PMIX_POST_OBJECT(req);
+            tv.tv_sec = timeout;
+            prte_event_evtimer_add(&req->cycle, &tv);
         }
         return;
     }
-    if (NULL == (proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, pproc.rank))) {
+
+    /* we know about this job - look for the proc */
+    proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, pproc.rank);
+    if (NULL == proc) {
         /* this is truly an error, so notify the sender */
-        send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, room_num);
+        send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, index);
         return;
     }
     if (!PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_LOCAL)) {
         /* send back an error - they obviously have made a mistake */
-        send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, room_num);
+        send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, index);
         return;
     }
 
@@ -1223,7 +1290,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         /* see if we have it */
         if (PMIX_SUCCESS != PMIx_Get(&pproc, key, info, ninfo, &pval)) {
             pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                "%s dmdx:recv key %s not found - checking into hotel",
+                                "%s dmdx:recv key %s not found - delaying",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), key);
             /* we don't - wait for awhile */
             req = PMIX_NEW(pmix_server_req_t);
@@ -1233,22 +1300,28 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
             req->info = info;
             req->ninfo = ninfo;
             req->key = strdup(key);
-            req->remote_room_num = room_num;
-            /* adjust the timeout to reflect the size of the job as it can take some
-             * amount of time to start the job */
-            PRTE_ADJUST_TIMEOUT(req);
-            /* check us into the hotel */
-            rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-            if (PMIX_SUCCESS != rc) {
-                pmix_show_help("help-prted.txt", "noroom", true, req->operation,
-                               prte_pmix_server_globals.num_rooms);
-                PMIX_RELEASE(req);
-                rc = prte_pmix_convert_status(rc);
-                send_error(rc, &pproc, sender, room_num);
+            req->remote_index = index;
+            /* store it in my remote reqs, assigning the index in that array
+             * to the req->local_index as this is MY index to the request */
+            req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.remote_reqs, req);
+
+            /* setup the cycle timer so we periodically wake up and try again */
+            prte_event_evtimer_set(prte_event_base, &req->cycle, dmdx_check, req);
+            prte_event_set_priority(&req->cycle, PRTE_MSG_PRI);
+            req->cycle_active = true;
+            PMIX_POST_OBJECT(req);
+            tv.tv_sec = 2;
+            prte_event_evtimer_add(&req->cycle, &tv);
+
+            /* if they asked for a timeout, then set that too */
+            if (0 < timeout) {
+                prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
+                prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
+                req->event_active = true;
+                PMIX_POST_OBJECT(req);
+                tv.tv_sec = timeout;
+                prte_event_evtimer_add(&req->ev, &tv);
             }
-            pmix_output_verbose(2, prte_pmix_server_globals.output,
-                                "%s:%d CHECKING REQ FOR KEY %s TO %d REMOTE ROOM %d", __FILE__,
-                                __LINE__, req->key, req->room_num, req->remote_room_num);
             return;
         }
         /* we do already have it, so go get the payload */
@@ -1266,26 +1339,36 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
     req->info = info;
     req->ninfo = ninfo;
-    req->remote_room_num = room_num;
-    /* adjust the timeout to reflect the size of the job as it can take some
-     * amount of time to start the job */
-    PRTE_ADJUST_TIMEOUT(req);
-    rc = pmix_hotel_checkin(&prte_pmix_server_globals.reqs, req, &req->room_num);
-    if (PMIX_SUCCESS != rc) {
-        pmix_show_help("help-prted.txt", "noroom", true, req->operation,
-                       prte_pmix_server_globals.num_rooms);
-        PMIX_RELEASE(req);
-        rc = prte_pmix_convert_status(rc);
-        send_error(rc, &pproc, sender, room_num);
-        return;
+    req->remote_index = index;
+    /* store it in my remote reqs, assigning the index in that array
+     * to the req->local_index as this is MY index to the request */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.remote_reqs, req);
+
+    /* if they asked for a timeout, then set that too */
+    if (0 < timeout) {
+        prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
+        prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
+        req->event_active = true;
+        PMIX_POST_OBJECT(req);
+        tv.tv_sec = timeout;
+        prte_event_evtimer_add(&req->ev, &tv);
     }
 
-    /* ask our local pmix server for the data */
-    if (PMIX_SUCCESS != (prc = PMIx_server_dmodex_request(&pproc, modex_resp, req))) {
+    /* ask our local PMIx server for the data */
+    req->inprogress = true;
+    prc = PMIx_server_dmodex_request(&pproc, modex_resp, req);
+    if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);
-        pmix_hotel_checkout(&prte_pmix_server_globals.reqs, req->room_num);
-        PMIX_RELEASE(req);
-        send_error(rc, &pproc, sender, room_num);
+        if (req->event_active) {
+            /* delete the timeout event */
+            prte_event_del(&req->ev);
+        }
+        if (req->cycle_active) {
+            prte_event_del(&req->cycle);
+        }
+        req->inprogress = false;
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        send_error(rc, &pproc, sender, index);
         return;
     }
     return;
@@ -1322,7 +1405,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
                                   pmix_data_buffer_t *buffer,
                                   prte_rml_tag_t tg, void *cbdata)
 {
-    int room_num, rnum;
+    int index, n;
     int32_t cnt;
     pmix_server_req_t *req;
     datacaddy_t *d;
@@ -1354,9 +1437,9 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* unpack our tracking room number */
+    /* unpack our tracking index */
     cnt = 1;
-    if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &room_num, &cnt, PMIX_INT))) {
+    if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &index, &cnt, PMIX_INT))) {
         PMIX_ERROR_LOG(prc);
         PMIX_RELEASE(d);
         return;
@@ -1386,24 +1469,24 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
     }
 
     /* get the request out of the tracking array */
-    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room_num);
+    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, index);
     /* return the returned data to the requestor */
     if (NULL != req) {
         if (NULL != req->mdxcbfunc) {
             PMIX_RETAIN(d);
             req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
         }
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, index, NULL);
         PMIX_RELEASE(req);
     } else {
         pmix_output_verbose(2, prte_pmix_server_globals.output,
-                            "REQ WAS NULL IN ROOM %d",
-                            room_num);
+                            "REQ WAS NULL IN ARRAY INDEX %d",
+                            index);
     }
 
     /* now see if anyone else was waiting for data from this target */
-    for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
-        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
+    for (n = 0; n < prte_pmix_server_globals.local_reqs.size; n++) {
+        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, n);
         if (NULL == req) {
             continue;
         }
@@ -1412,7 +1495,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
                 PMIX_RETAIN(d);
                 req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
             }
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, rnum, NULL);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, n, NULL);
             PMIX_RELEASE(req);
         }
     }
@@ -1737,6 +1820,8 @@ static void opcon(prte_pmix_server_op_caddy_t *p)
     p->apps = NULL;
     p->napps = 0;
     p->cbfunc = NULL;
+    p->allocdir = 0;
+    p->sessionID = UINT32_MAX;
     p->infocbfunc = NULL;
     p->toolcbfunc = NULL;
     p->spcbfunc = NULL;
@@ -1749,13 +1834,18 @@ PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t,
 
 static void rqcon(pmix_server_req_t *p)
 {
+    p->event_active = false;
+    p->cycle_active = false;
+    p->inprogress = false;
+    p->timed_out = false;
     p->operation = NULL;
     p->cmdline = NULL;
     p->key = NULL;
     p->flag = true;
     p->launcher = false;
     p->scheduler = false;
-    p->remote_room_num = -1;
+    p->local_index = -1;
+    p->remote_index = -1;
     p->uid = 0;
     p->gid = 0;
     p->pid = 0;
@@ -1775,6 +1865,7 @@ static void rqcon(pmix_server_req_t *p)
     p->lkcbfunc = NULL;
     p->rlcbfunc = NULL;
     p->toolcbfunc = NULL;
+    p->infocbfunc = NULL;
     p->cbdata = NULL;
 }
 static void rqdes(pmix_server_req_t *p)

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -892,6 +892,8 @@ int pmix_server_init(void)
         rc = prte_pmix_convert_status(prc);
         return rc;
     }
+
+    PMIX_INFO_LIST_RELEASE(ilist);
     info = (pmix_info_t*)darray.array;
     ninfo = darray.size;
     prc = PMIx_server_register_resources(info, ninfo, NULL, NULL);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -145,11 +145,11 @@ static void spawn(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(req);
 
     /* add this request to our tracker array */
-    req->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
     /* include the request room number for quick retrieval */
     prte_set_attribute(&req->jdata->attributes, PRTE_JOB_ROOM_NUM,
-                       PRTE_ATTR_GLOBAL, &req->room_num, PMIX_INT);
+                       PRTE_ATTR_GLOBAL, &req->local_index, PMIX_INT);
 
     /* construct a spawn message */
     PMIX_DATA_BUFFER_CREATE(buf);
@@ -159,7 +159,7 @@ static void spawn(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         goto callback;
     }
 
@@ -167,7 +167,7 @@ static void spawn(int sd, short args, void *cbdata)
     rc = prte_job_pack(buf, req->jdata);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
@@ -176,7 +176,7 @@ static void spawn(int sd, short args, void *cbdata)
     PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_PLM);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -593,18 +593,20 @@ static void _toolconn(int sd, short args, void *cbdata)
 
     /* if this is the scheduler and we are not the DVM master, then
      * this is not allowed */
-    if (cd->scheduler && !PRTE_PROC_IS_MASTER) {
-        cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
-        PMIX_RELEASE(cd);
-        return;
-    } else {
-        /* mark that the scheduler has attached to us */
-        prte_pmix_server_globals.scheduler_connected = true;
-        PMIX_LOAD_PROCID(&prte_pmix_server_globals.scheduler,
-                         cd->target.nspace, cd->target.rank);
-        /* we cannot immediately set the scheduler to be our
-         * PMIx server as the PMIx library hasn't finished
-         * recording it */
+    if (cd->scheduler) {
+        if (!PRTE_PROC_IS_MASTER) {
+            cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+            PMIX_RELEASE(cd);
+            return;
+        } else {
+            /* mark that the scheduler has attached to us */
+            prte_pmix_server_globals.scheduler_connected = true;
+            PMIX_LOAD_PROCID(&prte_pmix_server_globals.scheduler,
+                             cd->target.nspace, cd->target.rank);
+            /* we cannot immediately set the scheduler to be our
+             * PMIx server as the PMIx library hasn't finished
+             * recording it */
+        }
     }
 
     /* if we are not the HNP or master, and the tool doesn't

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -621,14 +621,14 @@ static void _toolconn(int sd, short args, void *cbdata)
             free(tmp);
             prte_plm_globals.next_jobid++;
         } else {
-            cd->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
+            cd->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
             /* we need to send this to the HNP for a jobid */
             PMIX_DATA_BUFFER_CREATE(buf);
             rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
-            rc = PMIx_Data_pack(NULL, buf, &cd->room_num, 1, PMIX_INT);
+            rc = PMIx_Data_pack(NULL, buf, &cd->local_index, 1, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
             }
@@ -638,7 +638,7 @@ static void _toolconn(int sd, short args, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 xrc = prte_pmix_convert_rc(rc);
-                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->room_num, NULL);
+                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->local_index, NULL);
                 PMIX_DATA_BUFFER_RELEASE(buf);
                 if (NULL != cd->toolcbfunc) {
                     cd->toolcbfunc(xrc, NULL, cd->cbdata);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -157,14 +157,14 @@ static void execute(int sd, short args, void *cbdata)
     }
 
     /* add this request to our tracker array */
-    req->room_num = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
     stored = true;
 
     /* setup the xfer */
     PMIX_DATA_BUFFER_CREATE(xfer);
 
     /* pack the room number */
-    rc = PMIx_Data_pack(NULL, xfer, &req->room_num, 1, PMIX_INT);
+    rc = PMIx_Data_pack(NULL, xfer, &req->local_index, 1, PMIX_INT);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(xfer);
@@ -210,7 +210,7 @@ callback:
         req->lkcbfunc(rc, NULL, 0, req->cbdata);
     }
     if (stored) {
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->room_num, NULL);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     }
     PMIX_RELEASE(req);
 }

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -38,6 +38,7 @@
 
 #include "prte_stdint.h"
 #include "src/hwloc/hwloc-internal.h"
+#include "src/include/hash_string.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/error.h"
@@ -112,6 +113,16 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         return rc;
     }
     PMIX_INFO_LIST_ADD(ret, info, PMIX_SERVER_RANK, &prte_process_info.myproc.rank, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_INFO_LIST_RELEASE(info);
+        rc = prte_pmix_convert_status(ret);
+        return rc;
+    }
+
+    /* pass the session ID - just a 32-bit hash of our nspace for now */
+    PRTE_HASH_STR(prte_process_info.myproc.nspace, ui32);
+    PMIX_INFO_LIST_ADD(ret, info, PMIX_SESSION_ID, &ui32, PMIX_UINT32);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(info);

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -11,6 +11,179 @@
 
 #include "src/pmix/pmix-internal.h"
 #include "src/prted/pmix/pmix_server_internal.h"
+#include "src/rml/rml.h"
+
+static void localrelease(void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+static void infocbfunc(pmix_status_t status,
+                       pmix_info_t *info, size_t ninfo,
+                       void *cbdata,
+                       pmix_release_cbfunc_t rel, void *relcbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(status, info, ninfo, req->cbdata, localrelease, req);
+        if (NULL != rel) {
+            rel(relcbdata);
+        }
+        return;
+    }
+    /* need to cleanup ourselves */
+    if (NULL != rel) {
+        rel(relcbdata);
+    }
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+static void pass_request(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
+    pmix_server_req_t *req;
+    pmix_data_buffer_t *buf;
+    uint8_t command;
+    pmix_status_t rc;
+
+    /* create a request tracker for this operation */
+    req = PMIX_NEW(pmix_server_req_t);
+    if (0 < cd->allocdir) {
+        pmix_asprintf(&req->operation, "ALLOCATE: %u", cd->allocdir);
+        command = 0;
+    } else {
+        pmix_asprintf(&req->operation, "SESSIONCTRL: %u", cd->sessionID);
+        command = 1;
+    }
+    req->infocbfunc = cd->infocbfunc;
+    req->cbdata = cd->cbdata;
+    /* add this request to our local request tracker array */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    /* if we are the DVM master, then handle this ourselves */
+    if (PRTE_PROC_IS_MASTER) {
+        if (!prte_pmix_server_globals.scheduler_connected) {
+            /* the scheduler has not attached to us - there is
+             * nothing we can do */
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            goto callback;
+        }
+
+        /* if we have not yet set the scheduler as our server, do so */
+        if (!prte_pmix_server_globals.scheduler_set_as_server) {
+            rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                goto callback;
+            }
+            prte_pmix_server_globals.scheduler_set_as_server = true;
+        }
+
+        if (0 == command) {
+            rc = PMIx_Allocation_request_nb(cd->allocdir, cd->info, cd->ninfo,
+                                            infocbfunc, req);
+        } else {
+            rc = PMIx_Session_control(cd->sessionID, cd->info, cd->ninfo,
+                                      infocbfunc, req);
+        }
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto callback;
+        }
+        return;
+    }
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+
+    /* construct a request message for the command */
+    rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    /* pack the local requestor ID */
+    rc = PMIx_Data_pack(NULL, buf, &req->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    /* pack the requestor */
+    rc = PMIx_Data_pack(NULL, buf, &cd->proc, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+
+    if (0 == command) {
+        /* pack the allocation directive */
+        rc = PMIx_Data_pack(NULL, buf, &cd->allocdir, 1, PMIX_ALLOC_DIRECTIVE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    } else {
+        /* pack the sessionID */
+        rc = PMIx_Data_pack(NULL, buf, &cd->sessionID, 1, PMIX_UINT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    }
+
+    /* pack the number of info */
+    rc = PMIx_Data_pack(NULL, buf, &cd->ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        goto callback;
+    }
+    if (0 < cd->ninfo) {
+        /* pack the info */
+        rc = PMIx_Data_pack(NULL, buf, cd->info, cd->ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+            goto callback;
+        }
+    }
+
+    /* send this request to the DVM controller - might be us */
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        goto callback;
+    }
+    PMIX_RELEASE(cd);
+    return;
+
+callback:
+    PMIX_RELEASE(cd);
+    /* this section gets executed solely upon an error */
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+        return;
+    }
+    PMIX_RELEASE(req);
+}
 
 pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
                                    pmix_alloc_directive_t directive,

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -86,8 +86,12 @@ static void pass_request(int sd, short args, void *cbdata)
             rc = PMIx_Allocation_request_nb(cd->allocdir, cd->info, cd->ninfo,
                                             infocbfunc, req);
         } else {
-            rc = PMIx_Session_control(cd->sessionID, cd->info, cd->ninfo,
-                                      infocbfunc, req);
+#if PMIX_NUMERIC_VERSION < 0x00050000
+        rc = PMIX_ERR_NOT_SUPPORTED;
+#else
+        rc = PMIx_Session_control(cd->sessionID, cd->info, cd->ninfo,
+                                  infocbfunc, req);
+#endif
         }
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
- * Copyright (c) 2022      Triad National Security, LLC.
+ * Copyright (c) 2022-2023 Triad National Security, LLC.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -123,7 +123,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     /* Setup application context */
     app = PMIX_NEW(prte_pmix_app_t);
     app->app.argv = PMIX_ARGV_COPY_COMPAT(results.tail);
-    app->app.cmd = strdup(app->app.argv[0]);
+    // app->app.cmd is setup below.
 
     /* see if we are to forward the environment */
     fwd = prte_fwd_environment;

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,6 +47,7 @@ static int verbosity = 0;
 
 void prte_rml_register(void)
 {
+    int ret;
 
     prte_rml_base.max_retries = 3;
     pmix_mca_base_var_register("prte", "rml", "base", "max_retries",
@@ -74,10 +75,13 @@ void prte_rml_register(void)
         pmix_output_set_verbosity(prte_rml_base.routed_output, verbosity);
     }
 
-    pmix_mca_base_var_register("prte", "rml", "base", "radix",
-                               "Radix to be used for routing tree",
-                               PMIX_MCA_BASE_VAR_TYPE_INT,
-                               &prte_rml_base.radix);
+    ret = pmix_mca_base_var_register("prte", "rml", "base", "radix",
+                                     "Radix to be used for routing tree",
+                                     PMIX_MCA_BASE_VAR_TYPE_INT,
+                                     &prte_rml_base.radix);
+    pmix_mca_base_var_register_synonym(ret, "prte", "routed", "radix", NULL,
+                                       PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
 }
 
 void prte_rml_close(void)

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -219,6 +219,10 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 
 /* error propagate  */
 #define PRTE_RML_TAG_PROPAGATE 71
+
+/* scheduler requests */
+#define PRTE_RML_TAG_SCHED 72
+
 
 #define PRTE_RML_TAG_MAX 100
 

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -211,6 +211,12 @@ void prte_rml_compute_routing_tree(void)
         PMIX_LIST_FOREACH(child, &prte_rml_base.children, prte_routed_tree_t)
         {
             d = (prte_proc_t *) pmix_pointer_array_get_item(dmns->procs, child->rank);
+            if (NULL == d || NULL == d->node || NULL == d->node->name) {
+                pmix_output(0, "%s: \tchild %d ",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            child->rank);
+                continue;
+            }
             pmix_output(0, "%s: \tchild %d node %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         child->rank, d->node->name);
             for (j = 0; j < (int) prte_process_info.num_daemons; j++) {

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -22,7 +22,7 @@
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2022      Triad National Security, LLC. All rights
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -644,6 +644,7 @@ int main(int argc, char *argv[])
     PMIx_Register_event_handler(&code, 1, &info, 1, parent_died_fn, evhandler_reg_callbk,
                                 (void *) &mylock);
     PRTE_PMIX_WAIT_THREAD(&mylock.lock);
+    PMIX_INFO_DESTRUCT(&info);
     PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
 
     /* check for launch directives in case we were launched by a

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1136,17 +1136,18 @@ int main(int argc, char *argv[])
         pname.rank = 0;
     }
     if (PMIX_RANK_INVALID != pname.rank) {
-        PMIX_INFO_CREATE(iptr, 1);
-        PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
+        pmix_info_t *iptr2;
+        PMIX_INFO_CREATE(iptr2, 1);
+        PMIX_INFO_LOAD(&iptr2[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
         PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        ret = PMIx_IOF_push(&pname, 1, NULL, iptr, 1, opcbfunc, &lock);
+        ret = PMIx_IOF_push(&pname, 1, NULL, iptr2, 1, opcbfunc, &lock);
         if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
             pmix_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
         } else if (PMIX_SUCCESS == ret) {
             PRTE_PMIX_WAIT_THREAD(&lock);
         }
         PRTE_PMIX_DESTRUCT_LOCK(&lock);
-        PMIX_INFO_FREE(iptr, 1);
+        PMIX_INFO_FREE(iptr2, 1);
     }
 
 proceed:

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
     prte_pmix_lock_t lock;
     pmix_list_t apps;
     prte_pmix_app_t *app;
-    pmix_info_t *iptr, info;
+    pmix_info_t *iptr, *iptr2, info;
     pmix_status_t ret;
     bool flag;
     size_t n, ninfo, param_len;
@@ -1136,7 +1136,6 @@ int main(int argc, char *argv[])
         pname.rank = 0;
     }
     if (PMIX_RANK_INVALID != pname.rank) {
-        pmix_info_t *iptr2;
         PMIX_INFO_CREATE(iptr2, 1);
         PMIX_INFO_LOAD(&iptr2[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
         PRTE_PMIX_CONSTRUCT_LOCK(&lock);

--- a/src/tools/prte_info/version.c
+++ b/src/tools/prte_info/version.c
@@ -192,9 +192,8 @@ void prte_info_show_component_version(const char *type_name, const char *compone
     /* Now that we have a valid type, find the right component list */
     components = NULL;
     for (j = 0; j < prte_component_map.size; j++) {
-        if (NULL
-            == (map = (prte_info_component_map_t *) pmix_pointer_array_get_item(&prte_component_map,
-                                                                                j))) {
+        map = (prte_info_component_map_t*) pmix_pointer_array_get_item(&prte_component_map, j);
+        if (NULL == map) {
             continue;
         }
         if (0 == strcmp(type_name, map->type)) {
@@ -216,6 +215,11 @@ void prte_info_show_component_version(const char *type_name, const char *compone
                 }
             }
         }
+    } else {
+        /* there are no components, but we still show their type */
+        pmix_asprintf(&pos, "MCA %s", type_name);
+        prte_info_out(pos, NULL, " no components");
+        free(pos);
     }
 }
 

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -692,12 +692,22 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* start by sending it to ourselves */
-    PRTE_RML_SEND(ret, PRTE_PROC_MY_NAME->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
-    if (PRTE_SUCCESS != ret) {
-        PRTE_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(buffer);
-        goto DONE;
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_TREE_SPAWN)) {
+        /* if we are tree-spawning, start by sending it to ourselves */
+        PRTE_RML_SEND(ret, PRTE_PROC_MY_NAME->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(buffer);
+            goto DONE;
+        }
+    } else {
+        /* send it to the HNP */
+        PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, buffer, PRTE_RML_TAG_PRTED_CALLBACK);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(buffer);
+            goto DONE;
+        }
     }
 
     /* if we are tree-spawning, then we need to capture the MCA params

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -421,6 +421,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         prte_process_info.num_daemons = daemons->num_procs;
         prte_rml_compute_routing_tree();
     }
+
+    /* update the routing tree */
+    prte_rml_compute_routing_tree();
 
 cleanup:
     if (NULL != vpid) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -419,10 +419,10 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     /* update num procs */
     if (prte_process_info.num_daemons != daemons->num_procs) {
         prte_process_info.num_daemons = daemons->num_procs;
+        /* update the routing tree */
+        prte_rml_compute_routing_tree();
     }
 
-    /* update the routing tree */
-    prte_rml_compute_routing_tree();
 
 cleanup:
     if (NULL != vpid) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -419,7 +419,6 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     /* update num procs */
     if (prte_process_info.num_daemons != daemons->num_procs) {
         prte_process_info.num_daemons = daemons->num_procs;
-        prte_rml_compute_routing_tree();
     }
 
     /* update the routing tree */


### PR DESCRIPTION
[Plug small memory leaks.](https://github.com/openpmix/prrte/commit/48a471a603bb92bb8483a721f1f3a8dab77c8219)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8842a6a88cc3ac3548c65ef5378488ce81be236e)

[Plug memory leaks.](https://github.com/openpmix/prrte/commit/ad71019accba9c9d143045d34116a97a4dcdc1d8)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/208edd542f3ca55c97fe7fdddfb43509e475ddd4)

[Adhere to project's variable declaration convention.](https://github.com/openpmix/prrte/commit/b98f0bbcfdf812c7e3ad7aef2afefd2355f5704e)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5f047e54668dbe817be76be3cd507eabf160af3b)

[Cleanup initial implementation of allocate and session ctrl](https://github.com/openpmix/prrte/commit/626115b0a899e20a6ad7fdd2a3c6b65b28fabe2f)

Handle the upcalls ourselves if we are the DVM master.
Cleanup the relay to the DVM master if needed.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7230e4900e3c38b6633b251f6c6824438d67e15d)

[Protect one more place for Session_control](https://github.com/openpmix/prrte/commit/0189d593c88a1a02bfec1cfa2731a341aa04ce77)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f4663915e17905f0c7056cc21070cd84a5b8f3ba)

[Fix the routing for non-tree-spawn launch](https://github.com/openpmix/prrte/commit/c2e12aeed38e228fa06d7ea0db3527108bc79bb3)

The prted should send directly back to the HNP in this
scenario. Nidmap needs to update the routing tree when
we update the map as the number of daemons may have changed.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/fd0ecb9c1c944a5381487b9664f54799437f3137)

[Cleanup prte_info output](https://github.com/openpmix/prrte/commit/63ccaf6861e4e3f5dac9499ba9795736bd321f8c)

Include the non-framework types when no cmd line
arguments are given so the user at least knows
they exist.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3a89e3e5ab70967c812edcea8cd7a1e1731cd6be)

[Ensure we exit cleanly when a daemon fails to start](https://github.com/openpmix/prrte/commit/db8ec65f16d89bdf9c72b94496c55f3c66151932)

We need the DVM controller to terminate and not stay
alive in a "hung" state, or to segfault while trying
to exit.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5ddaef1b24addf2133b87b4965904238080f92b3)

[Store prted URI under correct name](https://github.com/openpmix/prrte/commit/629265344c7a02ce0369d59b8bb113a538b4b50d)

The HNP URI was being stored under the name of the
host prted instead of the HNP. Ensure we also store
the host prted's URI for later use.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5594d0603e95542d4293a59c398d1a647a6c8337)

[Remove duplicate computation of routing tree](https://github.com/openpmix/prrte/commit/68cc9918a05e1f065e706484ab3e0f1cc35847b0)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/2ba440d3b1b84eda28d6c5de9479c393a4a5e788)

[Minor cleanup of verbose output](https://github.com/openpmix/prrte/commit/5054a8cf3f31b391c666f528b770d758472442ab)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/d898bc2985397165b2ad030bad462f4f74bbc64d)

[Fix typo](https://github.com/openpmix/prrte/commit/3caa114c0088a1016f2d3901119a620e200ac0af)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1fdb27944647711477e71cbee8b09a92cc6c7f3d)

[Send direct to HNP if we don't know a route](https://github.com/openpmix/prrte/commit/1e2ace65ee9bd55993cbb64e7717b589998177c1)

If the prted doesn't have a route, then redirect
the send directly to the HNP.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/bc12ca3c7145daaa6cf37e36123897ab4f30170d)

[Cleanup some mangled formatting](https://github.com/openpmix/prrte/commit/04bf0481860d437a271414f266ff9c2c4d7d464c)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/aa74f0f54baa404c44bcc1c3b26ca65c2e83bde0)

[Cleanup some debug output](https://github.com/openpmix/prrte/commit/ea8f238c23d63431dbf875f1e0a94e25bcfcd834)

Protect against NULL entries

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e45e258a5d1e163cacc97475c2c73446bd6d0075)

[Update the pmix server integration](https://github.com/openpmix/prrte/commit/2a9d9f66be6736d43da214c874bd6e3c99c3c5d6)

Track master branch

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick