### PR TITLE
Don't link to pmixcc if we don't find it

### DIFF
--- a/src/tools/pcc/Makefile.am
+++ b/src/tools/pcc/Makefile.am
@@ -21,8 +21,12 @@
 # $HEADER$
 #
 
+if PRTE_HAVE_PMIXCC
+
 install-exec-hook:
 	(cd $(DESTDIR)$(bindir); rm -f pcc; $(LN_S) $(PMIXCC_PATH)$(EXEEXT) pcc)
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/pcc$(EXEEXT)
+
+endif


### PR DESCRIPTION
If configure cannot find "pmixcc", then don't attempt to create the "pcc" link as that creates an infinite loop when someone attempts to resolve it.