### PR TITLE
Quick fix for PMIx master

### DIFF
--- a/src/rml/oob/oob_tcp_connection.h
+++ b/src/rml/oob/oob_tcp_connection.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,11 +47,13 @@ typedef struct {
 } prte_oob_tcp_conn_op_t;
 PMIX_CLASS_DECLARATION(prte_oob_tcp_conn_op_t);
 
+#ifndef CLOSE_THE_SOCKET
 #define CLOSE_THE_SOCKET(socket) \
     do {                         \
         shutdown(socket, 2);     \
         close(socket);           \
     } while (0)
+#endif
 
 #define PRTE_ACTIVATE_TCP_CONN_STATE(p, cbfunc)                                             \
     do {                                                                                    \

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -225,10 +225,6 @@ int prte_init_minimum(void)
     if (NULL != path) {
         free(path);
     }
-    if (PMIX_SUCCESS != ret) {
-        return prte_pmix_convert_status(ret);
-    }
-    ret = pmix_show_help_add_dir(prte_install_dirs.prtedatadir);
     if (PMIX_SUCCESS != ret) {
         return prte_pmix_convert_status(ret);
     }


### PR DESCRIPTION
PMIx master has deprecated the pmix_show_help_add_dir function, so remove it for now. Will replace it with in-memory help messages in a follow-on PR.