### PR TITLE
Revamp the session directory system

### DIFF
--- a/src/mca/errmgr/base/errmgr_base_fns.c
+++ b/src/mca/errmgr/base/errmgr_base_fns.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,49 +91,4 @@ void prte_errmgr_base_log(int error_code, char *filename, int line)
 
     pmix_output(0, "%s PRTE_ERROR_LOG: %s in file %s at line %d",
                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), errstring, filename, line);
-}
-
-void prte_errmgr_base_abort(int error_code, char *fmt, ...)
-{
-    va_list arglist;
-
-    /* If there was a message, output it */
-    va_start(arglist, fmt);
-    if (NULL != fmt) {
-        char *buffer = NULL;
-        pmix_vasprintf(&buffer, fmt, arglist);
-        pmix_output(0, "%s", buffer);
-        free(buffer);
-    }
-    va_end(arglist);
-
-    /* if I am a daemon or the HNP... */
-    if (PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON) {
-        /* whack my local procs */
-        if (NULL != prte_odls.kill_local_procs) {
-            prte_odls.kill_local_procs(NULL);
-        }
-        /* whack any session directories */
-        prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
-    }
-
-    /* if a critical connection failed, or a sensor limit was exceeded, exit without dropping a core
-     */
-    if (PRTE_ERR_CONNECTION_FAILED == error_code || PRTE_ERR_SENSOR_LIMIT_EXCEEDED == error_code) {
-        prte_ess.abort(error_code, false);
-    } else {
-        prte_ess.abort(error_code, true);
-    }
-
-    /*
-     * We must exit in prte_ess.abort; all implementations of prte_ess.abort
-     * contain __prte_attribute_noreturn__
-     */
-    /* No way to reach here */
-}
-
-int prte_errmgr_base_abort_peers(pmix_proc_t *procs, int32_t num_procs, int error_code)
-{
-    PRTE_HIDE_UNUSED_PARAMS(procs, num_procs, error_code);
-    return PRTE_ERR_NOT_IMPLEMENTED;
 }

--- a/src/mca/errmgr/base/errmgr_base_frame.c
+++ b/src/mca/errmgr/base/errmgr_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,27 +48,21 @@
 
 #include "src/mca/errmgr/base/static-components.h"
 
-/*
- * Globals
- */
-prte_errmgr_base_t prte_errmgr_base = {
-    .error_cbacks = PMIX_LIST_STATIC_INIT
-};
-
 /* Public module provides a wrapper around previous functions */
-prte_errmgr_base_module_t prte_errmgr_default_fns = {.init = NULL,     /* init     */
-                                                     .finalize = NULL, /* finalize */
-                                                     .logfn = prte_errmgr_base_log,
-                                                     .abort = prte_errmgr_base_abort,
-                                                     .abort_peers = prte_errmgr_base_abort_peers,
-                                                     .enable_detector = NULL};
+prte_errmgr_base_module_t prte_errmgr_default_fns = {
+    .init = NULL,     /* init     */
+    .finalize = NULL, /* finalize */
+    .logfn = prte_errmgr_base_log
+};
 
 /* NOTE: ABSOLUTELY MUST initialize this
  * struct to include the log function as it
  * gets called even if the errmgr hasn't been
  * opened yet due to error
  */
-prte_errmgr_base_module_t prte_errmgr = {.logfn = prte_errmgr_base_log};
+prte_errmgr_base_module_t prte_errmgr = {
+    .logfn = prte_errmgr_base_log
+};
 
 static int prte_errmgr_base_close(void)
 {
@@ -79,9 +73,6 @@ static int prte_errmgr_base_close(void)
 
     /* always leave a default set of fn pointers */
     prte_errmgr = prte_errmgr_default_fns;
-
-    /* destruct the callback list */
-    PMIX_LIST_DESTRUCT(&prte_errmgr_base.error_cbacks);
 
     return pmix_mca_base_framework_components_close(&prte_errmgr_base_framework, NULL);
 }
@@ -94,9 +85,6 @@ static int prte_errmgr_base_open(pmix_mca_base_open_flag_t flags)
 {
     /* load the default fns */
     prte_errmgr = prte_errmgr_default_fns;
-
-    /* initialize the error callback list */
-    PMIX_CONSTRUCT(&prte_errmgr_base.error_cbacks, pmix_list_t);
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&prte_errmgr_base_framework, flags);

--- a/src/mca/errmgr/base/errmgr_private.h
+++ b/src/mca/errmgr/base/errmgr_private.h
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +48,6 @@
  */
 BEGIN_C_DECLS
 
-/* define a struct to hold framework-global values */
-typedef struct {
-    pmix_list_t error_cbacks;
-} prte_errmgr_base_t;
-
-PRTE_EXPORT extern prte_errmgr_base_t prte_errmgr_base;
-
 /* declare the base default module */
 PRTE_EXPORT extern prte_errmgr_base_module_t prte_errmgr_default_fns;
 
@@ -62,10 +55,6 @@ PRTE_EXPORT extern prte_errmgr_base_module_t prte_errmgr_default_fns;
  * Base functions
  */
 PRTE_EXPORT void prte_errmgr_base_log(int error_code, char *filename, int line);
-
-PRTE_EXPORT void prte_errmgr_base_abort(int error_code, char *fmt, ...)
-    __prte_attribute_format__(__printf__, 2, 3);
-PRTE_EXPORT int prte_errmgr_base_abort_peers(pmix_proc_t *procs, int32_t num_procs, int error_code);
 
 END_C_DECLS
 #endif

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,9 +71,7 @@ static int finalize(void);
 prte_errmgr_base_module_t prte_errmgr_dvm_module = {
     .init = init,
     .finalize = finalize,
-    .logfn = prte_errmgr_base_log,
-    .abort = prte_errmgr_base_abort,
-    .abort_peers = prte_errmgr_base_abort_peers
+    .logfn = prte_errmgr_base_log
 };
 
 /*

--- a/src/mca/errmgr/errmgr.h
+++ b/src/mca/errmgr/errmgr.h
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,27 +99,6 @@ typedef int (*prte_errmgr_base_module_finalize_fn_t)(void);
  */
 typedef void (*prte_errmgr_base_module_log_fn_t)(int error_code, char *filename, int line);
 
-/**
- * Alert - self aborting
- * This function is called when a process is aborting due to some internal error.
- * It will finalize the process
- * itself, and then exit - it takes no other actions. The intent here is to provide
- * a last-ditch exit procedure that attempts to clean up a little.
- */
-typedef void (*prte_errmgr_base_module_abort_fn_t)(int error_code, char *fmt, ...)
-    __prte_attribute_format_funcptr__(__printf__, 2, 3);
-
-/**
- * Alert - abort peers
- *  This function is called when a process wants to abort one or more peer processes.
- *  For example, MPI_Abort(comm) will use this function to terminate peers in the
- *  communicator group before aborting itself.
- */
-typedef int (*prte_errmgr_base_module_abort_peers_fn_t)(pmix_proc_t *procs, int32_t num_procs,
-                                                        int error_code);
-
-typedef void (*prte_errmgr_base_module_enable_detector_fn_t)(bool flag);
-
 /*
  * Module Structure
  */
@@ -130,11 +109,6 @@ struct prte_errmgr_base_module_2_3_0_t {
     prte_errmgr_base_module_finalize_fn_t finalize;
 
     prte_errmgr_base_module_log_fn_t logfn;
-    prte_errmgr_base_module_abort_fn_t abort;
-    prte_errmgr_base_module_abort_peers_fn_t abort_peers;
-
-    /* start error detector and propagator */
-    prte_errmgr_base_module_enable_detector_fn_t enable_detector;
 };
 typedef struct prte_errmgr_base_module_2_3_0_t prte_errmgr_base_module_2_3_0_t;
 typedef prte_errmgr_base_module_2_3_0_t prte_errmgr_base_module_t;

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -10,7 +10,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,12 +64,11 @@ static void prted_abort(int error_code, char *fmt, ...);
 /******************
  * prted module
  ******************/
-prte_errmgr_base_module_t prte_errmgr_prted_module = {.init = init,
-                                                      .finalize = finalize,
-                                                      .logfn = prte_errmgr_base_log,
-                                                      .abort = prted_abort,
-                                                      .abort_peers = prte_errmgr_base_abort_peers,
-                                                      .enable_detector = NULL};
+prte_errmgr_base_module_t prte_errmgr_prted_module = {
+    .init = init,
+    .finalize = finalize,
+    .logfn = prte_errmgr_base_log
+};
 
 /* Local functions */
 static bool any_live_children(pmix_nspace_t job);
@@ -671,8 +670,8 @@ static void proc_errors(int fd, short args, void *cbdata)
 
         /* remove all of this job's children from the global list */
         for (i = 0; i < prte_local_children->size; i++) {
-            if (NULL
-                == (ptr = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i))) {
+            ptr = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+            if (NULL == ptr) {
                 continue;
             }
             if (PMIX_CHECK_NSPACE(jdata->nspace, ptr->name.nspace)) {
@@ -680,9 +679,6 @@ static void proc_errors(int fd, short args, void *cbdata)
                 PMIX_RELEASE(ptr);
             }
         }
-
-        /* ensure the job's local session directory tree is removed */
-        prte_session_dir_cleanup(jdata->nspace);
 
         /* remove this job from our local job data since it is complete */
         PMIX_RELEASE(jdata);

--- a/src/mca/ess/alps/ess_alps_module.c
+++ b/src/mca/ess/alps/ess_alps_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,9 +46,10 @@ static int alps_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_alps_module = {.init = rte_init,
-                                               .finalize = rte_finalize,
-                                               .abort = NULL};
+prte_ess_base_module_t prte_ess_alps_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /* Local variables */
 static pmix_rank_t starting_vpid = 0;

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +47,6 @@
 prte_ess_base_module_t prte_ess = {
     .init = NULL,
     .finalize = NULL,
-    .abort = NULL,
 };
 int prte_ess_base_num_procs = -1;
 char *prte_ess_base_nspace = NULL;

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,9 +73,10 @@ static int env_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_env_module = {.init = rte_init,
-                                              .finalize = rte_finalize,
-                                              .abort = NULL};
+prte_ess_base_module_t prte_ess_env_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 static int rte_init(int argc, char **argv)
 {

--- a/src/mca/ess/ess.h
+++ b/src/mca/ess/ess.h
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,26 +56,12 @@ typedef int (*prte_ess_base_module_init_fn_t)(int argc, char **argv);
  */
 typedef int (*prte_ess_base_module_finalize_fn_t)(void);
 
-/**
- * Abort the current application
- *
- * Aborts currently running application, NOTE: We do NOT call the
- * regular C-library "abort" function, even
- * though that would have alerted us to the fact that this is
- * an abnormal termination, because it would automatically cause
- * a core file to be generated. The "report" flag indicates if the
- * function should create an appropriate file to alert the local
- * orted that termination was abnormal.
- */
-typedef void (*prte_ess_base_module_abort_fn_t)(int status, bool report);
-
 /*
  * the standard module data structure
  */
 struct prte_ess_base_module_3_0_0_t {
     prte_ess_base_module_init_fn_t init;
     prte_ess_base_module_finalize_fn_t finalize;
-    prte_ess_base_module_abort_fn_t abort;
 };
 typedef struct prte_ess_base_module_3_0_0_t prte_ess_base_module_3_0_0_t;
 typedef struct prte_ess_base_module_3_0_0_t prte_ess_base_module_t;

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,9 +50,10 @@ static int lsf_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_lsf_module = {.init = rte_init,
-                                              .finalize = rte_finalize,
-                                              .abort = NULL};
+prte_ess_base_module_t prte_ess_lsf_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /*
  * Local variables

--- a/src/mca/ess/pals/ess_pals_module.c
+++ b/src/mca/ess/pals/ess_pals_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -55,9 +55,10 @@ static int pals_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_pals_module = {.init = rte_init,
-                                                .finalize = rte_finalize,
-                                                .abort = NULL};
+prte_ess_base_module_t prte_ess_pals_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 static int rte_init(int argc, char **argv)
 {

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,9 +53,10 @@ static int slurm_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_slurm_module = {.init = rte_init,
-                                                .finalize = rte_finalize,
-                                                .abort = NULL};
+prte_ess_base_module_t prte_ess_slurm_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 static int rte_init(int argc, char **argv)
 {

--- a/src/mca/ess/tm/ess_tm_module.c
+++ b/src/mca/ess/tm/ess_tm_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,9 +52,10 @@ static int tm_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_tm_module = {.init = rte_init,
-                                             .finalize = rte_finalize,
-                                             .abort = NULL};
+prte_ess_base_module_t prte_ess_tm_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /*
  * Local variables

--- a/src/mca/oob/tcp/oob_tcp_listener.c
+++ b/src/mca/oob/tcp/oob_tcp_listener.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -800,7 +800,6 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
             pmix_show_help("help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
                            prte_socket_errno, strerror(prte_socket_errno),
                            "Out of file descriptors");
-            prte_errmgr.abort(PRTE_ERROR_DEFAULT_EXIT_CODE, NULL);
             return;
         }
 

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -111,7 +111,8 @@ int prte_plm_base_comm_stop(void)
 }
 
 /* process incoming messages in order of receipt */
-void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+void prte_plm_base_recv(int status, pmix_proc_t *sender,
+                        pmix_data_buffer_t *buffer,
                         prte_rml_tag_t tag, void *cbdata)
 {
     prte_plm_cmd_flag_t command;
@@ -232,7 +233,8 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
         }
 
         /* get the parent's job object */
-        if (NULL != (parent = prte_get_job_data_object(nptr->nspace))) {
+        if (NULL != (parent = prte_get_job_data_object(nptr->nspace)) &&
+            !PMIX_CHECK_NSPACE(parent->nspace, PRTE_PROC_MY_NAME->nspace)) {
             /* link the spawned job to the spawner */
             PMIX_RETAIN(jdata);
             pmix_list_append(&parent->children, &jdata->super);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -540,7 +540,6 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata,
     proc = PMIX_NEW(prte_proc_t);
     /* set the jobid */
     PMIX_LOAD_NSPACE(proc->name.nspace, jdata->nspace);
-    proc->job = jdata;
     /* flag the proc as ready for launch */
     proc->state = PRTE_PROC_STATE_INIT;
     proc->app_idx = idx;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -783,9 +783,9 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
     }
 
     // session dir + / (1) + lsf_rf. (7) + XXXXXX (6) + \0 (1)
-    len = strlen(prte_process_info.jobfam_session_dir) + 1 + 7 + 6 + 1;
+    len = strlen(prte_process_info.top_session_dir) + 1 + 7 + 6 + 1;
     (*aff_rankfile) = (char*) malloc(sizeof(char) * len);
-    sprintf(*aff_rankfile, "%s/lsf_rf.XXXXXX", prte_process_info.jobfam_session_dir);
+    sprintf(*aff_rankfile, "%s/lsf_rf.XXXXXX", prte_process_info.top_session_dir);
 
     /* open the file */
     fp = fopen(affinity_file, "r");

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -541,12 +541,6 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             PMIx_server_deregister_client(proc, opcbfunc, &lock);
             PRTE_PMIX_WAIT_THREAD(&lock);
             PRTE_PMIX_DESTRUCT_LOCK(&lock);
-
-            /* Clean up the session directory as if we were the process
-             * itself.  This covers the case where the process died abnormally
-             * and didn't cleanup its own session directory.
-             */
-            prte_session_dir_finalize(proc);
         }
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -4,8 +4,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022  Consulting.  All rights reserved.
- * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -476,11 +475,6 @@ static void track_procs(int fd, short argc, void *cbdata)
         PRTE_FLAG_SET(pdata, PRTE_PROC_FLAG_RECORDED);
         PRTE_FLAG_UNSET(pdata, PRTE_PROC_FLAG_ALIVE);
         pdata->state = state;
-        /* Clean up the session directory as if we were the process
-         * itself.  This covers the case where the process died abnormally
-         * and didn't cleanup its own session directory.
-         */
-        prte_session_dir_finalize(proc);
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs
          * remain (might be some from another job)

--- a/src/mca/state/state.h
+++ b/src/mca/state/state.h
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -529,10 +529,6 @@ static void lost_connection_hdlr(size_t evhdlr_registration_id, pmix_status_t st
     PMIX_LIST_FOREACH(tl, &prte_pmix_server_globals.tools, prte_pmix_tool_t)
     {
         if (PMIX_CHECK_PROCID(&tl->name, source)) {
-            /* remove the session directory we created for it */
-            if (NULL != tl->nsdir) {
-                pmix_os_dirpath_destroy(tl->nsdir, true, NULL);
-            }
             /* take this tool off the list */
             pmix_list_remove_item(&prte_pmix_server_globals.tools, &tl->super);
             /* release it */
@@ -637,7 +633,7 @@ int pmix_server_init(void)
 
     /* tell the server our temp directory */
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_TMPDIR,
-                       prte_process_info.jobfam_session_dir,
+                       prte_process_info.top_session_dir,
                        PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
         PMIX_INFO_LIST_RELEASE(ilist);
@@ -2023,16 +2019,6 @@ PMIX_CLASS_INSTANCE(pmix_server_pset_t,
                     pmix_list_item_t,
                     pscon, psdes);
 
-static void tlcon(prte_pmix_tool_t *p)
-{
-    p->nsdir = NULL;
-}
-static void tldes(prte_pmix_tool_t *p)
-{
-    if (NULL != p->nsdir) {
-        free(p->nsdir);
-    }
-}
 PMIX_CLASS_INSTANCE(prte_pmix_tool_t,
                     pmix_list_item_t,
-                    tlcon, tldes);
+                    NULL, NULL);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -242,6 +242,7 @@ static void interim(int sd, short args, void *cbdata)
     for (n = 0; n < cd->napps; n++) {
         papp = &cd->apps[n];
         app = PMIX_NEW(prte_app_context_t);
+        app->job = (struct prte_job_t*)jdata;
         app->idx = pmix_pointer_array_add(jdata->apps, app);
         jdata->num_apps++;
         if (NULL != papp->cmd) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,7 +135,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
 typedef struct {
     pmix_list_item_t super;
     pmix_proc_t name;
-    char *nsdir;
 } prte_pmix_tool_t;
 PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
 

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -501,15 +501,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         /* cleanup any pending server ops */
         PMIX_LOAD_PROCID(&pname, job, PMIX_RANK_WILDCARD);
         prte_pmix_server_clear(&pname);
-        /* remove the session directory tree */
-        if (0 > pmix_asprintf(&cmd_str, "%s/%d", prte_process_info.jobfam_session_dir,
-                              PRTE_LOCAL_JOBID(jdata->nspace))) {
-            ret = PRTE_ERR_OUT_OF_RESOURCE;
-            goto CLEANUP;
-        }
-        pmix_os_dirpath_destroy(cmd_str, true, NULL);
-        free(cmd_str);
-        cmd_str = NULL;
+
         PMIX_RELEASE(jdata);
         break;
 

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -225,7 +225,7 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
             if (NULL == (proc = (prte_proc_t *) pmix_pointer_array_get_item(src->procs, j))) {
                 continue;
             }
-            if (proc->job != jdata) {
+            if (!PMIX_CHECK_NSPACE(proc->name.nspace, jdata->nspace)) {
                 continue;
             }
             prte_proc_print(&tmp2, jdata, proc);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,11 +43,14 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/rmaps/rmaps.h"
 #include "src/rml/rml.h"
+#include "src/mca/state/state.h"
+
 #include "src/util/pmix_argv.h"
 #include "src/util/name_fns.h"
 #include "src/util/pmix_net.h"
 #include "src/util/pmix_output.h"
 #include "src/util/proc_info.h"
+#include "src/util/session_dir.h"
 
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
@@ -405,6 +408,7 @@ bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2)
 
 static void prte_app_context_construct(prte_app_context_t *app_context)
 {
+    app_context->job = NULL;
     app_context->idx = 0;
     app_context->app = NULL;
     app_context->num_procs = 0;
@@ -466,6 +470,7 @@ static void prte_job_construct(prte_job_t *job)
     job->personality = NULL;
     job->schizo = NULL;
     PMIX_LOAD_NSPACE(job->nspace, NULL);
+    job->session_dir = NULL;
     job->index = -1;
     job->offset = 0;
     job->apps = PMIX_NEW(pmix_pointer_array_t);
@@ -517,14 +522,10 @@ static void prte_job_destruct(prte_job_t *job)
         return;
     }
 
-    if (prte_debug_flag) {
-        pmix_output(0, "%s Releasing job data for %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                    PRTE_JOBID_PRINT(job->nspace));
-    }
-
     if (NULL != job->personality) {
         PMIX_ARGV_FREE_COMPAT(job->personality);
     }
+
     for (n = 0; n < job->apps->size; n++) {
         if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(job->apps, n))) {
             continue;
@@ -569,6 +570,7 @@ static void prte_job_destruct(prte_job_t *job)
         if (NULL == (proc = (prte_proc_t *) pmix_pointer_array_get_item(job->procs, n))) {
             continue;
         }
+        pmix_pointer_array_set_item(job->procs, n, NULL);
         PMIX_RELEASE(proc);
     }
     PMIX_RELEASE(job->procs);
@@ -585,6 +587,14 @@ static void prte_job_destruct(prte_job_t *job)
     }
 
     PMIX_LIST_DESTRUCT(&job->children);
+
+    if (NULL != job->session_dir) {
+        prte_job_session_dir_finalize(job);
+        if (NULL != job->session_dir) {
+            free(job->session_dir);
+            job->session_dir = NULL;
+        }
+    }
 
     if (NULL != prte_job_data && 0 <= job->index) {
         /* remove the job from the global array */
@@ -670,13 +680,12 @@ static void prte_node_destruct(prte_node_t *node)
     PMIX_LIST_DESTRUCT(&node->attributes);
 }
 
-PMIX_CLASS_INSTANCE(prte_node_t, pmix_list_item_t, prte_node_construct, prte_node_destruct);
+PMIX_CLASS_INSTANCE(prte_node_t, pmix_list_item_t,
+                    prte_node_construct, prte_node_destruct);
 
 static void prte_proc_construct(prte_proc_t *proc)
 {
     proc->name = *PRTE_NAME_INVALID;
-    proc->job = NULL;
-    proc->rank = PMIX_RANK_INVALID;
     proc->parent = PMIX_RANK_INVALID;
     proc->pid = 0;
     proc->local_rank = PRTE_LOCAL_RANK_INVALID;
@@ -713,7 +722,8 @@ static void prte_proc_destruct(prte_proc_t *proc)
     PMIX_LIST_DESTRUCT(&proc->attributes);
 }
 
-PMIX_CLASS_INSTANCE(prte_proc_t, pmix_list_item_t, prte_proc_construct, prte_proc_destruct);
+PMIX_CLASS_INSTANCE(prte_proc_t, pmix_list_item_t,
+                    prte_proc_construct, prte_proc_destruct);
 
 static void prte_job_map_construct(prte_job_map_t *map)
 {
@@ -751,7 +761,8 @@ static void prte_job_map_destruct(prte_job_map_t *map)
     PMIX_RELEASE(map->nodes);
 }
 
-PMIX_CLASS_INSTANCE(prte_job_map_t, pmix_object_t, prte_job_map_construct, prte_job_map_destruct);
+PMIX_CLASS_INSTANCE(prte_job_map_t, pmix_object_t,
+                    prte_job_map_construct, prte_job_map_destruct);
 
 static void prte_attr_cons(prte_attribute_t *p)
 {
@@ -763,7 +774,8 @@ static void prte_attr_des(prte_attribute_t *p)
 {
     PMIX_VALUE_DESTRUCT(&p->data);
 }
-PMIX_CLASS_INSTANCE(prte_attribute_t, pmix_list_item_t, prte_attr_cons, prte_attr_des);
+PMIX_CLASS_INSTANCE(prte_attribute_t, pmix_list_item_t,
+                    prte_attr_cons, prte_attr_des);
 
 static void tcon(prte_topology_t *t)
 {
@@ -779,7 +791,8 @@ static void tdes(prte_topology_t *t)
         free(t->sig);
     }
 }
-PMIX_CLASS_INSTANCE(prte_topology_t, pmix_object_t, tcon, tdes);
+PMIX_CLASS_INSTANCE(prte_topology_t, pmix_object_t,
+                    tcon, tdes);
 
 #if PRTE_PICKY_COMPILERS
 void prte_hide_unused_params(int x, ...)

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -191,6 +191,7 @@ typedef uint16_t prte_job_controls_t;
  * defining it - resolves potential circular definition
  */
 struct prte_proc_t;
+struct prte_job_t;
 struct prte_job_map_t;
 struct prte_schizo_base_module_t;
 
@@ -211,6 +212,8 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_topology_t);
 typedef struct {
     /** Parent object */
     pmix_object_t super;
+    /** the job this app belongs to */
+    struct prte_job_t *job;
     /** Unique index when multiple apps per job */
     prte_app_idx_t idx;
     /** Absolute pathname of argv[0] */
@@ -312,6 +315,8 @@ typedef struct {
     struct prte_schizo_base_module_t *schizo;
     /* jobid for this job */
     pmix_nspace_t nspace;
+    // session directory for this job
+    char *session_dir;
     int index; // index in the job array where this is stored
     /* offset to the total number of procs so shared memory
      * components can potentially connect to any spawned jobs*/
@@ -377,8 +382,6 @@ struct prte_proc_t {
     pmix_list_item_t super;
     /* process name */
     pmix_proc_t name;
-    prte_job_t *job;
-    pmix_rank_t rank;
     /* the vpid of my parent - the daemon vpid for an app
      * or the vpid of the parent in the routing tree of
      * a daemon */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,7 +55,6 @@ static char *prte_tmpdir_base = NULL;
 static char *prte_local_tmpdir_base = NULL;
 static char *prte_remote_tmpdir_base = NULL;
 static char *prte_top_session_dir = NULL;
-static char *prte_jobfam_session_dir = NULL;
 static char *local_setup_slots = NULL;
 
 char *prte_signal_string = NULL;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
@@ -1319,7 +1319,7 @@ static void abort_signal_callback(int fd)
         second = false;
     } else {
         surekill();  // ensure we attempt to kill everything
-        pmix_os_dirpath_destroy(prte_process_info.jobfam_session_dir, true, NULL);
+        pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, NULL);
         exit(1);
     }
 }
@@ -1371,16 +1371,12 @@ static int prep_singleton(const char *name)
     /* create a proc for the singleton */
     proc = PMIX_NEW(prte_proc_t);
     PMIX_LOAD_PROCID(&proc->name, jdata->nspace, rank);
-    proc->rank = proc->name.rank;
     proc->parent = PRTE_PROC_MY_NAME->rank;
     proc->app_idx = 0;
     proc->app_rank = rank;
     proc->local_rank = 0;
     proc->node_rank = 0;
     proc->state = PRTE_PROC_STATE_RUNNING;
-    /* link it to the job */
-    PMIX_RETAIN(jdata);
-    proc->job = jdata;
     /* link it to the app */
     PMIX_RETAIN(proc);
     pmix_pointer_array_set_item(&app->procs, rank, proc);

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -200,6 +200,7 @@ int main(int argc, char *argv[])
     int pargc;
     prte_schizo_base_module_t *schizo;
     pmix_cli_item_t *opt;
+    prte_job_t *jdata;
 
     char *umask_str = getenv("PRTE_DAEMON_UMASK_VALUE");
     if (NULL != umask_str) {
@@ -440,7 +441,8 @@ int main(int argc, char *argv[])
                  * indicating clean termination! Instead, just forcibly cleanup
                  * the local session_dir tree and exit
                  */
-                prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+                jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+                PMIX_RELEASE(jdata);
 
                 /* if we were ordered to abort, do so */
                 if (prted_abort) {
@@ -808,7 +810,9 @@ DONE:
     /* cleanup and leave */
     prte_finalize();
 
-    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    PMIX_RELEASE(jdata);
+
     /* cleanup the process info */
     prte_proc_info_finalize();
 
@@ -822,6 +826,7 @@ static void shutdown_callback(int fd, short flags, void *arg)
 {
     prte_timer_t *tm = (prte_timer_t *) arg;
     bool suicide = false;
+    prte_job_t *jdata;
     PRTE_HIDE_UNUSED_PARAMS(fd, flags);
 
     if (NULL != tm) {
@@ -844,7 +849,8 @@ static void shutdown_callback(int fd, short flags, void *arg)
             exit(1);
         }
         prte_odls.kill_local_procs(NULL);
-        prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+        jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+        PMIX_RELEASE(jdata);
         abort();
     }
     pmix_output(0, "%s is executing clean abnormal termination",
@@ -854,7 +860,8 @@ static void shutdown_callback(int fd, short flags, void *arg)
      * the local session_dir tree and exit
      */
     prte_odls.kill_local_procs(NULL);
-    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    PMIX_RELEASE(jdata);
     exit(PRTE_ERROR_DEFAULT_EXIT_CODE);
 }
 

--- a/src/tools/psched/backend.c
+++ b/src/tools/psched/backend.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,72 +72,28 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
 /* add any info that the tool couldn't self-assign */
 static int register_tool(pmix_nspace_t nspace)
 {
-    void *ilist;
     pmix_status_t ret;
-    char *tmp;
-    pmix_data_array_t darray;
-    pmix_info_t *iptr;
-    size_t ninfo;
     prte_pmix_lock_t lock;
     int rc;
     prte_pmix_tool_t *tl;
 
-    PMIX_INFO_LIST_START(ilist);
-
-    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_TMPDIR,
-                       prte_process_info.jobfam_session_dir, PMIX_STRING);
-
-    /* create and pass a job-level session directory */
-    if (0 > pmix_asprintf(&tmp, "%s/%u", prte_process_info.jobfam_session_dir,
-                          PRTE_LOCAL_JOBID(nspace))) {
-        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-    rc = pmix_os_dirpath_create(tmp, S_IRWXU);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        free(tmp);
-        rc = prte_pmix_convert_status(rc);
-        return rc;
-    }
-    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_NSDIR, tmp, PMIX_STRING);
-
     /* record this tool */
     tl = PMIX_NEW(prte_pmix_tool_t);
     PMIX_LOAD_PROCID(&tl->name, nspace, 0);
-    tl->nsdir = tmp;
     pmix_list_append(&psched_globals.tools, &tl->super);
 
-    /* pass it down */
-    PMIX_INFO_LIST_CONVERT(ret, ilist, &darray);
-    if (PMIX_ERR_EMPTY == ret) {
-        iptr = NULL;
-        ninfo = 0;
-    } else if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        rc = prte_pmix_convert_status(ret);
-        PMIX_INFO_LIST_RELEASE(ilist);
-        return rc;
-    } else {
-        iptr = (pmix_info_t *) darray.array;
-        ninfo = darray.size;
-    }
-    PMIX_INFO_LIST_RELEASE(ilist);
-
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    ret = PMIx_server_register_nspace(nspace, 1, iptr, ninfo,
+    ret = PMIx_server_register_nspace(nspace, 1, NULL, 0,
                                       opcbfunc, &lock);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         rc = prte_pmix_convert_status(ret);
-        PMIX_INFO_FREE(iptr, ninfo);
         PRTE_PMIX_DESTRUCT_LOCK(&lock);
         return rc;
     }
     PRTE_PMIX_WAIT_THREAD(&lock);
     rc = lock.status;
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PMIX_INFO_FREE(iptr, ninfo);
     return rc;
 }
 

--- a/src/tools/psched/errmgr.c
+++ b/src/tools/psched/errmgr.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,9 +71,7 @@ static int finalize(void);
 prte_errmgr_base_module_t psched_errmgr_module = {
     .init = init,
     .finalize = finalize,
-    .logfn = prte_errmgr_base_log,
-    .abort = prte_errmgr_base_abort,
-    .abort_peers = prte_errmgr_base_abort_peers
+    .logfn = prte_errmgr_base_log
 };
 
 /*

--- a/src/tools/psched/server.c
+++ b/src/tools/psched/server.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -261,10 +261,6 @@ static void lost_connection_hdlr(size_t evhdlr_registration_id, pmix_status_t st
     PMIX_LIST_FOREACH(tl, &psched_globals.tools, prte_pmix_tool_t)
     {
         if (PMIX_CHECK_PROCID(&tl->name, source)) {
-            /* remove the session directory we created for it */
-            if (NULL != tl->nsdir) {
-                pmix_os_dirpath_destroy(tl->nsdir, true, NULL);
-            }
             /* take this tool off the list */
             pmix_list_remove_item(&psched_globals.tools, &tl->super);
             /* release it */
@@ -409,7 +405,7 @@ int psched_server_init(pmix_cli_result_t *results)
 
     /* tell the server our temp directory */
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_TMPDIR,
-                       prte_process_info.jobfam_session_dir,
+                       prte_process_info.top_session_dir,
                        PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
         PMIX_INFO_LIST_RELEASE(ilist);

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,10 +53,10 @@
 extern bool prte_keep_fqdn_hostnames;
 
 PRTE_EXPORT prte_process_info_t prte_process_info = {
-    .myproc = {{0}, 0},
-    .my_hnp = {{0}, 0},
+    .myproc = PMIX_PROC_STATIC_INIT,
+    .my_hnp = PMIX_PROC_STATIC_INIT,
     .my_hnp_uri = NULL,
-    .my_parent = {{0}, 0},
+    .my_parent = PMIX_PROC_STATIC_INIT,
     .hnp_pid = 0,
     .num_daemons = 1,
     .num_nodes = 1,
@@ -65,15 +65,8 @@ PRTE_EXPORT prte_process_info_t prte_process_info = {
     .pid = 0,
     .proc_type = PRTE_PROC_TYPE_NONE,
     .my_port = 0,
-    .num_restarts = 0,
     .tmpdir_base = NULL,
     .top_session_dir = NULL,
-    .jobfam_session_dir = NULL,
-    .job_session_dir = NULL,
-    .proc_session_dir = NULL,
-    .sock_stdin = NULL,
-    .sock_stdout = NULL,
-    .sock_stderr = NULL,
     .cpuset = NULL,
     .shared_fs = false
 };
@@ -225,13 +218,6 @@ int prte_proc_info(void)
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &prte_process_info.num_nodes);
 
-    /* get the number of times this proc has restarted */
-    prte_process_info.num_restarts = 0;
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "num_restarts",
-                                      "Number of times this proc has restarted",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_process_info.num_restarts);
-
     return PRTE_SUCCESS;
 }
 
@@ -251,21 +237,6 @@ int prte_proc_info_finalize(void)
         prte_process_info.top_session_dir = NULL;
     }
 
-    if (NULL != prte_process_info.jobfam_session_dir) {
-        free(prte_process_info.jobfam_session_dir);
-        prte_process_info.jobfam_session_dir = NULL;
-    }
-
-    if (NULL != prte_process_info.job_session_dir) {
-        free(prte_process_info.job_session_dir);
-        prte_process_info.job_session_dir = NULL;
-    }
-
-    if (NULL != prte_process_info.proc_session_dir) {
-        free(prte_process_info.proc_session_dir);
-        prte_process_info.proc_session_dir = NULL;
-    }
-
     if (NULL != prte_process_info.nodename) {
         free(prte_process_info.nodename);
         prte_process_info.nodename = NULL;
@@ -274,21 +245,6 @@ int prte_proc_info_finalize(void)
     if (NULL != prte_process_info.cpuset) {
         free(prte_process_info.cpuset);
         prte_process_info.cpuset = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stdin) {
-        free(prte_process_info.sock_stdin);
-        prte_process_info.sock_stdin = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stdout) {
-        free(prte_process_info.sock_stdout);
-        prte_process_info.sock_stdout = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stderr) {
-        free(prte_process_info.sock_stderr);
-        prte_process_info.sock_stderr = NULL;
     }
 
     prte_process_info.proc_type = PRTE_PROC_TYPE_NONE;

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +76,6 @@ typedef struct prte_process_info_t {
     pid_t pid;                  /**< Local process ID for this process */
     prte_proc_type_t proc_type; /**< Type of process */
     uint16_t my_port;           /**< TCP port for out-of-band comm */
-    int num_restarts;           /**< number of times this proc has restarted */
     /* The session directory has the form
      * <prefix>/<openmpi-sessions-user>/<jobid>/<procid>, where the prefix
      * can either be provided by the user via the
@@ -85,15 +84,8 @@ typedef struct prte_process_info_t {
      */
     char *tmpdir_base;        /**< Base directory of the session dir tree */
     char *top_session_dir;    /**< Top-most directory of the session tree */
-    char *jobfam_session_dir; /**< Session directory for this family of jobs (i.e., share same
-                                 mpirun) */
-    char *job_session_dir;    /**< Session directory for job */
-    char *proc_session_dir;   /**< Session directory for the process */
     bool rm_session_dirs;     /**< Session directories will be cleaned up by RM */
 
-    char *sock_stdin;  /**< Path name to temp file for stdin. */
-    char *sock_stdout; /**< Path name to temp file for stdout. */
-    char *sock_stderr; /**< Path name to temp file for stderr. */
     char *cpuset;      /**< String-representation of bitmap where we are bound */
     bool shared_fs;     // whether the tmpdir is on a shared file system
 } prte_process_info_t;

--- a/src/util/session_dir.h
+++ b/src/util/session_dir.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,69 +22,6 @@
  *
  * Find and/or create PRTE session directory.
  *
- * The prte_session_dir() function searches for a temporary directory
- * that is used by the PRTE system for storing system-critical
- * information. For a given system and user, the function attempts to
- * find (or create, if not found and create is requested) a directory
- * that will be used to independently house information for multiple
- * universes, as the user creates them. Thus, the function pursues a
- * directory tree of the form:
- *
- * \par \em [prefix-dir] An absolute path that identifies a temporary
- * directory that is read-write-execute accessible to everyone. The
- * function first checks to see if the user has specified the [prefix]
- * directory on the command line. If so, then the function will use
- * that [prefix] if the access permissions are correct, or will return
- * an error condition if not - the function will not search for
- * alternative locations if the user provides the [prefix] name.
- *
- * \par If the [prefix] is not provided by the user, the function
- * searches for a suitable directory in a specific order, taking the
- * first option that meets the access permission requirement, using:
- * (a) the "OMPI_PREFIX_ENV" environment variable; (b) the "TMPDIR"
- * environment variable; and (c) the "TMP" environment variabley. If
- * none of those environmental variables have been defined and/or the
- * function was unable to create a suitable directory within any of
- * them, then the function tries to use a default location of "/tmp",
- * where the "/" represents the top-level directory of the local
- * system. If none of these options are successful, the function
- * returns an error code.
- *
- * \par \em [openmpi-sessions]-[user-id]@[host]:[batchid] This serves
- * as a concentrator for all PRTE session directories for this
- * user on the local system. If it doesn't already exist, this
- * directory is created with read-write-execute permissions
- * exclusively restricted to the user. If it does exist, the access
- * permissions are checked to ensure they are correct - if not, the
- * program attempts to correct them. If they can't' be changed to the
- * correct values, an error condition is returned. The [host] and
- * [batchid] fields are included to provide uniqueness on shared file
- * systems and batch schedulers, respectively.
- *
- * \par Note: The [prefix]/openmpi-sessions-[user-id]@[host]:[batchid]
- * directory is left on the system upon termination of an application
- * and/or an PRTE universe for future use by the user. Thus, when
- * checking a potential location for the directory, the
- * prte_session_tree_init() function first checks to see if an
- * appropriate directory already exists, and uses it if it does.
- *
- * \par \em [universe-name] A directory is created for the specified
- * universe name. This is the directory that will be used to house all
- * information relating to the specific universe. If the directory
- * already exists (indicating that the user is joining an existing
- * universe), then the function ensures that the user has exclusive
- * read-write-execute permissions on the directory.
- *
- * \par \em [job] A directory is created for the specified job
- * name. This will house all information relating to that specific
- * job, including directories for each process within that job on this
- * host.
- *
- * \par \em [process] A directory for the specific process, will house
- * all information for that process.
- *
- * \par If \c create is \c true, the directory will be created and the
- * proc_info structure will be updated.  If proc_info is false,
  */
 
 #ifndef PRTE_SESSION_DIR_H_HAS_BEEN_INCLUDED
@@ -92,60 +29,33 @@
 
 #include "prte_config.h"
 #include "types.h"
+#include "src/runtime/prte_globals.h"
 
 BEGIN_C_DECLS
 
-/** @param create A boolean variable that indicates whether or not to
- *                create the specified directory. If set to "false",
- *                the function only checks to see if an existing
- *                directory can be found. This is typically used to
- *                locate an already existing universe for reconnection
- *                purposes. If set to "true", then the function
- *                creates the directory, if possible.
- * @param proc    Pointer to a process name for which the session
- *                dir name is desired
+/** @param proc    Pointer to a process name for which the session
+ *                dir name is desired. Passing:
  *
- * @retval PRTE_SUCCESS The directory was found and/or created with
+ *                PRTE_NAME_INVALID - top-level session directory
+ *                will be created.
+ *
+ *                PRTE_NAME_WILDCARD - job-level session directory
+ *                will be created
+ *
+ *                Valid procID - proc-level session directory will
+ *                be created
+ *
+ *@retval PRTE_SUCCESS The directory was found and/or created with
  *                the proper permissions.
- * @retval OMPI_ERROR The directory cannot be found (if create is
- *                "false") or created (if create is "true").
+ * @retval PRTE_ERROR The directory cannot be found or created
  */
-PRTE_EXPORT int prte_session_dir(bool create, pmix_proc_t *proc);
+PRTE_EXPORT int prte_session_dir(pmix_proc_t *proc);
 
-/*
- * Setup session-related directory paths
+/** The session_dir_finalize functions perform a cleanup of the
+ * relevant session directory tree.
  */
-PRTE_EXPORT int prte_session_setup_base(pmix_proc_t *proc);
 
-PRTE_EXPORT int prte_setup_top_session_dir(void);
-
-/** The prte_session_dir_finalize() function performs a cleanup of the
- * session directory tree. It first removes the session directory for
- * the calling process. It then checks to see if the job-level session
- * directory is now empty - if so, it removes that level as
- * well. Finally, it checks to see if the universe-level session
- * directory is now empty - if so, it also removes that level. This
- * three-part "last-one-out" procedure ensures that the directory tree
- * is properly removed if all processes and applications within a
- * universe have completed.
- *
- * @param None
- * @retval PRTE_SUCCESS If the directory tree is properly cleaned up.
- * @retval OMPI_ERROR If something prevents the tree from being
- *                properly cleaned up.
- */
-PRTE_EXPORT int prte_session_dir_finalize(pmix_proc_t *proc);
-
-/** The prte_session_dir_cleanup() function performs a cleanup of the
- * session directory tree when a job is aborted. It cleans up all
- * process directories for a given job and then backs up the tree.
- *
- * @param jobid
- * @retval OMPI_SUCCESS If the directory tree is properly cleaned up.
- * @retval OMPI_ERROR If something prevents the tree from being
- *                properly cleaned up.
- */
-PRTE_EXPORT int prte_session_dir_cleanup(pmix_nspace_t jobid);
+PRTE_EXPORT void prte_job_session_dir_finalize(prte_job_t *jdata);
 
 END_C_DECLS
 


### PR DESCRIPTION
We now have multiple tools (e.g., psched, prte, and even multiple prte instances) running on the same node. Keeping all those session directory trees under a single root is problematic and leading to inadvertent deletion of contact files. So simplify things and put each instance under its own session directory tree root.

Add the pid and uid to the session directory root name. Prefix the root name with the argv[0] of the tool so we know what generated it.

Fix an error in PRRTE that assumed the job-level session was a global name. It is not - it is different for each job, so we need to track it by job. Have the prte_job_t destructor call the session_dir_destroy function to remove it when the job is complete.

Fix refcounts so the job object destructor gets called upon job completion.