### PR TITLE
Allow specifying ppr as the default mapping policy

### DIFF
--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,6 +76,7 @@ typedef struct {
      * when the directive comes thru MCA param */
     char *file;
     hwloc_cpuset_t available, baseset;  // scratch for binding calculation
+    char *default_mapping_policy;
 } prte_rmaps_base_t;
 
 /**

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -343,6 +343,12 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps mapping given by MCA param");
                 jdata->map->mapping = prte_rmaps_base.mapping;
+                if (PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
+                    tmp = strchr(prte_rmaps_base.default_mapping_policy, ':');
+                    ++tmp;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR,
+                                       PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
+                }
                 did_map = true;
             }
         }


### PR DESCRIPTION
The MCA help output includes it and there is no real reason to block it - just a little extra code required to support it.