### PR TITLE
3.0: fix support for MPIEXEC_TIMEOUT

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
     pmix_info_t *iptr, *iptr2, info;
     pmix_status_t ret;
     bool flag;
-    size_t n, m, ninfo, param_len;
+    size_t n, ninfo, param_len;
     pmix_app_t *papps;
     size_t napps;
     mylock_t mylock;
@@ -1085,11 +1085,11 @@ int main(int argc, char *argv[])
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_TIMEOUT);
     if (NULL != opt || NULL != (timeoutenv = getenv("MPIEXEC_TIMEOUT"))) {
         if (NULL != timeoutenv) {
-            m = strtoul(timeoutenv, NULL, 10);
+            i = strtol(timeoutenv, NULL, 10);
             /* both cannot be present, or they must agree */
             if (NULL != opt) {
-                n = strtoul(opt->values[0], NULL, 10);
-                if (m != n) {
+                n = strtol(opt->values[0], NULL, 10);
+                if (i != (int)n) {
                     pmix_show_help("help-prun.txt", "prun:timeoutconflict", false,
                                    prte_tool_basename, n, timeoutenv);
                     PRTE_UPDATE_EXIT_STATUS(1);


### PR DESCRIPTION
linter fix for comparison of int to uint resulted in MPIEXEC_TIMEOUT env being ignored. Affects openmpi >=5.0.3: https://github.com/open-mpi/ompi/issues/12837

Regression introduced in the non-cherry-picked commit 7948675dc1c0c5481e60ca67e8f8f0e6d1333473 in #1979 [here](https://github.com/openpmix/prrte/commit/7948675dc1c0c5481e60ca67e8f8f0e6d1333473#diff-071bbfcc38573dff1c5e4b0667acaf039043b1fbc9b324499c5b4388ac277ebcL1108-R1111) to satisfy `devel-check`.

master already had this fix for this warning in #1940 [here](https://github.com/openpmix/prrte/pull/1940/files#diff-071bbfcc38573dff1c5e4b0667acaf039043b1fbc9b324499c5b4388ac277ebcR1113), this PR makes 3.0x match master.

bot:notacherrypick