### PR TITLE
guard against possible segfault in prted

### DIFF
--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -810,9 +810,6 @@ DONE:
     /* cleanup and leave */
     prte_finalize();
 
-    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-    PMIX_RELEASE(jdata);
-
     /* cleanup the process info */
     prte_proc_info_finalize();
 


### PR DESCRIPTION
as it exits.  reliably shows up for me with the --debug-daemons option.