### PR TITLE
Multiple commits

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -58,6 +58,7 @@ Copyright (c) 2017-2023 Amazon.com, Inc. or its affiliates.  All Rights
 Copyright (c) 2018      DataDirect Networks. All rights reserved.
 Copyright (c) 2020-2023 Nanook Consulting. All rights reserved.
 Copyright (c) 2022-2023 Triad National Security, LLC. All rights reserved
+Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
 
 $COPYRIGHT$
 

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -8,6 +8,7 @@
  *                         and Technology (RIST). All rights reserved.
  *
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -350,6 +351,11 @@ PRTE_EXPORT int prte_hwloc_base_memory_set(prte_hwloc_base_memory_segment_t *seg
 PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
                                            bool use_hwthread_cpus,
                                            hwloc_topology_t topo);
+
+PRTE_EXPORT void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
+                                             bool use_hwthread_cpus,
+                                             hwloc_topology_t topo, int *pkgnum, 
+                                             char *cores, int sz);
 
 /* get the hwloc object that corresponds to the given processor id  and type */
 PRTE_EXPORT hwloc_obj_t prte_hwloc_base_get_pu(hwloc_topology_t topo, bool use_hwthread_cpus,

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -390,6 +390,8 @@ PRTE_EXPORT void prte_hwloc_build_map(hwloc_topology_t topo,
                                       bool use_hwthread_cpus,
                                       hwloc_bitmap_t coreset);
 
+PRTE_EXPORT bool prte_hwloc_base_core_cpus(hwloc_topology_t topo);
+
 END_C_DECLS
 
 #endif /* PRTE_HWLOC_H_ */

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1260,49 +1260,48 @@ int hwloc_bitmap_list_snprintf_exp(char *__hwloc_restrict buf, size_t buflen,
     int res, ret = 0;
 
     /* mark the end in case we do nothing later */
-    if (buflen > 0)
+    if (buflen > 0) {
         tmp[0] = '\0';
+    }
 
-    while (1)
-    {
+    while (1) {
         int begin, end;
 
         begin = hwloc_bitmap_next(set, prev);
-        if (begin == -1)
+        if (begin == -1) {
             break;
+        }
         end = hwloc_bitmap_next_unset(set, begin);
 
-        if (end == begin + 1)
-        {
+        if (end == begin + 1) {
             res = snprintf(tmp, size, "%*c<%s>%d</%s>\n", 20, ' ', type, begin, type);
-        }
-        else if (end == -1)
-        {
+        } else if (end == -1) {
             res = snprintf(tmp, size, "%*c<%s>%d</%s>\n", 20, ' ', type, begin, type);
-        }
-        else
-        {
-            for (int i = begin; i <= end - 1; i++)
-            {
+        } else {
+            for (int i = begin; i <= end - 1; i++) {
                 res = snprintf(tmp, size, "%*c<%s>%d</%s>\n", 20, ' ', type, i, type);
-                if (i != (end - 1))
+                if (i != (end - 1)) {
                     tmp += res;
+                }
             }
         }
-        if (res < 0)
+        if (res < 0) {
             return -1;
+        }
         ret += res;
 
-        if (res >= size)
+        if (res >= size) {
             res = size > 0 ? (int)size - 1 : 0;
+        }
 
         tmp += res;
         size -= res;
 
-        if (end == -1)
+        if (end == -1) {
             break;
-        else
+        } else {
             prev = end - 1;
+        }
     }
     return ret;
 }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -18,6 +18,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -792,16 +793,19 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
         bool compressed;
         uint8_t *cmpdata = NULL;
         size_t cmplen;
-        /* report the size of the launch message */
-        compressed = PMIx_Data_compress((uint8_t *) jdata->launch_msg.base_ptr,
-                                        jdata->launch_msg.bytes_used, &cmpdata, &cmplen);
-        if (compressed) {
-            pmix_output(0, "LAUNCH MSG RAW SIZE: %d COMPRESSED SIZE: %d",
-                        (int) jdata->launch_msg.bytes_used, (int) cmplen);
-            free(cmpdata);
-            cmpdata = NULL;
-        } else {
-            pmix_output(0, "LAUNCH MSG RAW SIZE: %d", (int) jdata->launch_msg.bytes_used);
+
+        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
+            /* report the size of the launch message */
+            compressed = PMIx_Data_compress((uint8_t *) jdata->launch_msg.base_ptr,
+                                            jdata->launch_msg.bytes_used, &cmpdata, &cmplen);
+            if (compressed) {
+                pmix_output(0, "LAUNCH MSG RAW SIZE: %d COMPRESSED SIZE: %d",
+                            (int) jdata->launch_msg.bytes_used, (int) cmplen);
+                free(cmpdata);
+                cmpdata = NULL;
+            } else {
+                pmix_output(0, "LAUNCH MSG RAW SIZE: %d", (int) jdata->launch_msg.bytes_used);
+            }
         }
         /* go ahead and register the job */
         rc = prte_pmix_server_register_nspace(jdata);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -239,7 +239,6 @@ void prte_plm_base_vm_ready(int fd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(caddy);
 
-pmix_output(0, "VM READY");
     /* progress the job */
     caddy->jdata->state = PRTE_JOB_STATE_VM_READY;
 
@@ -248,13 +247,11 @@ pmix_output(0, "VM READY");
      * launch any daemons */
     node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, 1);
     if (NULL == node) {
-        pmix_output(0, "FETCH NODE 0");
         node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, 0);
     }
     if (NULL != node && NULL != node->topology &&
         NULL != node->topology->topo) {
         prte_rmaps_base.require_hwtcpus = !prte_hwloc_base_core_cpus(node->topology->topo);
-        pmix_output(0, "VMREADY HWT CPUS: %s", prte_rmaps_base.require_hwtcpus ? "T" : "F");
     }
 
     /* position any required files */
@@ -809,23 +806,6 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
 
     /* if we don't want to launch the apps, now is the time to leave */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
-        bool compressed;
-        uint8_t *cmpdata = NULL;
-        size_t cmplen;
-
-        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
-            /* report the size of the launch message */
-            compressed = PMIx_Data_compress((uint8_t *) jdata->launch_msg.base_ptr,
-                                            jdata->launch_msg.bytes_used, &cmpdata, &cmplen);
-            if (compressed) {
-                pmix_output(0, "LAUNCH MSG RAW SIZE: %d COMPRESSED SIZE: %d",
-                            (int) jdata->launch_msg.bytes_used, (int) cmplen);
-                free(cmpdata);
-                cmpdata = NULL;
-            } else {
-                pmix_output(0, "LAUNCH MSG RAW SIZE: %d", (int) jdata->launch_msg.bytes_used);
-            }
-        }
         /* go ahead and register the job */
         rc = prte_pmix_server_register_nspace(jdata);
         if (PRTE_SUCCESS != rc) {
@@ -840,9 +820,6 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALL_JOBS_COMPLETE);
         }
         PMIX_RELEASE(caddy);
-        if (NULL != cmpdata) {
-            free(cmpdata);
-        }
         return;
     }
 

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -16,6 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -178,6 +179,10 @@ static void display_cpus(prte_topology_t *t,
     bool parsable;
 
     parsable = prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
+
+    if (parsable) {
+        return;
+    }
 
     npus = hwloc_get_nbobjs_by_type(t->topo, HWLOC_OBJ_PU);
     ncores = hwloc_get_nbobjs_by_type(t->topo, HWLOC_OBJ_CORE);

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -77,6 +77,8 @@ typedef struct {
     char *file;
     hwloc_cpuset_t available, baseset;  // scratch for binding calculation
     char *default_mapping_policy;
+    /* whether or not to require hwtcpus due to topology limitations */
+    bool require_hwtcpus;
 } prte_rmaps_base_t;
 
 /**

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -317,7 +317,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     } else {
         options.cpus_per_rank = 1;
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) ||
+        prte_rmaps_base.require_hwtcpus) {
         options.use_hwthreads = true;
     }
 

--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -167,9 +167,9 @@ notify the developers
 #
 [binding-pe-conflict]
 The PE=<list> mapping directive cannot be combined with a
-binding directive as it already mandates that we bind to
-the specified cpu(s). The conflicting directives that were
-given are:
+binding directive other than "core" or "hwt" as it already
+mandates that we bind to the specified cpu(s). The conflicting
+directives that were given are:
 
   map-by:  %s
   bind-to: %s

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -534,6 +534,11 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     newopt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_BINDTO);
     if (NULL != opt && NULL != newopt) {
         if (NULL != strcasestr(opt->values[0], "PE")) {
+            /* if we are binding to a PE, then there is no conflict */
+            if (NULL != strcasestr(newopt->values[0], "core") ||
+                NULL != strcasestr(newopt->values[0], "hwt")) {
+                return PRTE_SUCCESS;
+            }
             pmix_show_help("help-schizo-base.txt", "binding-pe-conflict", true,
                            opt->values[0], newopt->values[0]);
             return PRTE_ERR_SILENT;


### PR DESCRIPTION
[Parsable output in an XML format](https://github.com/openpmix/prrte/commit/20c2c851c1caef0fe2757b8c6e3de112d8d70dfd)

Signed-off-by: Manu Shantharam <manu.shantharam@amd.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3d20a814375fdeeb1311e3d616b162443ca9d8a3)

[Support odd topologies and relax pe-binding rules](https://github.com/openpmix/prrte/commit/727a810bfb1b978ef1c8476231026f67013ea863)

It appears that hwloc can at least sometimes report
a "core" and a "pu" that have identical cpusets. This
was causing problems for the map/bind system as it
became confused as to what cpuset comprised a core vs
a hwt. So test for this scenario and force hwtcpus
when it is encountered.

Relax the rule about pe=N conflicting with bind-to
directives - there is no conflict if the directive
was to bind to cpu.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/697c6e9a4bc91fdab179f0ddb91916d70f83562d)

[Cleanup some formatting and unnecessary debug](https://github.com/openpmix/prrte/commit/67ee2451ecbaf0c3bbda0be3bdd4a73052ea366a)

Minor formatting cleanup. Remove the stale launch msg
size output when not launching. Remove some inadvertent
debug from prior commit.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8b4e74a0f45c2a141e59968e9959c38f0c653a43)
