### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/builds-older.yaml
+++ b/.github/workflows/builds-older.yaml
@@ -16,6 +16,51 @@ jobs:
             submodules: recursive
             repository: openpmix/openpmix
             path: openpmix/v5
+            ref: v5.0.3
+    - name: Build OpenPMIx
+      run: |
+        cd openpmix/v5
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+        cp examples/.libs/hello $RUNNER_TEMP/pmixinstall/bin
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            clean: false
+    - name: Build PRRTE
+      run: |
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-devel-check
+        make -j
+        make install
+    - name: Tweak PRRTE
+      run:  |
+         # Tweak PRRTE
+         mca_params="$HOME/.prte/mca-params.conf"
+         mkdir -p "$(dirname "$mca_params")"
+         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+    - name: Run simple test
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         prterun -n 4 $RUNNER_TEMP/pmixinstall/bin/hello
+
+  ubuntu5:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: openpmix/v5
             ref: v5.0
     - name: Build OpenPMIx
       run: |
@@ -33,7 +78,7 @@ jobs:
     - name: Build PRRTE
       run: |
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-devel-check
         make -j
         make install
     - name: Tweak PRRTE
@@ -49,6 +94,53 @@ jobs:
          prterun -n 4 $RUNNER_TEMP/pmixinstall/bin/hello
 
   ubuntuClang:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev clang
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: openpmix/v5
+            ref: v5.0.3
+    - name: Build OpenPMIx
+      run: |
+        cd openpmix/v5
+        ./autogen.pl
+        CC=clang ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+        cp examples/.libs/hello $RUNNER_TEMP/pmixinstall/bin
+    - name: Git clone PRRTE
+      uses: actions/checkout@v3
+      with:
+            submodules: recursive
+            clean: false
+    - name: Build PRRTE
+      run: |
+        ./autogen.pl
+
+        pip3 install -r docs/requirements.txt
+        CC=clang ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
+        make -j
+        make install
+    - name: Tweak PRRTE
+      run:  |
+         # Tweak PRRTE
+         mca_params="$HOME/.prte/mca-params.conf"
+         mkdir -p "$(dirname "$mca_params")"
+         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+    - name: Run simple test
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         prterun -n 4 $RUNNER_TEMP/pmixinstall/bin/hello
+
+  ubuntuClang5:
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
@@ -80,7 +172,7 @@ jobs:
         ./autogen.pl
 
         pip3 install -r docs/requirements.txt
-        CC=clang ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx
+        CC=clang ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
         make -j
         make install
     - name: Tweak PRRTE

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -68,7 +68,7 @@ jobs:
         libevent_cppflags=$(pkg-config libevent --cflags)
         libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
 
-        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx \
+        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check \
             CPPFLAGS=$libevent_cppflags \
             LDFLAGS=$libevent_ldflags
         make -j
@@ -122,7 +122,7 @@ jobs:
             c=../configure
         fi
 
-        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx
+        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
         make -j
         make install
         make uninstall
@@ -161,7 +161,7 @@ jobs:
         sphinx=--enable-sphinx
 
         c=./configure
-        CC=clang $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx
+        CC=clang $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
         make -j
         make install
         make uninstall
@@ -196,5 +196,5 @@ jobs:
       run: |
         pip install -r docs/requirements.txt
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-sphinx
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-sphinx --enable-devel-check
         make distcheck AM_DISTCHECK_MAKEFLAGS=-j AM_DISTCHECK_CONFIGURE_FLAGS="--with-pmix=$RUNNER_TEMP/pmixinstall"

--- a/.github/workflows/dvm.yaml
+++ b/.github/workflows/dvm.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Build PRRTE
       run: |
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-devel-check
         make -j
         make install
     - name: Tweak PRRTE

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Build PRRTE
       run: |
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-devel-check
         make -j
         make install
     - name: Tweak PRRTE

--- a/examples/debugger/attach.c
+++ b/examples/debugger/attach.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -360,7 +360,9 @@ static int attach_to_running_job(char *nspace)
     /* No environment variables */
     app->env = NULL;
     /* Set the daemon's working directory to our current directory */
-    getcwd(cwd, _POSIX_PATH_MAX);
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) {
+        exit(1);
+    }
     app->cwd = strdup(cwd);
     /* No attributes set in the pmix_app_t structure */
     app->info = NULL;
@@ -386,7 +388,7 @@ static int attach_to_running_job(char *nspace)
     PMIX_INFO_LIST_ADD(rc, dirs, PMIX_FWD_STDERR, NULL, PMIX_BOOL);
     /* Set up daemon mapping based on options */
     if (0 < daemon_colocate_per_node) {
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_DEBUG_DAEMONS_PER_NODE, 
+        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_DEBUG_DAEMONS_PER_NODE,
                            &daemon_colocate_per_node, PMIX_UINT16);
     } else if (0 < daemon_colocate_per_proc) {
         PMIX_INFO_LIST_ADD(rc, dirs, PMIX_DEBUG_DAEMONS_PER_PROC,
@@ -394,7 +396,7 @@ static int attach_to_running_job(char *nspace)
     } else if (NULL != hostfile) {
         PMIX_INFO_LIST_ADD(rc, dirs, PMIX_HOSTFILE, hostfile, PMIX_STRING);
         PMIX_INFO_LIST_ADD(rc, dirs, PMIX_MAPBY, "ppr:1:node", PMIX_STRING);
-    } 
+    }
     else {
         PMIX_INFO_LIST_ADD(rc, dirs, PMIX_MAPBY, "ppr:1:node", PMIX_STRING);
     }

--- a/examples/debugger/direct-multi.c
+++ b/examples/debugger/direct-multi.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -262,7 +262,7 @@ static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, voi
 }
 
 /* Register a callback for an application event notification */
-void register_app_notification(pmix_status_t code, myrel_t *myrel, pmix_notification_fn_t callback) 
+void register_app_notification(pmix_status_t code, myrel_t *myrel, pmix_notification_fn_t callback)
 {
     void *tinfo;
     pmix_info_t *info;
@@ -283,10 +283,10 @@ void register_app_notification(pmix_status_t code, myrel_t *myrel, pmix_notifica
     PMIX_INFO_LIST_RELEASE(tinfo);
 
     DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, info, ninfo, callback, 
+    PMIx_Register_event_handler(&code, 1, info, ninfo, callback,
                                 evhandler_reg_callbk, (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
-    printf("Debugger: Registered for event %s on nspace %s\n", 
+    printf("Debugger: Registered for event %s on nspace %s\n",
            PMIx_Error_string(code), client_nspace);
     rc = mylock.status;
     DEBUG_DESTRUCT_LOCK(&mylock);
@@ -549,7 +549,9 @@ static pmix_status_t spawn_app(void)
     /* Setup the executable */
     app.cmd = strdup("hello");
     PMIX_ARGV_APPEND(rc, app.argv, "./hello");
-    getcwd(cwd, _POSIX_PATH_MAX); // point us to our current directory
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) { // point us to our current directory
+        exit(1);
+    }
     app.cwd = strdup(cwd);
     if (app_np > 0) {
         app.maxprocs = app_np;
@@ -608,7 +610,9 @@ static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
     /* No environment variables */
     debugger[0].env = NULL;
     /* Set the working directory to our current directory */
-    getcwd(cwd, _POSIX_PATH_MAX);
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) {
+        exit(1);
+    }
     debugger[0].cwd = strdup(cwd);
     /* Spawn daemon processes - 1 per node if not colocating */
     if (daemon_colocate_per_proc < 0 && daemon_colocate_per_node < 0) {

--- a/examples/debugger/direct.c
+++ b/examples/debugger/direct.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -261,7 +261,7 @@ static void debug_ready_cb(size_t evhdlr_registration_id, pmix_status_t status,
 
 /* Register for a PMIX_READY_FOR_DEBUG event issued by the system server then
  * wait for that event to be issued or until the timeout limit is reached */
-static int wait_for_ready(myrel_t *myrel) 
+static int wait_for_ready(myrel_t *myrel)
 {
     void *dirs;
     pmix_info_t *info;
@@ -286,7 +286,7 @@ static int wait_for_ready(myrel_t *myrel)
                                 evhandler_reg_callbk, (void *) &mylock);
     DEBUG_WAIT_THREAD(&mylock);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
-    printf("Debugger: Registered for READY_FOR_DEBUG event for nspace %s\n", 
+    printf("Debugger: Registered for READY_FOR_DEBUG event for nspace %s\n",
            connected_servers[0].nspace);
     rc = mylock.status;
     DEBUG_DESTRUCT_LOCK(&mylock);
@@ -357,7 +357,9 @@ static int cospawn_launch(myrel_t *myrel)
     PMIX_ARGV_APPEND(rc, app->argv, app[0].cmd);
     app[0].env = NULL;
     /* Set the working directory */
-    getcwd(cwd, _POSIX_PATH_MAX);
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) {
+        exit(1);
+    }
     app[0].cwd = strdup(cwd);
     /* Two application processes */
     if (app_np > 0) {
@@ -468,7 +470,9 @@ static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
     /* No environment variables */
     debugger[0].env = NULL;
     /* Set the working directory to our current directory */
-    getcwd(cwd, _POSIX_PATH_MAX);
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) {
+        exit(1);
+    }
     debugger[0].cwd = strdup(cwd);
     /* Spawn daemon processes - 1 per node if not colocating */
     if (daemon_colocate_per_proc < 0 && daemon_colocate_per_node < 0) {
@@ -687,7 +691,7 @@ int main(int argc, char **argv)
     printf("Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank,
            (unsigned long) pid);
 
-    /* We need to know the server we connected to so we can register for 
+    /* We need to know the server we connected to so we can register for
      * PMIX_READY_FOR_DEBUG notifications from that server when target processes
      * are ready for debug. There should be only one server */
     if (PMIX_SUCCESS != PMIx_tool_get_servers(&connected_servers, &num_servers)) {
@@ -803,7 +807,9 @@ int main(int argc, char **argv)
         /* Setup the executable */
         app[0].cmd = strdup("hello");
         PMIX_ARGV_APPEND(rc, app[0].argv, "./hello");
-        getcwd(cwd, _POSIX_PATH_MAX); // point us to our current directory
+        if (NULL == getcwd(cwd, _POSIX_PATH_MAX)) { // point us to our current directory
+            exit(1);
+        }
         app[0].cwd = strdup(cwd);
         if (app_np > 0) {
             app[0].maxprocs = app_np;

--- a/examples/debugger/indirect-multi.c
+++ b/examples/debugger/indirect-multi.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -206,7 +206,9 @@ static pmix_status_t spawn_daemons(char **dbgrs)
     PMIX_APP_CONSTRUCT(&app);
     app.cmd = strdup("./daemon");
     PMIX_ARGV_APPEND(rc, app.argv, "./daemon");
-    getcwd(cwd, _POSIX_PATH_MAX - 1); // point us to our current directory
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX - 1)) { // point us to our current directory
+        exit(1);
+    }
     app.cwd = strdup(cwd);
     if ((0 < daemon_colocate_per_node) || (0 < daemon_colocate_per_proc)) {
         app.maxprocs = 0;
@@ -280,7 +282,9 @@ static pmix_status_t spawn_app(char *myuri, int argc, char **argv,
     for (n = 1; n < argc; n++) {
         PMIX_ARGV_APPEND(rc, app.argv, argv[n]);
     }
-    getcwd(cwd, _POSIX_PATH_MAX - 1); // point us to our current directory
+    if (NULL == getcwd(cwd, _POSIX_PATH_MAX - 1)) { // point us to our current directory
+        exit(1);
+    }
     app.cwd = strdup(cwd);
     app.maxprocs = 1; // only start one instance of the IL
 

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -254,7 +254,9 @@ int main(int argc, char **argv)
     for (n = 2; n < argc; n++) {
         PMIX_ARGV_APPEND(rc, app[0].argv, argv[n]);
     }
-    getcwd(cwd, 1024); // point us to our current directory
+    if (NULL == getcwd(cwd, 1024)) { // point us to our current directory
+        exit(1);
+    }
     app[0].cwd = strdup(cwd);
     app[0].maxprocs = 1; // only start one instance of the IL
 
@@ -414,7 +416,9 @@ int main(int argc, char **argv)
     PMIX_APP_CREATE(mydata->apps, mydata->napps);
     mydata->apps[0].cmd = strdup("./daemon");
     PMIX_ARGV_APPEND(rc, mydata->apps[0].argv, "./daemon");
-    getcwd(cwd, 1024); // point us to our current directory
+    if (NULL == getcwd(cwd, 1024)) { // point us to our current directory
+        exit(1);
+    }
     mydata->apps[0].cwd = strdup(cwd);
     mydata->apps[0].maxprocs = 1;
     PMIX_LOAD_PROCID(&target_proc, (void *) appnspace, PMIX_RANK_WILDCARD);

--- a/examples/server.c
+++ b/examples/server.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -220,7 +220,10 @@ int main(int argc, char **argv)
             exit(1);
         }
     }
-    asprintf(&cleanup, "rm -rf %s", tmpdir);
+    if (0 > asprintf(&cleanup, "rm -rf %s", tmpdir)) {
+        fprintf(stderr, "Out of memory\n");
+        exit(1);
+    }
     PMIX_INFO_CREATE(info, 1);
     PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TMPDIR, tmpdir, PMIX_STRING);
 
@@ -264,7 +267,10 @@ int main(int argc, char **argv)
     /* we have a single namespace for all clients */
     atmp = NULL;
     for (n = 0; n < nprocs; n++) {
-        asprintf(&tmp, "%d", n);
+        if (0 > asprintf(&tmp, "%d", n)) {
+            fprintf(stderr, "Out of memory\n");
+            exit(1);
+        }
         PMIX_ARGV_APPEND_COMPAT(&atmp, tmp);
         free(tmp);
     }

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -1227,7 +1227,7 @@ static int bitmap_list_snprintf_exp(char *__hwloc_restrict buf, size_t buflen,
     char *tmp = buf;
     int prev = -1;
     ssize_t size = buflen;
-    int res;
+    int res = -1;
 
     /* mark the end in case we do nothing later */
     if (buflen > 0) {

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -344,7 +344,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
      * the ability for transport specifications */
     PMIX_INFO_LIST_START(mlist);
 
-    asprintf(&tmp, "%s.net", jdata->nspace);
+    pmix_asprintf(&tmp, "%s.net", jdata->nspace);
     PMIX_INFO_LIST_ADD(ret, mlist, PMIX_ALLOC_NETWORK_ID, tmp, PMIX_STRING);
     free(tmp);
     PMIX_INFO_LIST_ADD(ret, mlist, PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -21,7 +21,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -119,6 +119,7 @@
 #include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_fd.h"
 #include "src/util/pmix_environ.h"
+#include "src/util/pmix_getcwd.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/sys_limits.h"
 
@@ -405,13 +406,13 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     /* Exec the new executable */
     execve(cd->cmd, cd->argv, cd->env);
     /* If we get here, an error has occurred. */
-    (void) getcwd(dir, sizeof(dir));
+    pmix_getcwd(dir, sizeof(dir));
     struct stat stats;
     char *msg;
     /* If errno is ENOENT, that indicates either cd->cmd does not exist, or
      * cd->cmd is a script, but has a bad interpreter specified. */
     if (ENOENT == errno && 0 == stat(cd->app->app, &stats)) {
-        asprintf(&msg, "%s has a bad interpreter on the first line.", cd->app->app);
+        pmix_asprintf(&msg, "%s has a bad interpreter on the first line.", cd->app->app);
     } else {
         msg = strdup(strerror(errno));
     }

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -20,7 +20,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,6 +45,7 @@
 
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
+#include "src/util/pmix_getcwd.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_environ.h"
@@ -343,7 +344,7 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
     }
 
     if (NULL == path) {
-        getcwd(cwd, PRTE_PATH_MAX);
+        pmix_getcwd(cwd, PRTE_PATH_MAX);
     } else {
         pmix_string_copy(cwd, path, PRTE_PATH_MAX);
     }

--- a/src/mca/prtebacktrace/execinfo/backtrace_execinfo.c
+++ b/src/mca/prtebacktrace/execinfo/backtrace_execinfo.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -32,6 +32,7 @@
 #endif
 
 #include "constants.h"
+#include "src/util/pmix_fd.h"
 #include "src/mca/prtebacktrace/prtebacktrace.h"
 
 int prte_backtrace_print(FILE *file, char *prefix, int strip)
@@ -54,10 +55,10 @@ int prte_backtrace_print(FILE *file, char *prefix, int strip)
 
     for (i = strip; i < trace_size; i++) {
         if (NULL != prefix) {
-            write(fd, prefix, strlen(prefix));
+            pmix_fd_write(fd, strlen(prefix), prefix);
         }
         len = snprintf(buf, sizeof(buf), "[%2d] ", i - strip);
-        write(fd, buf, len);
+        pmix_fd_write(fd, len, buf);
         backtrace_symbols_fd(&trace[i], 1, fd);
     }
 

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,6 +42,7 @@
 #include "src/class/pmix_pointer_array.h"
 #include "src/hwloc/hwloc-internal.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_fd.h"
 #include "src/util/pmix_if.h"
 #include "src/util/pmix_net.h"
 #include "src/util/proc_info.h"
@@ -905,7 +906,7 @@ static int prte_rmaps_rf_lsf_convert_affinity_to_rankfile(char *affinity_file, c
         len = 5 + 10 + 1 + strlen(hstname) + 6 + strlen(sep) + 1;
         tmp_str = (char *)malloc(sizeof(char) * len);
         sprintf(tmp_str, "rank %d=%s slot=%s\n", cur_rank, hstname, sep);
-        write(fp_rank, tmp_str, strlen(tmp_str));
+        pmix_fd_write(fp_rank, strlen(tmp_str), tmp_str);
         free(tmp_str);
         ++cur_rank;
     }

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -46,7 +46,7 @@ int prte_rmaps_rr_byslot(prte_job_t *jdata,
                          pmix_rank_t num_procs,
                          prte_rmaps_options_t *options)
 {
-    int i, rc, nprocs_mapped, ncpus;
+    int i, rc=PRTE_SUCCESS, nprocs_mapped, ncpus;
     prte_node_t *node, *nd;
     int extra_procs_to_assign = 0, nxtra_nodes = 0;
     float balance;
@@ -221,7 +221,7 @@ int prte_rmaps_rr_bynode(prte_job_t *jdata,
                          pmix_rank_t num_procs,
                          prte_rmaps_options_t *options)
 {
-    int rc, j, nprocs_mapped, ncpus;
+    int rc=PRTE_SUCCESS, j, nprocs_mapped, ncpus;
     prte_node_t *node, *nd;
     bool second_pass = false;
     prte_proc_t *proc;
@@ -564,11 +564,11 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                         pmix_rank_t num_procs,
                         prte_rmaps_options_t *options)
 {
-    int rc, nprocs_mapped;
+    int rc=PRTE_SUCCESS, nprocs_mapped;
     prte_node_t *node, *nnext;
     int ncpus;
     prte_proc_t *proc;
-    bool nodefull, allfull, outofcpus;
+    bool nodefull, allfull, outofcpus=false;
     hwloc_obj_t obj = NULL;
     unsigned j, nobjs;
 

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -265,7 +265,7 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
             p2 = prte_schizo_base_strip_quotes(argv[i + 2]);
             if (NULL == target) {
                 /* push it into our environment */
-                asprintf(&param, "PRTE_MCA_%s", p1);
+                pmix_asprintf(&param, "PRTE_MCA_%s", p1);
                 pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                     "%s schizo:prte:parse_cli pushing %s=%s into environment",
                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), param, p2);
@@ -319,7 +319,7 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                 }
                 if (NULL == target) {
                     /* push it into our environment */
-                    asprintf(&param, "PRTE_MCA_%s", p1);
+                    pmix_asprintf(&param, "PRTE_MCA_%s", p1);
                     pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                         "%s schizo:prte:parse_cli pushing %s into environment",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), p1);
@@ -365,7 +365,7 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
             p2 = prte_schizo_base_strip_quotes(argv[i + 2]);
             if (NULL == target) {
                 /* push it into our environment */
-                asprintf(&param, "PMIX_MCA_%s", p1);
+                pmix_asprintf(&param, "PMIX_MCA_%s", p1);
                 pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                     "%s schizo:pmix:parse_cli pushing %s into environment",
                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), param);
@@ -399,12 +399,12 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                  * apply the param to ALL of them
                  */
                 if (NULL == target) {
-                    asprintf(&param, "PMIX_MCA_%s", p1);
+                    pmix_asprintf(&param, "PMIX_MCA_%s", p1);
                     setenv(param, p2, true);
                     free(param);
                     // PRRTE shares the MCA base with PMIx, so no
                     // need to cover that project
-                    asprintf(&param, "OMPI_MCA_%s", p1);
+                    pmix_asprintf(&param, "OMPI_MCA_%s", p1);
                     setenv(param, p2, true);
                     free(param);
                 } else {
@@ -445,7 +445,7 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                 }
                 if (NULL == target) {
                     /* push it into our environment */
-                    asprintf(&param, "PMIX_MCA_%s", p1);
+                    pmix_asprintf(&param, "PMIX_MCA_%s", p1);
                     pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                         "%s schizo:pmix:parse_cli pushing %s into environment",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), param);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -265,7 +265,7 @@ static void set_classpath_jar_file(prte_pmix_app_t *app, int index, char *jarfil
         char *fmt = ':' == app->app.argv[index][strlen(app->app.argv[index]-1)]
                     ? "%s%s/%s" : "%s:%s/%s";
         char *str;
-        asprintf(&str, fmt, app->app.argv[index], ompi_install_dirs_libdir, jarfile);
+        pmix_asprintf(&str, fmt, app->app.argv[index], ompi_install_dirs_libdir, jarfile);
         free(app->app.argv[index]);
         app->app.argv[index] = str;
     }
@@ -315,9 +315,9 @@ static int setup_app(prte_pmix_app_t *app)
             if (NULL == strstr(app->app.argv[i], ompi_install_dirs_libdir)) {
                 /* doesn't appear to - add it to be safe */
                 if (':' == app->app.argv[i][strlen(app->app.argv[i]-1)]) {
-                    asprintf(&value, "-Djava.library.path=%s%s", dptr, ompi_install_dirs_libdir);
+                    pmix_asprintf(&value, "-Djava.library.path=%s%s", dptr, ompi_install_dirs_libdir);
                 } else {
-                    asprintf(&value, "-Djava.library.path=%s:%s", dptr, ompi_install_dirs_libdir);
+                    pmix_asprintf(&value, "-Djava.library.path=%s:%s", dptr, ompi_install_dirs_libdir);
                 }
                 free(app->app.argv[i]);
                 app->app.argv[i] = value;
@@ -328,7 +328,7 @@ static int setup_app(prte_pmix_app_t *app)
 
     if (!found) {
         /* need to add it right after the java command */
-        asprintf(&value, "-Djava.library.path=%s", ompi_install_dirs_libdir);
+        pmix_asprintf(&value, "-Djava.library.path=%s", ompi_install_dirs_libdir);
         pmix_argv_insert_element(&app->app.argv, 1, value);
         free(value);
     }
@@ -350,7 +350,7 @@ static int setup_app(prte_pmix_app_t *app)
             }
             free(value);
             /* always add the local directory */
-            asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[i+1]);
+            pmix_asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[i+1]);
             free(app->app.argv[i+1]);
             app->app.argv[i+1] = value;
             break;
@@ -372,7 +372,7 @@ static int setup_app(prte_pmix_app_t *app)
                 }
                 free(value);
                 /* always add the local directory */
-                (void)asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[1]);
+                pmix_asprintf(&value, "%s:%s", app->app.cwd, app->app.argv[1]);
                 free(app->app.argv[1]);
                 app->app.argv[1] = value;
                 pmix_argv_insert_element(&app->app.argv, 1, "-cp");
@@ -392,7 +392,7 @@ static int setup_app(prte_pmix_app_t *app)
             /* check for mpi.jar */
             value = pmix_os_path(false, ompi_install_dirs_libdir, "mpi.jar", NULL);
             if (access(value, F_OK ) != -1) {
-                (void)asprintf(&str2, "%s:%s", str, value);
+                pmix_asprintf(&str2, "%s:%s", str, value);
                 free(str);
                 str = str2;
             }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -24,6 +24,7 @@
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_fd.h"
 #include "src/util/nidmap.h"
 #include "src/util/pmix_os_dirpath.h"
 #include "src/util/pmix_output.h"
@@ -339,7 +340,7 @@ static void vm_ready(int fd, short args, void *cbdata)
             }
         } else {
             char ok = 'K';
-            write(prte_state_base.parent_fd, &ok, 1);
+            pmix_fd_write(prte_state_base.parent_fd, 1, &ok);
             close(prte_state_base.parent_fd);
             prte_state_base.parent_fd = -1;
         }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -92,7 +92,6 @@ static void _query(int sd, short args, void *cbdata)
     prte_proc_t *proct;
     pmix_proc_t *proc;
     size_t sz;
-    bool found;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -846,6 +845,7 @@ static void _query(int sd, short args, void *cbdata)
                 pmix_list_t procs;
                 int idx;
                 prte_proc_t *p2;
+                bool found = false;
                 // must at least have given us a hostname
                 if (NULL == hostname) {
                     ret = PMIX_ERR_BAD_PARAM;

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -343,7 +343,9 @@ int prun_common(pmix_cli_result_t *results,
      * otherwise, remain attached so output can get to us
      */
     if (pmix_cmd_line_is_taken(results, PRTE_CLI_DAEMONIZE)) {
-        pipe(wait_pipe);
+        if (0 > pipe(wait_pipe)) {
+            return PRTE_ERROR;
+        }
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -766,7 +766,6 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     bool flag;
     prte_pmix_app_t *app;
     char *param;
-    pmix_info_t info;
 
     /* pass the personality */
     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_PERSONALITY, schizo->name, PMIX_STRING);
@@ -895,6 +894,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     }
 #endif
 #ifdef PMIX_GPU_SUPPORT
+    pmix_info_t info;
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_GPU_SUPPORT);
     if (NULL != opt) {
         // they could be enabling or disabling it

--- a/src/runtime/prte_data_server.c
+++ b/src/runtime/prte_data_server.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -188,7 +188,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
     bool wait = false;
     int room_number;
     uint32_t uid = UINT32_MAX;
-    pmix_data_range_t range;
+    pmix_data_range_t range=PMIX_RANGE_UNDEF;
     prte_data_req_t *req, *rqnext;
     pmix_data_buffer_t pbkt;
     pmix_byte_object_t pbo;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -584,7 +584,9 @@ int main(int argc, char *argv[])
      * otherwise, remain attached so output can get to us
      */
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_DAEMONIZE)) {
-        pipe(wait_pipe);
+        if (0 > pipe(wait_pipe)) {
+            return PRTE_ERROR;
+        }
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);
@@ -1283,7 +1285,7 @@ static int prep_singleton(const char *name)
     app->app = strdup(jdata->nspace);
     app->num_procs = 1;
     PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->argv, app->app);
-    getcwd(cwd, sizeof(cwd));
+    pmix_getcwd(cwd, sizeof(cwd));
     app->cwd = strdup(cwd);
     pmix_pointer_array_set_item(jdata->apps, 0, app);
     jdata->num_apps = 1;

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -341,7 +341,9 @@ int main(int argc, char *argv[])
      * otherwise, remain attached so output can get to us
      */
     if (!prte_leave_session_attached && !prte_debug_daemons_flag) {
-        pipe(wait_pipe);
+        if (0 > pipe(wait_pipe)) {
+            return PRTE_ERROR;
+        }
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -79,7 +79,6 @@
 #include "src/util/pmix_path.h"
 #include "src/util/pmix_printf.h"
 #include "src/util/pmix_environ.h"
-#include "src/util/pmix_getcwd.h"
 #include "src/util/pmix_show_help.h"
 
 #include "src/class/pmix_pointer_array.h"

--- a/src/util/bipartite_graph.c
+++ b/src/util/bipartite_graph.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2017      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -55,7 +55,11 @@
 /* ensure that (a+b<=max) */
 static inline void check_add64_overflow(int64_t a, int64_t b)
 {
+#if PRTE_ENABLE_DEBUG
     assert(!((b > 0) && (a > (INT64_MAX - b))) && !((b < 0) && (a < (INT64_MIN - b))));
+#else
+    PRTE_HIDE_UNUSED_PARAMS(a, b);
+#endif
 }
 
 static void edge_constructor(prte_bp_graph_edge_t *e)

--- a/src/util/malloc.c
+++ b/src/util/malloc.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,6 +107,8 @@ void *prte_malloc(size_t size, const char *file, int line)
                         line);
         }
     }
+#else
+    PRTE_HIDE_UNUSED_PARAMS(file, line);
 #endif /* PRTE_ENABLE_DEBUG */
 
     addr = malloc(size);
@@ -135,6 +137,8 @@ void *prte_calloc(size_t nmembers, size_t size, const char *file, int line)
                         (long) nmembers, (long) size, file, line);
         }
     }
+#else
+    PRTE_HIDE_UNUSED_PARAMS(file, line);
 #endif /* PRTE_ENABLE_DEBUG */
     addr = calloc(nmembers, size);
 #if PRTE_ENABLE_DEBUG
@@ -167,6 +171,8 @@ void *prte_realloc(void *ptr, size_t size, const char *file, int line)
             }
         }
     }
+#else
+    PRTE_HIDE_UNUSED_PARAMS(file, line);
 #endif /* PRTE_ENABLE_DEBUG */
     addr = realloc(ptr, size);
 #if PRTE_ENABLE_DEBUG
@@ -193,5 +199,7 @@ void prte_malloc_debug(int level)
 {
 #if PRTE_ENABLE_DEBUG
     prte_malloc_debug_level = level;
+#else
+    PRTE_HIDE_UNUSED_PARAMS(level);
 #endif /* PRTE_ENABLE_DEBUG */
 }

--- a/test/cmspawn.c
+++ b/test/cmspawn.c
@@ -9,7 +9,7 @@
 int main(int argc, char *argv[])
 {
     pmix_status_t rc;
-    int size;
+    int size, n;
     pid_t pid;
     pmix_proc_t myproc;
     pmix_proc_t proc, parent;
@@ -70,21 +70,23 @@ int main(int argc, char *argv[])
 
             PMIX_LOAD_PROCID(&peers[0], myproc.nspace, 0);
             PMIX_LOAD_PROCID(&peers[1], nspace, PMIX_RANK_WILDCARD);
-            /* connect to the children */
-            printf("%s.%u: Connecting to children - signature %s %s\n",
-                   myproc.nspace, myproc.rank,
-                   peers[0].nspace, peers[1].nspace);
-            rc = PMIx_Connect(peers, 2, NULL, 0);
-            if (PMIX_SUCCESS != rc) {
-                printf("Connect to children failed!\n");
+            for (n=0; n < 10; n++) {
+                /* connect to the children */
+                printf("%s.%u: Connecting to children - signature %s %s\n",
+                       myproc.nspace, myproc.rank,
+                       peers[0].nspace, peers[1].nspace);
+                rc = PMIx_Connect(peers, 2, NULL, 0);
+                if (PMIX_SUCCESS != rc) {
+                    printf("Connect to children failed!\n");
+                }
+                printf("%s.%u: Connect complete!\n", myproc.nspace, myproc.rank);
+                printf("%s.%u: Disconnecting from children\n", myproc.nspace, myproc.rank);
+                rc = PMIx_Disconnect(peers, 2, NULL, 0);
+                if (PMIX_SUCCESS != rc) {
+                    printf("Disonnect from children failed!\n");
+                }
+                printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
             }
-            printf("%s.%u: Connect complete!\n", myproc.nspace, myproc.rank);
-            printf("%s.%u: Disconnecting from children\n", myproc.nspace, myproc.rank);
-            rc = PMIx_Disconnect(peers, 2, NULL, 0);
-            if (PMIX_SUCCESS != rc) {
-                printf("Disonnect from children failed!\n");
-            }
-            printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
         }
         PMIX_LOAD_PROCID(&peers[0], myproc.nspace, PMIX_RANK_WILDCARD);
         PMIx_Fence(&peers[0], 1, NULL, 0);
@@ -102,25 +104,27 @@ int main(int argc, char *argv[])
             sleep(2);
             printf("\n\n\n");
         }
-        printf("%s.%u: Connecting to parent - signature %s %s\n",
-               myproc.nspace, myproc.rank,
-               peers[0].nspace, peers[1].nspace);
-        rc = PMIx_Connect(peers, 2, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            printf("%s.%u: Connect to parent failed!\n", myproc.nspace, myproc.rank);
-        }
-        printf("%s.%u: Connect complete!\n", myproc.nspace, myproc.rank);
+        for (n=0; n < 10; n++) {
+            printf("%s.%u: Connecting to parent - signature %s %s\n",
+                   myproc.nspace, myproc.rank,
+                   peers[0].nspace, peers[1].nspace);
+            rc = PMIx_Connect(peers, 2, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                printf("%s.%u: Connect to parent failed!\n", myproc.nspace, myproc.rank);
+            }
+            printf("%s.%u: Connect complete!\n", myproc.nspace, myproc.rank);
 
-        printf("%s.%u: Disconnecting from parent\n", myproc.nspace, myproc.rank);
-        if (2 == myproc.rank) {
-            sleep(2);
-            printf("\n\n\n");
+            printf("%s.%u: Disconnecting from parent\n", myproc.nspace, myproc.rank);
+            if (2 == myproc.rank) {
+                sleep(2);
+                printf("\n\n\n");
+            }
+            rc = PMIx_Disconnect(peers, 2, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                printf("Disonnect from parent failed!\n");
+            }
+            printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
         }
-        rc = PMIx_Disconnect(peers, 2, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            printf("Disonnect from parent failed!\n");
-        }
-        printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
     }
 
 done:


### PR DESCRIPTION
[gcc compilation failure fixes](https://github.com/openpmix/prrte/commit/dd3ba2ff22744c296d65497a39ea68f1b9f88150)

when configured with --enable-debug several files failed to compile
using gcc 8.5.0 on RHEL8.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit https://github.com/openpmix/prrte/commit/57b672c9a31df79072707821b7bd0e87189a1f31)

[Update CI workflow](https://github.com/openpmix/prrte/commit/c1ca579d78726f7ac3c2daf590a92b52b79c5c7f)

Use a specific older v5.0.3 tag as the head of the v5.0
branch has been updated

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/b87c8fc5d16c1f0098cef2ff525086a481b716a8)

[Silence warnings exposed by revised CI](https://github.com/openpmix/prrte/commit/9faecb96eb8fd24f632adc590295fcad3d0e24ed)

Fix all the warnings exposed by the addition of
`--enable-devel-check` to all the CI workflows.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f691d030ccfa8fb156093d48b80888ae8c8964fe)
