### PR TITLE
Check for presence of git before using it in configure

### DIFF
--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -54,9 +54,15 @@ AC_DEFINE_UNQUOTED([PRTE_WANT_PRTE_PREFIX_BY_DEFAULT],
 # Is this a developer copy?
 #
 
-if git describe 350564b9f381dfbdbe119f26585f07da6f4b9e8a &> /dev/null ; then
-    PRTE_DEVEL=1
+AC_CHECK_PROG(prte_git_cmd, git, [git])
+if test "$prte_git_cmd" != ""; then
+    if git describe 350564b9f381dfbdbe119f26585f07da6f4b9e8a &> /dev/null ; then
+        PRTE_DEVEL=1
+    else
+        PRTE_DEVEL=0
+    fi
 else
+    # we cannot check, so assume it isn't a repo build
     PRTE_DEVEL=0
 fi
 


### PR DESCRIPTION
If we are going to use the "git" command to check if we are in a git repo build, then first check that the cmd is available.