### PR TITLE
src/docs/prrte-rst-content: Add missing file to Makefile.am

### DIFF
--- a/src/docs/prrte-rst-content/Makefile.am
+++ b/src/docs/prrte-rst-content/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+# Copyright (c) 2023-2025 Jeffrey M. Squyres.  All rights reserved.
 # Copyright (c) 2023-2025 Nanook Consulting  All rights reserved.
 #
 # $COPYRIGHT$
@@ -45,6 +45,7 @@ dist_rst_DATA = \
     cli-prefix.rst \
     cli-prepend-env.rst \
     cli-prtemca.rst \
+    cli-no-app-prefix.rst \
     cli-rank-by.rst \
     cli-runtime-options.rst \
     cli-stream-buffering.rst \


### PR DESCRIPTION
It looks like the schizo/ompi/schizo-ompi-cli.rstxt grew a reference to the prrte-rst-content/cli-no-app-prefix.rst file in f7cc125041cbc7cfa1f75d96419c10115b71df18, but this file was mistakenly not included to src/docs/prrte-rst-content/Makefile.am's dist_rst_DATA, even though cli-no-app-prefix.rst was already present in the source tree.

Fixes https://github.com/open-mpi/ompi/issues/13275