### PR TITLE
docs: update for Python 3.12

### DIFF
--- a/src/docs/show-help-files/build-dummy-ini-files.py
+++ b/src/docs/show-help-files/build-dummy-ini-files.py
@@ -2,7 +2,7 @@
 #
 # Copyright 2023 Jeffrey M. Squyres.  All rights reserved.
 #
-# Copyright (c) 2023      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2023-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -57,7 +57,7 @@ for outfile in sys.argv:
     # Find all the "[section]" lines.
     sections = list()
     for line in src_rst:
-        match = re.search('\s*\[(.+)\]\s*$', line)
+        match = re.search(r"\s*\[(.+)\]\s*$", line)
         if match:
             sections.append(match.group(1))
 


### PR DESCRIPTION
Python 3.12 no longer allows escapes in regular expressions. Instead, use "r" strings.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 5906e63380728042619f94727d795e0be6b92f00)