### PR TITLE
Use the PMIx utilities to check param project

### DIFF
--- a/src/event/event-internal.h
+++ b/src/event/event-internal.h
@@ -8,7 +8,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,7 +164,7 @@ typedef struct {
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_event_list_item_t);
 
 /* define a threadshift macro */
-#define PMIX_THREADSHIFT(x, eb, f, p)                                  \
+#define PRTE_PMIX_THREADSHIFT(x, eb, f, p)                                  \
     do {                                                               \
         prte_event_set((eb), &((x)->ev), -1, PRTE_EV_WRITE, (f), (x)); \
         prte_event_set_priority(&((x)->ev), (p));                      \

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -524,7 +524,7 @@ static int raw_preposition_files(prte_job_t *jdata,
         xfer->app_idx = fs->app_idx;
         xfer->outbound = outbound;
         pmix_list_append(&outbound->xfers, &xfer->super);
-        PMIX_THREADSHIFT(xfer, prte_event_base, send_chunk, PRTE_MSG_PRI);
+        PRTE_PMIX_THREADSHIFT(xfer, prte_event_base, send_chunk, PRTE_MSG_PRI);
         PMIX_RELEASE(item);
     }
     PMIX_DESTRUCT(&fsets);
@@ -1054,7 +1054,7 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
         }
         free(tmp);
         incoming->pending = true;
-        PMIX_THREADSHIFT(incoming, prte_event_base, write_handler, PRTE_MSG_PRI);
+        PRTE_PMIX_THREADSHIFT(incoming, prte_event_base, write_handler, PRTE_MSG_PRI);
     }
     /* create an output object for this data */
     output = PMIX_NEW(prte_filem_raw_output_t);

--- a/src/mca/oob/base/base.h
+++ b/src/mca/oob/base/base.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,7 +116,7 @@ PRTE_EXPORT void prte_oob_base_send_nb(int fd, short args, void *cbdata);
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__, __LINE__);              \
         prte_oob_send_cd = PMIX_NEW(prte_oob_send_t);                                             \
         prte_oob_send_cd->msg = (m);                                                              \
-        PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb, PRTE_MSG_PRI); \
+        PRTE_PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb, PRTE_MSG_PRI); \
     } while (0)
 
 PRTE_EXPORT prte_oob_base_peer_t *prte_oob_base_get_peer(const pmix_proc_t *pr);

--- a/src/mca/oob/tcp/oob_tcp_connection.h
+++ b/src/mca/oob/tcp/oob_tcp_connection.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,7 +61,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_conn_op_t);
                             __FILE__, __LINE__, PRTE_NAME_PRINT((&(p)->name)));             \
         cop = PMIX_NEW(prte_oob_tcp_conn_op_t);                                             \
         cop->peer = (p);                                                                    \
-        PMIX_THREADSHIFT(cop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                     \
+        PRTE_PMIX_THREADSHIFT(cop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                     \
     } while (0);
 
 #define PRTE_ACTIVATE_TCP_ACCEPT_STATE(s, a, cbfunc)                               \

--- a/src/mca/oob/tcp/oob_tcp_peer.h
+++ b/src/mca/oob/tcp/oob_tcp_peer.h
@@ -17,7 +17,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,7 +86,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_peer_op_t);
         prte_oob_tcp_peer_op_t *pop;                                    \
         pop = PMIX_NEW(prte_oob_tcp_peer_op_t);                         \
         PMIX_XFER_PROCID(&pop->peer, &(p)->name);                       \
-        PMIX_THREADSHIFT(pop, prte_event_base, (cbfunc), PRTE_MSG_PRI); \
+        PRTE_PMIX_THREADSHIFT(pop, prte_event_base, (cbfunc), PRTE_MSG_PRI); \
     } while (0);
 
 #endif /* _MCA_OOB_TCP_PEER_H_ */

--- a/src/mca/oob/tcp/oob_tcp_sendrecv.h
+++ b/src/mca/oob/tcp/oob_tcp_sendrecv.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -86,7 +86,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
     do {                                                                              \
         (s)->peer = (struct prte_oob_tcp_peer_t *) (p);                               \
         (s)->activate = (f);                                                          \
-        PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg, PRTE_MSG_PRI); \
+        PRTE_PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg, PRTE_MSG_PRI); \
     } while (0)
 
 /* queue a message to be sent by one of our modules - must
@@ -201,7 +201,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_op_t);
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((ms)->dst)));               \
         mop = PMIX_NEW(prte_oob_tcp_msg_op_t);                                                \
         mop->msg = (ms);                                                                      \
-        PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                       \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                       \
     } while (0);
 
 typedef struct {
@@ -243,7 +243,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_error_t);
         }                                                                                          \
         PMIX_XFER_PROCID(&mop->hop, (h));                                                          \
         /* this goes to the OOB framework, so use that event base */                               \
-        PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                            \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                            \
     } while (0)
 
 #define PRTE_ACTIVATE_TCP_NO_ROUTE(r, h, c)                                                       \
@@ -257,7 +257,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_error_t);
         PMIX_XFER_PROCID(&mop->hop, (h));                                                         \
         /* this goes to the component, so use the framework                                       \
          * event base */                                                                          \
-        PMIX_THREADSHIFT(mop, prte_event_base, (c), PRTE_MSG_PRI);                                \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (c), PRTE_MSG_PRI);                                \
     } while (0)
 
 #endif /* _MCA_OOB_TCP_SENDRECV_H_ */

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -80,7 +80,7 @@ void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t stat
                 caddy->job_state = state;
                 PMIX_RETAIN(jdata);
             }
-            PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
             return;
         }
     }
@@ -109,7 +109,7 @@ void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t stat
         PMIX_RETAIN(jdata);
     }
     PRTE_REACHING_JOB_STATE(jdata, state, s->priority);
-    PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
 }
 
 int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cbfunc, int priority)
@@ -237,7 +237,7 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
             caddy = PMIX_NEW(prte_state_caddy_t);
             caddy->name = *proc;
             caddy->proc_state = state;
-            PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
             return;
         }
     }
@@ -262,7 +262,7 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
     caddy->name = *proc;
     caddy->proc_state = state;
     PRTE_REACHING_PROC_STATE(proc, state, s->priority);
-    PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
 }
 
 int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t cbfunc,

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -86,7 +86,7 @@ pmix_status_t pmix_server_client_connected_fn(const pmix_proc_t *proc, void *ser
 {
     /* need to thread-shift this request as we are going
      * to access our global list of registered events */
-    PRTE_PMIX_THREADSHIFT(proc, server_object, PRTE_SUCCESS,
+    PRTE_SERVER_PMIX_THREADSHIFT(proc, server_object, PRTE_SUCCESS,
                           NULL, NULL, 0, _client_conn,
                           cbfunc, cbdata);
     return PRTE_SUCCESS;
@@ -118,7 +118,7 @@ pmix_status_t pmix_server_client_finalized_fn(const pmix_proc_t *proc, void *ser
 {
     /* need to thread-shift this request as we are going
      * to access our global list of registered events */
-    PRTE_PMIX_THREADSHIFT(proc, server_object, PRTE_SUCCESS,
+    PRTE_SERVER_PMIX_THREADSHIFT(proc, server_object, PRTE_SUCCESS,
                           NULL, NULL, 0, _client_finalized,
                           cbfunc, cbdata);
     return PRTE_SUCCESS;
@@ -151,7 +151,7 @@ pmix_status_t pmix_server_abort_fn(const pmix_proc_t *proc, void *server_object,
 {
     /* need to thread-shift this request as we are going
      * to access our global list of registered events */
-    PRTE_PMIX_THREADSHIFT(proc, server_object, status, msg, procs, nprocs, _client_abort, cbfunc,
+    PRTE_SERVER_PMIX_THREADSHIFT(proc, server_object, status, msg, procs, nprocs, _client_abort, cbfunc,
                           cbdata);
     return PRTE_SUCCESS;
 }
@@ -784,7 +784,7 @@ done:
     /* we cannot directly execute the callback here
      * as it would threadlock - so shift to somewhere
      * safe */
-    PRTE_PMIX_THREADSHIFT(PRTE_NAME_WILDCARD, NULL, rc, NULL, NULL, 0, lgcbfn, cbfunc, cbdata);
+    PRTE_SERVER_PMIX_THREADSHIFT(PRTE_NAME_WILDCARD, NULL, rc, NULL, NULL, 0, lgcbfn, cbfunc, cbdata);
 }
 
 pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_proc_t targets[],

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -200,7 +200,7 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);
 
-#define PRTE_PMIX_THREADSHIFT(p, s, st, m, pl, pn, fn, cf, cb)                     \
+#define PRTE_SERVER_PMIX_THREADSHIFT(p, s, st, m, pl, pn, fn, cf, cb)                     \
     do {                                                                           \
         prte_pmix_server_op_caddy_t *_cd;                                          \
         _cd = PMIX_NEW(prte_pmix_server_op_caddy_t);                               \

--- a/src/rml/rml_recv.c
+++ b/src/rml/rml_recv.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@ void prte_rml_recv_buffer_nb(pmix_proc_t *peer,
     req->post->persistent = persistent;
     req->post->cbfunc = cbfunc;
     req->post->cbdata = cbdata;
-    PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
+    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
 }
 void prte_rml_recv_cancel(pmix_proc_t *peer, prte_rml_tag_t tag)
 {
@@ -90,5 +90,5 @@ void prte_rml_recv_cancel(pmix_proc_t *peer, prte_rml_tag_t tag)
     req->cancel = true;
     PMIX_XFER_PROCID(&req->post->peer, peer);
     req->post->tag = tag;
-    PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
+    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
 }

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -70,6 +70,7 @@
 #include "src/mca/odls/base/base.h"
 #include "src/mca/oob/base/base.h"
 #include "src/mca/plm/base/base.h"
+#include "src/mca/pmdl/base/base.h"
 #include "src/mca/prtebacktrace/base/base.h"
 #include "src/mca/prteinstalldirs/base/base.h"
 #include "src/mca/ras/base/base.h"
@@ -468,9 +469,9 @@ static void preload_default_mca_params(void)
 
     /* now process the final list - but do not overwrite if the
      * user already has the param in our environment as their
-     * environment settings override all defaults*/
+     * environment settings override all defaults */
     PMIX_LIST_FOREACH(fv, &pfinal, pmix_mca_base_var_file_value_t) {
-        if (prte_schizo_base_check_prte_param(fv->mbvfv_var)) {
+        if (pmix_pmdl_base_check_prte_param(fv->mbvfv_var)) {
             pmix_asprintf(&tmp, "PRTE_MCA_%s", fv->mbvfv_var);
             // set it, but don't overwrite if they already
             // have a value in our environment
@@ -480,7 +481,7 @@ static void preload_default_mca_params(void)
             // or mca frameworks, then we also need to set
             // the equivalent PMIx value
             check_pmix_overlap(fv->mbvfv_var, fv->mbvfv_value);
-        } else if (prte_schizo_base_check_pmix_param(fv->mbvfv_var)) {
+        } else if (pmix_pmdl_base_check_pmix_param(fv->mbvfv_var)) {
             pmix_asprintf(&tmp, "PMIX_MCA_%s", fv->mbvfv_var);
             // set it, but don't overwrite if they already
             // have a value in our environment

--- a/src/runtime/prte_wait.c
+++ b/src/runtime/prte_wait.c
@@ -15,7 +15,7 @@
  *                         et Automatique. All rights reserved.
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -216,7 +216,7 @@ void prte_wait_cb_cancel(prte_proc_t *child)
     trk = PMIX_NEW(prte_wait_tracker_t);
     PMIX_RETAIN(child); // protect against race conditions
     trk->child = child;
-    PMIX_THREADSHIFT(trk, prte_event_base, cancel_callback, PRTE_SYS_PRI);
+    PRTE_PMIX_THREADSHIFT(trk, prte_event_base, cancel_callback, PRTE_SYS_PRI);
 }
 
 /* callback from the event library whenever a SIGCHLD is received */


### PR DESCRIPTION
PMIx now provides a utility to check param names
for their associated project - use it. Cleanup
redefinition of PMIX_THREADSHIFT