### PR TITLE
Multiple commits

### DIFF
--- a/src/event/event-internal.h
+++ b/src/event/event-internal.h
@@ -40,18 +40,6 @@ typedef event_callback_fn prte_event_cbfunc_t;
 
 BEGIN_C_DECLS
 
-/* set the number of event priority levels */
-#define PRTE_EVENT_NUM_PRI 8
-
-#define PRTE_EV_ERROR_PRI   0
-#define PRTE_EV_MSG_HI_PRI  1
-#define PRTE_EV_SYS_HI_PRI  2
-#define PRTE_EV_MSG_LO_PRI  3
-#define PRTE_EV_SYS_LO_PRI  4
-#define PRTE_EV_INFO_HI_PRI 5
-#define PRTE_EV_INFO_LO_PRI 6
-#define PRTE_EV_LOWEST_PRI  7
-
 #define PRTE_EVENT_SIGNAL(ev) prte_event_get_signal(ev)
 
 #define PRTE_TIMEOUT_DEFAULT \
@@ -101,8 +89,6 @@ PRTE_EXPORT prte_event_t *prte_event_alloc(void);
 
 /* Event priority APIs */
 #define prte_event_base_priority_init(b, n) event_base_priority_init((b), (n))
-
-#define prte_event_set_priority(x, n) event_priority_set((x), (n))
 
 /* Basic event APIs */
 #define prte_event_enable_debug_mode() event_enable_debug_mode()
@@ -164,10 +150,9 @@ typedef struct {
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_event_list_item_t);
 
 /* define a threadshift macro */
-#define PRTE_PMIX_THREADSHIFT(x, eb, f, p)                                  \
+#define PRTE_PMIX_THREADSHIFT(x, eb, f)                                \
     do {                                                               \
         prte_event_set((eb), &((x)->ev), -1, PRTE_EV_WRITE, (f), (x)); \
-        prte_event_set_priority(&((x)->ev), (p));                      \
         PMIX_POST_OBJECT((x));                                         \
         prte_event_active(&((x)->ev), PRTE_EV_WRITE, 1);               \
     } while (0)

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -39,11 +39,6 @@ int prte_event_base_open(void)
     /* PRTE tools "block" in their own loop over the event
      * base, so no progress thread is required */
     prte_event_base = prte_sync_event_base;
-
-    /* set the number of priorities */
-    if (0 < PRTE_EVENT_NUM_PRI) {
-        prte_event_base_priority_init(prte_sync_event_base, PRTE_EVENT_NUM_PRI);
-    }
 
     initialized = true;
     return PRTE_SUCCESS;

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -88,14 +88,14 @@ static void check_send_notification(prte_job_t *jdata,
 static int init(void)
 {
     /* setup state machine to trap job errors */
-    prte_state.add_job_state(PRTE_JOB_STATE_ERROR, job_errors, PRTE_ERROR_PRI);
+    prte_state.add_job_state(PRTE_JOB_STATE_ERROR, job_errors);
 
     /* set the lost connection state to run at MSG priority so
      * we can process any last messages from the proc
      */
-    prte_state.add_proc_state(PRTE_PROC_STATE_COMM_FAILED, proc_errors, PRTE_MSG_PRI);
+    prte_state.add_proc_state(PRTE_PROC_STATE_COMM_FAILED, proc_errors);
 
-    prte_state.add_proc_state(PRTE_PROC_STATE_ERROR, proc_errors, PRTE_ERROR_PRI);
+    prte_state.add_proc_state(PRTE_PROC_STATE_ERROR, proc_errors);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -410,8 +410,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             t2 = PMIX_NEW(prte_wait_tracker_t);
             PMIX_RETAIN(child); // protect against race conditions
             t2->child = child;
-            t2->evb = prte_event_base;
-            prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE,
+            prte_event_set(prte_event_base, &t2->ev, -1, PRTE_EV_WRITE,
                            prte_odls_base_default_wait_local_proc, t2);
             prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
             goto cleanup;

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -87,15 +87,15 @@ static void proc_errors(int fd, short args, void *cbdata);
 static int init(void)
 {
     /* setup state machine to trap job errors */
-    prte_state.add_job_state(PRTE_JOB_STATE_ERROR, job_errors, PRTE_ERROR_PRI);
+    prte_state.add_job_state(PRTE_JOB_STATE_ERROR, job_errors);
 
     /* set the lost connection state to run at MSG priority so
      * we can process any last messages from the proc
      */
-    prte_state.add_proc_state(PRTE_PROC_STATE_COMM_FAILED, proc_errors, PRTE_MSG_PRI);
+    prte_state.add_proc_state(PRTE_PROC_STATE_COMM_FAILED, proc_errors);
 
     /* setup state machine to trap proc errors */
-    prte_state.add_proc_state(PRTE_PROC_STATE_ERROR, proc_errors, PRTE_ERROR_PRI);
+    prte_state.add_proc_state(PRTE_PROC_STATE_ERROR, proc_errors);
 
     return PRTE_SUCCESS;
 }
@@ -229,7 +229,6 @@ cleanup:
     timer->tv.tv_sec = 5;
     timer->tv.tv_usec = 0;
     prte_event_evtimer_set(prte_event_base, timer->ev, wakeup, NULL);
-    prte_event_set_priority(timer->ev, PRTE_ERROR_PRI);
     PMIX_POST_OBJECT(timer);
     prte_event_evtimer_add(timer->ev, &timer->tv);
 }
@@ -414,7 +413,6 @@ static void proc_errors(int fd, short args, void *cbdata)
             t2->evb = prte_event_base;
             prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE,
                            prte_odls_base_default_wait_local_proc, t2);
-            prte_event_set_priority(&t2->ev, PRTE_MSG_PRI);
             prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
             goto cleanup;
         }

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,7 +90,6 @@ static prte_event_t *forward_signals_events = NULL;
 static void setup_sighandler(int signal, prte_event_t *ev, prte_event_cbfunc_t cbfunc)
 {
     prte_event_signal_set(prte_event_base, ev, signal, cbfunc, ev);
-    prte_event_set_priority(ev, PRTE_ERROR_PRI);
     prte_event_signal_add(ev, NULL);
 }
 

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -524,7 +524,7 @@ static int raw_preposition_files(prte_job_t *jdata,
         xfer->app_idx = fs->app_idx;
         xfer->outbound = outbound;
         pmix_list_append(&outbound->xfers, &xfer->super);
-        PRTE_PMIX_THREADSHIFT(xfer, prte_event_base, send_chunk, PRTE_MSG_PRI);
+        PRTE_PMIX_THREADSHIFT(xfer, prte_event_base, send_chunk);
         PMIX_RELEASE(item);
     }
     PMIX_DESTRUCT(&fsets);
@@ -1054,7 +1054,7 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
         }
         free(tmp);
         incoming->pending = true;
-        PRTE_PMIX_THREADSHIFT(incoming, prte_event_base, write_handler, PRTE_MSG_PRI);
+        PRTE_PMIX_THREADSHIFT(incoming, prte_event_base, write_handler);
     }
     /* create an output object for this data */
     output = PMIX_NEW(prte_filem_raw_output_t);

--- a/src/mca/grpcomm/base/grpcomm_base_stubs.c
+++ b/src/mca/grpcomm/base/grpcomm_base_stubs.c
@@ -176,7 +176,6 @@ int prte_grpcomm_API_allgather(prte_pmix_mdx_caddy_t *cd)
     /* must push this into the event library to ensure we can
      * access framework-global data safely */
     prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, allgather_stub, cd);
-    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;

--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -184,7 +184,6 @@ static inline bool prte_iof_base_fd_always_ready(int fd)
                 prte_event_set(prte_event_base, ep->wev->ev, ep->wev->fd, PRTE_EV_WRITE, wrthndlr, \
                                ep);                                                                \
             }                                                                                      \
-            prte_event_set_priority(ep->wev->ev, PRTE_MSG_PRI);                                    \
         }                                                                                          \
         *(snk) = ep;                                                                               \
         PMIX_POST_OBJECT(ep);                                                                      \
@@ -234,7 +233,6 @@ static inline bool prte_iof_base_fd_always_ready(int fd)
         } else {                                                                              \
             prte_event_set(prte_event_base, rev->ev, (fid), PRTE_EV_READ, (cbfunc), rev);     \
         }                                                                                     \
-        prte_event_set_priority(rev->ev, PRTE_MSG_PRI);                                       \
         if ((actv)) {                                                                         \
             PRTE_IOF_READ_ACTIVATE(rev)                                                       \
         }                                                                                     \

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -122,7 +122,6 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_odls_launch_local_t);
         ll->fork_local = (f);                                      \
         prte_event_set(prte_event_base, ll->ev, -1, PRTE_EV_WRITE, \
                        prte_odls_base_default_launch_local, ll);   \
-        prte_event_set_priority(ll->ev, PRTE_SYS_PRI);             \
         prte_event_active(ll->ev, PRTE_EV_WRITE, 1);               \
     } while (0);
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1527,6 +1527,8 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
     bool flag = false;
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
+    PMIX_ACQUIRE_OBJECT(t2);
+
     pmix_output_verbose(5, prte_odls_base_framework.framework_output,
                         "%s odls:wait_local_proc child process %s pid %ld terminated",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name),

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1397,7 +1397,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             /* set the waitpid callback here for thread protection and
              * to ensure we can capture the callback on shortlived apps */
             PRTE_FLAG_SET(child, PRTE_PROC_FLAG_ALIVE);
-            prte_wait_cb(child, prte_odls_base_default_wait_local_proc, evb, NULL);
+            prte_wait_cb(child, prte_odls_base_default_wait_local_proc, prte_event_base, NULL);
 
             /* dispatch this child to the next available launch thread */
             cd = PMIX_NEW(prte_odls_spawn_caddy_t);
@@ -1411,8 +1411,8 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             cd->opts.usepty = PRTE_ENABLE_PTY_SUPPORT;
 
             /* do we want to setup stdin? */
-            if (jobdat->stdin_target == PMIX_RANK_WILDCARD
-                || child->name.rank == jobdat->stdin_target) {
+            if (jobdat->stdin_target == PMIX_RANK_WILDCARD ||
+                child->name.rank == jobdat->stdin_target) {
                 cd->opts.connect_stdin = true;
             } else {
                 cd->opts.connect_stdin = false;
@@ -1439,7 +1439,6 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&child->name),
                                 prte_odls_globals.next_base);
             prte_event_set(evb, &cd->ev, -1, PRTE_EV_WRITE, prte_odls_base_spawn_proc, cd);
-            prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
             prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
         }
     }
@@ -2054,13 +2053,12 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
         prte_odls_globals.next_base = 0;
     }
     evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
-    prte_wait_cb(child, prte_odls_base_default_wait_local_proc, evb, NULL);
+    prte_wait_cb(child, prte_odls_base_default_wait_local_proc, prte_event_base, NULL);
 
     PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output, "%s restarting app %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), app->app));
 
     prte_event_set(evb, &cd->ev, -1, PRTE_EV_WRITE, prte_odls_base_spawn_proc, cd);
-    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
 
 CLEANUP:

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1397,7 +1397,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             /* set the waitpid callback here for thread protection and
              * to ensure we can capture the callback on shortlived apps */
             PRTE_FLAG_SET(child, PRTE_PROC_FLAG_ALIVE);
-            prte_wait_cb(child, prte_odls_base_default_wait_local_proc, prte_event_base, NULL);
+            prte_wait_cb(child, prte_odls_base_default_wait_local_proc, NULL);
 
             /* dispatch this child to the next available launch thread */
             cd = PMIX_NEW(prte_odls_spawn_caddy_t);
@@ -2053,7 +2053,7 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
         prte_odls_globals.next_base = 0;
     }
     evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
-    prte_wait_cb(child, prte_odls_base_default_wait_local_proc, prte_event_base, NULL);
+    prte_wait_cb(child, prte_odls_base_default_wait_local_proc, NULL);
 
     PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output, "%s restarting app %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), app->app));

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -194,6 +194,8 @@ startup:
         }
         prte_odls_globals.ev_bases = prte_event_base_ptr;
     } else {
+        pmix_output_verbose(5, prte_odls_base_framework.framework_output,
+                            "START %d LAUNCH THREADS", prte_odls_globals.num_threads);
         prte_odls_globals.ev_bases = (prte_event_base_t **) malloc(prte_odls_globals.num_threads
                                                                    * sizeof(prte_event_base_t *));
         for (i = 0; i < prte_odls_globals.num_threads; i++) {
@@ -337,7 +339,10 @@ static void launch_local_dest(prte_odls_launch_local_t *ptr)
 {
     prte_event_free(ptr->ev);
 }
-PMIX_CLASS_INSTANCE(prte_odls_launch_local_t, pmix_object_t, launch_local_const, launch_local_dest);
+PMIX_CLASS_INSTANCE(prte_odls_launch_local_t,
+                    pmix_object_t,
+                    launch_local_const,
+                    launch_local_dest);
 
 static void sccon(prte_odls_spawn_caddy_t *p)
 {
@@ -362,4 +367,6 @@ static void scdes(prte_odls_spawn_caddy_t *p)
         PMIX_ARGV_FREE_COMPAT(p->env);
     }
 }
-PMIX_CLASS_INSTANCE(prte_odls_spawn_caddy_t, pmix_object_t, sccon, scdes);
+PMIX_CLASS_INSTANCE(prte_odls_spawn_caddy_t,
+                    pmix_object_t,
+                    sccon, scdes);

--- a/src/mca/oob/base/base.h
+++ b/src/mca/oob/base/base.h
@@ -116,7 +116,7 @@ PRTE_EXPORT void prte_oob_base_send_nb(int fd, short args, void *cbdata);
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__, __LINE__);              \
         prte_oob_send_cd = PMIX_NEW(prte_oob_send_t);                                             \
         prte_oob_send_cd->msg = (m);                                                              \
-        PRTE_PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb, PRTE_MSG_PRI); \
+        PRTE_PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb);          \
     } while (0)
 
 PRTE_EXPORT prte_oob_base_peer_t *prte_oob_base_get_peer(const pmix_proc_t *pr);

--- a/src/mca/oob/tcp/oob_tcp_connection.c
+++ b/src/mca/oob/tcp/oob_tcp_connection.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2016      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -606,7 +606,6 @@ static void tcp_peer_event_init(prte_oob_tcp_peer_t *peer)
         assert(!peer->send_ev_active && !peer->recv_ev_active);
         prte_event_set(prte_event_base, &peer->recv_event, peer->sd, PRTE_EV_READ | PRTE_EV_PERSIST,
                        prte_oob_tcp_recv_handler, peer);
-        prte_event_set_priority(&peer->recv_event, PRTE_MSG_PRI);
         if (peer->recv_ev_active) {
             prte_event_del(&peer->recv_event);
             peer->recv_ev_active = false;
@@ -614,7 +613,6 @@ static void tcp_peer_event_init(prte_oob_tcp_peer_t *peer)
 
         prte_event_set(prte_event_base, &peer->send_event, peer->sd,
                        PRTE_EV_WRITE | PRTE_EV_PERSIST, prte_oob_tcp_send_handler, peer);
-        prte_event_set_priority(&peer->send_event, PRTE_MSG_PRI);
         if (peer->send_ev_active) {
             prte_event_del(&peer->send_event);
             peer->send_ev_active = false;

--- a/src/mca/oob/tcp/oob_tcp_connection.h
+++ b/src/mca/oob/tcp/oob_tcp_connection.h
@@ -61,7 +61,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_conn_op_t);
                             __FILE__, __LINE__, PRTE_NAME_PRINT((&(p)->name)));             \
         cop = PMIX_NEW(prte_oob_tcp_conn_op_t);                                             \
         cop->peer = (p);                                                                    \
-        PRTE_PMIX_THREADSHIFT(cop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                     \
+        PRTE_PMIX_THREADSHIFT(cop, prte_event_base, (cbfunc));                              \
     } while (0);
 
 #define PRTE_ACTIVATE_TCP_ACCEPT_STATE(s, a, cbfunc)                               \
@@ -69,7 +69,6 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_conn_op_t);
         prte_oob_tcp_conn_op_t *cop;                                               \
         cop = PMIX_NEW(prte_oob_tcp_conn_op_t);                                    \
         prte_event_set(prte_event_base, &cop->ev, s, PRTE_EV_READ, (cbfunc), cop); \
-        prte_event_set_priority(&cop->ev, PRTE_MSG_PRI);                           \
         PMIX_POST_OBJECT(cop);                                                     \
         prte_event_add(&cop->ev, 0);                                               \
     } while (0);

--- a/src/mca/oob/tcp/oob_tcp_listener.c
+++ b/src/mca/oob/tcp/oob_tcp_listener.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,7 +160,6 @@ int prte_oob_tcp_start_listening(void)
         listener->ev_active = true;
         prte_event_set(prte_event_base, &listener->event, listener->sd,
                        PRTE_EV_READ | PRTE_EV_PERSIST, connection_event_handler, 0);
-        prte_event_set_priority(&listener->event, PRTE_MSG_PRI);
         PMIX_POST_OBJECT(listener);
         prte_event_add(&listener->event, 0);
     }
@@ -643,7 +642,6 @@ static void *listen_thread(pmix_object_t *obj)
                 pending_connection = PMIX_NEW(prte_oob_tcp_pending_connection_t);
                 prte_event_set(prte_event_base, &pending_connection->ev, -1, PRTE_EV_WRITE,
                                connection_handler, pending_connection);
-                prte_event_set_priority(&pending_connection->ev, PRTE_MSG_PRI);
                 pending_connection->fd = accept(sd, (struct sockaddr *) &(pending_connection->addr),
                                                 &addrlen);
 
@@ -737,7 +735,6 @@ done:
                    PRTE_EV_READ|PRTE_EV_PERSIST,
                    connection_event_handler,
                    0);
-        prte_event_set_priority(listener->event, PRTE_MSG_PRI);
         prte_event_add(listener->event, 0);
     }
 #endif

--- a/src/mca/oob/tcp/oob_tcp_peer.h
+++ b/src/mca/oob/tcp/oob_tcp_peer.h
@@ -81,12 +81,12 @@ typedef struct {
 } prte_oob_tcp_peer_op_t;
 PMIX_CLASS_DECLARATION(prte_oob_tcp_peer_op_t);
 
-#define PRTE_ACTIVATE_TCP_CMP_OP(p, cbfunc)                             \
-    do {                                                                \
-        prte_oob_tcp_peer_op_t *pop;                                    \
-        pop = PMIX_NEW(prte_oob_tcp_peer_op_t);                         \
-        PMIX_XFER_PROCID(&pop->peer, &(p)->name);                       \
-        PRTE_PMIX_THREADSHIFT(pop, prte_event_base, (cbfunc), PRTE_MSG_PRI); \
+#define PRTE_ACTIVATE_TCP_CMP_OP(p, cbfunc)                     \
+    do {                                                        \
+        prte_oob_tcp_peer_op_t *pop;                            \
+        pop = PMIX_NEW(prte_oob_tcp_peer_op_t);                 \
+        PMIX_XFER_PROCID(&pop->peer, &(p)->name);               \
+        PRTE_PMIX_THREADSHIFT(pop, prte_event_base, (cbfunc));  \
     } while (0);
 
 #endif /* _MCA_OOB_TCP_PEER_H_ */

--- a/src/mca/oob/tcp/oob_tcp_sendrecv.h
+++ b/src/mca/oob/tcp/oob_tcp_sendrecv.h
@@ -82,11 +82,11 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
  * s => pointer to prte_oob_tcp_send_t
  * f => true if send event is to be activated
  */
-#define MCA_OOB_TCP_QUEUE_MSG(p, s, f)                                                \
-    do {                                                                              \
-        (s)->peer = (struct prte_oob_tcp_peer_t *) (p);                               \
-        (s)->activate = (f);                                                          \
-        PRTE_PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg, PRTE_MSG_PRI); \
+#define MCA_OOB_TCP_QUEUE_MSG(p, s, f)                                          \
+    do {                                                                        \
+        (s)->peer = (struct prte_oob_tcp_peer_t *) (p);                         \
+        (s)->activate = (f);                                                    \
+        PRTE_PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg);    \
     } while (0)
 
 /* queue a message to be sent by one of our modules - must
@@ -201,7 +201,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_op_t);
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((ms)->dst)));               \
         mop = PMIX_NEW(prte_oob_tcp_msg_op_t);                                                \
         mop->msg = (ms);                                                                      \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                       \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc));                                \
     } while (0);
 
 typedef struct {
@@ -243,7 +243,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_error_t);
         }                                                                                          \
         PMIX_XFER_PROCID(&mop->hop, (h));                                                          \
         /* this goes to the OOB framework, so use that event base */                               \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc), PRTE_MSG_PRI);                            \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc));                                     \
     } while (0)
 
 #define PRTE_ACTIVATE_TCP_NO_ROUTE(r, h, c)                                                       \
@@ -257,7 +257,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_error_t);
         PMIX_XFER_PROCID(&mop->hop, (h));                                                         \
         /* this goes to the component, so use the framework                                       \
          * event base */                                                                          \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (c), PRTE_MSG_PRI);                                \
+        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (c));                                         \
     } while (0)
 
 #endif /* _MCA_OOB_TCP_SENDRECV_H_ */

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -558,7 +558,7 @@ static int plm_alps_start_proc(int argc, char **argv, char **env, char *prefix)
     /* be sure to mark it as alive so we don't instantly fire */
     PRTE_FLAG_SET(alpsrun, PRTE_PROC_FLAG_ALIVE);
     /* setup the waitpid so we can find out if alps succeeds! */
-    prte_wait_cb(alpsrun, alps_wait_cb, prte_event_base, NULL);
+    prte_wait_cb(alpsrun, alps_wait_cb, NULL);
 
     if (0 == alps_pid) { /* child */
         char *bin_base = NULL, *lib_base = NULL;

--- a/src/mca/plm/alps/plm_alps_module.c
+++ b/src/mca/plm/alps/plm_alps_module.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -138,8 +138,7 @@ static int plm_alps_init(void)
 
     /* point to our launch command */
     if (PRTE_SUCCESS
-        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
-                                          PRTE_SYS_PRI))) {
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons))) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -668,7 +668,6 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
         timer = PMIX_NEW(prte_timer_t);
         timer->payload = caddy->jdata;
         prte_event_evtimer_set(prte_event_base, timer->ev, spawn_timeout_cb, caddy->jdata);
-        prte_event_set_priority(timer->ev, PRTE_ERROR_PRI);
         timer->tv.tv_sec = time;
         timer->tv.tv_usec = 0;
         prte_set_attribute(&caddy->jdata->attributes, PRTE_SPAWN_TIMEOUT_EVENT, PRTE_ATTR_LOCAL, timer, PMIX_POINTER);
@@ -683,7 +682,6 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
         timer = PMIX_NEW(prte_timer_t);
         timer->payload = caddy->jdata;
         prte_event_evtimer_set(prte_event_base, timer->ev, job_timeout_cb, caddy->jdata);
-        prte_event_set_priority(timer->ev, PRTE_ERROR_PRI);
         timer->tv.tv_sec = time;
         timer->tv.tv_usec = 0;
         prte_set_attribute(&caddy->jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, PRTE_ATTR_LOCAL, timer, PMIX_POINTER);

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -131,8 +131,7 @@ int plm_lsf_init(void)
 
     /* point to our launch command */
     if (PRTE_SUCCESS
-        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
-                                          PRTE_SYS_PRI))) {
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons))) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -654,7 +654,7 @@ static int plm_slurm_start_proc(int argc, char **argv, char *prefix)
     /* be sure to mark it as alive so we don't instantly fire */
     PRTE_FLAG_SET(dummy, PRTE_PROC_FLAG_ALIVE);
     /* setup the waitpid so we can find out if srun succeeds! */
-    prte_wait_cb(dummy, srun_wait_cb, prte_event_base, NULL);
+    prte_wait_cb(dummy, srun_wait_cb, NULL);
 
     if (0 == srun_pid) { /* child */
         char *bin_base = NULL, *lib_base = NULL;

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -144,8 +144,7 @@ static int plm_slurm_init(void)
 
     /* point to our launch command */
     if (PRTE_SUCCESS
-        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
-                                          PRTE_SYS_PRI))) {
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons))) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -224,8 +224,7 @@ static int ssh_init(void)
 
     /* point to our launch command */
     if (PRTE_SUCCESS
-        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
-                                          PRTE_SYS_PRI))) {
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons))) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }
@@ -233,7 +232,6 @@ static int ssh_init(void)
     /* setup the event for metering the launch */
     PMIX_CONSTRUCT(&launch_list, pmix_list_t);
     prte_event_set(prte_event_base, &launch_event, -1, 0, process_launch_list, NULL);
-    prte_event_set_priority(&launch_event, PRTE_SYS_PRI);
 
     /* start the recvs */
     if (PRTE_SUCCESS != (rc = prte_plm_base_comm_start())) {

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -592,7 +592,11 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             if (0 == strcmp(orted_cmd, "prted")) {
                 /* if the cmd is our standard one, then add the prefix */
                 value = pmix_basename(prte_install_dirs.bindir);
-                pmix_asprintf(&tmp, "%s/%s", prefix_dir, value);
+                if ('/' == prefix_dir[strlen(prefix_dir)-1]) {
+                    pmix_asprintf(&tmp, "%s%s", prefix_dir, value);
+                } else {
+                    pmix_asprintf(&tmp, "%s/%s", prefix_dir, value);
+                }
                 free(value);
                 pmix_asprintf(&full_orted_cmd, "%s/%s", tmp, orted_cmd);
                 free(tmp);

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -932,7 +932,7 @@ static void process_launch_list(int fd, short args, void *cbdata)
         caddy = (prte_plm_ssh_caddy_t *) item;
         /* register the sigchild callback */
         PRTE_FLAG_SET(caddy->daemon, PRTE_PROC_FLAG_ALIVE);
-        prte_wait_cb(caddy->daemon, ssh_wait_daemon, prte_event_base, (void *) caddy);
+        prte_wait_cb(caddy->daemon, ssh_wait_daemon, (void *) caddy);
 
         /* fork a child to exec the ssh/ssh session */
         pid = fork();

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -130,8 +130,7 @@ static int plm_tm_init(void)
 
     /* point to our launch command */
     if (PRTE_SUCCESS
-        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons,
-                                          PRTE_SYS_PRI))) {
+        != (rc = prte_state.add_job_state(PRTE_JOB_STATE_LAUNCH_DAEMONS, launch_daemons))) {
         PRTE_ERROR_LOG(rc);
         return rc;
     }

--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -47,3 +47,18 @@ file could not be opened for reading:
   File: %s
 
 Please check the filename and try again.
+#
+[ras-base:nonuniform-slots]
+A request was made to add hosts from a hostfile while operating
+in a managed allocation. In this case, either the slots must be
+specified in the given hostfile, or the number of slots assigned
+by the resource manager on the existing nodes must be uniform.
+
+The current allocation does not conform to that requirement:
+
+   Base number of slots: %d
+   Node: %s
+   Number of slots: %d
+
+Please assign a number of slots for each node to be added to the
+allocation.

--- a/src/mca/ras/testrm/Makefile.am
+++ b/src/mca/ras/testrm/Makefile.am
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
+# Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+        ras_testrm.h \
+        ras_testrm_component.c \
+        ras_testrm.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_prte_ras_testrm_DSO
+lib =
+lib_sources =
+component = prte_mca_ras_testrm.la
+component_sources = $(sources)
+else
+lib = libprtemca_ras_testrm.la
+lib_sources = $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(prtelibdir)
+mcacomponent_LTLIBRARIES = $(component)
+prte_mca_ras_testrm_la_SOURCES = $(component_sources)
+prte_mca_ras_testrm_la_LDFLAGS = -module -avoid-version
+prte_mca_ras_testrm_la_LIBADD = $(top_builddir)/src/libprrte.la
+
+noinst_LTLIBRARIES = $(lib)
+libprtemca_ras_testrm_la_SOURCES = $(lib_sources)
+libprtemca_ras_testrm_la_LDFLAGS = -module -avoid-version

--- a/src/mca/ras/testrm/ras_testrm.c
+++ b/src/mca/ras/testrm/ras_testrm.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include "src/class/pmix_list.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/hostfile/hostfile.h"
+#include "ras_testrm.h"
+
+/*
+ * Local functions
+ */
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes);
+static int finalize(void);
+
+/*
+ * Global variable
+ */
+prte_ras_base_module_t prte_ras_testrm_module = {
+    .init = NULL,
+    .allocate = allocate,
+    .deallocate = NULL,
+    .finalize = finalize
+};
+
+static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
+{
+    int rc;
+
+    rc = prte_util_add_hostfile_nodes(nodes, prte_mca_ras_testrm_component.hostfile);
+    return rc;
+}
+
+/*
+ * There's really nothing to do here
+ */
+static int finalize(void)
+{
+    return PRTE_SUCCESS;
+}

--- a/src/mca/ras/testrm/ras_testrm.h
+++ b/src/mca/ras/testrm/ras_testrm.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_RAS_TESTRM_H
+#define PRTE_RAS_TESTRM_H
+
+#include "prte_config.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/ras/ras.h"
+
+BEGIN_C_DECLS
+
+struct prte_ras_testrm_component_t {
+    prte_ras_base_component_t super;
+    char *hostfile;
+};
+typedef struct prte_ras_testrm_component_t prte_ras_testrm_component_t;
+
+PRTE_EXPORT extern prte_ras_testrm_component_t prte_mca_ras_testrm_component;
+PRTE_EXPORT extern prte_ras_base_module_t prte_ras_testrm_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/ras/testrm/ras_testrm_component.c
+++ b/src/mca/ras/testrm/ras_testrm_component.c
@@ -1,0 +1,84 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/mca/base/pmix_base.h"
+
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "ras_testrm.h"
+#include "src/mca/ras/base/ras_private.h"
+
+/*
+ * Local functions
+ */
+static int ras_testrm_register(void);
+static int ras_testrm_component_query(pmix_mca_base_module_t **module, int *priority);
+
+prte_ras_testrm_component_t prte_mca_ras_testrm_component = {
+    .super = {
+        PRTE_RAS_BASE_VERSION_2_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "testrm",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+        .pmix_mca_query_component = ras_testrm_component_query,
+        .pmix_mca_register_component_params = ras_testrm_register
+    }
+};
+
+static int ras_testrm_register(void)
+{
+    pmix_mca_base_component_t *component = &prte_mca_ras_testrm_component.super;
+
+    prte_mca_ras_testrm_component.hostfile = NULL;
+    (void) pmix_mca_base_component_var_register(component, "hostfile",
+                                                "Name of file containing hosts for allocation",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_ras_testrm_component.hostfile);
+
+    return PRTE_SUCCESS;
+}
+
+static int ras_testrm_component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    if (NULL != prte_mca_ras_testrm_component.hostfile) {
+        *module = (pmix_mca_base_module_t *) &prte_ras_testrm_module;
+        *priority = 1000;
+        return PRTE_SUCCESS;
+    }
+
+    /* Sadly, no */
+    *module = NULL;
+    *priority = 0;
+    return PRTE_ERROR;
+}

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -327,6 +327,10 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                     pmix_asprintf(&param, "prtedl_%s", &p1[strlen("dl_")]);
                     free(p1);
                     p1 = param;
+                } else if (0 == strncasecmp(p1, "plm_rsh", strlen("plm_rsh"))) {
+                    pmix_asprintf(&param, "plm_ssh_%s", &p1[strlen("plm_rsh_")]);
+                    free(p1);
+                    p1 = param;
                 }
                 if (NULL == target) {
                     /* push it into our environment */

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -1807,6 +1807,14 @@ static bool check_prte_overlap(char *var, char *value)
         setenv(tmp, value, false);
         free(tmp);
         return true;
+    } else if (0 == strncmp(var, "plm_rsh_", strlen("plm_rsh_"))) {
+        // need to convert rsh to ssh
+        pmix_asprintf(&tmp, "PRTE_MCA_plm_ssh_%s", &var[strlen("plm_rsh_")]);
+        // set it, but don't overwrite if they already
+        // have a value in our environment
+        setenv(tmp, value, false);
+        free(tmp);
+        return true;
     } else if (0 == strncmp(var, "orte_", strlen("orte_"))) {
         // need to convert "orte" to "prte"
         pmix_asprintf(&tmp, "PRTE_MCA_prte_%s", &var[strlen("orte_")]);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -403,12 +403,27 @@ cleanup:
     return rc;
 }
 
+static bool mcaoption(char *s)
+{
+    size_t len = strlen(s);
+
+    if (3 > len) {
+        return false;
+    }
+    if ('a' == s[len-1] &&
+        'c' == s[len-2] &&
+        'm' == s[len-3]) {
+        return true;
+    }
+    return false;
+}
+
 static int parse_cli(char **argv, pmix_cli_result_t *results,
                      bool silent)
 {
-    int rc, n;
+    int rc, m, n;
     pmix_cli_item_t *opt;
-    char *p1;
+    char *p1, *p2;
     char **pargv;
 
     /* backup the argv */
@@ -437,6 +452,19 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     for (n=1; NULL != pargv[n]; n++) {
         /* check for option */
         if ('-' != pargv[n][0]) {
+            continue;
+        }
+        // if this is an mca spec, then skip it
+        if (mcaoption(pargv[n])) {
+            if ('-' != pargv[n][1]) {
+                // make it a "--" option
+                p2 = strdup(pargv[n]);
+                free(pargv[n]);
+                pmix_asprintf(&pargv[n], "-%s", p2);
+                free(p2);
+            }
+            // now skip the next two positions
+            n += 2;
             continue;
         }
         /* check for single-dash errors */

--- a/src/mca/state/base/base.h
+++ b/src/mca/state/base/base.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,13 +68,10 @@ PRTE_EXPORT int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spe
  */
 PRTE_EXPORT void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t state);
 
-PRTE_EXPORT int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cbfunc,
-                                              int priority);
+PRTE_EXPORT int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cbfunc);
 
 PRTE_EXPORT int prte_state_base_set_job_state_callback(prte_job_state_t state,
                                                        prte_state_cbfunc_t cbfunc);
-
-PRTE_EXPORT int prte_state_base_set_job_state_priority(prte_job_state_t state, int priority);
 
 PRTE_EXPORT int prte_state_base_remove_job_state(prte_job_state_t state);
 
@@ -82,13 +79,10 @@ PRTE_EXPORT void prte_util_print_job_state_machine(void);
 
 PRTE_EXPORT void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t state);
 
-PRTE_EXPORT int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t cbfunc,
-                                               int priority);
+PRTE_EXPORT int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t cbfunc);
 
 PRTE_EXPORT int prte_state_base_set_proc_state_callback(prte_proc_state_t state,
                                                         prte_state_cbfunc_t cbfunc);
-
-PRTE_EXPORT int prte_state_base_set_proc_state_priority(prte_proc_state_t state, int priority);
 
 PRTE_EXPORT int prte_state_base_remove_proc_state(prte_proc_state_t state);
 

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -65,7 +65,7 @@ void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t stat
             error = itm;
         }
         if (s->job_state == state) {
-            PRTE_REACHING_JOB_STATE(jdata, state, s->priority);
+            PRTE_REACHING_JOB_STATE(jdata, state);
             if (NULL == s->cbfunc) {
                 PMIX_OUTPUT_VERBOSE((1, prte_state_base_framework.framework_output,
                                      "%s NULL CBFUNC FOR JOB %s STATE %s",
@@ -80,7 +80,7 @@ void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t stat
                 caddy->job_state = state;
                 PMIX_RETAIN(jdata);
             }
-            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc);
             return;
         }
     }
@@ -108,11 +108,11 @@ void prte_state_base_activate_job_state(prte_job_t *jdata, prte_job_state_t stat
         caddy->job_state = state;
         PMIX_RETAIN(jdata);
     }
-    PRTE_REACHING_JOB_STATE(jdata, state, s->priority);
-    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+    PRTE_REACHING_JOB_STATE(jdata, state);
+    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc);
 }
 
-int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cbfunc, int priority)
+int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cbfunc)
 {
     pmix_list_item_t *item;
     prte_state_t *st;
@@ -131,7 +131,6 @@ int prte_state_base_add_job_state(prte_job_state_t state, prte_state_cbfunc_t cb
     st = PMIX_NEW(prte_state_t);
     st->job_state = state;
     st->cbfunc = cbfunc;
-    st->priority = priority;
     pmix_list_append(&prte_job_states, &(st->super));
 
     return PRTE_SUCCESS;
@@ -155,26 +154,9 @@ int prte_state_base_set_job_state_callback(prte_job_state_t state, prte_state_cb
     st = PMIX_NEW(prte_state_t);
     st->job_state = state;
     st->cbfunc = cbfunc;
-    st->priority = PRTE_SYS_PRI;
     pmix_list_append(&prte_job_states, &(st->super));
 
     return PRTE_SUCCESS;
-}
-
-int prte_state_base_set_job_state_priority(prte_job_state_t state, int priority)
-{
-    pmix_list_item_t *item;
-    prte_state_t *st;
-
-    for (item = pmix_list_get_first(&prte_job_states); item != pmix_list_get_end(&prte_job_states);
-         item = pmix_list_get_next(item)) {
-        st = (prte_state_t *) item;
-        if (st->job_state == state) {
-            st->priority = priority;
-            return PRTE_SUCCESS;
-        }
-    }
-    return PRTE_ERR_NOT_FOUND;
 }
 
 int prte_state_base_remove_job_state(prte_job_state_t state)
@@ -226,7 +208,7 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
             error = itm;
         }
         if (s->proc_state == state) {
-            PRTE_REACHING_PROC_STATE(proc, state, s->priority);
+            PRTE_REACHING_PROC_STATE(proc, state);
             if (NULL == s->cbfunc) {
                 PMIX_OUTPUT_VERBOSE((1, prte_state_base_framework.framework_output,
                                      "%s NULL CBFUNC FOR PROC %s STATE %s",
@@ -237,7 +219,7 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
             caddy = PMIX_NEW(prte_state_caddy_t);
             caddy->name = *proc;
             caddy->proc_state = state;
-            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+            PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc);
             return;
         }
     }
@@ -249,8 +231,8 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
     } else if (NULL != any) {
         s = (prte_state_t *) any;
     } else {
-        PMIX_OUTPUT_VERBOSE(
-            (1, prte_state_base_framework.framework_output, "INCREMENT: ANY STATE NOT FOUND"));
+        PMIX_OUTPUT_VERBOSE((1, prte_state_base_framework.framework_output,
+                             "INCREMENT: ANY STATE NOT FOUND"));
         return;
     }
     if (NULL == s->cbfunc) {
@@ -261,12 +243,11 @@ void prte_state_base_activate_proc_state(pmix_proc_t *proc, prte_proc_state_t st
     caddy = PMIX_NEW(prte_state_caddy_t);
     caddy->name = *proc;
     caddy->proc_state = state;
-    PRTE_REACHING_PROC_STATE(proc, state, s->priority);
-    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc, s->priority);
+    PRTE_REACHING_PROC_STATE(proc, state);
+    PRTE_PMIX_THREADSHIFT(caddy, prte_event_base, s->cbfunc);
 }
 
-int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t cbfunc,
-                                   int priority)
+int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t cbfunc)
 {
     pmix_list_item_t *item;
     prte_state_t *st;
@@ -285,7 +266,6 @@ int prte_state_base_add_proc_state(prte_proc_state_t state, prte_state_cbfunc_t 
     st = PMIX_NEW(prte_state_t);
     st->proc_state = state;
     st->cbfunc = cbfunc;
-    st->priority = priority;
     pmix_list_append(&prte_proc_states, &(st->super));
 
     return PRTE_SUCCESS;
@@ -301,22 +281,6 @@ int prte_state_base_set_proc_state_callback(prte_proc_state_t state, prte_state_
         st = (prte_state_t *) item;
         if (st->proc_state == state) {
             st->cbfunc = cbfunc;
-            return PRTE_SUCCESS;
-        }
-    }
-    return PRTE_ERR_NOT_FOUND;
-}
-
-int prte_state_base_set_proc_state_priority(prte_proc_state_t state, int priority)
-{
-    pmix_list_item_t *item;
-    prte_state_t *st;
-
-    for (item = pmix_list_get_first(&prte_proc_states);
-         item != pmix_list_get_end(&prte_proc_states); item = pmix_list_get_next(item)) {
-        st = (prte_state_t *) item;
-        if (st->proc_state == state) {
-            st->priority = priority;
             return PRTE_SUCCESS;
         }
     }

--- a/src/mca/state/base/state_base_frame.c
+++ b/src/mca/state/base/state_base_frame.c
@@ -6,7 +6,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,7 +136,6 @@ static void prte_state_construct(prte_state_t *state)
     state->job_state = PRTE_JOB_STATE_UNDEF;
     state->proc_state = PRTE_PROC_STATE_UNDEF;
     state->cbfunc = NULL;
-    state->priority = PRTE_INFO_PRI;
 }
 PMIX_CLASS_INSTANCE(prte_state_t, pmix_list_item_t, prte_state_construct, NULL);
 

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -69,12 +69,10 @@ prte_state_base_module_t prte_state_dvm_module = {
     .activate_job_state = prte_state_base_activate_job_state,
     .add_job_state = prte_state_base_add_job_state,
     .set_job_state_callback = prte_state_base_set_job_state_callback,
-    .set_job_state_priority = prte_state_base_set_job_state_priority,
     .remove_job_state = prte_state_base_remove_job_state,
     .activate_proc_state = prte_state_base_activate_proc_state,
     .add_proc_state = prte_state_base_add_proc_state,
     .set_proc_state_callback = prte_state_base_set_proc_state_callback,
-    .set_proc_state_priority = prte_state_base_set_proc_state_priority,
     .remove_proc_state = prte_state_base_remove_proc_state
 };
 
@@ -183,24 +181,23 @@ static int init(void)
     num_states = sizeof(launch_states) / sizeof(prte_job_state_t);
     for (i = 0; i < num_states; i++) {
         if (PRTE_SUCCESS
-            != (rc = prte_state.add_job_state(launch_states[i], launch_callbacks[i],
-                                              PRTE_SYS_PRI))) {
+            != (rc = prte_state.add_job_state(launch_states[i], launch_callbacks[i]))) {
             PRTE_ERROR_LOG(rc);
         }
     }
     /* add the termination response */
-    rc = prte_state.add_job_state(PRTE_JOB_STATE_DAEMONS_TERMINATED, prte_quit, PRTE_SYS_PRI);
+    rc = prte_state.add_job_state(PRTE_JOB_STATE_DAEMONS_TERMINATED, prte_quit);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
     /* add a default error response */
-    rc = prte_state.add_job_state(PRTE_JOB_STATE_FORCED_EXIT, force_quit, PRTE_ERROR_PRI);
+    rc = prte_state.add_job_state(PRTE_JOB_STATE_FORCED_EXIT, force_quit);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
     /* add callback to report progress, if requested */
     rc = prte_state.add_job_state(PRTE_JOB_STATE_REPORT_PROGRESS,
-                                  prte_state_base_report_progress, PRTE_ERROR_PRI);
+                                  prte_state_base_report_progress);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
@@ -213,7 +210,7 @@ static int init(void)
      */
     num_states = sizeof(proc_states) / sizeof(prte_proc_state_t);
     for (i = 0; i < num_states; i++) {
-        rc = prte_state.add_proc_state(proc_states[i], proc_callbacks[i], PRTE_SYS_PRI);
+        rc = prte_state.add_proc_state(proc_states[i], proc_callbacks[i]);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
         }

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -54,12 +54,10 @@ prte_state_base_module_t prte_state_prted_module = {
     .activate_job_state = prte_state_base_activate_job_state,
     .add_job_state = prte_state_base_add_job_state,
     .set_job_state_callback = prte_state_base_set_job_state_callback,
-    .set_job_state_priority = prte_state_base_set_job_state_priority,
     .remove_job_state = prte_state_base_remove_job_state,
     .activate_proc_state = prte_state_base_activate_proc_state,
     .add_proc_state = prte_state_base_add_proc_state,
     .set_proc_state_callback = prte_state_base_set_proc_state_callback,
-    .set_proc_state_priority = prte_state_base_set_proc_state_priority,
     .remove_proc_state = prte_state_base_remove_proc_state
 };
 
@@ -108,19 +106,18 @@ static int init(void)
 
     num_states = sizeof(job_states) / sizeof(prte_job_state_t);
     for (i = 0; i < num_states; i++) {
-        rc = prte_state.add_job_state(job_states[i], job_callbacks[i], PRTE_SYS_PRI);
+        rc = prte_state.add_job_state(job_states[i], job_callbacks[i]);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
         }
     }
     /* add a default error response */
-    rc = prte_state.add_job_state(PRTE_JOB_STATE_FORCED_EXIT, prte_quit, PRTE_ERROR_PRI);
+    rc = prte_state.add_job_state(PRTE_JOB_STATE_FORCED_EXIT, prte_quit);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
     /* add a state for when we are ordered to terminate */
-    rc = prte_state.add_job_state(PRTE_JOB_STATE_DAEMONS_TERMINATED, prte_quit,
-                                  PRTE_SYS_PRI);
+    rc = prte_state.add_job_state(PRTE_JOB_STATE_DAEMONS_TERMINATED, prte_quit);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
     }
@@ -133,7 +130,7 @@ static int init(void)
      */
     num_states = sizeof(proc_states) / sizeof(prte_proc_state_t);
     for (i = 0; i < num_states; i++) {
-        rc = prte_state.add_proc_state(proc_states[i], proc_callbacks[i], PRTE_SYS_PRI);
+        rc = prte_state.add_proc_state(proc_states[i], proc_callbacks[i]);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
         }

--- a/src/mca/state/state.h
+++ b/src/mca/state/state.h
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -113,31 +113,31 @@ PRTE_EXPORT extern pmix_mca_base_framework_t prte_state_base_framework;
     } while (0);
 
 /* Called when actually arriving (reaching) the state with priority k */
-#define PRTE_REACHING_JOB_STATE(j, s, k)                                                      \
+#define PRTE_REACHING_JOB_STATE(j, s)                                                         \
     do {                                                                                      \
         prte_job_t *shadow = (j);                                                             \
         if (prte_state_base_framework.framework_verbose > 0) {                                \
             double timestamp = 0.0;                                                           \
             PRTE_STATE_GET_TIMESTAMP(timestamp);                                              \
             pmix_output_verbose(1, prte_state_base_framework.framework_output,                \
-                                "%s [%f] ACTIVATING JOB %s STATE %s PRI %d",                  \
+                                "%s [%f] ACTIVATING JOB %s STATE %s",                         \
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), timestamp,                \
                                 (NULL == shadow) ? "NULL" : PRTE_JOBID_PRINT(shadow->nspace), \
-                                prte_job_state_to_str((s)), k);                               \
+                                prte_job_state_to_str((s)));                                  \
         }                                                                                     \
     } while (0);
 
-#define PRTE_REACHING_PROC_STATE(p, s, k)                                            \
+#define PRTE_REACHING_PROC_STATE(p, s)                                               \
     do {                                                                             \
         pmix_proc_t *shadow = (p);                                                   \
         if (prte_state_base_framework.framework_verbose > 0) {                       \
             double timestamp = 0.0;                                                  \
             PRTE_STATE_GET_TIMESTAMP(timestamp);                                     \
             pmix_output_verbose(1, prte_state_base_framework.framework_output,       \
-                                "%s [%f] ACTIVATING PROC %s STATE %s PRI %d",        \
+                                "%s [%f] ACTIVATING PROC %s STATE %s",               \
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), timestamp,       \
                                 (NULL == shadow) ? "NULL" : PRTE_NAME_PRINT(shadow), \
-                                prte_proc_state_to_str((s)), k);                     \
+                                prte_proc_state_to_str((s)));                        \
         }                                                                            \
     } while (0);
 
@@ -193,19 +193,13 @@ typedef void (*prte_state_base_module_activate_job_state_fn_t)(prte_job_t *jdata
  *
  */
 typedef int (*prte_state_base_module_add_job_state_fn_t)(prte_job_state_t state,
-                                                         prte_state_cbfunc_t cbfunc, int priority);
+                                                         prte_state_cbfunc_t cbfunc);
 
 /* Set the callback function for a state in the job state machine.
  *
  */
 typedef int (*prte_state_base_module_set_job_state_callback_fn_t)(prte_job_state_t state,
                                                                   prte_state_cbfunc_t cbfunc);
-
-/* Set the event priority for a state in the job state machine.
- *
- */
-typedef int (*prte_state_base_module_set_job_state_priority_fn_t)(prte_job_state_t state,
-                                                                  int priority);
 
 /* Remove a state from the job state machine.
  *
@@ -248,19 +242,13 @@ typedef void (*prte_state_base_module_activate_proc_state_fn_t)(pmix_proc_t *pro
  *
  */
 typedef int (*prte_state_base_module_add_proc_state_fn_t)(prte_proc_state_t state,
-                                                          prte_state_cbfunc_t cbfunc, int priority);
+                                                          prte_state_cbfunc_t cbfunc);
 
 /* Set the callback function for a state in the proc state machine.
  *
  */
 typedef int (*prte_state_base_module_set_proc_state_callback_fn_t)(prte_proc_state_t state,
                                                                    prte_state_cbfunc_t cbfunc);
-
-/* Set the event priority for a state in the proc state machine.
- *
- */
-typedef int (*prte_state_base_module_set_proc_state_priority_fn_t)(prte_proc_state_t state,
-                                                                   int priority);
 
 /* Remove a state from the proc state machine.
  *
@@ -279,13 +267,11 @@ struct prte_state_base_module_1_0_0_t {
     prte_state_base_module_activate_job_state_fn_t activate_job_state;
     prte_state_base_module_add_job_state_fn_t add_job_state;
     prte_state_base_module_set_job_state_callback_fn_t set_job_state_callback;
-    prte_state_base_module_set_job_state_priority_fn_t set_job_state_priority;
     prte_state_base_module_remove_job_state_fn_t remove_job_state;
     /* Proc state APIs */
     prte_state_base_module_activate_proc_state_fn_t activate_proc_state;
     prte_state_base_module_add_proc_state_fn_t add_proc_state;
     prte_state_base_module_set_proc_state_callback_fn_t set_proc_state_callback;
-    prte_state_base_module_set_proc_state_priority_fn_t set_proc_state_priority;
     prte_state_base_module_remove_proc_state_fn_t remove_proc_state;
 };
 typedef struct prte_state_base_module_1_0_0_t prte_state_base_module_1_0_0_t;

--- a/src/mca/state/state_types.h
+++ b/src/mca/state/state_types.h
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -61,7 +61,6 @@ typedef struct {
     prte_job_state_t job_state;
     prte_proc_state_t proc_state;
     prte_state_cbfunc_t cbfunc;
-    int priority;
 } prte_state_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_state_t);
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1107,7 +1107,6 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
         req->sz = sz;
     }
     prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, _mdxresp, req);
-    prte_event_set_priority(&(req->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 }
@@ -1291,7 +1290,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
 
         /* setup the cycle timer so we periodically wake up and try again */
         prte_event_evtimer_set(prte_event_base, &req->cycle, dmdx_check, req);
-        prte_event_set_priority(&req->cycle, PRTE_MSG_PRI);
         req->cycle_active = true;
         PMIX_POST_OBJECT(req);
         tv.tv_sec = 2;
@@ -1300,7 +1298,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         /* if they asked for a timeout, then set that too */
         if (0 < timeout) {
             prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
-            prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
             req->event_active = true;
             PMIX_POST_OBJECT(req);
             tv.tv_sec = timeout;
@@ -1345,7 +1342,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
 
             /* setup the cycle timer so we periodically wake up and try again */
             prte_event_evtimer_set(prte_event_base, &req->cycle, dmdx_check, req);
-            prte_event_set_priority(&req->cycle, PRTE_MSG_PRI);
             req->cycle_active = true;
             PMIX_POST_OBJECT(req);
             tv.tv_sec = 2;
@@ -1354,7 +1350,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
             /* if they asked for a timeout, then set that too */
             if (0 < timeout) {
                 prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
-                prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
                 req->event_active = true;
                 PMIX_POST_OBJECT(req);
                 tv.tv_sec = timeout;
@@ -1385,7 +1380,6 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     /* if they asked for a timeout, then set that too */
     if (0 < timeout) {
         prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
-        prte_event_set_priority(&req->ev, PRTE_MSG_PRI);
         req->event_active = true;
         PMIX_POST_OBJECT(req);
         tv.tv_sec = timeout;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -861,7 +861,6 @@ int pmix_server_spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[], 
     cd->spcbfunc = cbfunc;
     cd->cbdata = cbdata;
     prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, interim, cd);
-    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;
@@ -1287,7 +1286,6 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     op->cbfunc = cbfunc;
     op->cbdata = cbdata;
     prte_event_set(prte_event_base, &(op->ev), -1, PRTE_EV_WRITE, _cnct, op);
-    prte_event_set_priority(&(op->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(op);
     prte_event_active(&(op->ev), PRTE_EV_WRITE, 1);
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -190,7 +190,6 @@ pmix_status_t pmix_server_register_events_fn(pmix_status_t *codes, size_t ncodes
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _register_events, cd);
-    prte_event_set_priority(&(cd->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
     return PMIX_SUCCESS;
@@ -224,7 +223,6 @@ pmix_status_t pmix_server_deregister_events_fn(pmix_status_t *codes, size_t ncod
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _deregister_events, cd);
-    prte_event_set_priority(&(cd->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;
@@ -679,7 +677,6 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
     cd->target.rank = 0; // set default for tool
 
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _toolconn, cd);
-    prte_event_set_priority(&(cd->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -149,7 +149,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         _cd->cbfunc = (cfn);                                                       \
         _cd->cbdata = (cbd);                                                       \
         prte_event_set(prte_event_base, &(_cd->ev), -1, PRTE_EV_WRITE, (fn), _cd); \
-        prte_event_set_priority(&(_cd->ev), PRTE_MSG_PRI);                         \
         PMIX_POST_OBJECT(_cd);                                                     \
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);
@@ -165,7 +164,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         _req->mdxcbfunc = (ocf);                                                     \
         _req->cbdata = (ocd);                                                        \
         prte_event_set(prte_event_base, &(_req->ev), -1, PRTE_EV_WRITE, (cf), _req); \
-        prte_event_set_priority(&(_req->ev), PRTE_MSG_PRI);                          \
         PMIX_POST_OBJECT(_req);                                                      \
         prte_event_active(&(_req->ev), PRTE_EV_WRITE, 1);                            \
     } while (0);
@@ -179,7 +177,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         _req->spcbfunc = (ocf);                                                      \
         _req->cbdata = (ocd);                                                        \
         prte_event_set(prte_event_base, &(_req->ev), -1, PRTE_EV_WRITE, (cf), _req); \
-        prte_event_set_priority(&(_req->ev), PRTE_MSG_PRI);                          \
         PMIX_POST_OBJECT(_req);                                                      \
         prte_event_active(&(_req->ev), PRTE_EV_WRITE, 1);                            \
     } while (0);
@@ -195,7 +192,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         _cd->cbfunc = (cf);                                                        \
         _cd->cbdata = (cb);                                                        \
         prte_event_set(prte_event_base, &(_cd->ev), -1, PRTE_EV_WRITE, (fn), _cd); \
-        prte_event_set_priority(&(_cd->ev), PRTE_MSG_PRI);                         \
         PMIX_POST_OBJECT(_cd);                                                     \
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);
@@ -213,7 +209,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
         _cd->cbfunc = (cf);                                                        \
         _cd->cbdata = (cb);                                                        \
         prte_event_set(prte_event_base, &(_cd->ev), -1, PRTE_EV_WRITE, (fn), _cd); \
-        prte_event_set_priority(&(_cd->ev), PRTE_MSG_PRI);                         \
         PMIX_POST_OBJECT(_cd);                                                     \
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -275,7 +275,6 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
 
     /* thread-shift so we can store the tracker */
     prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, execute, req);
-    prte_event_set_priority(&(req->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
@@ -360,7 +359,6 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
 
     /* thread-shift so we can store the tracker */
     prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, execute, req);
-    prte_event_set_priority(&(req->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
@@ -442,7 +440,6 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
 
     /* thread-shift so we can store the tracker */
     prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, execute, req);
-    prte_event_set_priority(&(req->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -824,7 +824,6 @@ pmix_status_t pmix_server_query_fn(pmix_proc_t *proct, pmix_query_t *queries, si
     cd->cbdata = cbdata;
 
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _query, cd);
-    prte_event_set_priority(&(cd->ev), PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -209,7 +209,6 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
     cd->infocbfunc = cbfunc;
     cd->cbdata = cbdata;
     prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
-    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;
@@ -237,7 +236,6 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
     cd->infocbfunc = cbfunc;
     cd->cbdata = cbdata;
     prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
-    prte_event_set_priority(&cd->ev, PRTE_MSG_PRI);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -336,7 +336,6 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     char **temp_argv, **env;
     prte_pmix_app_t *app;
     bool made_app;
-    bool ddash = false;
 
     /* Make the apps */
     temp_argv = NULL;
@@ -348,13 +347,6 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
 
     env = NULL;
     for (i = 1; NULL != argv[i]; ++i) {
-        // if this is a `--`, then everything beyond it
-        // belongs to the application
-        if (0 == strcmp(argv[i], "--")) {
-            ddash = true;
-            ++i;
-            break;
-        }
         if (0 == strcmp(argv[i], ":")) {
             /* Make an app with this argv */
             if (PMIX_ARGV_COUNT_COMPAT(temp_argv) > 1) {
@@ -394,13 +386,9 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
         }
         if (made_app) {
             pmix_list_append(jdata, &app->super);
-            if (ddash && NULL != argv[i]) {
-                for (j=i; NULL != argv[j]; j++) {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->app.argv, argv[j]);
-                }
-            }
         }
     }
+
     if (NULL != env) {
         PMIX_ARGV_FREE_COMPAT(env);
     }

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -192,7 +192,6 @@ PRTE_EXPORT pmix_rank_t prte_rml_get_route(pmix_rank_t target);
         /* setup the event */                                                                   \
         prte_event_set(prte_event_base, &msg->ev, -1, PRTE_EV_WRITE,                            \
                        prte_rml_base_process_msg, msg);                                         \
-        prte_event_set_priority(&msg->ev, PRTE_MSG_PRI);                                        \
         prte_event_active(&msg->ev, PRTE_EV_WRITE, 1);                                          \
     } while (0);
 
@@ -201,7 +200,6 @@ PRTE_EXPORT pmix_rank_t prte_rml_get_route(pmix_rank_t target);
         /* setup the event */                                                                   \
         prte_event_set(prte_event_base, &(m)->ev, -1, PRTE_EV_WRITE,                            \
                        prte_rml_base_process_msg, (m));                                         \
-        prte_event_set_priority(&(m)->ev, PRTE_MSG_PRI);                                        \
         prte_event_active(&(m)->ev, PRTE_EV_WRITE, 1);                                          \
     } while (0);
 

--- a/src/rml/rml_recv.c
+++ b/src/rml/rml_recv.c
@@ -67,7 +67,7 @@ void prte_rml_recv_buffer_nb(pmix_proc_t *peer,
     req->post->persistent = persistent;
     req->post->cbfunc = cbfunc;
     req->post->cbdata = cbdata;
-    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
+    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv);
 }
 void prte_rml_recv_cancel(pmix_proc_t *peer, prte_rml_tag_t tag)
 {
@@ -90,5 +90,5 @@ void prte_rml_recv_cancel(pmix_proc_t *peer, prte_rml_tag_t tag)
     req->cancel = true;
     PMIX_XFER_PROCID(&req->post->peer, peer);
     req->post->tag = tag;
-    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv, PRTE_MSG_PRI);
+    PRTE_PMIX_THREADSHIFT(req, prte_event_base, prte_rml_base_post_recv);
 }

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -125,18 +125,6 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_timer_t);
 
 PRTE_EXPORT extern int prte_exit_status;
 
-/* PRTE event priorities - we define these
- * at levels that permit higher layers such as
- * OMPI to handle their events at higher priority,
- * with the exception of errors. Errors generally
- * require exception handling (e.g., ctrl-c termination)
- * that overrides the need to process MPI messages
- */
-#define PRTE_ERROR_PRI PRTE_EV_ERROR_PRI
-#define PRTE_MSG_PRI   PRTE_EV_MSG_LO_PRI
-#define PRTE_SYS_PRI   PRTE_EV_SYS_LO_PRI
-#define PRTE_INFO_PRI  PRTE_EV_INFO_LO_PRI
-
 /* define some common keys used in PRTE */
 #define PRTE_DB_DAEMON_VPID "prte.daemon.vpid"
 

--- a/src/runtime/prte_wait.c
+++ b/src/runtime/prte_wait.c
@@ -116,7 +116,6 @@ int prte_wait_init(void)
 
     prte_event_set(prte_event_base, &handler, SIGCHLD, PRTE_EV_SIGNAL | PRTE_EV_PERSIST,
                    wait_signal_callback, &handler);
-    prte_event_set_priority(&handler, PRTE_SYS_PRI);
 
     prte_event_add(&handler, NULL);
     return PRTE_SUCCESS;
@@ -156,7 +155,6 @@ void prte_wait_cb(prte_proc_t *child, prte_wait_cbfunc_t callback, prte_event_ba
             t2->cbfunc = callback;
             t2->cbdata = data;
             prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
-            prte_event_set_priority(&t2->ev, PRTE_MSG_PRI);
             prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
         }
         return;
@@ -216,7 +214,7 @@ void prte_wait_cb_cancel(prte_proc_t *child)
     trk = PMIX_NEW(prte_wait_tracker_t);
     PMIX_RETAIN(child); // protect against race conditions
     trk->child = child;
-    PRTE_PMIX_THREADSHIFT(trk, prte_event_base, cancel_callback, PRTE_SYS_PRI);
+    PRTE_PMIX_THREADSHIFT(trk, prte_event_base, cancel_callback);
 }
 
 /* callback from the event library whenever a SIGCHLD is received */
@@ -257,7 +255,6 @@ static void wait_signal_callback(int fd, short event, void *arg)
                 pmix_list_remove_item(&pending_cbs, &t2->super);
                 if (NULL != t2->cbfunc) {
                     prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
-                    prte_event_set_priority(&t2->ev, PRTE_MSG_PRI);
                     prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
                 } else {
                     PMIX_RELEASE(t2);

--- a/src/runtime/prte_wait.c
+++ b/src/runtime/prte_wait.c
@@ -75,7 +75,8 @@ static void timer_dest(prte_timer_t *tm)
 {
     prte_event_free(tm->ev);
 }
-PMIX_CLASS_INSTANCE(prte_timer_t, pmix_object_t, timer_const, timer_dest);
+PMIX_CLASS_INSTANCE(prte_timer_t, pmix_object_t,
+                    timer_const, timer_dest);
 
 static void wccon(prte_wait_tracker_t *p)
 {
@@ -89,7 +90,8 @@ static void wcdes(prte_wait_tracker_t *p)
         PMIX_RELEASE(p->child);
     }
 }
-PMIX_CLASS_INSTANCE(prte_wait_tracker_t, pmix_list_item_t, wccon, wcdes);
+PMIX_CLASS_INSTANCE(prte_wait_tracker_t, pmix_list_item_t,
+                    wccon, wcdes);
 
 /* Local Variables */
 static prte_event_t handler;
@@ -114,7 +116,8 @@ int prte_wait_init(void)
 {
     PMIX_CONSTRUCT(&pending_cbs, pmix_list_t);
 
-    prte_event_set(prte_event_base, &handler, SIGCHLD, PRTE_EV_SIGNAL | PRTE_EV_PERSIST,
+    prte_event_set(prte_event_base, &handler, SIGCHLD,
+                   PRTE_EV_SIGNAL | PRTE_EV_PERSIST,
                    wait_signal_callback, &handler);
 
     prte_event_add(&handler, NULL);
@@ -133,7 +136,8 @@ int prte_wait_finalize(void)
 
 /* this function *must* always be called from
  * within an event in the prte_event_base */
-void prte_wait_cb(prte_proc_t *child, prte_wait_cbfunc_t callback, prte_event_base_t *evb,
+void prte_wait_cb(prte_proc_t *child,
+                  prte_wait_cbfunc_t callback,
                   void *data)
 {
     prte_wait_tracker_t *t2;
@@ -151,10 +155,9 @@ void prte_wait_cb(prte_proc_t *child, prte_wait_cbfunc_t callback, prte_event_ba
             t2 = PMIX_NEW(prte_wait_tracker_t);
             PMIX_RETAIN(child); // protect against race conditions
             t2->child = child;
-            t2->evb = evb;
             t2->cbfunc = callback;
             t2->cbdata = data;
-            prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
+            prte_event_set(prte_event_base, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
             prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
         }
         return;
@@ -173,7 +176,6 @@ void prte_wait_cb(prte_proc_t *child, prte_wait_cbfunc_t callback, prte_event_ba
     t2 = PMIX_NEW(prte_wait_tracker_t);
     PMIX_RETAIN(child); // protect against race conditions
     t2->child = child;
-    t2->evb = evb;
     t2->cbfunc = callback;
     t2->cbdata = data;
     pmix_list_append(&pending_cbs, &t2->super);
@@ -254,7 +256,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
                 t2->child->exit_code = status;
                 pmix_list_remove_item(&pending_cbs, &t2->super);
                 if (NULL != t2->cbfunc) {
-                    prte_event_set(t2->evb, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
+                    prte_event_set(prte_event_base, &t2->ev, -1, PRTE_EV_WRITE, t2->cbfunc, t2);
                     prte_event_active(&t2->ev, PRTE_EV_WRITE, 1);
                 } else {
                     PMIX_RELEASE(t2);

--- a/src/runtime/prte_wait.h
+++ b/src/runtime/prte_wait.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -139,7 +139,6 @@ PRTE_EXPORT void prte_wait_cb_cancel(prte_proc_t *proc);
         tmp = PMIX_NEW(prte_timer_t);                                                             \
         tmp->payload = (cbd);                                                                     \
         prte_event_evtimer_set(prte_event_base, tmp->ev, (cbfunc), tmp);                          \
-        prte_event_set_priority(tmp->ev, PRTE_ERROR_PRI);                                         \
         timeout = (deltat) * (n);                                                                 \
         if ((maxwait) > 0 && timeout > (maxwait)) {                                               \
             timeout = (maxwait);                                                                  \
@@ -161,12 +160,11 @@ PRTE_EXPORT void prte_wait_cb_cancel(prte_proc_t *proc);
  * event back to the event pool when done! Otherwise, the finalize
  * function will take care of it.
  */
-#define PRTE_TIMER_EVENT(sec, usec, cbfunc, pri)                                                \
+#define PRTE_TIMER_EVENT(sec, usec, cbfunc)                                                     \
     do {                                                                                        \
         prte_timer_t *tm;                                                                       \
         tm = PMIX_NEW(prte_timer_t);                                                            \
         prte_event_evtimer_set(prte_event_base, tm->ev, (cbfunc), tm);                          \
-        prte_event_set_priority(tm->ev, (pri));                                                 \
         tm->tv.tv_sec = (sec) + (usec) / 1000000;                                               \
         tm->tv.tv_usec = (usec) % 1000000;                                                      \
         PMIX_OUTPUT_VERBOSE((1, prte_debug_output,                                              \

--- a/src/runtime/prte_wait.h
+++ b/src/runtime/prte_wait.h
@@ -63,7 +63,6 @@ typedef void (*prte_wait_cbfunc_t)(int fd, short args, void *cb);
 typedef struct {
     pmix_list_item_t super;
     prte_event_t ev;
-    prte_event_base_t *evb;
     prte_proc_t *child;
     prte_wait_cbfunc_t cbfunc;
     void *cbdata;
@@ -86,8 +85,9 @@ PRTE_EXPORT void prte_wait_disable(void);
  * \c waitpid() will have already been called on the process at this
  * time.
  */
-PRTE_EXPORT void prte_wait_cb(prte_proc_t *proc, prte_wait_cbfunc_t callback,
-                              prte_event_base_t *evb, void *data);
+PRTE_EXPORT void prte_wait_cb(prte_proc_t *proc,
+                              prte_wait_cbfunc_t callback,
+                              void *data);
 
 PRTE_EXPORT void prte_wait_cb_cancel(prte_proc_t *proc);
 

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -24,6 +24,7 @@
  *                         reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
  *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -702,14 +703,15 @@ int main(int argc, char *argv[])
             param[param_len - 1] = '\0';
             param_len--;
             if (0 == param_len) {
-                pmix_show_help("help-prun.txt", "prun:empty-prefix", true, prte_tool_basename,
-                               prte_tool_basename);
-                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                goto DONE;
+                /* We get here if we removed all PATH_SEP's and end up
+                   with an empty string.  In this case, the prefix is
+                   just a single PATH_SEP. */
+                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
+                break;
             }
         }
-        prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL, param,
-                           PMIX_STRING);
+        prte_set_attribute(&dapp->attributes, PRTE_APP_PREFIX_DIR, PRTE_ATTR_GLOBAL,
+                           param, PMIX_STRING);
         free(param);
     } else {
         /* Check if called with fully-qualified path to prte.

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -430,7 +430,7 @@ int main(int argc, char *argv[])
              * and have it kill us
              */
             if (0 < prted_debug_failure_delay) {
-                PRTE_TIMER_EVENT(prted_debug_failure_delay, 0, shutdown_callback, PRTE_SYS_PRI);
+                PRTE_TIMER_EVENT(prted_debug_failure_delay, 0, shutdown_callback);
 
             } else {
                 pmix_output(0, "%s is executing clean %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -25,7 +25,7 @@
 #include "src/util/pmix_string_copy.h"
 
 #include "src/mca/errmgr/errmgr.h"
-
+#include "src/runtime/prte_globals.h"
 #include "src/util/attr.h"
 
 #define MAX_CONVERTERS            5
@@ -888,4 +888,148 @@ int prte_attr_unload(prte_attribute_t *kv, void **data, pmix_data_type_t type)
         return PRTE_ERR_NOT_SUPPORTED;
     }
     return PRTE_SUCCESS;
+}
+
+char* prte_print_proc_flags(struct prte_proc_t *ptr)
+{
+    prte_proc_t *p = (prte_proc_t*)ptr;
+    char **tmp = NULL;
+    char *ans;
+
+    // start with the proc name
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, PRTE_NAME_PRINT(&p->name));
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_ALIVE)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ALIVE");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_ABORT)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ABORT");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_UPDATED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "UPDATED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_LOCAL)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LOCAL");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_REPORTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "REPORTED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_REG)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "REGISTERED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_HAS_DEREG)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DEREGISTERED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_AS_MPI)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MPI");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_IOF_COMPLETE)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "IOF-COMPLETE");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_WAITPID)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "WAITPID");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_RECORDED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RECORDED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_DATA_IN_SM)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DATA-IN-SM");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_DATA_RECVD)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DATA-RECVD");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_SM_ACCESS)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "SM-ACCESS");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_TERM_REPORTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TERMINATED");
+    }
+    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
+    PMIX_ARGV_FREE_COMPAT(tmp);
+    return ans;
+}
+
+char* prte_print_node_flags(struct prte_node_t *ptr)
+{
+    prte_node_t *p = (prte_node_t*)ptr;
+    char **tmp = NULL;
+    char *ans;
+
+    // start with the node name
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, p->name);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DAEMON-LAUNCHED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_LOC_VERIFIED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LOCATION");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "OVERSUBSCRIBED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_MAPPED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MAPPED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "SLOTS-GIVEN");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_NODE_NON_USABLE)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "NONUSABLE");
+    }
+    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
+    PMIX_ARGV_FREE_COMPAT(tmp);
+    return ans;
+}
+
+char* prte_print_job_flags(struct prte_job_t *ptr)
+{
+    prte_job_t *p = (prte_job_t*)ptr;
+    char **tmp = NULL;
+    char *ans;
+
+    // start with the job name
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, PRTE_JOBID_PRINT(p->nspace));
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_UPDATED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "UPDATED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_RESTARTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RESTARTED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_ABORTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ABORTED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "FORWARD-OUTPUT");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_DO_NOT_MONITOR)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DO-NOT-MONITOR");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_FORWARD_COMM)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "FWD-COM");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_RESTART)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RESTART");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_PROCS_MIGRATING)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MIGRATING");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_OVERSUBSCRIBED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "OVERSUBSCRIBED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_TOOL)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TOOL");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_LAUNCHER)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LAUNCHER");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_ERR_REPORTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ERROR-REPORTED");
+    }
+    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
+    PMIX_ARGV_FREE_COMPAT(tmp);
+    return ans;
 }

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -325,3 +325,12 @@ PRTE_EXPORT int prte_attr_register(const char *project, prte_attribute_key_t key
         free(_output);                                                              \
     } while (0)
 #endif
+
+// forward declarations
+struct prte_proc_t;
+struct prte_node_t;
+struct prte_job_t;
+
+PRTE_EXPORT char* prte_print_proc_flags(struct prte_proc_t *p);
+PRTE_EXPORT char* prte_print_node_flags(struct prte_node_t *p);
+PRTE_EXPORT char* prte_print_job_flags(struct prte_job_t *p);

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -412,7 +412,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         }
     }
 
-    if (prte_managed_allocation) {
+    if (prte_managed_allocation && !allocating) {
         prte_node_t *node_from_pool = NULL;
         PMIX_LIST_FOREACH(node, nodes, prte_node_t) {
             needcheck = true;


### PR DESCRIPTION
[prte.c: a prefix of "/" is ok](https://github.com/openpmix/prrte/commit/36b8bfc6a8360ebe159226111bff8f1049ac3964)

It's not an error if the prefix ends up being a plain "/".  More
specifically, if we strip off all trailing "/" characters from the
prefix and end up with an empty string, then the prefix is just "/".

Protect against a NULL prefix being added to the app's attributes.

Protect against a double-/ in the prted cmd path in the ssh
launch component.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ce7f686eae454b368022ca7d8d9a8d50f4a8ce37)

[Correctly translate the plm_rsh MCA params](https://github.com/openpmix/prrte/commit/d6837721197c5aaf1bb0f1c26eb455aad55ee701)

Need to convert to plm_ssh

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/d7d00954a78b4f55731147e2ae27053bfc164747)

[Fix add-hostfile and add-host operations](https://github.com/openpmix/prrte/commit/47a66cf6c2a3a36c78b668ffe5f5d461015d1b97)

When in a managed allocation, allow addition of nodes
provided that either (a) all the nodes in the managed
portion of the allocation have the same #slots in them
so we can infer how many are in the new nodes, or (b)
the user specifies the #slots for the new nodes.

Check node names as well as aliases for match.

Add a new ras component to simulate a managed allocation.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/bffbc40d0625bab0d69046ebbb22bcd20cd89990)

[Add print functions for node, job, and proc flags](https://github.com/openpmix/prrte/commit/4a6a24fc24626df911398f44f5159339b01088ce)

Make it easier to understand what flags are set.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f4e67ac12c364c0476bd929993d91046fb3b35a6)

[Add missing "acquire_object"](https://github.com/openpmix/prrte/commit/44d2461ceecb9ac6513ab2bff719e05f2d7d429f)

Ensure we have a memory barrier prior to
using the object when called from the
progress thread.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/2835e0983c43ed6dd193c8b12897e33a3cbf56be)

[Fix handling of "--" in cmd line](https://github.com/openpmix/prrte/commit/593ff8bb868e01ac303e7fb0985363cad492f167)

Allow the app parser to see the line and rely on
the PMIx cmd line parser to handle it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/81b4e60755db5659971b5194a1c1e7a863969592)

[Use global PRRTE event base for sigchld callback](https://github.com/openpmix/prrte/commit/99fbd2b610b59f0afa81eb08da67b41f2d298874)

Even when we utilize multiple odls progress threads
to locally fork/exec procs, we have to direct the
waitpid callback to the global event base to ensure
that all servicing of sigchld returns happens in a
thread-safe environment.

Remove the unused event base priorities as an
unnecessary distraction.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/066b56055c4f9017a581dc472864c9e2d8c189cc)

[Remove the event base param to prte_wait_cb](https://github.com/openpmix/prrte/commit/19acfa7ab8f4f3cf62b77c165cc7c914ec74fd1f)

Reduce potential for mistakes by locking the
wait callbacks to occur in the main event thread.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ad63c0f30ea8499fd25a5591a2bd4f7e1f134b4b)

[Fix OMPI cmd line processing](https://github.com/openpmix/prrte/commit/1cc02bb5651fc78aa3ad623e3618ee9474ddcc17)

Don't touch provided values of MCA params when
converting single-dash to double-dash options.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/0da200068ebe2a7aa461b6914dee6b527304707c)
