### PR TITLE
Multiple commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ test/chkfs
 
 test/mpi/spawn_multiple
 test/mpi/create_comm_from_group
+test/mpi/fwd
 
 docs/_build
 docs/_static

--- a/config/prte_config_threads.m4
+++ b/config/prte_config_threads.m4
@@ -14,6 +14,7 @@ dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2025      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -62,7 +63,18 @@ THREAD_LIBS="$PTHREAD_LIBS"
 
 PRTE_CHECK_PTHREAD_PIDS
 
-AC_DEFINE_UNQUOTED([PRTE_ENABLE_MULTI_THREADS], [1],
-                   [Whether we should enable thread support within the PRTE code base])
+#update the flags
+CFLAGS="$CFLAGS $THREAD_CFLAGS"
+LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
+LIBS="$LIBS $THREAD_LIBS"
+
+# Check for the setaffinity function - must come after
+# we update the flags
+AC_CHECK_FUNCS([pthread_setaffinity_np])
+
+# Some folks apparently split that function definition
+# into a separate header, even though they leave the
+# function in pthreads.h. Go figure.
+AC_CHECK_HEADERS([pthread_np.h])
 
 ])dnl

--- a/configure.ac
+++ b/configure.ac
@@ -604,10 +604,6 @@ AC_C_BIGENDIAN
 
 PRTE_CONFIG_THREADS
 
-CFLAGS="$CFLAGS $THREAD_CFLAGS"
-LDFLAGS="$LDFLAGS $THREAD_LDFLAGS"
-LIBS="$LIBS $THREAD_LIBS"
-
 #
 # What is the local equivalent of "ln -s"
 #
@@ -615,9 +611,6 @@ LIBS="$LIBS $THREAD_LIBS"
 AC_PROG_LN_S
 AC_PROG_GREP
 AC_PROG_EGREP
-
-# This check must come after PRTE_CONFIG_THREADS
-AC_CHECK_FUNCS([pthread_setaffinity_np])
 
 #
 # We need as and lex

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -456,8 +456,9 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
             PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                                  "%s hnp:stdin:write:handler incomplete write %d - adjusting data",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_written));
-            /* incomplete write - adjust data to avoid duplicate output */
-            memmove(output->data, &output->data[num_written], output->numbytes - num_written);
+            /* incomplete write - adjust data and count to avoid duplicate output */
+            output->numbytes -= num_written;
+            memmove(output->data, &output->data[num_written], output->numbytes);
             /* push this item back on the front of the list */
             pmix_list_prepend(&wev->outputs, item);
             /* leave the write event running so it will call us again

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -337,6 +337,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         /* we always inherit a parent's fwd environment directive unless the job assigned it */
         if (prte_get_attribute(&parent->attributes, PRTE_JOB_FWD_ENVIRONMENT, (void **) &fptr, PMIX_BOOL)) {
             if (flag) {
+                // update the child's flag so any subsequent children can inherit it
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_FWD_ENVIRONMENT, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                // forward the environment
                 for (n = 0; n < jdata->apps->size; n++) {
                     app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, n);
                     if (NULL == app) {

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -16,7 +16,10 @@
 #    include <unistd.h>
 #endif
 #include <string.h>
-
+#include <pthread.h>
+#ifdef HAVE_PTHREAD_NP_H
+#    include <pthread_np.h>
+#endif
 #include "src/class/pmix_list.h"
 #include "src/event/event-internal.h"
 #include "src/runtime/prte_globals.h"

--- a/test/mpi/fwd.c
+++ b/test/mpi/fwd.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+#include <stdbool.h>
+
+#define SPAWN 1
+
+int main(int argc, char *argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm parent = MPI_COMM_NULL;
+    MPI_Comm_get_parent(&parent);
+
+    bool am_parent = parent == MPI_COMM_NULL;
+    bool second_child = false;
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    if (SPAWN)
+    {
+        if (am_parent)
+        {
+            MPI_Info the_info;
+            MPI_Info_create(&the_info);
+            MPI_Info_set(the_info, "PMIX_MAPBY", "PPR:1:NODE");
+
+            char *args[] = {"GO", NULL}; // Just so we can know when to quit spawning
+            MPI_Comm_spawn(argv[0], args, 2, the_info, 0, MPI_COMM_WORLD, &parent, MPI_ERRCODES_IGNORE);
+
+            MPI_Info_free(&the_info);
+        }
+        else
+        {
+            if (argc > 1)
+            {
+                MPI_Info the_info;
+                MPI_Info_create(&the_info);
+                MPI_Info_set(the_info, "PMIX_MAPBY", "PPR:1:NODE");
+                MPI_Comm_spawn(argv[0], MPI_ARGV_NULL, 2, the_info, 0, MPI_COMM_WORLD, &parent, MPI_ERRCODES_IGNORE);
+                MPI_Info_free(&the_info);
+            }
+            else
+            {
+                second_child = true;
+            }
+        }
+    }
+
+    const char *vars[] = {"DUMMY_VAR"};
+    const int nvars = sizeof(vars) / sizeof(vars[0]);
+
+    char processor[MPI_MAX_PROCESSOR_NAME];
+    int len_ignore;
+
+    MPI_Get_processor_name(processor, &len_ignore);
+
+    for (int i = 0; i < nvars; i++)
+    {
+        char *value = getenv(vars[i]);
+        if (value)
+        {
+            printf("Hi from rank %d on %s. Child? %s%s. Environment variable %s found with value: %s\n",
+                   rank, processor, am_parent ? "F" : "T", second_child ? " (second)" : "", vars[i], value);
+        }
+        else
+        {
+            printf("Hi from rank %d on %s. Child? %s%s. Environment variable %s NOT found.\n",
+                   rank, processor, am_parent ? "F" : "T", second_child ? " (second)" : "", vars[i]);
+        }
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}
+


### PR DESCRIPTION
[Update child job's fwd environment flag](https://github.com/openpmix/prrte/commit/e3d573f82f322689f22bfdbb01d6eea7ffcf42fd)

If a child inherits the fwd environment directive of its parent,
then update the child's attributes as well as forwarding its
environment so that any subsequent grandchildren also inherit
the flag.

Add a user-provided reproducer

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/fdc57b74c47273950e27df49615d0a30bbad132f)

[Check for pthread_np.h header](https://github.com/openpmix/prrte/commit/8877ece743524de080d967bfe9c1d10d8cf12740)

We use the pthread_setaffinity_np function if it is found in the standard pthread library. Apparently, however, some folks split the definition of that function from pthreads.h into a separate header, even though they leave the function itself in the pthread library. Go figure.

Port of https://github.com/openpmix/openpmix/pull/3615

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/9ca8bd84a80e8e9c231223267a33080bf11e21bd)

[iof/hnp: correctly handle short write to stdin](https://github.com/openpmix/prrte/commit/cd69e7dbf6bbb2061931259cf867ede2cc080962)

when a short write occurs, on top of adjusting the data, also adjust
the number of bytes to be sent

Refs https://github.com/openpmix/prrte/issues/2220

Thanks Kim Doyoung for raising this issue on Stack Overflow

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>
(cherry picked from commit https://github.com/openpmix/prrte/commit/8f936a84e8a0d608ef98094993f1a3f85f679743)
