### PR TITLE
Register the singleton's nspace with the PMIx server

### DIFF
--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -104,6 +104,7 @@
 #include "src/runtime/runtime.h"
 
 #include "include/prte.h"
+#include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/prted/prted.h"
 
@@ -1437,7 +1438,10 @@ static int prep_singleton(const char *name)
     node->num_procs = 1;
     node->slots_inuse = 1;
 
-    return PRTE_SUCCESS;
+    // register the info with our PMIx server
+    rc = prte_pmix_server_register_nspace(jdata);
+
+    return rc;
 }
 
 static void signal_forward_callback(int signum, short args, void *cbdata)


### PR DESCRIPTION
Once we have created the necessary PRRTE infrastructure to support the singleton, we need to register that info with our internal PMIx server so it can be served to any requesting clients.