### PR TITLE
Fix typos in the --enable-dlopen support

### DIFF
--- a/config/prte_mca.m4
+++ b/config/prte_mca.m4
@@ -14,7 +14,7 @@ dnl Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2019      Research Organization for Information Science
 dnl                         and Technology (RIST).  All rights reserved.
-dnl Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -112,7 +112,7 @@ AC_DEFUN([PRTE_MCA],[
     if test "$enable_static" != "no"; then
         DSO_all=0
         msg="none (static libraries built)"
-    elif test "$PRRTE_ENABLE_DLOPEN_SUPPORT" = 0; then
+    elif test "$PRTE_ENABLE_DLOPEN_SUPPORT" = 0; then
         DSO_all=0
         msg="none (dlopen disabled)"
     elif test -z "$enable_mca_dso"; then

--- a/src/mca/prtedl/configure.m4
+++ b/src/mca/prtedl/configure.m4
@@ -2,6 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -21,26 +22,26 @@ m4_define(MCA_prte_prtedl_CONFIGURE_MODE, STOP_AT_FIRST)
 AC_DEFUN([MCA_prte_prtedl_CONFIG],[
     PRTE_HAVE_DL_SUPPORT=0
 
-    # If --disable-prtedlopen was used, then have all the components fail
+    # If --disable-dlopen was used, then have all the components fail
     # (we still need to configure them all so that things like "make
     # dist" work", but we just want the MCA system to (artificially)
     # conclude that it can't build any of the components.
-    AS_IF([test "$enable_prtedlopen" = "no"],
+    AS_IF([test $PRTE_ENABLE_DLOPEN_SUPPORT -eq 0],
           [want_prtedl=0], [want_prtedl=1])
 
     MCA_CONFIGURE_FRAMEWORK([prtedl], [$want_prtedl])
 
-    # If we found no suitable static prtedl component and prtedlopen support
+    # If we found no suitable static prtedl component and dlopen support
     # was not specifically disabled, this is an error.
     AS_IF([test "$MCA_prte_prtedl_STATIC_COMPONENTS" = "" && \
-           test "$enable_prtedlopen" != "no"],
+           test "$enable_dlopen" != "no"],
           [AC_MSG_WARN([Did not find a suitable static prte prtedl component])
            AC_MSG_WARN([You might need to install libltld (and its headers) or])
-           AC_MSG_WARN([specify --disable-prtedlopen to configure.])
+           AC_MSG_WARN([specify --disable-dlopen to configure.])
            AC_MSG_ERROR([Cannot continue])])
 
     # If we have a winning component (which, per above, will only
-    # happen if --disable-prtedlopen was *not* specified), do some more
+    # happen if --disable-dlopen was *not* specified), do some more
     # logic.
     AS_IF([test "$MCA_prte_prtedl_STATIC_COMPONENTS" != ""],
        [ # We had a winner -- w00t!

--- a/src/mca/prtedl/dlopen/configure.m4
+++ b/src/mca/prtedl/dlopen/configure.m4
@@ -5,6 +5,7 @@
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +24,19 @@ AC_DEFUN([MCA_prte_prtedl_dlopen_COMPILE_MODE], [
     AC_MSG_RESULT([$$3])
 ])
 
+# MCA_prte_prtedl_pdlopen_POST_CONFIG()
+# ---------------------------------
+AC_DEFUN([MCA_prte_prtedl_pdlopen_POST_CONFIG],[
+    # If we won, then do all the rest of the setup
+    AS_IF([test "$1" = "1"],
+          [
+           # Add some stuff to CPPFLAGS so that the rest of the source
+           # tree can be built
+           LDFLAGS="$LDFLAGS $prte_prtedl_pdlopen_ADD_LDFLAGS"
+           LIBS="$LIBS $prte_prtedl_pdlopen_ADD_LIBS"
+          ])
+])dnl
+
 # MCA_prtedl_dlopen_CONFIG([action-if-can-compile],
 #                      [action-if-cant-compile])
 # ------------------------------------------------
@@ -31,13 +45,13 @@ AC_DEFUN([MCA_prte_prtedl_dlopen_CONFIG],[
 
     dnl This is effectively a back-door for PRTE developers to
     dnl force the use of the libltprtedl prtedl component.
-    AC_ARG_ENABLE([prtedl-dlopen],
-        [AS_HELP_STRING([--disable-prtedl-dlopen],
-            [Disable the "dlopen" PRTE DL component (and probably force the use of the "libltdl" DL component).  This option should really only be used by PRTE developers.  You are probably actually looking for the "--disable-prtedlopen" option, which disables all dlopen-like functionality from PRTE.])
+    AC_ARG_ENABLE([prte-dlopen],
+        [AS_HELP_STRING([--disable-prte-dlopen],
+            [Disable the "dlopen" PRTE DL component (and probably force the use of the "libltdl" DL component).  This option should really only be used by PRTE developers.  You are probably actually looking for the "--disable-dlopen" option, which disables all dlopen-like functionality from PRTE.])
         ])
 
-    prte_prtedl_prtedlopen_happy=no
-    AS_IF([test "$enable_prtedl_prtedlopen" != "no"],
+    prte_prtedl_dlopen_happy=no
+    AS_IF([test "$enable_prte_dlopen" != "no"],
           [OAC_CHECK_PACKAGE([dlopen],
               [prte_prtedl_dlopen],
               [dlfcn.h],

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +57,7 @@ static int dlopen_open(const char *fname, bool use_ext, bool private_namespace,
 
     *handle = NULL;
 
-    /* Setup the prtedlopen flags */
+    /* Setup the dlopen flags */
     int flags = RTLD_LAZY;
     if (private_namespace) {
         flags |= RTLD_LOCAL;
@@ -95,8 +95,8 @@ static int dlopen_open(const char *fname, bool use_ext, bool private_namespace,
                 continue;
             }
 
-            /* Yes, the file exists -- try to prtedlopen it.  If we can't
-               prtedlopen it, bail. */
+            /* Yes, the file exists -- try to dlopen it.  If we can't
+               dlopen it, bail. */
             do_dlopen(name, flags, &local_handle, err_msg);
             free(name);
             break;

--- a/src/mca/prtedl/libltdl/configure.m4
+++ b/src/mca/prtedl/libltdl/configure.m4
@@ -3,7 +3,7 @@
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 #
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -58,7 +58,7 @@ AC_DEFUN([MCA_prte_prtedl_libltdl_CONFIG],[
                   [prte_prtedl_libltdl],
                   [ltprtedl.h],
                   [ltprtedl],
-                  [lt_prtedlopen],
+                  [lt_dlopen],
                   [prte_prtedl_libltdl_happy=yes],
                   [prte_prtedl_libltdl_happy=no])
               ])

--- a/src/mca/prtedl/prtedl.h
+++ b/src/mca/prtedl/prtedl.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -19,7 +19,7 @@
  *
  * General Description:
  *
- * This framework provides portable access to prtedlopen- and prtedlsym-like
+ * This framework provides portable access to dlopen- and prtedlsym-like
  * functionality, very similar to Libtool's libltprtedl.  Indeed, one of
  * the components in this framework will use libltprtedl, if it is
  * present/available.  However, on some common types systems where
@@ -41,7 +41,7 @@
  * https://github.com/open-mpi/ompi/pull/390).  That being said, we,
  * as a developer community, still wanted to be able to natively use
  * DSOs by default.  A small/simple framework for DL functionality,
- * along with a simple component that supports prtedlopen/prtedlsym on POSIX
+ * along with a simple component that supports dlopen/prtedlsym on POSIX
  * platforms and another component that natively uses libltprtedl seemed
  * like a good solution.
  */


### PR DESCRIPTION
Confusion over calling it prtedlopen vs dlopen.

Ref: https://github.com/open-mpi/ompi/issues/11886

Thanks to Jakub Benda for the report