### PR TITLE
Enable devel-check by default in Git repos

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -55,6 +55,45 @@ jobs:
         make install
         make uninstall
 
+  ubuntuClang:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev clang
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: openpmix/master
+            ref: master
+    - name: Build OpenPMIx
+      run: |
+        cd openpmix/master
+        ./autogen.pl
+        CC=clang ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            clean: false
+    - name: Build PRRTE
+      run: |
+        ./autogen.pl
+
+        pip3 install -r docs/requirements.txt
+        sphinx=--enable-sphinx
+
+        c=./configure
+        CC=clang $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx
+        make -j
+        make install
+        make uninstall
+
   distcheck:
     runs-on: ubuntu-latest
     steps:

--- a/config/prte_summary.m4
+++ b/config/prte_summary.m4
@@ -6,7 +6,7 @@ dnl Copyright (c) 2016-2023 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -41,6 +41,12 @@ EOF
         echo "Debug build: no" >&2
     else
         echo "Debug build: yes" >&2
+    fi
+
+    if test $WANT_PICKY_COMPILER = 0 ; then
+        echo "Devel check enabled: no" >& 2
+    else
+        echo "Devel check enabled: yes" >& 2
     fi
 
     if test ! -z $with_prte_platform ; then

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -219,6 +219,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     int rc;
     prte_job_map_t *map = NULL;
     prte_node_t *node;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     /* setup the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);

--- a/src/prted/pmix/pmix_server_group.c
+++ b/src/prted/pmix/pmix_server_group.c
@@ -242,6 +242,7 @@ static void local_complete(int sd, short args, void *cbdata)
     pmix_server_pset_t *pset;
     pmix_data_array_t *members;
     pmix_proc_t *p;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     if (PMIX_GROUP_CONSTRUCT == cd->op) {
 
@@ -303,7 +304,6 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *grpid,
     int rc;
     size_t i;
     bool assignID = false;
-    pmix_server_pset_t *pset;
     bool fence = false;
     bool force_local = false;
     pmix_proc_t *members = NULL;

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -110,11 +110,6 @@ pmix_nspace_t prte_nspace_wildcard = {0};
 static bool util_initialized = false;
 static bool min_initialized = false;
 
-#if PRTE_CC_USE_PRAGMA_IDENT
-#    pragma ident PRTE_IDENT_STRING
-#elif PRTE_CC_USE_IDENT
-#    ident PRTE_IDENT_STRING
-#endif
 const char prte_version_string[] = PRTE_IDENT_STRING;
 
 static bool check_exist(char *path)


### PR DESCRIPTION
Now that we have a broader group of contributors starting to show up, we probably need to start paying more attention to code quality of contributions. Enable devel-check by default in Git clones that are configured with enable-debug.