### PR TITLE
PMIx minimum versions

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -20,6 +20,7 @@
 # Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -77,16 +78,24 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
 
     # if the version file exists, then we need to parse it to find
     # the actual release series
-    AC_MSG_CHECKING([version at or above v4.2.4])
+    # NOTE: We have already read PRRTE's VERSION file, so we can use
+    # $pmix_min_version.
+    AC_MSG_CHECKING([version at or above v$pmix_min_version])
+    # Convert a.b.c to hex for comparison to the PMIX_NUMERIC_VERSION
+    # C macro
+    pmix_min_major=`echo $pmix_min_version | cut -d. -f1`
+    pmix_min_minor=`echo $pmix_min_version | cut -d. -f2`
+    pmix_min_release=`echo $pmix_min_version | cut -d. -f3`
+    pmix_min_version_hex=`printf "0x%02x%02x%02x" $pmix_min_major $pmix_min_minor $pmix_min_release`
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
                                         #include <pmix_version.h>
-                                        #if (PMIX_NUMERIC_VERSION < 0x00040204)
-                                        #error "not version 4.2.4 or above"
+                                        #if (PMIX_NUMERIC_VERSION < $pmix_min_version_hex)
+                                        #error "not version $pmix_min_version or above"
                                         #endif
                                        ], [])],
                       [AC_MSG_RESULT([yes])],
                       [AC_MSG_RESULT(no)
-                       AC_MSG_WARN([PRRTE requires PMIx v4.2.4 or above.])
+                       AC_MSG_WARN([PRRTE requires PMIx v$pmix_min_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_CHECK_HEADER([src/util/pmix_argv.h], [],

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,6 +9,18 @@ PMIx Reference RunTime Environment (PRRTE).  More information is
 available `in the FAQ section on the PRRTE web site
 <https://github.com/openpmix/prrte>`_.
 
+Minimum PMIx version
+--------------------
+
+The ``configure`` script in PRRTE |prte_ver| must be able to find an
+OpenPMIx installation that is |pmix_min_version| or higher.  If
+``configure`` cannot find a suitable OpenPMIx version, it will abort
+with an error.
+
+If OpenPMIx cannot be found in default preprocessor and linker search
+paths, you can specify the ``--with-pmix=DIR`` CLI option to tell
+``configure`` where to find it.
+
 
 Developer Builds
 ----------------


### PR DESCRIPTION
See individual commit messages for more detail:

1. Show the minimum PMIx version number in the docs.  See https://prrte--1819.org.readthedocs.build/en/1819/install.html#minimum-pmix-version for an example.
2. Have `prte_setup_pmix.m4` dynamically read the minimum PMIx version number from `VERSIONS`