### PR TITLE
Provide error message when ssh fails

### DIFF
--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -310,10 +310,12 @@ static void proc_errors(int fd, short args, void *cbdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc)));
             /* record the first one to fail */
             if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
-                /* output an error message so the user knows what happened */
-                pmix_show_help("help-errmgr-base.txt", "node-died", true,
-                               PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_process_info.nodename,
-                               PRTE_NAME_PRINT(proc), pptr->node->name);
+                if (PRTE_PROC_STATE_FAILED_TO_START != state) {
+                    /* output an error message so the user knows what happened */
+                    pmix_show_help("help-errmgr-base.txt", "node-died", true,
+                                   PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_process_info.nodename,
+                                   PRTE_NAME_PRINT(proc), pptr->node->name);
+                }
                 /* mark the daemon job as failed */
                 jdata->state = PRTE_JOB_STATE_COMM_FAILED;
                 /* point to the lowest rank to cause the problem */

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -304,11 +304,25 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
             daemon->state = PRTE_PROC_STATE_FAILED_TO_START;
         } else {
             jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+            pmix_output(prte_clean_output,
+                        "------------------------------------------------------------\n"
+                        "A daemon failed to report back after being spawned. This could\n"
+                        "be due to several factors, including inability to find the\n"
+                        "daemon executable, or the executable was unable to find its\n"
+                        "required supporting libraries. In some cases, the daemon was\n"
+                        "able to execute, but was unable to complete a TCP connection\n"
+                        "back to %s:\n\n"
+                        "  Local host:    %s\n"
+                        "  Remote host:   %s\n"
+                        "  Daemon exit status: %d\n\n"
+                        "This may also be caused by a firewall on the remote host. Please\n"
+                        "check that any firewall (e.g., iptables) has been disabled and\n"
+                        "try again.\n"
+                        "------------------------------------------------------------",
+                        prte_tool_basename, prte_process_info.nodename,
+                        (NULL == daemon->node->name) ? "<unknown>" : daemon->node->name,
+                        WEXITSTATUS(daemon->exit_code));
 
-            PMIX_OUTPUT_VERBOSE(
-                (1, prte_plm_base_framework.framework_output, "%s daemon %s failed with status %d",
-                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_VPID_PRINT(daemon->name.rank),
-                 WEXITSTATUS(daemon->exit_code)));
             /* set the exit status */
             PRTE_UPDATE_EXIT_STATUS(WEXITSTATUS(daemon->exit_code));
             /* note that this daemon failed */

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -407,8 +407,8 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
          * not be connected to the HNP at this point */
         pmix_output(prte_clean_output,
                     "------------------------------------------------------------\n"
-                    "A process or daemon was unable to complete a TCP connection\n"
-                    "to another process:\n"
+                    "A daemon was unable to complete a TCP connection\n"
+                    "to another daemon:\n"
                     "  Local host:    %s\n"
                     "  Remote host:   %s\n"
                     "This is usually caused by a firewall on the remote host. Please\n"
@@ -1058,6 +1058,13 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
         return;
     }
 
+    /* if we were connected, then inform the component-level that we have lost a connection so
+     * it can decide what to do about it.
+     */
+    if (MCA_OOB_TCP_CONNECTED == peer->state) {
+        PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_lost_connection);
+    }
+
     peer->state = MCA_OOB_TCP_CLOSED;
     if (NULL != peer->active_addr) {
         peer->active_addr->state = MCA_OOB_TCP_CLOSED;
@@ -1072,11 +1079,6 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
         prte_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
-
-    /* inform the component-level that we have lost a connection so
-     * it can decide what to do about it.
-     */
-    PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_lost_connection);
 
     if (prte_prteds_term_ordered || prte_finalizing || prte_abnormal_term_ordered) {
         /* nothing more to do */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -352,13 +352,16 @@ int main(int argc, char *argv[])
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);
+    } else {
+        // the daemon_init_callback fn already setsid, so don't
+        // do it twice!
+    #if defined(HAVE_SETSID)
+        /* see if we were directed to separate from current session */
+        if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SET_SID)) {
+            setsid();
+        }
+    #endif
     }
-#if defined(HAVE_SETSID)
-    /* see if we were directed to separate from current session */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SET_SID)) {
-        setsid();
-    }
-#endif
 
     /* ensure we silence any compression warnings */
     PMIX_SETENV_COMPAT("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);


### PR DESCRIPTION
If we fail to ssh a daemon, we currently only output a message when (a) we are configured with debug enabled, and (b) plm verbosity is set. Instead, let's always generate a visible error message so the user can know that something is wrong rather than just getting a prompt with a non-zero exit status.