### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/ess/base/ess_base_bootstrap.c
+++ b/src/mca/ess/base/ess_base_bootstrap.c
@@ -68,7 +68,7 @@ static pmix_status_t regex_parse_value_range(char *base, char *range,
                                              char ***names);
 static pmix_status_t read_file(char *regexp, char ***names);
 
-#if PMIX_NUMERIC_VERSION < 0x00040208
+#if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -128,8 +128,8 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
 
     /* if we are not launching, then we just assume that all
      * daemons share our topology */
-    if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)
-        && PMIX_CHECK_NSPACE(caddy->jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
+    if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
+        PMIX_CHECK_NSPACE(caddy->jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
         t = node->topology;
         for (i = 1; i < prte_node_pool->size; i++) {
@@ -345,7 +345,7 @@ static void stack_trace_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t
     int rc;
     pmix_byte_object_t bo;
 
-    PMIX_DATA_BUFFER_CONSTRUCT(&blob);    
+    PMIX_DATA_BUFFER_CONSTRUCT(&blob);
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     pmix_output_verbose(5, prte_plm_base_framework.framework_output,
@@ -640,7 +640,8 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(caddy);
 
-    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output, "%s plm:base:setup_job",
+    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                         "%s plm:base:setup_job",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
     if (PRTE_JOB_STATE_INIT != caddy->job_state) {
@@ -687,6 +688,16 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
         prte_set_attribute(&caddy->jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, PRTE_ATTR_LOCAL, timer, PMIX_POINTER);
         PMIX_POST_OBJECT(timer);
         prte_event_evtimer_add(timer->ev, &timer->tv);
+    }
+
+    // if we are not going to launch this job, then ensure we output something - otherwise,
+    // we will simply silently exit
+    if (!prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
+        !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL) &&
+        !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
+        // default to the devel map
+        prte_set_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, PRTE_ATTR_GLOBAL,
+                           NULL, PMIX_BOOL);
     }
 
     /* set the job state to the next position */

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -59,7 +59,7 @@
 
 #include "src/mca/ras/base/ras_private.h"
 
-#if PMIX_NUMERIC_VERSION < 0x00040208
+#if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/ras/simulator/ras_sim_component.c
+++ b/src/mca/ras/simulator/ras_sim_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -60,13 +60,13 @@ static int ras_sim_register(void)
 {
     pmix_mca_base_component_t *component = &prte_mca_ras_simulator_component.super;
 
-    prte_mca_ras_simulator_component.slots = "1";
+    prte_mca_ras_simulator_component.slots = NULL;
     (void) pmix_mca_base_component_var_register(component, "slots",
                                                 "Comma-separated list of number of slots on each node to simulate",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING,
                                                 &prte_mca_ras_simulator_component.slots);
 
-    prte_mca_ras_simulator_component.slots_max = "0";
+    prte_mca_ras_simulator_component.slots_max = NULL;
     (void) pmix_mca_base_component_var_register(component, "max_slots",
                                                 "Comma-separated list of number of max slots on each node to simulate",
                                                 PMIX_MCA_BASE_VAR_TYPE_STRING,

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -132,18 +132,17 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
             pmix_asprintf(&node->name, "%s%0*d", prefix, dig, i);
             node->state = PRTE_NODE_STATE_UP;
             node->slots_inuse = 0;
-            if (NULL == max_slot_cnt || NULL == max_slot_cnt[n]) {
-                node->slots_max = 0;
-            } else {
-                obj = hwloc_get_root_obj(t->topo);
-                node->slots_max = prte_hwloc_base_get_npus(t->topo, use_hwthread_cpus, available,
-                                                           obj);
-            }
             if (NULL == slot_cnt || NULL == slot_cnt[n]) {
                 obj = hwloc_get_root_obj(t->topo);
                 node->slots = prte_hwloc_base_get_npus(t->topo, use_hwthread_cpus, available, obj);
             } else {
                 node->slots = strtol(slot_cnt[n], NULL, 10);
+            }
+            if (NULL == max_slot_cnt || NULL == max_slot_cnt[n]) {
+                obj = hwloc_get_root_obj(t->topo);
+                node->slots_max = prte_hwloc_base_get_npus(t->topo, use_hwthread_cpus, available, obj);
+            } else {
+                node->slots_max = strtol(max_slot_cnt[n], NULL, 10);
             }
             PMIX_RETAIN(t);
             node->topology = t;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -71,7 +71,7 @@ static int prte_rmaps_rf_process_lsf_affinity_hostfile(prte_job_t *jdata, prte_r
 
 char *prte_rmaps_rank_file_slot_list = NULL;
 
-#if PMIX_NUMERIC_VERSION < 0x00040208
+#if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,7 +109,7 @@ static bool quickmatch(prte_node_t *nd, char *name)
     return false;
 }
 
-#if PMIX_NUMERIC_VERSION < 0x00040208
+#if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -256,7 +256,7 @@ static void shutdown_callback(int fd, short flags, void *arg)
     exit(PRTE_ERROR_DEFAULT_EXIT_CODE);
 }
 
-#if PMIX_NUMERIC_VERSION < 0x00040208
+#if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
     char *ret, *buff;


### PR DESCRIPTION
[Use of pmix_getline from PMIx started in v4.2.5](https://github.com/openpmix/prrte/commit/960ddde0763cc9446c3916c6dcbca4cfe6b96407)

Correct the protection to use static versions of
pmix_getline if PMIx version is less than v4.2.5

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5cde35d439a4361fca0c48090aa690bc3718d22f)

[Update the allocation simulator](https://github.com/openpmix/prrte/commit/90cae33233d8ac77d2a8011d60837cca55fa1856)

Always default the number of slots to the available cpus
in the topology. Ensure that we always display some form
of the resulting proces map, or else we will silently
exit.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f01e2a2f55a616a7704fa852c44fa3f19a050675)
