### PR TITLE
Correct min version for pmix_getline util

### DIFF
--- a/src/mca/ess/base/ess_base_bootstrap.c
+++ b/src/mca/ess/base/ess_base_bootstrap.c
@@ -68,7 +68,7 @@ static pmix_status_t regex_parse_value_range(char *base, char *range,
                                              char ***names);
 static pmix_status_t read_file(char *regexp, char ***names);
 
-#if PMIX_NUMERIC_VERSION < 0x00040207
+#if PMIX_NUMERIC_VERSION < 0x00040208
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -59,7 +59,7 @@
 
 #include "src/mca/ras/base/ras_private.h"
 
-#if PMIX_NUMERIC_VERSION < 0x00040207
+#if PMIX_NUMERIC_VERSION < 0x00040208
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -71,7 +71,7 @@ static int prte_rmaps_rf_process_lsf_affinity_hostfile(prte_job_t *jdata, prte_r
 
 char *prte_rmaps_rank_file_slot_list = NULL;
 
-#if PMIX_NUMERIC_VERSION < 0x00040207
+#if PMIX_NUMERIC_VERSION < 0x00040208
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -109,7 +109,7 @@ static bool quickmatch(prte_node_t *nd, char *name)
     return false;
 }
 
-#if PMIX_NUMERIC_VERSION < 0x00040207
+#if PMIX_NUMERIC_VERSION < 0x00040208
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;


### PR DESCRIPTION
Wasn't made globally visible until PMIx v4.2.8