### PR TITLE
Multiple commits

### DIFF
--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -182,7 +182,8 @@ void prte_data_server(int status, pmix_proc_t *sender,
     prte_data_object_t *data;
     pmix_data_buffer_t *answer, *reply;
     int rc, k;
-    uint32_t ninfo, i;
+    size_t ninfo;
+    uint32_t i;
     char **keys = NULL, *str;
     bool wait = false;
     int room_number;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -104,6 +104,7 @@
 #include "src/runtime/runtime.h"
 
 #include "include/prte.h"
+#include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/prted/prted.h"
 
@@ -1435,7 +1436,10 @@ static int prep_singleton(const char *name)
     node->num_procs = 1;
     node->slots_inuse = 1;
 
-    return PRTE_SUCCESS;
+    // register the info with our PMIx server
+    rc = prte_pmix_server_register_nspace(jdata);
+
+    return rc;
 }
 
 static void signal_forward_callback(int signum, short args, void *cbdata)


### PR DESCRIPTION
[Register the singleton's nspace with the PMIx server](https://github.com/openpmix/prrte/commit/394283eef099696566340d4986c85e8ef1219c9d)

Once we have created the necessary PRRTE infrastructure
to support the singleton, we need to register that info
with our internal PMIx server so it can be served to
any requesting clients.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/89fdffe9ea807d9de765f0e82506a297f109ba8c)

[Fix data type declaration in data server](https://github.com/openpmix/prrte/commit/a55b7e9eb6ab91abcb442af4bf215d29f6fa5c73)

The ninfo variable is used as a size_t, so declare
it as such.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/0bfee1d11c760f5e6f9ac2f20ef98c0adebce732)
