### PR TITLE
Protect against running with PMIx versions too high

### DIFF
--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -169,7 +169,8 @@ int prte_init_minimum(void)
      * in the v4.x series, we only need to check v4 vs 5
      * and above */
     if ((PMIX_VERSION_MAJOR > 4 && 4 == major) ||
-        (PMIX_VERSION_MAJOR == 4 && 5 <= major)) {
+        (PMIX_VERSION_MAJOR == 4 && 5 <= major) ||
+        6 <= major) {
         print_error(major, minor, release);
         return PRTE_ERR_SILENT;
     }


### PR DESCRIPTION
PRRTE v3.x is incompatible with PMIx versions greater than or equal to v6.0. Although we checked for that at time of configure, it is possible that someone could build us against a compatible version of PMIx and then attempt to execute using an incompatible version - so check that at runtime and abort.

bot:notacherrypick