### PR TITLE
Reduce min Python version to 3.6

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -29,7 +29,7 @@ automake_min_version=1.13.4
 autoconf_min_version=2.69.0
 libtool_min_version=2.4.2
 flex_min_version=2.5.4
-python_min_version=3.7.0
+python_min_version=3.6
 
 # greek is generally used for alpha or beta release tags.  If it is
 # non-empty, it will be appended to the version number.  It does not

--- a/configure.ac
+++ b/configure.ac
@@ -728,6 +728,9 @@ AS_IF([test "$prte_need_python" = "yes"],
                       [AC_MSG_ERROR([PRRTE requires Python >= $python_min_version to build. Aborting.])])],
       [prte_have_good_python=0])
 
+AS_IF([test $prte_have_good_python -eq 1],
+      [PRTE_SUMMARY_ADD([Required Packages], [Python], [], [yes ($PYTHON_VERSION)])])
+
 #
 # Setup Sphinx processing
 #

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -112,6 +112,9 @@ prtedir = $(prteincludedir)/$(subdir)
 prte_HEADERS = $(headers)
 endif
 
+clean-local:
+	rm -f prte_show_help_content.c prte_show_help_content.lo
+
 MAINTAINERCLEANFILES = \
 	prte_show_help_content.c
 


### PR DESCRIPTION
Decrease the minimum required Python version to v3.6. Note that this only applies when building from a git clone, not a tarball. Ensure we cleanup the show-help content file when doing "make clean".