### PR TITLE
Provide mechanism for disabling legacy tool names

### DIFF
--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -159,11 +159,11 @@ jobs:
     - name: Test mpi4py (np=4)
       run:  mpiexec -n 4 python test/main.py -v -f
       if:   ${{ true }}
-      timeout-minutes: 5
+      timeout-minutes: 10
     - name: Test mpi4py (np=5)
       run:  mpiexec -n 5 python test/main.py -v -f
       if:   ${{ true }}
-      timeout-minutes: 5
+      timeout-minutes: 10
 
     - name: Test mpi4py.run
       run:  python demo/test-run/test_run.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -157,12 +157,15 @@ src/mca/rmaps/rank_file/rmaps_rank_file_lex.c
 src/mca/rmaps/rank_file/rankfile_lex.c
 
 src/tools/prun/prun
+src/tools/prun/prte-submit
 src/tools/prte_info/prte_info
+src/tools/prte_info/prte-info
 src/tools/prted/prted
 src/tools/prte/prte
 src/tools/pcc/pcc
 src/tools/pcc/pcc-wrapper-data.txt
 src/tools/pterm/pterm
+src/tools/pterm/prte-term
 
 src/util/hostfile/hostfile_lex.c
 src/util/keyval/keyval_lex.c

--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -384,4 +384,21 @@ fi
 AC_DEFINE_UNQUOTED([PRTE_ENABLE_GETPWUID], [$prte_want_getpwuid],
                    [Disable getpwuid support (default: enabled)])
 
+# some people don't want the legacy tools
+AC_MSG_CHECKING([if want legacy tools installed])
+AC_ARG_ENABLE([legacy-tools],
+    [AS_HELP_STRING([--disable-legacy-tools],
+        [Do not install the legacy tools (default: enabled)])])
+if test "$enable_legacy_tools" = "no"; then
+    AC_MSG_RESULT([no])
+    prte_legacy_tools=no
+    PRTE_WANT_LEGACY_TOOLS=0
+else
+    AC_MSG_RESULT([yes])
+    prte_legacy_tools=yes
+    PRTE_WANT_LEGACY_TOOLS=1
+fi
+AM_CONDITIONAL(PRTE_WANT_LEGACY_TOOLS, test "$PRTE_WANT_LEGACY_TOOLS" = 1)
+PRTE_SUMMARY_ADD([Miscellaneous], [Install legacy tools], [], [$prte_legacy_tools])
+
 ])dnl

--- a/src/tools/prte_info/Makefile.am
+++ b/src/tools/prte_info/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,35 +23,45 @@
 #
 
 AM_CFLAGS = \
-            -DPRTE_CONFIGURE_USER="\"@PRTE_CONFIGURE_USER@\"" \
-            -DPRTE_CONFIGURE_HOST="\"@PRTE_CONFIGURE_HOST@\"" \
-            -DPRTE_CONFIGURE_DATE="\"@PRTE_CONFIGURE_DATE@\"" \
-            -DPRTE_BUILD_USER="\"$$USER\"" \
-            -DPRTE_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
-            -DPRTE_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
-            -DPRTE_BUILD_CFLAGS="\"@CFLAGS@\"" \
-            -DPRTE_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
-            -DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
-            -DPRTE_BUILD_LIBS="\"@LIBS@\"" \
-            -DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
-            -DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
-            -DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
-            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
+			-DPRTE_CONFIGURE_USER="\"@PRTE_CONFIGURE_USER@\"" \
+			-DPRTE_CONFIGURE_HOST="\"@PRTE_CONFIGURE_HOST@\"" \
+			-DPRTE_CONFIGURE_DATE="\"@PRTE_CONFIGURE_DATE@\"" \
+			-DPRTE_BUILD_USER="\"$$USER\"" \
+			-DPRTE_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
+			-DPRTE_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
+			-DPRTE_BUILD_CFLAGS="\"@CFLAGS@\"" \
+			-DPRTE_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
+			-DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
+			-DPRTE_BUILD_LIBS="\"@LIBS@\"" \
+			-DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
+			-DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
+			-DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
+			-DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
 
 AM_LDFLAGS = $(prte_hwloc_LDFLAGS) $(prte_libevent_LDFLAGS) $(prte_pmix_LDFLAGS)
 
-bin_PROGRAMS = prte_info
+bin_PROGRAMS = prte-info
 
 prte_info_SOURCES = \
-        pinfo.h \
-        prte_info.c \
-        output.c \
-        param.c \
-        components.c \
-        version.c
+		pinfo.h \
+		prte_info.c \
+		output.c \
+		param.c \
+		components.c \
+		version.c
 
 prte_info_LDADD = \
-    $(prte_libevent_LIBS) \
-    $(prte_hwloc_LIBS) \
-    $(prte_pmix_LIBS) \
+	$(prte_libevent_LIBS) \
+	$(prte_hwloc_LIBS) \
+	$(prte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
+
+if PRTE_WANT_LEGACY_TOOLS
+
+install-exec-hook:
+	(cd $(DESTDIR)$(bindir); rm -f prte_info$(EXEEXT); $(LN_S) prte-info$(EXEEXT) prte_info$(EXEEXT))
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/prte_info$(EXEEXT)
+
+endif

--- a/src/tools/prun/Makefile.am
+++ b/src/tools/prun/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,30 +24,40 @@
 
 AM_LDFLAGS = $(prte_hwloc_LDFLAGS) $(prte_libevent_LDFLAGS) $(prte_pmix_LDFLAGS)
 AM_CFLAGS = \
-            -DPRTE_CONFIGURE_USER="\"@PRTE_CONFIGURE_USER@\"" \
-            -DPRTE_CONFIGURE_HOST="\"@PRTE_CONFIGURE_HOST@\"" \
-            -DPRTE_CONFIGURE_DATE="\"@PRTE_CONFIGURE_DATE@\"" \
-            -DPRTE_BUILD_USER="\"$$USER\"" \
-            -DPRTE_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
-            -DPRTE_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
-            -DPRTE_BUILD_CFLAGS="\"@CFLAGS@\"" \
-            -DPRTE_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
-            -DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
-            -DPRTE_BUILD_LIBS="\"@LIBS@\"" \
-            -DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
-            -DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
-            -DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
-            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
+			-DPRTE_CONFIGURE_USER="\"@PRTE_CONFIGURE_USER@\"" \
+			-DPRTE_CONFIGURE_HOST="\"@PRTE_CONFIGURE_HOST@\"" \
+			-DPRTE_CONFIGURE_DATE="\"@PRTE_CONFIGURE_DATE@\"" \
+			-DPRTE_BUILD_USER="\"$$USER\"" \
+			-DPRTE_BUILD_HOST="\"$${HOSTNAME:-`(hostname || uname -n) | sed 1q`}\"" \
+			-DPRTE_BUILD_DATE="\"`$(top_srcdir)/config/getdate.sh`\"" \
+			-DPRTE_BUILD_CFLAGS="\"@CFLAGS@\"" \
+			-DPRTE_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
+			-DPRTE_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
+			-DPRTE_BUILD_LIBS="\"@LIBS@\"" \
+			-DPRTE_CC_ABSOLUTE="\"@PRTE_CC_ABSOLUTE@\"" \
+			-DPRTE_GREEK_VERSION="\"@PRTE_GREEK_VERSION@\"" \
+			-DPRTE_REPO_REV="\"@PRTE_REPO_REV@\"" \
+			-DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
 
-bin_PROGRAMS = prun
+bin_PROGRAMS = prte-submit
 
-prun_SOURCES = \
-        main.c \
-        prun.c \
-        prun.h
+prte_submit_SOURCES = \
+		main.c \
+		prun.c \
+		prun.h
 
-prun_LDADD = \
-    $(prte_libevent_LIBS) \
-    $(prte_hwloc_LIBS) \
-    $(prte_pmix_LIBS) \
+prte_submit_LDADD = \
+	$(prte_libevent_LIBS) \
+	$(prte_hwloc_LIBS) \
+	$(prte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
+
+if PRTE_WANT_LEGACY_TOOLS
+
+install-exec-hook:
+	(cd $(DESTDIR)$(bindir); rm -f prun$(EXEEXT); $(LN_S) prte-submit$(EXEEXT) prun$(EXEEXT))
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/prun$(EXEEXT)
+
+endif

--- a/src/tools/pterm/Makefile.am
+++ b/src/tools/pterm/Makefile.am
@@ -14,7 +14,7 @@
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2019      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -24,13 +24,23 @@
 
 AM_LDFLAGS = $(prte_hwloc_LDFLAGS) $(prte_libevent_LDFLAGS) $(prte_pmix_LDFLAGS)
 
-bin_PROGRAMS = pterm
+bin_PROGRAMS = prte-term
 
-pterm_SOURCES = \
+prte_term_SOURCES = \
         pterm.c
 
-pterm_LDADD = \
+prte_term_LDADD = \
     $(prte_libevent_LIBS) \
     $(prte_hwloc_LIBS) \
     $(prte_pmix_LIBS) \
 	$(top_builddir)/src/libprrte.la
+
+if PRTE_WANT_LEGACY_TOOLS
+
+install-exec-hook:
+	(cd $(DESTDIR)$(bindir); rm -f pterm$(EXEEXT); $(LN_S) prte-term$(EXEEXT) pterm$(EXEEXT))
+
+uninstall-local:
+	rm -f $(DESTDIR)$(bindir)/pterm$(EXEEXT)
+
+endif


### PR DESCRIPTION
Current PRRTE tool names can conflict with those from other packages (e.g., "pterm" with Putty). While this can be resolved through use of PATH, we can try to be a bit more friendly and revise the tool names. However, we have to also be considerate of those who already use PRRTE tools, so let's create a compromise.

Rename the tools of concern in a "standardized" manner so people can easily discern the new variations:

  "pterm" moves to "prte-term"
  "prun" moves to "prte-submit"
  "prte_info" moves to "prte-info"

We leave "prte", "prterun", and "prted" alone. This provides a consistent naming scheme. We also add a new configure option ("--enable-legacy-tools") that causes the original tool names to be symlinked to the corresponding new name. Thus, "pterm" is retained in that situation.

For now, we default the new configure option to be "yes" so that the old names are present. If someone wants to build without the old names, then they will need to "--disable-legacy-tools".

Fixes #1836
