### PR TITLE
configure.ac: generate prte_version.h properly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,8 @@ AC_MSG_RESULT([$ltversion])
 
 # List header files to generate
 
-AC_CONFIG_HEADERS([src/include/prte_config.h])
+AC_CONFIG_HEADERS([src/include/prte_config.h
+                   include/prte_version.h])
 
 prte_show_subtitle "Initialization, setup"
 
@@ -1016,7 +1017,6 @@ AC_CONFIG_FILES([
     config/Makefile
     contrib/Makefile
     include/Makefile
-    include/prte_version.h
     docs/Makefile
     src/docs/Makefile
     src/docs/prrte-rst-content/Makefile


### PR DESCRIPTION
Have prte_version.h generated via AC_CONFIG_HEADERS, not AC_CONFIG_FILES.  This properly quotes strings (which technically doesn't matter here since prte_version.h doesn't include any strings) and also won't overwrite the resulting .h file if it hasn't changed.

NOTE: This is a fix for the original commit that brought in this functionality (4da431af56) which broke in at least some Linux environments.  Apparently, AC_CONFIG_HEADERS -- unlike AC_CONFIG_FILES -- does not like extra newlines at the beginning or end of the file list parameter in at least some Linux environments (although it seems to work find on macOS).  Shrug!

Signed-off-by: Jeff Squyres <jeff@squyres.com>
(cherry picked from commit b7196af5789cac03b4ef7fd01feecec73a25877a)