### PR TITLE
Fix daemon suicide and preserve output files

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -530,12 +530,6 @@ int prte_ess_base_prted_finalize(void)
         signals_set = false;
     }
 
-    /* cleanup */
-    if (NULL != log_path) {
-        unlink(log_path);
-    }
-
-
     if (NULL != prte_errmgr.finalize) {
         prte_errmgr.finalize();
     }

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,11 +100,12 @@ void prte_rml_open(void)
     PMIX_CONSTRUCT(&prte_rml_base.posted_recvs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_rml_base.unmatched_msgs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_rml_base.children, pmix_list_t);
-    prte_rml_base.lifeline = PRTE_PROC_MY_PARENT->rank;
 
     /* compute the routing tree - only thing we need to know is the
      * number of daemons in the DVM */
     prte_rml_compute_routing_tree();
+
+    prte_rml_base.lifeline = PRTE_PROC_MY_PARENT->rank;
 }
 
 void prte_rml_send_callback(int status, pmix_proc_t *peer,

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -534,6 +534,9 @@ int main(int argc, char *argv[])
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS)) {
         prte_debug_daemons_flag = true;
     }
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS_FILE)) {
+        prte_debug_daemons_file_flag = true;
+    }
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_LEAVE_SESSION_ATTACHED)) {
         prte_leave_session_attached = true;
     }

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -322,6 +322,9 @@ int main(int argc, char *argv[])
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS)) {
         prte_debug_daemons_flag = true;
     }
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS_FILE)) {
+        prte_debug_daemons_file_flag = true;
+    }
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_LEAVE_SESSION_ATTACHED)) {
         prte_leave_session_attached = true;
     }

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -354,7 +354,8 @@ static bool _check_file(const char *root, const char *path)
      *  - non-zero files starting with "output-"
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
-        fullpath = pmix_os_path(false, &fullpath, root, path, NULL);
+        memset(&st, 0, sizeof(struct stat));
+        fullpath = pmix_os_path(false, root, path, NULL);
         stat(fullpath, &st);
         free(fullpath);
         if (0 == st.st_size) {


### PR DESCRIPTION
Correctly set parent rank so that the OOB can
correctly identify its lifeline and cause the
daemon to abort when it dies. Fix the
`--debug-daemons-file` flag so it works, and
preserve the resulting output file from cleanup.