### PR TITLE
Preserve formatting in show-help output

### DIFF
--- a/src/mca/schizo/prte/help-prterun.txt
+++ b/src/mca/schizo/prte/help-prterun.txt
@@ -1485,8 +1485,8 @@ The "--runtime-options" command line option has no qualifiers.
 
 Note:
 
-  Directives are case-insensitive.  "FWD-ENVIRONMENT" is the same as
-  "fwd-environment".
+  Directives are case-insensitive - e.g., "FWD-ENVIRONMENT" is the same
+  as "fwd-environment".
 
 #
 [display]

--- a/src/util/prte-convert-help.py
+++ b/src/util/prte-convert-help.py
@@ -104,7 +104,7 @@ def parse_help_files(file_paths, data, citations, verbose=False):
         with open(file_path) as file:
             for line in file:
                 stripped = line.rstrip()
-                if not stripped:
+                if not stripped and current_section is None:
                     continue
                 if stripped.startswith("#include"):
                     # this line includes a file/topic from another file


### PR DESCRIPTION
Preserve empty lines in the show-help array so
that we retain the author's intended formatting
when displayed.