### PR TITLE
Revise cmd line parsing to handle special case

### DIFF
--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -99,13 +99,17 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     /* parse the cmd line - do this every time thru so we can
      * repopulate the globals */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
-    rc = schizo->parse_cli(argv, &results, PMIX_CLI_SILENT);
-    if (PRTE_SUCCESS != rc) {
-        if (PRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", argv[0], prte_strerror(rc));
+    if ('-' != argv[1][0]) {
+        results.tail = PMIx_Argv_copy(&argv[1]);
+    } else {
+        rc = schizo->parse_cli(argv, &results, PMIX_CLI_SILENT);
+        if (PRTE_SUCCESS != rc) {
+            if (PRTE_ERR_SILENT != rc) {
+                fprintf(stderr, "%s: command line error (%s)\n", argv[0], prte_strerror(rc));
+            }
+            PMIX_DESTRUCT(&results);
+            return rc;
         }
-        PMIX_DESTRUCT(&results);
-        return rc;
     }
     // sanity check the results
     rc = schizo->check_sanity(&results);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -460,16 +460,21 @@ int main(int argc, char *argv[])
 
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
-    rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
-    if (PRTE_SUCCESS != rc) {
-        PMIX_DESTRUCT(&results);
-        if (PRTE_OPERATION_SUCCEEDED == rc) {
-            return PRTE_SUCCESS;
+    // check for special case of executable immediately following tool
+    if (proxyrun && '-' != pargv[1][0]) {
+        results.tail = PMIx_Argv_copy(&pargv[1]);
+    } else {
+        rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DESTRUCT(&results);
+            if (PRTE_OPERATION_SUCCEEDED == rc) {
+                return PRTE_SUCCESS;
+            }
+            if (PRTE_ERR_SILENT != rc) {
+                fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
+            }
+            return rc;
         }
-        if (PRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
-        }
-        return rc;
     }
 
     /* check if we are running as root - if we are, then only allow


### PR DESCRIPTION
Deal with the scenario of "tool foo options" - i.e., where the executable immediately follows the tool name. Need to ensure the options don't get parsed as they belong to the executable.