### PR TITLE
Raise min required HWLOC version to 2.1.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -23,7 +23,7 @@ release=0
 # List in x.y.z format.
 
 pmix_min_version=4.2.4
-hwloc_min_version=1.11.0
+hwloc_min_version=2.1.0
 event_min_version=2.0.21
 automake_min_version=1.13.4
 autoconf_min_version=2.69.0

--- a/src/docs/show-help-files/help-prte-hwloc-base.txt
+++ b/src/docs/show-help-files/help-prte-hwloc-base.txt
@@ -50,7 +50,6 @@ unusual error; it may indicate a system configuration error.  This
 additional information may be of help:
 
    Message:     %s
-   Cache level: %d
 
 [missing-cpulist]
 

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -28,24 +28,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <hwloc.h>
-#if HWLOC_API_VERSION >= 0x20000
-#   include <hwloc/shmem.h>
-#endif
-
-#if HWLOC_API_VERSION < 0x10b00
-#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
-#define HWLOC_OBJ_PACKAGE HWLOC_OBJ_SOCKET
-#endif
-#if HWLOC_API_VERSION < 0x10a00
-static inline hwloc_obj_t hwloc_get_numanode_obj_by_os_index(hwloc_topology_t topology, unsigned os_index)
-{
-    hwloc_obj_t obj = NULL;
-    while ((obj = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, obj)) != NULL)
-        if (obj->os_index == os_index)
-            return obj;
-    return NULL;
-}
-#endif
+#include <hwloc/shmem.h>
 
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_value_array.h"
@@ -161,20 +144,6 @@ PRTE_EXPORT extern hwloc_obj_type_t prte_hwloc_levels[];
 PRTE_EXPORT extern char *prte_hwloc_default_cpu_list;
 PRTE_EXPORT extern bool prte_hwloc_default_use_hwthread_cpus;
 
-#if HWLOC_API_VERSION < 0x20000
-#    define HWLOC_OBJ_L3CACHE HWLOC_OBJ_CACHE
-#    define HWLOC_OBJ_L2CACHE HWLOC_OBJ_CACHE
-#    define HWLOC_OBJ_L1CACHE HWLOC_OBJ_CACHE
-#    if HWLOC_API_VERSION < 0x10a00
-#        define HWLOC_OBJ_PACKAGE HWLOC_OBJ_SOCKET
-#    endif
-#    define HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC 0
-#    define HAVE_HWLOC_TOPOLOGY_DUP          0
-#else
-#    define HAVE_DECL_HWLOC_OBJ_OSDEV_COPROC 1
-#    define HAVE_HWLOC_TOPOLOGY_DUP          1
-#endif
-
 /**
  * Debugging output stream
  */
@@ -209,20 +178,6 @@ PRTE_EXPORT extern bool prte_hwloc_synthetic_topo;
         }                                                                                       \
         hwloc_bitmap_free(bind);                                                                \
     } while (0);
-
-#if HWLOC_API_VERSION < 0x20000
-#    define PRTE_HWLOC_MAKE_OBJ_CACHE(level, obj, cache_level) \
-        do {                                                   \
-            obj = HWLOC_OBJ_CACHE;                             \
-            cache_level = level;                               \
-        } while (0)
-#else
-#    define PRTE_HWLOC_MAKE_OBJ_CACHE(level, obj, cache_level) \
-        do {                                                   \
-            obj = HWLOC_OBJ_L##level##CACHE;                   \
-            cache_level = 0;                                   \
-        } while (0)
-#endif
 
 PRTE_EXPORT prte_hwloc_locality_t prte_hwloc_base_get_relative_locality(hwloc_topology_t topo,
                                                                         char *cpuset1,
@@ -283,17 +238,6 @@ PRTE_EXPORT hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo
 
 PRTE_EXPORT hwloc_cpuset_t prte_hwloc_base_filter_cpus(hwloc_topology_t topo);
 
-/**
- * Free the hwloc topology.
- */
-PRTE_EXPORT unsigned int prte_hwloc_base_get_nbobjs_by_type(hwloc_topology_t topo,
-                                                            hwloc_obj_type_t target,
-                                                            unsigned cache_level);
-
-PRTE_EXPORT hwloc_obj_t prte_hwloc_base_get_obj_by_type(hwloc_topology_t topo,
-                                                        hwloc_obj_type_t target,
-                                                        unsigned cache_level,
-                                                        unsigned int instance);
 PRTE_EXPORT unsigned int prte_hwloc_base_get_obj_idx(hwloc_topology_t topo, hwloc_obj_t obj);
 
 /**
@@ -354,7 +298,7 @@ PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
 
 PRTE_EXPORT void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
                                              bool use_hwthread_cpus,
-                                             hwloc_topology_t topo, int *pkgnum, 
+                                             hwloc_topology_t topo, int *pkgnum,
                                              char *cores, int sz);
 
 /* get the hwloc object that corresponds to the given processor id  and type */

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -377,23 +377,12 @@ int prte_hwloc_base_set_default_binding(void *jd, void *opt)
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_PACKAGE);
             } else if (HWLOC_OBJ_NUMANODE== options->maptype) {
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_NUMA);
-#if HWLOC_API_VERSION < 0x20000
-            } else if (HWLOC_OBJ_CACHE == options->maptype) {
-                if (1 == options->cmaplvl) {
-                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L1CACHE);
-                } else if (2 == options->cmaplvl) {
-                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L2CACHE);
-                } else if (3 == options->cmaplvl) {
-                    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L3CACHE);
-                }
-#else
             } else if (HWLOC_OBJ_L1CACHE == options->maptype) {
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L1CACHE);
             } else if (HWLOC_OBJ_L2CACHE == options->maptype) {
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L2CACHE);
             } else if (HWLOC_OBJ_L3CACHE == options->maptype) {
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_L3CACHE);
-#endif
             } else if (HWLOC_OBJ_CORE == options->maptype) {
                 PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_CORE);
             } else if (HWLOC_OBJ_PU == options->maptype) {

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -198,11 +198,7 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
                                     context->app, __FILE__, __LINE__);
             }
             /* bind this proc to all available processors */
-#if HWLOC_API_VERSION < 0x20000
-            cpuset = root->allowed_cpuset;
-#else
             cpuset = (hwloc_cpuset_t)hwloc_topology_get_allowed_cpuset(prte_hwloc_topology);
-#endif
             rc = hwloc_set_cpubind(prte_hwloc_topology, cpuset, 0);
             /* if we got an error and this wasn't a default binding policy, then report it */
             if (rc < 0 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -83,29 +83,29 @@ void prte_plm_base_set_slots(prte_node_t *node)
 {
     if (0 == strncmp(prte_set_slots, "cores", strlen(prte_set_slots))) {
         if (NULL != node->topology && NULL != node->topology->topo) {
-            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                             HWLOC_OBJ_CORE, 0);
+            node->slots = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                   HWLOC_OBJ_CORE);
         }
     } else if (0 == strncmp(prte_set_slots, "sockets", strlen(prte_set_slots))) {
         if (NULL != node->topology && NULL != node->topology->topo) {
-            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                             HWLOC_OBJ_SOCKET, 0);
+            node->slots = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                   HWLOC_OBJ_SOCKET);
             if (0 == node->slots) {
                 /* some systems don't report sockets - in this case,
                  * use numanodes */
-                node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                 HWLOC_OBJ_NUMANODE, 0);
+                node->slots = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                       HWLOC_OBJ_NUMANODE);
             }
         }
     } else if (0 == strncmp(prte_set_slots, "numas", strlen(prte_set_slots))) {
         if (NULL != node->topology && NULL != node->topology->topo) {
-            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                             HWLOC_OBJ_NUMANODE, 0);
+            node->slots = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                   HWLOC_OBJ_NUMANODE);
         }
     } else if (0 == strncmp(prte_set_slots, "hwthreads", strlen(prte_set_slots))) {
         if (NULL != node->topology && NULL != node->topology->topo) {
-            node->slots = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                             HWLOC_OBJ_PU, 0);
+            node->slots = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                   HWLOC_OBJ_PU);
         }
     } else {
         /* must be a number */

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -400,13 +400,13 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             options.maptype = HWLOC_OBJ_NUMANODE;
             options.mapdepth = PRTE_BIND_TO_NUMA;
         } else if (0 == strncasecmp(ck[1], "l1cache", len)) {
-            PRTE_HWLOC_MAKE_OBJ_CACHE(1, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L1CACHE;
             options.mapdepth = PRTE_BIND_TO_L1CACHE;
         } else if (0 == strncasecmp(ck[1], "l2cache", len)) {
-            PRTE_HWLOC_MAKE_OBJ_CACHE(2, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L2CACHE;
             options.mapdepth = PRTE_BIND_TO_L2CACHE;
         } else if (0 == strncasecmp(ck[1], "l3cache", len)) {
-            PRTE_HWLOC_MAKE_OBJ_CACHE(3, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L3CACHE;
             options.mapdepth = PRTE_BIND_TO_L3CACHE;
         } else {
             /* unknown spec */
@@ -452,43 +452,34 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             } else if (HWLOC_OBJ_PACKAGE == options.maptype) {
                 /* add in #packages for each node */
                 PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        HWLOC_OBJ_PACKAGE, 0);
+                    app->num_procs += options.pprn * hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                                              HWLOC_OBJ_PACKAGE);
                 }
             } else if (HWLOC_OBJ_NUMANODE== options.maptype) {
                 /* add in #numa for each node */
                 PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        HWLOC_OBJ_NUMANODE, 0);
+                    app->num_procs += options.pprn * hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                                              HWLOC_OBJ_NUMANODE);
                 }
-#if HWLOC_API_VERSION < 0x20000
-            } else if (HWLOC_OBJ_CACHE == options.maptype) {
-                /* add in #cache for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        options.maptype, options.cmaplvl);
-                }
-#else
             } else if (HWLOC_OBJ_L1CACHE == options.maptype ||
                        HWLOC_OBJ_L2CACHE == options.maptype ||
                        HWLOC_OBJ_L3CACHE == options.maptype) {
                 /* add in #cache for each node */
                 PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        options.maptype, options.cmaplvl);
+                    app->num_procs += options.pprn * hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                                              options.maptype);
                 }
-#endif
             } else if (HWLOC_OBJ_CORE == options.maptype) {
                 /* add in #cores for each node */
                 PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        HWLOC_OBJ_CORE, 0);
+                    app->num_procs += options.pprn * hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                                              HWLOC_OBJ_CORE);
                 }
             } else if (HWLOC_OBJ_PU == options.maptype) {
                 /* add in #hwt for each node */
                 PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                                        HWLOC_OBJ_PU, 0);
+                    app->num_procs += options.pprn * hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                                              HWLOC_OBJ_PU);
                 }
             }
         } else {
@@ -575,15 +566,15 @@ ranking:
             break;
         case PRTE_MAPPING_BYL3CACHE:
             options.mapdepth = PRTE_BIND_TO_L3CACHE;
-            PRTE_HWLOC_MAKE_OBJ_CACHE(3, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L3CACHE;
             break;
         case PRTE_MAPPING_BYL2CACHE:
             options.mapdepth = PRTE_BIND_TO_L2CACHE;
-            PRTE_HWLOC_MAKE_OBJ_CACHE(2, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L2CACHE;
             break;
         case PRTE_MAPPING_BYL1CACHE:
             options.mapdepth = PRTE_BIND_TO_L1CACHE;
-            PRTE_HWLOC_MAKE_OBJ_CACHE(1, options.maptype, options.cmaplvl);
+            options.maptype = HWLOC_OBJ_L1CACHE;
             break;
         case PRTE_MAPPING_BYCORE:
             if (1 < options.cpus_per_rank &&
@@ -735,13 +726,13 @@ ranking:
             options.hwb = HWLOC_OBJ_NUMANODE;
             break;
         case PRTE_BIND_TO_L3CACHE:
-            PRTE_HWLOC_MAKE_OBJ_CACHE(3, options.hwb, options.clvl);
+            options.hwb = HWLOC_OBJ_L3CACHE;
             break;
         case PRTE_BIND_TO_L2CACHE:
-            PRTE_HWLOC_MAKE_OBJ_CACHE(2, options.hwb, options.clvl);
+            options.hwb = HWLOC_OBJ_L2CACHE;
             break;
         case PRTE_BIND_TO_L1CACHE:
-            PRTE_HWLOC_MAKE_OBJ_CACHE(1, options.hwb, options.clvl);
+            options.hwb = HWLOC_OBJ_L1CACHE;
             break;
         case PRTE_BIND_TO_CORE:
             options.hwb = HWLOC_OBJ_CORE;

--- a/src/mca/rmaps/base/rmaps_base_ranking.c
+++ b/src/mca/rmaps/base/rmaps_base_ranking.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Huawei Technologies Co., Ltd.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -196,11 +196,11 @@ int prte_rmaps_base_compute_vpids(prte_job_t *jdata,
                 continue;
             }
             lrank = 0;
-            nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                       options->maptype, options->cmaplvl);
+            nobjs = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                             options->maptype);
             for (k=0; k < nobjs; k++) {
-                obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                                      options->maptype, options->cmaplvl, k);
+                obj = hwloc_get_obj_by_type(node->topology->topo,
+                                            options->maptype, k);
                 for (m=0; m < node->procs->size; m++) {
                     proc = (prte_proc_t*)pmix_pointer_array_get_item(node->procs, m);
                     if (NULL == proc) {
@@ -247,14 +247,14 @@ int prte_rmaps_base_compute_vpids(prte_job_t *jdata,
                 if (NULL == node) {
                     continue;
                 }
-                nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                           options->maptype, options->cmaplvl);
+                nobjs = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                 options->maptype);
                 lrank = pass * nobjs;
                 /* make a pass across all objects on this node */
                 for (k=0; k < nobjs && rank < jdata->num_procs; k++) {
                     /* get this object */
-                    obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                                          options->maptype, options->cmaplvl, k);
+                    obj = hwloc_get_obj_by_type(node->topology->topo,
+                                                options->maptype, k);
                     /* find an unranked proc on this object */
                     for (m=0; m < node->procs->size && rank < jdata->num_procs; m++) {
                         proc = (prte_proc_t*)pmix_pointer_array_get_item(node->procs, m);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -637,11 +637,7 @@ int prte_rmaps_base_get_ncpus(prte_node_t *node,
         hwloc_bitmap_and(prte_rmaps_base.available, node->available, options->job_cpuset);
     }
     if (NULL != obj) {
-#if HWLOC_API_VERSION < 0x20000
-        hwloc_bitmap_and(prte_rmaps_base.available, prte_rmaps_base.available, obj->allowed_cpuset);
-#else
         hwloc_bitmap_and(prte_rmaps_base.available, prte_rmaps_base.available, obj->cpuset);
-#endif
     }
     if (options->use_hwthreads) {
         ncpus = hwloc_bitmap_weight(prte_rmaps_base.available);

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -110,23 +110,12 @@ static int ppr_mapper(prte_job_t *jdata,
             mapping = PRTE_MAPPING_BYPACKAGE;
     } else if (HWLOC_OBJ_NUMANODE== options->maptype) {
             mapping = PRTE_MAPPING_BYNUMA;
-#if HWLOC_API_VERSION < 0x20000
-    } else if (HWLOC_OBJ_CACHE == options->maptype) {
-        if (1 == options->cmaplvl) {
-            mapping = PRTE_MAPPING_BYL1CACHE;
-        } else if (2 == options->cmaplvl) {
-            mapping = PRTE_MAPPING_BYL2CACHE;
-        } else if (3 == options->cmaplvl) {
-            mapping = PRTE_MAPPING_BYL3CACHE;
-        }
-#else
     } else if (HWLOC_OBJ_L1CACHE == options->maptype) {
         mapping = PRTE_MAPPING_BYL1CACHE;
     } else if (HWLOC_OBJ_L2CACHE == options->maptype) {
         mapping = PRTE_MAPPING_BYL2CACHE;
     } else if (HWLOC_OBJ_L3CACHE == options->maptype) {
         mapping = PRTE_MAPPING_BYL3CACHE;
-#endif
     } else if (HWLOC_OBJ_CORE == options->maptype) {
         mapping = PRTE_MAPPING_BYCORE;
     } else if (HWLOC_OBJ_PU == options->maptype) {
@@ -247,8 +236,8 @@ static int ppr_mapper(prte_job_t *jdata,
                 }
             } else {
                 /* get the number of resources on this node */
-                nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                           options->maptype, options->cmaplvl);
+                nobjs = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                                 options->maptype);
                 if (0 == nobjs) {
                     continue;
                 }
@@ -267,8 +256,8 @@ static int ppr_mapper(prte_job_t *jdata,
                 }
                 /* map the specified number of procs to each such resource on this node */
                 for (i = 0; i < nobjs && nprocs_mapped < app->num_procs; i++) {
-                    obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                                          options->maptype, options->cmaplvl, i);
+                    obj = hwloc_get_obj_by_type(node->topology->topo,
+                                                options->maptype, i);
                     if (!prte_rmaps_base_check_avail(jdata, app, node, &node_list, obj, options)) {
                         continue;
                     }

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -432,11 +432,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 }
 
                 /* Mark these slots as taken on this node */
-#if HWLOC_API_VERSION < 0x20000
                 hwloc_bitmap_andnot(node->available, node->available, proc_bitmap);
-#else
-                hwloc_bitmap_andnot(node->available, node->available, proc_bitmap);
-#endif
 
                 /* cleanup */
                 free(cpu_bitmap);

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -97,7 +97,6 @@ typedef struct {
     unsigned ncpus;
     int nprocs;
     hwloc_obj_type_t maptype;
-    unsigned cmaplvl;
     /* #procs/resource as per PPR */
     int pprn;
 
@@ -112,7 +111,6 @@ typedef struct {
     prte_binding_policy_t bind;
     bool dobind;
     hwloc_obj_type_t hwb;
-    unsigned clvl;
     uint16_t limit;
 
     /* usage tracking */

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -627,8 +627,8 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
             /* have to delay checking for availability until we have the object */
 
             /* get the number of objects of this type on this node */
-            nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                       options->maptype, options->cmaplvl);
+            nobjs = hwloc_get_nbobjs_by_type(node->topology->topo,
+                                             options->maptype);
             if (0 == nobjs) {
                 /* this node doesn't have any objects of this type, so
                  * we might as well drop it from consideration */
@@ -647,8 +647,8 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                 pmix_output_verbose(10, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps:rr: assigning proc to object %d", j);
                 /* get the hwloc object */
-                obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                                      options->maptype, options->cmaplvl, j);
+                obj = hwloc_get_obj_by_type(node->topology->topo,
+                                            options->maptype, j);
                 if (NULL == obj) {
                     /* out of objects on this node */
                     break;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -793,11 +793,7 @@ release:
                             pmix_output(0, "COULD NOT GET BOUND CPU FOR RESOURCE RELEASE");
                             continue;
                         }
-#if HWLOC_API_VERSION < 0x20000
-                        tgt = obj->allowed_cpuset;
-#else
                         tgt = obj->cpuset;
-#endif
                     }
                     hwloc_bitmap_or(node->available, node->available, tgt);
                 }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -375,20 +375,12 @@ static void _query(int sd, short args, void *cbdata)
                     char *xmlbuffer = NULL;
                     int len;
                     kv = PMIX_NEW(prte_info_item_t);
-#if HWLOC_API_VERSION < 0x20000
-                    /* get this from the v1.x API */
-                    if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len)) {
-                        PMIX_RELEASE(kv);
-                        continue;
-                    }
-#else
                     /* get it from the v2 API */
                     if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
                                                              HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
                         PMIX_RELEASE(kv);
                         continue;
                     }
-#endif
                     PMIX_INFO_LIST_ADD(rc, results, PMIX_HWLOC_XML_V1, xmlbuffer, PMIX_STRING);
                     free(xmlbuffer);
                     if (PMIX_SUCCESS != rc) {
@@ -398,8 +390,6 @@ static void _query(int sd, short args, void *cbdata)
                 }
 
             } else if (0 == strcmp(q->keys[n], PMIX_HWLOC_XML_V2)) {
-                /* we cannot provide it if we are using v1.x */
-#if HWLOC_API_VERSION >= 0x20000
                 if (NULL != prte_hwloc_topology) {
                     char *xmlbuffer = NULL;
                     int len;
@@ -415,7 +405,6 @@ static void _query(int sd, short args, void *cbdata)
                         goto done;
                     }
                 }
-#endif
 
             } else if (0 == strcmp(q->keys[n], PMIX_PROC_URI)) {
                 /* they want our URI */
@@ -755,18 +744,10 @@ static void _query(int sd, short args, void *cbdata)
                         continue;
                     }
                     /* convert the topology to XML representation */
-#if HWLOC_API_VERSION < 0x20000
-                    /* get this from the v1.x API */
-                    if (0 != hwloc_topology_export_xmlbuffer(topo->topo, &str, &len)) {
-                        continue;
-                    }
-                    PMIX_INFO_LIST_ADD(rc, nodelist, PMIX_HWLOC_XML_V1, str, PMIX_STRING);
-#else
                     if (0 != hwloc_topology_export_xmlbuffer(topo->topo, &str, &len, 0)) {
                         continue;
                     }
                     PMIX_INFO_LIST_ADD(rc, nodelist, PMIX_HWLOC_XML_V2, str, PMIX_STRING);
-#endif
                     free(str);
                 }
                 /* convert list to array */

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -302,11 +302,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     /* total available physical memory */
     machine = hwloc_get_next_obj_by_type(prte_hwloc_topology, HWLOC_OBJ_MACHINE, NULL);
     if (NULL != machine) {
-#if HWLOC_API_VERSION < 0x20000
-        PMIX_INFO_LIST_ADD(ret, info, PMIX_AVAIL_PHYS_MEMORY, &machine->memory.total_memory, PMIX_UINT64);
-#else
         PMIX_INFO_LIST_ADD(ret, info, PMIX_AVAIL_PHYS_MEMORY, &machine->total_memory, PMIX_UINT64);
-#endif
     }
 
     /* pass the mapping policy used for this job */


### PR DESCRIPTION
We no longer support all the way to pre-StoneAge
versions.