### PR TITLE
Multiple commits

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -234,6 +234,8 @@ int prte_hwloc_base_register(void)
                                      &prte_hwloc_base_topo_file);
     (void) pmix_mca_base_var_register_synonym(ret, "prte", "ras", "simulator", "topo_files",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", "hwloc", "base", "use_topo_file",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     /* register parameters */
     return PRTE_SUCCESS;

--- a/src/include/prte_stdatomic.h
+++ b/src/include/prte_stdatomic.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,6 +19,7 @@
 #    define PRTE_STDATOMIC_H
 
 #    include "prte_stdint.h"
+#    include <stdbool.h>
 
 #    if PRTE_ATOMIC_C11
 
@@ -26,6 +28,7 @@
 typedef atomic_int prte_atomic_int_t;
 typedef atomic_long prte_atomic_long_t;
 
+typedef _Atomic bool prte_atomic_bool_t;
 typedef _Atomic int32_t prte_atomic_int32_t;
 typedef _Atomic uint32_t prte_atomic_uint32_t;
 typedef _Atomic int64_t prte_atomic_int64_t;
@@ -41,6 +44,7 @@ typedef _Atomic uintptr_t prte_atomic_uintptr_t;
 typedef volatile int prte_atomic_int_t;
 typedef volatile long prte_atomic_long_t;
 
+typedef volatile bool prte_atomic_bool_t;
 typedef volatile int32_t prte_atomic_int32_t;
 typedef volatile uint32_t prte_atomic_uint32_t;
 typedef volatile int64_t prte_atomic_int64_t;

--- a/src/mca/oob/tcp/oob_tcp_component.h
+++ b/src/mca/oob/tcp/oob_tcp_component.h
@@ -18,6 +18,7 @@
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,6 +35,7 @@
 #    include <sys/time.h>
 #endif
 
+#include "src/include/prte_stdatomic.h"
 #include "src/class/pmix_bitmap.h"
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_pointer_array.h"
@@ -79,7 +81,7 @@ typedef struct {
     int num_hnp_ports;           /**< number of ports the HNP should listen on */
     pmix_list_t listeners;       /**< List of sockets being monitored by event or thread */
     pmix_thread_t listen_thread; /**< handle to the listening thread */
-    bool listen_thread_active;
+    prte_atomic_bool_t listen_thread_active;
     struct timeval listen_thread_tv; /**< Timeout when using listen thread */
     int stop_thread[2];              /**< pipe used to exit the listen thread */
     int keepalive_probes;   /**< number of keepalives that can be missed before declaring error */

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -571,8 +571,22 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
             free(spec);
             return PRTE_ERR_SILENT;
         }
-        ptr = strchr(spec, '='); // cannot be NULL as we checked for it
+        ptr = strchr(spec, '=');
+        if (NULL == ptr) {
+            /* malformed option */
+            pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+                           true, spec);
+            free(spec);
+            return PRTE_ERR_SILENT;
+        }
         ptr++; // move past the equal sign
+        if (NULL == ptr) {
+            /* malformed option */
+            pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+                           true, spec);
+            free(spec);
+            return PRTE_ERR_SILENT;
+        }
         /* Verify the list is composed of numeric tokens */
         temp_parm = strdup(ptr);
         temp_token = strtok(temp_parm, ",");

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -403,9 +403,7 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
     tmp = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
     ntomap = PMIX_ARGV_COUNT_COMPAT(tmp);
     PMIX_ARGV_FREE_COMPAT(tmp);
-    if (NULL != options->cpuset) {
-        savecpuset = strdup(options->cpuset);
-    }
+    savecpuset = strdup(options->cpuset);
 
 pass:
     PMIX_LIST_FOREACH_SAFE(node, nd, node_list, prte_node_t)
@@ -506,6 +504,10 @@ pass:
             hwloc_bitmap_free(options->job_cpuset);
             options->job_cpuset = NULL;
         }
+        if (NULL != options->cpuset) {
+            free(options->cpuset);
+        }
+        options->cpuset = strdup(savecpuset);
     } // next node
 
     /* second pass: if we haven't mapped everyone yet, it is
@@ -529,7 +531,10 @@ pass:
             extra_procs_to_assign++;
         }
         /* restore the cpuset */
-        options->cpuset = savecpuset;
+        if (NULL != options->cpuset) {
+            free(options->cpuset);
+        }
+        options->cpuset = strdup(savecpuset);
         // Rescan the nodes
         second_pass = true;
         goto pass;

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -43,6 +43,7 @@
 #include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/proc_info.h"
 
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
@@ -87,6 +88,11 @@ pmix_status_t pmix_server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     pmix_data_buffer_t buf;
     pmix_byte_object_t payload;
     int rc;
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s FENCE UPCALLED ON NODE %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        prte_process_info.nodename);
 
     cd = PMIX_NEW(prte_pmix_mdx_caddy_t);
     cd->mdxcbfunc = cbfunc;


### PR DESCRIPTION
[Fix map-by object](https://github.com/openpmix/prrte/commit/39feb9c6c11534195bd71a827d639cbdc7d95682)

Only map one proc at a time before moving to the next object
and then loop within the node until full. Add another common
synonym for "hwloc_use_topo_file" to avoid confusion.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/fadd15ca5d8006d56cfa487f9324537910b682c3)

[Properly maintain accounting when binding to multiple cpus](https://github.com/openpmix/prrte/commit/4cc04da561bb108dd8ca2ca35cc97cba6efb4828)

Need to take into account the node available cpus

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1e7a4f03ac7e25b7be5424098320bf49d796a7c5)

[config/oac: Update OAC submodule pointer](https://github.com/openpmix/prrte/commit/a1271124c7458b6f1195b6e1d3c46c4d008770e4)

Update to latest OAC main HEAD.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8a9b623eb09a9aa98a7b52ad13af70cac4905414)

[Fix pe-list mapping across nodes](https://github.com/openpmix/prrte/commit/14c93c66aa32d614aaa6e2a7270d38c9077d9f3d)

Restore the pe-list before moving to the next node

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5e288894842b4f36aea15aabc2bf1fc7400335db)

[Add debug output in fence upcall](https://github.com/openpmix/prrte/commit/56ae91618ff8e65eb3d95fb185d6b9fcaf5592cb)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/d8bd12b3ffda4af6918d641f024a6b0118789700)

[Silence TSan data race warning.](https://github.com/openpmix/prrte/commit/ef231e25599ad29e9bda099188d382fd4e26dab6)

Signed-off-by: Samuel K. Gutierrez <samuel@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/aa498b9b410445aac83b4fefbab4fd981f989b79)
