### PR TITLE
Multiple commits

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1865,18 +1865,12 @@ int prte_hwloc_base_topology_set_flags(hwloc_topology_t topology, unsigned long 
 {
     if (io) {
 #if HWLOC_API_VERSION < 0x00020000
-        flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
         flags |= HWLOC_TOPOLOGY_FLAG_IO_DEVICES;
 #else
         int ret = hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
         if (0 != ret) {
             return ret;
         }
-#    if HWLOC_API_VERSION < 0x00020100
-        flags |= HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM;
-#    else
-        flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
-#    endif
 #endif
     }
     // Blacklist the "gl" component due to potential conflicts.

--- a/src/mca/plm/base/plm_base_select.c
+++ b/src/mca/plm/base/plm_base_select.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,13 +48,18 @@ int prte_plm_base_select(void)
     /*
      * Select the best component
      */
-    if (PRTE_SUCCESS
-        == (rc = pmix_mca_base_select("plm", prte_plm_base_framework.framework_output,
-                                      &prte_plm_base_framework.framework_components,
-                                      (pmix_mca_base_module_t **) &best_module,
-                                      (pmix_mca_base_component_t **) &best_component, NULL))) {
+    rc = pmix_mca_base_select("plm", prte_plm_base_framework.framework_output,
+                              &prte_plm_base_framework.framework_components,
+                              (pmix_mca_base_module_t **) &best_module,
+                              (pmix_mca_base_component_t **) &best_component, NULL);
+    if (PMIX_SUCCESS == rc) {
         /* Save the winner */
         prte_plm = *best_module;
+    } else {
+        // leave the default in case they don't need a launcher - i.e.,
+        // for the use-case of purely local operations. We will generate
+        // an error when they try to launch daemons
+        rc = PRTE_SUCCESS;
     }
 
     return rc;

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -196,7 +196,6 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
     if (0 < jptr->num_procs) {
         prte_proc_t *proc;
         for (j = 0; j < jptr->num_procs; j++) {
-            n = 1;
             rc = prte_proc_unpack(bkt, &proc);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
[Fix the binding algorithm to handle partial disablement](https://github.com/openpmix/prrte/commit/c3f741c3fd8d9ad5b278a1ae9cd76550bf995929)

We need to ignore the disallowed CPUs when computing bindings
so we don't incorrectly declare an object to be overloaded.
Easiest way to do that is to not include them in the cpuset
field of the HWLOC object - they will still be in the
complete_cpuset field if we need them.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f297a9e2eb96c2db9d7756853f56315ea5a127cd)

[Allow execution without an active plm component](https://github.com/openpmix/prrte/commit/7f18ca4c26627d524ddec60b8f764258da6af5c0)

In some circumstances, the environment may not contain any
launch components - e.g., in a container that lacks ssh.
We can still allow operation so long as they don't involve
launch of a daemon onto another node.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1c0c483f91bd22c97b7d41c2dd7b928a333e8a0c)
