### PR TITLE
Always set waitpid-fired flag when proc exits

### DIFF
--- a/examples/fault.c
+++ b/examples/fault.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -173,6 +173,11 @@ int main(int argc, char **argv)
     DEBUG_WAIT_THREAD(&myrel.lock);
     DEBUG_DESTRUCT_MYREL(&myrel);
 
+    /* rank 1 waits longer to check that we don't cleanup
+     * until all ranks are done */
+    if (1 == myproc.rank) {
+        sleep(5);
+    }
 done:
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1556,6 +1556,9 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         goto MOVEON;
     }
 
+    /* mark that the waitpid fired */
+    PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_WAITPID);
+
     /* if the proc called "abort", then we just need to flag that it
      * came thru here */
     if (PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_ABORT)) {
@@ -1566,7 +1569,6 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                              "%s odls:waitpid_fired child %s died by call to abort",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
         state = PRTE_PROC_STATE_CALLED_ABORT;
-        PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_WAITPID);
         goto MOVEON;
     }
 
@@ -1583,7 +1585,6 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
                              "%s odls:waitpid_fired child %s was ordered to die",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
-        PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_WAITPID);
         goto MOVEON;
     }
 

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -563,11 +563,10 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
         }
     } else if (PRTE_PROC_STATE_TERMINATED == state) {
         if (pdata->state == state) {
-            pmix_output_verbose(
-                5, prte_state_base_framework.framework_output,
-                "%s state:base:track_procs proc %s already in state %s. Skip transition.",
-                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
-                prte_proc_state_to_str(state));
+            pmix_output_verbose(5, prte_state_base_framework.framework_output,
+                                "%s state:base:track_procs proc %s already in state %s. Skip transition.",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
+                                prte_proc_state_to_str(state));
             goto cleanup;
         }
 
@@ -602,9 +601,9 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
                 }
             }
             /* call our appropriate exit procedure */
-            PMIX_OUTPUT_VERBOSE((5, prte_state_base_framework.framework_output,
+            pmix_output_verbose(5, prte_state_base_framework.framework_output,
                                  "%s state:base all routes and children gone - exiting",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
             goto cleanup;
         }


### PR DESCRIPTION
Regardless of the reason for the exit, we need to flag that the waitpid was fired to avoid hanging.