### PR TITLE
Properly handle group membership in bootstrap operations

### DIFF
--- a/src/mca/grpcomm/base/grpcomm_base_frame.c
+++ b/src/mca/grpcomm/base/grpcomm_base_frame.c
@@ -134,6 +134,8 @@ static void scon(prte_grpcomm_signature_t *p)
     p->addmembers = NULL;
     p->nmembers = 0;
     p->bootstrap = 0;
+    p->finalmembership = NULL;
+    p->nfinal = 0;
 }
 static void sdes(prte_grpcomm_signature_t *p)
 {
@@ -145,6 +147,9 @@ static void sdes(prte_grpcomm_signature_t *p)
     }
     if (NULL != p->addmembers) {
         free(p->addmembers);
+    }
+    if (NULL != p->finalmembership) {
+        free(p->finalmembership);
     }
 }
 PMIX_CLASS_INSTANCE(prte_grpcomm_signature_t,

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -71,6 +71,8 @@ typedef struct {
     pmix_proc_t *addmembers;
     size_t nmembers;
     size_t bootstrap;
+    pmix_proc_t *finalmembership;
+    size_t nfinal;
 } prte_grpcomm_signature_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_signature_t);
 

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -666,5 +666,19 @@ int prte_grpcomm_sig_pack(pmix_data_buffer_t *bkt,
         return prte_pmix_convert_status(rc);
     }
 
+    // pack final membership, if given
+    rc = PMIx_Data_pack(NULL, bkt, &sig->nfinal, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    if (0 < sig->nfinal) {
+        rc = PMIx_Data_pack(NULL, bkt, sig->finalmembership, sig->nfinal, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
+    }
+
     return PRTE_SUCCESS;
 }

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -789,6 +789,25 @@ int prte_grpcomm_sig_unpack(pmix_data_buffer_t *buffer,
         return prte_pmix_convert_status(rc);
     }
 
+    // unpack the final membership
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &s->nfinal, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(s);
+        return prte_pmix_convert_status(rc);
+    }
+    if (0 < s->nfinal) {
+        PMIX_PROC_CREATE(s->finalmembership, s->nfinal);
+        cnt = s->nfinal;
+        rc = PMIx_Data_unpack(NULL, buffer, s->finalmembership, &cnt, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(s);
+            return prte_pmix_convert_status(rc);
+        }
+    }
+
     *sig = s;
     return PRTE_SUCCESS;
 }


### PR DESCRIPTION
Create an aggregated group membership array while ensuring that duplicates are eliminated, including procs that are covered by a PMIX_RANK_WILDCARD entry. Communicate the final membership to both original callers and to invited additional members.