### PR TITLE
Cleanup attachment to scheduler

### DIFF
--- a/src/tools/psched/psched.h
+++ b/src/tools/psched/psched.h
@@ -129,6 +129,8 @@ typedef struct {
     // allocation request info
     pmix_proc_t requestor;
     pmix_alloc_directive_t directive;
+    // whether the data is a local copy
+    bool copy;
     // original info keys
     pmix_info_t *data;
     size_t ndata;

--- a/src/tools/psched/state.c
+++ b/src/tools/psched/state.c
@@ -315,6 +315,7 @@ PMIX_CLASS_INSTANCE(psched_state_t,
 static void req_con(psched_req_t *p)
 {
     PMIx_Load_procid(&p->requestor, NULL, PMIX_RANK_INVALID);
+    p->copy = false;  // data is not a local copy
     p->data = NULL;
     p->ndata = 0;
     p->user_refid = NULL;
@@ -341,7 +342,7 @@ static void req_con(psched_req_t *p)
 }
 static void req_des(psched_req_t *p)
 {
-    if (NULL != p->data) {
+    if (NULL != p->data && p->copy) {
         PMIx_Info_free(p->data, p->ndata);
     }
     if (NULL != p->user_refid) {


### PR DESCRIPTION
If a scheduler request is received and we are not already attached to the scheduler, then use PMIx_tool_attach_to_server to setup the connection. Note that the function will simply return if we are already attached, but PRRTE doesn't know about it yet.