### PR TITLE
Multiple commits

### DIFF
--- a/src/docs/show-help-files/help-prte-runtime.rst
+++ b/src/docs/show-help-files/help-prte-runtime.rst
@@ -158,3 +158,31 @@ the regex of participating nodes on at least one node:
    error:  %s
 
 Please fix the error and try again.
+
+[prte:session:dir:shared]
+
+PRTE has detected that the head of the session directory
+tree (where scratch files and shared memory backing storage
+will be placed) resides on a shared file system:
+
+.. code::
+
+   Directory: %s
+   File system type: %s
+
+For performance reasons, it is strongly recommended that the
+session directory be located on a local file system. This can
+be controlled by setting the system temporary directory to be
+used by PRTE using either the TMPDIR envar or the "prte_tmpdir_base"
+MCA param.
+
+If you need the temporary directory to be different
+on remote nodes from the local one where %s is running (e.g.,
+when a login node is being employed), then you can set the
+local temporary directory using the "prte_local_tmpdir_base"
+MCA param and the one to be used on all other nodes using the
+"prte_remote_tmpdir_base" param.
+
+This is only a warning advisory and your job will continue.
+You can disable this warning in the future by setting the
+"prte_silence_shared_fs" MCA param to "1".

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1958,7 +1958,9 @@ int prte_odls_base_default_kill_local_procs(pmix_pointer_array_t *procs,
             cd->child->pid = 0;
 
             /* mark the child as "killed" */
-            cd->child->state = PRTE_PROC_STATE_KILLED_BY_CMD; /* we ordered it to die */
+            if (cd->child->state < PRTE_PROC_STATE_TERMINATED) {
+                cd->child->state = PRTE_PROC_STATE_KILLED_BY_CMD; /* we ordered it to die */
+            }
 
             /* ensure the child's session directory is cleaned up */
             prte_session_dir_finalize(&cd->child->name);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -48,6 +48,7 @@
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_environ.h"
+#include "src/util/proc_info.h"
 #include "src/util/prte_cmd_line.h"
 #include "src/runtime/pmix_init_util.h"
 #include "src/util/session_dir.h"
@@ -1794,6 +1795,17 @@ static int parse_env(char **srcenv, char ***dstenv,
         PMIX_ARGV_FREE_COMPAT(xparams);
         PMIX_ARGV_FREE_COMPAT(xvals);
     }
+
+#if PMIX_NUMERIC_VERSION != 0x00040208
+    /* add a flag indicating that we did indeed check the tmpdir
+     * for a shared file system */
+    if (prte_process_info.shared_fs) {
+        p1 = "TRUE";
+    } else {
+        p1 = "FALSE";
+    }
+    PMIX_SETENV_COMPAT("PRTE_SHARED_FS", p1, true, dstenv);
+#endif
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -4,7 +4,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -625,7 +625,7 @@ static void check_complete(int fd, short args, void *cbdata)
                 pmix_byte_object_t bo;
                 PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
                 bo.bytes = (char *) msg;
-                bo.size = strlen(msg) + 1;
+                bo.size = strlen(msg);
                 PRTE_PMIX_CONSTRUCT_LOCK(&lock);
                 rc = PMIx_server_IOF_deliver(&prte_process_info.myproc,
                                              PMIX_FWD_STDDIAG_CHANNEL,

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -20,6 +20,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -624,11 +626,12 @@ static void _query(int sd, short args, void *cbdata)
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
-                /* define the array that holds the membership - no need to allocate anything */
+                /* define the array that holds the membership - no need to allocate anything if we are careful */
                 dry.array = psptr->members;
-                dry.type = PMIX_PROC_RANK;
+                dry.type = PMIX_PROC;
                 dry.size = psptr->num_members;
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PSET_MEMBERSHIP, &dry, PMIX_DATA_ARRAY);
+                dry.array = NULL;  /* say no to array destructor freeing the pset members array */
                 PMIX_DATA_ARRAY_DESTRUCT(&dry);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -20,6 +20,8 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2024      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -422,12 +424,15 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
                     pmix_list_append(&members, &nm->super);
                 }
             }
+            pset->num_members = pmix_list_get_size(&members);
             if (0 < (i = pmix_list_get_size(&members))) {
                 PMIX_DATA_ARRAY_CONSTRUCT(&darray, i, PMIX_PROC);
                 procptr = (pmix_proc_t*)darray.array;
                 k = 0;
+                pset->members = (pmix_proc_t *)malloc(i * sizeof (pmix_proc_t));
                 PMIX_LIST_FOREACH(nm, &members, prte_namelist_t) {
                     PMIX_LOAD_PROCID(&procptr[k], nm->name.nspace, nm->name.rank);
+                    PMIX_LOAD_PROCID(&pset->members[k], nm->name.nspace, nm->name.rank);
                     ++k;
                 }
                 PMIX_INFO_LIST_ADD(ret, iarray, PMIX_PSET_MEMBERS, &darray, PMIX_DATA_ARRAY);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -74,6 +74,7 @@ PRTE_EXPORT extern char *prte_progress_thread_cpus;
 PRTE_EXPORT extern bool prte_bind_progress_thread_reqd;
 PRTE_EXPORT extern bool prte_show_launch_progress;
 PRTE_EXPORT extern bool prte_bootstrap_setup;
+PRTE_EXPORT extern bool prte_silence_shared_fs;
 
 /**
  * Global indicating where this process was bound to at launch (will

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,7 +67,7 @@ char *prte_set_max_sys_limits = NULL;
 int prte_pmix_verbose_output = 0;
 char *prte_progress_thread_cpus = NULL;
 bool prte_bind_progress_thread_reqd = false;
-
+bool prte_silence_shared_fs = false;
 int prte_max_thread_in_progress = 1;
 
 int prte_register_params(void)
@@ -497,6 +497,11 @@ int prte_register_params(void)
                                       "Whether binding of internal PRRTE progress thread is required",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_bind_progress_thread_reqd);
+
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "silence_shared_fs",
+                                      "Silence the shared file system warning",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_silence_shared_fs);
 
     /* pickup the RML params */
     prte_rml_register();

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -228,7 +228,8 @@ static char *print_aborted_job(prte_job_t *job,
             }
         }
         return output;
-    } else if (PRTE_PROC_STATE_ABORTED == proc->state) {
+    } else if (PRTE_PROC_STATE_ABORTED == proc->state ||
+               PRTE_PROC_STATE_CALLED_ABORT == proc->state) {
         output = pmix_show_help_string("help-prun.txt", "prun:proc-ordered-abort", true,
                                        prte_tool_basename, (unsigned long) proc->name.rank,
                                        (unsigned long) proc->pid, node->name, prte_tool_basename);

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,7 +74,9 @@ PRTE_EXPORT prte_process_info_t prte_process_info = {
     .sock_stdin = NULL,
     .sock_stdout = NULL,
     .sock_stderr = NULL,
-    .cpuset = NULL};
+    .cpuset = NULL,
+    .shared_fs = false
+};
 
 static bool init = false;
 static char *prte_strip_prefix;

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,6 +95,7 @@ typedef struct prte_process_info_t {
     char *sock_stdout; /**< Path name to temp file for stdout. */
     char *sock_stderr; /**< Path name to temp file for stderr. */
     char *cpuset;      /**< String-representation of bitmap where we are bound */
+    bool shared_fs;     // whether the tmpdir is on a shared file system
 } prte_process_info_t;
 
 /**

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,7 +136,6 @@ static int _setup_tmpdir_base(void)
     // as we know this will impact launch as well as
     // application execution performance
     prte_process_info.shared_fs = pmix_path_nfs(prte_process_info.tmpdir_base, &fstype);
-    prte_process_info.shared_fs = true;
     if (prte_process_info.shared_fs && !prte_silence_shared_fs) {
         // this is a shared file system - warn the user
         pmix_show_help("help-prte-runtime.txt", "prte:session:dir:shared", true,


### PR DESCRIPTION
[Use pmix_path_nfs to detect shared file systems](https://github.com/openpmix/prrte/commit/405ccfc9af10c86c7468e66286bd3a2daffe074d)

Check if tmpdir is a shared file system, and warn the user
as to the performance issues this can cause. Purely a warning
and the job will continue. Provide an MCA param to shut off
the warning. Provide an MCA param to OMPI indicating that
this check has been performed so the apps don't do it again.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/bc5de986e13c14db575141714a8b5e0089f4d0bf)

[Remove debug](https://github.com/openpmix/prrte/commit/ba794bbc1042c531e7dd1e8edcb1a5d3e9ef368d)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/4358f5055814f67ca6749babde7debb93d67d9b2)

[Remove extra character at end of error messages](https://github.com/openpmix/prrte/commit/0c9135f4968e5b09acb04ffbd2d35c2a08f3c95f)

We do not pass NULL-terminated strings to the IOF
delivery system, just byte objects - so don't extend
the byte object size by one. Procs calling abort might
have state "aborted" and "called_abort", depending
upon any shim they might have used.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/24aedd0fe57f3d5a0b412b3bc061e7b26c7d5f21)

[psets: fix some problems with PMIX_QUERY_PSET_MEMBERSHIP query.](https://github.com/openpmix/prrte/commit/8a8790e62c4a2e2a31a39bc85f67b097d44180b7)

Related to https://github.com/open-mpi/ompi/issues/10862

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5cb219c90a419bfbd8cd34f064609c74870b3778)