### PR TITLE
Cleanups in the psched daemon

### DIFF
--- a/src/tools/psched/psched.c
+++ b/src/tools/psched/psched.c
@@ -334,6 +334,7 @@ int main(int argc, char *argv[])
                        "event base open", PRTE_ERROR_NAME(ret), ret);
         return ret;
     }
+
     /* setup an event to attempt normal termination on signal */
     prte_event_set(prte_event_base, &term_handler, term_pipe[0], PRTE_EV_READ, clean_abort, NULL);
     prte_event_add(&term_handler, NULL);
@@ -413,6 +414,7 @@ int main(int argc, char *argv[])
     pmix_pointer_array_init(prte_cache, 1, INT_MAX, 1);
 
     /* setup the SCHIZO module */
+    psched_schizo_init();
     schizo = &psched_schizo_module;
 
     /* parse the CLI to load the MCA params */
@@ -442,7 +444,8 @@ int main(int argc, char *argv[])
         prte_debug_flag = true;
     }
     // leave_session_attached is used to indicate that we are not to daemonize
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_LEAVE_SESSION_ATTACHED)) {
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_LEAVE_SESSION_ATTACHED) ||
+        pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG)) {
         prte_leave_session_attached = true;
     }
 
@@ -577,6 +580,9 @@ int main(int argc, char *argv[])
         pmix_output(0, "%s", output);
         free(output);
     }
+
+    // setup the scheduler itself
+    psched_scheduler_init();
 
     /* output a message indicating we are alive, our name, and our pid
      * for debugging purposes

--- a/src/tools/psched/psched.h
+++ b/src/tools/psched/psched.h
@@ -41,10 +41,12 @@ typedef struct {
     bool controller_connected;
     int verbosity;
     int output;
+    int scheduler_output;
 } psched_globals_t;
 
 extern psched_globals_t psched_globals;
 
+void psched_schizo_init(void);
 void psched_state_init(void);
 void psched_errmgr_init(void);
 int psched_server_init(void);

--- a/src/tools/psched/scheduler.c
+++ b/src/tools/psched/scheduler.c
@@ -21,11 +21,30 @@
 #include <string.h>
 
 #include "src/pmix/pmix-internal.h"
+#include "src/mca/base/pmix_mca_base_var.h"
 
 #include "src/tools/psched/psched.h"
 
+static int sched_base_verbose = -1;
 void psched_scheduler_init(void)
 {
+    pmix_output_stream_t lds;
+
+    pmix_mca_base_var_register("prte", "scheduler", "base", "verbose",
+                               "Verbosity for debugging scheduler operations",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &sched_base_verbose);
+    if (0 <= sched_base_verbose) {
+        PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
+        lds.lds_want_stdout = true;
+        psched_globals.scheduler_output = pmix_output_open(&lds);
+        PMIX_DESTRUCT(&lds);
+        pmix_output_set_verbosity(psched_globals.scheduler_output, sched_base_verbose);
+    }
+
+    pmix_output_verbose(2, psched_globals.scheduler_output,
+                        "%s scheduler:psched: initialize",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
     return;
 }
 

--- a/src/tools/psched/schizo.c
+++ b/src/tools/psched/schizo.c
@@ -120,6 +120,28 @@ static struct option pschedoptions[] = {
 };
 static char *pschedshorts = "h::vVx:H:";
 
+static int schizo_base_verbose = -1;
+void psched_schizo_init(void)
+{
+    pmix_output_stream_t lds;
+
+    pmix_mca_base_var_register("prte", "schizo", "base", "verbose",
+                               "Verbosity for debugging schizo framework",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &schizo_base_verbose);
+    if (0 <= schizo_base_verbose) {
+        PMIX_CONSTRUCT(&lds, pmix_output_stream_t);
+        lds.lds_want_stdout = true;
+        prte_schizo_base_framework.framework_output = pmix_output_open(&lds);
+        PMIX_DESTRUCT(&lds);
+        pmix_output_set_verbosity(prte_schizo_base_framework.framework_output, schizo_base_verbose);
+    }
+
+    pmix_output_verbose(2, prte_schizo_base_framework.framework_output,
+                        "%s schizo:psched: initialize",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+}
+
 static int parse_cli(char **argv, pmix_cli_result_t *results,
                      bool silent)
 {

--- a/src/tools/psched/server.c
+++ b/src/tools/psched/server.c
@@ -208,7 +208,6 @@ static prte_regattr_input_t prte_attributes[] = {
     {.function = ""},
 };
 
-static char *generate_dist = "fabric,gpu,network";
 void psched_register_params(void)
 {
     /* register a verbosity */
@@ -219,6 +218,9 @@ void psched_register_params(void)
     if (0 <= psched_globals.verbosity) {
         psched_globals.output = pmix_output_open(NULL);
         pmix_output_set_verbosity(psched_globals.output,
+                                  psched_globals.verbosity);
+        prte_pmix_server_globals.output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(prte_pmix_server_globals.output,
                                   psched_globals.verbosity);
     }
 
@@ -294,6 +296,12 @@ int psched_server_init(void)
     pmix_pointer_array_init(&psched_globals.requests, 128, INT_MAX, 2);
     PMIX_CONSTRUCT(&psched_globals.tools, pmix_list_t);
     psched_globals.syscontroller = *PRTE_NAME_INVALID;
+
+    psched_register_params();
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s server:psched: initialize",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     PMIX_INFO_LIST_START(ilist);
 


### PR DESCRIPTION
Ensure we can still set framework verbose levels
for areas where we have custom modules that exist
outside the typical framework location.