### PR TITLE
Fix testing of suicide for daemons

### DIFF
--- a/src/docs/show-help-files/help-prte.rst
+++ b/src/docs/show-help-files/help-prte.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
    Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
 
    $COPYRIGHT$
@@ -78,9 +78,6 @@ option to the help request as ``--help <option>``.
 
    * - ``--leave-session-attached``
      - Do not discard stdout/stderr of remote PRRTE daemons
-
-   * - ``--test-suicide <arg0>``
-     - Direct that the specified daemon suicide after delay
 
    * - ``--display <arg0>``
      - Comma-delimited list of options for displaying information

--- a/src/docs/show-help-files/help-prterun.rst
+++ b/src/docs/show-help-files/help-prterun.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
    Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
 
    $COPYRIGHT$
@@ -106,9 +106,6 @@ option to the help request as ``--help <option>``.
    * - ``--stop-in-app``
      - Direct the specified processes to stop at an
        application-controlled location
-
-   * - ``--test-suicide <arg0>``
-     - Direct that the specified daemon suicide after delay
 
    * - ``--do-not-launch``
      - Perform all necessary operations to prepare to launch the

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -98,7 +98,6 @@ static struct option prteoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_SET_SID, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_PID, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_URI, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_TEST_SUICIDE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_DEFAULT_HOSTFILE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_SINGLETON, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_KEEPALIVE, PMIX_ARG_REQD),
@@ -152,7 +151,6 @@ static struct option prterunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_SET_SID, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_PID, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_URI, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_TEST_SUICIDE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_DEFAULT_HOSTFILE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_KEEPALIVE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_LAUNCH_AGENT, PMIX_ARG_REQD),

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -89,7 +89,7 @@ bool prte_show_resolved_nodenames = false;
 bool prte_do_not_resolve = false;
 int prte_hostname_cutoff = 1000;
 
-int prted_debug_failure = -1;
+pmix_rank_t prted_debug_failure = PMIX_RANK_INVALID;
 int prted_debug_failure_delay = -1;
 bool prte_never_launched = false;
 bool prte_devel_level_output = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -524,7 +524,7 @@ PRTE_EXPORT extern int prte_hostname_cutoff;
 PRTE_EXPORT extern bool prte_do_not_resolve;
 
 /* debug flags */
-PRTE_EXPORT extern int prted_debug_failure;
+PRTE_EXPORT extern pmix_rank_t prted_debug_failure;
 PRTE_EXPORT extern int prted_debug_failure_delay;
 
 PRTE_EXPORT extern bool prte_never_launched;

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -327,7 +327,7 @@ void prte_job_session_dir_finalize(prte_job_t *jdata)
     if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
         if (prte_finalizing) {
             if (NULL != prte_process_info.top_session_dir) {
-                pmix_os_dirpath_destroy(prte_process_info.top_session_dir, false, _check_file);
+                pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, _check_file);
                 rmdir(prte_process_info.top_session_dir);
                 free(prte_process_info.top_session_dir);
                 prte_process_info.top_session_dir = NULL;
@@ -336,7 +336,7 @@ void prte_job_session_dir_finalize(prte_job_t *jdata)
         return;
     }
 
-    pmix_os_dirpath_destroy(jdata->session_dir, false, _check_file);
+    pmix_os_dirpath_destroy(jdata->session_dir, true, _check_file);
     /* if the job-level session dir is now empty, remove it */
     rmdir(jdata->session_dir);
     free(jdata->session_dir);


### PR DESCRIPTION
We don't support a cmd line option for this as it isn't something a user should ever do. Instead, we use two MCA params to specify it:

prte_daemon_fail <N> - specifies the daemon rank that should commit suicide

prte_daemon_fail_delay <N> - time in seconds the target rank should wait before dying. A value of zero means no delay, just die after calling init. This is the default value.