### PR TITLE
Check for stdatomic.h

### DIFF
--- a/config/prte_setup_cc.m4
+++ b/config/prte_setup_cc.m4
@@ -21,7 +21,7 @@ dnl Copyright (c) 2020      Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2021      IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -174,16 +174,16 @@ AC_DEFUN([PRTE_SETUP_CC],[
     if test $prte_cv_c11_supported = no ; then
         # It is not currently an error if C11 support is not available. Uncomment the
         # following lines and update the warning when we require a C11 compiler.
-        # AC_MSG_WARNING([Open MPI requires a C11 (or newer) compiler])
+        # AC_MSG_WARNING([PRRTE requires a C11 (or newer) compiler])
         # AC_MSG_ERROR([Aborting.])
-        # From Open MPI 1.7 on we require a C99 compiant compiler
+        # We require a C99 compiant compiler
         # with autoconf 2.70 AC_PROG_CC makes AC_PROG_CC_C99 obsolete
         m4_version_prereq([2.70],
             [],
             [AC_PROG_CC_C99])
         # The C99 result of AC_PROG_CC is stored in ac_cv_prog_cc_c99
         if test "x$ac_cv_prog_cc_c99" = xno ; then
-            AC_MSG_WARN([Open MPI requires a C99 (or newer) compiler. C11 is recommended.])
+            AC_MSG_WARN([PRRTE requires a C99 (or newer) compiler. C11 is recommended.])
             AC_MSG_ERROR([Aborting.])
         fi
 
@@ -398,7 +398,7 @@ AC_DEFUN([_PRTE_PROG_CC],[
     AC_PROG_CC
     BASECC="`basename $CC`"
     CFLAGS="$prte_cflags_save"
-    AC_DEFINE_UNQUOTED(PRTE_CC, "$CC", [OMPI underlying C compiler])
+    AC_DEFINE_UNQUOTED(PRTE_CC, "$CC", [PRRTE underlying C compiler])
     set dummy $CC
     prte_cc_argv0=[$]2
     PRTE_WHICH([$prte_cc_argv0], [PRTE_CC_ABSOLUTE])

--- a/configure.ac
+++ b/configure.ac
@@ -414,7 +414,7 @@ AC_CHECK_HEADERS([arpa/inet.h dirent.h \
                   sys/types.h sys/uio.h sys/un.h net/uio.h sys/utsname.h sys/wait.h syslog.h \
                   termios.h unistd.h util.h malloc.h \
                   paths.h \
-                  ioLib.h sockLib.h hostLib.h])
+                  ioLib.h sockLib.h hostLib.h stdatomic.h])
 
 # Needed to work around Darwin requiring sys/socket.h for
 # net/if.h

--- a/src/include/prte_stdatomic.h
+++ b/src/include/prte_stdatomic.h
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
@@ -23,7 +23,9 @@
 
 #    if PRTE_ATOMIC_C11
 
+#ifdef HAVE_STDATOMIC_H
 #        include <stdatomic.h>
+#endif
 
 typedef atomic_int prte_atomic_int_t;
 typedef atomic_long prte_atomic_long_t;


### PR DESCRIPTION
Protect against it not being found. Cleanup
a few OMPI vs PRRTE typos

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit acb1b121936949c8cfdba235d4faed5a760e8f72)