### PR TITLE
Multiple commits

### DIFF
--- a/src/docs/prrte-rst-content/Makefile.am
+++ b/src/docs/prrte-rst-content/Makefile.am
@@ -21,6 +21,7 @@ rstdir = $(prtedatadir)/rst/prrte-rst-content
 dist_rst_DATA = \
     cli-allow-run-as-root.rst \
     cli-app-prefix.rst \
+    cli-append-env.rst \
     cli-bind-to.rst \
     cli-dash-host.rst \
     cli-debug-daemons-file.rst \
@@ -38,11 +39,13 @@ dist_rst_DATA = \
     cli-pmixmca.rst \
     cli-pmix-prefix.rst \
     cli-prefix.rst \
+    cli-prepend-env.rst \
     cli-prtemca.rst \
     cli-rank-by.rst \
     cli-runtime-options.rst \
     cli-stream-buffering.rst \
     cli-tune.rst \
+    cli-unset-env.rst \
     cli-x.rst \
     definitions-pes.rst \
     definitions-slots.rst \

--- a/src/docs/prrte-rst-content/cli-append-env.rst
+++ b/src/docs/prrte-rst-content/cli-append-env.rst
@@ -1,0 +1,21 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: ``--append-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
+
+``LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib``

--- a/src/docs/prrte-rst-content/cli-prepend-env.rst
+++ b/src/docs/prrte-rst-content/cli-prepend-env.rst
@@ -1,0 +1,21 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: ``--prepend-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
+
+``LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH``

--- a/src/docs/prrte-rst-content/cli-unset-env.rst
+++ b/src/docs/prrte-rst-content/cli-unset-env.rst
@@ -1,0 +1,16 @@
+.. -*- rst -*-
+
+   Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+   Copyright (c) 2023 Jeffrey M. Squyres.  All rights reserved.
+
+   $COPYRIGHT$
+
+   Additional copyrights may follow
+
+   $HEADER$
+
+.. The following line is included so that Sphinx won't complain
+   about this file not being directly included in some toctree
+
+Unset the named environmental variable. Note ``--unset-env foo*`` unsets all
+current environmental variables starting with "foo"

--- a/src/docs/show-help-files/help-prterun.txt
+++ b/src/docs/show-help-files/help-prterun.txt
@@ -203,7 +203,28 @@ option to the help request as "--help <option>".
 |                      | processes                                     |
 +----------------------+-----------------------------------------------+
 | "-x <name>"          | Export an environment variable, optionally    |
-|                      | specifying a value                            |
+|                      | specifying a value (e.g., "-x foo" exports    |
+|                      | the environment variable foo and takes its    |
+|                      | value from the current environment; "-x       |
+|                      | foo=bar" exports the environment variable     |
+|                      | name foo and sets its value to "bar" in the   |
+|                      | started processes; "-x foo*" exports all      |
+|                      | current environmental variables starting with |
+|                      | "foo")                                        |
++----------------------+-----------------------------------------------+
+| "--unset-env <name>" | Unset the named environmental variable. Note  |
+|                      | "--unset-env foo*" unsets all current         |
+|                      | environmental variables starting with "foo"   |
++----------------------+-----------------------------------------------+
+| "--append-env        | Append the named environment variable with    |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when appending the value.                     |
++----------------------+-----------------------------------------------+
+| "--prepend-env       | Prepend the named environment variable with   |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when prepending the value.                    |
 +----------------------+-----------------------------------------------+
 | "--gpu-support <val>"| Direct application to either enable (true) or |
 |                      | disable (false) its internal library's GPU    |
@@ -506,6 +527,40 @@ PMIx prefix has been given to PRRTE, but the application has been built
 against a PMIx library that (a) is different from the one used by PRRTE,
 and (b) was not moved. Otherwise, PRRTE will apply its default prefix to
 the application.
+
+[x]
+
+Export an environment variable, optionally specifying a value. For example,
+"-x foo" exports the environment variable "foo" and takes its value
+from the current environment, while "-x foo=bar" exports the environment
+variable name "foo" and sets its value to "bar" in the started processes.
+Note that "-x foo*" exports all current environmental variables starting with
+"foo"
+
+[unset-env]
+
+Unset the named environmental variable. Note "--unset-env foo*" unsets all
+current environmental variables starting with "foo"
+
+[append-env]
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--append-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib
+
+[prepend-env]
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--prepend-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH
 
 [forward-signals]
 

--- a/src/docs/show-help-files/help-prun.txt
+++ b/src/docs/show-help-files/help-prun.txt
@@ -214,6 +214,20 @@ option to the help request as "--help <option>".
 |                      | current environmental variables starting with |
 |                      | "foo")                                        |
 +----------------------+-----------------------------------------------+
+| "--unset-env <name>" | Unset the named environmental variable. Note  |
+|                      | "--unset-env foo*" unsets all current         |
+|                      | environmental variables starting with "foo"   |
++----------------------+-----------------------------------------------+
+| "--append-env        | Append the named environment variable with    |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when appending the value.                     |
++----------------------+-----------------------------------------------+
+| "--prepend-env       | Prepend the named environment variable with   |
+| <name[c]> <value>"   | given value. The "[c]" must be appended to    |
+|                      | the name to specify the separator to be used  |
+|                      | when prepending the value.                    |
++----------------------+-----------------------------------------------+
 | "--gpu-support <val>"| Direct application to either enable (true) or |
 |                      | disable (false) its internal library's GPU    |
 |                      | support                                       |
@@ -1185,6 +1199,40 @@ against a PMIx library that (a) is different from the one used by PRRTE,
 and (b) was not moved. Otherwise, PRRTE will apply its default prefix to
 the application.
 
+[x]
+
+Export an environment variable, optionally specifying a value. For example,
+"-x foo" exports the environment variable "foo" and takes its value
+from the current environment, while "-x foo=bar" exports the environment
+variable name "foo" and sets its value to "bar" in the started processes.
+Note that "-x foo*" exports all current environmental variables starting with
+"foo"
+
+[unset-env]
+
+Unset the named environmental variable. Note "--unset-env foo*" unsets all
+current environmental variables starting with "foo"
+
+[append-env]
+
+Append the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--append-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib
+
+[prepend-env]
+
+Prepend the named environment variable with the given value. The "[c]" must
+be appended to the name to specify the separator to be used when appending
+the value.
+
+Example: "--prepend-envar LD_LIBRARY_PATH[:] foo/lib" will result in:
+
+LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH
+
 [prun:executable-not-specified]
 
 No executable was specified on the %s command line.
@@ -1611,3 +1659,11 @@ found or could not be opened:
    file: %s
 
 Please correct the option and try again.
+#
+[malformed-envar]
+A command line option was given to %s an envar for an application:
+
+  App: %s
+  Envar: %s
+
+Please correct the error and try again.

--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -81,8 +81,17 @@ Launch options
 
 * ``--wdir <dir>``: Set the working directory of the started processes.
 
-* ``-x <var>``: Export a environment variable, optionally specifying a value.
+* ``-x <var>``: Export an environment variable, optionally specifying a value.
   :ref:`See below for details <label-schizo-ompi-x>`.
+
+* ``--unset-env <var>``: Unset an environment variable.
+  :ref:`See below for details <label-schizo-ompi-unset-env>`.
+
+* ``--prepend-env <var[c]> <val>``: Prepend a value to an environment variable
+  :ref:`See below for details <label-schizo-ompi-prepend-env>`.
+
+* ``--append-env <var[c]> <val>``: Prepend a value to an environment variable
+  :ref:`See below for details <label-schizo-ompi-append-env>`.
 
 * ``--gpu-support <val>``: Direct application to either enable (true) or
   disable (false) its internal library's GPU support
@@ -422,6 +431,25 @@ The ``-x`` option
 ~~~~~~~~~~~~~~~~~
 
 .. include:: /prrte-rst-content/cli-x.rst
+
+.. _label-schizo-ompi-unset-env
+
+The ``--unset-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-unset-env.rst
+
+.. _label-schizo-ompi-prepend-env
+
+The ``--prepend-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-prepend-env.rst
+
+
+.. _label-schizo-ompi-apppend-env
+
+The ``--apppend-env`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: /prrte-rst-content/cli-apppend-env.rst
 
 
 Deprecated command line options

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -158,6 +158,15 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_PRELOAD_FILES, PMIX_ARG_REQD),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_PRELOAD_BIN, PMIX_ARG_NONE, 's'),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_FWD_ENVAR, PMIX_ARG_REQD, 'x'),
+#ifdef PMIX_CLI_PREPEND_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
+#endif
+#ifdef PMIX_CLI_APPEND_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_APPEND_ENVAR, PMIX_ARG_REQD),
+#endif
+#ifdef PMIX_CLI_UNSET_ENVAR
+    PMIX_OPTION_DEFINE(PMIX_CLI_UNSET_ENVAR, PMIX_ARG_REQD),
+#endif
     PMIX_OPTION_DEFINE(PRTE_CLI_WDIR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("wd", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_PATH, PMIX_ARG_REQD),
@@ -1812,36 +1821,6 @@ static int parse_env(char **srcenv, char ***dstenv,
         }
     }
     PMIX_ARGV_FREE_COMPAT(envlist);
-
-    /* now look for -x options - not allowed to conflict with a -mca option */
-    if (NULL != (opt = pmix_cmd_line_get_param(results, "x"))) {
-        for (i = 0; NULL != opt->values[i]; ++i) {
-            /* the value is the envar */
-            p1 = opt->values[i];
-            /* if there is an '=' in it, then they are setting a value */
-            if (NULL != (p2 = strchr(p1, '='))) {
-                *p2 = '\0';
-                ++p2;
-            } else {
-                p2 = getenv(p1);
-                if (NULL == p2) {
-                    continue;
-                }
-            }
-            /* not allowed to duplicate anything from an MCA param on the cmd line */
-            rc = check_cache_noadd(&cache, &cachevals, p1, p2);
-            if (PRTE_SUCCESS != rc) {
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
-                PMIX_ARGV_FREE_COMPAT(xparams);
-                PMIX_ARGV_FREE_COMPAT(xvals);
-                return rc;
-            }
-            /* cache this for later inclusion */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xparams, p1);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&xvals, p2);
-        }
-    }
 
     /* process the resulting cache into the dstenv */
     if (NULL != cache) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -270,19 +270,24 @@ static void interim(int sd, short args, void *cbdata)
                 if (PMIX_CHECK_KEY(info, PMIX_HOST)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_DASH_HOST, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_HOSTFILE)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_HOSTFILE, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_ADD_HOSTFILE)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_ADD_HOSTFILE, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_ADD_HOST)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_ADD_HOST, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_PREFIX)) {
                     prte_prepend_attribute(&app->attributes, PRTE_APP_PMIX_PREFIX,
                                            PRTE_ATTR_GLOBAL,
                                            info->value.data.string, PMIX_STRING);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_WDIR)) {
                     /* if this is a relative path, convert it to an absolute path */
                     if (pmix_path_is_absolute(info->value.data.string)) {
@@ -297,14 +302,17 @@ static void interim(int sd, short args, void *cbdata)
                         /* construct the absolute path */
                         app->cwd = pmix_os_path(false, cwd, info->value.data.string, NULL);
                     }
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_WDIR_USER_SPECIFIED)) {
                     flag = PMIX_INFO_TRUE(info);
                     prte_set_attribute(&app->attributes, PRTE_APP_USER_CWD, PRTE_ATTR_GLOBAL,
                                        &flag, PMIX_BOOL);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_SET_SESSION_CWD)) {
                     flag = PMIX_INFO_TRUE(info);
                     prte_set_attribute(&app->attributes, PRTE_APP_SSNDIR_CWD, PRTE_ATTR_GLOBAL,
                                        &flag, PMIX_BOOL);
+
                 } else if (PMIX_CHECK_KEY(info, PMIX_PRELOAD_FILES)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
@@ -312,44 +320,76 @@ static void interim(int sd, short args, void *cbdata)
                 } else if (PMIX_CHECK_KEY(info, PMIX_PRELOAD_BIN)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_BIN, PRTE_ATTR_GLOBAL,
                                        NULL, PMIX_BOOL);
+
                     /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
                     /* there can be multiple of these, so we add them to the attribute list */
                 } else if (PMIX_CHECK_KEY(info, PMIX_SET_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    if (0 == app->idx) {
+                        prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    } else {
+                        prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    }
                 } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    if (0 == app->idx) {
+                        prte_prepend_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    } else {
+                        prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    }
                 } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           info->value.data.string, PMIX_STRING);
+                    if (0 == app->idx) {
+                        prte_prepend_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               info->value.data.string, PMIX_STRING);
+                    } else {
+                        prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               info->value.data.string, PMIX_STRING);
+                    }
                 } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    if (0 == app->idx) {
+                        prte_prepend_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    } else {
+                        prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    }
                 } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
                     envar.envar = info->value.data.envar.envar;
                     envar.value = info->value.data.envar.value;
                     envar.separator = info->value.data.envar.separator;
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    if (0 == app->idx) {
+                        prte_prepend_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    } else {
+                        prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
+                                               PRTE_ATTR_GLOBAL,
+                                               &envar, PMIX_ENVAR);
+                    }
 
                 } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {
                     prte_set_attribute(&app->attributes, PRTE_APP_PSET_NAME, PRTE_ATTR_GLOBAL,
                                        info->value.data.string, PMIX_STRING);
+
                 } else {
                     /* unrecognized key */
                     if (9 < pmix_output_get_verbosity(prte_pmix_server_globals.output)) {

--- a/src/runtime/prte_wait.h
+++ b/src/runtime/prte_wait.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -132,23 +132,23 @@ PRTE_EXPORT void prte_wait_cb_cancel(prte_proc_t *proc);
  * NOTE: the callback function is responsible for releasing the timer
  * event back to the event pool!
  */
-#define PRTE_DETECT_TIMEOUT(n, deltat, maxwait, cbfunc, cbd)                                      \
-    do {                                                                                          \
-        prte_timer_t *tmp;                                                                        \
-        int timeout;                                                                              \
-        tmp = PMIX_NEW(prte_timer_t);                                                             \
-        tmp->payload = (cbd);                                                                     \
-        prte_event_evtimer_set(prte_event_base, tmp->ev, (cbfunc), tmp);                          \
-        timeout = (deltat) * (n);                                                                 \
-        if ((maxwait) > 0 && timeout > (maxwait)) {                                               \
-            timeout = (maxwait);                                                                  \
-        }                                                                                         \
-        tmp->tv.tv_sec = timeout / 1000000;                                                       \
-        tmp->tv.tv_usec = timeout % 1000000;                                                      \
-        PMIX_OUTPUT_VERBOSE((1, prte_debug_output, "defining timeout: %ld sec %ld usec at %s:%d", \
-                             (long) tmp->tv.tv_sec, (long) tmp->tv.tv_usec, __FILE__, __LINE__)); \
-        PMIX_POST_OBJECT(tmp);                                                                    \
-        prte_event_evtimer_add(tmp->ev, &tmp->tv);                                                \
+#define PRTE_DETECT_TIMEOUT(n, deltat, maxwait, cbfunc, cbd)                                        \
+    do {                                                                                            \
+        prte_timer_t *_t;                                                                           \
+        int _timeout;                                                                               \
+        _t = PMIX_NEW(prte_timer_t);                                                                \
+        _t->payload = (cbd);                                                                        \
+        prte_event_evtimer_set(prte_event_base, _t->ev, (cbfunc), _t);                              \
+        _timeout = (deltat) * (n);                                                                  \
+        if ((maxwait) > 0 && _timeout > (maxwait)) {                                                \
+            _timeout = (maxwait);                                                                   \
+        }                                                                                           \
+        _t->tv.tv_sec = _timeout / 1000000;                                                         \
+        _t->tv.tv_usec = _timeout % 1000000;                                                        \
+        PMIX_OUTPUT_VERBOSE((1, prte_debug_output, "defining timeout: %ld sec %ld usec at %s:%d",   \
+                             (long) _t->tv.tv_sec, (long) _t->tv.tv_usec, __FILE__, __LINE__));     \
+        PMIX_POST_OBJECT(_t);                                                                       \
+        prte_event_evtimer_add(_t->ev, &_t->tv);                                                    \
     } while (0);
 
 /**


### PR DESCRIPTION
[Extend support for envar operations](https://github.com/openpmix/prrte/commit/aaa7f6993a3e96ceb1f7930f00219f860b8a96c5)

PMIx supports forward/set, unset, append, and prepend of
environmental variables. However, PRRTE didn't provide
cmd line parsing support for these operations. PMIx has
been extended to do so - add those options to the schizo
components.

Forward (-x) of envars can be just the envar name (to pickup
the local value and forward it), or can be envar=value to
set the envar to a specific value.

Unset (--unset-env) takes just the name of the envar.

Append (--append-env) takes two arguments:
   * the name of the envar, appended with a "[c]" where
     the 'c' is the character to be used as the separator
     between envar values
   * the value to be appended
So it looks like "--append-env FOO[:] 20"

Prepend (--prepend-env) behaves exactly like append except
it prepends the value to whatever current envar value it finds

Multiple instances of any of these options may be present on
the cmd line. Each instance will have its arguments appended
to the parameter's pmix_cli_item_t's values argv-array.

Fix precedence so that app's env overwrites local environment.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/ea8c38c639947d2a1aa26d5dc8d0fdc8c5d2905a)

[Do not require PMIx wrapper compiler](https://github.com/openpmix/prrte/commit/9aff9208a61aa44f0529d8b26db8774aba7d8ab2)

Use the flags to set the PMIx paths so we can simply
use the standard compiler to test for PMIx capability
flags.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/7e76597a0d109f4fa5d04c132297c89e27f450aa)
