### PR TITLE
Add missing "acquire_object"

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1527,6 +1527,8 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
     bool flag = false;
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
+    PMIX_ACQUIRE_OBJECT(t2);
+
     pmix_output_verbose(5, prte_odls_base_framework.framework_output,
                         "%s odls:wait_local_proc child process %s pid %ld terminated",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name),


### PR DESCRIPTION
Ensure we have a memory barrier prior to
using the object when called from the
progress thread.