### PR TITLE
.github/workflows: update actions versions

### DIFF
--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -23,6 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.0
+        uses: open-mpi/pr-git-commit-checker@v1.0.1
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/run-special.yml
+++ b/.github/workflows/run-special.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out the code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       # Run the container tester


### PR DESCRIPTION
Update all Open MPI GitHub Actions scripts to v1.0.1, and update Github-provided actions to newer versions, too. This will squelch warnings that we get about using outdated Node.js versions.