### PR TITLE
Remove unused MCA param

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -73,7 +73,6 @@ char *prte_tool_actual = NULL;
 bool prte_dvm_ready = false;
 pmix_pointer_array_t *prte_cache = NULL;
 bool prte_persistent = true;
-bool prte_add_pid_to_session_dirname = false;
 bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;
 bool prte_show_launch_progress = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -508,7 +508,6 @@ PRTE_EXPORT extern char *prte_data_server_uri;
 PRTE_EXPORT extern bool prte_dvm_ready;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
-PRTE_EXPORT extern bool prte_add_pid_to_session_dirname;
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
 

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -298,12 +298,6 @@ int prte_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &prte_prohibited_session_dirs);
 
-    prte_add_pid_to_session_dirname = false;
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "add_pid_to_session_dirname",
-                                      "Add pid to the DVM top-level session directory name",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                      &prte_add_pid_to_session_dirname);
-
     prte_fwd_environment = false;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "fwd_environment",
                                       "Forward the entire local environment",


### PR DESCRIPTION
Session directories now always include the PID of the daemon