### PR TITLE
Allow --add-host to modify slot allocations of existing nodes

### DIFF
--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -284,6 +284,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "NODE-HOSTID";
         case PRTE_NODE_SERIAL_NUMBER:
             return "NODE-SERIAL-NUM";
+        case PRTE_NODE_ADD_SLOTS:
+            return "NODE-ADD-SLOTS";
 
         case PRTE_JOB_LAUNCH_MSG_SENT:
             return "JOB-LAUNCH-MSG-SENT";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -83,6 +83,7 @@ typedef uint8_t prte_node_flags_t;
                                                           // we need to know the id of our "host" to help any procs on us to determine locality
 #define PRTE_NODE_SERIAL_NUMBER (PRTE_NODE_START_KEY + 5) // string - serial number: used if node is a coprocessor
 #define PRTE_NODE_PORT          (PRTE_NODE_START_KEY + 6) // int32 - Alternate port to be passed to plm
+#define PRTE_NODE_ADD_SLOTS     (PRTE_NODE_START_KEY + 7) // bool - slots are being added to existing node
 
 #define PRTE_NODE_MAX_KEY (PRTE_NODE_START_KEY + 100)
 

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -117,6 +117,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
     char *cptr;
     char *shortname;
     char *rawname;
+    bool add_slots = false;
 
     PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                          "%s dashhost: parsing args %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
@@ -263,6 +264,10 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                 slots_given = false;
             } else {
                 slots = strtol(cptr, NULL, 10);
+                if ('+' == *cptr || '-' == *cptr) {
+                    // mark that we are being asked to increase/decrease #slots
+                    add_slots = true;
+                }
                 slots_given = true;
             }
         }
@@ -295,6 +300,10 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             if (slots_given) {
                 node->slots += slots;
                 PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+                if (add_slots) {
+                    prte_set_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS,
+                                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                }
             } else if (slots < 0) {
                 node->slots = 0;
                 PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
@@ -344,6 +353,10 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             if (slots_given) {
                 node->slots = slots;
                 PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+                if (add_slots) {
+                    prte_set_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS,
+                                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                }
             } else if (slots < 0) {
                 node->slots = 0;
                 PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);


### PR DESCRIPTION
The --add-host option can already add hosts to an existing allocation, with the number of slots for the new host set to the given value (e.g., `--add-host nodeC:5`). Extend that feature to allow adjustment of the number of slots for existing nodes:
```
--add-host nodeA:+5
```
to add five slots to nodeA, or
```
--add-host nodeB:-3
```
to subtract three slots from nodeB.