### PR TITLE
Fix add-hosts behaviour to include user specified slots

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -975,6 +975,7 @@ proceed:
                         node->name = strdup(cptr);
                         node->slots = slots;
                         node->state = PRTE_NODE_STATE_ADDED;
+                        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
                         pmix_list_append(&nodes, &node->super);
                     }
                     free(line);


### PR DESCRIPTION
Mark slots as user-specified when adding new hosts.