### PR TITLE
prte_setup_pmix.m4: check for specific PMIx capability flags

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -39,7 +39,7 @@ AC_DEFUN([PRTE_CHECK_PMIX_CAP],[
     prte_cpp_save=$CPP
     CPP="$PMIXCC_PATH -E"
     AC_PREPROC_IFELSE(
-        [AC_LANG_PROGRAM([#include <pmix.h>],
+        [AC_LANG_PROGRAM([#include <pmix_version.h>],
                          [#if !defined(PMIX_CAPABILITIES)
                           #error This PMIx does not have any capability flags
                           #endif
@@ -176,27 +176,20 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     # then it definitely does not have the capability flags we're
     # looking for.
 
-    # We must have this capability.  If we don't, abort.
-    PRTE_CHECK_PMIX_CAP([202311CLI], [],
-                        [AC_MSG_WARN([Your PMIx version is too old.])
-                         AC_MSG_WARN([This PRRTE needs a PMIx with the PMIX_CAP_202311CLI capability flag])
-                         AC_MSG_ERROR([Cannot continue])])
+    # For now, we just check for the "base" capability to exercise
+    # this feature - essentially retaining this as an example for
+    # future times when we actually need to check capabilities
+    PRTE_CHECK_PMIX_CAP([BASE],
+                        [PRTE_PMIX_BASE_CAPABILITY=1],
+                        [AC_MSG_WARN([Your PMIx version is either does not])
+                         AC_MSG_WARN([the capabilities feature or does not])
+                         AC_MSG_WARN([include the PMIX_CAP_BASE capability flag])
+                         AC_MSG_WARN([Ignoring this for now])
+                         PRTE_PMIX_BASE_CAPABILITY=0])
 
-    # We'd like to have this capability, but we can handle it if we
-    # don't.
-    PRTE_SAD_BECAUSE_PMIX_DOES_NOT_HAVE_CAP_SOMETHING_ELSE=0
-    PRTE_CHECK_PMIX_CAP([SOMETHING_ELSE], [],
-                        [AC_MSG_WARN([Your PMIx version does not have PMIX_CAP_SOMETHING_ELSE])
-                         AC_MSG_WARN([PRRTE will function, but in a degraded state])
-                         PRTE_SAD_BECAUSE_PMIX_DOES_NOT_HAVE_CAP_SOMETHING_ELSE=1])
-    AC_DEFINE_UNQUOTED([PRTE_SAD_BECAUSE_PMIX_DOES_NOT_HAVE_CAP_SOMETHING_ELSE],
-                       [$RESULT],
-                       [PRTE is sad because the PMIx we are compiling against does not have PMIX_CAP_SOMETHING_ELSE])
-
-    # Test for a capability that we know does not exist, just to make
-    # sure that CHECK_PMIX_CAP correctly handles it.
-    PRTE_CHECK_PMIX_CAP([BOGUS], [],
-                        [AC_MSG_WARN([Your PMIx version does not have PMIX_CAP_BOGUS])])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_BASE_CAPABILITY],
+                       [$PRTE_PMIX_BASE_CAPABILITY],
+                       [Whether or not PMIx has the BASE capability flag set])
 
     PRTE_SUMMARY_ADD([Required Packages], [PMIx], [], [$prte_pmix_SUMMARY])
 


### PR DESCRIPTION
Paired with https://github.com/openpmix/openpmix/pull/3198

Demo showing how to check for PMIx capability flags.  This commit:

* Will abort configure if:
  * PMIX_CAPABILITIES does not exist (i.e., this PMIx is so old that it does not have any capability flags)
  * PMIX_CAP_202311CLI capability flag goes not exist
  * PMIX_CAP_202311CLI is not set in PMIX_CAPABILITIES

* Will warn if these capability flags are not set in PMIX_CAPABILITIES (to include PMIX_CAPABILITIES not being defined at all, or either of these flags not being defined at all):
  * PMIX_CAP_SOMETHING_ELSE
  * PMIX_CAP_BOGUS (which doesn't exist -- this simulates a new PRRTE with an old PMIx)