### PR TITLE
Multiple commits

### DIFF
--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -252,6 +252,13 @@ static int rte_init(int argc, char **argv)
         error = "pmix_server_init";
         goto error;
     }
+
+    /* if we are using xml for output, put a start tag */
+    if (prte_xml_output) {
+        fprintf(stdout, "<%s>\n", prte_tool_basename);
+        fflush(stdout);
+    }
+
     /* Setup the communication infrastructure */
     if (PRTE_SUCCESS
         != (ret = pmix_mca_base_framework_open(&prte_prtereachable_base_framework,
@@ -489,6 +496,11 @@ static int rte_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_state_base_framework);
 
     free(prte_topo_signature);
+
+    if (prte_xml_output) {
+        fprintf(stdout, "</%s>\n", prte_tool_basename);
+        fflush(stdout);
+    }
 
     /* shutdown the pmix server */
     pmix_server_finalize();

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -77,6 +77,7 @@ bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;
 bool prte_show_launch_progress = false;
 bool prte_bootstrap_setup = false;
+bool prte_xml_output = false;
 
 /* PRTE OOB port flags */
 bool prte_static_ports = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -510,6 +510,7 @@ PRTE_EXPORT extern pmix_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
+PRTE_EXPORT extern bool prte_xml_output;
 
 /* PRTE OOB port flags */
 PRTE_EXPORT extern bool prte_static_ports;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -453,6 +453,18 @@ int main(int argc, char *argv[])
             return rc;
         }
     }
+    // check if they asked for XML output from us
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
+    if (NULL != opt) {
+        split = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        for (n = 0; NULL != split[n]; n++) {
+            if (PMIX_CHECK_CLI_OPTION(split[n], PRTE_CLI_XML)) {
+                prte_xml_output = true;
+                break;
+            }
+        }
+        PMIX_ARGV_FREE_COMPAT(split);
+    }
 
     /* check if we are running as root - if we are, then only allow
      * us to proceed if the allow-run-as-root flag was given. Otherwise,


### PR DESCRIPTION
[Enclose XML output in a high-level tag](https://github.com/openpmix/prrte/commit/cbc2c5815cdd51e3d7129ec9b97a5337a86427b2)

Trap output between a high-level tag
(e.g., <prterun>...</prterun>). Note that
show_help output will still not be XML formatted,
and any output prior to setting up the IOF
subsystem will also not be formatted.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/91c77cd5bd0a3218b11f18f7d4f9edfcb263cefe)

[Add support for show_help XML output](https://github.com/openpmix/prrte/commit/1e0d7cfaa9e5d5ad9ae8fecb9289549623cd6230)

Tell the PMIx server that we want our output
done in XML format, which will then apply to
show_help.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e78a2979e50743685a742cc93a5557f3e8c5e241)

[Properly build the nidmap](https://github.com/openpmix/prrte/commit/fad93aa96675c25e772b23ef53144b8373786466)

When operating in a managed environment where the
user subdivides the allocation (e.g., by providing
a hostfile that contains only some of the allocated
nodes), the nidmap was overrunning the allocated
array for daemon vpids. Properly index the vpid
entries to avoid the memory corruption problem.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/cfda8004f7907ad3d5d7d7e748f8722fdcc04b59)