### PR TITLE
Add explicit test for Python >= v3.7 in configure

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -29,6 +29,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
+python_min_version=3.7.0
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not

--- a/autogen.pl
+++ b/autogen.pl
@@ -762,6 +762,11 @@ sub get_and_define_min_versions() {
                   export_version("FLEX", $fields[1]);
               }
           }
+          elsif($fields[0] eq "python_min_version") {
+              if ($fields[1] ne "\n") {
+                  export_version("PYTHON", $fields[1]);
+              }
+          }
     }
     close(IN);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ PRTE_LOAD_PLATFORM
 #
 # Start it up
 #
-
+. $srcdir/VERSION
 PRTE_CONFIGURE_SETUP
 
 prte_show_title "Configuring PRTE"
@@ -713,13 +713,30 @@ AC_INCLUDES_DEFAULT
 #include <sys/resource.h>
 #endif])
 
+# We need Python if we are building in a git clone
+# (not a distribution tarball)
+AC_MSG_CHECKING([if we need Python])
+prte_need_python=no
+AS_IF([test -d "${PRTE_TOP_SRCDIR}/.git"],
+      [prte_need_python=yes],
+      [prte_need_python=no])
+AC_MSG_RESULT([$prte_need_python])
+# if we need it, then check the min version
+AS_IF([test "$prte_need_python" = "yes"],
+      [AM_PATH_PYTHON([$python_min_version],
+                      [prte_have_good_python=1],
+                      [AC_MSG_ERROR([PRRTE requires Python >= $python_min_version to build. Aborting.])])],
+      [prte_have_good_python=0])
+
 #
 # Setup Sphinx processing
 #
+# Note that we have to double escape the URL below
+# so that the # it contains doesn't confuse the Autotools
 
-OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html], [],
+OAC_SETUP_SPHINX([$srcdir/docs/_build/html/index.html],
+                 [[https://docs.prrte.org/en/main/developers/prerequisites.html#sphinx-and-therefore-python]],
                  [$srcdir/docs/requirements.txt])
-AC_CHECK_PROGS(PYTHON, [python3 python python2])
 
 AS_IF([test -n "$OAC_MAKEDIST_DISABLE"],
       [AS_IF([test -n "$PRTE_MAKEDIST_DISABLE"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ automake_min_version = f"{prte_data['automake_min_version']}"
 autoconf_min_version = f"{prte_data['autoconf_min_version']}"
 libtool_min_version = f"{prte_data['libtool_min_version']}"
 flex_min_version = f"{prte_data['flex_min_version']}"
+python_min_version = f"{prte_data['python_min_version']}"
 
 # "release" is a sphinx config variable: assign it to the computed
 # PRRTE version number.  The prte_ver string begins with a "v"; the
@@ -239,6 +240,7 @@ rst_prolog = f"""
 .. |autoconf_min_version| replace:: {autoconf_min_version}
 .. |libtool_min_version| replace:: {libtool_min_version}
 .. |flex_min_version| replace:: {flex_min_version}
+.. |python_min_version| replace:: {python_min_version}
 
 """
 

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -43,6 +43,17 @@ build them manually, see the :ref:`how to build and install GNU
 Autotools section <developers-installing-autotools-label>` for much
 more detail.
 
+Python
+------
+
+Python >= |python_min_version| is required when building PRRTE
+from a Git clone for generating the "show help" messages and
+building the PRRTE documentation and man pages.
+
+Generating the show help messages can be accomplished with core
+Python; only building the full PRRTE documentation and man pages
+requires additional Python packages (:ref:`see below <developers-requirements-sphinx-label>`).
+
 Perl
 ----
 
@@ -83,6 +94,8 @@ your operating system's packaging system (to include Homebrew or
 MacPorts on MacOS), see `the Flex Github repository
 <https://github.com/westes/flex>`_.
 
+
+.. _developers-requirements-sphinx-label:
 
 Sphinx (and therefore Python)
 -----------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,6 +34,9 @@ must then run:
 
    shell$ ./autogen.pl
 
+PRRTE requires Perl and Python >= |python_min_version| to build
+from a Git clone.
+
 You will need very recent versions of GNU Autoconf, Automake, and
 Libtool.  If ``autogen.pl`` fails, read the :doc:`Developer's Guide
 </developers/index>`.  If anything else fails, read the


### PR DESCRIPTION
PRRTE now requires Python to build when in a Git clone for building the show-help in-memory text (prte_show_help_content.c) and the Sphinx-based documentation pages.

Check for an adequate Python version for these purposes.