### PR TITLE
Ensure psched answers an alloc request

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -519,6 +519,8 @@ int main(int argc, char *argv[])
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_NO_READY_MSG)) {
         prte_state_base.ready_msg = false;
+    } else {
+        prte_state_base.ready_msg = true;
     }
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYSTEM_SERVER)) {

--- a/src/tools/psched/psched.c
+++ b/src/tools/psched/psched.c
@@ -496,6 +496,8 @@ int main(int argc, char *argv[])
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_NO_READY_MSG)) {
         prte_state_base.ready_msg = false;
+    } else {
+        prte_state_base.ready_msg = true;
     }
 
     /* if we were asked to report a uri, set the MCA param to do so */

--- a/src/tools/psched/scheduler.c
+++ b/src/tools/psched/scheduler.c
@@ -169,6 +169,14 @@ void psched_request_queue(int fd, short args, void *cbdata)
     pmix_output_verbose(2, psched_globals.output,
                         "%s scheduler:psched: queue request",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+    // need to reply to requestor so they don't hang
+    if (NULL != req->cbfunc) {
+        req->cbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, 0, req->cbdata, NULL, NULL);
+    }
+    // cannot continue processing the request
+    PMIX_RELEASE(req);
+
 }
 
 void psched_session_complete(int fd, short args, void *cbdata)

--- a/src/tools/psched/schizo.c
+++ b/src/tools/psched/schizo.c
@@ -154,7 +154,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
                                                       PRTE_RELEASE_VERSION, PRTE_GREEK_VERSION, NULL);
 
     rc = pmix_cmd_line_parse(argv, pschedshorts, pschedoptions, NULL,
-                             results, "help-schizo-prte.txt");
+                             results, "help-psched.txt");
     if (PMIX_SUCCESS != rc) {
         if (PMIX_OPERATION_SUCCEEDED == rc) {
             /* pmix cmd line interpreter output result


### PR DESCRIPTION
Don't let the caller hang pending completion
of implementation.