### PR TITLE
docs/show-help-files: Re-enable Sphinx warning checks

### DIFF
--- a/src/docs/show-help-files/Makefile.am
+++ b/src/docs/show-help-files/Makefile.am
@@ -29,8 +29,7 @@
 
 OUTDIR         = _build
 SPHINX_CONFIG  = conf.py
-#SPHINX_OPTS   ?= -W --keep-going -j auto
-SPHINX_OPTS   ?= --keep-going -j auto
+SPHINX_OPTS   ?= -W --keep-going -j auto
 
 # All RST source files, including those that are not installed
 RST_SOURCE_FILES = \


### PR DESCRIPTION
This was accidentally commented out during development.  Re-enable it to keep our Sphinx builds clean.