### PR TITLE
Extend support for envar operations

### DIFF
--- a/src/docs/prrte-rst-content/Makefile.am
+++ b/src/docs/prrte-rst-content/Makefile.am
@@ -23,6 +23,7 @@ dist_rst_DATA = \
     cli-add-hostfile.rst \
     cli-allow-run-as-root.rst \
     cli-app-prefix.rst \
+    cli-append-env.rst \
     cli-bind-to.rst \
     cli-dash-host.rst \
     cli-debug-daemons-file.rst \
@@ -41,11 +42,13 @@ dist_rst_DATA = \
     cli-pmixmca.rst \
     cli-pmix-prefix.rst \
     cli-prefix.rst \
+    cli-prepend-env.rst \
     cli-prtemca.rst \
     cli-rank-by.rst \
     cli-runtime-options.rst \
     cli-stream-buffering.rst \
     cli-tune.rst \
+    cli-unset-env.rst \
     cli-x.rst \
     definitions-pes.rst \
     definitions-slots.rst \

--- a/src/docs/prrte-rst-content/cli-append-env.rst
+++ b/src/docs/prrte-rst-content/cli-append-env.rst
@@ -1,0 +1,21 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: ``--append-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
+
+``LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib``

--- a/src/docs/prrte-rst-content/cli-prepend-env.rst
+++ b/src/docs/prrte-rst-content/cli-prepend-env.rst
@@ -1,0 +1,21 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: ``--prepend-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
+
+``LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH``

--- a/src/docs/prrte-rst-content/cli-unset-env.rst
+++ b/src/docs/prrte-rst-content/cli-unset-env.rst
@@ -1,0 +1,16 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Unset the named environmental variable. Note ``--unset-env foo*`` unsets all
+current environmental variables starting with "foo"

--- a/src/docs/show-help-files/help-prterun.txt
+++ b/src/docs/show-help-files/help-prterun.txt
@@ -203,7 +203,28 @@ option to the help request as "--help <option>".
 |                      | processes                                     |
 +----------------------+-----------------------------------------------+
 | "-x <name>"          | Export an environment variable, optionally    |
-|                      | specifying a value                            |
+|                      | specifying a value (e.g., "-x foo" exports    |
+|                      | the environment variable foo and takes its    |
+|                      | value from the current environment; "-x       |
+|                      | foo=bar" exports the environment variable     |
+|                      | name foo and sets its value to "bar" in the   |
+|                      | started processes; "-x foo*" exports all      |
+|                      | current environmental variables starting with |
+|                      | "foo")                                        |
++----------------------+-----------------------------------------------+
+| "--unset-env <name>" | Unset the named environmental variable. Note  |
+|                      | "--unset-env foo*" unsets all current         |
+|                      | environmental variables starting with "foo"   |
++----------------------+-----------------------------------------------+
+| "--append-env        | Append the named environment variable with    |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when appending the value.                     |
++----------------------+-----------------------------------------------+
+| "--prepend-env       | Prepend the named environment variable with   |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when prepending the value.                    |
 +----------------------+-----------------------------------------------+
 | "--gpu-support <val>"| Direct application to either enable (true) or |
 |                      | disable (false) its internal library's GPU    |
@@ -506,6 +527,40 @@ PMIx prefix has been given to PRRTE, but the application has been built
 against a PMIx library that (a) is different from the one used by PRRTE,
 and (b) was not moved. Otherwise, PRRTE will apply its default prefix to
 the application.
+
+[x]
+
+Export an environment variable, optionally specifying a value. For example,
+"-x foo" exports the environment variable "foo" and takes its value
+from the current environment, while "-x foo=bar" exports the environment
+variable name "foo" and sets its value to "bar" in the started processes.
+Note that "-x foo*" exports all current environmental variables starting with
+"foo"
+
+[unset-env]
+
+Unset the named environmental variable. Note "--unset-env foo*" unsets all
+current environmental variables starting with "foo"
+
+[append-env]
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--append-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib
+
+[prepend-env]
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--prepend-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH
 
 [forward-signals]
 

--- a/src/docs/show-help-files/help-prun.txt
+++ b/src/docs/show-help-files/help-prun.txt
@@ -214,6 +214,20 @@ option to the help request as "--help <option>".
 |                      | current environmental variables starting with |
 |                      | "foo")                                        |
 +----------------------+-----------------------------------------------+
+| "--unset-env <name>" | Unset the named environmental variable. Note  |
+|                      | "--unset-env foo*" unsets all current         |
+|                      | environmental variables starting with "foo"   |
++----------------------+-----------------------------------------------+
+| "--append-env        | Append the named environment variable with    |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when appending the value.                     |
++----------------------+-----------------------------------------------+
+| "--prepend-env       | Prepend the named environment variable with   |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when prepending the value.                    |
++----------------------+-----------------------------------------------+
 | "--gpu-support <val>"| Direct application to either enable (true) or |
 |                      | disable (false) its internal library's GPU    |
 |                      | support                                       |
@@ -1192,6 +1206,40 @@ against a PMIx library that (a) is different from the one used by PRRTE,
 and (b) was not moved. Otherwise, PRRTE will apply its default prefix to
 the application.
 
+[x]
+
+Export an environment variable, optionally specifying a value. For example,
+"-x foo" exports the environment variable "foo" and takes its value
+from the current environment, while "-x foo=bar" exports the environment
+variable name "foo" and sets its value to "bar" in the started processes.
+Note that "-x foo*" exports all current environmental variables starting with
+"foo"
+
+[unset-env]
+
+Unset the named environmental variable. Note "--unset-env foo*" unsets all
+current environmental variables starting with "foo"
+
+[append-env]
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--append-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib
+
+[prepend-env]
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--prepend-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH
+
 [prun:executable-not-specified]
 
 No executable was specified on the %s command line.
@@ -1618,3 +1666,11 @@ found or could not be opened:
    file: %s
 
 Please correct the option and try again.
+#
+[malformed-envar]
+A command line option was given to %s an envar for an application:
+
+  App: %s
+  Envar: %s
+
+Please correct the error and try again.

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -757,8 +757,6 @@ next:
         }
     }
 
-    /* set any app envars */
-
     /* reset the mapped flags */
     for (n = 0; n < jdata->map->nodes->size; n++) {
         node = (prte_node_t *) pmix_pointer_array_get_item(jdata->map->nodes, n);
@@ -1099,6 +1097,148 @@ errorout:
     PMIX_RELEASE(cd);
 }
 
+static void process_envars(prte_job_t *jdata,
+                           prte_app_context_t *app)
+{
+    prte_attribute_t *attr;
+    pmix_value_t *val;
+    pmix_envar_t *envar;
+    char *ptr, *tmp, *p2;
+    size_t n;
+    bool found;
+
+    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t) {
+        val = &attr->data;
+        envar = &val->data.envar;
+        if (attr->key == PRTE_JOB_SET_ENVAR) {
+            PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+
+        } else if (attr->key == PRTE_JOB_ADD_ENVAR) {
+            PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+
+        } else if (attr->key == PRTE_JOB_UNSET_ENVAR) {
+            // need to support the wildcard here
+            if (NULL != strchr(envar->envar, '*')) {
+                ptr = strdup(envar->envar);
+                ptr[strlen(ptr)-1] = '\0';  // trim off the '*'
+                for (n=0; NULL != app->env[n]; n++) {
+                    if (0 == strncmp(app->env[n], ptr, strlen(ptr))) {
+                        // find the '=' sign
+                        tmp = strdup(app->env[n]);
+                        p2 = strchr(tmp, '=');
+                        *p2 = '\0';
+                        pmix_unsetenv(tmp, &app->env);
+                        free(tmp);
+                    }
+                }
+                free(ptr);
+            } else {
+                pmix_unsetenv(envar->envar, &app->env);
+            }
+
+        } else if (attr->key == PRTE_JOB_PREPEND_ENVAR) {
+            // see if this envar exists
+            ptr = NULL;
+            found = false;
+            for (n=0; NULL != app->env[n]; n++) {
+                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
+                    // find the value - this is a copied env, so we can modify
+                    ptr = strchr(app->env[n], '=');
+                    ++ptr; // step over the '='
+                    pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, envar->value, envar->separator, ptr);
+                    free(app->env[n]);
+                    app->env[n] = tmp;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                // didn't find it
+                PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+            }
+
+        } else if (attr->key == PRTE_JOB_APPEND_ENVAR) {
+            // see if this envar exists
+            ptr = NULL;
+            found = false;
+            for (n=0; NULL != app->env[n]; n++) {
+                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
+                    // find the value - this is a copied env, so we can modify
+                    ptr = strchr(app->env[n], '=');
+                    ++ptr; // step over the '='
+                    pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, ptr, envar->separator, envar->value);
+                    free(app->env[n]);
+                    app->env[n] = tmp;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                // didn't find it
+                PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+            }
+        }
+    }
+
+    // app trumps job, so do it after the job
+    PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t) {
+        val = &attr->data;
+        envar = &val->data.envar;
+        if (attr->key == PRTE_APP_SET_ENVAR) {
+            PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+
+        } else if (attr->key == PRTE_APP_ADD_ENVAR) {
+            PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+
+        } else if (attr->key == PRTE_APP_UNSET_ENVAR) {
+            pmix_unsetenv(envar->envar, &app->env);
+
+        } else if (attr->key == PRTE_APP_PREPEND_ENVAR) {
+            // see if this envar exists
+            ptr = NULL;
+            found = false;
+            for (n=0; NULL != app->env[n]; n++) {
+                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
+                    // find the value - this is a copied env, so we can modify
+                    ptr = strchr(app->env[n], '=');
+                    ++ptr; // step over the '='
+                    pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, envar->value, envar->separator, ptr);
+                    free(app->env[n]);
+                    app->env[n] = tmp;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                // didn't find it
+                PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+            }
+
+        } else if (attr->key == PRTE_APP_APPEND_ENVAR) {
+            // see if this envar exists
+            ptr = NULL;
+            found = false;
+            for (n=0; NULL != app->env[n]; n++) {
+                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
+                    // find the value - this is a copied env, so we can modify
+                    ptr = strchr(app->env[n], '=');
+                    ++ptr; // step over the '='
+                    pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, ptr, envar->separator, envar->value);
+                    free(app->env[n]);
+                    app->env[n] = tmp;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                // didn't find it
+                PMIX_SETENV_COMPAT(envar->envar, envar->value, true, &app->env);
+            }
+        }
+    }
+}
+
+
 void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
 {
     prte_app_context_t *app;
@@ -1116,7 +1256,6 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
     prte_odls_spawn_caddy_t *cd;
     prte_event_base_t *evb;
     prte_schizo_base_module_t *schizo;
-
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -1246,10 +1385,14 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         if (NULL == app->env) {
             app->env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
         } else {
-            xfer = pmix_environ_merge(app->env, prte_launch_environ);
+            xfer = pmix_environ_merge(prte_launch_environ, app->env);
             PMIX_ARGV_FREE_COMPAT(app->env);
             app->env = xfer;
         }
+
+        // process any provided env directives
+        process_envars(jobdat, app);
+
 
         if (PRTE_SUCCESS != (rc = schizo->setup_fork(jobdat, app))) {
 

--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -81,8 +81,17 @@ Launch options
 
 * ``--wdir <dir>``: Set the working directory of the started processes.
 
-* ``-x <var>``: Export a environment variable, optionally specifying a value.
+* ``-x <var>``: Export an environment variable, optionally specifying a value.
   :ref:`See below for details <label-schizo-ompi-x>`.
+
+* ``--unset-env <var>``: Unset an environment variable.
+  :ref:`See below for details <label-schizo-ompi-unset-env>`.
+
+* ``--prepend-env <var[c]> <val>``: Prepend a value to an environment variable
+  :ref:`See below for details <label-schizo-ompi-prepend-env>`.
+
+* ``--append-env <var[c]> <val>``: Prepend a value to an environment variable
+  :ref:`See below for details <label-schizo-ompi-append-env>`.
 
 * ``--gpu-support <val>``: Direct application to either enable (true) or
   disable (false) its internal library's GPU support
@@ -422,6 +431,25 @@ The ``-x`` option
 ~~~~~~~~~~~~~~~~~
 
 .. include:: /prrte-rst-content/cli-x.rst
+
+.. _label-schizo-ompi-unset-env
+
+The ``--unset-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-unset-env.rst
+
+.. _label-schizo-ompi-prepend-env
+
+The ``--prepend-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-prepend-env.rst
+
+
+.. _label-schizo-ompi-apppend-env
+
+The ``--apppend-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-apppend-env.rst
 
 
 Deprecated command line options

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -158,6 +158,15 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_PRELOAD_FILES, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_PRELOAD_BIN, PMIX_ARG_NONE, 's'),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_FWD_ENVAR, PMIX_ARG_REQD, 'x'),
+#ifdef PMIX_CLI_PREPEND_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
+#endif
+#ifdef PMIX_CLI_APPEND_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_APPEND_ENVAR, PMIX_ARG_REQD),
+#endif
+#ifdef PMIX_CLI_UNSET_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_UNSET_ENVAR, PMIX_ARG_REQD),
+#endif
     PMIX_OPTION_DEFINE(PRTE_CLI_WDIR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("wd", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_PATH, PMIX_ARG_REQD),
@@ -1812,36 +1821,6 @@ static int parse_env(char **srcenv, char ***dstenv,
         }
     }
     PMIX_ARGV_FREE_COMPAT(envlist);
-
-    /* now look for -x options - not allowed to conflict with a -mca option */
-    if (NULL != (opt = pmix_cmd_line_get_param(results, "x"))) {
-        for (i = 0; NULL != opt->values[i]; ++i) {
-            /* the value is the envar */
-            p1 = opt->values[i];
-            /* if there is an '=' in it, then they are setting a value */
-            if (NULL != (p2 = strchr(p1, '='))) {
-                *p2 = '\0';
-                ++p2;
-            } else {
-                p2 = getenv(p1);
-                if (NULL == p2) {
-                    continue;
-                }
-            }
-            /* not allowed to duplicate anything from an MCA param on the cmd line */
-            rc = check_cache_noadd(&cache, &cachevals, p1, p2);
-            if (PRTE_SUCCESS != rc) {
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
-                PMIX_ARGV_FREE_COMPAT(xparams);
-                PMIX_ARGV_FREE_COMPAT(xvals);
-                return rc;
-            }
-            /* cache this for later inclusion */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xparams, p1);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xvals, p2);
-        }
-    }
 
     /* process the resulting cache into the dstenv */
     if (NULL != cache) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -785,34 +785,64 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
-                prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
-                                       PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                if (0 == app->idx) {
+                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                } else {
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                }
             } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
-                prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
-                                       PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                if (0 == app->idx) {
+                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                } else {
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                }
             } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-                prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
-                                       PRTE_ATTR_GLOBAL,
-                                       info->value.data.string, PMIX_STRING);
+                if (0 == app->idx) {
+                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           info->value.data.string, PMIX_STRING);
+                } else {
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           info->value.data.string, PMIX_STRING);
+                }
             } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
-                prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
-                                       PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                if (0 == app->idx) {
+                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                } else {
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                }
             } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
-                prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
-                                       PRTE_ATTR_GLOBAL,
-                                       &envar, PMIX_ENVAR);
+                if (0 == app->idx) {
+                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                } else {
+                    prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
+                                           PRTE_ATTR_GLOBAL,
+                                           &envar, PMIX_ENVAR);
+                }
 
             } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {
                 prte_set_attribute(&app->attributes, PRTE_APP_PSET_NAME, PRTE_ATTR_GLOBAL,

--- a/src/runtime/prte_wait.h
+++ b/src/runtime/prte_wait.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -132,23 +132,23 @@ PRTE_EXPORT void prte_wait_cb_cancel(prte_proc_t *proc);
  * NOTE: the callback function is responsible for releasing the timer
  * event back to the event pool!
  */
-#define PRTE_DETECT_TIMEOUT(n, deltat, maxwait, cbfunc, cbd)                                      \
-    do {                                                                                          \
-        prte_timer_t *tmp;                                                                        \
-        int timeout;                                                                              \
-        tmp = PMIX_NEW(prte_timer_t);                                                             \
-        tmp->payload = (cbd);                                                                     \
-        prte_event_evtimer_set(prte_event_base, tmp->ev, (cbfunc), tmp);                          \
-        timeout = (deltat) * (n);                                                                 \
-        if ((maxwait) > 0 && timeout > (maxwait)) {                                               \
-            timeout = (maxwait);                                                                  \
-        }                                                                                         \
-        tmp->tv.tv_sec = timeout / 1000000;                                                       \
-        tmp->tv.tv_usec = timeout % 1000000;                                                      \
-        PMIX_OUTPUT_VERBOSE((1, prte_debug_output, "defining timeout: %ld sec %ld usec at %s:%d", \
-                             (long) tmp->tv.tv_sec, (long) tmp->tv.tv_usec, __FILE__, __LINE__)); \
-        PMIX_POST_OBJECT(tmp);                                                                    \
-        prte_event_evtimer_add(tmp->ev, &tmp->tv);                                                \
+#define PRTE_DETECT_TIMEOUT(n, deltat, maxwait, cbfunc, cbd)                                        \
+    do {                                                                                            \
+        prte_timer_t *_t;                                                                           \
+        int _timeout;                                                                               \
+        _t = PMIX_NEW(prte_timer_t);                                                                \
+        _t->payload = (cbd);                                                                        \
+        prte_event_evtimer_set(prte_event_base, _t->ev, (cbfunc), _t);                              \
+        _timeout = (deltat) * (n);                                                                  \
+        if ((maxwait) > 0 && _timeout > (maxwait)) {                                                \
+            _timeout = (maxwait);                                                                   \
+        }                                                                                           \
+        _t->tv.tv_sec = _timeout / 1000000;                                                         \
+        _t->tv.tv_usec = _timeout % 1000000;                                                        \
+        PMIX_OUTPUT_VERBOSE((1, prte_debug_output, "defining timeout: %ld sec %ld usec at %s:%d",   \
+                             (long) _t->tv.tv_sec, (long) _t->tv.tv_usec, __FILE__, __LINE__));     \
+        PMIX_POST_OBJECT(_t);                                                                       \
+        prte_event_evtimer_add(_t->ev, &_t->tv);                                                    \
     } while (0);
 
 /**


### PR DESCRIPTION
PMIx supports forward/set, unset, append, and prepend of environmental variables. However, PRRTE didn't provide cmd line parsing support for these operations. PMIx has been extended to do so - add those options to the schizo components.

Forward (-x) of envars can be just the envar name (to pickup the local value and forward it), or can be envar=value to set the envar to a specific value.

Unset (--unset-env) takes just the name of the envar.

Append (--append-env) takes two arguments:
   * the name of the envar, appended with a "[c]" where the 'c' is the character
     to be used as the separator between envar values
   * the value to be appended So it looks like "--append-env FOO[:] 20"

Prepend (--prepend-env) behaves exactly like append except it prepends the
value to whatever current envar value it finds

Multiple instances of any of these options may be present on the cmd line. Each instance will have its arguments appended to the parameter's pmix_cli_item_t's values argv-array.

Fix precedence so that app's env overwrites local environment.