### PR TITLE
Enable shim-based testing of PLM launchers

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -68,7 +68,9 @@ jobs:
         libevent_cppflags=$(pkg-config libevent --cflags)
         libevent_ldflags=$(pkg-config libevent --libs | perl -pe 's/^.*(-L[^ ]+).*$/\1/')
 
-        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check \
+        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx \
+            --enable-devel-check \
+            --enable-testbuild-launchers \
             CPPFLAGS=$libevent_cppflags \
             LDFLAGS=$libevent_ldflags
         make -j
@@ -122,7 +124,9 @@ jobs:
             c=../configure
         fi
 
-        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
+        $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx \
+            --enable-devel-check \
+            --enable-testbuild-launchers
         make -j
         make install
         make uninstall
@@ -161,7 +165,9 @@ jobs:
         sphinx=--enable-sphinx
 
         c=./configure
-        CC=clang $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx --enable-devel-check
+        CC=clang $c --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall $sphinx \
+            --enable-devel-check \
+            --enable-testbuild-launchers
         make -j
         make install
         make uninstall
@@ -196,5 +202,7 @@ jobs:
       run: |
         pip install -r docs/requirements.txt
         ./autogen.pl
-        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-sphinx --enable-devel-check
+        ./configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall --enable-sphinx \
+            --enable-devel-check \
+            --enable-testbuild-launchers
         make distcheck AM_DISTCHECK_MAKEFLAGS=-j AM_DISTCHECK_CONFIGURE_FLAGS="--with-pmix=$RUNNER_TEMP/pmixinstall"

--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -18,7 +18,7 @@ dnl                         reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl
 dnl Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+dnl Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
 dnl                         All Rights reserved.
 dnl $COPYRIGHT$
@@ -116,7 +116,7 @@ AC_DEFINE_UNQUOTED(PRTE_PICKY_COMPILERS, $WANT_PICKY_COMPILER,
 AC_MSG_CHECKING([if want memory sanitizers])
 AC_ARG_ENABLE(memory-sanitizers,
     AS_HELP_STRING([--memory-sanitizers],
-                   [enable developer-level memory sanitizers when building PMIx (default: disabled)]))
+                   [enable developer-level memory sanitizers when building PRRTE (default: disabled)]))
 if test "$enable_memory_sanitizers" = "yes"; then
     AC_MSG_RESULT([yes])
     WANT_MEMORY_SANITIZERS=1
@@ -402,5 +402,24 @@ else
 fi
 AM_CONDITIONAL(PRTE_WANT_LEGACY_TOOLS, test "$PRTE_WANT_LEGACY_TOOLS" = 1)
 PRTE_SUMMARY_ADD([Miscellaneous], [Install legacy tools], [], [$prte_legacy_tools])
+
+# use header "shims" for 3rd-party libraries to test-build
+# the PLM launchers
+AC_MSG_CHECKING([if want to test-build PLM launchers that require 3rd-party headers/libraries])
+AC_ARG_ENABLE([testbuild-launchers],
+    [AS_HELP_STRING([--enable-testbuild-launchers],
+        [Test-build PLM launchers that require 3rd-party headers/libraries (default: disabled)])])
+if test "$enable_testbuild_launchers" = "yes"; then
+    AC_MSG_RESULT([yes])
+    prte_testbuild_launchers=1
+    prte_testbuild_launchers_msg=yes
+else
+    AC_MSG_RESULT([no])
+    prte_testbuild_launchers=0
+    prte_testbuild_launchers_msg=no
+fi
+AC_DEFINE_UNQUOTED([PRTE_TESTBUILD_LAUNCHERS], [$prte_testbuild_launchers],
+                   [Enable testbuild PLM launchers (default: disabled)])
+PRTE_SUMMARY_ADD([Miscellaneous], [Testbuild launchers], [], [$prte_testbuild_launchers_msg])
 
 ])dnl

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -3,10 +3,16 @@ Release Notes
 
 - Systems that have been tested are:
 
-  - Linux (various flavors/distros), 32 bit, with gcc
-  - Linux (various flavors/distros), 64 bit (x86), with gcc, Intel,
-    and Portland (*)
-  - OS X (10.7 and above), 32 and 64 bit (x86_64), with gcc (*)
+  - Linux (various flavors/distros), 64 bit (x86 and ARM), with gcc
+  - OS X (14.0 and above), 64 bit (x86_64 and ARM), with gcc and clang
+
+- Launch environment testing status:
+
+  - ssh: fully tested
+  - slurm: compiled, no testing
+  - lsf: compiled using a shim header, no testing
+  - pals: compiled, no testing
+  - tm (Torque): compiled using a shim header, no testing
 
 - PRRTE has taken some steps towards Reproducible Builds
   (https://reproducible-builds.org/).  Specifically, PRRTE's

--- a/src/mca/plm/lsf/Makefile.am
+++ b/src/mca/plm/lsf/Makefile.am
@@ -14,7 +14,7 @@
 #                         et Automatique. All rights reserved.
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,6 +25,9 @@
 AM_CPPFLAGS = $(plm_lsf_CPPFLAGS)
 
 dist_prtedata_DATA = help-plm-lsf.txt
+
+EXTRA_DIST = \
+        testbuild_lsf.h
 
 sources = \
         plm_lsf.h \

--- a/src/mca/plm/lsf/configure.m4
+++ b/src/mca/plm/lsf/configure.m4
@@ -14,7 +14,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,7 +31,7 @@ AC_DEFUN([MCA_prte_plm_lsf_CONFIG],[
 
     # if check worked, set wrapper flags if so.
     # Evaluate succeed / fail
-    AS_IF([test "$plm_lsf_good" = "1"],
+    AS_IF([test "$plm_lsf_good" = "1" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/plm/lsf/plm_lsf_component.c
+++ b/src/mca/plm/lsf/plm_lsf_component.c
@@ -35,7 +35,11 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#if PRTE_TESTBUILD_LAUNCHERS
+#include "testbuild_lsf.h"
+#else
 #include <lsf/lsbatch.h>
+#endif
 
 #include "src/util/pmix_output.h"
 

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -56,13 +56,19 @@
 #endif
 
 #define SR1_PJOBS
+#if PRTE_TESTBUILD_LAUNCHERS
+#include "testbuild_lsf.h"
+int lsberrno;
+#else
 #include <lsf/lsbatch.h>
+#endif
 
 #include "src/pmix/pmix-internal.h"
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/mca/pinstalldirs/pinstalldirs_types.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/pmix_basename.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/pmix_printf.h"
@@ -170,16 +176,17 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char **nodelist_argv;
     int nodelist_argc;
     char *vpid_string;
-    int i;
     char *cur_prefix;
     int proc_vpid_index = 0;
     bool failed_launch = true;
-    prte_app_context_t *app;
     prte_node_t *node;
     int32_t nnode;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
     prte_job_t *jdata;
+    char *pmix_prefix = NULL;
+    char *newenv;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(state);
     jdata = state->jdata;

--- a/src/mca/plm/lsf/testbuild_lsf.h
+++ b/src/mca/plm/lsf/testbuild_lsf.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_PLM_LSF_TESTBUILD_H
+#define PRTE_PLM_LSF_TESTBUILD_H
+
+#include "prte_config.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/plm/plm.h"
+
+BEGIN_C_DECLS
+
+#define LSF_DJOB_REPLACE_ENV 0x1
+#define LSF_DJOB_NOWAIT 0x2
+
+int lsb_init(char *str);
+int lsb_launch(char **nodelist_argv, char **argv, int flags, char **env);
+char *lsb_sysmsg(void);
+
+extern int lsberrno;
+
+END_C_DECLS
+
+#endif /* PRTE_PLM_LSF_TESTBUILD_H */

--- a/src/mca/plm/pals/configure.m4
+++ b/src/mca/plm/pals/configure.m4
@@ -14,7 +14,7 @@
 # Copyright (c) 2011-2016 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2023      Triad National Security, LLC. All rights
 #                         reserved.
 # $COPYRIGHT$
@@ -33,7 +33,7 @@ AC_DEFUN([MCA_prte_plm_pals_CONFIG],[
 
     # if check worked, set wrapper flags if so.
     # Evaluate succeed / fail
-    AS_IF([test "$plm_pals_good" = "1"],
+    AS_IF([test "$plm_pals_good" = "1" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 ])dnl

--- a/src/mca/plm/pals/plm_pals_module.c
+++ b/src/mca/plm/pals/plm_pals_module.c
@@ -177,19 +177,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
     int rc;
     char *tmp;
     char **env = NULL;
-    char *nodelist_flat;
-    char **nodelist_argv;
-    int nodelist_argc;
     char *vpid_string;
     char **custom_strings;
     int num_args, i;
     char *cur_prefix, *pmix_prefix;
     int proc_vpid_index;
-    prte_app_context_t *app;
-    prte_node_t *node;
-    int32_t nnode;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(state);
 
@@ -415,7 +410,6 @@ cleanup:
 static int plm_pals_terminate_prteds(void)
 {
     int rc;
-    prte_job_t *jdata;
 
     PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
                          "%s plm:pals: terminating prteds", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
@@ -444,6 +438,8 @@ static int plm_pals_terminate_prteds(void)
  */
 static int plm_pals_signal_job(pmix_nspace_t jobid, int32_t signal)
 {
+    PRTE_HIDE_UNUSED_PARAMS(jobid);
+
     if (NULL != palsrun && 0 != palsrun->pid) {
         kill(palsrun->pid, (int) signal);
     }
@@ -471,6 +467,7 @@ static void pals_wait_cb(int sd, short args, void *cbdata)
     prte_wait_tracker_t *t2 = (prte_wait_tracker_t *) cbdata;
     prte_proc_t *proc = t2->child;
     prte_job_t *jdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     /* According to the ALPS folks, pals always returns the highest exit
        code of our remote processes. Thus, a non-zero exit status doesn't
@@ -513,6 +510,7 @@ static int plm_pals_start_proc(int argc, char **argv, char **env,
     char *exec_argv = pmix_path_findv(argv[0], 0, env, NULL);
     char *p;
     char *oldenv, *newenv;
+    PRTE_HIDE_UNUSED_PARAMS(argc);
 
     if (NULL == exec_argv) {
         return PRTE_ERR_NOT_FOUND;

--- a/src/mca/plm/tm/Makefile.am
+++ b/src/mca/plm/tm/Makefile.am
@@ -12,7 +12,7 @@
 # Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2017      IBM Corporation.  All rights reserved.
 # Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -23,6 +23,9 @@
 AM_CPPFLAGS = $(plm_tm_CPPFLAGS)
 
 dist_prtedata_DATA = help-plm-tm.txt
+
+EXTRA_DIST = \
+        testbuild_tm.h
 
 sources = \
         plm_tm.h \

--- a/src/mca/plm/tm/configure.m4
+++ b/src/mca/plm/tm/configure.m4
@@ -14,7 +14,7 @@
 #                         All rights reserved.
 # Copyright (c) 2009-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,7 +31,7 @@ AC_DEFUN([MCA_prte_plm_tm_CONFIG],[
 
     # if check worked, set wrapper flags if so.
     # Evaluate succeed / fail
-    AS_IF([test "$plm_tm_good" = "1"],
+    AS_IF([test "$plm_tm_good" = "1" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -55,7 +55,11 @@
 #    include <sys/time.h>
 #endif
 #include <errno.h>
+#if PRTE_TESTBUILD_LAUNCHERS
+#include "testbuild_tm.h"
+#else
 #include <tm.h>
+#endif
 
 #include "src/event/event-internal.h"
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
@@ -167,7 +171,6 @@ static int plm_tm_launch_job(prte_job_t *jdata)
 static void launch_daemons(int fd, short args, void *cbdata)
 {
     prte_job_map_t *map = NULL;
-    prte_app_context_t *app;
     prte_node_t *node;
     int proc_vpid_index;
     char *param;
@@ -187,6 +190,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
     int32_t launchid, *ldptr;
     char *prefix_dir = NULL;
+    char *pmix_prefix = NULL;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(state);
 
@@ -316,7 +321,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
             pmix_asprintf(&newenv, "%s/%s", prefix_dir, bin_base);
         }
         PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
-        PMIX_OUTPUT_VERBOSE((1, "plm:tm: reset PATH: %s", newenv));
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "plm:tm: reset PATH: %s", newenv));
         free(newenv);
 
         /* Reset LD_LIBRARY_PATH */
@@ -327,7 +333,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
             pmix_asprintf(&newenv, "%s/%s", prefix_dir, lib_base);
         }
         PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
-        PMIX_OUTPUT_VERBOSE((1, "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
         free(newenv);
         // add the prefix itself to the environment
         PMIX_SETENV_COMPAT("PRTE_PREFIX", prefix_dir, true, &env);
@@ -347,7 +354,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
         }
         free(p);
         PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
-        PMIX_OUTPUT_VERBOSE((1, "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
         free(newenv);
         // add the prefix itself to the environment
         PMIX_SETENV_COMPAT("PMIX_PREFIX", pmix_prefix, true, &env);
@@ -437,6 +445,7 @@ static void poll_spawns(int fd, short args, void *cbdata)
     bool failed_launch = true;
     int local_err;
     tm_event_t event;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(state);
 

--- a/src/mca/plm/tm/testbuild_tm.h
+++ b/src/mca/plm/tm/testbuild_tm.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_PLM_TM_TESTBUILD_H
+#define PRTE_PLM_TM_TESTBUILD_H
+
+#include "prte_config.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/plm/plm.h"
+
+BEGIN_C_DECLS
+
+typedef int tm_event_t;
+typedef int tm_node_id;
+typedef unsigned long tm_task_id;
+
+typedef struct  tm_roots {
+    tm_task_id  tm_me;
+    tm_task_id  tm_parent;
+    int     tm_nnodes;
+    int     tm_ntasks;
+    int     tm_taskpoolid;
+    tm_task_id  *tm_tasklist;
+} tm_roots;
+
+#define TM_NULL_EVENT   ((tm_event_t)0)
+#define TM_SUCCESS 0
+
+int tm_init(void *info, struct tm_roots *roots);
+
+int tm_poll(tm_event_t poll_event, tm_event_t *result_event, int wait, int *tm_errno);
+
+int tm_spawn(int argc, char **argv, char **env, tm_node_id launchid,
+             tm_task_id *tid, tm_event_t *event);
+
+int tm_finalize(void);
+
+END_C_DECLS
+
+#endif /* PRTE_PLM_TM_TESTBUILD_H */


### PR DESCRIPTION
It isn't possible to install the environments required to test every launcher in PRRTE. What we can do, though, is provide a new configure option "--enable-testbuild-launchers" that will utilize shim headers to allow the components to at least build.

Note that we are NOT testing the components - we only verify that they should build.

Fixes https://github.com/openpmix/prrte/issues/2188