### PR TITLE
Implement the PMIX_JOB_CHILD_SEP support

### DIFF
--- a/src/docs/show-help-files/help-state-base.txt
+++ b/src/docs/show-help-files/help-state-base.txt
@@ -40,3 +40,20 @@ behavior:
 
 You must specify one of the above in combination with NOTIFYERRORS in order
 to receive notifications of errors. Please correct the situation and try again.
+#
+[child-term]
+At least one child job is being terminated due to termination of
+its parent:
+
+  Parent: %s
+  Child:  %s
+
+This behavior is controlled by setting the PMIX_JOB_CHILD_SEP attribute
+in the job info provided at time of spawn for the child job. When set to
+"true", the runtime will "separate" the child from its parent and allow
+it to continue execution after parent termination. Note that this is only
+true for parents that normally terminate - abnormal termination will always
+result in a complete teardown of all child jobs.
+
+In the absence of the attribute, the runtime will default to the "true"
+behavior.

--- a/src/mca/state/base/help-state-base.txt
+++ b/src/mca/state/base/help-state-base.txt
@@ -3,7 +3,7 @@
 # Copyright (c) 2018      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -40,3 +40,20 @@ behavior:
 
 You must specify one of the above in combination with NOTIFYERRORS in order
 to receive notifications of errors. Please correct the situation and try again.
+#
+[child-term]
+At least one child job is being terminated due to termination of
+its parent:
+
+  Parent: %s
+  Child:  %s
+
+This behavior is controlled by setting the PMIX_JOB_CHILD_SEP attribute
+in the job info provided at time of spawn for the child job. When set to
+"true", the runtime will "separate" the child from its parent and allow
+it to continue execution after parent termination. Note that this is only
+true for parents that normally terminate - abnormal termination will always
+result in a complete teardown of all child jobs.
+
+In the absence of the attribute, the runtime will default to the "true"
+behavior.

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -368,6 +368,12 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+            /*** CHILD INDEPENDENCE  ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_CHILD_SEP)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_CHILD_SEP, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+
             /***   MAX RESTARTS  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAX_RESTARTS)) {
             for (i = 0; i < jdata->apps->size; i++) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -507,6 +507,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "ALLOC REF ID";
         case PRTE_JOB_BINDING_LIMIT:
             return "JOB BINDING LIMIT";
+        case PRTE_JOB_CHILD_SEP:
+            return "CHILD SEP";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -228,6 +228,9 @@ typedef uint16_t prte_job_flags_t;
                                                                        //         from the request
 #define PRTE_JOB_BINDING_LIMIT              (PRTE_JOB_START_KEY + 115) // (uint16_t) - Max number of procs to bind to specified
                                                                        //          target type before moving to next target
+#define PRTE_JOB_CHILD_SEP                  (PRTE_JOB_START_KEY + 116) // bool - child job is to be considered independent
+                                                                       //        from its parent, do not terminate if
+                                                                       //        parent dies first
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 


### PR DESCRIPTION
Provide an optional way to determine the fate of
child jobs if/when the parent job terminates. In
the current implementation, we do not support
continuation after parent job abnormally
terminates - has to be a normal termination.

Users can toggle the behavior by providing
the PMIX_JOB_CHILD_SEP attribute in their
job info passed to PMIx_Spawn. In the absence
of that attribute, we default to allowing the
child to continue executing.

Refs https://github.com/open-mpi/ompi/issues/12867