### PR TITLE
Allow execution without an active plm component

### DIFF
--- a/src/mca/plm/base/plm_base_select.c
+++ b/src/mca/plm/base/plm_base_select.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +48,18 @@ int prte_plm_base_select(void)
     /*
      * Select the best component
      */
-    if (PRTE_SUCCESS
-        == (rc = pmix_mca_base_select("plm", prte_plm_base_framework.framework_output,
-                                      &prte_plm_base_framework.framework_components,
-                                      (pmix_mca_base_module_t **) &best_module,
-                                      (pmix_mca_base_component_t **) &best_component, NULL))) {
+    rc = pmix_mca_base_select("plm", prte_plm_base_framework.framework_output,
+                              &prte_plm_base_framework.framework_components,
+                              (pmix_mca_base_module_t **) &best_module,
+                              (pmix_mca_base_component_t **) &best_component, NULL);
+    if (PMIX_SUCCESS == rc) {
         /* Save the winner */
         prte_plm = *best_module;
+    } else {
+        // leave the default in case they don't need a launcher - i.e.,
+        // for the use-case of purely local operations. We will generate
+        // an error when they try to launch daemons
+        rc = PRTE_SUCCESS;
     }
 
     return rc;

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -196,7 +196,6 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
     if (0 < jptr->num_procs) {
         prte_proc_t *proc;
         for (j = 0; j < jptr->num_procs; j++) {
-            n = 1;
             rc = prte_proc_unpack(bkt, &proc);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
In some circumstances, the environment may not contain any launch components - e.g., in a container that lacks ssh. We can still allow operation so long as they don't involve launch of a daemon onto another node.