### PR TITLE
Fix support for hetero LSF environments

### DIFF
--- a/src/docs/show-help-files/help-rmaps_rank_file.txt
+++ b/src/docs/show-help-files/help-rmaps_rank_file.txt
@@ -102,3 +102,9 @@ to a different process.
 If this is intentional then you must pass the "overload-allowed"
 qualifier to the --bind-to option.
   --bind-to :overload-allowed
+#
+[resource-not-found]
+The specified LSF affinity file contained a node (%s) that is not in your
+allocation. We therefore cannot map a process rank to it. Please
+check your allocation and affinity file to ensure the latter only
+contains allocated nodes.


### PR DESCRIPTION
Don't assume that all nodes share the same topology as the HNP - it is an unnecessary restriction since we know the actual topology of each node.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit c515f92c301ded306532cd84448414d1109f927d)