### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -1,0 +1,65 @@
+# The idea behind this Action is to prevent the situation where a user
+# files a Github Issue, someone asks for clarification / more
+# information, but the original poster never provides the information.
+# The issue then becomes forgotten and abondoned.
+#
+# Instead of that scenario, PMIx community members can assign a
+# label to Github Issues indicating that we're waiting for the user to
+# reply.  If too much time elapses with no reply, mark the Issue as
+# stale and emit a warning that we'll close the issue if we continue
+# to receive no reply.  If we timeout again with no reply after the
+# warning, close the Issue and emit a comment explaining why.
+#
+# If the user *does* reply, the label is removed, and this bot won't
+# touch the Issue.  Specifically: this bot will never mark stale /
+# close an Issue that doesn't have the specified label.
+#
+# Additionally, we are *only* marking stale / auto-closing Github
+# Issues -- not Pull Requests.
+#
+# This is a cron-based Action that runs a few times a day, just so
+# that we don't mark stale / close a bunch of issues all at once.
+#
+# While the actions/stale bot Action used here is capable of removing
+# the label when a user replies to the Issue, we actually use a 2nd
+# Action (removing-awaiting-user-info-label.yaml) to remove the label.
+# We do this because that 2nd Action runs whenever a comment is
+# created -- not via cron.  Hence, the 2nd Action will remove the
+# label effectively immediately when the user replies (vs. up to
+# several hours later).
+
+name: Close stale issues
+on:
+  schedule:
+    # Run it a few times a day so as not to necessarily mark stale /
+    # close a bunch of issues at once.
+    - cron: '0 1,5,9,13,17,21 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/close-stale-issues
+      - uses: actions/stale@v9
+        with:
+          # If there are no replies for 14 days, mark the issue as
+          # "stale" (and emit a warning).
+          days-before-stale: 14
+          # If there are no replies for 14 days after becoming stale,
+          # then close the issue (and emit a message explaining why).
+          days-before-close: 14
+
+          # Never close PRs
+          days-before-pr-close: -1
+
+          # We only close issues with this label
+          only-labels: "Awaiting response"
+          close-issue-label: Closed due to no reply
+
+          # Messages that we put in comments on issues
+          stale-issue-message: |
+            It looks like this issue is expecting a response, but hasn't gotten one yet.  If there are no responses in the next 2 weeks, we'll assume that the issue has been abandoned and will close it.
+          close-issue-message: |
+            Per the above comment, it has been a month with no reply on this issue.  It looks like this issue has been abandoned.
+
+            I'm going to close this issue.  If I'm wrong and this issue is *not* abandoned, please feel free to re-open it.  Thank you!

--- a/.github/workflows/remove-awaiting-user-info-label.yaml
+++ b/.github/workflows/remove-awaiting-user-info-label.yaml
@@ -1,0 +1,30 @@
+# This Action is run in conjunction with close-stale-issues.yaml.  See
+# that file for a more complete description of how they work together.
+
+name: 'Remove "Awaiting response" label when there has been a reply'
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # From
+    # https://github.com/marketplace/actions/close-issues-after-no-reply:
+    # only remove the label if someone replies to an issue who is not
+    # an owner or collaborator on the repo.
+    if: |
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    steps:
+      - name: 'Remove "Awaiting response" label'
+        uses: octokit/request-action@v2.x
+        continue-on-error: true
+        with:
+          route: DELETE /repos/:repository/issues/:issue/labels/:label
+          repository: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          label: "Awaiting response"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@
 #                         All Rights reserved.
 # Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
 # Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
-# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2023-2024 Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -720,7 +720,8 @@ AC_INCLUDES_DEFAULT
 # Setup Sphinx processing
 #
 
-OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [])
+OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [],
+                 [$srcdir/docs/requirements.txt])
 AC_CHECK_PROGS(PYTHON, [python3 python python2])
 
 AS_IF([test -n "$OAC_MAKEDIST_DISABLE"],

--- a/src/docs/show-help-files/help-prte.rst
+++ b/src/docs/show-help-files/help-prte.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
    Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
 
    $COPYRIGHT$
@@ -78,9 +78,6 @@ option to the help request as ``--help <option>``.
 
    * - ``--leave-session-attached``
      - Do not discard stdout/stderr of remote PRRTE daemons
-
-   * - ``--test-suicide <arg0>``
-     - Direct that the specified daemon suicide after delay
 
    * - ``--display <arg0>``
      - Comma-delimited list of options for displaying information

--- a/src/docs/show-help-files/help-prterun.rst
+++ b/src/docs/show-help-files/help-prterun.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
    Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
 
    $COPYRIGHT$
@@ -106,9 +106,6 @@ option to the help request as ``--help <option>``.
    * - ``--stop-in-app``
      - Direct the specified processes to stop at an
        application-controlled location
-
-   * - ``--test-suicide <arg0>``
-     - Direct that the specified daemon suicide after delay
 
    * - ``--do-not-launch``
      - Perform all necessary operations to prepare to launch the

--- a/src/mca/errmgr/base/errmgr_base_fns.c
+++ b/src/mca/errmgr/base/errmgr_base_fns.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -91,49 +91,4 @@ void prte_errmgr_base_log(int error_code, char *filename, int line)
 
     pmix_output(0, "%s PRTE_ERROR_LOG: %s in file %s at line %d",
                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), errstring, filename, line);
-}
-
-void prte_errmgr_base_abort(int error_code, char *fmt, ...)
-{
-    va_list arglist;
-
-    /* If there was a message, output it */
-    va_start(arglist, fmt);
-    if (NULL != fmt) {
-        char *buffer = NULL;
-        pmix_vasprintf(&buffer, fmt, arglist);
-        pmix_output(0, "%s", buffer);
-        free(buffer);
-    }
-    va_end(arglist);
-
-    /* if I am a daemon or the HNP... */
-    if (PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON) {
-        /* whack my local procs */
-        if (NULL != prte_odls.kill_local_procs) {
-            prte_odls.kill_local_procs(NULL);
-        }
-        /* whack any session directories */
-        prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
-    }
-
-    /* if a critical connection failed, or a sensor limit was exceeded, exit without dropping a core
-     */
-    if (PRTE_ERR_CONNECTION_FAILED == error_code || PRTE_ERR_SENSOR_LIMIT_EXCEEDED == error_code) {
-        prte_ess.abort(error_code, false);
-    } else {
-        prte_ess.abort(error_code, true);
-    }
-
-    /*
-     * We must exit in prte_ess.abort; all implementations of prte_ess.abort
-     * contain __prte_attribute_noreturn__
-     */
-    /* No way to reach here */
-}
-
-int prte_errmgr_base_abort_peers(pmix_proc_t *procs, int32_t num_procs, int error_code)
-{
-    PRTE_HIDE_UNUSED_PARAMS(procs, num_procs, error_code);
-    return PRTE_ERR_NOT_IMPLEMENTED;
 }

--- a/src/mca/errmgr/base/errmgr_base_frame.c
+++ b/src/mca/errmgr/base/errmgr_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,27 +48,21 @@
 
 #include "src/mca/errmgr/base/static-components.h"
 
-/*
- * Globals
- */
-prte_errmgr_base_t prte_errmgr_base = {
-    .error_cbacks = PMIX_LIST_STATIC_INIT
-};
-
 /* Public module provides a wrapper around previous functions */
-prte_errmgr_base_module_t prte_errmgr_default_fns = {.init = NULL,     /* init     */
-                                                     .finalize = NULL, /* finalize */
-                                                     .logfn = prte_errmgr_base_log,
-                                                     .abort = prte_errmgr_base_abort,
-                                                     .abort_peers = prte_errmgr_base_abort_peers,
-                                                     .enable_detector = NULL};
+prte_errmgr_base_module_t prte_errmgr_default_fns = {
+    .init = NULL,     /* init     */
+    .finalize = NULL, /* finalize */
+    .logfn = prte_errmgr_base_log
+};
 
 /* NOTE: ABSOLUTELY MUST initialize this
  * struct to include the log function as it
  * gets called even if the errmgr hasn't been
  * opened yet due to error
  */
-prte_errmgr_base_module_t prte_errmgr = {.logfn = prte_errmgr_base_log};
+prte_errmgr_base_module_t prte_errmgr = {
+    .logfn = prte_errmgr_base_log
+};
 
 static int prte_errmgr_base_close(void)
 {
@@ -79,9 +73,6 @@ static int prte_errmgr_base_close(void)
 
     /* always leave a default set of fn pointers */
     prte_errmgr = prte_errmgr_default_fns;
-
-    /* destruct the callback list */
-    PMIX_LIST_DESTRUCT(&prte_errmgr_base.error_cbacks);
 
     return pmix_mca_base_framework_components_close(&prte_errmgr_base_framework, NULL);
 }
@@ -94,9 +85,6 @@ static int prte_errmgr_base_open(pmix_mca_base_open_flag_t flags)
 {
     /* load the default fns */
     prte_errmgr = prte_errmgr_default_fns;
-
-    /* initialize the error callback list */
-    PMIX_CONSTRUCT(&prte_errmgr_base.error_cbacks, pmix_list_t);
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&prte_errmgr_base_framework, flags);

--- a/src/mca/errmgr/base/errmgr_private.h
+++ b/src/mca/errmgr/base/errmgr_private.h
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +48,6 @@
  */
 BEGIN_C_DECLS
 
-/* define a struct to hold framework-global values */
-typedef struct {
-    pmix_list_t error_cbacks;
-} prte_errmgr_base_t;
-
-PRTE_EXPORT extern prte_errmgr_base_t prte_errmgr_base;
-
 /* declare the base default module */
 PRTE_EXPORT extern prte_errmgr_base_module_t prte_errmgr_default_fns;
 
@@ -62,10 +55,6 @@ PRTE_EXPORT extern prte_errmgr_base_module_t prte_errmgr_default_fns;
  * Base functions
  */
 PRTE_EXPORT void prte_errmgr_base_log(int error_code, char *filename, int line);
-
-PRTE_EXPORT void prte_errmgr_base_abort(int error_code, char *fmt, ...)
-    __prte_attribute_format__(__printf__, 2, 3);
-PRTE_EXPORT int prte_errmgr_base_abort_peers(pmix_proc_t *procs, int32_t num_procs, int error_code);
 
 END_C_DECLS
 #endif

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,9 +71,7 @@ static int finalize(void);
 prte_errmgr_base_module_t prte_errmgr_dvm_module = {
     .init = init,
     .finalize = finalize,
-    .logfn = prte_errmgr_base_log,
-    .abort = prte_errmgr_base_abort,
-    .abort_peers = prte_errmgr_base_abort_peers
+    .logfn = prte_errmgr_base_log
 };
 
 /*

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -488,6 +488,7 @@ keep_going:
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_ABORTED);
             /* kill the job */
             _terminate_job(jdata->nspace);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FAILED_TO_START);
         }
         /* if this was a daemon, report it */
         if (PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
@@ -495,7 +496,6 @@ keep_going:
             pmix_show_help("help-errmgr-base.txt", "failed-daemon-launch",
                            true, prte_tool_basename);
         }
-        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FAILED_TO_START);
         break;
 
     case PRTE_PROC_STATE_CALLED_ABORT:

--- a/src/mca/errmgr/errmgr.h
+++ b/src/mca/errmgr/errmgr.h
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -99,27 +99,6 @@ typedef int (*prte_errmgr_base_module_finalize_fn_t)(void);
  */
 typedef void (*prte_errmgr_base_module_log_fn_t)(int error_code, char *filename, int line);
 
-/**
- * Alert - self aborting
- * This function is called when a process is aborting due to some internal error.
- * It will finalize the process
- * itself, and then exit - it takes no other actions. The intent here is to provide
- * a last-ditch exit procedure that attempts to clean up a little.
- */
-typedef void (*prte_errmgr_base_module_abort_fn_t)(int error_code, char *fmt, ...)
-    __prte_attribute_format_funcptr__(__printf__, 2, 3);
-
-/**
- * Alert - abort peers
- *  This function is called when a process wants to abort one or more peer processes.
- *  For example, MPI_Abort(comm) will use this function to terminate peers in the
- *  communicator group before aborting itself.
- */
-typedef int (*prte_errmgr_base_module_abort_peers_fn_t)(pmix_proc_t *procs, int32_t num_procs,
-                                                        int error_code);
-
-typedef void (*prte_errmgr_base_module_enable_detector_fn_t)(bool flag);
-
 /*
  * Module Structure
  */
@@ -130,11 +109,6 @@ struct prte_errmgr_base_module_2_3_0_t {
     prte_errmgr_base_module_finalize_fn_t finalize;
 
     prte_errmgr_base_module_log_fn_t logfn;
-    prte_errmgr_base_module_abort_fn_t abort;
-    prte_errmgr_base_module_abort_peers_fn_t abort_peers;
-
-    /* start error detector and propagator */
-    prte_errmgr_base_module_enable_detector_fn_t enable_detector;
 };
 typedef struct prte_errmgr_base_module_2_3_0_t prte_errmgr_base_module_2_3_0_t;
 typedef prte_errmgr_base_module_2_3_0_t prte_errmgr_base_module_t;

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -10,7 +10,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,12 +64,11 @@ static void prted_abort(int error_code, char *fmt, ...);
 /******************
  * prted module
  ******************/
-prte_errmgr_base_module_t prte_errmgr_prted_module = {.init = init,
-                                                      .finalize = finalize,
-                                                      .logfn = prte_errmgr_base_log,
-                                                      .abort = prted_abort,
-                                                      .abort_peers = prte_errmgr_base_abort_peers,
-                                                      .enable_detector = NULL};
+prte_errmgr_base_module_t prte_errmgr_prted_module = {
+    .init = init,
+    .finalize = finalize,
+    .logfn = prte_errmgr_base_log
+};
 
 /* Local functions */
 static bool any_live_children(pmix_nspace_t job);
@@ -671,8 +670,8 @@ static void proc_errors(int fd, short args, void *cbdata)
 
         /* remove all of this job's children from the global list */
         for (i = 0; i < prte_local_children->size; i++) {
-            if (NULL
-                == (ptr = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i))) {
+            ptr = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+            if (NULL == ptr) {
                 continue;
             }
             if (PMIX_CHECK_NSPACE(jdata->nspace, ptr->name.nspace)) {
@@ -680,9 +679,6 @@ static void proc_errors(int fd, short args, void *cbdata)
                 PMIX_RELEASE(ptr);
             }
         }
-
-        /* ensure the job's local session directory tree is removed */
-        prte_session_dir_cleanup(jdata->nspace);
 
         /* remove this job from our local job data since it is complete */
         PMIX_RELEASE(jdata);

--- a/src/mca/ess/alps/ess_alps_module.c
+++ b/src/mca/ess/alps/ess_alps_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,9 +46,10 @@ static int alps_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_alps_module = {.init = rte_init,
-                                               .finalize = rte_finalize,
-                                               .abort = NULL};
+prte_ess_base_module_t prte_ess_alps_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /* Local variables */
 static pmix_rank_t starting_vpid = 0;

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,7 +47,6 @@
 prte_ess_base_module_t prte_ess = {
     .init = NULL,
     .finalize = NULL,
-    .abort = NULL,
 };
 int prte_ess_base_num_procs = -1;
 char *prte_ess_base_nspace = NULL;

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -539,12 +539,6 @@ int prte_ess_base_prted_finalize(void)
         signals_set = false;
     }
 
-    /* cleanup */
-    if (NULL != log_path) {
-        unlink(log_path);
-    }
-
-
     if (NULL != prte_errmgr.finalize) {
         prte_errmgr.finalize();
     }

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,6 +100,7 @@ int prte_ess_base_prted_setup(void)
     char log_file[PATH_MAX];
     char *error = NULL;
     char *uri = NULL;
+    char *tmp;
     prte_job_t *jdata;
     prte_proc_t *proc;
     prte_app_context_t *app;
@@ -212,60 +213,6 @@ int prte_ess_base_prted_setup(void)
             goto error;
         }
     }
-    /* setup my session directory here as the OOB may need it */
-    PMIX_OUTPUT_VERBOSE(
-        (2, prte_ess_base_framework.framework_output,
-         "%s setting up session dir with\n\ttmpdir: %s\n\thost %s",
-         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-         (NULL == prte_process_info.tmpdir_base) ? "UNDEF" : prte_process_info.tmpdir_base,
-         prte_process_info.nodename));
-
-    /* take a pass thru the session directory code to fillin the
-     * tmpdir names - don't create anything yet
-     */
-    if (PRTE_SUCCESS != (ret = prte_session_dir(false, PRTE_PROC_MY_NAME))) {
-        PRTE_ERROR_LOG(ret);
-        error = "prte_session_dir define";
-        goto error;
-    }
-    /* clear the session directory just in case there are
-     * stale directories laying around
-     */
-    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
-    /* now actually create the directory tree */
-    if (PRTE_SUCCESS != (ret = prte_session_dir(true, PRTE_PROC_MY_NAME))) {
-        PRTE_ERROR_LOG(ret);
-        error = "prte_session_dir";
-        goto error;
-    }
-    /* set the pmix_output env file location to be in the
-     * proc-specific session directory. */
-    pmix_output_set_output_file_info(prte_process_info.proc_session_dir, "output-", NULL, NULL);
-    /* setup stdout/stderr */
-    if (prte_debug_daemons_file_flag) {
-        /* if we are debugging to a file, then send stdout/stderr to
-         * the prted log file
-         */
-
-        /* define a log file name in the session directory */
-        snprintf(log_file, PATH_MAX, "output-prted-%s-%s.log", prte_process_info.myproc.nspace,
-                 prte_process_info.nodename);
-        log_path = pmix_os_path(false, prte_process_info.top_session_dir, log_file, NULL);
-
-        fd = open(log_path, O_RDWR | O_CREAT | O_TRUNC, 0640);
-        if (fd < 0) {
-            /* couldn't open the file for some reason, so
-             * just connect everything to /dev/null
-             */
-            fd = open("/dev/null", O_RDWR | O_CREAT | O_TRUNC, 0666);
-        } else {
-            dup2(fd, STDOUT_FILENO);
-            dup2(fd, STDERR_FILENO);
-            if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
-                close(fd);
-            }
-        }
-    }
 
     /* Setup the job data object for the daemons */
     /* create and store the job data object */
@@ -289,8 +236,6 @@ int prte_ess_base_prted_setup(void)
     /* create and store a proc object for us */
     proc = PMIX_NEW(prte_proc_t);
     PMIX_LOAD_PROCID(&proc->name, PRTE_PROC_MY_NAME->nspace, PRTE_PROC_MY_NAME->rank);
-    proc->job = jdata;
-    proc->rank = proc->name.rank;
     proc->pid = prte_process_info.pid;
     proc->state = PRTE_PROC_STATE_RUNNING;
     pmix_pointer_array_set_item(jdata->procs, proc->name.rank, proc);
@@ -299,6 +244,54 @@ int prte_ess_base_prted_setup(void)
     jdata->state = PRTE_JOB_STATE_RUNNING;
     /* obviously, we have "reported" */
     jdata->num_reported = 1;
+
+    /* setup my session directory here as the OOB may need it */
+    PMIX_OUTPUT_VERBOSE(
+        (2, prte_ess_base_framework.framework_output,
+         "%s setting up session dir with\n\ttmpdir: %s\n\thost %s",
+         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+         (NULL == prte_process_info.tmpdir_base) ? "UNDEF" : prte_process_info.tmpdir_base,
+         prte_process_info.nodename));
+
+    /* create the directory tree */
+    if (PRTE_SUCCESS != (ret = prte_session_dir(PRTE_PROC_MY_NAME))) {
+        PRTE_ERROR_LOG(ret);
+        error = "prte_session_dir";
+        goto error;
+    }
+
+    /* set the pmix_output env file location to be in the
+     * proc-specific session directory. */
+    pmix_asprintf(&tmp, "%s/%s", jdata->session_dir,
+                              PMIX_RANK_PRINT(PRTE_PROC_MY_NAME->rank));
+    pmix_output_set_output_file_info(tmp, "output-", NULL, NULL);
+    free(tmp);
+    /* setup stdout/stderr */
+    if (prte_debug_daemons_file_flag) {
+        /* if we are debugging to a file, then send stdout/stderr to
+         * the prted log file
+         */
+
+        /* define a log file name in the session directory */
+        snprintf(log_file, PATH_MAX, "output-prted-%s-%s.log",
+                 prte_process_info.myproc.nspace,
+                 prte_process_info.nodename);
+        log_path = pmix_os_path(false, prte_process_info.top_session_dir, log_file, NULL);
+
+        fd = open(log_path, O_RDWR | O_CREAT | O_TRUNC, 0640);
+        if (fd < 0) {
+            /* couldn't open the file for some reason, so
+             * just connect everything to /dev/null
+             */
+            fd = open("/dev/null", O_RDWR | O_CREAT | O_TRUNC, 0666);
+        } else {
+            dup2(fd, STDOUT_FILENO);
+            dup2(fd, STDERR_FILENO);
+            if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
+                close(fd);
+            }
+        }
+    }
 
     /* setup the PMIx server - we need this here in case the
      * communications infrastructure wants to register
@@ -509,12 +502,10 @@ int prte_ess_base_prted_setup(void)
     return PRTE_SUCCESS;
 
 error:
-    pmix_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
-                   PRTE_ERROR_NAME(ret), ret);
+    pmix_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+                   error, PRTE_ERROR_NAME(ret), ret);
     /* remove our use of the session directory tree */
-    prte_session_dir_finalize(PRTE_PROC_MY_NAME);
-    /* ensure we scrub the session directory tree */
-    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
+    PMIX_RELEASE(jdata);
     return PRTE_ERR_SILENT;
 }
 
@@ -559,10 +550,6 @@ int prte_ess_base_prted_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_oob_base_framework);
     (void) pmix_mca_base_framework_close(&prte_prtereachable_base_framework);
     (void) pmix_mca_base_framework_close(&prte_state_base_framework);
-    /* remove our use of the session directory tree */
-    prte_session_dir_finalize(PRTE_PROC_MY_NAME);
-    /* ensure we scrub the session directory tree */
-    prte_session_dir_cleanup(PRTE_JOBID_WILDCARD);
 
     /* shutdown the pmix server */
     pmix_server_finalize();

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -73,9 +73,10 @@ static int env_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_env_module = {.init = rte_init,
-                                              .finalize = rte_finalize,
-                                              .abort = NULL};
+prte_ess_base_module_t prte_ess_env_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 static int rte_init(int argc, char **argv)
 {

--- a/src/mca/ess/ess.h
+++ b/src/mca/ess/ess.h
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2012-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -56,26 +56,12 @@ typedef int (*prte_ess_base_module_init_fn_t)(int argc, char **argv);
  */
 typedef int (*prte_ess_base_module_finalize_fn_t)(void);
 
-/**
- * Abort the current application
- *
- * Aborts currently running application, NOTE: We do NOT call the
- * regular C-library "abort" function, even
- * though that would have alerted us to the fact that this is
- * an abnormal termination, because it would automatically cause
- * a core file to be generated. The "report" flag indicates if the
- * function should create an appropriate file to alert the local
- * orted that termination was abnormal.
- */
-typedef void (*prte_ess_base_module_abort_fn_t)(int status, bool report);
-
 /*
  * the standard module data structure
  */
 struct prte_ess_base_module_3_0_0_t {
     prte_ess_base_module_init_fn_t init;
     prte_ess_base_module_finalize_fn_t finalize;
-    prte_ess_base_module_abort_fn_t abort;
 };
 typedef struct prte_ess_base_module_3_0_0_t prte_ess_base_module_3_0_0_t;
 typedef struct prte_ess_base_module_3_0_0_t prte_ess_base_module_t;

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,9 +50,10 @@ static int lsf_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_lsf_module = {.init = rte_init,
-                                              .finalize = rte_finalize,
-                                              .abort = NULL};
+prte_ess_base_module_t prte_ess_lsf_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /*
  * Local variables

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,9 +53,10 @@ static int slurm_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_slurm_module = {.init = rte_init,
-                                                .finalize = rte_finalize,
-                                                .abort = NULL};
+prte_ess_base_module_t prte_ess_slurm_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 static int rte_init(int argc, char **argv)
 {

--- a/src/mca/ess/tm/ess_tm_module.c
+++ b/src/mca/ess/tm/ess_tm_module.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,9 +52,10 @@ static int tm_set_name(void);
 static int rte_init(int argc, char **argv);
 static int rte_finalize(void);
 
-prte_ess_base_module_t prte_ess_tm_module = {.init = rte_init,
-                                             .finalize = rte_finalize,
-                                             .abort = NULL};
+prte_ess_base_module_t prte_ess_tm_module = {
+    .init = rte_init,
+    .finalize = rte_finalize
+};
 
 /*
  * Local variables

--- a/src/mca/oob/tcp/oob_tcp_listener.c
+++ b/src/mca/oob/tcp/oob_tcp_listener.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -800,7 +800,6 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
             pmix_show_help("help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
                            prte_socket_errno, strerror(prte_socket_errno),
                            "Out of file descriptors");
-            prte_errmgr.abort(PRTE_ERROR_DEFAULT_EXIT_CODE, NULL);
             return;
         }
 

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -111,7 +111,8 @@ int prte_plm_base_comm_stop(void)
 }
 
 /* process incoming messages in order of receipt */
-void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+void prte_plm_base_recv(int status, pmix_proc_t *sender,
+                        pmix_data_buffer_t *buffer,
                         prte_rml_tag_t tag, void *cbdata)
 {
     prte_plm_cmd_flag_t command;
@@ -232,7 +233,8 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
         }
 
         /* get the parent's job object */
-        if (NULL != (parent = prte_get_job_data_object(nptr->nspace))) {
+        if (NULL != (parent = prte_get_job_data_object(nptr->nspace)) &&
+            !PMIX_CHECK_NSPACE(parent->nspace, PRTE_PROC_MY_NAME->nspace)) {
             /* link the spawned job to the spawner */
             PMIX_RETAIN(jdata);
             pmix_list_append(&parent->children, &jdata->super);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -540,7 +540,6 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata,
     proc = PMIX_NEW(prte_proc_t);
     /* set the jobid */
     PMIX_LOAD_NSPACE(proc->name.nspace, jdata->nspace);
-    proc->job = jdata;
     /* flag the proc as ready for launch */
     proc->state = PRTE_PROC_STATE_INIT;
     proc->app_idx = idx;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -783,9 +783,9 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
     }
 
     // session dir + / (1) + lsf_rf. (7) + XXXXXX (6) + \0 (1)
-    len = strlen(prte_process_info.jobfam_session_dir) + 1 + 7 + 6 + 1;
+    len = strlen(prte_process_info.top_session_dir) + 1 + 7 + 6 + 1;
     (*aff_rankfile) = (char*) malloc(sizeof(char) * len);
-    sprintf(*aff_rankfile, "%s/lsf_rf.XXXXXX", prte_process_info.jobfam_session_dir);
+    sprintf(*aff_rankfile, "%s/lsf_rf.XXXXXX", prte_process_info.top_session_dir);
 
     /* open the file */
     fp = fopen(affinity_file, "r");

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -98,7 +98,6 @@ static struct option prteoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_SET_SID, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_PID, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_URI, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_TEST_SUICIDE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_DEFAULT_HOSTFILE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_SINGLETON, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_KEEPALIVE, PMIX_ARG_REQD),
@@ -152,7 +151,6 @@ static struct option prterunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_SET_SID, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_PID, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_URI, PMIX_ARG_REQD),
-    PMIX_OPTION_DEFINE(PRTE_CLI_TEST_SUICIDE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_DEFAULT_HOSTFILE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_KEEPALIVE, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_LAUNCH_AGENT, PMIX_ARG_REQD),

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -544,12 +544,6 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             PMIx_server_deregister_client(proc, opcbfunc, &lock);
             PRTE_PMIX_WAIT_THREAD(&lock);
             PRTE_PMIX_DESTRUCT_LOCK(&lock);
-
-            /* Clean up the session directory as if we were the process
-             * itself.  This covers the case where the process died abnormally
-             * and didn't cleanup its own session directory.
-             */
-            prte_session_dir_finalize(proc);
         }
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -4,8 +4,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022  Consulting.  All rights reserved.
- * Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -476,11 +475,6 @@ static void track_procs(int fd, short argc, void *cbdata)
         PRTE_FLAG_SET(pdata, PRTE_PROC_FLAG_RECORDED);
         PRTE_FLAG_UNSET(pdata, PRTE_PROC_FLAG_ALIVE);
         pdata->state = state;
-        /* Clean up the session directory as if we were the process
-         * itself.  This covers the case where the process died abnormally
-         * and didn't cleanup its own session directory.
-         */
-        prte_session_dir_finalize(proc);
         /* if we are trying to terminate and our routes are
          * gone, then terminate ourselves IF no local procs
          * remain (might be some from another job)

--- a/src/mca/state/state.h
+++ b/src/mca/state/state.h
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -529,10 +529,6 @@ static void lost_connection_hdlr(size_t evhdlr_registration_id, pmix_status_t st
     PMIX_LIST_FOREACH(tl, &prte_pmix_server_globals.tools, prte_pmix_tool_t)
     {
         if (PMIX_CHECK_PROCID(&tl->name, source)) {
-            /* remove the session directory we created for it */
-            if (NULL != tl->nsdir) {
-                pmix_os_dirpath_destroy(tl->nsdir, true, NULL);
-            }
             /* take this tool off the list */
             pmix_list_remove_item(&prte_pmix_server_globals.tools, &tl->super);
             /* release it */
@@ -637,7 +633,7 @@ int pmix_server_init(void)
 
     /* tell the server our temp directory */
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_TMPDIR,
-                       prte_process_info.jobfam_session_dir,
+                       prte_process_info.top_session_dir,
                        PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
         PMIX_INFO_LIST_RELEASE(ilist);
@@ -2024,16 +2020,6 @@ PMIX_CLASS_INSTANCE(pmix_server_pset_t,
                     pmix_list_item_t,
                     pscon, psdes);
 
-static void tlcon(prte_pmix_tool_t *p)
-{
-    p->nsdir = NULL;
-}
-static void tldes(prte_pmix_tool_t *p)
-{
-    if (NULL != p->nsdir) {
-        free(p->nsdir);
-    }
-}
 PMIX_CLASS_INSTANCE(prte_pmix_tool_t,
                     pmix_list_item_t,
-                    tlcon, tldes);
+                    NULL, NULL);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -242,6 +242,7 @@ static void interim(int sd, short args, void *cbdata)
     for (n = 0; n < cd->napps; n++) {
         papp = &cd->apps[n];
         app = PMIX_NEW(prte_app_context_t);
+        app->job = (struct prte_job_t*)jdata;
         app->idx = pmix_pointer_array_add(jdata->apps, app);
         jdata->num_apps++;
         if (NULL != papp->cmd) {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,7 +135,6 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
 typedef struct {
     pmix_list_item_t super;
     pmix_proc_t name;
-    char *nsdir;
 } prte_pmix_tool_t;
 PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
 

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -501,15 +501,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         /* cleanup any pending server ops */
         PMIX_LOAD_PROCID(&pname, job, PMIX_RANK_WILDCARD);
         prte_pmix_server_clear(&pname);
-        /* remove the session directory tree */
-        if (0 > pmix_asprintf(&cmd_str, "%s/%d", prte_process_info.jobfam_session_dir,
-                              PRTE_LOCAL_JOBID(jdata->nspace))) {
-            ret = PRTE_ERR_OUT_OF_RESOURCE;
-            goto CLEANUP;
-        }
-        pmix_os_dirpath_destroy(cmd_str, true, NULL);
-        free(cmd_str);
-        cmd_str = NULL;
+
         PMIX_RELEASE(jdata);
         break;
 

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -100,11 +100,12 @@ void prte_rml_open(void)
     PMIX_CONSTRUCT(&prte_rml_base.posted_recvs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_rml_base.unmatched_msgs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_rml_base.children, pmix_list_t);
-    prte_rml_base.lifeline = PRTE_PROC_MY_PARENT->rank;
 
     /* compute the routing tree - only thing we need to know is the
      * number of daemons in the DVM */
     prte_rml_compute_routing_tree();
+
+    prte_rml_base.lifeline = PRTE_PROC_MY_PARENT->rank;
 }
 
 void prte_rml_send_callback(int status, pmix_proc_t *peer,

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -225,7 +225,7 @@ void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
             if (NULL == (proc = (prte_proc_t *) pmix_pointer_array_get_item(src->procs, j))) {
                 continue;
             }
-            if (proc->job != jdata) {
+            if (!PMIX_CHECK_NSPACE(proc->name.nspace, jdata->nspace)) {
                 continue;
             }
             prte_proc_print(&tmp2, jdata, proc);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -86,7 +86,7 @@ bool prte_show_resolved_nodenames = false;
 bool prte_do_not_resolve = false;
 int prte_hostname_cutoff = 1000;
 
-int prted_debug_failure = -1;
+pmix_rank_t prted_debug_failure = PMIX_RANK_INVALID;
 int prted_debug_failure_delay = -1;
 bool prte_never_launched = false;
 bool prte_devel_level_output = false;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -70,7 +70,6 @@ char *prte_tool_actual = NULL;
 bool prte_dvm_ready = false;
 pmix_pointer_array_t *prte_cache = NULL;
 bool prte_persistent = true;
-bool prte_add_pid_to_session_dirname = false;
 bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;
 bool prte_show_launch_progress = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -191,6 +191,7 @@ typedef uint16_t prte_job_controls_t;
  * defining it - resolves potential circular definition
  */
 struct prte_proc_t;
+struct prte_job_t;
 struct prte_job_map_t;
 struct prte_schizo_base_module_t;
 
@@ -211,6 +212,8 @@ PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_topology_t);
 typedef struct {
     /** Parent object */
     pmix_object_t super;
+    /** the job this app belongs to */
+    struct prte_job_t *job;
     /** Unique index when multiple apps per job */
     prte_app_idx_t idx;
     /** Absolute pathname of argv[0] */
@@ -312,6 +315,8 @@ typedef struct {
     struct prte_schizo_base_module_t *schizo;
     /* jobid for this job */
     pmix_nspace_t nspace;
+    // session directory for this job
+    char *session_dir;
     int index; // index in the job array where this is stored
     /* offset to the total number of procs so shared memory
      * components can potentially connect to any spawned jobs*/
@@ -377,8 +382,6 @@ struct prte_proc_t {
     pmix_list_item_t super;
     /* process name */
     pmix_proc_t name;
-    prte_job_t *job;
-    pmix_rank_t rank;
     /* the vpid of my parent - the daemon vpid for an app
      * or the vpid of the parent in the routing tree of
      * a daemon */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -521,7 +521,7 @@ PRTE_EXPORT extern int prte_hostname_cutoff;
 PRTE_EXPORT extern bool prte_do_not_resolve;
 
 /* debug flags */
-PRTE_EXPORT extern int prted_debug_failure;
+PRTE_EXPORT extern pmix_rank_t prted_debug_failure;
 PRTE_EXPORT extern int prted_debug_failure_delay;
 
 PRTE_EXPORT extern bool prte_never_launched;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -505,7 +505,6 @@ PRTE_EXPORT extern char *prte_data_server_uri;
 PRTE_EXPORT extern bool prte_dvm_ready;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
-PRTE_EXPORT extern bool prte_add_pid_to_session_dirname;
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
 

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,7 +55,6 @@ static char *prte_tmpdir_base = NULL;
 static char *prte_local_tmpdir_base = NULL;
 static char *prte_remote_tmpdir_base = NULL;
 static char *prte_top_session_dir = NULL;
-static char *prte_jobfam_session_dir = NULL;
 static char *local_setup_slots = NULL;
 
 char *prte_signal_string = NULL;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -299,12 +299,6 @@ int prte_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &prte_prohibited_session_dirs);
 
-    prte_add_pid_to_session_dirname = false;
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "add_pid_to_session_dirname",
-                                      "Add pid to the DVM top-level session directory name",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                      &prte_add_pid_to_session_dirname);
-
     prte_fwd_environment = false;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "fwd_environment",
                                       "Forward the entire local environment",

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -534,6 +534,9 @@ int main(int argc, char *argv[])
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS)) {
         prte_debug_daemons_flag = true;
     }
+    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DEBUG_DAEMONS_FILE)) {
+        prte_debug_daemons_file_flag = true;
+    }
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_LEAVE_SESSION_ATTACHED)) {
         prte_leave_session_attached = true;
     }

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
@@ -1376,7 +1376,7 @@ static void abort_signal_callback(int fd)
         second = false;
     } else {
         surekill();  // ensure we attempt to kill everything
-        pmix_os_dirpath_destroy(prte_process_info.jobfam_session_dir, true, NULL);
+        pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, NULL);
         exit(1);
     }
 }
@@ -1428,16 +1428,12 @@ static int prep_singleton(const char *name)
     /* create a proc for the singleton */
     proc = PMIX_NEW(prte_proc_t);
     PMIX_LOAD_PROCID(&proc->name, jdata->nspace, rank);
-    proc->rank = proc->name.rank;
     proc->parent = PRTE_PROC_MY_NAME->rank;
     proc->app_idx = 0;
     proc->app_rank = rank;
     proc->local_rank = 0;
     proc->node_rank = 0;
     proc->state = PRTE_PROC_STATE_RUNNING;
-    /* link it to the job */
-    PMIX_RETAIN(jdata);
-    proc->job = jdata;
     /* link it to the app */
     PMIX_RETAIN(proc);
     pmix_pointer_array_set_item(&app->procs, rank, proc);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -99,6 +99,7 @@
 #include "src/mca/schizo/base/base.h"
 #include "src/mca/state/base/base.h"
 #include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_wait.h"
 #include "src/runtime/runtime.h"
 
 #include "include/prte.h"
@@ -226,6 +227,32 @@ static void setup_sighandler(int signal, prte_event_t *ev, prte_event_cbfunc_t c
 {
     prte_event_signal_set(prte_event_base, ev, signal, cbfunc, ev);
     prte_event_signal_add(ev, NULL);
+}
+
+static void shutdown_callback(int fd, short flags, void *arg)
+{
+    prte_timer_t *tm = (prte_timer_t *) arg;
+    prte_job_t *jdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, flags);
+
+    if (NULL != tm) {
+        /* release the timer */
+        PMIX_RELEASE(tm);
+    }
+
+    /* if we were ordered to abort, do so */
+    pmix_output(0, "%s is executing clean abnormal termination",
+                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+    /* do -not- call finalize as this will send a message to the HNP
+     * indicating clean termination! Instead, just forcibly cleanup
+     * the local session_dir tree and exit
+     */
+    prte_odls.kill_local_procs(NULL);
+    // mark that we are finalizing so the session directory will cleanup
+    prte_finalizing = true;
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    PMIX_RELEASE(jdata);
+    exit(PRTE_ERROR_DEFAULT_EXIT_CODE);
 }
 
 int main(int argc, char *argv[])
@@ -846,6 +873,35 @@ int main(int argc, char *argv[])
     if (!prte_dvm_ready) {
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
+    }
+
+    // see if we are to suicide
+    if (PMIX_RANK_INVALID != prted_debug_failure) {
+        /* are we the specified vpid? */
+        if (PRTE_PROC_MY_NAME->rank == prted_debug_failure ||
+            prted_debug_failure == PMIX_RANK_WILDCARD) {
+            /* if the user specified we delay, then setup a timer
+             * and have it kill us
+             */
+            if (0 < prted_debug_failure_delay) {
+                PRTE_TIMER_EVENT(prted_debug_failure_delay, 0, shutdown_callback);
+
+            } else {
+                pmix_output(0, "%s is executing clean abnormal termination",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+                /* do -not- call finalize as this will send a message to the HNP
+                 * indicating clean termination! Instead, just forcibly cleanup
+                 * the local session_dir tree and exit
+                 */
+                jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+                PMIX_RELEASE(jdata);
+
+                /* return with non-zero status */
+                ret = PRTE_ERROR_DEFAULT_EXIT_CODE;
+                goto DONE;
+            }
+        }
     }
 
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_REPORT_PID);

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,10 +53,10 @@
 extern bool prte_keep_fqdn_hostnames;
 
 PRTE_EXPORT prte_process_info_t prte_process_info = {
-    .myproc = {{0}, 0},
-    .my_hnp = {{0}, 0},
+    .myproc = PMIX_PROC_STATIC_INIT,
+    .my_hnp = PMIX_PROC_STATIC_INIT,
     .my_hnp_uri = NULL,
-    .my_parent = {{0}, 0},
+    .my_parent = PMIX_PROC_STATIC_INIT,
     .hnp_pid = 0,
     .num_daemons = 1,
     .num_nodes = 1,
@@ -65,15 +65,8 @@ PRTE_EXPORT prte_process_info_t prte_process_info = {
     .pid = 0,
     .proc_type = PRTE_PROC_TYPE_NONE,
     .my_port = 0,
-    .num_restarts = 0,
     .tmpdir_base = NULL,
     .top_session_dir = NULL,
-    .jobfam_session_dir = NULL,
-    .job_session_dir = NULL,
-    .proc_session_dir = NULL,
-    .sock_stdin = NULL,
-    .sock_stdout = NULL,
-    .sock_stderr = NULL,
     .cpuset = NULL,
     .shared_fs = false
 };
@@ -225,13 +218,6 @@ int prte_proc_info(void)
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &prte_process_info.num_nodes);
 
-    /* get the number of times this proc has restarted */
-    prte_process_info.num_restarts = 0;
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "num_restarts",
-                                      "Number of times this proc has restarted",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_process_info.num_restarts);
-
     return PRTE_SUCCESS;
 }
 
@@ -251,21 +237,6 @@ int prte_proc_info_finalize(void)
         prte_process_info.top_session_dir = NULL;
     }
 
-    if (NULL != prte_process_info.jobfam_session_dir) {
-        free(prte_process_info.jobfam_session_dir);
-        prte_process_info.jobfam_session_dir = NULL;
-    }
-
-    if (NULL != prte_process_info.job_session_dir) {
-        free(prte_process_info.job_session_dir);
-        prte_process_info.job_session_dir = NULL;
-    }
-
-    if (NULL != prte_process_info.proc_session_dir) {
-        free(prte_process_info.proc_session_dir);
-        prte_process_info.proc_session_dir = NULL;
-    }
-
     if (NULL != prte_process_info.nodename) {
         free(prte_process_info.nodename);
         prte_process_info.nodename = NULL;
@@ -274,21 +245,6 @@ int prte_proc_info_finalize(void)
     if (NULL != prte_process_info.cpuset) {
         free(prte_process_info.cpuset);
         prte_process_info.cpuset = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stdin) {
-        free(prte_process_info.sock_stdin);
-        prte_process_info.sock_stdin = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stdout) {
-        free(prte_process_info.sock_stdout);
-        prte_process_info.sock_stdout = NULL;
-    }
-
-    if (NULL != prte_process_info.sock_stderr) {
-        free(prte_process_info.sock_stderr);
-        prte_process_info.sock_stderr = NULL;
     }
 
     prte_process_info.proc_type = PRTE_PROC_TYPE_NONE;

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,7 +76,6 @@ typedef struct prte_process_info_t {
     pid_t pid;                  /**< Local process ID for this process */
     prte_proc_type_t proc_type; /**< Type of process */
     uint16_t my_port;           /**< TCP port for out-of-band comm */
-    int num_restarts;           /**< number of times this proc has restarted */
     /* The session directory has the form
      * <prefix>/<openmpi-sessions-user>/<jobid>/<procid>, where the prefix
      * can either be provided by the user via the
@@ -85,15 +84,8 @@ typedef struct prte_process_info_t {
      */
     char *tmpdir_base;        /**< Base directory of the session dir tree */
     char *top_session_dir;    /**< Top-most directory of the session tree */
-    char *jobfam_session_dir; /**< Session directory for this family of jobs (i.e., share same
-                                 mpirun) */
-    char *job_session_dir;    /**< Session directory for job */
-    char *proc_session_dir;   /**< Session directory for the process */
     bool rm_session_dirs;     /**< Session directories will be cleaned up by RM */
 
-    char *sock_stdin;  /**< Path name to temp file for stdin. */
-    char *sock_stdout; /**< Path name to temp file for stdout. */
-    char *sock_stderr; /**< Path name to temp file for stderr. */
     char *cpuset;      /**< String-representation of bitmap where we are bound */
     bool shared_fs;     // whether the tmpdir is on a shared file system
 } prte_process_info_t;

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -73,9 +73,9 @@
 /*******************************
  * Local function Declarations
  *******************************/
-static int prte_create_dir(char *directory);
+static bool _check_file(const char *root, const char *path);
 
-static bool prte_dir_check_file(const char *root, const char *path);
+static bool setup_base_complete = false;
 
 #define PRTE_PRINTF_FIX_STRING(a) ((NULL == a) ? "(null)" : a)
 
@@ -85,27 +85,12 @@ static bool prte_dir_check_file(const char *root, const char *path);
 /*
  * Check and create the directory requested
  */
-static int prte_create_dir(char *directory)
+static int _create_dir(char *directory)
 {
     mode_t my_mode = S_IRWXU; /* I'm looking for full rights */
     int ret;
 
-    /* Sanity check before creating the directory with the proper mode,
-     * Make sure it doesn't exist already */
-    if (PMIX_ERR_NOT_FOUND != (ret = pmix_os_dirpath_access(directory, my_mode))) {
-        /* Failure because pmix_os_dirpath_access() indicated that either:
-         * - The directory exists and we can access it (no need to create it again),
-         *    return PRTE_SUCCESS, or
-         * - don't have access rights, return PRTE_ERROR
-         */
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-        }
-        ret = prte_pmix_convert_status(ret);
-        return (ret);
-    }
-
-    /* Get here if the directory doesn't exist, so create it */
+    /* attempt to create it */
     if (PMIX_SUCCESS != (ret = pmix_os_dirpath_create(directory, my_mode))) {
         PMIX_ERROR_LOG(ret);
     }
@@ -153,7 +138,7 @@ exit:
     return rc;
 }
 
-int prte_setup_top_session_dir(void)
+static int _setup_top_session_dir(void)
 {
     int rc = PRTE_SUCCESS;
     /* get the effective uid */
@@ -165,82 +150,22 @@ int prte_setup_top_session_dir(void)
         if (PRTE_SUCCESS != (rc = _setup_tmpdir_base())) {
             return rc;
         }
-        if (NULL == prte_process_info.nodename || NULL == prte_process_info.tmpdir_base) {
+        if (NULL == prte_process_info.nodename ||
+            NULL == prte_process_info.tmpdir_base) {
             /* we can't setup top session dir */
             rc = PRTE_ERR_BAD_PARAM;
             goto exit;
         }
-        if (prte_add_pid_to_session_dirname) {
-            if (0 > pmix_asprintf(&prte_process_info.top_session_dir, "%s/prte.%s.%lu.%lu",
-                                  prte_process_info.tmpdir_base, prte_process_info.nodename,
-                                  (unsigned long)pid, (unsigned long) uid)) {
-                prte_process_info.top_session_dir = NULL;
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        } else {
-            if (0 > pmix_asprintf(&prte_process_info.top_session_dir, "%s/prte.%s.%lu",
-                                  prte_process_info.tmpdir_base, prte_process_info.nodename,
-                                  (unsigned long) uid)) {
-                prte_process_info.top_session_dir = NULL;
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        }
-    }
-exit:
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-    }
-    return rc;
-}
-
-static int _setup_jobfam_session_dir(pmix_proc_t *proc)
-{
-    int rc = PRTE_SUCCESS;
-    PRTE_HIDE_UNUSED_PARAMS(proc);
-
-    /* construct the top_session_dir if we need */
-    if (NULL == prte_process_info.jobfam_session_dir) {
-        if (PRTE_SUCCESS != (rc = prte_setup_top_session_dir())) {
-            PRTE_ERROR_LOG(rc);
-            return rc;
-        }
-
-        if (0 > pmix_asprintf(&prte_process_info.jobfam_session_dir, "%s/dvm.%lu",
-                              prte_process_info.top_session_dir,
-                              (unsigned long) prte_process_info.pid)) {
+        if (0 > pmix_asprintf(&prte_process_info.top_session_dir, "%s/%s.%s.%lu.%lu",
+                              prte_process_info.tmpdir_base, prte_tool_basename,
+                              prte_process_info.nodename,
+                              (unsigned long)pid, (unsigned long) uid)) {
+            prte_process_info.top_session_dir = NULL;
             rc = PRTE_ERR_OUT_OF_RESOURCE;
+            goto exit;
         }
     }
-
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-    }
-    return rc;
-}
-
-static int _setup_job_session_dir(pmix_proc_t *proc)
-{
-    int rc = PRTE_SUCCESS;
-
-    /* construct the top_session_dir if we need */
-    if (NULL == prte_process_info.job_session_dir) {
-        if (PRTE_SUCCESS != (rc = _setup_jobfam_session_dir(proc))) {
-            return rc;
-        }
-        if (!PMIX_NSPACE_INVALID(proc->nspace)) {
-            if (0 > pmix_asprintf(&prte_process_info.job_session_dir, "%s/%s",
-                                  prte_process_info.jobfam_session_dir,
-                                  PRTE_LOCAL_JOBID_PRINT(proc->nspace))) {
-                prte_process_info.job_session_dir = NULL;
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        } else {
-            prte_process_info.job_session_dir = NULL;
-        }
-    }
+    rc = _create_dir(prte_process_info.top_session_dir);
 
 exit:
     if (PRTE_SUCCESS != rc) {
@@ -249,48 +174,54 @@ exit:
     return rc;
 }
 
-static int _setup_proc_session_dir(pmix_proc_t *proc)
+static int _setup_job_session_dir(prte_job_t *jdata)
 {
     int rc = PRTE_SUCCESS;
 
-    /* construct the top_session_dir if we need */
-    if (NULL == prte_process_info.proc_session_dir) {
-        if (PRTE_SUCCESS != (rc = _setup_job_session_dir(proc))) {
-            return rc;
+    if (NULL == jdata->session_dir) {
+        if (0 > pmix_asprintf(&jdata->session_dir, "%s/%s",
+                              prte_process_info.top_session_dir,
+                              PRTE_LOCAL_JOBID_PRINT(jdata->nspace))) {
+            return PRTE_ERR_OUT_OF_RESOURCE;
         }
-        if (PMIX_RANK_INVALID != proc->rank) {
-            if (0 > pmix_asprintf(&prte_process_info.proc_session_dir, "%s/%s",
-                                  prte_process_info.job_session_dir, PRTE_VPID_PRINT(proc->rank))) {
-                prte_process_info.proc_session_dir = NULL;
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                goto exit;
-            }
-        } else {
-            prte_process_info.proc_session_dir = NULL;
-        }
-    }
-
-exit:
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+        rc = _create_dir(jdata->session_dir);
     }
     return rc;
 }
 
-int prte_session_setup_base(pmix_proc_t *proc)
+static int _setup_proc_session_dir(prte_job_t *jdata,
+                                   pmix_proc_t *p)
 {
     int rc;
+    char *tmp;
+
+    if (0 > pmix_asprintf(&tmp, "%s/%s", jdata->session_dir,
+                          PMIX_RANK_PRINT(p->rank))) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    rc = _create_dir(tmp);
+    free(tmp);
+    return rc;
+}
+
+static int setup_base(void)
+{
+    int rc;
+
+    // only do this once
+    if (setup_base_complete) {
+        return PRTE_SUCCESS;
+    }
+    setup_base_complete = true;
 
     /* Ensure that system info is set */
     prte_proc_info();
 
-    /* setup job and proc session directories */
-    if (PRTE_SUCCESS != (rc = _setup_job_session_dir(proc))) {
-        return rc;
-    }
-
-    if (PRTE_SUCCESS != (rc = _setup_proc_session_dir(proc))) {
-        return rc;
+    if (NULL == prte_process_info.tmpdir_base) {
+        if (PRTE_SUCCESS != (rc = _setup_tmpdir_base())) {
+            PRTE_ERROR_LOG(rc);
+            return rc;
+        }
     }
 
     /* BEFORE doing anything else, check to see if this prefix is
@@ -317,20 +248,25 @@ int prte_session_setup_base(pmix_proc_t *proc)
         }
         PMIX_ARGV_FREE_COMPAT(list); /* done with this */
     }
-    return PRTE_SUCCESS;
+
+    rc = _setup_top_session_dir();
+
+    return rc;
 }
 
 /*
  * Construct the session directory and create it if necessary
  */
-int prte_session_dir(bool create, pmix_proc_t *proc)
+int prte_session_dir(pmix_proc_t *proc)
 {
     int rc = PRTE_SUCCESS;
+    prte_job_t *jdata;
+    prte_proc_t *p;
 
     /*
      * Get the session directory full name
      */
-    if (PRTE_SUCCESS != (rc = prte_session_setup_base(proc))) {
+    if (PRTE_SUCCESS != (rc = setup_base())) {
         if (PRTE_ERR_FATAL == rc) {
             /* this indicates we should abort quietly */
             rc = PRTE_ERR_SILENT;
@@ -338,20 +274,26 @@ int prte_session_dir(bool create, pmix_proc_t *proc)
         goto cleanup;
     }
 
-    /*
-     * Now that we have the full path, go ahead and create it if necessary
-     */
-    if (create) {
-        if (PRTE_SUCCESS != (rc = prte_create_dir(prte_process_info.proc_session_dir))) {
+    /* setup job and proc session directories */
+    jdata = prte_get_job_data_object(proc->nspace);
+    if (NULL == jdata) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+    if (PRTE_SUCCESS != (rc = _setup_job_session_dir(jdata))) {
+        PRTE_ERROR_LOG(rc);
+        return rc;
+    }
+
+    if (PMIX_RANK_IS_VALID(proc->rank)) {
+        if (PRTE_SUCCESS != (rc = _setup_proc_session_dir(jdata, proc))) {
             PRTE_ERROR_LOG(rc);
-            goto cleanup;
+            return rc;
         }
     }
 
     if (prte_debug_flag) {
-        pmix_output(0, "procdir: %s", PRTE_PRINTF_FIX_STRING(prte_process_info.proc_session_dir));
-        pmix_output(0, "jobdir: %s", PRTE_PRINTF_FIX_STRING(prte_process_info.job_session_dir));
-        pmix_output(0, "job: %s", PRTE_PRINTF_FIX_STRING(prte_process_info.jobfam_session_dir));
+        pmix_output(0, "jobdir: %s", PRTE_PRINTF_FIX_STRING(jdata->session_dir));
         pmix_output(0, "top: %s", PRTE_PRINTF_FIX_STRING(prte_process_info.top_session_dir));
         pmix_output(0, "tmp: %s", PRTE_PRINTF_FIX_STRING(prte_process_info.tmpdir_base));
     }
@@ -360,200 +302,49 @@ cleanup:
     return rc;
 }
 
-/*
- * A job has aborted - so force cleanup of the session directory
- */
-int prte_session_dir_cleanup(pmix_nspace_t jobid)
+void prte_job_session_dir_finalize(prte_job_t *jdata)
 {
-    int ret;
-    PRTE_HIDE_UNUSED_PARAMS(jobid);
-
-    /* special case - if a daemon is colocated with mpirun,
-     * then we let mpirun do the rest to avoid a race
-     * condition. this scenario always results in the rank=1
-     * daemon colocated with mpirun */
-    if (prte_ras_base.launch_orted_on_hn && PRTE_PROC_IS_DAEMON && 1 == PRTE_PROC_MY_NAME->rank) {
-        return PRTE_SUCCESS;
-    }
-
     if (prte_process_info.rm_session_dirs) {
         /* RM will clean them up for us */
-        return PRTE_SUCCESS;
-    }
-
-    if (NULL == prte_process_info.jobfam_session_dir
-        || NULL == prte_process_info.proc_session_dir) {
-        /* this should never happen - it means we are calling
-         * cleanup *before* properly setting up the session
-         * dir system. This leaves open the possibility of
-         * accidentally removing directories we shouldn't
-         * touch
-         */
-        return PRTE_ERR_NOT_INITIALIZED;
-    }
-
-    /* recursively blow the whole session away for our job family,
-     * saving only output files
-     */
-    pmix_os_dirpath_destroy(prte_process_info.jobfam_session_dir, true, prte_dir_check_file);
-
-    if (pmix_os_dirpath_is_empty(prte_process_info.jobfam_session_dir)) {
-        if (prte_debug_flag) {
-            pmix_output(0, "sess_dir_cleanup: found jobfam session dir empty - deleting");
-        }
-        rmdir(prte_process_info.jobfam_session_dir);
-    } else {
-        if (prte_debug_flag) {
-            ret = pmix_os_dirpath_access(prte_process_info.job_session_dir, 0);
-            if (PMIX_ERR_NOT_FOUND == ret) {
-                pmix_output(0, "sess_dir_cleanup: job session dir does not exist");
-            } else {
-                pmix_output(0, "sess_dir_cleanup: job session dir not empty - leaving");
-            }
-        }
-    }
-
-    if (NULL != prte_process_info.top_session_dir) {
-        if (pmix_os_dirpath_is_empty(prte_process_info.top_session_dir)) {
-            if (prte_debug_flag) {
-                pmix_output(0, "sess_dir_cleanup: found top session dir empty - deleting");
-            }
-            rmdir(prte_process_info.top_session_dir);
-        } else {
-            if (prte_debug_flag) {
-                ret = pmix_os_dirpath_access(prte_process_info.top_session_dir, 0);
-                if (PMIX_ERR_NOT_FOUND == ret) {
-                    pmix_output(0, "sess_dir_cleanup: top session dir does not exist");
-                } else {
-                    pmix_output(0, "sess_dir_cleanup: top session dir not empty - leaving");
-                }
-            }
-        }
-    }
-
-    /* now attempt to eliminate the top level directory itself - this
-     * will fail if anything is present, but ensures we cleanup if
-     * we are the last one out
-     */
-    if (NULL != prte_process_info.top_session_dir) {
-        pmix_os_dirpath_destroy(prte_process_info.top_session_dir, false, prte_dir_check_file);
-    }
-
-    return PRTE_SUCCESS;
-}
-
-int prte_session_dir_finalize(pmix_proc_t *proc)
-{
-    int ret;
-
-    if (prte_process_info.rm_session_dirs) {
-        /* RM will clean them up for us */
-        return PRTE_SUCCESS;
-    }
-
-    if (NULL == prte_process_info.job_session_dir ||
-        NULL == prte_process_info.proc_session_dir) {
-        /* this should never happen - it means we are calling
-         * cleanup *before* properly setting up the session
-         * dir system. This leaves open the possibility of
-         * accidentally removing directories we shouldn't
-         * touch
-         */
-        return PRTE_ERR_NOT_INITIALIZED;
-    }
-
-    pmix_os_dirpath_destroy(prte_process_info.proc_session_dir, false, prte_dir_check_file);
-
-    if (pmix_os_dirpath_is_empty(prte_process_info.proc_session_dir)) {
-        if (prte_debug_flag) {
-            pmix_output(0, "sess_dir_finalize: found proc session dir empty - deleting");
-        }
-        rmdir(prte_process_info.proc_session_dir);
-    } else {
-        if (prte_debug_flag) {
-            ret = pmix_os_dirpath_access(prte_process_info.proc_session_dir, 0);
-            if (PMIX_ERR_NOT_FOUND == ret) {
-                pmix_output(0, "sess_dir_finalize: proc session dir does not exist");
-            } else {
-                pmix_output(0, "sess_dir_finalize: proc session dir not empty - leaving");
-            }
-        }
+        return;
     }
 
     /* special case - if a daemon is colocated with mpirun,
      * then we let mpirun do the rest to avoid a race
      * condition. this scenario always results in the rank=1
      * daemon colocated with mpirun */
-    if (prte_ras_base.launch_orted_on_hn && PRTE_PROC_IS_DAEMON && 1 == PRTE_PROC_MY_NAME->rank) {
-        return PRTE_SUCCESS;
+    if (prte_ras_base.launch_orted_on_hn && PRTE_PROC_IS_DAEMON &&
+        1 == PRTE_PROC_MY_NAME->rank) {
+        return;
     }
 
-    pmix_os_dirpath_destroy(prte_process_info.job_session_dir, false, prte_dir_check_file);
-
-    /* only remove the jobfam session dir if we are the
-     * local daemon and we are finalizing our own session dir */
-    if ((PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON) && (PRTE_PROC_MY_NAME == proc)) {
-        pmix_os_dirpath_destroy(prte_process_info.jobfam_session_dir, false, prte_dir_check_file);
+    if (NULL == jdata->session_dir) {
+        return;
     }
 
-    if (NULL != prte_process_info.top_session_dir) {
-        pmix_os_dirpath_destroy(prte_process_info.top_session_dir, false, prte_dir_check_file);
-    }
-
-    if (pmix_os_dirpath_is_empty(prte_process_info.job_session_dir)) {
-        if (prte_debug_flag) {
-            pmix_output(0, "sess_dir_finalize: found job session dir empty - deleting");
-        }
-        rmdir(prte_process_info.job_session_dir);
-    } else {
-        if (prte_debug_flag) {
-            ret = pmix_os_dirpath_access(prte_process_info.job_session_dir, 0);
-            if (PMIX_ERR_NOT_FOUND == ret) {
-                pmix_output(0, "sess_dir_finalize: job session dir does not exist");
-            } else {
-                pmix_output(0, "sess_dir_finalize: job session dir not empty - leaving");
+    /* if this is the DVM job, then we destroy the top-level
+     * session directory, but only if we are finalizing */
+    if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
+        if (prte_finalizing) {
+            if (NULL != prte_process_info.top_session_dir) {
+                pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, _check_file);
+                rmdir(prte_process_info.top_session_dir);
+                free(prte_process_info.top_session_dir);
+                prte_process_info.top_session_dir = NULL;
             }
         }
+        return;
     }
 
-    if (pmix_os_dirpath_is_empty(prte_process_info.jobfam_session_dir)) {
-        if (prte_debug_flag) {
-            pmix_output(0, "sess_dir_finalize: found jobfam session dir empty - deleting");
-        }
-        rmdir(prte_process_info.jobfam_session_dir);
-    } else {
-        if (prte_debug_flag) {
-            ret = pmix_os_dirpath_access(prte_process_info.jobfam_session_dir, 0);
-            if (PMIX_ERR_NOT_FOUND == ret) {
-                pmix_output(0, "sess_dir_finalize: jobfam session dir does not exist");
-            } else {
-                pmix_output(0, "sess_dir_finalize: jobfam session dir not empty - leaving");
-            }
-        }
-    }
-
-    if (NULL != prte_process_info.top_session_dir) {
-        if (pmix_os_dirpath_is_empty(prte_process_info.top_session_dir)) {
-            if (prte_debug_flag) {
-                pmix_output(0, "sess_dir_finalize: found top session dir empty - deleting");
-            }
-            rmdir(prte_process_info.top_session_dir);
-        } else {
-            if (prte_debug_flag) {
-                ret = pmix_os_dirpath_access(prte_process_info.top_session_dir, 0);
-                if (PMIX_ERR_NOT_FOUND == ret) {
-                    pmix_output(0, "sess_dir_finalize: top session dir does not exist");
-                } else {
-                    pmix_output(0, "sess_dir_finalize: top session dir not empty - leaving");
-                }
-            }
-        }
-    }
-
-    return PRTE_SUCCESS;
+    pmix_os_dirpath_destroy(jdata->session_dir, true, _check_file);
+    /* if the job-level session dir is now empty, remove it */
+    rmdir(jdata->session_dir);
+    free(jdata->session_dir);
+    jdata->session_dir = NULL;
+    return;
 }
 
-static bool prte_dir_check_file(const char *root, const char *path)
+static bool _check_file(const char *root, const char *path)
 {
     struct stat st;
     char *fullpath;
@@ -563,7 +354,8 @@ static bool prte_dir_check_file(const char *root, const char *path)
      *  - non-zero files starting with "output-"
      */
     if (0 == strncmp(path, "output-", strlen("output-"))) {
-        fullpath = pmix_os_path(false, &fullpath, root, path, NULL);
+        memset(&st, 0, sizeof(struct stat));
+        fullpath = pmix_os_path(false, root, path, NULL);
         stat(fullpath, &st);
         free(fullpath);
         if (0 == st.st_size) {

--- a/src/util/session_dir.h
+++ b/src/util/session_dir.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -22,69 +22,6 @@
  *
  * Find and/or create PRTE session directory.
  *
- * The prte_session_dir() function searches for a temporary directory
- * that is used by the PRTE system for storing system-critical
- * information. For a given system and user, the function attempts to
- * find (or create, if not found and create is requested) a directory
- * that will be used to independently house information for multiple
- * universes, as the user creates them. Thus, the function pursues a
- * directory tree of the form:
- *
- * \par \em [prefix-dir] An absolute path that identifies a temporary
- * directory that is read-write-execute accessible to everyone. The
- * function first checks to see if the user has specified the [prefix]
- * directory on the command line. If so, then the function will use
- * that [prefix] if the access permissions are correct, or will return
- * an error condition if not - the function will not search for
- * alternative locations if the user provides the [prefix] name.
- *
- * \par If the [prefix] is not provided by the user, the function
- * searches for a suitable directory in a specific order, taking the
- * first option that meets the access permission requirement, using:
- * (a) the "OMPI_PREFIX_ENV" environment variable; (b) the "TMPDIR"
- * environment variable; and (c) the "TMP" environment variabley. If
- * none of those environmental variables have been defined and/or the
- * function was unable to create a suitable directory within any of
- * them, then the function tries to use a default location of "/tmp",
- * where the "/" represents the top-level directory of the local
- * system. If none of these options are successful, the function
- * returns an error code.
- *
- * \par \em [openmpi-sessions]-[user-id]@[host]:[batchid] This serves
- * as a concentrator for all PRTE session directories for this
- * user on the local system. If it doesn't already exist, this
- * directory is created with read-write-execute permissions
- * exclusively restricted to the user. If it does exist, the access
- * permissions are checked to ensure they are correct - if not, the
- * program attempts to correct them. If they can't' be changed to the
- * correct values, an error condition is returned. The [host] and
- * [batchid] fields are included to provide uniqueness on shared file
- * systems and batch schedulers, respectively.
- *
- * \par Note: The [prefix]/openmpi-sessions-[user-id]@[host]:[batchid]
- * directory is left on the system upon termination of an application
- * and/or an PRTE universe for future use by the user. Thus, when
- * checking a potential location for the directory, the
- * prte_session_tree_init() function first checks to see if an
- * appropriate directory already exists, and uses it if it does.
- *
- * \par \em [universe-name] A directory is created for the specified
- * universe name. This is the directory that will be used to house all
- * information relating to the specific universe. If the directory
- * already exists (indicating that the user is joining an existing
- * universe), then the function ensures that the user has exclusive
- * read-write-execute permissions on the directory.
- *
- * \par \em [job] A directory is created for the specified job
- * name. This will house all information relating to that specific
- * job, including directories for each process within that job on this
- * host.
- *
- * \par \em [process] A directory for the specific process, will house
- * all information for that process.
- *
- * \par If \c create is \c true, the directory will be created and the
- * proc_info structure will be updated.  If proc_info is false,
  */
 
 #ifndef PRTE_SESSION_DIR_H_HAS_BEEN_INCLUDED
@@ -92,60 +29,33 @@
 
 #include "prte_config.h"
 #include "types.h"
+#include "src/runtime/prte_globals.h"
 
 BEGIN_C_DECLS
 
-/** @param create A boolean variable that indicates whether or not to
- *                create the specified directory. If set to "false",
- *                the function only checks to see if an existing
- *                directory can be found. This is typically used to
- *                locate an already existing universe for reconnection
- *                purposes. If set to "true", then the function
- *                creates the directory, if possible.
- * @param proc    Pointer to a process name for which the session
- *                dir name is desired
+/** @param proc    Pointer to a process name for which the session
+ *                dir name is desired. Passing:
  *
- * @retval PRTE_SUCCESS The directory was found and/or created with
+ *                PRTE_NAME_INVALID - top-level session directory
+ *                will be created.
+ *
+ *                PRTE_NAME_WILDCARD - job-level session directory
+ *                will be created
+ *
+ *                Valid procID - proc-level session directory will
+ *                be created
+ *
+ *@retval PRTE_SUCCESS The directory was found and/or created with
  *                the proper permissions.
- * @retval OMPI_ERROR The directory cannot be found (if create is
- *                "false") or created (if create is "true").
+ * @retval PRTE_ERROR The directory cannot be found or created
  */
-PRTE_EXPORT int prte_session_dir(bool create, pmix_proc_t *proc);
+PRTE_EXPORT int prte_session_dir(pmix_proc_t *proc);
 
-/*
- * Setup session-related directory paths
+/** The session_dir_finalize functions perform a cleanup of the
+ * relevant session directory tree.
  */
-PRTE_EXPORT int prte_session_setup_base(pmix_proc_t *proc);
 
-PRTE_EXPORT int prte_setup_top_session_dir(void);
-
-/** The prte_session_dir_finalize() function performs a cleanup of the
- * session directory tree. It first removes the session directory for
- * the calling process. It then checks to see if the job-level session
- * directory is now empty - if so, it removes that level as
- * well. Finally, it checks to see if the universe-level session
- * directory is now empty - if so, it also removes that level. This
- * three-part "last-one-out" procedure ensures that the directory tree
- * is properly removed if all processes and applications within a
- * universe have completed.
- *
- * @param None
- * @retval PRTE_SUCCESS If the directory tree is properly cleaned up.
- * @retval OMPI_ERROR If something prevents the tree from being
- *                properly cleaned up.
- */
-PRTE_EXPORT int prte_session_dir_finalize(pmix_proc_t *proc);
-
-/** The prte_session_dir_cleanup() function performs a cleanup of the
- * session directory tree when a job is aborted. It cleans up all
- * process directories for a given job and then backs up the tree.
- *
- * @param jobid
- * @retval OMPI_SUCCESS If the directory tree is properly cleaned up.
- * @retval OMPI_ERROR If something prevents the tree from being
- *                properly cleaned up.
- */
-PRTE_EXPORT int prte_session_dir_cleanup(pmix_nspace_t jobid);
+PRTE_EXPORT void prte_job_session_dir_finalize(prte_job_t *jdata);
 
 END_C_DECLS
 


### PR DESCRIPTION
[Fix testing of suicide for daemons](https://github.com/openpmix/prrte/commit/e2cff338c154fadc30939e99f2bee6b9a9e46da0)

We don't support a cmd line option for this as it isn't
something a user should ever do. Instead, we use two
MCA params to specify it:

prte_daemon_fail <N> - specifies the daemon rank that
should commit suicide

prte_daemon_fail_delay <N> - time in seconds the target
rank should wait before dying. A value of zero means
no delay, just die after calling init. This is the
default value.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/618dd0a5e948db0d0cab5333bb56aaa79ffd9819)

[Fix daemon suicide and preserve output files](https://github.com/openpmix/prrte/commit/fd088cfb933c6db31fd13a30e3f91de29a4b6720)

Correctly set parent rank so that the OOB can
correctly identify its lifeline and cause the
daemon to abort when it dies. Fix the
`--debug-daemons-file` flag so it works, and
preserve the resulting output file from cleanup.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a87d17257225b430afaaa223ccae2bd90fce0d61)
[Remove unused MCA param](https://github.com/openpmix/prrte/commit/f1a42222dc937572f9f847f721c55bc3e5215656)

Session directories now always include the PID of the daemon

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/c4d5f8197a8d397dcdd0f3365b0a4396c541bb4a)

[Only trigger job failed to start once](https://github.com/openpmix/prrte/commit/7b8059413af724ff73bd2e9984a4bf36d088888a)

Trigger the "job failed to start" state only when the
first process to do so reports. This avoids a "bounce"
effect that causes the job object to be multiply
released.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a38651483c035a65f8e799d92e695a742190d5b6)
[Add "close stale issues" actions](https://github.com/openpmix/prrte/commit/7714e042ea4bd09f07589513ab2c598f228b96f7)

Ported from https://github.com/open-mpi/ompi/pull/12329

Thanks to @jsquyres!

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/31c948f57cd2fed8e338d8d7bd07090299202e30)

[oac: strengthen Sphinx check](https://github.com/openpmix/prrte/commit/aa2df0efcde389c030c7e8b8282e264b5751f79f)

Update oac submodule pointer to pick up a stronger test for
Sphinx. Also add (new) optional 3rd param to OAC_SETUP_SPHINX.

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/d3171cc050d36a92799dfc160f101aa2b6ade050)

[Revamp the session directory system](https://github.com/openpmix/prrte/commit/9d54edab4ace4449ebe5fb357301fed3e6770d81)

We now have multiple tools (e.g., psched, prte, and even
multiple prte instances) running on the same node. Keeping
all those session directory trees under a single root is
problematic and leading to inadvertent deletion of contact
files. So simplify things and put each instance under its
own session directory tree root.

Add the pid and uid to the session directory root name. Prefix
the root name with the argv[0] of the tool so we know what
generated it.

Fix an error in PRRTE that assumed the job-level session was
a global name. It is not - it is different for each job, so
we need to track it by job. Have the prte_job_t destructor
call the session_dir_destroy function to remove it when
the job is complete.

Fix refcounts so the job object destructor gets called upon
job completion.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/14dd8181df29bec60deca5e62c9d268b4849bc92)

[guard against possible segfault in prted](https://github.com/openpmix/prrte/commit/e22cf809034357a9dd27b9d7bc7fd6f8ef1f9649)

as it exits by removing unneeded activity

Signed-off-by: Howard Pritchard <howardp@lanl.gov>

pr feedback

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/025d5ab960a74cf5644a6eec44ce6a5dd8f13416)


