### PR TITLE
Toughen the submodule checks in autogen.pl

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Build OpenPMIx
       run: |
         cd openpmix/master
+        git submodule update --init --recursive
         ./autogen.pl
         ./configure --prefix=$RUNNER_TEMP/pmixinstall
         make -j
@@ -33,6 +34,7 @@ jobs:
             clean: false
     - name: Build PRRTE
       run: |
+        git submodule update --init --recursive
         ./autogen.pl
 
         sphinx=
@@ -74,6 +76,7 @@ jobs:
     - name: Build OpenPMIx
       run: |
         cd openpmix/master
+        git submodule update --init --recursive
         ./autogen.pl
         ./configure --prefix=$RUNNER_TEMP/pmixinstall
         make -j
@@ -85,6 +88,7 @@ jobs:
             clean: false
     - name: Build PRRTE
       run: |
+        git submodule update --init --recursive
         ./autogen.pl
 
         sphinx=

--- a/autogen.pl
+++ b/autogen.pl
@@ -994,7 +994,7 @@ if (-f ".gitmodules") {
             next;
         }
         my $path = $1;
-
+        print("CHECKING \"$path\"\n");
         # Check that the path exists and is non-empty.
         my $happy = 1;
         my $havefiles = 1;

--- a/autogen.pl
+++ b/autogen.pl
@@ -996,10 +996,16 @@ if (-f ".gitmodules") {
         }
         my $path = $1;
         print("CHECKING \"$path\"\n");
+        if (-e $path) {
+            print("EXISTS");
+        } else {
+            print("DOES NOT EXIST");
+        }
         # Check that the path exists and is non-empty.
         my $happy = 1;
         my $havefiles = 1;
         if (! -d $path) {
+            print("IS NOT A DIRECTORY OR DOES NOT EXIST");
             $happy = 0;
         } else {
             opendir(DIR, $path) ||

--- a/autogen.pl
+++ b/autogen.pl
@@ -8,7 +8,7 @@
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2015      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 #
 # $COPYRIGHT$
@@ -981,33 +981,80 @@ verbose "\n$step. Checking for git submodules\n\n";
 # Make sure we got a submodule-full clone.  If not, abort and let a
 # human figure it out.
 if (-f ".gitmodules") {
-    open(IN, "git submodule status|")
-        || die "Can't run \"git submodule status\"";
-    while (<IN>) {
-        $_ =~ m/^(.)[0-9a-f]{40}\s+(\S+)/;
-        my $status = $1;
-        my $path   = $2;
+    print("   Doing some sanity checks for required submodule(s)...\n");
 
-        print("=== Submodule: $path\n");
-        # Make sure the submodule is there
-        if ($status eq "-") {
-            print("    ==> ERROR: Missing
+    # Do a quick sanity check to ensure that required
+    # submodule(s) are at least present (e.g., they won't be present
+    # if you downloaded a GitHub.com-created tarball).
+    open(IN, ".gitmodules") ||
+        die "Can't open .gitmodules";
+    while (<IN>) {
+        # Find "path = " lines
+        if (!($_ =~ m/^\s+path = (.+)$/)) {
+            next;
+        }
+        my $path = $1;
+
+        # Check that the path exists and is non-empty.
+        my $happy = 1;
+        my $havefiles = 1;
+        if (! -d $path) {
+            $happy = 0;
+        } else {
+            opendir(DIR, $path) ||
+                my_die "Can't open $path directory";
+            my @files = readdir(DIR);
+            closedir(DIR);
+
+            $havefiles = 0
+                if ($#files < 4);
+        }
+
+        if (!$happy) {
+            print("    ==> ERROR: Missing submodule directory
+
+The submodule path \"$path\" is missing.\n\n");
+            exit(1);
+        }
+
+        if (!$havefiles) {
+            print("    ==> ERROR: Missing submodule files
+
+The submodule \"$path\" files are missing.\n\n");
+            exit(1);
+        }
+
+    }
+    if (-d ".git") {
+        open(IN, "git submodule status|")
+            || die "Can't run \"git submodule status\"";
+        while (<IN>) {
+            $_ =~ m/^(.)[0-9a-f]{40}\s+(\S+)/;
+            my $status = $1;
+            my $path   = $2;
+
+            print("=== Submodule: $path\n");
+
+            # Make sure the submodule is there
+            if ($status eq "-") {
+                print("    ==> ERROR: Missing
 
 The submodule \"$path\" is missing.
 
 Perhaps you forgot to \"git clone --recursive ...\", or you need to
 \"git submodule update --init --recursive\"...?\n\n");
-            exit(1);
-        }
+                exit(1);
+            }
 
-        # See if the commit in the submodule is not the same as the
-        # commit that the git submodule thinks it should be.
-        elsif ($status eq "+") {
-            print("    ==> WARNING: Submodule hash is different than upstream.
-If this is not intentional, you may want to run:
-\"git submodule update --init --recursive\"\n");
-        } else {
-            print("    Local hash is what is expected by the submodule (good!)\n");
+            # See if the commit in the submodule is not the same as the
+            # commit that the git submodule thinks it should be.
+            elsif ($status eq "+") {
+                print("    ==> WARNING: Submodule hash is different than upstream.
+         If this is not intentional, you may want to run:
+         \"git submodule update --init --recursive\"\n");
+            } else {
+                print("    Local hash is what is expected by the submodule (good!)\n");
+            }
         }
     }
 }

--- a/autogen.pl
+++ b/autogen.pl
@@ -981,7 +981,8 @@ verbose "\n$step. Checking for git submodules\n\n";
 # Make sure we got a submodule-full clone.  If not, abort and let a
 # human figure it out.
 if (-f ".gitmodules") {
-    print("   Doing some sanity checks for required submodule(s)...\n");
+    my $mycwd = getcwd;
+    print("   Doing some sanity checks for required submodule(s)...in \"$mycwd\" \n");
 
     # Do a quick sanity check to ensure that required
     # submodule(s) are at least present (e.g., they won't be present


### PR DESCRIPTION
Based off of https://github.com/open-mpi/ompi/pull/12406. Modified to cover the case where the submodule's ".git" file exists, but the directory is actually unpopulated. Admittedly a "borked" installation, but surprisingly does happen.