### PR TITLE
Multiple commits

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -516,6 +516,7 @@ static hwloc_obj_t df_search(hwloc_topology_t topo, hwloc_obj_t start, hwloc_obj
                              unsigned cache_level, unsigned int nobj, unsigned int *num_objs)
 {
     int search_depth;
+    PRTE_HIDE_UNUSED_PARAMS(start);
 
     search_depth = hwloc_get_type_depth(topo, target);
     if (HWLOC_TYPE_DEPTH_MULTIPLE == search_depth) {
@@ -1304,6 +1305,7 @@ static int bitmap_list_snprintf_exp(char *__hwloc_restrict buf, size_t buflen,
         }
     }
 #else
+    PRTE_HIDE_UNUSED_PARAMS(set, type);
     if (buflen > 0) {
         tmp[0] = '\0';
     }
@@ -1876,10 +1878,12 @@ int prte_hwloc_base_topology_set_flags(hwloc_topology_t topology, unsigned long 
     // Blacklist the "gl" component due to potential conflicts.
     // See "https://github.com/open-mpi/ompi/issues/10025" for
     // an explanation
+#ifdef HWLOC_VERSION_MAJOR
 #if HWLOC_VERSION_MAJOR > 2
     hwloc_topology_set_components(topology, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
 #elif HWLOC_VERSION_MAJOR == 2 && HWLOC_VERSION_MINOR >= 1
     hwloc_topology_set_components(topology, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "gl");
+#endif
 #endif
     return hwloc_topology_set_flags(topology, flags);
 }


### PR DESCRIPTION
[Minor fixes to allow compile with pre-stone age HWLOC](https://github.com/openpmix/prrte/commit/b4f1b5c9b8b3769b44db27472a35996f68750f2f)

Enables build against v1.11.8 and above.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ac80553642344186ab0dab393673f69a98f12b19)

[Protect against missing HWLOC object types](https://github.com/openpmix/prrte/commit/c61fd458f6a3072eace0632f8965941309a7fb5a)

If we are trying to bind to an HWLOC object type that is not
defined on a given node, then (a) if the binding policy was
specified by user, then error out; and (b) if we are using
a default binding policy, then simply do not bind.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5d210591f22931ebfc6ec19aa68319abeeb44261)
