### PR TITLE
Extend group operations to support bootstrap

### DIFF
--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -133,6 +133,7 @@ static void scon(prte_grpcomm_signature_t *p)
     p->sz = 0;
     p->addmembers = NULL;
     p->nmembers = 0;
+    p->bootstrap = 0;
 }
 static void sdes(prte_grpcomm_signature_t *p)
 {

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -70,6 +70,7 @@ typedef struct {
     size_t sz;
     pmix_proc_t *addmembers;
     size_t nmembers;
+    size_t bootstrap;
 } prte_grpcomm_signature_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_signature_t);
 

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -650,6 +650,13 @@ int prte_grpcomm_sig_pack(pmix_data_buffer_t *bkt,
         }
     }
 
+    // pack bootstrap number
+    rc = PMIx_Data_pack(NULL, bkt, &sig->bootstrap, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+
     if (NULL != sig->groupID) {
         // add the groupID if one is given
         rc = PMIx_Data_pack(NULL, bkt, &sig->groupID, 1, PMIX_STRING);

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -770,6 +770,15 @@ int prte_grpcomm_sig_unpack(pmix_data_buffer_t *buffer,
         }
     }
 
+    // unpack the bootstrap count
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &s->bootstrap, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(s);
+        return prte_pmix_convert_status(rc);
+    }
+
     // try and unpack the groupID - error is okay, just means
     // one wasn't provided
     save = buffer->unpack_ptr;


### PR DESCRIPTION
Sometimes participants wanting to form a group
have limited knowledge of their co-participants.
For example, two procs may know that they "lead"
their respective subgroups, but may not know the
members of the other "leaders" subgroup. In this
case, we need to let the two procs that know about their subgroups tell us what they know, and let
the other procs simply join the collection.

All we really require is that everyone know the
groupID for the group they are trying to form, and that each leader know how many leaders are going to participate. We can use events under-the-covers to notify non-leaders of the group formation.

This is a collaborative change with the PMIx library, so we protect PRRTE against earlier versions that
lack the appropriate attribute.