### PR TITLE
Protect against old PMIx versions

### DIFF
--- a/examples/dynamic-dep.c
+++ b/examples/dynamic-dep.c
@@ -42,6 +42,14 @@ static pmix_proc_t myproc;
 
 int main(int argc, char **argv)
 {
+
+#ifndef PMIX_SPAWN_CHILD_SEP
+    EXAMPLES_HIDE_UNUSED_PARAMS(argc, argv);
+
+    fprintf(stderr, "PMIX_SPAWN_CHILD_SEP is not available - this example is not supported\n");
+    return -1;
+#else
+
     int rc, exitcode;
     char nsp2[PMIX_MAX_NSLEN + 1];
     pmix_proc_t proc;
@@ -97,4 +105,5 @@ done:
 
     fflush(stderr);
     return (0);
+#endif
 }

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -38,6 +38,20 @@
 #include "grpcomm_direct.h"
 #include "src/mca/grpcomm/base/base.h"
 
+#if PMIX_NUMERIC_VERSION < 0x00060000
+
+int prte_grpcomm_direct_group(pmix_group_operation_t op, char *grpid,
+                              const pmix_proc_t procs[], size_t nprocs,
+                              const pmix_info_t directives[], size_t ndirs,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(op, grpid, procs, nprocs, directives, ndirs, cbfunc, cbdata);
+
+    return PRTE_ERR_NOT_SUPPORTED;
+}
+
+#else
+
 static void group(int sd, short args, void *cbdata);
 
 static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *sig, bool create);
@@ -1397,3 +1411,5 @@ static int unpack_signature(pmix_data_buffer_t *buffer,
     *sig = s;
     return PRTE_SUCCESS;
 }
+
+#endif

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -347,6 +347,10 @@ PRTE_EXPORT int prte_pmix_register_cleanup(char *path, bool directory, bool igno
 #else
 #define PMIX_SETENV_COMPAT(a, b, c, d) \
         PMIx_Setenv(a, b, c, d)
+#endif
+
+#ifndef PMIX_GROUP_NONE
+#define PMIX_GROUP_NONE 2
 #endif
 
 END_C_DECLS

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -368,11 +368,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+#ifdef PMIX_SPAWN_CHILD_SEP
             /*** CHILD INDEPENDENCE  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_CHILD_SEP)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_CHILD_SEP, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
+#endif
 
             /***   MAX RESTARTS  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAX_RESTARTS)) {

--- a/src/prted/pmix/pmix_server_group.c
+++ b/src/prted/pmix/pmix_server_group.c
@@ -58,6 +58,20 @@
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
+#if PMIX_NUMERIC_VERSION < 0x00060000
+
+pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *grpid,
+                                   const pmix_proc_t procs[], size_t nprocs,
+                                   const pmix_info_t directives[], size_t ndirs,
+                                   pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(op, grpid, procs, nprocs, directives, ndirs, cbfunc, cbdata);
+
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+#else
+
 static void relcb(void *cbdata)
 {
     prte_pmix_grp_caddy_t *cd = (prte_pmix_grp_caddy_t*)cbdata;
@@ -275,3 +289,5 @@ pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *grpid,
     }
     return rc;
 }
+
+#endif


### PR DESCRIPTION
We technically support back to PMIx v4.2.4, so protect a few spots that depend on newer versions.