### PR TITLE
docs: fix HTML word wapping in table cells

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,3 +191,16 @@ rst_prolog = f"""
 .. |flex_min_version| replace:: {flex_min_version}
 
 """
+
+# The sphinx_rtd_theme does not properly handle wrapping long lines in
+# table cells when rendering to HTML due to a CSS issue (see
+# https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).  Until
+# the issue is fixed upstream in sphinx_rtd_theme, we can simply
+# override the CSS here.
+rst_prolog += """
+.. raw:: html
+
+   <style>
+   .wy-table-responsive table td,.wy-table-responsive table th{white-space:normal}
+   </style>
+"""


### PR DESCRIPTION
The sphinx_rtd_theme does not properly handle wrapping long lines in table cells when rendering to HTML due to a CSS issue (see https://github.com/readthedocs/sphinx_rtd_theme/issues/1505).

Until the issue is fixed upstream in sphinx_rtd_theme, we can simply override the CSS here (in conf.py).

The PRRTE docs don't use the RST ".. list-table::" directive much, so this change won't really have much of an effect here.  However, OMPI and PMIx were updated with this conf.py change, so we might as well keep all 3 projects more-or-less in sync.