### PR TITLE
Accommodate changes in Slurm version string

### DIFF
--- a/src/mca/plm/slurm/plm_slurm.h
+++ b/src/mca/plm/slurm/plm_slurm.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2022-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,6 +35,9 @@ struct prte_mca_plm_slurm_component_t {
     prte_plm_base_component_t super;
     char *custom_args;
     bool early;
+    bool ancient;
+    int major;
+    int minor;
 };
 typedef struct prte_mca_plm_slurm_component_t prte_mca_plm_slurm_component_t;
 


### PR DESCRIPTION
Debian has modified the Slurm version string, but for now we can still parse it be skipping to the first space instead of relying on the number of characters in the first word.

Eliminate checking the version twice by simply storing the initial result.

Refs https://github.com/openpmix/prrte/pull/2155