### PR TITLE
Fix the seq mapper

### DIFF
--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -359,7 +359,8 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
                 goto error;
             }
             rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
-            if (PRTE_SUCCESS != rc) {
+            if (PRTE_SUCCESS != rc &&
+                PRTE_ERR_TAKE_NEXT_OPTION != rc) {
                 PMIX_RELEASE(proc);
                 goto error;
             }


### PR DESCRIPTION
Just move on if the node is full - we'll catch any oversubscription if/when we try to place another
process on that node.