### PR TITLE
Implement the "limit" modifier for binding

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -111,6 +111,18 @@ typedef struct {
 } prte_hwloc_topo_data_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_hwloc_topo_data_t);
 
+/**
+ * Struct used to cache object-level data used
+ * when computing process placement - the struct
+ * is attached to the userdata of each object
+ * in the topology upon first use of that object
+ * in a placement computation
+ */
+typedef struct {
+    pmix_object_t super;
+    unsigned nprocs;
+} prte_hwloc_obj_data_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_hwloc_obj_data_t);
 
 /* define binding policies */
 typedef uint16_t prte_binding_policy_t;
@@ -262,6 +274,9 @@ PRTE_EXPORT unsigned int prte_hwloc_base_get_nbobjs_by_type(hwloc_topology_t top
 PRTE_EXPORT hwloc_obj_t prte_hwloc_base_get_obj_by_type(hwloc_topology_t topo,
                                                         hwloc_obj_type_t target,
                                                         unsigned int instance);
+
+// reset all obj counters
+PRTE_EXPORT void prte_hwloc_base_reset_counters(void);
 
 /**
  * Get the number of pu's under a given hwloc object.

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -683,3 +683,11 @@ PMIX_CLASS_INSTANCE(prte_hwloc_topo_data_t,
                     pmix_object_t,
                     topo_data_const, NULL);
 
+
+static void obj_data_const(prte_hwloc_obj_data_t *ptr)
+{
+    ptr->nprocs = 0;
+}
+PMIX_CLASS_INSTANCE(prte_hwloc_obj_data_t,
+                    pmix_object_t,
+                    obj_data_const, NULL);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -111,6 +111,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_BINDING_LIMIT, (void**) &u16ptr, PMIX_UINT16)) {
         options.limit = u16;
+        // reset any prior counters
+        prte_hwloc_base_reset_counters();
     }
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,


### PR DESCRIPTION
Sometimes a user wants to map/bind procs by an object type, but needs to limit the number of procs bound to any particular object to some arbitrary number (i.e., not the number of available CPUs on the object). Example might be to map/bind to a cache level, but limit the number of procs on any given cache to some smaller number before moving to the next cache.

Docs were updated to explain this in a prior commit.