### PR TITLE
Fix map-by object

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -234,6 +234,8 @@ int prte_hwloc_base_register(void)
                                      &prte_hwloc_base_topo_file);
     (void) pmix_mca_base_var_register_synonym(ret, "prte", "ras", "simulator", "topo_files",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", "hwloc", "base", "use_topo_file",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     /* register parameters */
     return PRTE_SUCCESS;


### PR DESCRIPTION
Only map one proc at a time before moving to the next object and then loop within the node until full. Add another common synonym for "hwloc_use_topo_file" to avoid confusion.