### PR TITLE
Enclose XML output in a high-level tag

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -251,6 +251,13 @@ static int rte_init(int argc, char **argv)
         error = "pmix_server_init";
         goto error;
     }
+
+    /* if we are using xml for output, put a start tag */
+    if (prte_xml_output) {
+        fprintf(stdout, "<%s>\n", prte_tool_basename);
+        fflush(stdout);
+    }
+
     /* Setup the communication infrastructure */
     if (PRTE_SUCCESS
         != (ret = pmix_mca_base_framework_open(&prte_prtereachable_base_framework,
@@ -446,6 +453,11 @@ static int rte_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_state_base_framework);
 
     free(prte_topo_signature);
+
+    if (prte_xml_output) {
+        fprintf(stdout, "</%s>\n", prte_tool_basename);
+        fflush(stdout);
+    }
 
     /* shutdown the pmix server */
     pmix_server_finalize();

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -684,6 +684,16 @@ int pmix_server_init(void)
             rc = prte_pmix_convert_status(prc);
             return rc;
         }
+        /* tell the IOF system to format our output in XML, if requested */
+        if (prte_xml_output) {
+            flag = true;
+            PMIX_INFO_LIST_ADD(prc, ilist, PMIX_IOF_XML_OUTPUT, &flag, PMIX_BOOL);
+            if (PMIX_SUCCESS != prc) {
+                PMIX_INFO_LIST_RELEASE(ilist);
+                rc = prte_pmix_convert_status(prc);
+                return rc;
+            }
+        }
         /* if requested, tell the server to drop a system-level
          * PMIx connection point - only do this for the HNP as, in
          * at least one case, a daemon can be colocated with the

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -77,6 +77,7 @@ bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;
 bool prte_show_launch_progress = false;
 bool prte_bootstrap_setup = false;
+bool prte_xml_output = false;
 
 /* PRTE OOB port flags */
 bool prte_static_ports = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -536,6 +536,7 @@ PRTE_EXPORT extern pmix_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
+PRTE_EXPORT extern bool prte_xml_output;
 
 /* PRTE OOB port flags */
 PRTE_EXPORT extern bool prte_static_ports;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -453,6 +453,18 @@ int main(int argc, char *argv[])
             return rc;
         }
     }
+    // check if they asked for XML output from us
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
+    if (NULL != opt) {
+        split = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        for (n = 0; NULL != split[n]; n++) {
+            if (PMIX_CHECK_CLI_OPTION(split[n], PRTE_CLI_XML)) {
+                prte_xml_output = true;
+                break;
+            }
+        }
+        PMIX_ARGV_FREE_COMPAT(split);
+    }
 
     /* check if we are running as root - if we are, then only allow
      * us to proceed if the allow-run-as-root flag was given. Otherwise,


### PR DESCRIPTION
Trap output between a high-level tag
(e.g., <prterun>...</prterun>). Note that
show_help output will still not be XML formatted,
and any output prior to setting up the IOF
subsystem will also not be formatted.

Fixes https://github.com/openpmix/openpmix/issues/3450