### PR TITLE
protect the info passed to pmix_tool_connected_fn

### DIFF
--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -663,6 +663,7 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
                             void *cbdata)
 {
     pmix_server_req_t *cd;
+    size_t n;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s TOOL CONNECTION REQUEST RECVD",
@@ -670,11 +671,16 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
 
     /* need to threadshift this request */
     cd = PMIX_NEW(pmix_server_req_t);
-    cd->info = info;
-    cd->ninfo = ninfo;
     cd->toolcbfunc = cbfunc;
     cd->cbdata = cbdata;
     cd->target.rank = 0; // set default for tool
+
+    /* protect the provided info */
+    cd->ninfo = ninfo;
+    PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    for(n = 0; n < ninfo; n++){
+        PMIX_INFO_XFER(&cd->info[n], &info[n]);
+    }
 
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _toolconn, cd);
     PMIX_POST_OBJECT(cd);


### PR DESCRIPTION
The info array passed to pmix_tool_connected_fn  is also part of the cbdata (i.e. a member of the pmix_pending_connection_t struct) and gets assigned to the pmix_server_req_t struct.

When calling the callback function provided by the openpmix server implementation, the PMIx server releases the pmix_pending_connection_t struct (including the info array).
Likewise,  PRRTE releases the pmix_server_req_t struct (including the info array). 
Thus a double free happens on the info array, potentially leading to invalid memory accesses.

This patch protects the info passed to pmix_tool_connected_fn by assigning a copy of the info to the pmix_server_req_t struct instead of the original info.