### PR TITLE
Use the provided groupID as the grpcomm signature

### DIFF
--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,11 +126,15 @@ PMIX_CLASS_INSTANCE(prte_grpcomm_base_active_t,
 
 static void scon(prte_grpcomm_signature_t *p)
 {
+    p->groupID = NULL;
     p->signature = NULL;
     p->sz = 0;
 }
 static void sdes(prte_grpcomm_signature_t *p)
 {
+    if (NULL != p->groupID) {
+        free(p->groupID);
+    }
     if (NULL != p->signature) {
         free(p->signature);
     }

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +63,7 @@ typedef int (*prte_grpcomm_rbcast_cb_t)(pmix_data_buffer_t *buffer);
  * track global collective id's */
 typedef struct {
     pmix_object_t super;
+    char *groupID;
     pmix_proc_t *signature;
     size_t sz;
 } prte_grpcomm_signature_t;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -1031,6 +1031,7 @@ static void dvm_notify(int sd, short args, void *cbdata)
 
         /* we have to send the notification to all daemons so that
          * anyone watching for it can receive it */
+        PMIX_CONSTRUCT(&sig, prte_grpcomm_signature_t);
         PMIX_PROC_CREATE(sig.signature, 1);
         PMIX_LOAD_PROCID(&sig.signature[0], PRTE_PROC_MY_NAME->nspace, PMIX_RANK_WILDCARD);
         sig.sz = 1;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2058,6 +2058,7 @@ PMIX_CLASS_INSTANCE(pmix_server_req_t,
 static void mdcon(prte_pmix_mdx_caddy_t *p)
 {
     p->sig = NULL;
+    p->grpid = NULL;
     p->buf = NULL;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->ctrls);
     p->procs = NULL;
@@ -2074,6 +2075,9 @@ static void mddes(prte_pmix_mdx_caddy_t *p)
 {
     if (NULL != p->sig) {
         PMIX_RELEASE(p->sig);
+    }
+    if (NULL != p->grpid) {
+        free(p->grpid);
     }
     if (NULL != p->buf) {
         PMIX_DATA_BUFFER_RELEASE(p->buf);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1234,8 +1234,8 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *grpid,
     }
 
     cd = PMIX_NEW(prte_pmix_mdx_caddy_t);
-    cd->grpid = grpid;
     cd->op = op;
+    cd->grpid = strdup(grpid);
     /* have to copy the procs in case we add members */
     PMIX_PROC_CREATE(cd->procs, nprocs);
     memcpy(cd->procs, procs, nprocs * sizeof(pmix_proc_t));
@@ -1245,8 +1245,9 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *grpid,
     cd->cbdata = cbdata;
 
     /* compute the signature of this collective */
+    cd->sig = PMIX_NEW(prte_grpcomm_signature_t);
+    cd->sig->groupID = strdup(grpid);
     if (NULL != procs) {
-        cd->sig = PMIX_NEW(prte_grpcomm_signature_t);
         cd->sig->sz = nprocs;
         cd->sig->signature = (pmix_proc_t *) malloc(cd->sig->sz * sizeof(pmix_proc_t));
         memcpy(cd->sig->signature, procs, cd->sig->sz * sizeof(pmix_proc_t));

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -29,6 +29,7 @@
 #include <string.h>
 
 #include "src/mca/errmgr/errmgr.h"
+#include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
@@ -158,5 +159,16 @@ int prte_map_copy(struct prte_job_map_t **d, struct prte_job_map_t *s)
         (*dest)->nodes->addr[i] = src->nodes->addr[i];
     }
 
+    return PRTE_SUCCESS;
+}
+
+/*
+ * GRPCOMM SIGNATURE
+ */
+int prte_grpcomm_sig_copy(prte_grpcomm_signature_t **d,
+                          prte_grpcomm_signature_t *s)
+{
+    *d = s;
+    PMIX_RETAIN(s);
     return PRTE_SUCCESS;
 }

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -597,6 +597,38 @@ int prte_map_pack(pmix_data_buffer_t *bkt, struct prte_job_map_t *mp)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return prte_pmix_convert_status(rc);
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/*
+ * GRPCOMM SIGNATURE
+ */
+int prte_grpcomm_sig_pack(pmix_data_buffer_t *bkt,
+                          prte_grpcomm_signature_t *sig)
+{
+    pmix_status_t rc;
+
+    // always send the participating procs
+    rc = PMIx_Data_pack(NULL, bkt, &sig->sz, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    rc = PMIx_Data_pack(NULL, bkt, sig->signature, sig->sz, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+
+    if (NULL != sig->groupID) {
+        // add the groupID if one is given
+        rc = PMIx_Data_pack(NULL, bkt, &sig->groupID, 1, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
     }
 
     return PRTE_SUCCESS;

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -100,7 +100,7 @@ static void display_cpus(prte_topology_t *t,
     if (NULL != coreset) {
         hwloc_bitmap_free(coreset);
     }
-    
+
     pmix_asprintf(output, "%s        </processors>\n", tmp1);
     free(tmp1);
     return;
@@ -198,7 +198,7 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
                       (NULL == src->name) ? "UNKNOWN" : src->name, (int) src->slots,
                       (int) src->slots_max);
 
-        pmix_asprintf(&tmp2,""); 
+        pmix_asprintf(&tmp2,"");
         for (j=0; j < prte_node_topologies->size; j++) {
             t = (prte_topology_t*)pmix_pointer_array_get_item(prte_node_topologies, j);
             if (NULL != t) {
@@ -218,7 +218,7 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
         free(tmp1);
         tmp1 = NULL;
         free(tmp);
-        tmp = tmp3; 
+        tmp = tmp3;
 
         /* loop through procs and print their rank */
         for (j = 0; j < src->procs->size; j++) {
@@ -368,11 +368,11 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
                           "%*c<package id=\"%d\">\n%s\n%*c</package>\n%*c</binding>\n%*c</rank>\n",
                           8, xmlsp, PRTE_VPID_PRINT(src->name.rank), (long) src->app_idx, 12, xmlsp,
                           16, xmlsp, pkgnum, cores, 16, xmlsp, 12, xmlsp, 8, xmlsp);
-            
+
             free (cores);
         } else {
-            pmix_asprintf(&tmp, "\n%*c<rank id=\"%s\">\n%*c<binding></binding>\n%*c</rank>\n", 
-                          8, xmlsp, PRTE_VPID_PRINT(src->name.rank), 12, xmlsp, 8, xmlsp);        
+            pmix_asprintf(&tmp, "\n%*c<rank id=\"%s\">\n%*c<binding></binding>\n%*c</rank>\n",
+                          8, xmlsp, PRTE_VPID_PRINT(src->name.rank), 12, xmlsp, 8, xmlsp);
         }
 
         /* set the return */
@@ -503,7 +503,7 @@ void prte_map_print(char **output, prte_job_t *jdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
         /* creating the output in an XML format */
         pmix_asprintf(&tmp4, "<?xml version=\"1.0\" ?>\n<map>\n");
-        pmix_asprintf(&tmp,""); 
+        pmix_asprintf(&tmp,"");
 
         /* loop through nodes */
         for (i = 0; i < src->nodes->size; i++) {
@@ -531,7 +531,7 @@ void prte_map_print(char **output, prte_job_t *jdata)
             tmp = tmp2;
         }
 
-        /* end of the xml "map" tag */  
+        /* end of the xml "map" tag */
         pmix_asprintf(&tmp2, "%s%s</map>\n", tmp4,tmp);
         *output = tmp2;
         free(tmp);
@@ -638,5 +638,19 @@ void prte_map_print(char **output, prte_job_t *jdata)
     /* set the return */
     *output = tmp;
 
+    return;
+}
+
+/* GRPCOMM SIG */
+void prte_grpcomm_sig_print(char **output, prte_grpcomm_signature_t *s)
+{
+    char *tmp;
+
+    if (NULL != s->groupID) {
+        pmix_asprintf(&tmp, "Group ID: %s", s->groupID);
+    } else {
+        tmp = strdup("No GroupID - signature is array of procs");
+    }
+    *output = tmp;
     return;
 }

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -50,6 +50,7 @@
 #include "src/pmix/pmix-internal.h"
 #include "src/threads/pmix_threads.h"
 
+#include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/plm/plm_types.h"
 #include "src/rml/rml_types.h"
 #include "src/runtime/runtime.h"
@@ -503,6 +504,15 @@ PRTE_EXPORT int prte_node_pack(pmix_data_buffer_t *bkt, prte_node_t *node);
 PRTE_EXPORT int prte_node_unpack(pmix_data_buffer_t *bkt, prte_node_t **node);
 PRTE_EXPORT int prte_node_copy(prte_node_t **dest, prte_node_t *src);
 PRTE_EXPORT void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src);
+
+/** grpcomm signature */
+PRTE_EXPORT int prte_grpcomm_sig_pack(pmix_data_buffer_t *bkt,
+                                      prte_grpcomm_signature_t *sig);
+PRTE_EXPORT int prte_grpcomm_sig_unpack(pmix_data_buffer_t *bkt,
+                                        prte_grpcomm_signature_t **sig);
+PRTE_EXPORT int prte_grpcomm_sig_copy(prte_grpcomm_signature_t **d,
+                                      prte_grpcomm_signature_t *s);
+PRTE_EXPORT void prte_grpcomm_sig_print(char **output, prte_grpcomm_signature_t *s);
 
 /**
  * Get a proc data object


### PR DESCRIPTION
If the user provides a groupID (e.g., in a PMIx_Group op), then use that as the signature of any involved grpcomm operations instead of the proc array. This allows the same collection of procs to participate in multiple PMIx_Group operations at the same time since PMIx requires the user provide a unique grpID for each operation.