### PR TITLE
Fix deprecation warnings for ppr on socket objects

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -81,7 +81,7 @@ static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
     (void) pmix_mca_base_var_register("prte", "rmaps", "default", "mapping_policy",
                                       "Default mapping Policy [slot | hwthread | core | l1cache | "
                                       "l2cache | l3cache | numa | package | node | seq | dist | ppr | "
-                                      "rankfile | likwid | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
+                                      "rankfile | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
                                       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
                                       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
                                       "DEVICE=dev (for dist policy), INHERIT, NOINHERIT, ORDERED, FILE=%s (path to file containing sequential "

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -388,7 +388,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             options.maptype = HWLOC_OBJ_CORE;
             options.mapdepth = PRTE_BIND_TO_CORE;
         } else if (0 == strncasecmp(ck[1], "package", len) ||
-                   0 == strncasecmp(ck[1], "skt", len)) {
+                   0 == strncasecmp(ck[1], "skt", len) ||
+                   0 == strncasecmp(ck[1], "socket", len)) {
             options.maptype = HWLOC_OBJ_PACKAGE;
             options.mapdepth = PRTE_BIND_TO_PACKAGE;
         } else if (0 == strncasecmp(ck[1], "numa", len) ||

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -140,6 +140,8 @@ bool prte_schizo_base_check_directives(char *directive,
         PRTE_CLI_L3CACHE,
         PRTE_CLI_NUMA,
         PRTE_CLI_PACKAGE,
+        "socket",  // dealt with elsewhere
+        "skt",     // dealt with elsewhere
         PRTE_CLI_NODE,
         NULL
     };

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -929,6 +929,31 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 free(p1);
                 free(opt->values[0]);
                 opt->values[0] = tmp;
+            } else if (0 == strncasecmp(opt->values[0], "ppr", strlen("ppr"))) {
+                // see if they specified "socket" as the resource
+                p1 = strdup(opt->values[0]);
+                p2 = strrchr(p1, ':');
+                ++p2;
+                if (0 == strncasecmp(p2, "socket", strlen("socket")) ||
+                    0 == strncasecmp(p2, "skt", strlen("skt"))) {
+                    *p2 = '\0';
+                    pmix_asprintf(&p2, "%spackage", p1);
+                    if (warn) {
+                        pmix_asprintf(&tmp, "%s %s", option, opt->values[0]);
+                        pmix_asprintf(&tmp2, "%s %s", option, p2);
+                        /* can't just call show_help as we want every instance to be reported */
+                        output = pmix_show_help_string("help-schizo-base.txt",
+                                                       "deprecated-converted", true,
+                                                       tmp, tmp2);
+                        fprintf(stderr, "%s\n", output);
+                        free(output);
+                        free(tmp);
+                        free(tmp2);
+                    }
+                    free(opt->values[0]);
+                    opt->values[0] = p2;
+                }
+                free(p1);
             }
         }
         /* --rank-by socket ->  --rank-by package */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -821,6 +821,31 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 free(p1);
                 free(opt->values[0]);
                 opt->values[0] = tmp;
+            } else if (0 == strncasecmp(opt->values[0], "ppr", strlen("ppr"))) {
+                // see if they specified "socket" as the resource
+                p1 = strdup(opt->values[0]);
+                p2 = strrchr(p1, ':');
+                ++p2;
+                if (0 == strncasecmp(p2, "socket", strlen("socket")) ||
+                    0 == strncasecmp(p2, "skt", strlen("skt"))) {
+                    *p2 = '\0';
+                    pmix_asprintf(&p2, "%spackage", p1);
+                    if (warn) {
+                        pmix_asprintf(&tmp, "%s %s", option, opt->values[0]);
+                        pmix_asprintf(&tmp2, "%s %s", option, p2);
+                        /* can't just call show_help as we want every instance to be reported */
+                        output = pmix_show_help_string("help-schizo-base.txt",
+                                                       "deprecated-converted", true,
+                                                       tmp, tmp2);
+                        fprintf(stderr, "%s\n", output);
+                        free(output);
+                        free(tmp);
+                        free(tmp2);
+                    }
+                    free(opt->values[0]);
+                    opt->values[0] = p2;
+                }
+                free(p1);
             }
         }
         /* --rank-by */


### PR DESCRIPTION
We have deprecated the "socket" object in favor of "package", so we need to extend that treatment to
the resource qualifier in the `--map-by ppr` directive. Detect both "socket" and the "skt" shorthand for
backward-compatibility reasons.

Refs https://github.com/open-mpi/ompi/issues/12852