### PR TITLE
Fix add-hostfile and add-host operations

### DIFF
--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -47,3 +47,18 @@ file could not be opened for reading:
   File: %s
 
 Please check the filename and try again.
+#
+[ras-base:nonuniform-slots]
+A request was made to add hosts from a hostfile while operating
+in a managed allocation. In this case, either the slots must be
+specified in the given hostfile, or the number of slots assigned
+by the resource manager on the existing nodes must be uniform.
+
+The current allocation does not conform to that requirement:
+
+   Base number of slots: %d
+   Node: %s
+   Number of slots: %d
+
+Please assign a number of slots for each node to be added to the
+allocation.

--- a/src/mca/ras/testrm/Makefile.am
+++ b/src/mca/ras/testrm/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        ras_testrm.h \
+        ras_testrm_component.c \
+        ras_testrm.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_ras_testrm_DSO
+lib =
+lib_sources =
+component = prte_mca_ras_testrm.la
+component_sources = $(sources)
+else
+lib = libprtemca_ras_testrm.la
+lib_sources = $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component)
+prte_mca_ras_testrm_la_SOURCES = $(component_sources)
+prte_mca_ras_testrm_la_LDFLAGS = -module -avoid-version
+prte_mca_ras_testrm_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(lib)
+libprtemca_ras_testrm_la_SOURCES = $(lib_sources)
+libprtemca_ras_testrm_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ras/testrm/ras_testrm.c
+++ b/src/mca/ras/testrm/ras_testrm.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include "src/class/pmix_list.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/hostfile/hostfile.h"
+#include "ras_testrm.h"
+
+/*
+ * Local functions
+ */
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes);
+static int finalize(void);
+
+/*
+ * Global variable
+ */
+prte_ras_base_module_t prte_ras_testrm_module = {
+    .init = NULL,
+    .allocate = allocate,
+    .deallocate = NULL,
+    .finalize = finalize
+};
+
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
+{
+    int rc;
+
+    rc = prte_util_add_hostfile_nodes(nodes, prte_mca_ras_testrm_component.hostfile);
+    return rc;
+}
+
+/*
+ * There's really nothing to do here
+ */
+static int finalize(void)
+{
+    return PRTE_SUCCESS;
+}

--- a/src/mca/ras/testrm/ras_testrm.h
+++ b/src/mca/ras/testrm/ras_testrm.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_RAS_TESTRM_H
+#define PRTE_RAS_TESTRM_H
+
+#include "prte_config.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/ras/ras.h"
+
+BEGIN_C_DECLS
+
+struct prte_ras_testrm_component_t {
+    prte_ras_base_component_t super;
+    char *hostfile;
+};
+typedef struct prte_ras_testrm_component_t prte_ras_testrm_component_t;
+
+PRTE_EXPORT extern prte_ras_testrm_component_t prte_mca_ras_testrm_component;
+PRTE_EXPORT extern prte_ras_base_module_t prte_ras_testrm_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/ras/testrm/ras_testrm_component.c
+++ b/src/mca/ras/testrm/ras_testrm_component.c
@@ -1,0 +1,84 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/mca/base/pmix_base.h"
+
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "ras_testrm.h"
+#include "src/mca/ras/base/ras_private.h"
+
+/*
+ * Local functions
+ */
+static int ras_testrm_register(void);
+static int ras_testrm_component_query(pmix_mca_base_module_t **module, int *priority);
+
+prte_ras_testrm_component_t prte_mca_ras_testrm_component = {
+    .super = {
+        PRTE_RAS_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "testrm",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+        .pmix_mca_query_component = ras_testrm_component_query,
+        .pmix_mca_register_component_params = ras_testrm_register
+    }
+};
+
+static int ras_testrm_register(void)
+{
+    pmix_mca_base_component_t *component = &prte_mca_ras_testrm_component.super;
+
+    prte_mca_ras_testrm_component.hostfile = NULL;
+    (void) pmix_mca_base_component_var_register(component, "hostfile",
+                                                "Name of file containing hosts for allocation",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_ras_testrm_component.hostfile);
+
+    return PRTE_SUCCESS;
+}
+
+static int ras_testrm_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    if (NULL != prte_mca_ras_testrm_component.hostfile) {
+        *module = (pmix_mca_base_module_t *) &prte_ras_testrm_module;
+        *priority = 1000;
+        return PRTE_SUCCESS;
+    }
+
+    /* Sadly, no */
+    *module = NULL;
+    *priority = 0;
+    return PRTE_ERROR;
+}

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -412,7 +412,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         }
     }
 
-    if (prte_managed_allocation) {
+    if (prte_managed_allocation && !allocating) {
         prte_node_t *node_from_pool = NULL;
         PMIX_LIST_FOREACH(node, nodes, prte_node_t) {
             needcheck = true;


### PR DESCRIPTION
When in a managed allocation, allow addition of nodes provided that either (a) all the nodes in the managed portion of the allocation have the same #slots in them so we can infer how many are in the new nodes, or (b) the user specifies the #slots for the new nodes.

Check node names as well as aliases for match.

Add a new ras component to simulate a managed allocation.