### PR TITLE
Multiple commits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,6 +336,9 @@ AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(long long)
 AC_CHECK_SIZEOF(void *)
+AS_IF([test "$ac_cv_sizeof_void_p" -eq 4],
+      [AC_MSG_WARN([PRRTE does not support 32 bit builds.])
+       AC_MSG_ERROR([Cannot continue])])
 AC_CHECK_SIZEOF(size_t)
 
 #

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -681,7 +681,8 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
+    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) ||
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1801,7 +1801,15 @@ static bool check_prte_overlap(char *var, char *value)
         return true;
     } else if (0 == strncmp(var, "reachable_", strlen("reachable_"))) {
         // need to convert reachable to prtereachable
-        pmix_asprintf(&tmp, "PRTE_MCA_prtereachable_%s", &var[strlen("reachable")]);
+        pmix_asprintf(&tmp, "PRTE_MCA_prtereachable_%s", &var[strlen("reachable_")]);
+        // set it, but don't overwrite if they already
+        // have a value in our environment
+        setenv(tmp, value, false);
+        free(tmp);
+        return true;
+    } else if (0 == strncmp(var, "orte_", strlen("orte_"))) {
+        // need to convert "orte" to "prte"
+        pmix_asprintf(&tmp, "PRTE_MCA_prte_%s", &var[strlen("orte_")]);
         // set it, but don't overwrite if they already
         // have a value in our environment
         setenv(tmp, value, false);

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -167,6 +167,15 @@ int prte_init_minimum(void)
         return prte_pmix_convert_status(ret);
     }
 
+    /* keyval lex-based parser */
+    /* Setup the parameter system */
+    if (PRTE_SUCCESS != (ret = pmix_mca_base_var_init())) {
+        return ret;
+    }
+
+    /* pre-load any default mca param files */
+    prte_preload_default_mca_params();
+
     return PRTE_SUCCESS;
 }
 
@@ -195,13 +204,6 @@ int prte_init_util(prte_proc_type_t flags)
     /* initialize the output system */
     pmix_output_init();
 
-    /* keyval lex-based parser */
-    /* Setup the parameter system */
-    if (PRTE_SUCCESS != (ret = pmix_mca_base_var_init())) {
-        error = "mca_base_var_init";
-        goto error;
-    }
-
     /* set the nodename so anyone who needs it has it - this
      * must come AFTER we initialize the installdirs */
     prte_setup_hostname();
@@ -218,15 +220,6 @@ int prte_init_util(prte_proc_type_t flags)
     if (PRTE_SUCCESS != (ret = prte_util_init_sys_limits(&error))) {
         pmix_show_help("help-prte-runtime.txt", "prte_init:syslimit", false, error);
         return PRTE_ERR_SILENT;
-    }
-
-    /* pre-load any default mca param files */
-    prte_preload_default_mca_params();
-
-    /* Register all MCA Params */
-    if (PRTE_SUCCESS != (ret = prte_register_params())) {
-        error = "prte_register_params";
-        goto error;
     }
 
     ret = pmix_mca_base_framework_open(&prte_prtebacktrace_base_framework,

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -44,6 +44,7 @@
 #include "src/class/pmix_object.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/mca/errmgr/errmgr.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/schizo/base/base.h"
 #include "src/prted/pmix/pmix_server.h"
@@ -134,6 +135,16 @@ int main(int argc, char *argv[])
     }
     if (NULL == personality) {
         personality = schizo->name;
+    }
+
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (ret = prte_register_params())) {
+        if (PRTE_ERR_SILENT != ret) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(ret), ret);
+        }
+        return 1;
     }
 
     /* parse the input argv to get values, including everyone's MCA params */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -297,6 +297,16 @@ int main(int argc, char *argv[])
         return ret;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (ret = prte_register_params())) {
+        if (PRTE_ERR_SILENT != ret) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(ret), ret);
+        }
+        return 1;
+    }
+
     /* check if we are running as root - if we are, then only allow
      * us to proceed if the allow-run-as-root flag was given. Otherwise,
      * exit with a giant warning message

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -182,6 +182,16 @@ int prun(int argc, char *argv[])
         personality = schizo->name;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (rc = prte_register_params())) {
+        if (PRTE_ERR_SILENT != rc) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(rc), rc);
+        }
+        return 1;
+    }
+
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
     rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -295,6 +295,16 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    /* Register all global MCA Params */
+    if (PRTE_SUCCESS != (rc = prte_register_params())) {
+        if (PRTE_ERR_SILENT != rc) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte register params",
+                           PRTE_ERROR_NAME(rc), rc);
+        }
+        return 1;
+    }
+
     rc = schizo->parse_cli(argv, &results, PMIX_CLI_WARN);
     if (PRTE_SUCCESS != rc) {
         PMIX_DESTRUCT(&results);


### PR DESCRIPTION
[Error out of attempts for 32-bit builds](https://github.com/openpmix/prrte/commit/9f69a1831cb4234170aa4feb3b640a6a8a7ef01c)

PRRTE doesn't support 32-bit environments - for one thing, it
would require a 32-bit PMIx, and PMIx doesn't support such
environments either. So error out of configure in such cases.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3e9a91f64ddb6dc897cd64e89f217f5db09a575c)

[Convert OMPI MCA params from legacy orte](https://github.com/openpmix/prrte/commit/14ac5b33ef7217c7ce90b10435d2597db3e232cf)

Pickup and convert all "OMPI_MCA_orte_xxx" params
to their PRRTE equivalent. Note that some don't
have a PRRTE equivalent, so those will silently
be ignored as it would be too big a job to try
and detect and warn for them.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/c3c6a9620f17622a66623181e31b68e4dd733e58)

[Fix display of DVM allocation](https://github.com/openpmix/prrte/commit/a1bec8a5315f6023eafb5f2fd1655729027165c2)

Delay processing of PRRTE params until after the
selected schizo component gets a chance to translate
params (e.g., from OMPI to PRRTE). Ensure we detect
the "--display alloc" request and honor it for the
DVM itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/0bae0b4ea30508a50151ad3cf43951d5a389b8a7)
