### PR TITLE
Check for PMIx version too high

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -24,6 +24,8 @@ release=0
 
 pmix_min_version=6.0.0
 hwloc_min_version=2.1.0
+pmix_max_version=1000.0.0
+hwloc_min_version=1.11.0
 event_min_version=2.0.21
 automake_min_version=1.13.4
 autoconf_min_version=2.69.0

--- a/autogen.pl
+++ b/autogen.pl
@@ -721,6 +721,15 @@ sub export_version {
     $m4 .= "m4_define([PRTE_${name}_NUMERIC_MIN_VERSION], [$hex])\n";
 }
 
+sub export_max_version {
+    my ($name,$version) = @_;
+    $version =~ s/[^a-zA-Z0-9,.]//g;
+    my @version_splits = split(/\./,$version);
+    my $hex = sprintf("0x%04x%02x%02x", $version_splits[0], $version_splits[1], $version_splits[2]);
+    $m4 .= "m4_define([PRTE_${name}_MAX_VERSION], [$version])\n";
+    $m4 .= "m4_define([PRTE_${name}_NUMERIC_MAX_VERSION], [$hex])\n";
+}
+
 sub get_and_define_min_versions() {
 
     open(IN, "VERSION") || my_die "Can't open VERSION";
@@ -745,6 +754,11 @@ sub get_and_define_min_versions() {
           elsif($fields[0] eq "pmix_min_version") {
               if ($fields[1] ne "\n") {
                   export_version("PMIX", $fields[1]);
+              }
+          }
+          elsif($fields[0] eq "pmix_max_version") {
+              if ($fields[1] ne "\n") {
+                  export_max_version("PMIX", $fields[1]);
               }
           }
           elsif($fields[0] eq "hwloc_min_version") {

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -118,6 +118,22 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        AC_MSG_WARN([PRRTE requires PMIx v$prte_pmix_min_num_version or above.])
                        AC_MSG_ERROR([Please select a supported version and configure again])])
 
+    # NOTE: We have already read PRRTE's VERSION file, so we can use
+    # $pmix_max_version.
+    prte_pmix_max_num_version=PRTE_PMIX_NUMERIC_MAX_VERSION
+    prte_pmix_max_version=PRTE_PMIX_MAX_VERSION
+    AC_MSG_CHECKING([version below v$prte_pmix_max_version])
+    AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                        #include <pmix_version.h>
+                                        #if !(PMIX_NUMERIC_VERSION < $prte_pmix_max_num_version)
+                                        #error "not below version $prte_pmix_max_num_version"
+                                        #endif
+                                       ], [])],
+                      [AC_MSG_RESULT([yes])],
+                      [AC_MSG_RESULT(no)
+                       AC_MSG_WARN([PRRTE requires PMIx be below v$prte_pmix_max_num_version.])
+                       AC_MSG_ERROR([Please select a supported version and configure again])])
+
     AC_CHECK_HEADER([src/util/pmix_argv.h], [],
                     [AC_MSG_ERROR([Could not find PMIx devel headers.  Can not continue.])])
 


### PR DESCRIPTION
Provide a max version value in VERSION that specifies the upper
bound on PMIx releases - i.e., the PMIx release being used must
be below the specified value. PRRTE v3 is incompatible with PMIx
versions 6.0 and above, so check and error out if someone attempts
to build with an incompatible PMIx.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f86c858d37924c1ac6ad5acde6364afec990b4bb)
