### PR TITLE
Unlock stdin target

### DIFF
--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -786,7 +786,7 @@ int prun_common(pmix_cli_result_t *results,
         } else if (0 == strcmp(opt->values[0], "none")) {
             pname.rank = PMIX_RANK_INVALID;
         } else {
-            pname.rank = 0;
+            pname.rank = strtoul(opt->values[0], NULL, 10);
         }
     } else {
         pname.rank = 0;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -1205,7 +1205,7 @@ int main(int argc, char *argv[])
         } else if (0 == strcmp(opt->values[0], "none")) {
             pname.rank = PMIX_RANK_INVALID;
         } else {
-            pname.rank = 0;
+            pname.rank = strtoul(opt->values[0], NULL, 10);
         }
     } else {
         pname.rank = 0;


### PR DESCRIPTION
Fix typo that locked the target to rank=0 and instead use the rank provided by user.

Fixes https://github.com/open-mpi/ompi/issues/12777
(requires submodule update)