### PR TITLE
Runtime check that PMIx meets min requirement

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -148,6 +148,10 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        [$prte_pmix_min_num_version],
                        [Minimum supported PMIx version])
 
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_MIN_VERSION_STRING],
+                       ["$prte_pmix_min_version"],
+                       [Minimum supported PMIx version])
+
     found_pmixcc=0
     PMIXCC_PATH="pmixcc"
     AS_IF([test -n "${with_pmix}"],


### PR DESCRIPTION
Check at runtime that the PMIx we are using meets
the minimum version requirement since someone
could build against one PMIx version and run
against another.