### PR TITLE
Check the PMIx version for min required

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -120,6 +120,10 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LDFLAGS, $prte_pmix_LDFLAGS)
     PRTE_FLAGS_APPEND_UNIQ(PRTE_FINAL_LIBS, $prte_pmix_LIBS)
 
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_MINIMUM_VERSION],
+                       [$prte_pmix_min_num_version],
+                       [Minimum supported PMIx version])
+
     found_pmixcc=0
     PMIXCC_PATH="pmixcc"
     AS_IF([test -n "${with_pmix}"],

--- a/src/docs/show-help-files/help-prted.rst
+++ b/src/docs/show-help-files/help-prted.rst
@@ -275,15 +275,15 @@ is alive:
 
 [mpir-debugger-detected]
 
-PRTE has detected that you have attached a debugger to this MPI
+PRRTE has detected that you have attached a debugger to this MPI
 job, and that debugger is using the legacy "MPIR" method of
 attachment.
 
-Please note that PRTE has deprecated the "MPIR" debugger
+Please note that PRRTE has deprecated the "MPIR" debugger
 attachment method in favor of the new "PMIx" debugger attchment
 mechanisms.
 
-.. warning:: This means that future versions of PRTE may not support
+.. warning:: This means that future versions of PRRTE may not support
              the "MPIR" debugger attachment method at all.
              Specifically: the debugger you just attached may not work
              with future versions of PRTE.
@@ -305,3 +305,14 @@ set:
 
 Only one of these can be set |mdash| please fix the options and try
 again.
+
+[min-pmix-violation]
+
+PRRTE has detected that the PMIx library being used to run this
+executable does not meet the minimum supported version:
+
+  Min PMIx version: %0x
+  Detected version: %0x
+
+Please check your LD_LIBRARY_PATH and ensure we are pointed to
+a version that meets the minimum requirement.


### PR DESCRIPTION
Need to check the PMIx version at runtime to ensure it meets the minimum requirements. Can only do this where supported (i.e., PMIx v4.2.7 and above).