### PR TITLE
Github action: bring back MacOS builds

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -3,6 +3,78 @@ name: Build tests
 on: [pull_request]
 
 jobs:
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        path: ['non-vpath', 'vpath']
+        sphinx: ['no-sphinx', 'sphinx']
+    steps:
+    - name: Install dependencies
+      run: brew install libevent hwloc autoconf automake libtool
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: openpmix/master
+            ref: master
+    - name: Build OpenPMIx
+      run: |
+        cd openpmix/master
+        # Homebrew doesn't install Libevent's (or libev's) header or
+        # library files into a default search location.  Shrug.  So
+        # use pkg-config to get the location and explicitly pass it to
+        # configure.
+        libevent_cppflags=$(pkg-config libevent --cflags)
+        libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall \
+            CPPFLAGS=$libevent_cppflags \
+            LDFLAGS=$libevent_ldflags
+        make -j
+        make install
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            clean: false
+    - name: Build PRRTE
+      run: |
+        ./autogen.pl
+
+        sphinx=
+        if test "${{ matrix.sphinx }}" = sphinx; then
+            # The macos Github Action environment gets angry at us if
+            # we try to pip install into the global environment.  So
+            # make a virtual environment and install sphinx into that.
+            python -m venv venv
+            . ./venv/bin/activate
+            pip3 install -r docs/requirements.txt
+            sphinx=--enable-sphinx
+        fi
+
+        c=./configure
+        if test "${{ matrix.path }}" = vpath; then
+            mkdir build
+            cd build
+            c=../configure
+        fi
+
+        # Homebrew doesn't install Libevent's (or libev's) header or
+        # library files into a default search location.  Shrug.  So
+        # use pkg-config to get the location and explicitly pass it to
+        # configure.
+        libevent_cppflags=$(pkg-config libevent --cflags)
+        libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
+
+        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx \
+            CPPFLAGS=$libevent_cppflags \
+            LDFLAGS=$libevent_ldflags
+        make -j
+        make install
+        make uninstall
+
   ubuntu:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Fix the issues with the MacOS builds so that they work again in Github Action environments.