### PR TITLE
maintain correct  ref count of child jobs

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -866,6 +866,8 @@ release:
 
 static void cleanup_job(int sd, short args, void *cbdata)
 {
+    pmix_proc_t *nptr;
+    prte_job_t *parent;
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -876,6 +878,16 @@ static void cleanup_job(int sd, short args, void *cbdata)
         prte_plm.terminate_orteds();
     }
     if (NULL != caddy->jdata) {
+        /* if the job had a spawn parent remove it from the parents child list */
+        if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC)) {
+            if(NULL != (parent = prte_get_job_data_object(nptr->nspace)) &&
+            !PMIX_CHECK_NSPACE(parent->nspace, PRTE_PROC_MY_NAME->nspace)){
+                pmix_list_remove_item(&parent->children, &caddy->jdata->super);
+                /* We retained the jdata before adding it to the list - maintain ref count */
+                PMIX_RELEASE(caddy->jdata);
+            }
+            PMIX_PROC_RELEASE(nptr);
+        }
         PMIX_RELEASE(caddy->jdata);
     }
     PMIX_RELEASE(caddy);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -708,12 +708,7 @@ static void prte_job_destruct(prte_job_t *job)
 
     PMIX_DATA_BUFFER_DESTRUCT(&job->launch_msg);
 
-    /* Clear the child list before destroying the list */
-    PMIX_LIST_FOREACH(child_jdata, &job->children, prte_job_t)
-    {
-        pmix_list_remove_item(&job->children, &child_jdata->super);
-    }
-
+    /* Release the child list - we retained the child jobs before adding them to the list*/
     PMIX_LIST_DESTRUCT(&job->children);
 
     if (NULL != job->session_dir) {


### PR DESCRIPTION
Attempt to fix issue #2084.

1. Changed `cleanup_job()` to remove the job from the parent's child list and decrement the ref count.
2. Likewise, prte_job_destruct() now destructs the child list without first removing the job data objects, so their ref counts get decremented.

 