### PR TITLE
Multiple commits

### DIFF
--- a/docs/news/news-v3.x.rst
+++ b/docs/news/news-v3.x.rst
@@ -4,6 +4,34 @@ PRRTE v3.x series
 This file contains all the NEWS updates for the PRRTE v3.x
 series, in reverse chronological order.
 
+3.0.9 -- TBD
+------------
+- PR #2145: Multiple commits
+   - Fix inheritance
+   - Provide a user error message when srun fails
+   - Update NEWS
+- PR #2142: Multiple commits
+   - gcc compilation failure fixes
+   - Update CI workflow
+   - Silence warnings exposed by revised CI
+- PR #2141: Multiple commits
+   - Silence warnings exposed by revised CI
+   - Add build against older PMIx CI
+   - Add mpi4py CI
+- PR #2137: Multiple commits
+   - Add spawn_multiple test
+   - Minor cleanups
+   - Implement query support for PMIx resolve functions
+   - Add ability to direct app GPU support
+- PR #2125: hurd: fix build
+- PR #2123: Refactor ranking algorithms
+- PR #2109: Multiple commits
+   - Add a test for CI purposes
+   - Try a DVM-based action
+   - Update users of pmix_os_dirpath_create
+   - Remove the group CI as this release branch doesn't support it
+
+
 3.0.8 -- 15 Dec 2024
 --------------------
 - PR #2103: Final update for release

--- a/src/docs/show-help-files/help-plm-slurm.txt
+++ b/src/docs/show-help-files/help-plm-slurm.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -82,57 +82,11 @@ This will result in use of the ssh process starter. This will have
 no impact on your application, but will result in any accounting
 being done solely at the allocation level instead of per-job.
 #
-[custom-args-in-env]
-The Slurm process starter for PRTE detected the presence of an MCA
-parameter in the environment that assigns custom command line arguments
-to the `srun` command used to start PRTE's daemons on remote nodes:
+[srun-failed]
+srun returned non-zero exit status (%d) from launching
+the per-node daemon. You may debug this problem further
+by augmenting the cmd line with:
 
-  Paramater value: %s
-
-This warning is provided to alert you (the user) to a perhaps
-unintentional setting of command line arguments, or the unseen
-overriding of your intended arguments by Slurm.
-
-Background: Starting with Slurm version 23.11, a command line argument
-(`--external-launcher`) was added to `srun` to indicate that the
-command was being initiated from within a third-party launcher (e.g.,
-`prte` or `prterun`). This allows Slurm to essentially freely modify
-the `srun` command line while retaining a backward compatibility
-capability when explicitly told to use it.  Notably, the Slurm
-environment does this by automatically setting the
-PRTE_MCA_plm_slurm_args environment variable to pass in its own
-command line arguments.  This has the side effect of overriding most
-user- or system-level settings.  Note that arguments passed on the
-PRTE command line will override any Slurm setting of the
-PRTE_MCA_plm_slurm_args environment variable, but with potentially
-undesirable side effects if newer versions of `srun` misinterpret or
-fail to understand the user-specified arguments.
-
-If the setting of the MCA parameter was intentional, or if the
-parameter looks acceptable to you, then please set the following
-MCA parameter to disable this warning:
-
-  Environment: PRTE_MCA_plm_slurm_disable_warning=true
-  Cmd line: --prtemca plm_slurm_disable_warning 1
-  Default MCA param file: plm_slurm_disable_warning = true
-
-If you did not intentionally set the identified command line
-arguments and do not wish them to be used, then set the
-following MCA param to have them ignored:
-
-  Environment: PRTE_MCA_plm_slurm_ignore_args=true
-  Cmd line: --prtemca plm_slurm_ignore_args 1
-  Default MCA param file: plm_slurm_ignore_args = true
-
-Note that if you wish to provide custom `srun` command line
-arguments and are finding them being overridden by Slurm, you
-can ensure that your values are used by setting them with the
-following param:
-
-  Environment: PRTE_MCA_plm_slurm_force_args=foo
-  Cmd line: --prtemca plm_slurm_force_args foo
-  Default MCA param file: plm_slurm_force_args = foo
-
-Note that you may need to add the `--external-launcher` option
-to your provided args to ensure that `srun` properly functions
-if you are using a relatively recent release of Slurm.
+* "--debug-daemons"
+* "--leave-session-attached"
+* "--prtemca plm_base_verbose N" where N > 0

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -600,10 +600,8 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
         /* an orted must have died unexpectedly - report
          * that the daemon has failed so we exit
          */
-        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                             "%s plm:slurm: srun returned non-zero exit status (%d) from launching "
-                             "the per-node daemon",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), proc->exit_code));
+        pmix_show_help("help-plm-slurm.txt", "srun-failed", true,
+                       proc->exit_code);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
     } else {
         /* otherwise, check to see if this is the primary pid */

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -228,9 +228,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             /* we do allow inheritance of the defaults */
             inherit = true;
         } else if (NULL != (parent = prte_get_job_data_object(nptr->nspace))) {
-            if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
+            if (prte_get_attribute(&parent->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
                 inherit = true;
-            } else if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
+            } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
                 inherit = false;
                 parent = NULL;
             } else {


### PR DESCRIPTION
[Fix inheritance](https://github.com/openpmix/prrte/commit/c9fcb691865b2222540e962cb1696551b8d31cee)

Based on the mapping modes of the parent, so correct typo
that incorrectly checked the job itself.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/55c8c51084074a6f36bf60435bbcf0c1b3331c0d)

[Provide a user error message when srun fails](https://github.com/openpmix/prrte/commit/db5a6d801353df6050f56ed28ccf7c496b003333)

When srun fails to launch the daemons, output
an error message before exiting.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7bb953b49deee877ae4efb95cac5f2a777c64618)

[Update NEWS](https://github.com/openpmix/prrte/commit/478504f69d34dad89278a5408e7863220e961f58)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick