### PR TITLE
Revert "configure.ac: generate prte_version.h properly"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -205,8 +205,7 @@ AC_MSG_RESULT([$ltversion])
 
 # List header files to generate
 
-AC_CONFIG_HEADERS([src/include/prte_config.h
-                   include/prte_version.h])
+AC_CONFIG_HEADERS([src/include/prte_config.h])
 
 prte_show_subtitle "Initialization, setup"
 
@@ -1017,6 +1016,7 @@ AC_CONFIG_FILES([
     config/Makefile
     contrib/Makefile
     include/Makefile
+    include/prte_version.h
     docs/Makefile
     src/docs/Makefile
     src/docs/prrte-rst-content/Makefile


### PR DESCRIPTION
This reverts commit b7196af5789cac03b4ef7fd01feecec73a25877a.