### PR TITLE
gcc compilation failure fixes

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -92,7 +92,6 @@ static void _query(int sd, short args, void *cbdata)
     prte_proc_t *proct;
     pmix_proc_t *proc;
     size_t sz;
-    bool found;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -846,6 +845,7 @@ static void _query(int sd, short args, void *cbdata)
                 pmix_list_t procs;
                 int idx;
                 prte_proc_t *p2;
+                bool found = false;
                 // must at least have given us a hostname
                 if (NULL == hostname) {
                     ret = PMIX_ERR_BAD_PARAM;

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -766,7 +766,6 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     bool flag;
     prte_pmix_app_t *app;
     char *param;
-    pmix_info_t info;
 
     /* pass the personality */
     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, schizo->name, PMIX_STRING);
@@ -895,6 +894,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     }
 #endif
 #ifdef PMIX_GPU_SUPPORT
+    pmix_info_t info;
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_GPU_SUPPORT);
     if (NULL != opt) {
         // they could be enabling or disabling it


### PR DESCRIPTION
when configured with --enable-debug several files failed to compile using gcc 8.5.0 on RHEL8.