### PR TITLE
Protect against HWLOC v3 and above

### DIFF
--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
 # Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -93,18 +93,33 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
            prte_have_topology_dup=1],
           [AC_MSG_RESULT([no])])
 
-    AC_MSG_CHECKING([if hwloc version is 2.0 or greater])
+    AC_MSG_CHECKING([if hwloc version is at least 2.0])
     AC_COMPILE_IFELSE(
           [AC_LANG_PROGRAM([#include <hwloc.h>],
           [[
     #if HWLOC_VERSION_MAJOR < 2
-    #error "hwloc version is less than 2.x"
+    #error "hwloc version is less than 2.0"
     #endif
           ]])],
           [AC_MSG_RESULT([yes])
            prte_version_high=1],
           [AC_MSG_RESULT([no])
            prte_version_high=0])
+
+    AC_MSG_CHECKING([if hwloc version is greater than 2.x])
+    AC_COMPILE_IFELSE(
+          [AC_LANG_PROGRAM([#include <hwloc.h>],
+          [[
+    #if HWLOC_VERSION_MAJOR > 2
+    #error "hwloc version is greater than 2.x"
+    #endif
+          ]])],
+          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([yes])
+           AC_MSG_WARN([This PRRTE version does not support HWLOC])
+           AC_MSG_WARN([versions 3.x or higher. Please direct us])
+           AC_MSG_WARN([to an HWLOC version in the 1.11-2.x range.])
+           AC_MSG_ERROR([Cannot continue])])
 
     CPPFLAGS=$prte_check_hwloc_save_CPPFLAGS
     LDFLAGS=$prte_check_hwloc_save_LDFLAGS


### PR DESCRIPTION
We currently only support HWLOC v1.11-2.x, so
error out during configure if something higher
is provided.