### PR TITLE
Multiple commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ test/spawn_multiple
 test/clichk
 test/chkfs
 
+test/mpi/spawn_multiple
 test/mpi/create_comm_from_group
 
 docs/_build

--- a/examples/client2.c
+++ b/examples/client2.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -127,6 +127,16 @@ int main(int argc, char **argv)
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
     fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+#ifdef PMIX_GPU_SUPPORT
+    /* see if we were given a GPU directive */
+    rc = PMIx_Get(&proc, PMIX_GPU_SUPPORT, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc) {
+        fprintf(stderr, "%s:%d GPU support: %s\n", myproc.nspace, myproc.rank, val->data.flag ? "ENABLED" : "DISABLED");
+    } else {
+        fprintf(stderr, "%s:%d GPU support: NOT GIVEN\n", myproc.nspace, myproc.rank);
+    }
+#endif
 
     /* put a data array of pmix_value's */
     val = (pmix_value_t *) malloc(32 * sizeof(pmix_value_t));

--- a/src/docs/show-help-files/help-prterun.txt
+++ b/src/docs/show-help-files/help-prterun.txt
@@ -195,6 +195,10 @@ option to the help request as "--help <option>".
 | "-x <name>"          | Export an environment variable, optionally    |
 |                      | specifying a value                            |
 +----------------------+-----------------------------------------------+
+| "--gpu-support <val>"| Direct application to either enable (true) or |
+|                      | disable (false) its internal library's GPU    |
+|                      | support                                       |
++----------------------+-----------------------------------------------+
 
 +----------------------+-----------------------------------------------+
 |                      | Specific Options                              |

--- a/src/docs/show-help-files/help-prun.txt
+++ b/src/docs/show-help-files/help-prun.txt
@@ -201,6 +201,10 @@ option to the help request as "--help <option>".
 |                      | current environmental variables starting with |
 |                      | "foo")                                        |
 +----------------------+-----------------------------------------------+
+| "--gpu-support <val>"| Direct application to either enable (true) or |
+|                      | disable (false) its internal library's GPU    |
+|                      | support                                       |
++----------------------+-----------------------------------------------+
 
 +----------------------+-----------------------------------------------+
 |                      | Specific Options                              |

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      UT-Battelle, LLC. All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -80,6 +80,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     pmix_data_array_t *darray = NULL;
     pmix_list_t nodes;
     int slots, len;
+    bool flag, *fptr;
 
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -99,6 +100,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     memset(&options, 0, sizeof(prte_rmaps_options_t));
     options.stream = prte_rmaps_base_framework.framework_output;
     options.verbosity = 5;  // usual value for base-level functions
+    fptr = &flag;
 
     /* check and set some general options */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
@@ -286,6 +288,13 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     }
                 }
             }
+            /* if not already assigned, inherit the parent's GPU support directive */
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, NULL, PMIX_BOOL)) {
+                if (prte_get_attribute(&parent->attributes, PRTE_JOB_GPU_SUPPORT, (void **) &fptr, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                }
+            }
+
         } else {
             if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
                 !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {

--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
    Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved.
    Copyright (c) 2022      IBM Corporation.  All rights reserved.
    Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
@@ -83,6 +83,9 @@ Launch options
 
 * ``-x <var>``: Export a environment variable, optionally specifying a value.
   :ref:`See below for details <label-schizo-ompi-x>`.
+
+* ``--gpu-support <val>``: Direct application to either enable (true) or
+  disable (false) its internal library's GPU support
 
 Mapping, ranking, and binding options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -198,7 +198,9 @@ static struct option ompioptions[] = {
     /* mpiexec mandated form launch key parameters - MPI 4.0 */
     PMIX_OPTION_DEFINE("initial-errhandler", PMIX_ARG_REQD),
     /* mpiexec mandated form launch key parameters  - MPI 4.1*/
-    PMIX_OPTION_DEFINE("memory-alloc-kinds", PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PRTE_CLI_MEM_ALLOC_KIND, PMIX_ARG_REQD),
+    /* GPU support - on/off */
+    PMIX_OPTION_DEFINE(PRTE_CLI_GPU_SUPPORT, PMIX_ARG_REQD),
 
     /* Display Commumication Protocol : MPI_Init */
     PMIX_OPTION_DEFINE("display-comm", PMIX_ARG_NONE),
@@ -1603,7 +1605,7 @@ static int parse_env(char **srcenv, char ***dstenv,
         }
     }
 
-    if (NULL != (opt = pmix_cmd_line_get_param(results, "memory-alloc-kinds"))) {
+    if (NULL != (opt = pmix_cmd_line_get_param(results, PRTE_CLI_MEM_ALLOC_KIND))) {
         rc = check_cache(&cache, &cachevals, "mpi_memory_alloc_kinds", opt->values[0]);
         if (PRTE_SUCCESS != rc) {
             PMIX_ARGV_FREE_COMPAT(cache);

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -197,6 +197,7 @@ static struct option prterunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_DO_NOT_AGG_HELP, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_FWD_ENVIRON, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_DEFINE(PRTE_CLI_MEM_ALLOC_KIND, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PRTE_CLI_GPU_SUPPORT, PMIX_ARG_REQD),
 
     // output options
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),
@@ -312,6 +313,7 @@ static struct option prunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_DO_NOT_AGG_HELP, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_FWD_ENVIRON, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_DEFINE(PRTE_CLI_MEM_ALLOC_KIND, PMIX_ARG_REQD),
+    PMIX_OPTION_DEFINE(PRTE_CLI_GPU_SUPPORT, PMIX_ARG_REQD),
 
     // output options
     PMIX_OPTION_DEFINE(PRTE_CLI_OUTPUT, PMIX_ARG_REQD),

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -598,6 +598,7 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
     int32_t i32, *i32ptr;
     prte_pmix_lock_t lock;
     prte_app_context_t *app;
+    pmix_server_pset_t *pst, *pst2;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -749,6 +750,13 @@ CHECK_DAEMONS:
         }
         PMIX_RELEASE(map);
         jdata->map = NULL;
+    }
+    // if this job has apps that named a pset, then remove them
+    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, pmix_server_pset_t) {
+        if (pst->jdata == jdata) {
+            pmix_list_remove_item(&prte_pmix_server_globals.psets, &pst->super);
+            PMIX_RELEASE(pst);
+        }
     }
 
 CHECK_ALIVE:

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -4,7 +4,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -516,6 +516,7 @@ static void check_complete(int fd, short args, void *cbdata)
     hwloc_obj_type_t type;
     hwloc_cpuset_t boundcpus, tgt;
     bool takeall, sep, *sepptr = &sep;
+    pmix_server_pset_t *pst, *pst2;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -811,6 +812,13 @@ release:
         hwloc_bitmap_free(boundcpus);
         PMIX_RELEASE(map);
         jdata->map = NULL;
+    }
+    // if this job has apps that named a pset, then remove them
+    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, pmix_server_pset_t) {
+        if (pst->jdata == jdata) {
+            pmix_list_remove_item(&prte_pmix_server_globals.psets, &pst->super);
+            PMIX_RELEASE(pst);
+        }
     }
 
     /* if requested, check fd status for leaks */

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -2066,6 +2066,7 @@ PMIX_CLASS_INSTANCE(pmix_server_req_t,
 static void pscon(pmix_server_pset_t *p)
 {
     p->name = NULL;
+    p->jdata = NULL;
     p->members = NULL;
     p->num_members = 0;
 }
@@ -2073,6 +2074,9 @@ static void psdes(pmix_server_pset_t *p)
 {
     if (NULL != p->name) {
         free(p->name);
+    }
+    if (NULL != p->jdata) {
+     PMIX_RELEASE(p->jdata);
     }
     if (NULL != p->members) {
         free(p->members);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -655,6 +655,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_NOAGG_HELP, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+#ifdef PMIX_GPU_SUPPORT
+        } else if (PMIX_CHECK_KEY(info, PMIX_GPU_SUPPORT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+#endif
+
             /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {
             pmix_server_cache_job_info(jdata, info);

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -354,6 +354,7 @@ pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
 typedef struct {
     pmix_list_item_t super;
     char *name;
+    prte_job_t *jdata;
     pmix_proc_t *members;
     size_t num_members;
 } pmix_server_pset_t;

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -319,7 +319,10 @@ static void _query(int sd, short args, void *cbdata)
                 }
                 /* add our findings to the results */
                 PMIX_INFO_LIST_CONVERT(rc, cache, &dry);
-                if (PMIX_SUCCESS != rc) {
+                if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
+                    // if the array is empty, then there is nothing wrong - we
+                    // simply didn't find any runnning jobs
+                    // otherwise, report the error and abort
                     PMIX_ERROR_LOG(rc);
                     PMIX_INFO_LIST_RELEASE(cache);
                     goto done;
@@ -587,18 +590,19 @@ static void _query(int sd, short args, void *cbdata)
                     PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
                 }
                 if (NULL == ans) {
-                    ret = PMIX_ERR_NOT_FOUND;
-                    goto done;
+                    tmp = NULL;;
                 } else {
                     tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
                     PMIX_ARGV_FREE_COMPAT(ans);
                     ans = NULL;
-                    PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
+                }
+                PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
+                if (NULL != tmp) {
                     free(tmp);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        goto done;
-                    }
+                }
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    goto done;
                 }
 
             } else if (0 == strcmp(q->keys[n], PMIX_QUERY_PSET_MEMBERSHIP)) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -376,6 +376,13 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     }
 #endif
 
+    // check for GPU directives
+#ifdef PMIX_GPU_SUPPORT
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, (void**)&fptr, PMIX_BOOL)) {
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_GPU_SUPPORT, &flag, PMIX_BOOL);
+    }
+#endif
+
     /* for each app in the job, create an app-array */
     for (n = 0; n < jdata->apps->size; n++) {
         if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, n))) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2024      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -402,6 +402,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             /* register it */
             pset = PMIX_NEW(pmix_server_pset_t);
             pset->name = strdup(tmp);
+            PMIX_RETAIN(jdata);
+            pset->jdata = jdata;
             pmix_list_append(&prte_pmix_server_globals.psets, &pset->super);
             free(tmp);
             /* and its membership */

--- a/src/prted/prted.h
+++ b/src/prted/prted.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -53,6 +53,9 @@ PRTE_EXPORT int prun_common(pmix_cli_result_t *cli,
                             prte_schizo_base_module_t *schizo,
                             int argc, char **argv);
 
+PRTE_EXPORT int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
+                                           prte_schizo_base_module_t *schizo,
+                                           pmix_list_t *apps);
 END_C_DECLS
 
 #endif /* PRTED_H */

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
@@ -250,18 +250,16 @@ static char *pmix_getline(FILE *fp)
 int main(int argc, char *argv[])
 {
     int rc = 1, i;
-    char *param, *timeoutenv, *tpath, *cptr;
+    char *param, *tpath, *cptr;
     prte_pmix_lock_t lock;
     pmix_list_t apps;
     prte_pmix_app_t *app;
     pmix_info_t *iptr, *iptr2, info;
     pmix_status_t ret;
-    bool flag;
     size_t n, ninfo, param_len;
     pmix_app_t *papps;
     size_t napps;
     mylock_t mylock;
-    uint32_t ui32;
     char **pargv, **split;
     int pargc;
     prte_job_t *jdata;
@@ -1006,135 +1004,10 @@ int main(int argc, char *argv[])
         PMIX_VALUE_RELEASE(val);
     }
 
-    /* pass the personality */
-    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, personality, PMIX_STRING);
-
-    /* get display options */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DISPLAY);
-    if (NULL != opt) {
-        ret = prte_schizo_base_parse_display(opt, jinfo);
-        if (PRTE_SUCCESS != ret) {
-            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-            goto DONE;
-        }
+    ret = prte_prun_parse_common_cli(jinfo, &results, schizo, &apps);
+    if (PRTE_SUCCESS != ret) {
+        goto DONE;
     }
-
-    /* get output options */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
-    if (NULL != opt) {
-        ret = prte_schizo_base_parse_output(opt, jinfo);
-        if (PRTE_SUCCESS != ret) {
-            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-            goto DONE;
-        }
-    }
-
-    /* check for runtime options */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_RTOS);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RUNTIME_OPTIONS, opt->values[0], PMIX_STRING);
-    }
-
-    /* check what user wants us to do with stdin */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_STDIN_TGT, opt->values[0], PMIX_STRING);
-    }
-
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_MAPBY);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, opt->values[0], PMIX_STRING);
-    }
-
-    /* if the user specified a ranking policy, then set it */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_RANKBY);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RANKBY, opt->values[0], PMIX_STRING);
-    }
-
-    /* if the user specified a binding policy, then set it */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_BINDTO);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, opt->values[0], PMIX_STRING);
-    }
-
-    /* check for an exec agent */
-   opt = pmix_cmd_line_get_param(&results, PRTE_CLI_EXEC_AGENT);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_EXEC_AGENT, opt->values[0], PMIX_STRING);
-    }
-
-    /* mark if recovery was enabled */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_ENABLE_RECOVERY)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_RECOVERABLE, NULL, PMIX_BOOL);
-    }
-    /* record the max restarts */
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_MAX_RESTARTS);
-    if (NULL != opt) {
-        ui32 = strtol(opt->values[0], NULL, 10);
-        PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
-        {
-            PMIX_INFO_LIST_ADD(ret, app->info, PMIX_MAX_RESTARTS, &ui32, PMIX_UINT32);
-        }
-    }
-    /* if continuous operation was specified */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_CONTINUOUS)) {
-        /* mark this job as continuously operating */
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_CONTINUOUS, NULL, PMIX_BOOL);
-    }
-#ifdef PMIX_ABORT_NONZERO_EXIT
-    /* if ignore non-zero exit was specified */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_TERM_NONZERO)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_ABORT_NONZERO_EXIT, NULL, PMIX_BOOL);
-    }
-#endif
-    /* if stop-on-exec was specified */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STOP_ON_EXEC)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);
-    }
-
-    /* check for a job timeout specification, to be provided in seconds
-     * as that is what MPICH used
-     */
-    timeoutenv = NULL;
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_TIMEOUT);
-    if (NULL != opt || NULL != (timeoutenv = getenv("MPIEXEC_TIMEOUT"))) {
-        if (NULL != timeoutenv) {
-            i = strtol(timeoutenv, NULL, 10);
-            /* both cannot be present, or they must agree */
-            if (NULL != opt) {
-                n = strtol(opt->values[0], NULL, 10);
-                if (i != (int)n) {
-                    pmix_show_help("help-prun.txt", "prun:timeoutconflict", false,
-                                   prte_tool_basename, n, timeoutenv);
-                    PRTE_UPDATE_EXIT_STATUS(1);
-                    goto DONE;
-                }
-            }
-        } else {
-            i = strtol(opt->values[0], NULL, 10);
-        }
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_TIMEOUT, &i, PMIX_INT);
-    }
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_STACK_TRACES)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_STACKTRACES, NULL, PMIX_BOOL);
-    }
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_REPORT_STATE)) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_REPORT_STATE, NULL, PMIX_BOOL);
-    }
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_SPAWN_TIMEOUT);
-    if (NULL != opt) {
-        i = strtol(opt->values[0], NULL, 10);
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_SPAWN_TIMEOUT, &i, PMIX_INT);
-    }
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_DO_NOT_AGG_HELP);
-    if (NULL != opt) {
-        flag = false;
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_LOG_AGG, &flag, PMIX_BOOL);
-    }
-
-    /* give the schizo components a chance to add to the job info */
-    schizo->job_info(&results, jinfo);
 
     /* convert the job info into an array */
     PMIX_INFO_LIST_CONVERT(ret, jinfo, &darray);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -509,6 +509,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB BINDING LIMIT";
         case PRTE_JOB_CHILD_SEP:
             return "CHILD SEP";
+        case PRTE_JOB_GPU_SUPPORT:
+            return "GPU SUPPORT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -231,6 +231,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_CHILD_SEP                  (PRTE_JOB_START_KEY + 116) // bool - child job is to be considered independent
                                                                        //        from its parent, do not terminate if
                                                                        //        parent dies first
+#define PRTE_JOB_GPU_SUPPORT                (PRTE_JOB_START_KEY + 117) // bool - enable/disable GPU support in app
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,6 +109,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_ENABLE_RECOVERY        "enable-recovery"           // none
 #define PRTE_CLI_DISABLE_RECOVERY       "disable-recovery"          // none
 #define PRTE_CLI_MEM_ALLOC_KIND			"memory-alloc-kinds"        // required
+#define PRTE_CLI_GPU_SUPPORT			"gpu-support"				// required
 
 // Placement options
 #define PRTE_CLI_MAPBY                  "map-by"                    // required

--- a/test/mpi/spawn_multiple.c
+++ b/test/mpi/spawn_multiple.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <mpi.h>
+
+int main(int argc, char* argv[])
+{
+    int msg;
+    MPI_Comm parent, child;
+    int rank, size;
+    char hostname[1024];
+    pid_t pid;
+    int i;
+    char *cmds[2];
+    char *argv0[] = { "foo", NULL };
+    char *argv1[] = { "bar", NULL };
+    char **spawn_argv[2];
+    int maxprocs[] = { 2, 2 };
+    MPI_Info info[] = { MPI_INFO_NULL, MPI_INFO_NULL };
+
+    cmds[1] = cmds[0] = argv[0];
+    spawn_argv[0] = argv0;
+    spawn_argv[1] = argv1;
+
+    MPI_Init(NULL, NULL);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_get_parent(&parent);
+    /* If we get COMM_NULL back, then we're the parent */
+    if (MPI_COMM_NULL == parent) {
+        pid = getpid();
+        printf("Parent [pid %ld] about to spawn!\n", (long)pid);
+        MPI_Comm_spawn_multiple(2, cmds, spawn_argv, maxprocs,
+                                info, 0, MPI_COMM_WORLD,
+                                &child, MPI_ERRCODES_IGNORE);
+        printf("Parent done with spawn\n");
+        MPI_Comm_disconnect(&child);
+        printf("Parent disconnected\n");
+    }
+    /* Otherwise, we're the child */
+    else {
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+        gethostname(hostname, sizeof(hostname));
+        pid = getpid();
+        printf("Hello from the child %d of %d on host %s pid %ld: argv[1] = %s\n", rank, size, hostname, (long)pid, argv[1]);
+        MPI_Comm_disconnect(&parent);
+        printf("Child %d disconnected\n", rank);
+    }
+
+    MPI_Finalize();
+    return 0;
+}


### PR DESCRIPTION
[Add spawn_multiple test](https://github.com/openpmix/prrte/commit/effb60a2f7658f3e2df40222d04823242bc8f78f)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/43dce07ee590d2275c6d0eaecad4f13662eb5a04)

[Minor cleanups](https://github.com/openpmix/prrte/commit/3e7ee407eb7af2d9aade43ea27972d132eb1b3e6)

If we didn't find any psets when queried about them, that isn't
a "not found" error - just return zero for the number and NULL
for the list of names.

Ensure we remove any pset names once the job containing those
names terminates - the pset name doesn't persist beyond the
lifetime of the job.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e67175242847d1b78eb51cfeb8f99f3ce4ac867b)

[Implement query support for PMIx resolve functions](https://github.com/openpmix/prrte/commit/f84b0501f9e604e987012c88312ce9a36f9fd374)

If we don't recognize a query key, then just return "not supported"
without pushing output to stderr unless verbosity is enabled.

Support the "resolve peers" and "resolve node" queries

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/46963c08da4a70e4744d97d20313a121cb27b4e1)

[Add ability to direct app GPU support](https://github.com/openpmix/prrte/commit/fe7fc9854f34c24ecfcdab2ec87a739abcfd78af)

There apparently are some circumstances when an application can
benefit from disabling the internal GPU support in one or more
of its libraries. Let's assume that a library might also provide
a mechanism by which that support can be defaulted to enabled
or disabled.

Add CLI support for specifying that GPU support be enabled or
disabled. We assume that:

(a) this is something that a tool might want to enquire about
    to see what an app was told to do

(b) a user might want/expect this to be a directive inherited
    by any spawned child jobs

Also note that there was a lot of code duplication between
prte and prun_common when it came to parsing the cmd line
for job-level directives. Collect those in a common function
as we see that some divergence had already occurred.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/0b74d3a917fe0a6b87b5679a5e665c326f4544c3)
