### PR TITLE
Protect against NULL returned obj

### DIFF
--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -840,7 +840,12 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
         for(i = 0; NULL != cpus[i]; ++i) {
             // assume HNP has the same topology as other nodes
             obj = hwloc_get_pu_obj_by_os_index(my_topo->topo, strtol(cpus[i], NULL, 10)) ;
-
+            if (NULL == obj) {
+                PMIX_ARGV_FREE_COMPAT(cpus);
+                fclose(fp);
+                close(fp_rank);
+                return PRTE_ERROR;
+            }
             free(cpus[i]);
             // 10 max number of digits in an int
             cpus[i] = (char*)malloc(sizeof(char) * 10);


### PR DESCRIPTION
Running into issues with LSF and the way they are indexing objects in their affinity files. Try to avoid a segfault in favor of just erroring out.