### PR TITLE
Multiple commits

### DIFF
--- a/autogen.pl
+++ b/autogen.pl
@@ -718,6 +718,61 @@ sub patch_autotools_output {
     unlink("configure.patched");
 }
 
+sub export_version {
+    my ($name,$version) = @_;
+    $version =~ s/[^a-zA-Z0-9,.]//g;
+    my @version_splits = split(/\./,$version);
+    my $hex = sprintf("0x%04x%02x%02x", $version_splits[0], $version_splits[1], $version_splits[2]);
+    $m4 .= "m4_define([PRTE_${name}_MIN_VERSION], [$version])\n";
+    $m4 .= "m4_define([PRTE_${name}_NUMERIC_MIN_VERSION], [$hex])\n";
+}
+
+sub get_and_define_min_versions() {
+
+    open(IN, "VERSION") || my_die "Can't open VERSION";
+    while (<IN>) {
+          my $line = $_;
+          my @fields = split(/=/,$line);
+          if ($fields[0] eq "automake_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_automake_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "autoconf_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_autoconf_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "libtool_min_version") {
+              if ($fields[1] ne "\n") {
+                  $prte_libtool_version = $fields[1];
+              }
+          }
+          elsif($fields[0] eq "pmix_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PMIX", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "hwloc_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("HWLOC", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "event_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("EVENT", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "flex_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("FLEX", $fields[1]);
+              }
+          }
+    }
+    close(IN);
+}
+
+
 ##############################################################################
 
 sub in_tarball {
@@ -910,6 +965,8 @@ my $step = 1;
 verbose "PRRTE autogen (buckle up!)
 
 $step. Checking tool versions\n\n";
+
+get_and_define_min_versions();
 
 # Check the autotools revision levels
 &find_and_check("autoconf", $prte_autoconf_search, $prte_autoconf_version);

--- a/config/prte_setup_hwloc.m4
+++ b/config/prte_setup_hwloc.m4
@@ -63,6 +63,9 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
         AC_MSG_ERROR([Cannot continue.])
     fi
 
+    # update global flags to test for HWLOC version
+    PRTE_FLAGS_PREPEND_UNIQ([CPPFLAGS], [$prte_hwloc_CPPFLAGS])
+
     # NOTE: We have already read PRRTE's VERSION file, so we can use
     # those values
     prte_hwloc_min_num_version=PRTE_HWLOC_NUMERIC_MIN_VERSION
@@ -92,6 +95,9 @@ AC_DEFUN([PRTE_SETUP_HWLOC],[
                        AC_MSG_WARN([versions 3.x or higher. Please direct us])
                        AC_MSG_WARN([to an HWLOC version in the $prte_hwloc_min_version-2.x range.])
                        AC_MSG_ERROR([Cannot continue])])
+
+    # reset global flags
+    CPPFLAGS=$prte_check_hwloc_save_CPPFLAGS
 
     PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_CPPFLAGS], [$prte_hwloc_CPPFLAGS])
     PRTE_FLAGS_APPEND_UNIQ([PRTE_FINAL_LDFLAGS], [$prte_hwloc_LDFLAGS])

--- a/config/prte_setup_libevent.m4
+++ b/config/prte_setup_libevent.m4
@@ -6,7 +6,7 @@
 # Copyright (c) 2017-2019 Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2020      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
 # $COPYRIGHT$
@@ -134,20 +134,24 @@ AC_DEFUN([PRTE_LIBEVENT_CONFIG],[
     fi
 
     if test $prte_libevent_support -eq 1; then
-        # Pin the "oldest supported" version to 2.0.21
-        AC_MSG_CHECKING([if libevent version is 2.0.21 or greater])
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <event2/event.h>]],
-                                           [[
-                                             #if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < 0x02001500
-                                             #error "libevent API version is less than 0x02001500"
-                                             #endif
-                                           ]])],
-                          [AC_MSG_RESULT([yes])],
-                          [AC_MSG_RESULT([no])
-                           AC_MSG_WARN([libevent version is too old (2.0.21 or later required)])
-                           prte_libevent_support=0])
+        prte_event_min_num_version=PRTE_EVENT_NUMERIC_MIN_VERSION
+        prte_event_min_version=PRTE_EVENT_MIN_VERSION
+        AC_MSG_CHECKING([version at or above v$prte_event_min_version])
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                            #include <event2/event.h>
+#if defined(_EVENT_NUMERIC_VERSION) && _EVENT_NUMERIC_VERSION < $prte_event_min_num_version
+#error "libevent API version is less than $prte_event_min_version"
+#elif defined(EVENT__NUMERIC_VERSION) && EVENT__NUMERIC_VERSION < $prte_event_min_num_version
+#error "libevent API version is less than $prte_event_min_version"
+#endif
+                                       ], [])],
+                      [prte_libevent_cv_version_check=yes
+                       AC_MSG_RESULT([yes])],
+                      [prte_libevent_cv_version_check=no
+                       AC_MSG_RESULT([no])])
+        AS_IF([test "${prte_libevent_cv_version_check}" = "no"],
+              [AC_MSG_WARN([libevent version is too old ($prte_event_min_version or later required)])
+               prte_libevent_support=0])
     fi
 
     # restore global flags

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -80,22 +80,18 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     # the actual release series
     # NOTE: We have already read PRRTE's VERSION file, so we can use
     # $pmix_min_version.
-    AC_MSG_CHECKING([version at or above v$pmix_min_version])
-    # Convert a.b.c to hex for comparison to the PMIX_NUMERIC_VERSION
-    # C macro
-    pmix_min_major=`echo $pmix_min_version | cut -d. -f1`
-    pmix_min_minor=`echo $pmix_min_version | cut -d. -f2`
-    pmix_min_release=`echo $pmix_min_version | cut -d. -f3`
-    pmix_min_version_hex=`printf "0x%02x%02x%02x" $pmix_min_major $pmix_min_minor $pmix_min_release`
+    prte_pmix_min_num_version=PRTE_PMIX_NUMERIC_MIN_VERSION
+    prte_pmix_min_version=PRTE_PMIX_MIN_VERSION
+    AC_MSG_CHECKING([version at or above v$prte_pmix_min_version])
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
                                         #include <pmix_version.h>
-                                        #if (PMIX_NUMERIC_VERSION < $pmix_min_version_hex)
-                                        #error "not version $pmix_min_version or above"
+                                        #if (PMIX_NUMERIC_VERSION < $prte_pmix_min_num_version)
+                                        #error "not version $prte_pmix_min_num_version or above"
                                         #endif
                                        ], [])],
                       [AC_MSG_RESULT([yes])],
                       [AC_MSG_RESULT(no)
-                       AC_MSG_WARN([PRRTE requires PMIx v$pmix_min_version or above.])
+                       AC_MSG_WARN([PRRTE requires PMIx v$prte_pmix_min_num_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_CHECK_HEADER([src/util/pmix_argv.h], [],

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -20,6 +20,7 @@
 # Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
+# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -77,16 +78,24 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
 
     # if the version file exists, then we need to parse it to find
     # the actual release series
-    AC_MSG_CHECKING([version at or above v4.2.4])
+    # NOTE: We have already read PRRTE's VERSION file, so we can use
+    # $pmix_min_version.
+    AC_MSG_CHECKING([version at or above v$pmix_min_version])
+    # Convert a.b.c to hex for comparison to the PMIX_NUMERIC_VERSION
+    # C macro
+    pmix_min_major=`echo $pmix_min_version | cut -d. -f1`
+    pmix_min_minor=`echo $pmix_min_version | cut -d. -f2`
+    pmix_min_release=`echo $pmix_min_version | cut -d. -f3`
+    pmix_min_version_hex=`printf "0x%02x%02x%02x" $pmix_min_major $pmix_min_minor $pmix_min_release`
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
                                         #include <pmix_version.h>
-                                        #if (PMIX_NUMERIC_VERSION < 0x00040204)
-                                        #error "not version 4.2.4 or above"
+                                        #if (PMIX_NUMERIC_VERSION < $pmix_min_version_hex)
+                                        #error "not version $pmix_min_version or above"
                                         #endif
                                        ], [])],
                       [AC_MSG_RESULT([yes])],
                       [AC_MSG_RESULT(no)
-                       AC_MSG_WARN([PRRTE requires PMIx v4.2.4 or above.])
+                       AC_MSG_WARN([PRRTE requires PMIx v$pmix_min_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
 
     AC_CHECK_HEADER([src/util/pmix_argv.h], [],

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,6 +9,18 @@ PMIx Reference RunTime Environment (PRRTE).  More information is
 available `in the FAQ section on the PRRTE web site
 <https://github.com/openpmix/prrte>`_.
 
+Minimum PMIx version
+--------------------
+
+The ``configure`` script in PRRTE |prte_ver| must be able to find an
+OpenPMIx installation that is |pmix_min_version| or higher.  If
+``configure`` cannot find a suitable OpenPMIx version, it will abort
+with an error.
+
+If OpenPMIx cannot be found in default preprocessor and linker search
+paths, you can specify the ``--with-pmix=DIR`` CLI option to tell
+``configure`` where to find it.
+
 
 Developer Builds
 ----------------


### PR DESCRIPTION
[docs: document minimum PMIx version needed](https://github.com/openpmix/prrte/commit/bd647c7ac98924d1e1dfd0a9e55eae59cf1d8e6a)

This value is already in VERSIONS and is propagated to the RST docs
through conf.py; just add some verbiage to show that value to the
user.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7bffaf7333ee16a3c3e9e9b95c02f23213d4810a)

[prte_setup_pmix.m4: use PMIx min version from VERSION](https://github.com/openpmix/prrte/commit/3da8efd419391b8b1856350245516a2bb60e6392)

Dynamically get the minimum required PMIx version from the VERSION
file (vs. having the version number hard-coded).

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/49985e85d3c17c12e113421920fb3aaae2c9dd7c)

[Make checking min versions consistent](https://github.com/openpmix/prrte/commit/70cf353d9fbc30184b5aae4109ccd13b30814987)

We have three dependent libraries we care about, and
minimum version requirements on all of them. Let's
connect them all to the min values in the VERSION file
and "standardize" the check configure code to make it
easier to understand and maintain.

Also, since we require a min HWLOC version of 1.11, there
is no longer a need to check for at least 1.8 so we know
we have hwloc_topology_dup.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/511e3334b504762954f23bf7ca9bdb8f06501458)

[Update CPPFLAGS for HWLOC config tests](https://github.com/openpmix/prrte/commit/88b76a01afc1c35e86bd3c657b82ec5bcd692420)

Ensure the tests can find the include file

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/26495841f78da048049dfdb2786cefd3e42e2fd1)
