### PR TITLE
Make checking min versions consistent

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -718,6 +718,61 @@ sub patch_autotools_output {
     unlink("configure.patched");
 }
 
+sub export_version {
+    my ($name,$version) = @_;
+    $version =~ s/[^a-zA-Z0-9,.]//g;
+    my @version_splits = split(/\./,$version);
+    my $hex = sprintf("0x%04x%02x%02x", $version_splits[0], $version_splits[1], $version_splits[2]);
+    $m4 .= "m4_define([PRTE_${name}_MIN_VERSION], [$version])\n";
+    $m4 .= "m4_define([PRTE_${name}_NUMERIC_MIN_VERSION], [$hex])\n";
+}
+
+sub get_and_define_min_versions() {
+
+    open(IN, "VERSION") || my_die "Can't open VERSION";
+    while (<IN>) {
+          my $line = $_;
+          my @fields = split(/=/,$line);
+          if ($fields[0] eq "automake_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_automake_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "autoconf_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_autoconf_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "libtool_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_libtool_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "pmix_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PMIX", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "hwloc_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("HWLOC", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "event_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("EVENT", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "flex_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("FLEX", $fields[1]);
+              }
+          }
+    }
+    close(IN);
+}
+
+
 ##############################################################################
 
 sub in_tarball {
@@ -910,6 +965,8 @@ my $step = 1;
 verbose "PRRTE autogen (buckle up!)
 
 $step. Checking tool versions\n\n";
+
+get_and_define_min_versions();
 
 # Check the autotools revision levels
 &find_and_check("autoconf", $prte_autoconf_search, $prte_autoconf_version);

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -134,20 +134,24 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
     fi
 
     if test $prte_libevent_support -eq 1; then
-        # Pin the "oldest supported" version to 2.0.21
-        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                           [[
-                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #endif
-                                           ]])],
-                          [AC_MSG_RESULT([yes])],
-                          [AC_MSG_RESULT([no])
-                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                           prte_libevent_support=0])
+        prte_event_min_num_version=PRTE_EVENT_NUMERIC_MIN_VERSION
+        prte_event_min_version=PRTE_EVENT_MIN_VERSION
+        AC_MSG_CHECKING([version at or above v$prte_event_min_version])
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                            #include <event2/event.h>
+#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < $prte_event_min_num_version
+#error "libevent API version is less than $prte_event_min_version"
+#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < $prte_event_min_num_version
+#error "libevent API version is less than $prte_event_min_version"
+#endif
+                                       ], [])],
+                      [prte_libevent_cv_version_check=yes
+                       AC_MSG_RESULT([yes])],
+                      [prte_libevent_cv_version_check=no
+                       AC_MSG_RESULT([no])])
+        AS_IF([test "${prte_libevent_cv_version_check}" = "no"],
+              [AC_MSG_WARN([libevent version is too old ($prte_event_min_version or later required)])
+               prte_libevent_support=0])
     fi
 
     # restore global flags

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -80,22 +80,18 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     # the actual release series
     # NOTE: We have already read PRRTE's VERSION file, so we can use
     # $pmix_min_version.
-    AC_MSG_CHECKING([version at or above v$pmix_min_version])
-    # Convert a.b.c to hex for comparison to the PMIX_NUMERIC_VERSION
-    # C macro
-    pmix_min_major=`echo $pmix_min_version | cut -d. -f1`
-    pmix_min_minor=`echo $pmix_min_version | cut -d. -f2`
-    pmix_min_release=`echo $pmix_min_version | cut -d. -f3`
-    pmix_min_version_hex=`printf "0x%02x%02x%02x" $pmix_min_major $pmix_min_minor $pmix_min_release`
+    prte_pmix_min_num_version=PRTE_PMIX_NUMERIC_MIN_VERSION
+    prte_pmix_min_version=PRTE_PMIX_MIN_VERSION
+    AC_MSG_CHECKING([version at or above v$prte_pmix_min_version])
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
                                         #include <pmix_version.h>
-                                        #if (PMIX_NUMERIC_VERSION < $pmix_min_version_hex)
-                                        #error "not version $pmix_min_version or above"
+                                        #if (PMIX_NUMERIC_VERSION < $prte_pmix_min_num_version)
+                                        #error "not version $prte_pmix_min_num_version or above"
                                         #endif
                                        ], [])],
                       [AC_MSG_RESULT([yes])],
                       [AC_MSG_RESULT(no)
-                       AC_MSG_WARN([PRRTE requires PMIx v$pmix_min_version or above.])
+                       AC_MSG_WARN([PRRTE requires PMIx v$prte_pmix_min_num_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_CHECK_HEADER([src/util/pmix_argv.h], [],


### PR DESCRIPTION
We have three dependent libraries we care about, and minimum version requirements on all of them. Let's connect them all to the min values in the VERSION file and "standardize" the check configure code to make it easier to understand and maintain.

Also, since we require a min HWLOC version of 1.11, there is no longer a need to check for at least 1.8 so we know we have hwloc_topology_dup.