### PR TITLE
Multiple commits

### DIFF
--- a/config/prte_config_threads.m4
+++ b/config/prte_config_threads.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2025      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -62,7 +63,18 @@ THREAD_LIBS="$PTHREAD_LIBS"
 
 PRTE_CHECK_PTHREAD_PIDS
 
-AC_DEFINE_UNQUOTED([PRTE_ENABLE_MULTI_THREADS], [1],
-                   [Whether we should enable thread support within the PRTE code base])
+#update the flags
+CFLAGS="$CFLAGS $THREAD_CFLAGS"
+LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
+LIBS="$LIBS $THREAD_LIBS"
+
+# Check for the setaffinity function - must come after
+# we update the flags
+AC_CHECK_FUNCS([pthread_setaffinity_np])
+
+# Some folks apparently split that function definition
+# into a separate header, even though they leave the
+# function in pthreads.h. Go figure.
+AC_CHECK_HEADERS([pthread_np.h])
 
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -615,10 +615,6 @@ AC_C_BIGENDIAN
 
 PRTE_CONFIG_THREADS
 
-CFLAGS="$CFLAGS $THREAD_CFLAGS"
-LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
-LIBS="$LIBS $THREAD_LIBS"
-
 #
 # What is the local equivalent of "ln -s"
 #
@@ -626,9 +622,6 @@ LIBS="$LIBS $THREAD_LIBS"
 AC_PROG_LN_S
 AC_PROG_GREP
 AC_PROG_EGREP
-
-# This check must come after PRTE_CONFIG_THREADS
-AC_CHECK_FUNCS([pthread_setaffinity_np])
 
 #
 # We need as and lex

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -456,8 +456,9 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
             PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                                  "%s hnp:stdin:write:handler incomplete write %d - adjusting data",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_written));
-            /* incomplete write - adjust data to avoid duplicate output */
-            memmove(output->data, &output->data[num_written], output->numbytes - num_written);
+            /* incomplete write - adjust data and count to avoid duplicate output */
+            output->numbytes -= num_written;
+            memmove(output->data, &output->data[num_written], output->numbytes);
             /* push this item back on the front of the list */
             pmix_list_prepend(&wev->outputs, item);
             /* leave the write event running so it will call us again

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +16,10 @@
 #    include <unistd.h>
 #endif
 #include <string.h>
-
+#include <pthread.h>
+#ifdef HAVE_PTHREAD_NP_H
+#    include <pthread_np.h>
+#endif
 #include "src/class/pmix_list.h"
 #include "src/event/event-internal.h"
 #include "src/runtime/prte_globals.h"


### PR DESCRIPTION
[iof/hnp: correctly handle short write to stdin](https://github.com/openpmix/prrte/commit/2d3e74e624f83b089cf5c5f76e327fc5ee6f5a6a)

when a short write occurs, on top of adjusting the data, also adjust
the number of bytes to be sent

Refs https://github.com/openpmix/prrte/issues/2220

Thanks Kim Doyoung for raising this issue on Stack Overflow

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8f936a84e8a0d608ef98094993f1a3f85f679743)

[Check for pthread_np.h header](https://github.com/openpmix/prrte/commit/6430e8548c43591d854698a3537f3b7506655958)

We use the pthread_setaffinity_np function if it is found in the standard pthread library. Apparently, however, some folks split the definition of that function from pthreads.h into a separate header, even though they leave the function itself in the pthread library. Go figure.

Port of https://github.com/openpmix/openpmix/pull/3615

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/9ca8bd84a80e8e9c231223267a33080bf11e21bd)
