### PR TITLE
Protect against old PMIx versions

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -518,11 +518,13 @@ static void interim(int sd, short args, void *cbdata)
             prte_set_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+#ifdef PMIX_SPAWN_CHILD_SEP
             /*** CHILD INDEPENDENCE  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_CHILD_SEP)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_CHILD_SEP, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
+#endif
 
             /***   MAX RESTARTS  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAX_RESTARTS)) {


### PR DESCRIPTION
We technically support back to PMIx v4.2.4, so protect against an attribute definition that doesn't go that far back.

bot:notacherrypick