### PR TITLE
Support fwd-environment directives for spawned child jobs

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -687,7 +687,6 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
     if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
         !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL) &&
         !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
-        pmix_output(0, "SETTING");
         // default to the devel map
         prte_set_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, PRTE_ATTR_GLOBAL,
                            NULL, PMIX_BOOL);

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -134,7 +134,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     pid_t pid;
     bool debugging, found;
     int i, room, *rmptr = &room;
-    char **env, *tmp;
+    char *tmp;
     pmix_value_t pidval = PMIX_VALUE_STATIC_INIT;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
@@ -324,21 +324,6 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             }
         }
         PMIX_PROC_RELEASE(nptr);
-
-        /* if the user asked to forward any envars, cycle through the app contexts
-         * in the comm_spawn request and add them
-         */
-        if (NULL != prte_forwarded_envars) {
-            for (i = 0; i < jdata->apps->size; i++) {
-                app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i);
-                if (NULL == app) {
-                    continue;
-                }
-                env = pmix_environ_merge(prte_forwarded_envars, app->env);
-                PMIX_ARGV_FREE_COMPAT(app->env);
-                app->env = env;
-            }
-        }
 
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                              "%s plm:base:receive adding hosts",

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -919,6 +919,13 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
        }
+        /* --fwd-environment  ->  --runtime-options fwd-env */
+        else if (0 == strcmp(option, "fwd-environment")) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_FWD_ENVIRON,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
         /* --map-by socket ->  --map-by package */
         else if (0 == strcmp(option, PRTE_CLI_MAPBY)) {
             /* check the value of the option for "socket" */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -575,6 +575,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             rc = prte_schizo_base_add_directive(results, option, PRTE_CLI_NP, opt->values[0], false);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --nolocal -> --map-by :nolocal */
         else if (0 == strcmp(option, "nolocal")) {
             rc = prte_schizo_base_add_qualifier(results, option,
@@ -582,6 +583,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --oversubscribe -> --map-by :OVERSUBSCRIBE */
         else if (0 == strcmp(option, "oversubscribe")) {
             rc = prte_schizo_base_add_qualifier(results, option,
@@ -589,6 +591,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --nooversubscribe -> --map-by :NOOVERSUBSCRIBE */
         else if (0 == strcmp(option, "nooversubscribe")) {
             rc = prte_schizo_base_add_qualifier(results, option,
@@ -596,6 +599,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --use-hwthread-cpus -> --map-by hwtcpus */
         else if (0 == strcmp(option, "use-hwthread-cpus")) {
             rc = prte_schizo_base_add_qualifier(results, option,
@@ -607,6 +611,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             }
             prte_set_slots = strdup("hwthreads");
         }
+
         /* --cpu-set and --cpu-list -> --map-by pe-list:X
          */
         else if (0 == strcmp(option, "cpu-set") || 0 == strcmp(option, "cpu-list")) {
@@ -617,6 +622,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --bind-to-core and --bind-to-socket -> --bind-to X */
         else if (0 == strcmp(option, "bind-to-core")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -629,6 +635,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --bynode -> "--map-by X --rank-by X" */
         else if (0 == strcmp(option, "bynode")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -636,6 +643,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --bycore -> "--map-by X --rank-by X" */
         else if (0 == strcmp(option, "bycore")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -643,6 +651,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --byslot -> "--map-by X --rank-by X" */
         else if (0 == strcmp(option, "byslot")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -650,6 +659,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --cpus-per-proc/rank X -> --map-by :pe=X */
         else if (0 == strcmp(option, "cpus-per-proc") || 0 == strcmp(option, "cpus-per-rank")) {
             pmix_asprintf(&p2, "%s%s", PRTE_CLI_PE, opt->values[0]);
@@ -659,6 +669,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* -N ->   map-by ppr:N:node */
         else if (0 == strcmp(option, "N")) {
             pmix_asprintf(&p2, "ppr:%s:node", opt->values[0]);
@@ -668,7 +679,8 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --npernode X and --npersocket X -> --map-by ppr:X:node/socket */
+
+        /* --npernode X -> --map-by ppr:X:node */
         else if (0 == strcmp(option, "npernode")) {
             pmix_asprintf(&p2, "ppr:%s:node", opt->values[0]);
             rc = prte_schizo_base_add_directive(results, option,
@@ -676,11 +688,15 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+
+        /* --pernode X -> --map-by ppr:1:node */
         } else if (0 == strcmp(option, "pernode")) {
             rc = prte_schizo_base_add_directive(results, option,
                                                 PRTE_CLI_MAPBY, "ppr:1:node",
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+
+        /* -npersocket X -> --map-by ppr:X:package */
         } else if (0 == strcmp(option, "npersocket")) {
             pmix_asprintf(&p2, "ppr:%s:package", opt->values[0]);
             rc = prte_schizo_base_add_directive(results, option,
@@ -689,6 +705,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --ppr X -> --map-by ppr:X */
         else if (0 == strcmp(option, "ppr")) {
             /* if they didn't specify a complete pattern, then this is an error */
@@ -703,6 +720,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --am[ca] X -> --tune X */
         else if (0 == strcmp(option, "amca") || 0 == strcmp(option, "am")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -710,6 +728,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --rankfile X -> map-by rankfile:file=X */
         else if (0 == strcmp(option, "rankfile")) {
             pmix_asprintf(&p2, "%s%s", PRTE_CLI_QFILE, opt->values[0]);
@@ -719,6 +738,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --tag-output  ->  "--output tag */
         else if (0 == strcmp(option, "tag-output")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -726,6 +746,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --timestamp-output  ->  --output timestamp */
         else if (0 == strcmp(option, "timestamp-output")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -733,6 +754,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --output-directory DIR  ->  --output dir=DIR */
         else if (0 == strcmp(option, "output-directory")) {
             pmix_asprintf(&p2, "dir=%s", opt->values[0]);
@@ -742,6 +764,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --output-filename DIR  ->  --output file=file */
         else if (0 == strcmp(option, "--output-filename")) {
             pmix_asprintf(&p2, "file=%s", opt->values[0]);
@@ -751,6 +774,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --xml  ->  --output xml */
         else if (0 == strcmp(option, "xml")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -758,6 +782,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --display-devel-map  -> --display allocation-devel */
         else if (0 == strcmp(option, "display-devel-map")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -765,6 +790,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --output-proctable  ->  --runtime-options output-proctable */
         else if (0 == strcmp(option, PRTE_CLI_OUTPUT_PROCTABLE)) {
             if (NULL != opt->values && NULL != opt->values[0]) {
@@ -778,6 +804,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --display-map  ->  --display map */
         else if (0 == strcmp(option, "display-map")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -785,6 +812,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --display-topo  ->  --display topo */
         else if (0 == strcmp(option, "display-topo")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -792,6 +820,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --report-bindings  ->  --display bind */
         else if (0 == strcmp(option, "report-bindings")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -799,6 +828,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --display-allocation  ->  --display allocation */
         else if (0 == strcmp(option, "display-allocation")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -806,6 +836,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --debug will be deprecated starting with open mpi v5
          */
         else if (0 == strcmp(option, "debug")) {
@@ -815,6 +846,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
         /* --do-not-launch  ->  --runtime-options donotlaunch */
         else if (0 == strcmp(option, "do-not-launch")) {
             rc = prte_schizo_base_add_directive(results, option,
@@ -822,6 +854,15 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+
+        /* --fwd-environment  ->  --runtime-options fwd-env */
+        else if (0 == strcmp(option, "fwd-environment")) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_FWD_ENVIRON,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
         /* --map-by socket ->  --map-by package */
         else if (0 == strcmp(option, PRTE_CLI_MAPBY)) {
             /* check the value of the option for "socket" */
@@ -878,6 +919,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 free(p1);
             }
         }
+
         /* --rank-by */
         else if (0 == strcmp(option, PRTE_CLI_RANKBY)) {
             /* check the value of the option for object-level directives - show help
@@ -915,6 +957,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 opt->values[0] = tmp;
             }
         }
+
         /* --bind-to socket ->  --bind-to package */
         else if (0 == strcmp(option, PRTE_CLI_BINDTO)) {
             /* check the value of the option for "socket" */

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -107,7 +107,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
             }
         }
 
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL)) {
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, (void**)&fptr, PMIX_BOOL)) {
             /* it is present - check the value */
             if (!flag) {
                 /* remove the attribute */
@@ -135,7 +135,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
             }
         }
 
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_ERRORS, NULL, PMIX_BOOL)) {
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_ERRORS, (void**)&fptr, PMIX_BOOL)) {
             /* it is present - check the value */
             if (!flag) {
                 /* remove the attribute */
@@ -149,7 +149,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
             }
         }
 
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_AUTORESTART, NULL, PMIX_BOOL)) {
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_AUTORESTART, (void**)&fptr, PMIX_BOOL)) {
             /* it is present - check the value */
             if (!flag) {
                 /* remove the attribute */
@@ -168,6 +168,20 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_EXEC_AGENT,
                                    PRTE_ATTR_GLOBAL,
                                    prte_odls_globals.exec_agent, PMIX_STRING);
+            }
+        }
+
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT, (void**)&fptr, PMIX_BOOL)) {
+            /* it is present - check the value */
+            if (!flag) {
+                /* remove the attribute */
+                prte_remove_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT);
+            }
+        } else {
+            /* set it based on default value */
+            if (prte_fwd_environment) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT,
+                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
             }
         }
 
@@ -335,6 +349,11 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 }
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_PROCTABLE,
                                     PRTE_ATTR_GLOBAL, ptr, PMIX_STRING);
+
+            } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_FWD_ENVIRON)) {
+                flag = PMIX_CHECK_TRUE(&value);
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT, PRTE_ATTR_GLOBAL,
+                                   &flag, PMIX_BOOL);
 
             } else {
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true,

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -680,11 +680,19 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
                                &flag, PMIX_BOOL);
 #endif
 
+#ifdef PMIX_FWD_ENVIRONMENT
+        } else if (PMIX_CHECK_KEY(info, PMIX_FWD_ENVIRONMENT)) {
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+#endif
+
             /***   DEFAULT - CACHE FOR INCLUSION WITH JOB INFO   ***/
         } else {
             pmix_server_cache_job_info(jdata, info);
         }
     }
+
     return PRTE_SUCCESS;
 }
 

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -90,8 +90,6 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     pmix_cli_item_t *opt, *opt2;
     pmix_cli_result_t results;
     char *tval;
-    bool fwd;
-    pmix_value_t val;
     prte_info_item_t *iptr;
     pmix_envar_t envt;
     PRTE_HIDE_UNUSED_PARAMS(app_env);
@@ -130,23 +128,6 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     app = PMIX_NEW(prte_pmix_app_t);
     app->app.argv = PMIX_ARGV_COPY_COMPAT(results.tail);
     // app->app.cmd is setup below.
-
-    /* see if we are to forward the environment */
-    fwd = prte_fwd_environment;
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_FWD_ENVIRON);
-    if (NULL != opt) {
-        /* cmd line trumps the MCA param */
-        if (NULL != opt->values) {
-            val.type = PMIX_STRING;
-            val.data.string = opt->values[0];
-            fwd = PMIX_CHECK_TRUE(&val);
-        } else {
-            fwd = true;
-        }
-    }
-    if (fwd) {
-        app->app.env = PMIX_ARGV_COPY_COMPAT(environ);
-    }
 
     /* get the cwd - we may need it in several places */
     if (PRTE_SUCCESS != (rc = pmix_getcwd(cwd, sizeof(cwd)))) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -161,9 +161,6 @@ struct timeval prte_child_time_to_exit = {0};
 /* length of stat history to keep */
 int prte_stat_history_size = -1;
 
-/* envars to forward */
-char **prte_forwarded_envars = NULL;
-
 /* maximum size of virtual machine - used to subdivide allocation */
 int prte_max_vm_size = -1;
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -619,9 +619,6 @@ PRTE_EXPORT extern struct timeval prte_child_time_to_exit;
 /* length of stat history to keep */
 PRTE_EXPORT extern int prte_stat_history_size;
 
-/* envars to forward */
-PRTE_EXPORT extern char **prte_forwarded_envars;
-
 /* maximum size of virtual machine - used to subdivide allocation */
 PRTE_EXPORT extern int prte_max_vm_size;
 

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -515,6 +515,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE-JOB-PREFIX";
         case PRTE_JOB_PMIX_PREFIX:
             return "PRTE-JOB-PMIX-PREFIX";
+        case PRTE_JOB_FWD_ENVIRONMENT:
+            return "FWD ENVIRONMENT";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -234,6 +234,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_GPU_SUPPORT                (PRTE_JOB_START_KEY + 117) // bool - enable/disable GPU support in app
 #define PRTE_JOB_PREFIX                     (PRTE_JOB_START_KEY + 118) // string - PRTE_PREFIX for daemons
 #define PRTE_JOB_PMIX_PREFIX                (PRTE_JOB_START_KEY + 119) // string - PMIX_PREFIX for daemons
+#define PRTE_JOB_FWD_ENVIRONMENT            (PRTE_JOB_START_KEY + 120) // bool - forward local environment to procs in this job
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 


### PR DESCRIPTION
Correctly implement fwd-env as a runtime-options directive, marking the former "--fwd-environment" cmd line option as deprecated. Let the MCA param set the default behavior. Ensure that child jobs can inherit their parent's setting. Inherit by default unless the spawn request specifies otherwise with "noinherit" directive or provides its own fwd environment directive.