### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2004-2011 The University of Tennessee and The University
+ * Copyright (c) 2004-2023 The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
@@ -516,9 +516,12 @@ static void proc_errors(int fd, short args, void *cbdata)
                 PRTE_ERROR_LOG(rc);
                 PMIX_RELEASE(alert);
             }
-            /* mark that we notified the HNP for this job so we don't do it again */
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_FAIL_NOTIFIED, PRTE_ATTR_LOCAL, NULL,
-                               PMIX_BOOL);
+            /* mark that we notified the HNP for this job so we don't do it again;
+             * recoverable jobs need to receive every notifications, though. */
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL)) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FAIL_NOTIFIED, PRTE_ATTR_LOCAL, NULL,
+                                   PMIX_BOOL);
+            }
         }
         /* if the proc has terminated, notify the state machine */
         if (PRTE_FLAG_TEST(child, PRTE_PROC_FLAG_IOF_COMPLETE)
@@ -629,9 +632,12 @@ static void proc_errors(int fd, short args, void *cbdata)
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
             }
-            /* mark that we notified the HNP for this job so we don't do it again */
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_FAIL_NOTIFIED, PRTE_ATTR_LOCAL, NULL,
-                               PMIX_BOOL);
+            /* mark that we notified the HNP for this job so we don't do it again;
+             * recoverable jobs need to receive every notifications, though. */
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL)) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FAIL_NOTIFIED, PRTE_ATTR_LOCAL, NULL,
+                                   PMIX_BOOL);
+            }
         }
         /* if the proc has terminated, notify the state machine */
         if (PRTE_FLAG_TEST(child, PRTE_PROC_FLAG_IOF_COMPLETE)

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -362,9 +362,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
         break;
 
     case PRTE_PLM_UPDATE_PROC_STATE:
-            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                            "%s plm:base:receive update proc state command from %s",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)));
+            pmix_output_verbose(5, prte_plm_base_framework.framework_output,
+                                "\n\n%s plm:base:receive update proc state command from %s\n\n",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender));
         count = 1;
         rc = PMIx_Data_unpack(NULL, buffer, &job, &count, PMIX_PROC_NSPACE);
         while (PMIX_SUCCESS == rc) {

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -224,20 +224,22 @@ typedef uint16_t prte_job_flags_t;
 
 /*** PROC FLAGS - never sent anywhere ***/
 typedef uint16_t prte_proc_flags_t;
-#define PRTE_PROC_FLAG_ALIVE        0x0001 // proc has been launched and has not yet terminated
-#define PRTE_PROC_FLAG_ABORT        0x0002 // proc called abort
-#define PRTE_PROC_FLAG_UPDATED      0x0004 // proc has been updated and need to be included in the next pidmap message
-#define PRTE_PROC_FLAG_LOCAL        0x0008 // indicate that this proc is local
-#define PRTE_PROC_FLAG_REPORTED     0x0010 // indicate proc has reported in
-#define PRTE_PROC_FLAG_REG          0x0020 // proc has registered
-#define PRTE_PROC_FLAG_HAS_DEREG    0x0040 // proc has deregistered
-#define PRTE_PROC_FLAG_AS_MPI       0x0080 // proc is MPI process
-#define PRTE_PROC_FLAG_IOF_COMPLETE 0x0100 // IOF has completed
-#define PRTE_PROC_FLAG_WAITPID      0x0200 // waitpid fired
-#define PRTE_PROC_FLAG_RECORDED     0x0400 // termination has been recorded
-#define PRTE_PROC_FLAG_DATA_IN_SM   0x0800 // modex data has been stored in the local shared memory region
-#define PRTE_PROC_FLAG_DATA_RECVD   0x1000 // modex data for this proc has been received
-#define PRTE_PROC_FLAG_SM_ACCESS    0x2000 // indicate if process can read modex data from shared memory region
+#define PRTE_PROC_FLAG_ALIVE            0x0001 // proc has been launched and has not yet terminated
+#define PRTE_PROC_FLAG_ABORT            0x0002 // proc called abort
+#define PRTE_PROC_FLAG_UPDATED          0x0004 // proc has been updated and need to be included in the next pidmap message
+#define PRTE_PROC_FLAG_LOCAL            0x0008 // indicate that this proc is local
+#define PRTE_PROC_FLAG_REPORTED         0x0010 // indicate proc has reported in
+#define PRTE_PROC_FLAG_REG              0x0020 // proc has registered
+#define PRTE_PROC_FLAG_HAS_DEREG        0x0040 // proc has deregistered
+#define PRTE_PROC_FLAG_AS_MPI           0x0080 // proc is MPI process
+#define PRTE_PROC_FLAG_IOF_COMPLETE     0x0100 // IOF has completed
+#define PRTE_PROC_FLAG_WAITPID          0x0200 // waitpid fired
+#define PRTE_PROC_FLAG_RECORDED         0x0400 // termination has been recorded
+#define PRTE_PROC_FLAG_DATA_IN_SM       0x0800 // modex data has been stored in the local shared memory region
+#define PRTE_PROC_FLAG_DATA_RECVD       0x1000 // modex data for this proc has been received
+#define PRTE_PROC_FLAG_SM_ACCESS        0x2000 // indicate if process can read modex data from shared memory region
+#define PRTE_PROC_FLAG_TERM_REPORTED    0x4000 // proc termination has been reported
+
 
 /***   PROCESS ATTRIBUTE KEYS   ***/
 #define PRTE_PROC_START_KEY PRTE_JOB_MAX_KEY


### PR DESCRIPTION
[Recoverable jobs may report more than one proc error over the lifetime](https://github.com/openpmix/prrte/commit/0ec8150eab9e5f09fbf6cb1e0ba93d234c359d35)

of the prted daemon. Thus we bypass the mechanism that prevents multiple
reports if the job is tagged 'recoverable'.

Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>
(cherry picked from commit https://github.com/openpmix/prrte/commit/08943c450bd3da56928668b14402c073e1666f3a)

[Fix double-counting of failed procs in recoverable jobs](https://github.com/openpmix/prrte/commit/f7769996ce16443d657af911aed8e85b3ad2ade1)

If procs in a recoverable job are killed by signal, then
the prted errmgr will report that failure immediately
(on a per-proc basis) to the HNP. However, this results
in a double-reporting of each proc's termination. Once
half of the procs have terminated, the HNP will cleanup
the remainder of the job.

So flag that a proc has been reported and only include
it once, either in an error report or in the normal
termination report - but not in both.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/9b1e66571b79214f55de66ee4e9826957717c1e5)
