### PR TITLE
Complete cleanup of support of PMIx group operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,8 @@ test/spawn_multiple
 test/clichk
 test/chkfs
 
+test/mpi/create_comm_from_group
+
 docs/_build
 docs/_static
 docs/_static/css/custom.css

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -115,7 +115,7 @@ static void group(int sd, short args, void *cbdata)
     if (NULL != cd->procs) {
         sig.nmembers = cd->nprocs;
         PMIX_PROC_CREATE(sig.members, sig.nmembers);
-        memcpy(sig.members, cd->procs, cd->nprocs * sizeof(pmix_proc_t));
+        memcpy(sig.members, cd->procs, sig.nmembers * sizeof(pmix_proc_t));
     }
     sig.op = cd->op;
 
@@ -262,7 +262,7 @@ static void group(int sd, short args, void *cbdata)
 
     /* send this to ourselves for processing */
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                         "%s grpcomm:direct:grp_construct sending to ourself",
+                         "%s grpcomm:direct:grp sending to ourself",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
     PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, relay,
@@ -301,7 +301,7 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                         "%s grpcomm:direct grp_construct recvd from %s",
+                         "%s grpcomm:direct grp recvd from %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)));
 
     // empty buffer indicates lost connection

--- a/test/mpi/create_comm_from_group.c
+++ b/test/mpi/create_comm_from_group.c
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+
+int main(int argc, char* argv[])
+{
+    int rc;
+    int size, my_rank;
+    MPI_Group world_group;
+    MPI_Comm foo;
+    char *err;
+    int len;
+    int ranks[2] = {0, 1};
+    MPI_Group new_group;
+    MPI_Comm new_communicator = MPI_COMM_NULL;
+    int value;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    if (3 > size)
+    {
+        printf("Please run this application with at least 3 processes.\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+
+    MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+
+    // create an initial communicator from comm_world
+    rc = MPI_Comm_create_from_group(world_group, "mygroup", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &foo);
+    MPI_Error_string(rc, err, &len);
+    printf("Process %d creating comm from mygroup result: %s(%d)\n", my_rank, err, rc);
+
+    // Keep only the processes 0 and 1 in the new group.
+    MPI_Group_incl(world_group, 2, ranks, &new_group);
+
+    // Create a new communicator from that group of processes.
+    if (my_rank < 2){
+        rc = MPI_Comm_create_from_group(new_group, "mygroup2", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &new_communicator);
+        MPI_Error_string(rc, err, &len);
+        printf("Process %d succeeded %s(%d)\n", my_rank, err, rc);
+    }
+
+    // Do a broadcast between all processes
+    MPI_Bcast(&value, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    printf("Process %d took part to the global communicator broadcast.\n", my_rank);
+
+    // Let's wait all processes before proceeding to the second phase.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Do a broadcast only between the processes of the new communicator.
+    if(new_communicator == MPI_COMM_NULL)
+    {
+        printf("Process %d did not take part to the new communicator broadcast.\n", my_rank);
+    } else {
+        MPI_Bcast(&value, 1, MPI_INT, 0, new_communicator);
+        printf("Process %d took part to the new communicator broadcast.\n", my_rank);
+    }
+
+    MPI_Finalize();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Support the basic construct/destruct operation where every process participates with the full parameter list. Include a new MPI test