### PR TITLE
rmaps/base: add missing call to hwloc_bitmap_andnot() in bind_generic()

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -169,6 +169,7 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
         /* reset the availability */
         hwloc_bitmap_copy(node->available, node->jobcache);
     }
+    hwloc_bitmap_andnot(options->target, options->target, tmp_obj->cpuset);
 #endif
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
In bind_generic(), there is call to hwloc_bitmap_andnot() for API < 0x20000, but the corresponding call for API >= 0x20000 is missing. This patch added it.