### PR TITLE
prte.c: a prefix of "/" is ok

### DIFF
--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -592,7 +592,11 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             if (0 == strcmp(orted_cmd, "prted")) {
                 /* if the cmd is our standard one, then add the prefix */
                 value = pmix_basename(prte_install_dirs.bindir);
-                pmix_asprintf(&tmp, "%s/%s", prefix_dir, value);
+                if ('/' == prefix_dir[strlen(prefix_dir)-1]) {
+                    pmix_asprintf(&tmp, "%s%s", prefix_dir, value);
+                } else {
+                    pmix_asprintf(&tmp, "%s/%s", prefix_dir, value);
+                }
                 free(value);
                 pmix_asprintf(&full_orted_cmd, "%s/%s", tmp, orted_cmd);
                 free(tmp);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -24,6 +24,7 @@
  *                         reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -692,14 +693,15 @@ int main(int argc, char *argv[])
             param[param_len - 1] = '\0';
             param_len--;
             if (0 == param_len) {
-                pmix_show_help("help-prun.txt", "prun:empty-prefix", true, prte_tool_basename,
-                               prte_tool_basename);
-                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                goto DONE;
+                /* We get here if we removed all PATH_SEP's and end up
+                   with an empty string.  In this case, the prefix is
+                   just a single PATH_SEP. */
+                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
+                break;
             }
         }
-        prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL, param,
-                           PMIX_STRING);
+        prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
+                           param, PMIX_STRING);
         free(param);
     } else {
         /* Check if called with fully-qualified path to prte.
@@ -725,8 +727,10 @@ int main(int argc, char *argv[])
                 }
                 free(tmp_basename);
             }
-            prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
-                               tpath, PMIX_STRING);
+            if (NULL != tpath) {
+                prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
+                                   tpath, PMIX_STRING);
+            }
         }
     }
 


### PR DESCRIPTION
It's not an error if the prefix ends up being a plain "/".  More specifically, if we strip off all trailing "/" characters from the prefix and end up with an empty string, then the prefix is just "/".

--------------

Refs https://github.com/open-mpi/ompi/issues/12071

@rhc54 Does this PR look right to you?  I can't remember a reason why we thought that a prefix of `/` is actually an error.  Specifically: the original code (rightfully) strips off all trailing `/` characters.  If we end up with an empty string, we declare that to be an error (this is not new -- this scheme goes all the way back to ORTE).

But I can't think of a reason why a prefix of `/` is an error.  Can you?  If we can't think of any reasons why a prefix of `/` is an error, this PR adjusts the string handling so that if we end up with an empty string, that means that the prefix is really just `/`, so put that back.
