### PR TITLE
Extract the install prefix from the shared library.

### DIFF
--- a/src/mca/prteinstalldirs/runtime/Makefile.am
+++ b/src/mca/prteinstalldirs/runtime/Makefile.am
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_LTLIBRARIES = libprtemca_prteinstalldirs_runtime.la
+
+libprtemca_prteinstalldirs_runtime_la_SOURCES = \
+	prte_installdirs_runtime.c
+

--- a/src/mca/prteinstalldirs/runtime/configure.m4
+++ b/src/mca/prteinstalldirs/runtime/configure.m4
@@ -1,0 +1,45 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+AC_DEFUN([MCA_prte_prteinstalldirs_runtime_PRIORITY], [5])
+
+AC_DEFUN([MCA_prte_prteinstalldirs_runtime_COMPILE_MODE], [
+    AC_MSG_CHECKING([for MCA component $2:$3 compile mode])
+    $4="static"
+    AC_MSG_RESULT([$$4])
+])
+
+# MCA_prteinstalldirs_config_CONFIG(action-if-can-compile,
+#                        [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_prte_prteinstalldirs_runtime_CONFIG], [
+    # Check if we are building a shared library or not. Disable if static
+    AC_MSG_CHECKING([if shared libraries are enabled])
+    AS_IF([test "$enable_shared" != "yes"],
+          [prteinstalldirs_runtime_happy="no"],
+          [prteinstalldirs_runtime_happy="yes"])
+    AC_MSG_RESULT([$prteinstalldirs_runtime_happy])
+
+    # Check if dladdr is available
+    AS_IF([test "$prteinstalldirs_runtime_happy" = "yes"],
+          [AC_CHECK_HEADERS([dlfcn.h],
+                            [],
+                            [prteinstalldirs_runtime_happy="no"])])
+    AS_IF([test "$prteinstalldirs_runtime_happy" = "yes"],
+          [AC_CHECK_LIB([dl], [dladdr],
+                        [],
+                        [prteinstalldirs_runtime_happy="no"])
+          ])
+    #
+    AS_IF([test "$prteinstalldirs_runtime_happy" = "yes"],
+          [AC_CONFIG_FILES([src/mca/prteinstalldirs/runtime/Makefile])
+           $1], [$2])
+])
+

--- a/src/mca/prteinstalldirs/runtime/prte_installdirs_runtime.c
+++ b/src/mca/prteinstalldirs/runtime/prte_installdirs_runtime.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025      NVIDIA Corporation.  All rights reserved.
+ * Copyright (c) 2025      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/mca/prteinstalldirs/prteinstalldirs.h"
+#include <dlfcn.h>
+#include "src/util/pmix_basename.h"
+
+static int prteinstalldirs_runtime_open(void);
+
+prte_prteinstalldirs_base_component_t prte_mca_prteinstalldirs_runtime_component = {
+    /* First, the mca_component_t struct containing meta information
+       about the component itself */
+    .component = {
+        PRTE_INSTALLDIRS_BASE_VERSION_2_0_0,
+
+         /* Component name and version */
+         .pmix_mca_component_name = "runtime",
+         PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PRTE_MAJOR_VERSION,
+                                   PRTE_MINOR_VERSION,
+                                   PRTE_RELEASE_VERSION),
+         /* Component open and close functions */
+         .pmix_mca_open_component = prteinstalldirs_runtime_open
+    },
+
+    /* Next the prte_install_dirs_t install_dirs_data information */
+    {
+        .prefix = NULL,
+        .exec_prefix = NULL,
+        .bindir = NULL,
+        .sbindir = NULL,
+        .libexecdir = NULL,
+        .datarootdir = NULL,
+        .datadir = NULL,
+        .sysconfdir = NULL,
+        .sharedstatedir = NULL,
+        .localstatedir = NULL,
+        .libdir = NULL,
+        .includedir = NULL,
+        .infodir = NULL,
+        .mandir = NULL,
+        .prtedatadir = NULL,
+        .prtelibdir = NULL,
+        .prteincludedir = NULL,
+    },
+};
+PMIX_MCA_BASE_COMPONENT_INIT(prte, prteinstalldirs, runtime)
+
+static int prteinstalldirs_runtime_open(void)
+{
+    Dl_info info;
+    void* prte_fct;
+
+    /* Casting from void* to fct pointer according to POSIX.1-2001 and POSIX.1-2008 */
+    *(void **)&prte_fct = dlsym(RTLD_DEFAULT, "pmix_init_util");
+
+    if( 0 == dladdr(prte_fct, &info) ) {
+        /* Can't find the symbol */
+        return PRTE_ERROR;
+    }
+
+    char* dname = pmix_dirname(info.dli_fname);
+    char* prefix = pmix_dirname(dname);
+    free(dname);
+
+    prte_mca_prteinstalldirs_runtime_component.install_dirs_data.prefix = prefix;
+
+    return PRTE_SUCCESS;
+}


### PR DESCRIPTION
This is part of a multi-project effort, a similar PR will be created in OpenPMIX and OMPI. The goal of each of these changes is the same: instead of using build-time generated prefix that ignore a project rebase, take the prefix from the shared library of each project and derive the necessary paths from it. The user can however overwrite this using the environment variables, and the configuration files.

Add missing declaration
(Transferred from original PR to fork'd clone of this repo)
