### PR TITLE
Support odd topologies and relax pe-binding rules

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -390,6 +390,8 @@ PRTE_EXPORT void prte_hwloc_build_map(hwloc_topology_t topo,
                                       bool use_hwthread_cpus,
                                       hwloc_bitmap_t coreset);
 
+PRTE_EXPORT bool prte_hwloc_base_core_cpus(hwloc_topology_t topo);
+
 END_C_DECLS
 
 #endif /* PRTE_HWLOC_H_ */

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -77,6 +77,8 @@ typedef struct {
     char *file;
     hwloc_cpuset_t available, baseset;  // scratch for binding calculation
     char *default_mapping_policy;
+    /* whether or not to require hwtcpus due to topology limitations */
+    bool require_hwtcpus;
 } prte_rmaps_base_t;
 
 /**

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -317,7 +317,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     } else {
         options.cpus_per_rank = 1;
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) ||
+        prte_rmaps_base.require_hwtcpus) {
         options.use_hwthreads = true;
     }
 

--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -167,9 +167,9 @@ notify the developers
 #
 [binding-pe-conflict]
 The PE=<list> mapping directive cannot be combined with a
-binding directive as it already mandates that we bind to
-the specified cpu(s). The conflicting directives that were
-given are:
+binding directive other than "core" or "hwt" as it already
+mandates that we bind to the specified cpu(s). The conflicting
+directives that were given are:
 
   map-by:  %s
   bind-to: %s

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -534,6 +534,11 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     newopt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_BINDTO);
     if (NULL != opt && NULL != newopt) {
         if (NULL != strcasestr(opt->values[0], "PE")) {
+            /* if we are binding to a PE, then there is no conflict */
+            if (NULL != strcasestr(newopt->values[0], "core") ||
+                NULL != strcasestr(newopt->values[0], "hwt")) {
+                return PRTE_SUCCESS;
+            }
             pmix_show_help("help-schizo-base.txt", "binding-pe-conflict", true,
                            opt->values[0], newopt->values[0]);
             return PRTE_ERR_SILENT;


### PR DESCRIPTION
It appears that hwloc can at least sometimes report a "core" and a "pu" that have identical cpusets. This was causing problems for the map/bind system as it became confused as to what cpuset comprised a core vs a hwt. So test for this scenario and force hwtcpus when it is encountered.

Relax the rule about pe=N conflicting with bind-to directives - there is no conflict if the directive was to bind to cpu.