### PR TITLE
Require pmixcc be available to build PRRTE

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -146,8 +146,9 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     PRTE_LOG_MSG([pmixcc version: $pmixcc_showme_results])
     AS_IF([test $found_pmixcc -eq 0],
           [AC_MSG_WARN([Could not find $PMIXCC_PATH])
-           PMIXCC_PATH=])
-    AM_CONDITIONAL([PRTE_HAVE_PMIXCC], [test $found_pmixcc -eq 1])
+           AC_MSG_WARN([$PMIXCC_PATH is required for PRRTE to build])
+           AC_MSG_WARN([Please ensure it was installed])
+           AC_MSG_ERROR([Cannot continue])])
     AC_SUBST([PMIXCC_PATH])
 
     # Check for any needed capabilities from the PMIx we found.

--- a/src/tools/pcc/Makefile.am
+++ b/src/tools/pcc/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2019 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,12 +21,8 @@
 # $HEADER$
 #
 
-if PRTE_HAVE_PMIXCC
-
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f pcc; $(LN_S) $(PMIXCC_PATH)$(EXEEXT) pcc)
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/pcc$(EXEEXT)
-
-endif


### PR DESCRIPTION
We need the wrapper compiler so we can determine the LTO compatibility of the PMIx version we have been given. Thus, it is no longer optional.