### PR TITLE
Avoid adding NULL prefix value to app attributes

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -735,8 +735,10 @@ int main(int argc, char *argv[])
                 }
                 free(tmp_basename);
             }
-            prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
-                               tpath, PMIX_STRING);
+            if (NULL != tpath) {
+                prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
+                                   tpath, PMIX_STRING);
+            }
         }
     }
 


### PR DESCRIPTION
Makes no sense to do so

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit b2686e9e08c346df31e6730df2fa14a47b982b20)