### PR TITLE
Do not require PMIx wrapper compiler

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -32,10 +32,7 @@ dnl $1 is the base cap name (i.e., what comes after "PMIX_CAP_")
 dnl $2 is the action if happy
 dnl $3 is the action if not happy
 AC_DEFUN([PRTE_CHECK_PMIX_CAP],[
-    PRTE_VAR_SCOPE_PUSH([prte_cpp_save])
 
-    prte_cpp_save=$CPP
-    CPP="$PMIXCC_PATH -E"
     AC_PREPROC_IFELSE(
         [AC_LANG_PROGRAM([#include <pmix_version.h>],
                          [#if !defined(PMIX_CAPABILITIES)
@@ -53,9 +50,6 @@ AC_DEFUN([PRTE_CHECK_PMIX_CAP],[
         [$2],
         [$3])
 
-    CPP=$prte_cpp_save
-
-    PRTE_VAR_SCOPE_POP
 ])
 
 AC_DEFUN([PRTE_CHECK_PMIX],[
@@ -146,9 +140,8 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     PRTE_LOG_MSG([pmixcc version: $pmixcc_showme_results])
     AS_IF([test $found_pmixcc -eq 0],
           [AC_MSG_WARN([Could not find $PMIXCC_PATH])
-           AC_MSG_WARN([$PMIXCC_PATH is required for PRRTE to build])
-           AC_MSG_WARN([Please ensure it was installed])
-           AC_MSG_ERROR([Cannot continue])])
+           PMIXCC_PATH=])
+    AM_CONDITIONAL([PRTE_HAVE_PMIXCC], [test $found_pmixcc -eq 1])
     AC_SUBST([PMIXCC_PATH])
 
     # Check for any needed capabilities from the PMIx we found.
@@ -156,6 +149,14 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     # Note: if the PMIx we found does not define capability flags,
     # then it definitely does not have the capability flags we're
     # looking for.
+
+    prte_external_pmix_save_CPPFLAGS=$CPPFLAGS
+    prte_external_pmix_save_LDFLAGS=$LDFLAGS
+    prte_external_pmix_save_LIBS=$LIBS
+
+    PRTE_FLAGS_APPEND_UNIQ(CPPFLAGS, $PRTE_FINAL_CPPFLAGS)
+    PRTE_FLAGS_APPEND_UNIQ(LDFLAGS, $PRTE_FINAL_LDFLAGS)
+    PRTE_FLAGS_APPEND_UNIQ(LIBS, $PRTE_FINAL_LIBS)
 
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
@@ -173,6 +174,11 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     AC_DEFINE_UNQUOTED([PRTE_PMIX_LTO_CAPABILITY],
                        [$PRTE_PMIX_LTO_CAPABILITY],
                        [Whether or not PMIx has the LTO capability flag set])
+
+    # restore the global flags
+    CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
+    LDFLAGS=$prte_external_pmix_save_LDFLAGS
+    LIBS=$prte_external_pmix_save_LIBS
 
     PRTE_SUMMARY_ADD([Required Packages], [PMIx], [], [$prte_pmix_SUMMARY])
 


### PR DESCRIPTION
Use the flags to set the PMIx paths so we can simply use the standard compiler to test for PMIx capability flags.