### PR TITLE
Preserve backward compatibility

### DIFF
--- a/src/mca/ess/base/ess_base_bootstrap.c
+++ b/src/mca/ess/base/ess_base_bootstrap.c
@@ -68,6 +68,23 @@ static pmix_status_t regex_parse_value_range(char *base, char *range,
                                              char ***names);
 static pmix_status_t read_file(char *regexp, char ***names);
 
+#if PMIX_NUMERIC_VERSION < 0x00040207
+static char *pmix_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[1024];
+
+    ret = fgets(input, 1024, fp);
+    if (NULL != ret) {
+        input[strlen(input) - 1] = '\0'; /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
+}
+#endif
+
 int prte_ess_base_bootstrap(void)
 {
     char *path, *line, *ptr;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -59,6 +59,23 @@
 
 #include "src/mca/ras/base/ras_private.h"
 
+#if PMIX_NUMERIC_VERSION < 0x00040207
+static char *pmix_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[1024];
+
+    ret = fgets(input, 1024, fp);
+    if (NULL != ret) {
+        input[strlen(input) - 1] = '\0'; /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
+}
+#endif
+
 char *prte_ras_base_flag_string(prte_node_t *node)
 {
     char *tmp, *t3, **t2 = NULL;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -71,6 +71,23 @@ static int prte_rmaps_rf_process_lsf_affinity_hostfile(prte_job_t *jdata, prte_r
 
 char *prte_rmaps_rank_file_slot_list = NULL;
 
+#if PMIX_NUMERIC_VERSION < 0x00040207
+static char *pmix_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[1024];
+
+    ret = fgets(input, 1024, fp);
+    if (NULL != ret) {
+        input[strlen(input) - 1] = '\0'; /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
+}
+#endif
+
 /*
  * Local variable
  */

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -109,6 +109,23 @@ static bool quickmatch(prte_node_t *nd, char *name)
     return false;
 }
 
+#if PMIX_NUMERIC_VERSION < 0x00040207
+static char *pmix_getline(FILE *fp)
+{
+    char *ret, *buff;
+    char input[1024];
+
+    ret = fgets(input, 1024, fp);
+    if (NULL != ret) {
+        input[strlen(input) - 1] = '\0'; /* remove newline */
+        buff = strdup(input);
+        return buff;
+    }
+
+    return NULL;
+}
+#endif
+
 /*
  * Sequentially map the ranks according to the placement in the
  * specified hostfile


### PR DESCRIPTION
For earlier versions of PMIx, we won't have access to the pmix_getline utility - so preserve the static
versions of that function where required for those earlier versions.