### PR TITLE
Revert "Check for presence of git before using it in configure"

### DIFF
--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -54,15 +54,9 @@ AC_DEFINE_UNQUOTED([PRTE_WANT_PRTE_PREFIX_BY_DEFAULT],
 # Is this a developer copy?
 #
 
-AC_CHECK_PROG(prte_git_cmd, git, [git])
-if test "$prte_git_cmd" != ""; then
-    if git describe 350564b9f381dfbdbe119f26585f07da6f4b9e8a &> /dev/null ; then
-        PRTE_DEVEL=1
-    else
-        PRTE_DEVEL=0
-    fi
+if test -d .git; then
+    PRTE_DEVEL=1
 else
-    # we cannot check, so assume it isn't a repo build
     PRTE_DEVEL=0
 fi
 


### PR DESCRIPTION
This reverts commit 9af88ef22276154076f46bb9522754c788860e3b.

Revert "Use git describe on a known PRRTE commit sha instead of checking for .git directory"

This reverts commit 4a5c1e8201f865bf6479cef745d130ebd9c669a3.