### PR TITLE
added some support for tracking allocations

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2022-2023 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 #
-# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -39,6 +39,8 @@ RST_SOURCE_FILES = \
         $(srcdir)/prrte-rst-content/*.rst \
         $(srcdir)/placement/*.rst \
         $(srcdir)/hosts/*.rst \
+        $(srcdir)/how-things-work/*.rst \
+        $(srcdir)/how-things-work/schedulers/*.rst \
         $(srcdir)/developers/*.rst \
         $(srcdir)/man/*.rst \
         $(srcdir)/man/man1/*.rst \

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -1,0 +1,13 @@
+How Things Work
+===============
+
+This section explains how some of the functions inside
+PRRTE perform their job. If you have questions about, for
+example, how session directory trees work, then you will
+find information on that subject here.
+
+.. toctree::
+   :maxdepth: 2
+
+   session_dirs.rst
+   schedulers/index.rst

--- a/docs/how-things-work/schedulers/flow_of_control.rst
+++ b/docs/how-things-work/schedulers/flow_of_control.rst
@@ -1,0 +1,28 @@
+Flow-of-Control
+===============
+
+Describe how allocation requests are flowed to the scheduler,
+scheduler attachment upon startup of either side, where response
+to allocation requests are returned and how they get back to
+the requestor, where session controls are received for allocation
+instantiation and how that is done, where session control is
+called to indicate all jobs complete in session.
+
+Probably best to start with an overview of how things flow
+and then drill down into the respective steps.
+
+Allocation requests have to be serviced by the scheduler. Since
+a requestor could attach directly to the scheduler (e.g., in the
+case of a tool submitting a session request) or to a daemon within
+the RM (who must then relay it to its system controller for forwarding
+to the scheduler), the scheduler must inform the RM of the allocation
+via the ``PMIx_Session_control`` API - i.e., the RM cannot guarantee
+its ability to intercept and process an allocation response to learn
+of a session that needs to be instantiated.
+
+PRRTE's role in the ``PMIx_Allocation_request`` flow is simply to
+pass the request on to the scheduler, and transport the reply back
+to the requestor.
+
+PRRTE only creates a session object as a result of a call from the
+scheduler via ``PMIx_Session_control``.

--- a/docs/how-things-work/schedulers/index.rst
+++ b/docs/how-things-work/schedulers/index.rst
@@ -1,0 +1,14 @@
+
+Scheduler Integration
+=====================
+
+This section describes PRRTE support for interactions
+with schedulers, including PRRTE's own ``psched``
+pseudo-scheduler.
+
+.. toctree::
+   :maxdepth: 2
+
+   overview.rst
+   structures.rst
+   flow_of_control.rst

--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -1,0 +1,23 @@
+Overview
+========
+
+While PRRTE does not itself contain a scheduler, it does support scheduler-related
+operations as a means of providing users and researchers with an environment within
+which they can investigate/explore dynamic operations. It will , of course, interact
+with any PMIx-based scheduler to support allocation requests and directives for
+executing jobs within an allocation.
+
+In addition, however, PRRTE provides a pseudo-scheduler for research purposes. The
+``psched`` daemon is not a full scheduler - i.e., it does not provide even remotely
+optimal resource assignments, nor is it in any way production qualified. For example,
+the ``psched`` algorithms are not particularly fast and are focused more on providing
+functionality than supporting large volumes of requests.
+
+Within that context, ``psched`` will:
+
+* assemble a resource pool based on the usual PRRTE resource discovery methods. This
+  includes reading the allocation made by a host environment, or provided by hostfile
+  and/or dash-host command line options.
+
+* upon receipt of allocation requests (either directly from tools or relayed by PRRTE),
+  check to see if the specified resources are available.

--- a/docs/how-things-work/schedulers/structures.rst
+++ b/docs/how-things-work/schedulers/structures.rst
@@ -1,0 +1,270 @@
+Objects and Definitions
+=======================
+
+The following objects and definitions are used in PRRTE for support of
+scheduler operations. Where applicable, modifications to previously
+existing structures is highlighted.
+
+
+prte_session_t
+--------------
+PMIx "sessions" equate to a scheduler's allocation - i.e., a session consists
+of a collection of assigned resources within which the RTE will execute one
+or more jobs. Sessions can be related to one another - i.e., a session can
+be defined as a result of a ``PMIx_Allocation_request`` from a process within
+an existing session. This relationship must be tracked as termination of the
+parent session mandates termination of all child sessions, unless the user
+requested that child sessions continue on their own.
+
+PRRTE defines the following structure for tracking sessions:
+
+.. code:: c
+
+	typedef struct{
+	    pmix_object_t super;
+	    uint32_t session_id;
+	    char *user_refid;
+	    char *alloc_refid;
+	    pmix_pointer_array_t *nodes;
+	    pmix_pointer_array_t *jobs;
+	    pmix_pointer_array_t *children;
+	} prte_session_t;
+
+with the following fields:
+
+* super: the usual PRRTE object header
+
+* session_id: the numerical ID assigned by the scheduler to
+  the session. Schedulers can assign both a numerical ID and
+  a string ID for a session - the two do not necessarily relate
+  to one another. Both IDs are provided as the numerical ID
+  can provide a faster lookup of the session, while the string ID
+  is considered more user-friendly. Note that the scheduler is
+  required to provide the numerical ID, but the string ID is
+  optional. The session ID is included in both the response to
+  the allocation request and in the ``PMIx_Session_control``
+  directive given to the RTE via the ``PMIX_SESSION_ID`` attribute.
+
+* user_refid: the user's string ID provided to the allocation request
+  that generated this session via the ``PMIX_ALLOC_REQ_ID``. This will
+  be ``NULL`` if the user chose not to provide the ID.
+
+* alloc_refid: the string ID assigned by the scheduler to the session.
+  Note that a scheduler is not required to assign such an ID. It is
+  communicated in the ``PMIx_Session_control`` directive to the RTE
+  via the ``PMIX_ALLOC_ID`` attribute.
+
+* nodes: a pointer array containing pointers to `prte_node_t` objects
+  describing the individual nodes included in this session. Nodes can
+  belong to multiple sessions, although this isn't common in HPC (most
+  facilities configure their schedulers for sole-occupancy of resources).
+
+* jobs: a pointer array containing pointers to `prte_job_t` objects
+  describing the individual jobs executing within the session. Note that
+  jobs are not allowed to operate across sessions, though they may have
+  child jobs (i.e., jobs spawned by a process from within the parent job)
+  executing in another session.
+
+* children: a pointer array containing pointers to `prte_session_t` objects
+  that describe sessions resulting from a call to ``PMIx_Allocation_request``
+  by a process executing within this session. Child sessions are terminated
+  by default upon completion of their parent session - this behavior can be
+  overridden by including the ``PMIX_ALLOC_CHILD_SEP`` attribute when calling
+  ``PMIx_Allocation_request``, or by issuing a ``PMIx_Session_control`` request
+  with the ``PMIX_SESSION_SEP`` attribute.
+
+The session object is created upon receiving a ``PMIx_Session_control``
+directive from the scheduler - this occurs in ``src/prted/pmix/pmix_server_session.c``
+as an upcall from the PMIx server library. Session objects are stored in the
+``prte_sessions`` global pointer array.
+
+
+
+prte_job_t
+----------
+Extended to include pointer to the session within which this job is executing.
+Note addition of ``PMIX_SPAWN_CHILD_SEP`` and ``PMIX_JOB_CTRL_SEP`` attributes.
+
+.. code:: c
+
+	typedef struct{
+	    pmix_list_item_t super;
+	    int exit_code;
+	    char **personality;
+	    struct prte_schizo_base_module_t *schizo;
+	    pmix_nspace_t nspace;
+	    char *session_dir;
+	    int index;
+	    pmix_rank_t offset;
+	    prte_session_t *session;   <========  ADDED
+	    pmix_pointer_array_t *apps;
+	    prte_app_idx_t num_apps;
+	    pmix_rank_t stdin_target;
+	    int32_t total_slots_alloc;
+	    pmix_rank_t num_procs;
+	    pmix_pointer_array_t *procs;
+	    struct prte_job_map_t *map;
+	    prte_node_t *bookmark;
+	    prte_job_state_t state;
+	    pmix_rank_t num_mapped;
+	    pmix_rank_t num_launched;
+	    pmix_rank_t num_reported;
+	    pmix_rank_t num_terminated;
+	    pmix_rank_t num_daemons_reported;
+	    pmix_rank_t num_ready_for_debug;
+	    pmix_proc_t originator;
+	    pmix_rank_t num_local_procs;
+	    prte_job_flags_t flags;
+	    pmix_list_t attributes;
+	    pmix_data_buffer_t launch_msg;
+	    pmix_list_t children;
+	    pmix_nspace_t launcher;
+	    uint32_t ntraces;
+	    char **traces;
+	    pmix_cli_result_t cli;
+	} prte_job_t;
+
+with the following fields:
+
+* super: the usual PRRTE list item header so the object can be
+  included on a PRRTE list
+
+* exit_code: the exit code for the job. This is usually taken as
+  the exit code from the first process to exit with a non-zero
+  status
+
+* personality: a string indicating the schizo component to be
+  used for parsing this job's command line (if applicable),
+  harvesting envars, and generally setting up the job
+
+* schizo: a pointer to the schizo module itself
+
+* nspace: the namespace of the job
+
+* session_dir: the job-level session directory assigned to the job
+
+* index: the position of this job object in the global ``prte_job_data``
+  pointer array
+
+* offset: offset to the total number of procs so shared memory
+  components can potentially connect to any spawned jobs
+
+* session: (**ADDED**) pointer to the session within which this job
+  is executing. This is provided to accelerate lookup operations when
+  referencing the session behind a given job.
+
+  .. warning::
+
+    One must `not`
+    ``PMIX_RETAIN`` the ``prte_session_t`` object before assigning it to
+    this field. Session objects clean up `after` all of their included
+    jobs terminate and clean up - a circular dependency can be created
+    that prevents job and session objects from executing their destructors.
+    The ``prte_job_t`` destructor will `not` release the ``session`` field.
+
+* apps: a pointer array containing pointers to the ``prte_app_context_t``
+  objects describing the applications executing within this job.
+
+* num_apps: the number of applications executing within this job
+
+* stdin_target: the rank of the process that is to receive forwarded stdin
+  data. A rank of ``PMIX_RANK_WILDCARD`` indicates that all processes in
+  the job are to receive a copy of the data.
+
+* total_slots_alloc: the sum total of all available slots on the nodes
+  assigned to this job. Note that a job does not necessarily have access
+  to all resources assigned to the session within which the job is executing.
+  The job's resources can be modified by hostfile, add-hostfile, dash-host,
+  and add-host directives.
+
+* procs: a pointer array containing pointers to the ``prte_proc_t`` objects
+  describing the individual processes executing as part of the job
+
+* num_procs: the number of processes executing within the job
+
+* map: a pointer to the job map detailing the location and binding of
+  each process within the job
+
+* bookmark: bookmark for where we are in mapping - this indicates the last
+  node used to map the job. Should a process within the job initiate a
+  "spawn" request, mapping of the spawned job will commence from this
+  point, assuming that the resource list for the new job includes the
+  bookmark location.
+
+* state: the PRRTE state of the overall job. This is the state within the
+  PRRTE state machine within which the job is currently executing.
+
+* num_mapped: bookkeeping counter used in the mapper subsystem
+
+* num_launched: bookkeeping counter used during job launch
+
+* num_reported: number of processes that have called ``PMIx_Init``
+
+* num_terminated: bookkeeping counter of process termination
+
+* num_daemons_reported: bookkeeping counter of number of daemons
+  spawned in support of the job that have reported "ready"
+
+* num_ready_for_debug: bookkeeping counter of number of processed
+  that have registered as ready for debug
+
+* originator: ID of process that requested spawn of this job
+
+* num_local_procs: bookkeeping counter of the number of processes
+  from this job on the local node
+
+* flags: set of bit-mapped flags used internally by PRRTE
+
+* attributes: list of job attributes controlling the job behavior
+
+* launch_msg: copy of the message sent to all daemons to launch
+  the job's processes
+
+* children: list of `prte_job_t` describing the jobs that have been
+  started by processes executing within this parent job.
+
+* launcher: the namespace of the tool that requested this job be
+  started
+
+* ntraces: number of stacktraces collected when PRRTE is asked to
+  collect stacktraces from failed processes
+
+* traces: the actual collected stacktraces from failed processes
+
+* cli: the results of parsing the command line used to generate
+  this job - only valid when the job is started from the ``prterun``
+  command line
+
+
+The job object is created in two places in the DVM system controller
+(a.k.a, "master" daemon):
+
+* upon directly receiving a ``PMIx_Spawn`` request in the PMIx server
+  library, which is then upcalled in ``src/prted/pmix/pmix_server_dyn.c``.
+  In this case, the job object is used to assemble the job description
+  based on the PMIx attributes passed up to the PRRTE function. The
+  object is subsequently packed and sent to the DVM master for processing - if
+  the server itself is the DVM master, then it will just be sent to itself.
+  This object is a temporary holding place for the job description and
+  will be released upon completion of the spawn.
+
+* while unpacking a relayed spawn request from another daemon in the
+  DVM (who received the request from a local client or tool) or a
+  "send-to-self" from the above function, in
+  ``src/mca/plm/base/plm_base_receive.c``. The job object is assigned
+  the relevant ``prte_session_t`` object based on the following (in
+  order of priority):
+
+  * the session ID, if specified
+  * the allocation ID, if given
+  * the user's allocation reference ID, if given
+  * the session of the parent job, if the spawn requestor is an
+    application process (and therefore has a parent job)
+  * the default session, which is composed of the global node pool, if
+    the spawn requestor is a tool
+
+A job is required to be assigned to a session - if no session is found,
+or the specified session is unknown to PRRTE, then the spawn request
+will be denied with an appropriate error code.
+
+

--- a/docs/how-things-work/session_dirs.rst
+++ b/docs/how-things-work/session_dirs.rst
@@ -1,0 +1,115 @@
+.. _session-dir-detail-label:
+
+Session Directories
+===================
+
+In general, servers, tools, and application processes all have access to their own ``session directory`` - a location where scratch files can be safely placed with a reasonable guarantee of automatic cleanup upon termination. Session directories provide a safe location (i.e., in a temporary file system and guaranteed not to conflict with other sessions/jobs/applications) for executables to use when creating scratch files such as shared memory backing files and rendezvous files. PMIx and PRRTE also provide a reasonable guarantee that any files and/or subdirectories created under the specified location will be automatically cleaned up at finalize and/or termination. In this case, ``reasonable`` means that we will do our best to remove all files and subdirectories, but cannot fully guarantee removal in situations outside of our control (e.g., being forcibly terminated via `SIGKILL`).
+
+   .. note:: In general, the host (e.g., PRRTE) is responsible for creating session
+   		 	 directories. In some cases, PMIx creates a limited set of session
+   		 	 directories if the host does not provide them - e.g., in the case of a
+   		 	 self-launched tool - for storing contact information. This is outlined
+   		 	 below.
+
+The following attributes can be used to pass session directory information to the PMIx library:
+
+* ``PMIX_SYSTEM_TMPDIR``: temporary directory for this system (typically ``/tmp`` for Linux systems).
+  The PMIx server will place tool rendezvous points and contact info in this location. In the
+  absence of this attribute during ``PMIx_Init`` (or the server/tool version), the PMIx library
+  will first look for the ``TMPDIR`` envar, then ``TEMP``, and finally ``TMP`` - if none of
+  those are found, the library will default to the ``/tmp`` location.
+
+* ``PMIX_SERVER_TMPDIR``: session directory where the PMIx server will place client rendezvous
+  points and contact info. If not provided, the library will first look for the ``PMIX_SERVER_TMPDIR``
+  envar, then ``TMPDIR``, ``TEMP``, and finally ``TMP`` - if none of those are found, the
+  library will default to the ``/tmp`` location.
+
+* ``PMIX_TMPDIR``: top-level temporary directory assigned to a session. Often equated to
+  ``PMIX_SERVER_TMPDIR`` by host environments.
+
+* ``PMIX_NSDIR``: session directory assigned to a namespace. Usually placed underneath the
+  ``PMIX_SERVER_TMPDIR`` and given a name based on the namespace itself.
+
+* ``PMIX_PROCDIR``: session directory assigned to an individual process. Usually placed underneath
+  the ``PMIX_NSDIR`` assigned to the namespace of the process, and given a string name equivalent
+  to the rank of the process.
+
+* ``PMIX_LAUNCHER_RENDEZVOUS_FILE``: the full path name of a file wherein a tool shall output its
+  connection information - e.g., a launcher to store contact information so that a debugger
+  can attach to it.
+
+* ``PMIX_TDIR_RMCLEAN``: the host environment (often known as the "resource manager" or "RM") will
+  cleanup the session directories. In the absence of this attribute, the PMIx library will
+  remove all files in any session directory it created and then remove the directory itself.
+
+These same attributes can be used in calls to ``PMIx_Get`` by application processes to retrieve
+the session directory locations for their own use.
+
+
+Client Session Directories
+--------------------------
+
+The PMIx client library does not create its own session directories as it does not publish
+contact information.  Host daemons often create one or more session directory levels for use
+by client application processes (e.g., for storing shared memory backing files) - the location
+of those directories is passed to clients using the above attributes.
+
+As the client library never creates session directories, it does not perform any cleanup of
+the session directory tree.
+
+
+Tool and Server Session Directories
+-----------------------------------
+
+The PMIx library utilizes appropriate session directory locations to store one or more
+"rendezvous files" - i.e., files containing connection information. Note that the library does not
+always create all levels of the session directory tree, although the process
+itself can of course create directories as it sees fit. Only the directories that (a) are required
+for generating the particular rendezvous file, and (b) do not already exist are created. Only
+directories actually created by the library are cleaned up and removed upon finalization.
+
+The following rendezvous files are provided:
+
+* if ``PMIX_LAUNCHER_RENDEZVOUS_FILE`` is given (either via an attribute to an "init" function
+  or as an envar), then the specified file (including any required path elements) will be created.
+
+* if the server is designated as a "system" server (i.e., the ``PMIX_SERVER_SYSTEM_SUPPORT`` attribute
+  was provided to ``PMIx_server_init``), then a rendezvous file named "pmix.sys.<hostname>" will be
+  created in the ``PMIX_SYSTEM_TMPDIR`` location.
+
+* if the server is designated as a "session" server (i.e., the ``PMIX_SERVER_SESSION_SUPPORT`` attribute
+  was provided to ``PMIx_server_init``), then a rendezvous file named "pmix.sys.<hostname>" will be
+  created in the ``PMIX_SERVER_TMPDIR`` location.
+
+* if the server declares that it will support tool connections (i.e., the ``PMIX_SERVER_TOOL_SUPPORT``
+  attribute was provided to ``PMIx_server_init``), then the following rendezvous files will be created
+  under the ``PMIX_SERVER_TMPDIR`` location:
+
+    * a PID file: "pmix.<hostname>.<pid>"
+
+    * a namespace file using the nspace of the server: "pmix.<hostname>.<nspace>"
+
+* if the server is designated as a "scheduler" (i.e., the ``PMIX_SERVER_SCHEDULER`` attribute
+  was provided to ``PMIx_server_init``), then a rendezvous file named "pmix.sched.<hostname>" will be
+  created in the ``PMIX_SYSTEM_TMPDIR`` location.
+
+* if the server is designated as a "system controller" (i.e., the ``PMIX_SERVER_SYS_CONTROLLER`` attribute
+  was provided to ``PMIx_server_init``), then a rendezvous file named "pmix.sysctrlr.<hostname>" will be
+  created in the ``PMIX_SYSTEM_TMPDIR`` location.
+
+   .. note:: The above rendezvous files are additive - i.e., generating any one of the files has
+             no bearing on whether another file will be output. Thus, a single server could
+             generate anywhere from one to five (or more) rendezvous files spanning several
+             directory levels.
+
+   .. warning:: There is a potential conflict in rendezvous file names - e.g., if multiple processes
+                declare themselves to be a "session" server on the same node. The format of the
+                names used by PMIx are intended to support tool connection in the absence of specific
+                connection directives - i.e., they provide a means by which PMIx can search for and
+                find the rendezvous file for a particular type of process without requiring the user
+                to manually identify it. Thus, a tool can request connection to the "system controller"
+                without necessarily knowing the PID of that process and PMIx can facilitate the
+                connection. As a result, only one system server can be operating on a node at a time.
+                This is also (independently) true for schedulers and system controllers.
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,8 @@ Table of contents
    getting-help
    install
    configuration
+   terminology
+   how-things-work/index
    hosts/index
    placement/index
    notifications

--- a/docs/session-directory.rst
+++ b/docs/session-directory.rst
@@ -8,6 +8,9 @@ daemon and its child processes.
 This is done to enable quick and easy cleanup in the event that PRRTE
 is unable to fully cleanup after itself.
 
+More detail on session directories is provided in the How Things Work
+:ref:`session directory <session-dir-detail-label>` section.
+
 Directory location
 ------------------
 
@@ -19,6 +22,13 @@ examining the following (in precedence order):
 
    .. note:: MCA parameters can be set via environment variables, on
              the command line, or in a parameter file.
+
+   .. note:: If necessary, the value of the top session directory on
+             the local node where the launcher (e.g., ``prun``, ``prterun``,
+             or ``mpirun``) is executing can be set separately from
+             the value to be used on compute nodes via the
+             ``prte_local_tmpdir_base`` and ``prte_remote_tmpdir_base``
+             parameters.
 
 #. If the environment variable ``TMPDIR`` is not empty, use that.
 #. If the environment variable ``TEMP`` is not empty, use that.
@@ -32,17 +42,24 @@ By default, the session directory name is set to
 
 .. code::
 
-   prte.<nodename>.<uid>
+   <tool>.<nodename>.<pid>.<uid>
 
-The session directory name can further be altered to include the PID
-of the daemon process, if desired:
+where `tool` is the argv[0] of the process setting up the
+session directory. In most cases, this will be either `prte`,
+`prterun`, or `prted` - though special tools such as `psched`
+may also create a session directory tree.
 
-.. code::
+The session directory name includes the PID
+of the daemon process to allow a user to have multiple
+instances of a tool concurrently executing on a node.
 
-   prte.<nodename>.<pid>.<uid>
+.. note::
 
-by setting the ``prte_add_pid_to_session_dirname`` MCA parameter to a
-"true" value (e.g., 1).
+   Each tool will generate its own session directory tree. This
+   is done to avoid cleanup race conditions where one tool might
+   cleanup the session directory, and thereby remove the contact
+   information for a tool that is continuing to execute.
+
 
 Tools
 -----

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -1,0 +1,29 @@
+Terminology
+=================
+
+PRRTE uses terms adopted from PMIx to describe its operations. Terms include:
+
+``Workload Manager (WLM)`` is often called the ``scheduler`` and is responsible for
+scheduling and assigning resources.
+
+``Resource Manager (RM)`` is the runtime environment (RTE)
+
+``Session`` refers to a set of resources assigned by the WLM that has been
+reserved for one or more users.
+A session is identified by a `session ID` that is
+unique within the scope of the governing WLM.
+Historically, HPC sessions have consisted of a static allocation of resources - i.e., a block of resources assigned to a user in response to a specific request and managed as a unified collection. However, this is changing in response to the growing use of dynamic programming models that require on-the-fly allocation and release of system resources. Accordingly, the term ``session`` in this project refers to a potentially dynamic entity, perhaps comprised of resources accumulated as a result of multiple allocation requests that are managed as a single unit by the WLM.
+
+``Job`` refers to a set of one or more ``applications`` executed as a single invocation by the user within a session with a unique identifier, the ``job ID``, assigned by the RM or launcher. For example, the command line `mpiexec -n 1 app1 : -n 2 app2` generates a single MPMD job containing two applications. A user may execute multiple jobs within a given session, either sequentially or concurrently.
+
+``Namespace`` refers to a character string value assigned by the RM to a job.  All applications executed as part of that job share the same namespace. The namespace assigned to each job must be unique within the scope of the governing RM and often is implemented as a string representation of the numerical ``Job ID``. The namespace and job terms will be used interchangeably throughout the project.
+
+``Application`` represents a set of identical, but not necessarily unique,
+execution contexts within a job.
+
+``Process`` is assumed for ease of presentation to be an operating system process, also commonly referred to as a heavyweight process. A process is often comprised of multiple lightweight threads, commonly known as simply `threads`.
+
+``Client`` refers to a process that was registered with the PMIx server prior to being started, and connects to that PMIx server via ``PMIx_Init`` using its assigned namespace and rank with the information required to connect to that server being provided to the process at time of start of execution.
+
+``Tool`` refers to a process that may or may not have been registered with the PMIx server prior to being started and intializes using ``PMIx_tool_init``.
+

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -184,6 +184,9 @@ static int rte_init(int argc, char **argv)
         goto error;
     }
 
+    /* Set the session of the daemon job to the default session */
+    jdata->session = prte_default_session;
+
     /* mark that the daemons have reported as we are the
      * only ones in the system right now, and we definitely
      * are running!

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -149,8 +149,8 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
      */
     if (!prte_managed_allocation || prte_set_slots_override) {
         caddy->jdata->total_slots_alloc = 0;
-        for (i = 0; i < prte_node_pool->size; i++) {
-            node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
+        for (i = 0; i < caddy->jdata->session->nodes->size; i++) {
+            node = (prte_node_t *) pmix_pointer_array_get_item(caddy->jdata->session->nodes, i);
             if (NULL == node) {
                 continue;
             }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -975,6 +975,7 @@ proceed:
                         node = PMIX_NEW(prte_node_t);
                         node->name = strdup(cptr);
                         node->slots = slots;
+                        node->state = PRTE_NODE_STATE_ADDED;
                         pmix_list_append(&nodes, &node->super);
                     }
                     free(line);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -999,7 +999,7 @@ proceed:
 
     /* We next check for and add any add-host options. Note this is
      * a -little- different than dash-host in that (a) we add these
-     * nodes to the global pool regardless of what may already be there,
+     * nodes to the global pool (avoiding duplication),
      * and (b) as a result, any job and/or app_context can access them.
      *
      * Note that any relative node syntax found in the add-host lists will

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -503,6 +503,7 @@ static void lkcbfunc(pmix_status_t status, void *cbdata)
 static void check_complete(int fd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
+    prte_session_t *session;
     prte_job_t *jdata, *jptr;
     prte_proc_t *proc;
     int i, rc;
@@ -720,6 +721,17 @@ release:
      * we call the errmgr so that any attempt to restart the job will
      * avoid doing so in the exact same place as the current job
      */
+    session = jdata->session;
+    if(NULL != session){
+        for(i = 0; i < session->jobs->size; i++){
+            if(NULL != (jptr = pmix_pointer_array_get_item(session->jobs, i))){
+                if(PMIX_CHECK_NSPACE(jdata->nspace, jptr->nspace)){
+                    pmix_pointer_array_set_item(session->jobs, i, NULL);
+                    break;
+                }
+            }
+        }
+    }
     if (NULL != jdata->map) {
         map = jdata->map;
         takeall = false;

--- a/src/prted/pmix/Makefile.am
+++ b/src/prted/pmix/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,4 +21,5 @@ libprrte_la_SOURCES += \
           prted/pmix/pmix_server_pub.c \
           prted/pmix/pmix_server_gen.c \
           prted/pmix/pmix_server_queries.c \
+          prted/pmix/pmix_server_allocate.c \
           prted/pmix/pmix_server_session.c

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -120,7 +120,7 @@ static pmix_server_module_t pmix_server = {
     .push_stdin = pmix_server_stdin_fn,
     .group = pmix_server_group_fn,
     .allocate = pmix_server_alloc_fn,
-#if PMIX_NUMERIC_VERSION >= 0x00050000
+#ifdef PMIX_SESSION_INSTANTIATE
     .session_control = pmix_server_session_ctrl_fn
 #endif
 };

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+
+#include "src/pmix/pmix-internal.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+#include "src/rml/rml.h"
+#include "src/util/dash_host/dash_host.h"
+#include "src/mca/ras/base/ras_private.h"
+
+static void localrelease(void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
+                                    pmix_data_buffer_t *buffer,
+                                    prte_rml_tag_t tg,
+                                    void *cbdata)
+{
+
+    int req_index, cnt;
+    pmix_status_t ret, rc;
+    pmix_server_req_t *req;
+
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
+
+    /* unpack the status - this is already a PMIx value */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = prte_pmix_convert_rc(rc);
+    }
+
+    /* we let the above errors fall thru in the vain hope that the req number can
+     * be successfully unpacked, thus allowing us to respond to the requestor */
+
+    /* unpack our tracking room number */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &req_index, &cnt, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        /* we are hosed */
+        return;
+    }
+
+    req = pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, req_index);
+
+    /* Report the error */
+    if (ret != PMIX_SUCCESS) {
+        goto ANSWER;
+    }
+
+    rc = PMIx_Data_unpack(NULL, buffer, &req->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = prte_pmix_convert_rc(rc);
+        goto ANSWER;
+    }
+
+    if (0 < req->ninfo) {
+        PMIX_INFO_CREATE(req->info, req->ninfo);
+
+        cnt = req->ninfo;
+        rc = PMIx_Data_unpack(NULL, buffer, req->info, &cnt, PMIX_INFO);
+
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            ret = prte_pmix_convert_rc(rc);
+            req->ninfo = 0;
+            goto ANSWER;
+        }
+    }
+
+ANSWER:
+    if (NULL != req->infocbfunc) {
+        // pass the response back to the requestor
+        req->infocbfunc(ret, req->info, req->ninfo, req, localrelease, req);
+    } else {
+        PMIX_RELEASE(req);
+    }
+}
+
+pmix_status_t prte_pmix_set_scheduler(void)
+{
+    pmix_status_t rc;
+    pmix_info_t info[2];
+
+    if (!prte_pmix_server_globals.scheduler_connected) {
+        /* the scheduler has not attached to us - see if we
+         * can attach to it, make it optional so we don't
+         * hang if there is no scheduler available */
+        PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_TOOL_CONNECT_OPTIONAL, NULL, PMIX_BOOL);
+        rc = PMIx_tool_attach_to_server(NULL, &prte_pmix_server_globals.scheduler,
+                                        info, 2);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        prte_pmix_server_globals.scheduler_set_as_server = true;
+    }
+
+    /* if we have not yet set the scheduler as our server, do so */
+    if (!prte_pmix_server_globals.scheduler_set_as_server) {
+        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        prte_pmix_server_globals.scheduler_set_as_server = true;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t prte_server_send_request(uint8_t cmd, pmix_server_req_t *req)
+{
+    pmix_data_buffer_t *buf;
+    pmix_status_t rc;
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+
+    /* construct a request message for the command */
+    rc = PMIx_Data_pack(NULL, buf, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+
+    /* pack the local reference ID */
+    rc = PMIx_Data_pack(NULL, buf, &req->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+
+    /* pack the requestor */
+    rc = PMIx_Data_pack(NULL, buf, &req->tproc, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+
+    if (PRTE_PMIX_ALLOC_REQ == cmd) {
+        /* pack the allocation directive */
+        rc = PMIx_Data_pack(NULL, buf, &req->allocdir, 1, PMIX_ALLOC_DIRECTIVE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return rc;
+        }
+    } else {
+        /* pack the sessionID */
+        rc = PMIx_Data_pack(NULL, buf, &req->sessionID, 1, PMIX_UINT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return rc;
+        }
+    }
+
+    /* pack the number of info */
+    rc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+    if (0 < req->ninfo) {
+        /* pack the info */
+        rc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return rc;
+        }
+    }
+
+    /* send this request to the DVM controller */
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+    return PMIX_SUCCESS;
+}
+
+/* Callbacks to process an allocate request answer from the scheduler
+ * and pass on any results to the requesting client
+ */
+static void passthru(int sd, short args, void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+
+    if (NULL != req->infocbfunc) {
+        // call the requestor's callback with the returned info
+        req->infocbfunc(req->status, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
+    } else {
+        // let them cleanup
+        req->rlcbfunc(req->rlcbdata);
+    }
+    // cleanup our request
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+static void infocbfunc(pmix_status_t status,
+                       pmix_info_t *info, size_t ninfo,
+                       void *cbdata,
+                       pmix_release_cbfunc_t rel, void *relcbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    // need to pass this into our progress thread for processing
+    // since we touch the global request array
+    req->status = status;
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+        req->copy = false;
+    }
+    req->info = info;
+    req->ninfo = ninfo;
+    req->rlcbfunc = rel;
+    req->rlcbdata = relcbdata;
+
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+}
+
+static void pass_request(int sd, short args, void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    pmix_status_t rc;
+    size_t n;
+    pmix_info_t *xfer;
+
+    /* add this request to our local request tracker array */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    if (!PRTE_PROC_IS_MASTER) {
+        /* if we are not the DVM master, then we have to send
+         * this request to the master for processing */
+        rc = prte_server_send_request(PRTE_PMIX_ALLOC_REQ, req);
+        if (PRTE_SUCCESS != rc) {
+            goto callback;
+        }
+        return;
+    }
+
+    /* if we are the DVM master, then handle this ourselves - start
+     * by ensuring the scheduler is connected to us */
+    rc = prte_pmix_set_scheduler();
+    if (PMIX_SUCCESS != rc) {
+        goto callback;
+    }
+
+#ifdef PMIX_REQUESTOR
+    // we need to pass the request on to the scheduler
+    // need to add the requestor's ID to the info array
+    PMIX_INFO_CREATE(xfer, req->ninfo + 1);
+    for (n=0; n < req->ninfo; n++) {
+        PMIX_INFO_XFER(&xfer[n], &req->info[n]);
+    }
+    PMIX_INFO_LOAD(&xfer[req->ninfo], PMIX_REQUESTOR, &req->tproc, PMIX_PROC);
+    // the current req object points to the caller's info array, so leave it alone
+    req->copy = true;
+    req->info = xfer;
+    req->ninfo++;
+#endif
+    /* pass the request to the scheduler */
+    rc = PMIx_Allocation_request_nb(req->allocdir, req->info, req->ninfo,
+                                    infocbfunc, req);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto callback;
+    }
+    return;
+
+callback:
+    /* this section gets executed solely upon an error */
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+        return;
+    }
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+/* this is the upcall from the PMIx server for the allocation
+ * request support. Since we are going to touch global structures
+ * (e.g., the session tracker pointer array), we have to threadshift
+ * this request into our own internal progress thread. Note that the
+ * allocation request could have come to this host from the
+ * scheduler, or a tool, or even an application process. */
+pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
+                                   pmix_alloc_directive_t directive,
+                                   const pmix_info_t data[], size_t ndata,
+                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_server_req_t *req;
+
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s allocate upcalled on behalf of proc %s:%u with %" PRIsize_t " infos",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), client->nspace, client->rank, ndata);
+
+    /* create a request tracker for this operation */
+    req = PMIX_NEW(pmix_server_req_t);
+    pmix_asprintf(&req->operation, "ALLOCATE: %u", directive);
+    PMIX_PROC_LOAD(&req->tproc, client->nspace, client->rank);
+    req->allocdir = directive;
+    req->info = (pmix_info_t *) data;
+    req->ninfo = ndata;
+    req->infocbfunc = cbfunc;
+    req->cbdata = cbdata;
+
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, pass_request, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+    return PRTE_SUCCESS;
+}

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -205,9 +205,11 @@ static void interim(int sd, short args, void *cbdata)
     pmix_info_t *info;
     int rc, i;
     char cwd[PRTE_PATH_MAX];
+    char *endptr;
     bool flag;
     size_t m, n;
     uint16_t u16;
+    uint32_t u32;
     pmix_rank_t rank;
     prte_rmaps_options_t options;
     prte_schizo_base_module_t *schizo;
@@ -265,6 +267,7 @@ static void interim(int sd, short args, void *cbdata)
             app->cwd = strdup(papp->cwd);
         }
         app->num_procs = papp->maxprocs;
+
         if (NULL != papp->info) {
             for (m = 0; m < papp->ninfo; m++) {
                 info = &papp->info[m];
@@ -386,6 +389,12 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC,
                                PRTE_ATTR_GLOBAL, &flag, PMIX_BOOL);
 
+            /***   ALLOC ID   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_ID)) {
+            
+            u32 = strtoul(info->value.data.string, &endptr, 10);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID,
+                               PRTE_ATTR_GLOBAL, &u32, PMIX_UINT32);
             /***   DISPLAY MAP   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_MAP)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -686,7 +686,6 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
                             void *cbdata)
 {
     pmix_server_req_t *cd;
-    size_t n;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s TOOL CONNECTION REQUEST RECVD",
@@ -697,13 +696,8 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
     cd->toolcbfunc = cbfunc;
     cd->cbdata = cbdata;
     cd->target.rank = 0; // set default for tool
-
-    /* protect the provided info */
+    cd->info = info;
     cd->ninfo = ninfo;
-    PMIX_INFO_CREATE(cd->info, cd->ninfo);
-    for(n = 0; n < ninfo; n++){
-        PMIX_INFO_XFER(&cd->info[n], &info[n]);
-    }
 
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _toolconn, cd);
     PMIX_POST_OBJECT(cd);

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -319,6 +319,10 @@ PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 
+PRTE_EXPORT extern void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
+                                                pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                                void *cbdata);
+
 #if PMIX_NUMERIC_VERSION >= 0x00050000
 PRTE_EXPORT extern pmix_status_t
 pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -337,12 +337,14 @@ PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, pmix_serv
 #define PRTE_PMIX_SESSION_CTRL   1
 
 
-#if PMIX_NUMERIC_VERSION >= 0x00050000
+#ifdef PMIX_SESSION_INSTANTIATE
+
 PRTE_EXPORT extern pmix_status_t
 pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                             uint32_t sessionID,
                             const pmix_info_t directives[], size_t ndirs,
                             pmix_info_cbfunc_t cbfunc, void *cbdata);
+
 #endif
 
 /* exposed shared variables */

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -75,9 +75,12 @@ typedef struct {
     bool flag;
     bool launcher;
     bool scheduler;
+    bool copy;  // info array has been copied and must be released
     uid_t uid;
     gid_t gid;
     pid_t pid;
+    pmix_alloc_directive_t allocdir;
+    uint32_t sessionID;
     pmix_info_t *info;
     size_t ninfo;
     char *data;
@@ -96,6 +99,7 @@ typedef struct {
     pmix_tool_connection_cbfunc_t toolcbfunc;
     pmix_info_cbfunc_t infocbfunc;
     void *cbdata;
+    void *rlcbdata;
 } pmix_server_req_t;
 PMIX_CLASS_DECLARATION(pmix_server_req_t);
 
@@ -122,8 +126,6 @@ typedef struct {
     size_t napps;
     pmix_query_t *queries;
     size_t nqueries;
-    pmix_alloc_directive_t allocdir;
-    uint32_t sessionID;
     pmix_op_cbfunc_t cbfunc;
     pmix_info_cbfunc_t infocbfunc;
     pmix_tool_connection_cbfunc_t toolcbfunc;
@@ -319,9 +321,21 @@ PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 
+PRTE_EXPORT extern int prte_pmix_xfer_job_info(prte_job_t *jdata, pmix_info_t *info);
+
+PRTE_EXPORT extern int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *app);
+
 PRTE_EXPORT extern void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
                                                 pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                                 void *cbdata);
+
+PRTE_EXPORT extern pmix_status_t prte_pmix_set_scheduler(void);
+
+PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, pmix_server_req_t *req);
+
+#define PRTE_PMIX_ALLOC_REQ      0
+#define PRTE_PMIX_SESSION_CTRL   1
+
 
 #if PMIX_NUMERIC_VERSION >= 0x00050000
 PRTE_EXPORT extern pmix_status_t

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -88,7 +88,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     size_t nmsize;
     pmix_server_pset_t *pset;
     pmix_cpuset_t cpuset;
-    uint32_t ui32;
+    uint32_t ui32, *ui32_ptr;
     prte_job_t *parent = NULL;
     pmix_device_distance_t *distances;
     size_t ndist;
@@ -125,14 +125,16 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         return rc;
     }
 
-    /* pass the session ID - just a 32-bit hash of our nspace for now */
-    PRTE_HASH_STR(prte_process_info.myproc.nspace, ui32);
-    PMIX_INFO_LIST_ADD(ret, info, PMIX_SESSION_ID, &ui32, PMIX_UINT32);
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        PMIX_INFO_LIST_RELEASE(info);
-        rc = prte_pmix_convert_status(ret);
-        return rc;
+    /* pass the session ID */
+    ui32_ptr = &ui32;
+    if(prte_get_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID, (void **) &ui32_ptr, PMIX_UINT32)){
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_SESSION_ID, &ui32, PMIX_UINT32); 
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            return rc;
+        }
     }
 
     /* jobid */

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -12,44 +12,260 @@
 #include "src/pmix/pmix-internal.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/rml/rml.h"
+#include "src/util/dash_host/dash_host.h"
+#include "src/mca/ras/base/ras_private.h"
 
 static void localrelease(void *cbdata)
 {
     pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    if(0 < req->ninfo && NULL != req->info){
+        PMIX_INFO_FREE(req->info, req->ninfo);
+    }
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
 }
 
+/* Callback to process the allocation request answer from the scheduler
+ * and pass on any results to the local client
+ */
 static void infocbfunc(pmix_status_t status,
                        pmix_info_t *info, size_t ninfo,
                        void *cbdata,
                        pmix_release_cbfunc_t rel, void *relcbdata)
 {
     pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    pmix_alloc_directive_t directive;
+    uint32_t session_id = UINT32_MAX;
+    char *endptr, *hosts, *tmp;
+    char **dir, **host_argv = NULL, **alloc_nlist = NULL, **alloc_clist = NULL;
+    pmix_list_t nodes;
+    prte_node_t *nptr;
+    prte_session_t *session;
+    prte_job_t *jdata;
+    size_t len, n, i;
+    pmix_status_t rc;
 
+    /* track this allocation so it can be referenced in e.g. a call to PMIx_Spawn */
+    if(PRTE_PROC_IS_MASTER && status == PMIX_SUCCESS){
+        for(int n = 0; n < ninfo; n++){
+            if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_ID)){
+                session_id = strtoul(info[n].value.data.string, &endptr, 10); 
+            }else if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NODE_LIST)){
+                alloc_nlist = PMIX_ARGV_SPLIT_COMPAT(info[n].value.data.string, ',');
+            }else if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NUM_CPU_LIST)){
+                alloc_clist = PMIX_ARGV_SPLIT_COMPAT(info[n].value.data.string, ',');
+            }
+        }
+        /* They did not provide an alloc id and nodelist. This is an error! */
+        if(session_id == UINT32_MAX || alloc_nlist == NULL){
+            status = PMIX_ERR_BAD_PARAM;
+            goto ANSWER;
+        }
+
+        dir = PMIX_ARGV_SPLIT_COMPAT(req->operation, ' ');
+        directive = strtoul(dir[1], &endptr, 10);
+        switch(directive){
+            case PMIX_ALLOC_RELEASE:
+                if(NULL == (session = prte_get_session_object(session_id))){
+                    status = PRTE_ERR_BAD_PARAM;
+                    PRTE_ERROR_LOG(status);
+                    goto ANSWER;
+                }
+                /* Remove specified nodes from session object */
+                len = PMIX_ARGV_COUNT_COMPAT(alloc_nlist);
+                for(n = 0; n < session->nodes->size; n++){
+                    if(NULL == (nptr = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, n))){
+                        continue;
+                    }
+                    for(i = 0; i < len; i++){
+                        if(0 == strcmp(nptr->name, alloc_nlist[i])){
+                            pmix_pointer_array_set_item(session->nodes, n, NULL);
+                        }
+                    }
+                }
+                PMIX_ARGV_FREE_COMPAT(alloc_nlist);
+                /* all done */
+                goto ANSWER;
+            case PMIX_ALLOC_NEW:
+                /* if we already have a session with this id that's an error */
+                if(NULL != (session = prte_get_session_object(session_id))){
+                    status = PRTE_ERR_BAD_PARAM;
+                    PRTE_ERROR_LOG(status);
+                    goto ANSWER;
+                }
+                /* create a new session object */
+                session = PMIX_NEW(prte_session_t);
+                if(NULL == session){
+                    status = PRTE_ERR_OUT_OF_RESOURCE;
+                    PRTE_ERROR_LOG(status);
+                    goto ANSWER;
+                }
+                session->session_id = session_id;
+                prte_set_session_object(session);
+
+                /* Track the session as a child session of session the requestor is running in */
+                jdata = prte_get_job_data_object(req->tproc.nspace);
+                if(NULL != jdata){
+                    pmix_pointer_array_add(jdata->session->children, session);
+                }else{
+                    /* default to our default session */
+                    pmix_pointer_array_add(prte_default_session->children, session);
+                }
+                break;
+            case PMIX_ALLOC_EXTEND:
+                /* Get the session object to extend */
+                if(NULL == (session = prte_get_session_object(session_id))){
+                    status = PRTE_ERR_BAD_PARAM;;
+                    PRTE_ERROR_LOG(status);
+                    goto ANSWER;
+                }
+                break;
+            case PMIX_ALLOC_REAQUIRE:
+                /* TODO: Not sure how to handle this */
+                goto ANSWER;
+        }
+
+        /* If we get here, we need to add specified nodes to the nodepool */
+        if(NULL != alloc_nlist && NULL == alloc_clist){
+            hosts = PMIX_ARGV_JOIN_COMPAT(alloc_nlist, ',');
+            PMIX_ARGV_FREE_COMPAT(alloc_nlist);
+        }else if (NULL != alloc_nlist && NULL != alloc_clist){
+            len = PMIX_ARGV_COUNT_COMPAT(alloc_nlist);
+            for(n = 0; n < len; n++){
+                tmp = malloc(strlen(alloc_nlist[n]) + strlen(alloc_clist[n]) + 2);
+                sprintf(tmp, "%s:%s", alloc_nlist[n], alloc_clist[n]);
+                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&host_argv, tmp);
+                free(tmp);
+            }
+            hosts = PMIX_ARGV_JOIN_COMPAT(host_argv, ',');
+            PMIX_ARGV_FREE_COMPAT(host_argv);
+            PMIX_ARGV_FREE_COMPAT(alloc_nlist);
+            PMIX_ARGV_FREE_COMPAT(alloc_clist);
+        }
+
+        /* Create a list of nodes from the hostlist */
+        PMIX_CONSTRUCT(&nodes, pmix_list_t);
+        if (PRTE_SUCCESS != (rc = prte_util_add_dash_host_nodes(&nodes, hosts, true))) {
+            PRTE_ERROR_LOG(rc);
+            status = rc;
+            goto ANSWER;
+        }
+        free(hosts);
+
+        /* If we got something back add it to */
+        if (!pmix_list_is_empty(&nodes)) {
+            /* Mark that this node was added */
+            PMIX_LIST_FOREACH(nptr, &nodes, prte_node_t){
+                nptr->state = PRTE_NODE_STATE_ADDED;
+                if(session != prte_default_session){
+                    pmix_pointer_array_add(session->nodes, nptr);
+                }
+            }
+            /* store the results in the global resource pool - this removes the
+             * list items
+             */
+            if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, NULL))) {
+                PRTE_ERROR_LOG(rc);
+                status = rc;
+                goto ANSWER;
+            }
+
+            /* mark that an updated nidmap must be communicated to existing daemons */
+            prte_nidmap_communicated = false;
+        }
+        for(n = 0; n < prte_node_pool->size; n++){
+            if(NULL == (nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n))){
+                continue;
+            }
+        }
+    }
+ANSWER:
     if (NULL != req->infocbfunc) {
-        req->infocbfunc(status, info, ninfo, req->cbdata, localrelease, req);
+        req->infocbfunc(status, info, ninfo, req->cbdata, rel, relcbdata);
+    }else{
         if (NULL != rel) {
             rel(relcbdata);
         }
+    }
+    /* Release our local request */
+    localrelease(req);
+    return;
+}
+
+void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
+                                                pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                                void *cbdata)
+{
+
+    int req_index, cnt;
+    pmix_status_t ret, rc;
+    pmix_server_req_t *req;
+
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
+
+    /* unpack the status - this is already a PMIx value */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = prte_pmix_convert_rc(rc);
+    }
+
+    /* we let the above errors fall thru in the vain hope that the req number can
+     * be successfully unpacked, thus allowing us to respond to the requestor */
+
+    /* unpack our tracking room number */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &req_index, &cnt, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        /* we are hosed */
         return;
     }
-    /* need to cleanup ourselves */
-    if (NULL != rel) {
-        rel(relcbdata);
+
+    req = pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, req_index);
+
+    /* Report the error */
+    if(ret != PMIX_SUCCESS){
+        goto ANSWER;
     }
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
+    
+    rc = PMIx_Data_unpack(NULL, buffer, &req->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = prte_pmix_convert_rc(rc);
+        goto ANSWER;
+    }
+
+    if(0 < req->ninfo){
+        PMIX_INFO_CREATE(req->info, req->ninfo);
+        
+        cnt = req->ninfo;  
+        rc = PMIx_Data_unpack(NULL, buffer, req->info, &cnt, PMIX_INFO);
+
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            ret = prte_pmix_convert_rc(rc);
+            req->ninfo = 0;
+            goto ANSWER;
+        }
+    }
+
+ANSWER:
+    infocbfunc(ret, req->info, req->ninfo, req, NULL, NULL);
 }
 
 static void pass_request(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
+    prte_job_t *client_job;
     pmix_server_req_t *req;
     pmix_data_buffer_t *buf;
+    size_t n, ninfo, need_id;
     uint8_t command;
     pmix_status_t rc;
     pmix_info_t info[2];
+    char alloc_id[64];
 
     /* create a request tracker for this operation */
     req = PMIX_NEW(pmix_server_req_t);
@@ -93,7 +309,31 @@ static void pass_request(int sd, short args, void *cbdata)
         }
 
         if (0 == command) {
-            rc = PMIx_Allocation_request_nb(cd->allocdir, cd->info, cd->ninfo,
+            /* check if they specified an alloc id - otherwise default to requestors session */
+            need_id = 1;
+            for(n = 0; n < cd->ninfo; n++){
+                if(PMIX_CHECK_KEY(&cd->info[n], PMIX_ALLOC_ID)){
+                    need_id = 0;
+                }
+            }
+            req->ninfo = cd->ninfo + need_id;
+            PMIX_INFO_CREATE(req->info, req->ninfo);
+            for(n = 0; n < cd->ninfo; n++){
+                PMIX_INFO_XFER(&req->info[n], &cd->info[n]);
+            }
+            if(need_id){
+                client_job = prte_get_job_data_object(cd->proc.nspace);
+                if(NULL != client_job){
+                    sprintf(alloc_id, "%u", client_job->session->session_id);
+                }else{
+                    /* default to the default session */
+                    sprintf(alloc_id, "%u", 0);
+                }
+                PMIX_INFO_LOAD(&req->info[cd->ninfo], PMIX_ALLOC_ID, alloc_id, PMIX_STRING);
+            }
+            PMIX_PROC_LOAD(&req->tproc, cd->proc.nspace, cd->proc.rank);
+
+            rc = PMIx_Allocation_request_nb(cd->allocdir, req->info, req->ninfo,
                                             infocbfunc, req);
         } else {
 #if PMIX_NUMERIC_VERSION < 0x00050000
@@ -107,6 +347,7 @@ static void pass_request(int sd, short args, void *cbdata)
             PMIX_ERROR_LOG(rc);
             goto callback;
         }
+        PMIX_RELEASE(cd);
         return;
     }
 

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -14,481 +14,396 @@
 #include "src/rml/rml.h"
 #include "src/util/dash_host/dash_host.h"
 #include "src/mca/ras/base/ras_private.h"
+#include "src/mca/rmaps/rmaps.h"
+#include "src/mca/schizo/base/base.h"
+
+#ifdef PMIX_SESSION_INSTANTIATE
 
 static void localrelease(void *cbdata)
 {
     pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
-    if(0 < req->ninfo && NULL != req->info){
-        PMIX_INFO_FREE(req->info, req->ninfo);
-    }
+
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
 }
 
-/* Callback to process the allocation request answer from the scheduler
- * and pass on any results to the local client
+/* Process the session control directive from the scheduler */
+static int process_directive(pmix_server_req_t *req)
+{
+    char *user_refid = NULL, *alloc_refid = NULL;
+    pmix_info_t *personality = NULL;
+    pmix_proc_t *requestor = NULL;
+    char *hosts = NULL;
+    prte_session_t *session = NULL;
+    prte_job_t *jdata = NULL;
+    prte_app_context_t *app;
+    pmix_app_t *apps;
+    size_t napps;
+    size_t n, i;
+    pmix_status_t rc;
+    bool terminate = false;
+    bool pause = false;
+    bool resume = false;
+    bool preempt = false;
+    bool restore = false;
+    bool signal = false;
+    bool extend = false;
+    int sigvalue, tval;
+
+    /* cycle across the directives to see what we are being asked to do */
+    for (n = 0; n < req->ninfo; n++) {
+
+        if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_INSTANTIATE)) {
+            // check to see if we already have this session
+            session = prte_get_session_object(req->sessionID);
+            if (NULL != session) {
+                // this is an error - cannot instantiate a preexisting
+                // session
+                rc = PMIX_ERR_BAD_PARAM;
+                goto ANSWER;
+            }
+            /* create a new session object */
+            session = PMIX_NEW(prte_session_t);
+            if (NULL == session) {
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                PRTE_ERROR_LOG(rc);
+                goto ANSWER;
+            }
+            session->session_id = req->sessionID;
+            rc = prte_set_session_object(session);
+            if (PRTE_SUCCESS != rc) {
+                PMIX_RELEASE(session);
+                goto ANSWER;
+            }
+            // if a job has already been described, add it here
+            if (NULL != jdata) {
+                pmix_pointer_array_add(session->jobs, jdata);
+            }
+            if (NULL != alloc_refid) {
+                session->alloc_refid = strdup(alloc_refid);
+                alloc_refid = NULL;
+            }
+            if (NULL != user_refid) {
+                session->user_refid = strdup(user_refid);
+                user_refid = NULL;
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_JOB)) {
+            if (NULL == jdata) {
+                jdata = PMIX_NEW(prte_job_t);
+                jdata->map = PMIX_NEW(prte_job_map_t);
+                /* default to the requestor as the originator */
+                if (NULL != requestor) {
+                    PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
+                }
+            }
+            // transfer the job description across
+            rc = prte_pmix_xfer_job_info(jdata, &req->info[n]);
+            if (PRTE_SUCCESS != rc) {
+                PRTE_ERROR_LOG(rc);
+                rc = prte_pmix_convert_rc(rc);
+                goto ANSWER;
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_APP)) {
+            // the apps that are to be started in the session
+            if (NULL == jdata) {
+                jdata = PMIX_NEW(prte_job_t);
+                jdata->map = PMIX_NEW(prte_job_map_t);
+                /* default to the requestor as the originator */
+                if (NULL != requestor) {
+                    PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
+                }
+            }
+            apps = (pmix_app_t*)req->info[n].value.data.darray->array;
+            napps = req->info[n].value.data.darray->size;
+            for (i=0; i < napps; i++) {
+                rc = prte_pmix_xfer_app(jdata, &apps[n]);
+                if (PRTE_SUCCESS != rc) {
+                    PRTE_ERROR_LOG(rc);
+                    rc = prte_pmix_convert_rc(rc);
+                    goto ANSWER;
+                }
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_PERSONALITY)) {
+            personality = &req->info[n];
+            if (NULL != jdata && NULL == jdata->personality) {
+                jdata->personality = PMIX_ARGV_SPLIT_COMPAT(personality->value.data.string, ',');
+                jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
+                pmix_server_cache_job_info(jdata, personality);
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_REQUESTOR)) {
+            requestor = req->info[n].value.data.proc;
+            if (NULL != jdata) {
+                PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION) ||
+                   PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_NODES) |
+                   PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_IMAGE)) {
+            // we don't support these directives
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            goto ANSWER;
+
+        } else if(PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_ID)) {
+            if (NULL != session) {
+                session->alloc_refid = strdup(req->info[n].value.data.string);
+            } else {
+                alloc_refid = req->info[n].value.data.string;
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_REQ_ID)) {
+            if (NULL != session) {
+                session->user_refid = strdup(req->info[n].value.data.string);
+            } else {
+                user_refid = req->info[n].value.data.string;
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_NODE_LIST)) {
+            hosts = req->info[n].value.data.string;
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_NUM_CPU_LIST)) {
+            // we don't support this directive
+            rc = PMIX_ERR_NOT_SUPPORTED;
+            goto ANSWER;
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PAUSE)) {
+            pause = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_RESUME)) {
+            resume = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_TERMINATE)) {
+            terminate = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PREEMPT)) {
+            preempt = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_RESTORE)) {
+            restore = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_SIGNAL)) {
+            signal = true;
+            PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, sigvalue, int);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_EXTEND)) {
+            extend = PMIX_INFO_TRUE(&req->info[n]);
+
+        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_TIMEOUT)) {
+            PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, tval, int);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
+        }
+    }  // for loop
+
+
+    if (NULL == session) {
+        // this operation is referring to a previously instantiated session
+        session = prte_get_session_object(req->sessionID);
+        if (NULL == session) {
+            // we don't know about it
+            return PRTE_ERR_NOT_FOUND;
+        }
+        // TODO: execute the specified operation on this session
+        return PRTE_SUCCESS;
+    }
+
+    // continue working on a new instantiation
+    if (NULL != jdata) {
+        /* find the personality being passed - we need this info to direct
+         * option parsing */
+        if (NULL == personality) {
+            // do a quick search for it
+            for (i=0; i < req->ninfo; i++) {
+                if (PMIX_CHECK_KEY(&req->info[i], PMIX_PERSONALITY)) {
+                    personality = &req->info[i];
+                    break;
+                }
+            }
+        }
+        if (NULL == personality) {
+            /* use the default */
+            jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(NULL);
+        } else {
+            jdata->personality = PMIX_ARGV_SPLIT_COMPAT(personality->value.data.string, ',');
+            jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
+            pmix_server_cache_job_info(jdata, personality);
+        }
+    }
+
+    if (NULL != hosts) {
+        /* add the designation to the apps in the job, if one was provided. These
+         * will be added to the global pool when the job is setup for launch */
+        if (NULL != jdata) {
+            for (n=0; n < jdata->num_apps; n++) {
+                app = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, n);
+                // the add_host attribute will be removed after processing
+                prte_set_attribute(&app->attributes, PRTE_APP_ADD_HOST, PRTE_ATTR_GLOBAL,
+                                   hosts, PMIX_STRING);
+                /* also provide it as dash-host (if not already specified) so the
+                 * job will use those nodes */
+                if (!prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, NULL, PMIX_STRING)) {
+                    prte_set_attribute(&app->attributes, PRTE_APP_DASH_HOST, PRTE_ATTR_GLOBAL,
+                                       hosts, PMIX_STRING);
+                }
+            }
+        }
+    }
+    return PRTE_SUCCESS;
+
+// only come here upon error
+ANSWER:
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+    } else {
+        PMIX_RELEASE(req);
+    }
+    return PRTE_SUCCESS;
+}
+
+/* Callbacks to process a session control answer from the scheduler
+ * and pass on any results to the requesting client
  */
+static void passthru(int sd, short args, void *cbdata)
+{
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+
+    if (NULL != req->infocbfunc) {
+        // call the requestor's callback with the returned info
+        req->infocbfunc(req->status, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
+    } else {
+        // let them cleanup
+        req->rlcbfunc(req->rlcbdata);
+    }
+    // cleanup our request
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
 static void infocbfunc(pmix_status_t status,
                        pmix_info_t *info, size_t ninfo,
                        void *cbdata,
                        pmix_release_cbfunc_t rel, void *relcbdata)
 {
     pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
-    pmix_alloc_directive_t directive;
-    uint32_t session_id = UINT32_MAX;
-    char *endptr, *hosts, *tmp;
-    char **dir, **host_argv = NULL, **alloc_nlist = NULL, **alloc_clist = NULL;
-    pmix_list_t nodes;
-    prte_node_t *nptr;
-    prte_session_t *session;
-    prte_job_t *jdata;
-    size_t len, n, i;
-    pmix_status_t rc;
 
-    /* track this allocation so it can be referenced in e.g. a call to PMIx_Spawn */
-    if(PRTE_PROC_IS_MASTER && status == PMIX_SUCCESS){
-        for(int n = 0; n < ninfo; n++){
-            if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_ID)){
-                session_id = strtoul(info[n].value.data.string, &endptr, 10); 
-            }else if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NODE_LIST)){
-                alloc_nlist = PMIX_ARGV_SPLIT_COMPAT(info[n].value.data.string, ',');
-            }else if(PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NUM_CPU_LIST)){
-                alloc_clist = PMIX_ARGV_SPLIT_COMPAT(info[n].value.data.string, ',');
-            }
-        }
-        /* They did not provide an alloc id and nodelist. This is an error! */
-        if(session_id == UINT32_MAX || alloc_nlist == NULL){
-            status = PMIX_ERR_BAD_PARAM;
-            goto ANSWER;
-        }
-
-        dir = PMIX_ARGV_SPLIT_COMPAT(req->operation, ' ');
-        directive = strtoul(dir[1], &endptr, 10);
-        switch(directive){
-            case PMIX_ALLOC_RELEASE:
-                if(NULL == (session = prte_get_session_object(session_id))){
-                    status = PRTE_ERR_BAD_PARAM;
-                    PRTE_ERROR_LOG(status);
-                    goto ANSWER;
-                }
-                /* Remove specified nodes from session object */
-                len = PMIX_ARGV_COUNT_COMPAT(alloc_nlist);
-                for(n = 0; n < session->nodes->size; n++){
-                    if(NULL == (nptr = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, n))){
-                        continue;
-                    }
-                    for(i = 0; i < len; i++){
-                        if(0 == strcmp(nptr->name, alloc_nlist[i])){
-                            pmix_pointer_array_set_item(session->nodes, n, NULL);
-                        }
-                    }
-                }
-                PMIX_ARGV_FREE_COMPAT(alloc_nlist);
-                /* all done */
-                goto ANSWER;
-            case PMIX_ALLOC_NEW:
-                /* if we already have a session with this id that's an error */
-                if(NULL != (session = prte_get_session_object(session_id))){
-                    status = PRTE_ERR_BAD_PARAM;
-                    PRTE_ERROR_LOG(status);
-                    goto ANSWER;
-                }
-                /* create a new session object */
-                session = PMIX_NEW(prte_session_t);
-                if(NULL == session){
-                    status = PRTE_ERR_OUT_OF_RESOURCE;
-                    PRTE_ERROR_LOG(status);
-                    goto ANSWER;
-                }
-                session->session_id = session_id;
-                prte_set_session_object(session);
-
-                /* Track the session as a child session of session the requestor is running in */
-                jdata = prte_get_job_data_object(req->tproc.nspace);
-                if(NULL != jdata){
-                    pmix_pointer_array_add(jdata->session->children, session);
-                }else{
-                    /* default to our default session */
-                    pmix_pointer_array_add(prte_default_session->children, session);
-                }
-                break;
-            case PMIX_ALLOC_EXTEND:
-                /* Get the session object to extend */
-                if(NULL == (session = prte_get_session_object(session_id))){
-                    status = PRTE_ERR_BAD_PARAM;;
-                    PRTE_ERROR_LOG(status);
-                    goto ANSWER;
-                }
-                break;
-            case PMIX_ALLOC_REAQUIRE:
-                /* TODO: Not sure how to handle this */
-                goto ANSWER;
-        }
-
-        /* If we get here, we need to add specified nodes to the nodepool */
-        if(NULL != alloc_nlist && NULL == alloc_clist){
-            hosts = PMIX_ARGV_JOIN_COMPAT(alloc_nlist, ',');
-            PMIX_ARGV_FREE_COMPAT(alloc_nlist);
-        }else if (NULL != alloc_nlist && NULL != alloc_clist){
-            len = PMIX_ARGV_COUNT_COMPAT(alloc_nlist);
-            for(n = 0; n < len; n++){
-                tmp = malloc(strlen(alloc_nlist[n]) + strlen(alloc_clist[n]) + 2);
-                sprintf(tmp, "%s:%s", alloc_nlist[n], alloc_clist[n]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&host_argv, tmp);
-                free(tmp);
-            }
-            hosts = PMIX_ARGV_JOIN_COMPAT(host_argv, ',');
-            PMIX_ARGV_FREE_COMPAT(host_argv);
-            PMIX_ARGV_FREE_COMPAT(alloc_nlist);
-            PMIX_ARGV_FREE_COMPAT(alloc_clist);
-        }
-
-        /* Create a list of nodes from the hostlist */
-        PMIX_CONSTRUCT(&nodes, pmix_list_t);
-        if (PRTE_SUCCESS != (rc = prte_util_add_dash_host_nodes(&nodes, hosts, true))) {
-            PRTE_ERROR_LOG(rc);
-            status = rc;
-            goto ANSWER;
-        }
-        free(hosts);
-
-        /* If we got something back add it to */
-        if (!pmix_list_is_empty(&nodes)) {
-            /* Mark that this node was added */
-            PMIX_LIST_FOREACH(nptr, &nodes, prte_node_t){
-                nptr->state = PRTE_NODE_STATE_ADDED;
-                if(session != prte_default_session){
-                    pmix_pointer_array_add(session->nodes, nptr);
-                }
-            }
-            /* store the results in the global resource pool - this removes the
-             * list items
-             */
-            if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, NULL))) {
-                PRTE_ERROR_LOG(rc);
-                status = rc;
-                goto ANSWER;
-            }
-
-            /* mark that an updated nidmap must be communicated to existing daemons */
-            prte_nidmap_communicated = false;
-        }
-        for(n = 0; n < prte_node_pool->size; n++){
-            if(NULL == (nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n))){
-                continue;
-            }
-        }
+    // need to pass this into our progress thread for processing
+    // since we touch the global request array
+    req->status = status;
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+        req->copy = false;
     }
-ANSWER:
-    if (NULL != req->infocbfunc) {
-        req->infocbfunc(status, info, ninfo, req->cbdata, rel, relcbdata);
-    }else{
-        if (NULL != rel) {
-            rel(relcbdata);
-        }
-    }
-    /* Release our local request */
-    localrelease(req);
-    return;
-}
+    req->info = info;
+    req->ninfo = ninfo;
+    req->rlcbfunc = rel;
+    req->rlcbdata = relcbdata;
 
-void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
-                                                pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
-                                                void *cbdata)
-{
-
-    int req_index, cnt;
-    pmix_status_t ret, rc;
-    pmix_server_req_t *req;
-
-    PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
-
-    /* unpack the status - this is already a PMIx value */
-    cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        ret = prte_pmix_convert_rc(rc);
-    }
-
-    /* we let the above errors fall thru in the vain hope that the req number can
-     * be successfully unpacked, thus allowing us to respond to the requestor */
-
-    /* unpack our tracking room number */
-    cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &req_index, &cnt, PMIX_INT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        /* we are hosed */
-        return;
-    }
-
-    req = pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, req_index);
-
-    /* Report the error */
-    if(ret != PMIX_SUCCESS){
-        goto ANSWER;
-    }
-    
-    rc = PMIx_Data_unpack(NULL, buffer, &req->ninfo, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        ret = prte_pmix_convert_rc(rc);
-        goto ANSWER;
-    }
-
-    if(0 < req->ninfo){
-        PMIX_INFO_CREATE(req->info, req->ninfo);
-        
-        cnt = req->ninfo;  
-        rc = PMIx_Data_unpack(NULL, buffer, req->info, &cnt, PMIX_INFO);
-
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            ret = prte_pmix_convert_rc(rc);
-            req->ninfo = 0;
-            goto ANSWER;
-        }
-    }
-
-ANSWER:
-    infocbfunc(ret, req->info, req->ninfo, req, NULL, NULL);
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
 }
 
 static void pass_request(int sd, short args, void *cbdata)
 {
-    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
-    prte_job_t *client_job;
-    pmix_server_req_t *req;
-    pmix_data_buffer_t *buf;
-    size_t n, ninfo, need_id;
-    uint8_t command;
+    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
     pmix_status_t rc;
-    pmix_info_t info[2];
-    char alloc_id[64];
+    size_t n;
+    pmix_info_t *xfer;
 
-    /* create a request tracker for this operation */
-    req = PMIX_NEW(pmix_server_req_t);
-    if (0 < cd->allocdir) {
-        pmix_asprintf(&req->operation, "ALLOCATE: %u", cd->allocdir);
-        command = 0;
-    } else {
-        pmix_asprintf(&req->operation, "SESSIONCTRL: %u", cd->sessionID);
-        command = 1;
-    }
-    req->infocbfunc = cd->infocbfunc;
-    req->cbdata = cd->cbdata;
     /* add this request to our local request tracker array */
     req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
-    /* if we are the DVM master, then handle this ourselves */
-    if (PRTE_PROC_IS_MASTER) {
-        if (!prte_pmix_server_globals.scheduler_connected) {
-            /* the scheduler has not attached to us - see if we
-             * can attach to it, make it optional so we don't
-             * hang if there is no scheduler available */
-            PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
-            PMIX_INFO_LOAD(&info[1], PMIX_TOOL_CONNECT_OPTIONAL, NULL, PMIX_BOOL);
-            rc = PMIx_tool_attach_to_server(NULL, &prte_pmix_server_globals.scheduler,
-                                            info, 2);
-            PMIX_INFO_DESTRUCT(&info[0]);
-            PMIX_INFO_DESTRUCT(&info[1]);
-            if (PMIX_SUCCESS != rc) {
-                goto callback;
-            }
-            prte_pmix_server_globals.scheduler_set_as_server = true;
-        }
-
-        /* if we have not yet set the scheduler as our server, do so */
-        if (!prte_pmix_server_globals.scheduler_set_as_server) {
-            rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
-            if (PMIX_SUCCESS != rc) {
-                goto callback;
-            }
-            prte_pmix_server_globals.scheduler_set_as_server = true;
-        }
-
-        if (0 == command) {
-            /* check if they specified an alloc id - otherwise default to requestors session */
-            need_id = 1;
-            for(n = 0; n < cd->ninfo; n++){
-                if(PMIX_CHECK_KEY(&cd->info[n], PMIX_ALLOC_ID)){
-                    need_id = 0;
-                }
-            }
-            req->ninfo = cd->ninfo + need_id;
-            PMIX_INFO_CREATE(req->info, req->ninfo);
-            for(n = 0; n < cd->ninfo; n++){
-                PMIX_INFO_XFER(&req->info[n], &cd->info[n]);
-            }
-            if(need_id){
-                client_job = prte_get_job_data_object(cd->proc.nspace);
-                if(NULL != client_job){
-                    sprintf(alloc_id, "%u", client_job->session->session_id);
-                }else{
-                    /* default to the default session */
-                    sprintf(alloc_id, "%u", 0);
-                }
-                PMIX_INFO_LOAD(&req->info[cd->ninfo], PMIX_ALLOC_ID, alloc_id, PMIX_STRING);
-            }
-            PMIX_PROC_LOAD(&req->tproc, cd->proc.nspace, cd->proc.rank);
-
-            rc = PMIx_Allocation_request_nb(cd->allocdir, req->info, req->ninfo,
-                                            infocbfunc, req);
-        } else {
-#if PMIX_NUMERIC_VERSION < 0x00050000
-            rc = PMIX_ERR_NOT_SUPPORTED;
-#else
-            rc = PMIx_Session_control(cd->sessionID, cd->info, cd->ninfo,
-                                      infocbfunc, req);
-#endif
-        }
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
+    if (!PRTE_PROC_IS_MASTER) {
+        /* if we are not the DVM master, then we have to send
+         * this request to the master for processing */
+        rc = prte_server_send_request(PRTE_PMIX_SESSION_CTRL, req);
+        if (PRTE_SUCCESS != rc) {
             goto callback;
         }
-        PMIX_RELEASE(cd);
         return;
     }
 
-    PMIX_DATA_BUFFER_CREATE(buf);
-
-    /* construct a request message for the command */
-    rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
+    /* if we are the DVM master, then handle this ourselves - start
+     * by ensuring the scheduler is connected to us */
+    rc = prte_pmix_set_scheduler();
     if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         goto callback;
     }
 
-    /* pack the local requestor ID */
-    rc = PMIx_Data_pack(NULL, buf, &req->local_index, 1, PMIX_INT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-        goto callback;
-    }
-
-    /* pack the requestor */
-    rc = PMIx_Data_pack(NULL, buf, &cd->proc, 1, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-        goto callback;
-    }
-
-    if (0 == command) {
-        /* pack the allocation directive */
-        rc = PMIx_Data_pack(NULL, buf, &cd->allocdir, 1, PMIX_ALLOC_DIRECTIVE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-            goto callback;
-        }
+    /* if the requestor is the scheduler, then this is a directive
+     * to the DVM - e.g., to instantiate or terminate a session.
+     * In that case, we process it here */
+    if (PMIX_CHECK_PROCID(&prte_pmix_server_globals.scheduler, &req->tproc)) {
+        rc = process_directive(req);
     } else {
-        /* pack the sessionID */
-        rc = PMIx_Data_pack(NULL, buf, &cd->sessionID, 1, PMIX_UINT32);
+        // we need to pass the request on to the scheduler
+        // need to add the requestor's ID to the info array
+        PMIX_INFO_CREATE(xfer, req->ninfo + 1);
+        for (n=0; n < req->ninfo; n++) {
+            PMIX_INFO_XFER(&xfer[n], &req->info[n]);
+        }
+        PMIX_INFO_LOAD(&xfer[req->ninfo], PMIX_REQUESTOR, &req->tproc, PMIX_PROC);
+        // the current req object points to the caller's info array, so leave it alone
+        req->copy = true;
+        req->info = xfer;
+        req->ninfo++;
+        rc = PMIx_Session_control(req->sessionID, req->info, req->ninfo,
+                                  infocbfunc, req);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
             goto callback;
         }
+        return;
     }
-
-    /* pack the number of info */
-    rc = PMIx_Data_pack(NULL, buf, &cd->ninfo, 1, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-        goto callback;
-    }
-    if (0 < cd->ninfo) {
-        /* pack the info */
-        rc = PMIx_Data_pack(NULL, buf, cd->info, cd->ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-            goto callback;
-        }
-    }
-
-    /* send this request to the DVM controller */
-    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        goto callback;
-    }
-    PMIX_RELEASE(cd);
-    return;
 
 callback:
-    PMIX_RELEASE(cd);
-    /* this section gets executed solely upon an error */
+    /* this section gets executed solely upon an error or if this was a
+     * directive to us from the scheduler */
     if (NULL != req->infocbfunc) {
         req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
         return;
     }
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
 }
 
-pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
-                                   pmix_alloc_directive_t directive,
-                                   const pmix_info_t data[], size_t ndata,
-                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
-{
-    prte_pmix_server_op_caddy_t *cd;
-
-
-    pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s allocate upcalled on behalf of proc %s:%u with %" PRIsize_t " infos",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), client->nspace, client->rank, ndata);
-
-    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
-    PMIX_LOAD_PROCID(&cd->proc, client->nspace, client->rank);
-    cd->allocdir = directive;
-    cd->info = (pmix_info_t *) data;
-    cd->ninfo = ndata;
-    cd->infocbfunc = cbfunc;
-    cd->cbdata = cbdata;
-    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
-    PMIX_POST_OBJECT(cd);
-    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
-    return PRTE_SUCCESS;
-}
-
-#if PMIX_NUMERIC_VERSION >= 0x00050000
-
+/* this is the upcall from the PMIx server for the session
+ * control support. Since we are going to touch global structures
+ * (e.g., the session tracker pointer array), we have to threadshift
+ * this request into our own internal progress thread. Note that the
+ * session control directive could have come to this host from the
+ * scheduler, or a tool, or even an application process. */
 pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                                           uint32_t sessionID,
                                           const pmix_info_t directives[], size_t ndirs,
                                           pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
-    prte_pmix_server_op_caddy_t *cd;
-
+    pmix_server_req_t *req;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s session ctrl upcalled on behalf of proc %s:%u with %" PRIsize_t " directives",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), requestor->nspace, requestor->rank, ndirs);
 
-    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
-    PMIX_LOAD_PROCID(&cd->proc, requestor->nspace, requestor->rank);
-    cd->sessionID = sessionID;
-    cd->info = (pmix_info_t *) directives;
-    cd->ninfo = ndirs;
-    cd->infocbfunc = cbfunc;
-    cd->cbdata = cbdata;
-    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, pass_request, cd);
-    PMIX_POST_OBJECT(cd);
-    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+    /* create a request tracker for this operation */
+    req = PMIX_NEW(pmix_server_req_t);
+    pmix_asprintf(&req->operation, "SESSIONCTRL: %u", sessionID);
+    PMIX_PROC_LOAD(&req->tproc, requestor->nspace, requestor->rank);
+    req->sessionID = sessionID;
+    req->info = (pmix_info_t *) directives;
+    req->ninfo = ndirs;
+    req->infocbfunc = cbfunc;
+    req->cbdata = cbdata;
+
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, pass_request, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
     return PRTE_SUCCESS;
 }
 

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -222,6 +222,7 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 
 /* scheduler requests */
 #define PRTE_RML_TAG_SCHED 72
+#define PRTE_RML_TAG_SCHED_RESP 73
 
 
 #define PRTE_RML_TAG_MAX 100

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -123,6 +123,7 @@ prte_timer_t *prte_mpiexec_timeout = NULL;
 int prte_stack_trace_wait_timeout = 30;
 
 /* global arrays for data storage */
+pmix_pointer_array_t *prte_sessions = NULL;
 pmix_pointer_array_t *prte_job_data = NULL;
 pmix_pointer_array_t *prte_node_pool = NULL;
 pmix_pointer_array_t *prte_node_topologies = NULL;
@@ -143,6 +144,7 @@ char *prte_default_hostfile = NULL;
 bool prte_default_hostfile_given = false;
 int prte_num_allocated_nodes = 0;
 char *prte_default_dash_host = NULL;
+prte_session_t *prte_default_session = NULL;
 
 /* tool communication controls */
 bool prte_report_events = false;
@@ -255,6 +257,85 @@ int prte_set_job_data_object(prte_job_t *jdata)
         return PRTE_ERROR;
     }
     return PRTE_SUCCESS;
+}
+
+prte_session_t *prte_get_session_object(const uint32_t session_id)
+{
+    prte_session_t *session;
+    int i;
+
+    /* if the job data wasn't setup, we cannot provide the data */
+    if (NULL == prte_sessions) {
+        return NULL;
+    }
+    /* if the nspace is invalid, then reject it */
+    if (session_id == UINT32_MAX) {
+        return NULL;
+    }
+    for (i = 0; i < prte_sessions->size; i++) {
+        if (NULL == (session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i))) {
+            continue;
+        }
+        if (session->session_id == session_id) {
+            return session;
+        }
+    }
+    return NULL;
+}
+
+int prte_set_session_object(prte_session_t *session)
+{
+    prte_session_t *session_ptr;
+    int i, index, save = -1;
+
+    /* if the session data wasn't setup, we cannot set the data */
+    if (NULL == prte_sessions) {
+        return PRTE_ERROR;
+    }
+    /* if the session_id is invalid, then that's an error */
+    if (session->session_id == UINT32_MAX) {
+        return PRTE_ERROR;
+    }
+    /* verify that we don't already have this object */
+    for (i = 0; i < prte_sessions->size; i++) {
+        if (NULL == (session_ptr = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i))) {
+            if (0 > save) {
+                save = i;
+            }
+            continue;
+        }
+        if (session_ptr->session_id == session->session_id) {
+            return PRTE_EXISTS;
+        }
+    }
+
+    if (-1 == save) {
+        pmix_pointer_array_add(prte_sessions, session);
+    } else {
+        pmix_pointer_array_set_item(prte_sessions, save, session);
+    }
+    if (0 > index) {
+        return PRTE_ERROR;
+    }
+    return PRTE_SUCCESS;
+}
+
+bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2){
+    size_t n;
+    prte_session_t *session_ptr;
+
+    if(session1->session_id == session2->session_id){
+        return true;
+    }
+
+    for(n = 0; n < session1->children->size; n++){
+        if(NULL != (session_ptr = (prte_session_t *) pmix_pointer_array_get_item(session1->children, n))){
+            if(session_ptr->session_id == session2->session_id){
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 prte_proc_t *prte_get_proc_object(const pmix_proc_t *proc)
@@ -466,6 +547,7 @@ PMIX_CLASS_INSTANCE(prte_app_context_t, pmix_object_t, prte_app_context_construc
 static void prte_job_construct(prte_job_t *job)
 {
     job->exit_code = 0;
+    job->session = NULL;
     job->personality = NULL;
     job->schizo = NULL;
     PMIX_LOAD_NSPACE(job->nspace, NULL);
@@ -792,6 +874,27 @@ static void tdes(prte_topology_t *t)
 }
 PMIX_CLASS_INSTANCE(prte_topology_t, pmix_object_t,
                     tcon, tdes);
+
+static void session_con(prte_session_t *s)
+{
+    s->session_id = UINT32_MAX;
+    s->nodes = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(s->nodes, PRTE_GLOBAL_ARRAY_BLOCK_SIZE, PRTE_GLOBAL_ARRAY_MAX_SIZE,
+                        PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+    s->jobs = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(s->jobs, PRTE_GLOBAL_ARRAY_BLOCK_SIZE, PRTE_GLOBAL_ARRAY_MAX_SIZE,
+                        PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+    s->children = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(s->children, PRTE_GLOBAL_ARRAY_BLOCK_SIZE, PRTE_GLOBAL_ARRAY_MAX_SIZE,
+                    PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+}
+static void session_des(prte_session_t *s)
+{
+    PMIX_RELEASE(s->nodes);
+    PMIX_RELEASE(s->jobs);
+    PMIX_RELEASE(s->children);
+}
+PMIX_CLASS_INSTANCE(prte_session_t, pmix_list_item_t, session_con, session_des);
 
 #if PRTE_PICKY_COMPILERS
 void prte_hide_unused_params(int x, ...)

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -206,6 +206,16 @@ typedef struct {
 } prte_topology_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_topology_t);
 
+/* Object for tracking allocations */
+typedef struct{
+    pmix_object_t super;
+    uint32_t session_id;
+    pmix_pointer_array_t *nodes;
+    pmix_pointer_array_t *jobs;
+    pmix_pointer_array_t *children;
+}prte_session_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_session_t);
+
 /**
  * Information about a specific application to be launched in the RTE.
  */
@@ -321,6 +331,8 @@ typedef struct {
     /* offset to the total number of procs so shared memory
      * components can potentially connect to any spawned jobs*/
     pmix_rank_t offset;
+    /* session this job is running in */
+    prte_session_t *session;
     /* app_context array for this job */
     pmix_pointer_array_t *apps;
     /* number of app_contexts in the array */
@@ -433,6 +445,13 @@ struct prte_proc_t {
 };
 typedef struct prte_proc_t prte_proc_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_proc_t);
+
+/** Get session object */
+PRTE_EXPORT prte_session_t *prte_get_session_object(const uint32_t session_id);
+
+PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
+
+PRTE_EXPORT bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2);
 
 /**
  * Get a job data object
@@ -557,6 +576,7 @@ PRTE_EXPORT extern float prte_max_timeout;
 PRTE_EXPORT extern prte_timer_t *prte_mpiexec_timeout;
 
 /* global arrays for data storage */
+PRTE_EXPORT extern pmix_pointer_array_t *prte_sessions;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_job_data;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_node_pool;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_node_topologies;
@@ -577,6 +597,7 @@ PRTE_EXPORT extern char *prte_default_hostfile;
 PRTE_EXPORT extern bool prte_default_hostfile_given;
 PRTE_EXPORT extern int prte_num_allocated_nodes;
 PRTE_EXPORT extern char *prte_default_dash_host;
+PRTE_EXPORT extern prte_session_t *prte_default_session;
 
 /* tool communication controls */
 PRTE_EXPORT extern bool prte_report_events;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -209,11 +209,15 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_topology_t);
 /* Object for tracking allocations */
 typedef struct{
     pmix_object_t super;
+    int index;
     uint32_t session_id;
+    char *user_refid;  // PMIX_ALLOC_REQ_ID
+    char *alloc_refid; // PMIX_ALLOC_ID
+    struct timeval timeout;  // time limit on session
     pmix_pointer_array_t *nodes;
     pmix_pointer_array_t *jobs;
     pmix_pointer_array_t *children;
-}prte_session_t;
+} prte_session_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_session_t);
 
 /**
@@ -448,6 +452,8 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_proc_t);
 
 /** Get session object */
 PRTE_EXPORT prte_session_t *prte_get_session_object(const uint32_t session_id);
+PRTE_EXPORT prte_session_t *prte_get_session_object_from_id(const char *id);
+PRTE_EXPORT prte_session_t *prte_get_session_object_from_refid(const char *refid);
 
 PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
 

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -308,6 +308,23 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
         error = "setup node array";
         goto error;
     }
+    prte_sessions = PMIX_NEW(pmix_pointer_array_t);
+    ret = pmix_pointer_array_init(prte_sessions,
+                                  PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
+                                  PRTE_GLOBAL_ARRAY_MAX_SIZE,
+                                  PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        error = "setup session array";
+        goto error;
+    }
+    /* Create a session object for the DVM and let it point to the node pool */
+    prte_default_session = PMIX_NEW(prte_session_t);
+    prte_default_session->session_id = 0;
+    PMIX_RELEASE(prte_default_session->nodes);
+    prte_default_session->nodes = prte_node_pool;
+    prte_set_session_object(prte_default_session);
+
     prte_node_topologies = PMIX_NEW(pmix_pointer_array_t);
     ret = pmix_pointer_array_init(prte_node_topologies, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
                                   PRTE_GLOBAL_ARRAY_MAX_SIZE,

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -320,10 +320,14 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
     }
     /* Create a session object for the DVM and let it point to the node pool */
     prte_default_session = PMIX_NEW(prte_session_t);
-    prte_default_session->session_id = 0;
+    prte_default_session->session_id = UINT32_MAX;
     PMIX_RELEASE(prte_default_session->nodes);
     prte_default_session->nodes = prte_node_pool;
-    prte_set_session_object(prte_default_session);
+    ret = prte_set_session_object(prte_default_session);
+    if (PRTE_SUCCESS != ret) {
+        error = "set session object";
+        goto error;
+    }
 
     prte_node_topologies = PMIX_NEW(pmix_pointer_array_t);
     ret = pmix_pointer_array_init(prte_node_topologies, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -54,7 +54,6 @@ static int prte_progress_thread_debug_level = -1;
 static char *prte_tmpdir_base = NULL;
 static char *prte_local_tmpdir_base = NULL;
 static char *prte_remote_tmpdir_base = NULL;
-static char *prte_top_session_dir = NULL;
 static char *local_setup_slots = NULL;
 
 char *prte_signal_string = NULL;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1185,7 +1185,6 @@ int main(int argc, char *argv[])
     if (verbose) {
         pmix_output(0, "Spawning job");
     }
-
     /* let the PMIx server handle it for us so that all the job infos
      * get properly recorded - e.g., forwarding IOF */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);

--- a/src/tools/psched/scheduler.c
+++ b/src/tools/psched/scheduler.c
@@ -4,7 +4,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,6 +70,17 @@ void psched_request_init(int fd, short args, void *cbdata)
             req->user_refid = strdup(req->data[n].value.data.string);
         } else if (PMIX_CHECK_KEY(&req->data[n], PMIX_ALLOC_ID)) {
             req->alloc_refid = strdup(req->data[n].value.data.string);
+        } else if (PMIX_CHECK_KEY(&req->data[n], PMIX_SESSION_ID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &req->data[n].value, req->sessionID, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                // track the first error
+                if (PMIX_SUCCESS == rcerr) {
+                    rcerr = rc;
+                }
+            }
+            // continue processing as we may need some of the info
+            // when reporting back the error
         } else if (PMIX_CHECK_KEY(&req->data[n], PMIX_ALLOC_NUM_NODES)) {
             PMIX_VALUE_GET_NUMBER(rc, &req->data[n].value, req->num_nodes, uint64_t);
             if (PMIX_SUCCESS != rc) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -499,6 +499,12 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "DISPLAY PARSEABLE OUTPUT";
         case PRTE_JOB_EXTEND_DVM:
             return "EXTEND DVM";
+        case PRTE_JOB_SESSION_ID:
+            return "SESSION ID";
+        case PRTE_JOB_ALLOC_ID:
+            return "ALLOC ID";
+        case PRTE_JOB_REF_ID:
+            return "ALLOC REF ID";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -221,6 +221,11 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT   (PRTE_JOB_START_KEY + 110) // bool - display output in machine parsable format
 #define PRTE_JOB_EXTEND_DVM                 (PRTE_JOB_START_KEY + 111) // bool - DVM is being extended
 #define PRTE_JOB_SESSION_ID                 (PRTE_JOB_START_KEY + 112) // uint32_t - session id of this job
+#define PRTE_JOB_ALLOC_ID                   (PRTE_JOB_START_KEY + 113) // char* - string identifier assigned by the host for the session
+                                                                       //         within which the job is to execute
+#define PRTE_JOB_REF_ID                     (PRTE_JOB_START_KEY + 114) // char* - string identifier assigned by the user to an allocation
+                                                                       //         request - carried along with the session that resulted
+                                                                       //         from the request
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -220,6 +220,7 @@ typedef uint16_t prte_job_flags_t;
                                                                        //         are to be displayed
 #define PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT   (PRTE_JOB_START_KEY + 110) // bool - display output in machine parsable format
 #define PRTE_JOB_EXTEND_DVM                 (PRTE_JOB_START_KEY + 111) // bool - DVM is being extended
+#define PRTE_JOB_SESSION_ID                 (PRTE_JOB_START_KEY + 112) // uint32_t - session id of this job
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -738,6 +738,7 @@ cleanup:
     return rc;
 }
 
+
 int prte_util_get_ordered_dash_host_list(pmix_list_t *nodes, char *hosts)
 {
     int rc, i;

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow


### PR DESCRIPTION
Based on the discussions with @rhc54 , @sonjahapp, and Isaias in the Dynamic Workflows WG and email threads I started implementing some support for tracking allocations in PRRTE. The required changes turned out to be more extensive than I expected and more work will be required also for Session_control. I'm a bit tied up with other work in the coming weeks so I thought I'd just share what I have so far. 

As Ralph suggested I created a prte_session_t struct which tracks the nodes, jobs, and child sessions associated with a session. 

So far I have added:

- support for answering allocation requests from remote daemons
- created a prte_session_t struct which tracks the nodes, jobs, and child sessions associated with a session
- support for PMIX_ALLOC_ID in PMIx_Spawn
- restrict mapping to nodes in a specific session
- creation/adaption of sessions based on PMIX_ALLOC_NEW/EXTEND/RELEASE

Some important assumptions:

1. The PMIX_ALLOC_ID is a string representation of the uint64_t PMIX_SESSION_ID. 
2. Jobs are only allowed to spawn into their own session or into a child session created with PMIX_ALLOC_NEW.
3. The default session's node array _IS_ the global node pool. Some care is required when releasing the session struct but I figured this way it would be easier to track the nodes in the default session
4. By default jobs run in the default session
5. The PRRTE DVM job runs in the default session 

I did some testing with the following scripts:
https://github.com/HawkmoonEternal/allocation_tracking_test

The allocation tracking seems to work for these test cases but I think some more extensive testing is required.
I also noticed that the default behavior of PRRTE is to abort all child jobs if the parent job is completed. I was wondering if we should maybe introduce an attribute in the PMIx_Spawn call to indicate that a job should persist. I could imagine situations such as postprocessing, insitu tasks etc. where the child jobs are expected to outlive the parent job.

 Looking forward to your feedback and discussing this in the next Working Group meeting.
