### PR TITLE
[v3.1] rmaps/base: remove call to hwloc_bitmap_andnot() in bind_generic()

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -162,7 +162,6 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
         /* reset the availability */
         hwloc_bitmap_copy(node->available, node->jobcache);
     }
-    hwloc_bitmap_andnot(options->target, options->target, tmp_obj->allowed_cpuset);
 #else
     hwloc_bitmap_andnot(node->available, node->available, tmp_obj->cpuset);
     if (hwloc_bitmap_iszero(node->available) && options->overload) {


### PR DESCRIPTION
In bind_generic(), there is a call to hwloc_bitmap_andnot() for API < 0x20000, but no corresponding call for API >= 0x20000.

The call for hwloc < 2 is unnecessary, this patch removed it.

Signed-off-by: Wei Zhang <wzam@amazon.com>
(cherry picked from commit a97bb5858303aaf8da5ce623b84ff6a9b31699b2)