### PR TITLE
Fix conversion of OMPI MCA params from legacy ORTE

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -681,7 +681,8 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
+    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) ||
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1801,7 +1801,15 @@ static bool check_prte_overlap(char *var, char *value)
         return true;
     } else if (0 == strncmp(var, "reachable_", strlen("reachable_"))) {
         // need to convert reachable to prtereachable
-        pmix_asprintf(&tmp, "PRTE_MCA_prtereachable_%s", &var[strlen("reachable")]);
+        pmix_asprintf(&tmp, "PRTE_MCA_prtereachable_%s", &var[strlen("reachable_")]);
+        // set it, but don't overwrite if they already
+        // have a value in our environment
+        setenv(tmp, value, false);
+        free(tmp);
+        return true;
+    } else if (0 == strncmp(var, "orte_", strlen("orte_"))) {
+        // need to convert "orte" to "prte"
+        pmix_asprintf(&tmp, "PRTE_MCA_prte_%s", &var[strlen("orte_")]);
         // set it, but don't overwrite if they already
         // have a value in our environment
         setenv(tmp, value, false);

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -167,6 +167,15 @@ int prte_init_minimum(void)
         return prte_pmix_convert_status(ret);
     }
 
+    /* keyval lex-based parser */
+    /* Setup the parameter system */
+    if (PRTE_SUCCESS != (ret = pmix_mca_base_var_init())) {
+        return ret;
+    }
+
+    /* pre-load any default mca param files */
+    prte_preload_default_mca_params();
+
     return PRTE_SUCCESS;
 }
 
@@ -195,13 +204,6 @@ int prte_init_util(prte_proc_type_t flags)
     /* initialize the output system */
     pmix_output_init();
 
-    /* keyval lex-based parser */
-    /* Setup the parameter system */
-    if (PRTE_SUCCESS != (ret = pmix_mca_base_var_init())) {
-        error = "mca_base_var_init";
-        goto error;
-    }
-
     /* set the nodename so anyone who needs it has it - this
      * must come AFTER we initialize the installdirs */
     prte_setup_hostname();
@@ -218,15 +220,6 @@ int prte_init_util(prte_proc_type_t flags)
     if (PRTE_SUCCESS != (ret = prte_util_init_sys_limits(&error))) {
         pmix_show_help("help-prte-runtime.txt", "prte_init:syslimit", false, error);
         return PRTE_ERR_SILENT;
-    }
-
-    /* pre-load any default mca param files */
-    prte_preload_default_mca_params();
-
-    /* Register all MCA Params */
-    if (PRTE_SUCCESS != (ret = prte_register_params())) {
-        error = "prte_register_params";
-        goto error;
     }
 
     ret = pmix_mca_base_framework_open(&prte_prtebacktrace_base_framework,

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -401,6 +401,16 @@ int main(int argc, char *argv[])
      * choice of proxy since some environments forward their envars */
     unsetenv("PRTE_MCA_schizo_proxy");
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (rc = prte_register_params())) {
+        if (PRTE_ERR_SILENT != rc) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(rc), rc);
+        }
+        return 1;
+    }
+
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
@@ -739,6 +749,26 @@ int main(int argc, char *argv[])
         if (PRTE_SUCCESS != rc) {
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             goto DONE;
+        }
+    }
+
+    /* check a couple of display options for the DVM itself */
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DISPLAY);
+    if (NULL != opt) {
+        char **targv;
+        for (n=0; NULL != opt->values[n]; n++) {
+            targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[n], ',');
+            for (i=0; NULL != targv[i]; i++) {
+                if (PMIX_CHECK_CLI_OPTION(targv[i], PRTE_CLI_ALLOC)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC,
+                                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_PARSEABLE) ||
+                           PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_PARSABLE)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT,
+                                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                }
+            }
+            PMIX_ARGV_FREE_COMPAT(targv);
         }
     }
 

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -44,6 +44,7 @@
 #include "src/class/pmix_object.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/mca/errmgr/errmgr.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/schizo/base/base.h"
 #include "src/prted/pmix/pmix_server.h"
@@ -134,6 +135,16 @@ int main(int argc, char *argv[])
     }
     if (NULL == personality) {
         personality = schizo->name;
+    }
+
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (ret = prte_register_params())) {
+        if (PRTE_ERR_SILENT != ret) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(ret), ret);
+        }
+        return 1;
     }
 
     /* parse the input argv to get values, including everyone's MCA params */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -297,6 +297,16 @@ int main(int argc, char *argv[])
         return ret;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (ret = prte_register_params())) {
+        if (PRTE_ERR_SILENT != ret) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(ret), ret);
+        }
+        return 1;
+    }
+
     /* check if we are running as root - if we are, then only allow
      * us to proceed if the allow-run-as-root flag was given. Otherwise,
      * exit with a giant warning message

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -182,6 +182,16 @@ int prun(int argc, char *argv[])
         personality = schizo->name;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (rc = prte_register_params())) {
+        if (PRTE_ERR_SILENT != rc) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(rc), rc);
+        }
+        return 1;
+    }
+
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -295,6 +295,16 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (rc = prte_register_params())) {
+        if (PRTE_ERR_SILENT != rc) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(rc), rc);
+        }
+        return 1;
+    }
+
     rc = schizo->parse_cli(argv, &results, PMIX_CLI_WARN);
     if (PRTE_SUCCESS != rc) {
         PMIX_DESTRUCT(&results);


### PR DESCRIPTION
[Convert OMPI MCA params from legacy orte](https://github.com/openpmix/prrte/commit/ea67d0a1e618355fdd9cbefcd9c3b09b3abd38d0)

Pickup and convert all "OMPI_MCA_orte_xxx" params
to their PRRTE equivalent. Note that some don't
have a PRRTE equivalent, so those will silently
be ignored as it would be too big a job to try
and detect and warn for them.

Signed-off-by: Ralph Castain <rhc@pmix.org>

[Fix display of DVM allocation](https://github.com/openpmix/prrte/commit/e63be913b4d1f14e548110b21c7d840eae63e9cd)

Delay processing of PRRTE params until after the
selected schizo component gets a chance to translate
params (e.g., from OMPI to PRRTE). Ensure we detect
the "--display alloc" request and honor it for the
DVM itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>