### PR TITLE
Fix local group operations

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1314,7 +1314,8 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
 {
     prte_pmix_server_op_caddy_t *op;
 
-    pmix_output_verbose(2, prte_pmix_server_globals.output, "%s connect called with %d procs",
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s connect called with %d procs",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nprocs);
 
     /* protect ourselves */


### PR DESCRIPTION
Group operations that are purely local go thru an
optimized path, but still need to return the
right set of info so the client can correctly
track the group.