### PR TITLE
Allow "not supported" to be returned by query upcall

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -976,16 +976,18 @@ done:
         ret = rc;
     }
     PMIX_INFO_LIST_RELEASE(results);
-    if (PMIX_ERR_EMPTY == rc) {
-        ret = PMIX_ERR_NOT_FOUND;
-    } else if (PMIX_SUCCESS == ret) {
-        if (0 == dry.size) {
+    if (PMIX_ERR_NOT_SUPPORTED != ret) {
+        if (PMIX_ERR_EMPTY == rc) {
             ret = PMIX_ERR_NOT_FOUND;
-        } else {
-            if (dry.size < cd->ninfo) {
-                ret = PMIX_QUERY_PARTIAL_SUCCESS;
+        } else if (PMIX_SUCCESS == ret) {
+            if (0 == dry.size) {
+                ret = PMIX_ERR_NOT_FOUND;
             } else {
-                ret = PMIX_SUCCESS;
+                if (dry.size < cd->ninfo) {
+                    ret = PMIX_QUERY_PARTIAL_SUCCESS;
+                } else {
+                    ret = PMIX_SUCCESS;
+                }
             }
         }
     }


### PR DESCRIPTION
Provide a path for the "not supported" status to be returned to the PMIx server