### PR TITLE
Silence warning

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -834,7 +834,7 @@ static void _query(int sd, short args, void *cbdata)
                 }
                 PMIX_LOAD_PROCID(&pproc, jobid, PMIX_RANK_WILDCARD);
                 PMIX_INFO_LOAD(&info, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
-                ret = PMIx_Get(&pproc, PMIX_MEM_ALLOC_KIND, &info, 1, (void**)&value);
+                ret = PMIx_Get(&pproc, PMIX_MEM_ALLOC_KIND, &info, 1, &value);
                 if (PMIX_SUCCESS != ret) {
                     goto done;
                 }


### PR DESCRIPTION
Get takes a (pmix_value_t**), so don't cast it to (void**)