### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -141,27 +141,27 @@ jobs:
         CFLAGS: "-O0"
 
     - name: Test mpi4py (singleton)
-      run:  python test/main.py -v
+      run:  python test/main.py -v -x test_doc
       if:   ${{ true }}
       timeout-minutes: 5
     - name: Test mpi4py (np=1)
-      run:  mpiexec -n 1 python test/main.py -v
+      run:  mpiexec -n 1 python test/main.py -v -x test_doc
       if:   ${{ true }}
       timeout-minutes: 5
     - name: Test mpi4py (np=2)
-      run:  mpiexec -n 2 python test/main.py -v -f
+      run:  mpiexec -n 2 python test/main.py -v -f -x test_doc
       if:   ${{ true }}
       timeout-minutes: 5
     - name: Test mpi4py (np=3)
-      run:  mpiexec -n 3 python test/main.py -v -f
+      run:  mpiexec -n 3 python test/main.py -v -f -x test_doc
       if:   ${{ true }}
       timeout-minutes: 5
     - name: Test mpi4py (np=4)
-      run:  mpiexec -n 4 python test/main.py -v -f
+      run:  mpiexec -n 4 python test/main.py -v -f -x test_doc
       if:   ${{ true }}
       timeout-minutes: 10
     - name: Test mpi4py (np=5)
-      run:  mpiexec -n 5 python test/main.py -v -f
+      run:  mpiexec -n 5 python test/main.py -v -f -x test_doc
       if:   ${{ true }}
       timeout-minutes: 10
 

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -310,10 +310,12 @@ static void proc_errors(int fd, short args, void *cbdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc)));
             /* record the first one to fail */
             if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
-                /* output an error message so the user knows what happened */
-                pmix_show_help("help-errmgr-base.txt", "node-died", true,
-                               PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_process_info.nodename,
-                               PRTE_NAME_PRINT(proc), pptr->node->name);
+                if (PRTE_PROC_STATE_FAILED_TO_START != state) {
+                    /* output an error message so the user knows what happened */
+                    pmix_show_help("help-errmgr-base.txt", "node-died", true,
+                                   PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_process_info.nodename,
+                                   PRTE_NAME_PRINT(proc), pptr->node->name);
+                }
                 /* mark the daemon job as failed */
                 jdata->state = PRTE_JOB_STATE_COMM_FAILED;
                 /* point to the lowest rank to cause the problem */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1136,6 +1136,52 @@ static PMIX_CLASS_INSTANCE(dcaddy_t,
                            pmix_list_item_t,
                            dcon, ddes);
 
+static void progress_daemons(prte_job_t *daemons,
+                             bool show_progress)
+{
+    int i;
+    prte_job_t *jdata;
+
+    if (prted_failed_launch) {
+        PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_FAILED_TO_START);
+        return;
+    } else {
+        daemons->num_reported++;
+        daemons->num_daemons_reported++;
+        if (show_progress &&
+            (0 == daemons->num_reported % 100 ||
+             daemons->num_reported == prte_process_info.num_daemons)) {
+            PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_REPORT_PROGRESS);
+        }
+        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                             "%s plm:base:progress_daemons recvd %d of %d reported daemons",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), daemons->num_reported,
+                             daemons->num_procs));
+
+        if (daemons->num_procs == daemons->num_reported) {
+            bool oneactivated = false;
+            daemons->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
+            /* activate the daemons_reported state for all jobs
+             * whose daemons were launched
+             */
+            for (i = 1; i < prte_job_data->size; i++) {
+                jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, i);
+                if (NULL == jdata) {
+                    continue;
+                }
+                if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
+                    oneactivated = true;
+                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
+                }
+            }
+            if (!oneactivated) {
+                /* must be launching a DVM - activate the state */
+                PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_DAEMONS_REPORTED);
+            }
+        }
+    }
+}
+
 /* callback for topology reports */
 void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
                                    pmix_data_buffer_t *buffer,
@@ -1144,8 +1190,7 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
     hwloc_topology_t topo;
     int rc, idx;
     char *sig;
-    int i;
-    prte_job_t *jdata;
+    bool show_progress;
     uint8_t flag;
     pmix_data_buffer_t datbuf, *data;
     pmix_byte_object_t bo, pbo;
@@ -1161,6 +1206,8 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
     if (NULL == jdatorted) {
         jdatorted = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     }
+    show_progress = prte_get_attribute(&jdatorted->attributes, PRTE_JOB_SHOW_PROGRESS, NULL, PMIX_BOOL);
+
     PMIX_DATA_BUFFER_CONSTRUCT(&datbuf);
     /* unpack the flag to see if this payload is compressed */
     idx = 1;
@@ -1249,40 +1296,11 @@ void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
 
 CLEANUP:
     PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                         "%s plm:base:prted:report_topo launch %s for daemon %s",
+                         "%s plm:base:daemon_topology launch %s for daemon %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                         prted_failed_launch ? "failed" : "completed", PRTE_NAME_PRINT(sender)));
-
-    if (prted_failed_launch) {
-        PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_FAILED_TO_START);
-        return;
-    } else {
-        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                             "%s plm:base:prted_report_launch recvd %d of %d reported daemons",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), jdatorted->num_reported,
-                             jdatorted->num_procs));
-        if (jdatorted->num_procs == jdatorted->num_reported) {
-            bool dvm = true;
-            jdatorted->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
-            /* activate the daemons_reported state for all jobs
-             * whose daemons were launched
-             */
-            for (i = 1; i < prte_job_data->size; i++) {
-                jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, i);
-                if (NULL == jdata) {
-                    continue;
-                }
-                dvm = false;
-                if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
-                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-                }
-            }
-            if (dvm) {
-                /* must be launching a DVM - activate the state */
-                PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_DAEMONS_REPORTED);
-            }
-        }
-    }
+                         prted_failed_launch ? "failed" : "completed",
+                         PRTE_NAME_PRINT(sender)));
+    progress_daemons(jdatorted, show_progress);
 }
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
@@ -1299,7 +1317,6 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     int idx;
     pmix_status_t ret;
     prte_proc_t *daemon = NULL, *dptr;
-    prte_job_t *jdata;
     pmix_proc_t dname;
     pmix_data_buffer_t *relay;
     char *sig;
@@ -1805,7 +1822,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
 
     CLEANUP:
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                             "%s plm:base:prted_report_launch %s for daemon %s at contact %s",
+                             "%s plm:base:prted_daemon_cback %s for daemon %s at contact %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                              prted_failed_launch ? "failed" : "completed", PRTE_NAME_PRINT(&dname),
                              (NULL == daemon) ? "UNKNOWN" : daemon->rml_uri));
@@ -1815,43 +1832,6 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             nodename = NULL;
         }
 
-        if (prted_failed_launch) {
-            PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_FAILED_TO_START);
-            return;
-        } else {
-            jdatorted->num_reported++;
-            jdatorted->num_daemons_reported++;
-            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                 "%s plm:base:prted_report_launch job %s recvd %d of %d reported daemons",
-                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdatorted->nspace),
-                 jdatorted->num_reported, jdatorted->num_procs));
-            if (show_progress &&
-                (0 == jdatorted->num_reported % 100 ||
-                 jdatorted->num_reported == prte_process_info.num_daemons)) {
-                PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_REPORT_PROGRESS);
-            }
-            if (jdatorted->num_procs == jdatorted->num_reported) {
-                bool dvm = true;
-                jdatorted->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
-                /* activate the daemons_reported state for all jobs
-                 * whose daemons were launched
-                 */
-                for (i = 1; i < prte_job_data->size; i++) {
-                    jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, i);
-                    if (NULL == jdata) {
-                        continue;
-                    }
-                    dvm = false;
-                    if (PRTE_JOB_STATE_DAEMONS_LAUNCHED == jdata->state) {
-                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);
-                    }
-                }
-                if (dvm) {
-                    /* must be launching a DVM - activate the state */
-                    PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_DAEMONS_REPORTED);
-                }
-            }
-        }
         idx = 1;
         ret = PMIx_Data_unpack(NULL, buffer, &dname, &idx, PMIX_PROC);
     }
@@ -1859,7 +1839,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != ret) {
         PMIX_ERROR_LOG(ret);
         PRTE_ACTIVATE_JOB_STATE(jdatorted, PRTE_JOB_STATE_FAILED_TO_START);
+        return;
     }
+    progress_daemons(jdatorted, show_progress);
 }
 
 void prte_plm_base_daemon_failed(int st, pmix_proc_t *sender, pmix_data_buffer_t *buffer,

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -305,11 +305,25 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
             daemon->state = PRTE_PROC_STATE_FAILED_TO_START;
         } else {
             jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+            pmix_output(prte_clean_output,
+                        "------------------------------------------------------------\n"
+                        "A daemon failed to report back after being spawned. This could\n"
+                        "be due to several factors, including inability to find the\n"
+                        "daemon executable, or the executable was unable to find its\n"
+                        "required supporting libraries. In some cases, the daemon was\n"
+                        "able to execute, but was unable to complete a TCP connection\n"
+                        "back to %s:\n\n"
+                        "  Local host:    %s\n"
+                        "  Remote host:   %s\n"
+                        "  Daemon exit status: %d\n\n"
+                        "This may also be caused by a firewall on the remote host. Please\n"
+                        "check that any firewall (e.g., iptables) has been disabled and\n"
+                        "try again.\n"
+                        "------------------------------------------------------------",
+                        prte_tool_basename, prte_process_info.nodename,
+                        (NULL == daemon->node->name) ? "<unknown>" : daemon->node->name,
+                        WEXITSTATUS(daemon->exit_code));
 
-            PMIX_OUTPUT_VERBOSE(
-                (1, prte_plm_base_framework.framework_output, "%s daemon %s failed with status %d",
-                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_VPID_PRINT(daemon->name.rank),
-                 WEXITSTATUS(daemon->exit_code)));
             /* set the exit status */
             PRTE_UPDATE_EXIT_STATUS(WEXITSTATUS(daemon->exit_code));
             /* note that this daemon failed */

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -880,6 +880,30 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+        /* --stop-in-init  ->  --runtime-options stop-in-init */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_IN_INIT)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_INIT,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --stop-in-app  ->  --runtime-options stop-in-app */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_IN_APP)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_APP,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --stop-on-exec  ->  --runtime-options stop-on-exec */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_ON_EXEC)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_ON_EXEC,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
         /* --display-map  ->  --display map */
         else if (0 == strcmp(option, "display-map")) {
             rc = prte_schizo_base_add_directive(results, option,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -777,6 +777,29 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
+        /* --stop-in-init  ->  --runtime-options stop-in-init */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_IN_INIT)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_INIT,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --stop-in-app  ->  --runtime-options stop-in-app */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_IN_APP)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_APP,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --stop-on-exec  ->  --runtime-options stop-on-exec */
+        else if (0 == strcmp(option, PRTE_CLI_STOP_ON_EXEC)) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_ON_EXEC,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
         /* --display-map  ->  --display map */
         else if (0 == strcmp(option, "display-map")) {
             rc = prte_schizo_base_add_directive(results, option,

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -527,9 +527,6 @@ static void _toolconn(int sd, short args, void *cbdata)
     pmix_data_buffer_t *buf;
     prte_plm_cmd_flag_t command = PRTE_PLM_ALLOC_JOBID_CMD;
     pmix_status_t xrc = PMIX_SUCCESS, trc;
-    bool primary = false;
-    bool nspace_given = false;
-    bool rank_given = false;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -526,7 +526,10 @@ static void _toolconn(int sd, short args, void *cbdata)
     size_t n;
     pmix_data_buffer_t *buf;
     prte_plm_cmd_flag_t command = PRTE_PLM_ALLOC_JOBID_CMD;
-    pmix_status_t xrc;
+    pmix_status_t xrc = PMIX_SUCCESS, trc;
+    bool primary = false;
+    bool nspace_given = false;
+    bool rank_given = false;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -543,22 +546,14 @@ static void _toolconn(int sd, short args, void *cbdata)
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_VERSION_INFO)) {
                 /* we ignore this for now */
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_USERID)) {
-                PMIX_VALUE_GET_NUMBER(xrc, &cd->info[n].value, cd->uid, uid_t);
-                if (PMIX_SUCCESS != xrc) {
-                    if (NULL != cd->toolcbfunc) {
-                        cd->toolcbfunc(xrc, NULL, cd->cbdata);
-                    }
-                    PMIX_RELEASE(cd);
-                    return;
+                PMIX_VALUE_GET_NUMBER(trc, &cd->info[n].value, cd->uid, uid_t);
+                if (PMIX_SUCCESS == xrc && PMIX_SUCCESS != trc) {
+                    xrc = trc;
                 }
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_GRPID)) {
-                PMIX_VALUE_GET_NUMBER(xrc, &cd->info[n].value, cd->gid, gid_t);
-                if (PMIX_SUCCESS != xrc) {
-                    if (NULL != cd->toolcbfunc) {
-                        cd->toolcbfunc(xrc, NULL, cd->cbdata);
-                    }
-                    PMIX_RELEASE(cd);
-                    return;
+                PMIX_VALUE_GET_NUMBER(trc, &cd->info[n].value, cd->gid, gid_t);
+                if (PMIX_SUCCESS == xrc && PMIX_SUCCESS != trc) {
+                    xrc = trc;
                 }
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_NSPACE)) {
                 PMIX_LOAD_NSPACE(cd->target.nspace, cd->info[n].value.data.string);
@@ -573,16 +568,20 @@ static void _toolconn(int sd, short args, void *cbdata)
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_SERVER_SCHEDULER)) {
                 cd->scheduler = PMIX_INFO_TRUE(&cd->info[n]);
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_PROC_PID)) {
-                PMIX_VALUE_GET_NUMBER(xrc, &cd->info[n].value, cd->pid, pid_t);
-                if (PMIX_SUCCESS != xrc) {
-                    if (NULL != cd->toolcbfunc) {
-                        cd->toolcbfunc(xrc, NULL, cd->cbdata);
-                    }
-                    PMIX_RELEASE(cd);
-                    return;
+                PMIX_VALUE_GET_NUMBER(trc, &cd->info[n].value, cd->pid, pid_t);
+                if (PMIX_SUCCESS == xrc && PMIX_SUCCESS != trc) {
+                    xrc = trc;
                 }
             }
         }
+    }
+
+    if (PMIX_SUCCESS != xrc) {
+        if (NULL != cd->toolcbfunc) {
+            cd->toolcbfunc(xrc, &cd->target, cd->cbdata);
+        }
+        PMIX_RELEASE(cd);
+        return;
     }
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -701,13 +701,16 @@ CLEANUP:
 static char *get_prted_comm_cmd_str(int command)
 {
     switch (command) {
+    case PRTE_DAEMON_CONTACT_QUERY_CMD:
+        return strdup("PRTE_DAEMON_CONTACT_QUERY_CMD");
     case PRTE_DAEMON_KILL_LOCAL_PROCS:
         return strdup("PRTE_DAEMON_KILL_LOCAL_PROCS");
     case PRTE_DAEMON_SIGNAL_LOCAL_PROCS:
         return strdup("PRTE_DAEMON_SIGNAL_LOCAL_PROCS");
     case PRTE_DAEMON_ADD_LOCAL_PROCS:
         return strdup("PRTE_DAEMON_ADD_LOCAL_PROCS");
-
+    case PRTE_DAEMON_HEARTBEAT_CMD:
+        return strdup("PRTE_DAEMON_HEARTBEAT_CMD");
     case PRTE_DAEMON_EXIT_CMD:
         return strdup("PRTE_DAEMON_EXIT_CMD");
     case PRTE_DAEMON_PROCESS_AND_RELAY_CMD:
@@ -715,8 +718,37 @@ static char *get_prted_comm_cmd_str(int command)
     case PRTE_DAEMON_NULL_CMD:
         return strdup("NULL");
 
+    case PRTE_DAEMON_REPORT_JOB_INFO_CMD:
+        return strdup("PRTE_DAEMON_REPORT_JOB_INFO_CMD");
+    case PRTE_DAEMON_REPORT_NODE_INFO_CMD:
+        return strdup("PRTE_DAEMON_REPORT_NODE_INFO_CMD");
+    case PRTE_DAEMON_REPORT_PROC_INFO_CMD:
+        return strdup("PRTE_DAEMON_REPORT_PROC_INFO_CMD");
+    case PRTE_DAEMON_SPAWN_JOB_CMD:
+        return strdup("PRTE_DAEMON_SPAWN_JOB_CMD");
+    case PRTE_DAEMON_TERMINATE_JOB_CMD:
+        return strdup("PRTE_DAEMON_TERMINATE_JOB_CMD");
     case PRTE_DAEMON_HALT_VM_CMD:
         return strdup("PRTE_DAEMON_HALT_VM_CMD");
+    case PRTE_DAEMON_HALT_DVM_CMD:
+        return strdup("PRTE_DAEMON_HALT_DVM_CMD");
+    case PRTE_DAEMON_REPORT_JOB_COMPLETE:
+        return strdup("PRTE_DAEMON_REPORT_JOB_COMPLETE");
+    case PRTE_DAEMON_DEFINE_PSET:
+        return strdup("PRTE_DAEMON_DEFINE_PSET");
+
+    case PRTE_DAEMON_TOP_CMD:
+        return strdup("PRTE_DAEMON_TOP_CMD");
+
+    case PRTE_DAEMON_NAME_REQ_CMD:
+        return strdup("PRTE_DAEMON_NAME_REQ_CMD");
+    case PRTE_DAEMON_CHECKIN_CMD:
+        return strdup("PRTE_DAEMON_CHECKIN_CMD");
+    case PRTE_TOOL_CHECKIN_CMD:
+        return strdup("PRTE_TOOL_CHECKIN_CMD");
+
+    case PRTE_DAEMON_PROCESS_CMD:
+        return strdup("PRTE_DAEMON_PROCESS_CMD");
 
     case PRTE_DAEMON_ABORT_PROCS_CALLED:
         return strdup("PRTE_DAEMON_ABORT_PROCS_CALLED");
@@ -729,6 +761,9 @@ static char *get_prted_comm_cmd_str(int command)
 
     case PRTE_DAEMON_GET_MEMPROFILE:
         return strdup("PRTE_DAEMON_GET_MEMPROFILE");
+
+    case PRTE_DAEMON_REPORT_TOPOLOGY_CMD:
+        return strdup("PRTE_DAEMON_REPORT_TOPOLOGY_CMD");
 
     case PRTE_DAEMON_DVM_CLEANUP_JOB_CMD:
         return strdup("PRTE_DAEMON_DVM_CLEANUP_JOB_CMD");

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -132,6 +132,7 @@ static void clean_abort(int fd, short flags, void *arg);
 static void signal_forward_callback(int fd, short args, void *cbdata);
 static void epipe_signal_callback(int fd, short args, void *cbdata);
 static int prep_singleton(const char *name);
+static bool keepalive = false;
 
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
@@ -159,9 +160,16 @@ static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
                            pmix_info_t results[], size_t nresults,
                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
+    pmix_server_req_t *cd;
     PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
-    clean_abort(0, 0, NULL);
+
+    // allow the pmix event base to continue
     cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+
+    // shift this into our event base
+    cd = PMIX_NEW(pmix_server_req_t);
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, clean_abort, cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 
 static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, void *cbdata)
@@ -565,6 +573,7 @@ int main(int argc, char *argv[])
     /* if we were given a keepalive pipe, set up to monitor it now */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_KEEPALIVE);
     if (NULL != opt) {
+        keepalive = true;
         PMIX_SETENV_COMPAT("PMIX_KEEPALIVE_PIPE", opt->values[0], true, &environ);
     }
 
@@ -1285,7 +1294,12 @@ DONE:
 
 static void clean_abort(int fd, short flags, void *arg)
 {
-    PRTE_HIDE_UNUSED_PARAMS(fd, flags, arg);
+    PRTE_HIDE_UNUSED_PARAMS(fd, flags);
+
+    if (keepalive && NULL == arg) {
+        // ignore this
+        return;
+    }
 
     /* if we have already ordered this once, don't keep
      * doing it to avoid race conditions
@@ -1320,6 +1334,9 @@ static void clean_abort(int fd, short flags, void *arg)
      Instead, we have to exit this handler and setup to call
      job_completed() after this. */
     prte_plm.terminate_orteds();
+    if (NULL != arg) {
+        PMIX_RELEASE(arg);
+    }
 }
 
 static bool first = true;

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -352,13 +352,16 @@ int main(int argc, char *argv[])
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);
+    } else {
+        // the daemon_init_callback fn already setsid, so don't
+        // do it twice!
+    #if defined(HAVE_SETSID)
+        /* see if we were directed to separate from current session */
+        if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SET_SID)) {
+            setsid();
+        }
+    #endif
     }
-#if defined(HAVE_SETSID)
-    /* see if we were directed to separate from current session */
-    if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SET_SID)) {
-        setsid();
-    }
-#endif
 
     /* ensure we silence any compression warnings */
     PMIX_SETENV_COMPAT("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);


### PR DESCRIPTION
[Properly handle sigterm when started by singleton](https://github.com/openpmix/prrte/commit/9231b1934be5447481288a30ba66e04494f28873)

A singleton that spins off prte provides a keepalive
pipe for us to monitor - that monitoring takes place
in the PMIx library. When the singleton receives a
SIGTERM, we need to avoid responding to it directly
and instead allow the pipe closure to trigger our
termination.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5aed7f29c46640fd7b09f917be0f211a1bb73a68)

[Ensure to progress job launch for singleton](https://github.com/openpmix/prrte/commit/e69da0c1542723626d0152b445ccb3d558e5980a)

If a singleton asks us to spawn a child job, that request
may arrive before the DVM is complete. In this case, the
request goes into the prte_cache for later processing. It
is necessary, therefore, to ensure that the launch procedure
is progressed once the DVM is complete.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3e52b80012e377b031c7dccb69123777115cbf9d)

[Update CI](https://github.com/openpmix/prrte/commit/3a2ae8770def37f0ec5e215229f4490b7d8dc60a)

Exclude docs from mpi4py tests

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/81a410a086108342f5c9bd4b32daf4fcc450c3a3)

[Process deprecated "stop" CLI](https://github.com/openpmix/prrte/commit/6af1ea93c7a01b8996493ccf2e772d2acb23e5f3)

Although we have deprecated the --stop-in-init, --stop-in-app,
and --stop-on-exec CLI options, we still need to convert them
to their --runtime-options NNN versions so they are respected.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/a809f3e68a6bd676616daaa21d388e92bad30bf8)

[Minor cleanups in tool connection](https://github.com/openpmix/prrte/commit/716aa75f936a2ddac280ce564f33ad867644f1ed)

Don't return a NULL to the PMIx server library's tool connected
routine. Instead, wait until we process all the provided keys
to (hopefully) capture the tool's procID and then return it
with an error, if we hit one.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/6b0217cebfc4cf13b2fcc5e336d6ac0292a08579)

[Add some missing command strings for debug output](https://github.com/openpmix/prrte/commit/066cb3c63fce8c67ec6d74bf5ce2eea021a58d1b)

The daemon cmd strings were missing some commands, resulting in
"unknown command" output during debug.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/68c54553969eaa916822cabb1a07d3d31ea3fec2)

[Provide error message when ssh fails](https://github.com/openpmix/prrte/commit/d72b65922b264eb987f0644fac115f21a3b43825)

If we fail to ssh a daemon, we currently only output
a message when (a) we are configured with debug enabled,
and (b) plm verbosity is set. Instead, let's always
generate a visible error message so the user can know
that something is wrong rather than just getting a prompt
with a non-zero exit status.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/dc7fceeea70465086a5d61213c57c9b97a95cfa4)
