### PR TITLE
Error out of attempts for 32-bit builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,6 +336,9 @@ AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(long long)
 AC_CHECK_SIZEOF(void *)
+AS_IF([test "$ac_cv_sizeof_void_p" -eq 4],
+      [AC_MSG_WARN([PRRTE does not support 32 bit builds.])
+       AC_MSG_ERROR([Cannot continue])])
 AC_CHECK_SIZEOF(size_t)
 
 #


### PR DESCRIPTION
PRRTE doesn't support 32-bit environments - for one thing, it would require a 32-bit PMIx, and PMIx doesn't support such environments either. So error out of configure in such cases.