### PR TITLE
Repair the binding algorithm

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1326,7 +1326,7 @@ void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
 
     /* if the cpuset is all zero, then something is wrong */
     if (hwloc_bitmap_iszero(cpuset)) {
-        snprintf(cores, sz, "\n%*c<NOT MAPPED/>\n", 20, ' ');
+        snprintf(cores, sz, "\n%*c<EMPTY CPUSET/>\n", 20, ' ');
     }
 
     /* if the cpuset includes all available cpus, and
@@ -1399,7 +1399,7 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
 
     /* if the cpuset is all zero, then something is wrong */
     if (hwloc_bitmap_iszero(cpuset)) {
-        return strdup("NOT MAPPED");
+        return strdup("EMPTY CPUSET");
     }
 
     /* if the cpuset includes all available cpus, and

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -635,27 +635,18 @@ int prte_rmaps_base_get_ncpus(prte_node_t *node,
 {
     int ncpus;
 
+    if (NULL == options->job_cpuset) {
+        hwloc_bitmap_copy(prte_rmaps_base.available, node->available);
+    } else {
+        hwloc_bitmap_and(prte_rmaps_base.available, node->available, options->job_cpuset);
+    }
+    if (NULL != obj) {
 #if HWLOC_API_VERSION < 0x20000
-    hwloc_obj_t root;
-    root = hwloc_get_root_obj(node->topology->topo);
-    if (NULL == options->job_cpuset) {
-        hwloc_bitmap_copy(prte_rmaps_base.available, root->allowed_cpuset);
-    } else {
-        hwloc_bitmap_and(prte_rmaps_base.available, root->allowed_cpuset, options->job_cpuset);
-    }
-    if (NULL != obj) {
         hwloc_bitmap_and(prte_rmaps_base.available, prte_rmaps_base.available, obj->allowed_cpuset);
-    }
 #else
-    if (NULL == options->job_cpuset) {
-        hwloc_bitmap_copy(prte_rmaps_base.available, hwloc_topology_get_allowed_cpuset(node->topology->topo));
-    } else {
-        hwloc_bitmap_and(prte_rmaps_base.available, hwloc_topology_get_allowed_cpuset(node->topology->topo), options->job_cpuset);
-    }
-    if (NULL != obj) {
         hwloc_bitmap_and(prte_rmaps_base.available, prte_rmaps_base.available, obj->cpuset);
-    }
 #endif
+    }
     if (options->use_hwthreads) {
         ncpus = hwloc_bitmap_weight(prte_rmaps_base.available);
     } else {
@@ -668,6 +659,7 @@ int prte_rmaps_base_get_ncpus(prte_node_t *node,
          */
         ncpus = hwloc_get_nbobjs_inside_cpuset_by_type(node->topology->topo, prte_rmaps_base.available, HWLOC_OBJ_CORE);
     }
+
     return ncpus;
 }
 


### PR DESCRIPTION
If we use one cpu from an object, then we will get a NULL response if we ask for the next object of that type within the remaining cpuset since not all of the cpus in the object are still available. This problem resulted from the recent change to only use available cpus in PRRTE topologies.

So instead scan across the cpus, check to see if it is inside the object of interest - if so, then we can bind to that cpu, if not then we keep searching.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 2d0a8408c9e313822ea6466bd22ed184b5978638)