### PR TITLE
Don't strip quotes from cmd line entries

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -320,8 +320,7 @@ int main(int argc, char *argv[])
         prte_tool_actual = "prte";
     }
     pargc = argc;
-    pargv = pmix_argv_copy_strip(argv); // strip any incoming quoted arguments
-
+    pargv = PMIx_Argv_copy(argv);
     /* save a pristine copy of the environment for launch purposes.
      * This MUST be done so that we can pass it to any local procs we
      * spawn - otherwise, those local procs will get a bunch of


### PR DESCRIPTION
We had problems in the past with quoted params, but stripping quotes also has consequences - not clear of the best solution. For now, let's try going the other way and see how many problems we encounter.