### PR TITLE
Check for appfile and ingest it if found

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -507,9 +507,6 @@ int main(int argc, char *argv[])
         }
         fclose(fp);
     }
-    for (n=0; NULL != pargv[n]; n++) {
-        fprintf(stderr, "APP: %s\n", pargv[n]);
-    }
 
     /* decide if we are to use a persistent DVM, or act alone */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DVM);


### PR DESCRIPTION
If someone specifies an appfile, then ingest its contents and add it to the argv array before constructing the app_contexts.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 2ed9b22b342e1d04c5f09089d9958e779f39a923)