### PR TITLE
docs: Add a "Last updated on:" HTML footer

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,6 +182,10 @@ html_additional_pages = {
     'configurator' : 'configurator.html',
 }
 
+# Put a "Last updated on:" timestamp at the bottom of each page.
+html_last_updated_fmt = '%Y-%m-%d %H:%M:%S %Z'
+
+
 # -- Options for MAN output -------------------------------------------------
 
 import os


### PR DESCRIPTION
Show the build time of the docs. Ported from
https://github.com/open-mpi/ompi/pull/13236