### PR TITLE
Minor tweaks of cmd line processing

### DIFF
--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -269,6 +269,10 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
     char *p1, *p2, *param;
 
     for (i = 0; i < (argc - start); ++i) {
+        if (0 == strcmp("--", argv[i])) {
+            // quit processing
+            return PRTE_SUCCESS;
+        }
         if (0 == strcmp("--prtemca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
@@ -409,6 +413,10 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
     char *p1, *p2, *param;
 
     for (i = 0; i < (argc - start); ++i) {
+        if (0 == strcmp("--", argv[i])) {
+            // quit processing
+            return PRTE_SUCCESS;
+        }
         if (0 == strcmp("--pmixmca", argv[i]) || 0 == strcmp("--gpmixmca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -450,6 +450,10 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
 
     /* Convert single dashes to multi-dashes. */
     for (n=1; NULL != pargv[n]; n++) {
+        if (0 == strcmp("--", pargv[n])) {
+            // quit processing
+            break;
+        }
         /* check for option */
         if ('-' != pargv[n][0]) {
             continue;


### PR DESCRIPTION
Stop at the '--' delineator when searching for MCA params and in the OMPI translation loop