### PR TITLE
Correct deprecation translation for use-hwthread-cpus

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -658,7 +658,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --use-hwthread-cpus -> --bind-to hwthread */
+        /* --use-hwthread-cpus -> --map-by hwtcpus */
         else if (0 == strcmp(option, "use-hwthread-cpus")) {
             rc = prte_schizo_base_add_qualifier(results, option,
                                                 PRTE_CLI_MAPBY, PRTE_CLI_HWTCPUS,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -564,10 +564,10 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --use-hwthread-cpus -> --bind-to hwthread */
+        /* --use-hwthread-cpus -> --map-by hwtcpus */
         else if (0 == strcmp(option, "use-hwthread-cpus")) {
             rc = prte_schizo_base_add_qualifier(results, option,
-                                                PRTE_CLI_BINDTO, PRTE_CLI_HWT,
+                                                PRTE_CLI_MAPBY, PRTE_CLI_HWTCPUS,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
             if (NULL != prte_set_slots) {


### PR DESCRIPTION
Translates to `--map-by :hwtcpus`.

Thanks to @albandi for the report.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 73a4d3f625e36c515f4a69f5e530e683020cf188)