### PR TITLE
Fix binding to multiple pe's

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -346,7 +346,7 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
 #endif
             hwloc_bitmap_and(prte_rmaps_base.available, prte_rmaps_base.available, node->available);
             ncpus = hwloc_get_nbobjs_inside_cpuset_by_type(node->topology->topo, prte_rmaps_base.available, type);
-            if (ncpus > options->cpus_per_rank) {
+            if (ncpus >= options->cpus_per_rank) {
                 /* this is a good spot */
                 moveon = true;
                 break;


### PR DESCRIPTION
Accept a package if it has enough pe's to satisfy
the binding - do not require that it have _more_
than required.

Thanks to Jakub Benda for the report and the fix!

Fixes #1780 