### PR TITLE
Protect against LTO optimizer

### DIFF
--- a/config/prte_check_cflags.m4
+++ b/config/prte_check_cflags.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -39,4 +39,16 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
             else
                 AC_MSG_RESULT([yes])
             fi
+])
+
+
+AC_DEFUN([_PRTE_CHECK_LTO_FLAG], [
+    chkflg=`echo $1 | grep -- -flto`
+    if test -n "$chkflg"; then
+        AC_MSG_WARN([Configure has detected the presence of the -flto])
+        AC_MSG_WARN([compiler directive in $2. PRRTE does not currently])
+        AC_MSG_WARN([support this flag as it conflicts with the])
+        AC_MSG_WARN([plugin architecture of the PRRTE code base.])
+        AC_MSG_ERROR([Please remove this directive and re-run configure.])
+    fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -931,6 +931,19 @@ CPPFLAGS="$CPP_INCLUDES $CPPFLAGS $PRTE_FINAL_CPPFLAGS"
 LDFLAGS="$LDFLAGS $PRTE_FINAL_LDFLAGS"
 LIBS="$LIBS $PRTE_FINAL_LIBS"
 
+
+# We do not currently support the "lto" optimizer as it
+# aggregates all the headers from our plugins, resulting
+# in a configuration that generates warnings/errors when
+# passed through their optimizer phase. We therefore check
+# for the flag, and if found, output a message explaining
+# the situation and aborting configure
+_PRTE_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
+_PRTE_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
+_PRTE_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
+_PRTE_CHECK_LTO_FLAG($LIBS, LIBS)
+
+
 # restore any user-provided Werror flags
 AS_IF([test ! -z "$PRTE_CFLAGS_cache"], [CFLAGS="$CFLAGS $PRTE_CFLAGS_cache"])
 


### PR DESCRIPTION
We currently do not support the LTO optimizer
as it is incompatible with our plugin component
architecture. So detect it has been specified
in configure and error out with an explanation.

Includes suggestions from @jsquyres