### PR TITLE
Return the final group membership for group_construct

### DIFF
--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -120,7 +120,9 @@ PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, grpcomm, "GRPCOMM", base_register, prte_gr
                                 prte_grpcomm_base_close, prte_grpcomm_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 
-PMIX_CLASS_INSTANCE(prte_grpcomm_base_active_t, pmix_list_item_t, NULL, NULL);
+PMIX_CLASS_INSTANCE(prte_grpcomm_base_active_t,
+                    pmix_list_item_t,
+                    NULL, NULL);
 
 static void scon(prte_grpcomm_signature_t *p)
 {
@@ -133,7 +135,9 @@ static void sdes(prte_grpcomm_signature_t *p)
         free(p->signature);
     }
 }
-PMIX_CLASS_INSTANCE(prte_grpcomm_signature_t, pmix_object_t, scon, sdes);
+PMIX_CLASS_INSTANCE(prte_grpcomm_signature_t,
+                    pmix_object_t,
+                    scon, sdes);
 
 static void ccon(prte_grpcomm_coll_t *p)
 {
@@ -147,6 +151,7 @@ static void ccon(prte_grpcomm_coll_t *p)
     p->assignID = false;
     p->timeout = 0;
     p->memsize = 0;
+    PMIX_CONSTRUCT(&p->addmembers, pmix_list_t);
     p->cbfunc = NULL;
     p->cbdata = NULL;
     p->buffers = NULL;
@@ -157,7 +162,10 @@ static void cdes(prte_grpcomm_coll_t *p)
         PMIX_RELEASE(p->sig);
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->bucket);
+    PMIX_LIST_DESTRUCT(&p->addmembers);
     free(p->dmns);
     free(p->buffers);
 }
-PMIX_CLASS_INSTANCE(prte_grpcomm_coll_t, pmix_list_item_t, ccon, cdes);
+PMIX_CLASS_INSTANCE(prte_grpcomm_coll_t,
+                    pmix_list_item_t,
+                    ccon, cdes);

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -167,7 +167,7 @@ static void allgather_recv(int status, pmix_proc_t *sender,
 {
     int32_t cnt;
     int rc, timeout;
-    size_t n, ninfo, memsize;
+    size_t n, ninfo, memsize, m;
     bool assignID = false;
     pmix_proc_t *addmembers = NULL;
     size_t num_members = 0;
@@ -289,9 +289,9 @@ static void allgather_recv(int status, pmix_proc_t *sender,
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ADD_MEMBERS)) {
             addmembers = (pmix_proc_t*)info[n].value.data.darray->array;
             num_members = info[n].value.data.darray->size;
-            for (n=0; n < num_members; n++) {
+            for (m=0; m < num_members; m++) {
                 nm = PMIX_NEW(prte_namelist_t);
-                PMIX_XFER_PROCID(&nm->name, &addmembers[n]);
+                PMIX_XFER_PROCID(&nm->name, &addmembers[m]);
                 pmix_list_append(&coll->addmembers, &nm->super);
             }
         }

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -91,6 +91,7 @@ typedef struct {
     bool assignID;
     int timeout;
     size_t memsize;
+    pmix_list_t addmembers;
     /* distance masks for receive */
     pmix_bitmap_t distance_mask_recv;
     /* received buckets */
@@ -106,8 +107,12 @@ typedef struct {
     pmix_object_t super;
     prte_event_t ev;
     prte_grpcomm_signature_t *sig;
+    pmix_group_operation_t op;
+    char *grpid;
     pmix_data_buffer_t *buf;
     pmix_byte_object_t ctrls;
+    pmix_proc_t *procs;
+    size_t nprocs;
     pmix_info_t *info;
     size_t ninfo;
     prte_grpcomm_cbfunc_t grpcbfunc;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1893,6 +1893,8 @@ static void mdcon(prte_pmix_mdx_caddy_t *p)
     p->sig = NULL;
     p->buf = NULL;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->ctrls);
+    p->procs = NULL;
+    p->nprocs = 0;
     p->info = NULL;
     p->ninfo = 0;
     p->cbdata = NULL;


### PR DESCRIPTION
Always return the final group membership to the return of PMIx_Group_construct as it can be different than the array of original procs (e.g., if someone adds members that are not visible to all other participants).