### PR TITLE
Runtime check both min/max PMIx versions

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -106,6 +106,7 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     # $pmix_min_version.
     prte_pmix_min_num_version=PRTE_PMIX_NUMERIC_MIN_VERSION
     prte_pmix_min_version=PRTE_PMIX_MIN_VERSION
+    prte_pmix_max_version=PRTE_PMIX_MAX_VERSION
     AC_MSG_CHECKING([version at or above v$prte_pmix_min_version])
     AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
                                         #include <pmix_version.h>
@@ -151,6 +152,10 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
     AC_DEFINE_UNQUOTED([PRTE_PMIX_MIN_VERSION_STRING],
                        ["$prte_pmix_min_version"],
                        [Minimum supported PMIx version])
+
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_MAX_VERSION_STRING],
+                       ["$prte_pmix_max_version"],
+                       [Maximum supported PMIx version])
 
     found_pmixcc=0
     PMIXCC_PATH="pmixcc"


### PR DESCRIPTION
Extend the runtime check to cover both min
and max PMIx version constraints as specified
in VERSION.