### PR TITLE
Blacklist the HWLOC GL component to avoid deadlock

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1878,6 +1878,14 @@ int prte_hwloc_base_topology_set_flags(hwloc_topology_t topology, unsigned long 
 #    endif
 #endif
     }
+    // Blacklist the "gl" component due to potential conflicts.
+    // See "https://github.com/open-mpi/ompi/issues/10025" for
+    // an explanation
+#if HWLOC_VERSION_MAJOR > 2
+    hwloc_topology_set_components(topology, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#elif HWLOC_VERSION_MAJOR == 2 && HWLOC_VERSION_MINOR >= 1
+    hwloc_topology_set_components(topology, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#endif
     return hwloc_topology_set_flags(topology, flags);
 }
 


### PR DESCRIPTION
See https://github.com/open-mpi/ompi/issues/10025
for an explanation of the problem.

Thanks to @bgoglin for the assistance.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit b8ee2c5c47a196133460d63a4412d09ca125cfc7)