### PR TITLE
Just ignore any lto settings

### DIFF
--- a/config/prte_check_cflags.m4
+++ b/config/prte_check_cflags.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2021 IBM Corporation.  All rights reserved.
 dnl
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -43,12 +43,20 @@ AC_MSG_CHECKING(if $CC supports ([$1]))
 
 
 AC_DEFUN([_PRTE_CHECK_LTO_FLAG], [
-    chkflg=`echo $1 | grep -- -flto`
+    chkflg=`echo $1 | grep -- lto`
     if test -n "$chkflg"; then
-        AC_MSG_WARN([Configure has detected the presence of the -flto])
-        AC_MSG_WARN([compiler directive in $2. PRRTE does not currently])
-        AC_MSG_WARN([support this flag as it conflicts with the])
-        AC_MSG_WARN([plugin architecture of the PRRTE code base.])
-        AC_MSG_ERROR([Please remove this directive and re-run configure.])
+        AC_MSG_WARN([Configure has detected the presence of one or more])
+        AC_MSG_WARN([compiler directives involving the lto optimizer])
+        AC_MSG_WARN([$2. PRRTE does not currently support such directives])
+        AC_MSG_WARN([as they conflict with the plugin architecture of the])
+        AC_MSG_WARN([PRRTE library. The directive is being ignored.])
+        newflg=
+        for item in $1; do
+            chkflg=`echo $item | grep -- lto`
+            if test ! -n "$chkflg"; then
+                newflg+="$item "
+            fi
+        done
+        $2="$newflg"
     fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@
 # Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
 # Copyright (c) 2018-2022 Amazon.com, Inc. or its affiliates.
 #                         All Rights reserved.
-# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2021      FUJITSU LIMITED.  All rights reserved.
 # Copyright (c) 2023-2024 Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
@@ -323,6 +323,17 @@ prte_show_title "Compiler and preprocessor tests"
 ##################################
 
 PRTE_SETUP_CC
+# We do not currently support the "lto" optimizer as it
+# aggregates all the headers from our plugins, resulting
+# in a configuration that generates warnings/errors when
+# passed through their optimizer phase. We therefore check
+# for the flag, and if found, output a message explaining
+# the situation and aborting configure
+_PRTE_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
+_PRTE_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
+_PRTE_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
+_PRTE_CHECK_LTO_FLAG($LIBS, LIBS)
+
 
 # Does the compiler support "ident"-like constructs?
 
@@ -930,18 +941,6 @@ CPP_INCLUDES="$(echo $cpp_includes | $SED 's/[[^ \]]* */'"$prte_cc_iquote"'&/g')
 CPPFLAGS="$CPP_INCLUDES $CPPFLAGS $PRTE_FINAL_CPPFLAGS"
 LDFLAGS="$LDFLAGS $PRTE_FINAL_LDFLAGS"
 LIBS="$LIBS $PRTE_FINAL_LIBS"
-
-
-# We do not currently support the "lto" optimizer as it
-# aggregates all the headers from our plugins, resulting
-# in a configuration that generates warnings/errors when
-# passed through their optimizer phase. We therefore check
-# for the flag, and if found, output a message explaining
-# the situation and aborting configure
-_PRTE_CHECK_LTO_FLAG($CPPFLAGS, CPPFLAGS)
-_PRTE_CHECK_LTO_FLAG($CFLAGS, CFLAGS)
-_PRTE_CHECK_LTO_FLAG($LDFLAGS, LDFLAGS)
-_PRTE_CHECK_LTO_FLAG($LIBS, LIBS)
 
 
 # restore any user-provided Werror flags


### PR DESCRIPTION
Rather than exiting configure with an error, print a warning
if lto-based directives are detected and ignore those flags.
This may help resolve rpm problems.