### PR TITLE
Update VERSION and rename news file

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -22,7 +22,7 @@ release=0
 # PRRTE required dependency versions.
 # List in x.y.z format.
 
-pmix_min_version=4.1.2
+pmix_min_version=4.2.4
 hwloc_min_version=1.11.0
 event_min_version=2.0.21
 automake_min_version=1.13.4

--- a/docs/news/index.rst
+++ b/docs/news/index.rst
@@ -35,6 +35,6 @@ included in the vX.Y.Z section and be denoted as:
 .. toctree::
    :maxdepth: 1
 
-   news-v3.x
+   news-v3.0
    news-v2.x
    news-v1.x

--- a/docs/news/news-v3.0.rst
+++ b/docs/news/news-v3.0.rst
@@ -1,7 +1,7 @@
 PRRTE v3.x series
 =================
 
-This file contains all the NEWS updates for the PRRTE v3.x
+This file contains all the NEWS updates for the PRRTE v3.0
 series, in reverse chronological order.
 
 3.0.1 -- 27 Sep 2023


### PR DESCRIPTION
Update VERSION to show min PMIx as v4.2.4 per the
configuration check. Rename news-v3.x.rst to
news-v3.0.rst to avoid confusion with the v3.1
series to come out in the near future.