### PR TITLE
Remove extra character at end of error messages

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1958,7 +1958,9 @@ int prte_odls_base_default_kill_local_procs(pmix_pointer_array_t *procs,
             cd->child->pid = 0;
 
             /* mark the child as "killed" */
-            cd->child->state = PRTE_PROC_STATE_KILLED_BY_CMD; /* we ordered it to die */
+            if (cd->child->state < PRTE_PROC_STATE_TERMINATED) {
+                cd->child->state = PRTE_PROC_STATE_KILLED_BY_CMD; /* we ordered it to die */
+            }
 
             /* ensure the child's session directory is cleaned up */
             prte_session_dir_finalize(&cd->child->name);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -4,7 +4,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -625,7 +625,7 @@ static void check_complete(int fd, short args, void *cbdata)
                 pmix_byte_object_t bo;
                 PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
                 bo.bytes = (char *) msg;
-                bo.size = strlen(msg) + 1;
+                bo.size = strlen(msg);
                 PRTE_PMIX_CONSTRUCT_LOCK(&lock);
                 rc = PMIx_server_IOF_deliver(&prte_process_info.myproc,
                                              PMIX_FWD_STDDIAG_CHANNEL,

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -228,7 +228,8 @@ static char *print_aborted_job(prte_job_t *job,
             }
         }
         return output;
-    } else if (PRTE_PROC_STATE_ABORTED == proc->state) {
+    } else if (PRTE_PROC_STATE_ABORTED == proc->state ||
+               PRTE_PROC_STATE_CALLED_ABORT == proc->state) {
         output = pmix_show_help_string("help-prun.txt", "prun:proc-ordered-abort", true,
                                        prte_tool_basename, (unsigned long) proc->name.rank,
                                        (unsigned long) proc->pid, node->name, prte_tool_basename);


### PR DESCRIPTION
We do not pass NULL-terminated strings to the IOF
delivery system, just byte objects - so don't extend the byte object size by one. Procs calling abort might have state "aborted" and "called_abort", depending upon any shim they might have used.

Refs https://github.com/open-mpi/ompi/issues/12201
