### PR TITLE
Use pmix_path_nfs to detect shared file systems

### DIFF
--- a/src/docs/show-help-files/help-prte-runtime.rst
+++ b/src/docs/show-help-files/help-prte-runtime.rst
@@ -158,3 +158,31 @@ the regex of participating nodes on at least one node:
    error:  %s
 
 Please fix the error and try again.
+
+[prte:session:dir:shared]
+
+PRTE has detected that the head of the session directory
+tree (where scratch files and shared memory backing storage
+will be placed) resides on a shared file system:
+
+.. code::
+
+   Directory: %s
+   File system type: %s
+
+For performance reasons, it is strongly recommended that the
+session directory be located on a local file system. This can
+be controlled by setting the system temporary directory to be
+used by PRTE using either the TMPDIR envar or the "prte_tmpdir_base"
+MCA param.
+
+If you need the temporary directory to be different
+on remote nodes from the local one where %s is running (e.g.,
+when a login node is being employed), then you can set the
+local temporary directory using the "prte_local_tmpdir_base"
+MCA param and the one to be used on all other nodes using the
+"prte_remote_tmpdir_base" param.
+
+This is only a warning advisory and your job will continue.
+You can disable this warning in the future by setting the
+"prte_silence_shared_fs" MCA param to "1".

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -48,6 +48,7 @@
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_environ.h"
+#include "src/util/proc_info.h"
 #include "src/util/prte_cmd_line.h"
 #include "src/runtime/pmix_init_util.h"
 #include "src/util/session_dir.h"
@@ -1794,6 +1795,17 @@ static int parse_env(char **srcenv, char ***dstenv,
         PMIX_ARGV_FREE_COMPAT(xparams);
         PMIX_ARGV_FREE_COMPAT(xvals);
     }
+
+#if PMIX_NUMERIC_VERSION != 0x00040208
+    /* add a flag indicating that we did indeed check the tmpdir
+     * for a shared file system */
+    if (prte_process_info.shared_fs) {
+        p1 = "TRUE";
+    } else {
+        p1 = "FALSE";
+    }
+    PMIX_SETENV_COMPAT("PRTE_SHARED_FS", p1, true, dstenv);
+#endif
 
     return PRTE_SUCCESS;
 }

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -74,6 +74,7 @@ PRTE_EXPORT extern char *prte_progress_thread_cpus;
 PRTE_EXPORT extern bool prte_bind_progress_thread_reqd;
 PRTE_EXPORT extern bool prte_show_launch_progress;
 PRTE_EXPORT extern bool prte_bootstrap_setup;
+PRTE_EXPORT extern bool prte_silence_shared_fs;
 
 /**
  * Global indicating where this process was bound to at launch (will

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@ char *prte_set_max_sys_limits = NULL;
 int prte_pmix_verbose_output = 0;
 char *prte_progress_thread_cpus = NULL;
 bool prte_bind_progress_thread_reqd = false;
-
+bool prte_silence_shared_fs = false;
 int prte_max_thread_in_progress = 1;
 
 int prte_register_params(void)
@@ -497,6 +497,11 @@ int prte_register_params(void)
                                       "Whether binding of internal PRRTE progress thread is required",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_bind_progress_thread_reqd);
+
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "silence_shared_fs",
+                                      "Silence the shared file system warning",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_silence_shared_fs);
 
     /* pickup the RML params */
     prte_rml_register();

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,7 +74,9 @@ PRTE_EXPORT prte_process_info_t prte_process_info = {
     .sock_stdin = NULL,
     .sock_stdout = NULL,
     .sock_stderr = NULL,
-    .cpuset = NULL};
+    .cpuset = NULL,
+    .shared_fs = false
+};
 
 static bool init = false;
 static char *prte_strip_prefix;

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,6 +95,7 @@ typedef struct prte_process_info_t {
     char *sock_stdout; /**< Path name to temp file for stdout. */
     char *sock_stderr; /**< Path name to temp file for stderr. */
     char *cpuset;      /**< String-representation of bitmap where we are bound */
+    bool shared_fs;     // whether the tmpdir is on a shared file system
 } prte_process_info_t;
 
 /**

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -55,6 +55,7 @@
 #include "src/util/pmix_os_dirpath.h"
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_path.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_environ.h"
 
@@ -100,6 +101,9 @@ static int prte_create_dir(char *directory)
 static int _setup_tmpdir_base(void)
 {
     int rc = PRTE_SUCCESS;
+#if PMIX_NUMERIC_VERSION != 0x00040208
+    char *fstype = NULL;
+#endif
 
     /* make sure that we have tmpdir_base set
      * if we need it
@@ -111,6 +115,23 @@ static int _setup_tmpdir_base(void)
             goto exit;
         }
     }
+
+#if PMIX_NUMERIC_VERSION != 0x00040208
+    // check to see if this is on a shared file system
+    // as we know this will impact launch as well as
+    // application execution performance
+    prte_process_info.shared_fs = pmix_path_nfs(prte_process_info.tmpdir_base, &fstype);
+    prte_process_info.shared_fs = true;
+    if (prte_process_info.shared_fs && !prte_silence_shared_fs) {
+        // this is a shared file system - warn the user
+        pmix_show_help("help-prte-runtime.txt", "prte:session:dir:shared", true,
+                       prte_process_info.tmpdir_base, fstype, prte_tool_basename);
+    }
+    if (NULL != fstype) {
+        free(fstype);
+    }
+#endif
+
 exit:
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);


### PR DESCRIPTION
Check if tmpdir is a shared file system, and warn the user as to the performance issues this can cause. Purely a warning and the job will continue. Provide an MCA param to shut off the warning. Provide an MCA param to OMPI indicating that this check has been performed so the apps don't do it again.

Fixes https://github.com/openpmix/prrte/issues/1866#