### PR TITLE
Customize the OMPI "allow-run-as-root" doc snippet

### DIFF
--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -279,7 +279,26 @@ above.
 The ``--allow-run-as-root`` option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /prrte-rst-content/cli-allow-run-as-root.rst
+Allow execution as root **(STRONGLY DISCOURAGED)**.
+
+Running as root exposes the user to potentially catastrophic file
+system corruption and damage |mdash| e.g., if the user accidentally
+points the root of the session directory to a system required point,
+this directory and all underlying elements will be deleted upon job
+completion, thereby rendering the system inoperable.
+
+It is recognized that some environments (e.g., containers) may require
+operation as root, and that the user accepts the risks in those
+scenarios. Accordingly, one can override PRRTE's run-as-root
+protection by providing one of the following:
+
+* The ``--allow-run-as-root`` command line directive
+* Adding **BOTH** of the following environmental parameters:
+
+    * ``OMPI_ALLOW_RUN_AS_ROOT=1``
+    * ``OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1``
+
+Again, we recommend this only be done if absolutely necessary.
 
 .. _label-schizo-ompi-bind-to:
 


### PR DESCRIPTION
Don't import the PRRTE doc snippet for "allow-run-as-root" as it specifically uses the PRTE version of the associated envars. Instead, copy/paste the text and replace the envars with their OMPI cousins.