### PR TITLE
Multiple commits

### DIFF
--- a/src/docs/show-help-files/Makefile.am
+++ b/src/docs/show-help-files/Makefile.am
@@ -29,8 +29,7 @@
 
 OUTDIR         = _build
 SPHINX_CONFIG  = conf.py
-#SPHINX_OPTS   ?= -W --keep-going -j auto
-SPHINX_OPTS   ?= --keep-going -j auto
+SPHINX_OPTS   ?= -W --keep-going -j auto
 
 # All RST source files, including those that are not installed
 RST_SOURCE_FILES = \


### PR DESCRIPTION
[docs/show-help-files: Re-enable Sphinx warning checks](https://github.com/openpmix/prrte/commit/579717377b00a34a586f07f2c06624da45723048)

This was accidentally commented out during development.  Re-enable it
to keep our Sphinx builds clean.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/9c8846415ffbc1c015131cd3790280001ff7cb20)

[Correctly forward stdin to remote procs](https://github.com/openpmix/prrte/commit/50105ce4bf9ca250b41785262214bcae74bb4951)

Find out where the target destination is executing
and the daemon hosting it, then send the stdin to
that host for local relay.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f80f12101b64a5b120d2a62ea87dcda5f6526958)
