### PR TITLE
Properly terminate RST label

### DIFF
--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -432,20 +432,20 @@ The ``-x`` option
 
 .. include:: /prrte-rst-content/cli-x.rst
 
-.. _label-schizo-ompi-unset-env
+.. _label-schizo-ompi-unset-env:
 
 The ``--unset-env`` option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. include:: /prrte-rst-content/cli-unset-env.rst
 
-.. _label-schizo-ompi-prepend-env
+.. _label-schizo-ompi-prepend-env:
 
 The ``--prepend-env`` option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. include:: /prrte-rst-content/cli-prepend-env.rst
 
 
-.. _label-schizo-ompi-apppend-env
+.. _label-schizo-ompi-apppend-env:
 
 The ``--apppend-env`` option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Needs a colon at the end.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 3a24d9bd888e5e9d74470efeaad0ca1b36c7dfda)