### PR TITLE
Multiple commits

### DIFF
--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -99,13 +99,17 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv, pmix_list_
     /* parse the cmd line - do this every time thru so we can
      * repopulate the globals */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
-    rc = schizo->parse_cli(argv, &results, PMIX_CLI_SILENT);
-    if (PRTE_SUCCESS != rc) {
-        if (PRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", argv[0], prte_strerror(rc));
+    if ('-' != argv[1][0]) {
+        results.tail = PMIx_Argv_copy(&argv[1]);
+    } else {
+        rc = schizo->parse_cli(argv, &results, PMIX_CLI_SILENT);
+        if (PRTE_SUCCESS != rc) {
+            if (PRTE_ERR_SILENT != rc) {
+                fprintf(stderr, "%s: command line error (%s)\n", argv[0], prte_strerror(rc));
+            }
+            PMIX_DESTRUCT(&results);
+            return rc;
         }
-        PMIX_DESTRUCT(&results);
-        return rc;
     }
     // sanity check the results
     rc = schizo->check_sanity(&results);

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -141,33 +141,6 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
     PRTE_PMIX_WAKEUP_THREAD(lock);
 }
 
-static void setupcbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
-                        void *provided_cbdata, pmix_op_cbfunc_t cbfunc, void *cbdata)
-{
-    mylock_t *mylock = (mylock_t *) provided_cbdata;
-    size_t n;
-
-    if (NULL != info) {
-        mylock->ninfo = ninfo;
-        PMIX_INFO_CREATE(mylock->info, mylock->ninfo);
-        /* cycle across the provided info */
-        for (n = 0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&mylock->info[n], &info[n]);
-        }
-    } else {
-        mylock->info = NULL;
-        mylock->ninfo = 0;
-    }
-    mylock->status = status;
-
-    /* release the caller */
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, cbdata);
-    }
-
-    PRTE_PMIX_WAKEUP_THREAD(&mylock->lock);
-}
-
 static void spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
 {
     prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -436,16 +436,21 @@ int main(int argc, char *argv[])
 
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
-    rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
-    if (PRTE_SUCCESS != rc) {
-        PMIX_DESTRUCT(&results);
-        if (PRTE_OPERATION_SUCCEEDED == rc) {
-            return PRTE_SUCCESS;
+    // check for special case of executable immediately following tool
+    if (proxyrun && '-' != pargv[1][0]) {
+        results.tail = PMIx_Argv_copy(&pargv[1]);
+    } else {
+        rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DESTRUCT(&results);
+            if (PRTE_OPERATION_SUCCEEDED == rc) {
+                return PRTE_SUCCESS;
+            }
+            if (PRTE_ERR_SILENT != rc) {
+                fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
+            }
+            return rc;
         }
-        if (PRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
-        }
-        return rc;
     }
 
     /* check if we are running as root - if we are, then only allow

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -191,16 +191,21 @@ int prun(int argc, char *argv[])
 
     /* parse the input argv to get values, including everyone's MCA params */
     PMIX_CONSTRUCT(&results, pmix_cli_result_t);
-    rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
-    if (PRTE_SUCCESS != rc) {
-        PMIX_DESTRUCT(&results);
-        if (PRTE_OPERATION_SUCCEEDED == rc) {
-            return PRTE_SUCCESS;
+    // check for special case of executable immediately following tool
+    if ('-' != pargv[1][0]) {
+        results.tail = PMIx_Argv_copy(&pargv[1]);
+    } else {
+        rc = schizo->parse_cli(pargv, &results, PMIX_CLI_WARN);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DESTRUCT(&results);
+            if (PRTE_OPERATION_SUCCEEDED == rc) {
+                return PRTE_SUCCESS;
+            }
+            if (PRTE_ERR_SILENT != rc) {
+                fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
+            }
+            return rc;
         }
-        if (PRTE_ERR_SILENT != rc) {
-            fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
-        }
-        return rc;
     }
 
     /* check if we are running as root - if we are, then only allow


### PR DESCRIPTION
[Remove unused function](https://github.com/openpmix/prrte/commit/4bbccb0620a2e4605aac8abc94095b1db03ff2a0)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e204c73a265a4b1b51cf8ab89344637cb52c3f60)

[Revise cmd line parsing to handle special case](https://github.com/openpmix/prrte/commit/c951f07066eb4b7f7d4011426ef719eae1ff27a1)

Deal with the scenario of "tool foo options" - i.e., where the
executable immediately follows the tool name. Need to ensure
the options don't get parsed as they belong to the executable.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7c1690f9572725bb5f1f13e74b705f1908d3710e)
