### PR TITLE
Correct name of help file for --hostfile

### DIFF
--- a/src/docs/show-help-files/Makefile.am
+++ b/src/docs/show-help-files/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2022-2023 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
-# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
 #
 # $COPYRIGHT$
 #
@@ -43,7 +43,7 @@ RST_SOURCE_FILES = \
         $(srcdir)/help-pterm.rst \
         $(srcdir)/help-cli.rst \
         $(srcdir)/help-dash-host.rst \
-        $(srcdir)/help-hostfiles.rst \
+        $(srcdir)/help-hostfile.rst \
         $(srcdir)/help-prte-hwloc-base.rst \
         $(srcdir)/help-prte-runtime.rst \
         $(srcdir)/help-prte-util.rst
@@ -62,7 +62,7 @@ ALL_TXT_BUILT = \
         $(TXT_OUTDIR)/help-pterm.txt \
         $(TXT_OUTDIR)/help-cli.txt \
         $(TXT_OUTDIR)/help-dash-host.txt \
-        $(TXT_OUTDIR)/help-hostfiles.txt \
+        $(TXT_OUTDIR)/help-hostfile.txt \
         $(TXT_OUTDIR)/help-prte-hwloc-base.txt \
         $(TXT_OUTDIR)/help-prte-runtime.txt \
         $(TXT_OUTDIR)/help-prte-util.txt

--- a/src/docs/show-help-files/help-hostfile.rst
+++ b/src/docs/show-help-files/help-hostfile.rst
@@ -15,6 +15,7 @@
    Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
    Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
    Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+   Copyright (c) 2024      Nanook Consulting  All rights reserved.
    $COPYRIGHT$
 
    Additional copyrights may follow

--- a/src/docs/show-help-files/index.rst
+++ b/src/docs/show-help-files/index.rst
@@ -33,6 +33,6 @@ harmelss by-products; we ignore them.
 
    Util <help-prte-util>
 
-   Hostfiles <help-hostfiles>
+   Hostfiles <help-hostfile>
 
    Dash host <help-dash-host>


### PR DESCRIPTION
It should be `help-hostfile.txt`, not `help-hostfiles.txt`

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit c34d91a3cf0ac83643239598cb753e8d1aa10dde)