### PR TITLE
Fix passing of envars for spawn

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,6 +107,7 @@ PRTE_EXPORT int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
 PRTE_EXPORT int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo);
 PRTE_EXPORT int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo);
 
+PRTE_EXPORT int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app);
 
 
 END_C_DECLS

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -525,3 +525,159 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
     }
     return PRTE_SUCCESS;
 }
+
+int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
+{
+    prte_attribute_t *attr;
+    bool exists;
+    char *param, *p2, *saveptr;
+    int i;
+
+    /* flag that we started this job */
+    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
+
+    /* now process any envar attributes - we begin with the job-level
+     * ones as the app-specific ones can override them. We have to
+     * process them in the order they were given to ensure we wind
+     * up in the desired final state */
+    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
+    {
+        if (PRTE_JOB_SET_ENVAR == attr->key) {
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                               attr->data.data.envar.value,
+                               true, &app->env);
+        } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                               attr->data.data.envar.value,
+                               false, &app->env);
+        } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
+            pmix_unsetenv(attr->data.data.string, &app->env);
+        } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
+            /* see if the envar already exists */
+            exists = false;
+            for (i = 0; NULL != app->env[i]; i++) {
+                saveptr = strchr(app->env[i], '='); // cannot be NULL
+                *saveptr = '\0';
+                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
+                    /* we have the var - prepend it */
+                    param = saveptr;
+                    ++param; // move past where the '=' sign was
+                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
+                                  attr->data.data.envar.separator, param);
+                    *saveptr = '='; // restore the current envar setting
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    free(p2);
+                    exists = true;
+                    break;
+                } else {
+                    *saveptr = '='; // restore the current envar setting
+                }
+            }
+            if (!exists) {
+                /* just insert it */
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                                   attr->data.data.envar.value,
+                                   true, &app->env);
+            }
+        } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
+            /* see if the envar already exists */
+            exists = false;
+            for (i = 0; NULL != app->env[i]; i++) {
+                saveptr = strchr(app->env[i], '='); // cannot be NULL
+                *saveptr = '\0';
+                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
+                    /* we have the var - prepend it */
+                    param = saveptr;
+                    ++param; // move past where the '=' sign was
+                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
+                                  attr->data.data.envar.value);
+                    *saveptr = '='; // restore the current envar setting
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    free(p2);
+                    exists = true;
+                    break;
+                } else {
+                    *saveptr = '='; // restore the current envar setting
+                }
+            }
+            if (!exists) {
+                /* just insert it */
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                                   attr->data.data.envar.value,
+                                   true, &app->env);
+            }
+        }
+    }
+
+    /* now do the same thing for any app-level attributes */
+    PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
+    {
+        if (PRTE_APP_SET_ENVAR == attr->key) {
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                               attr->data.data.envar.value,
+                               true, &app->env);
+        } else if (PRTE_APP_ADD_ENVAR == attr->key) {
+            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                               attr->data.data.envar.value,
+                               false, &app->env);
+        } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
+            pmix_unsetenv(attr->data.data.string, &app->env);
+        } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
+            /* see if the envar already exists */
+            exists = false;
+            for (i = 0; NULL != app->env[i]; i++) {
+                saveptr = strchr(app->env[i], '='); // cannot be NULL
+                *saveptr = '\0';
+                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
+                    /* we have the var - prepend it */
+                    param = saveptr;
+                    ++param; // move past where the '=' sign was
+                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
+                                  attr->data.data.envar.separator, param);
+                    *saveptr = '='; // restore the current envar setting
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    free(p2);
+                    exists = true;
+                    break;
+                } else {
+                    *saveptr = '='; // restore the current envar setting
+                }
+            }
+            if (!exists) {
+                /* just insert it */
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                                   attr->data.data.envar.value,
+                                   true, &app->env);
+            }
+        } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
+            /* see if the envar already exists */
+            exists = false;
+            for (i = 0; NULL != app->env[i]; i++) {
+                saveptr = strchr(app->env[i], '='); // cannot be NULL
+                *saveptr = '\0';
+                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
+                    /* we have the var - prepend it */
+                    param = saveptr;
+                    ++param; // move past where the '=' sign was
+                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
+                                  attr->data.data.envar.value);
+                    *saveptr = '='; // restore the current envar setting
+                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    free(p2);
+                    exists = true;
+                    break;
+                } else {
+                    *saveptr = '='; // restore the current envar setting
+                }
+            }
+            if (!exists) {
+                /* just insert it */
+                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                                   attr->data.data.envar.value,
+                                   true, &app->env);
+            }
+        }
+    }
+
+    return PRTE_SUCCESS;
+}

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -69,7 +69,6 @@ static int parse_env(char **srcenv, char ***dstenv, pmix_cli_result_t *cli);
 static void allow_run_as_root(pmix_cli_result_t *results);
 static int set_default_ranking(prte_job_t *jdata,
                                prte_rmaps_options_t *options);
-static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
 static void job_info(pmix_cli_result_t *results,
                      void *jobinfo);
 static int setup_app(prte_pmix_app_t *app);
@@ -80,7 +79,7 @@ prte_schizo_base_module_t prte_schizo_ompi_module = {
     .name = "ompi",
     .parse_cli = parse_cli,
     .parse_env = parse_env,
-    .setup_fork = setup_fork,
+    .setup_fork = prte_schizo_base_setup_fork,
     .setup_app = setup_app,
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
@@ -1849,151 +1848,6 @@ static bool check_pmix_overlap(char *var, char *value)
     }
     return false;
 }
-
-static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
-{
-    prte_attribute_t *attr;
-    bool exists;
-    char *param, *p2, *saveptr;
-    int i;
-
-    /* flag that we started this job */
-    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
-
-    /* now process any envar attributes - we begin with the job-level
-     * ones as the app-specific ones can override them. We have to
-     * process them in the order they were given to ensure we wind
-     * up in the desired final state */
-    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
-    {
-        if (PRTE_JOB_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
-        } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
-        } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-        } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        }
-    }
-
-    /* now do the same thing for any app-level attributes */
-    PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
-    {
-        if (PRTE_APP_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
-        } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
-        } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-        } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        }
-    }
-
-    return PRTE_SUCCESS;
-}
-
 
 static int detect_proxy(char *personalities)
 {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -63,7 +63,6 @@ static int parse_cli(char **argv, pmix_cli_result_t *results, bool silent);
 static int detect_proxy(char *argv);
 static int parse_env(char **srcenv, char ***dstenv, pmix_cli_result_t *cli);
 static void allow_run_as_root(pmix_cli_result_t *results);
-static int setup_fork(prte_job_t *jdata, prte_app_context_t *context);
 static void job_info(pmix_cli_result_t *results,
                      void *jobinfo);
 static int set_default_rto(prte_job_t *jdata,
@@ -73,7 +72,7 @@ prte_schizo_base_module_t prte_schizo_prte_module = {
     .name = "prte",
     .parse_cli = parse_cli,
     .parse_env = parse_env,
-    .setup_fork = setup_fork,
+    .setup_fork = prte_schizo_base_setup_fork,
     .detect_proxy = detect_proxy,
     .allow_run_as_root = allow_run_as_root,
     .job_info = job_info,
@@ -979,150 +978,6 @@ static int parse_env(char **srcenv, char ***dstenv,
         }
         PMIX_ARGV_FREE_COMPAT(xparams);
         PMIX_ARGV_FREE_COMPAT(xvals);
-    }
-
-    return PRTE_SUCCESS;
-}
-
-static int setup_fork(prte_job_t *jdata, prte_app_context_t *app)
-{
-    prte_attribute_t *attr;
-    bool exists;
-    char *param, *p2, *saveptr;
-    int i;
-
-    /* flag that we started this job */
-    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
-
-    /* now process any envar attributes - we begin with the job-level
-     * ones as the app-specific ones can override them. We have to
-     * process them in the order they were given to ensure we wind
-     * up in the desired final state */
-    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
-    {
-        if (PRTE_JOB_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
-        } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
-        } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-        } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        }
-    }
-
-    /* now do the same thing for any app-level attributes */
-    PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
-    {
-        if (PRTE_APP_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true, &app->env);
-        } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, false, &app->env);
-        } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-        } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar, attr->data.data.envar.value, true,
-                            &app->env);
-            }
-        }
     }
 
     return PRTE_SUCCESS;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -315,29 +315,34 @@ static void interim(int sd, short args, void *cbdata)
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_set_attribute(&app->attributes, PRTE_APP_SET_ENVAR, PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_set_attribute(&app->attributes, PRTE_APP_ADD_ENVAR, PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-                    prte_set_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
-                                       info->value.data.string, PMIX_STRING);
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           info->value.data.string, PMIX_STRING);
                 } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_set_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR, PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
                 } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_set_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR, PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
 
                 } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_PSET_NAME, PRTE_ATTR_GLOBAL,
@@ -715,29 +720,29 @@ static void interim(int sd, short args, void *cbdata)
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
-                               PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
+            prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+                                   PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR, PRTE_ATTR_GLOBAL, &envar,
-                               PMIX_ENVAR);
+            prte_prepend_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
+                                   PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
-                               info->value.data.string, PMIX_STRING);
+            prte_prepend_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
+                                   PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
         } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
-                               PMIX_ENVAR);
+            prte_prepend_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
+                                   PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR, PRTE_ATTR_GLOBAL, &envar,
-                               PMIX_ENVAR);
+            prte_prepend_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
+                                   PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
 


### PR DESCRIPTION
Since there can be multiple envars being set, unset, etc, we need to prepend them to the list of attributes instead of "set" them (as that overwrites any prior attribute for that operation). Also refactor the "setup_fork" entry in the schizo framework to remove duplicate code in the prte and ompi components.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 62fb02f3046e01826ff8a66452f5363336281bd9)