### PR TITLE
Adjust top session dir name

### DIFF
--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -514,6 +514,9 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         pmix_tool_org      = "Open MPI";
         pmix_tool_msg      = "Report bugs to https://www.open-mpi.org/community/help/";
     }
+    if (NULL == prte_process_info.sessdir_prefix) {
+        prte_process_info.sessdir_prefix = strdup("ompi");
+    }
 
     rc = pmix_cmd_line_parse(pargv, ompishorts, ompioptions, NULL,
                              results, "help-schizo-ompi.txt");

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -491,36 +491,46 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     struct option *myoptions = NULL;
     int rc, n;
     pmix_cli_item_t *opt = NULL;
+    char *sdprefix = "prte";
 
     if (0 == strcmp(prte_tool_actual, "prte")) {
         myoptions = prteoptions;
         shorts = prteshorts;
         helpfile = "help-prte.txt";
+        sdprefix = "prte";
     } else if (0 == strcmp(prte_tool_actual, "prterun")) {
         myoptions = prterunoptions;
         shorts = prterunshorts;
         helpfile = "help-prterun.txt";
+        sdprefix = "prtrn";
     } else if (0 == strcmp(prte_tool_actual, "prted")) {
         myoptions = prtedoptions;
         shorts = prtedshorts;
         helpfile = "help-prted.txt";
+        sdprefix = "prted";
     } else if (0 == strcmp(prte_tool_actual, "prun")) {
         myoptions = prunoptions;
         shorts = prunshorts;
         helpfile = "help-prun.txt";
+        sdprefix = "prun";
     } else if (0 == strcmp(prte_tool_actual, "pterm")) {
         myoptions = ptermoptions;
         shorts = ptermshorts;
         helpfile = "help-pterm.txt";
+        sdprefix = "prte";
     } else if (0 == strcmp(prte_tool_actual, "prte_info")) {
         myoptions = pinfooptions;
         shorts = pinfoshorts;
         helpfile = "help-prte-info.txt";
+        sdprefix = "prte";
     }
     pmix_tool_msg = "Report bugs to: https://github.com/openpmix/prrte";
     pmix_tool_org = "PRRTE";
     pmix_tool_version = prte_util_make_version_string("all", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
                                                       PRTE_RELEASE_VERSION, PRTE_GREEK_VERSION, NULL);
+    if (NULL == prte_process_info.sessdir_prefix) {
+        prte_process_info.sessdir_prefix = strdup(sdprefix);
+    }
 
     rc = pmix_cmd_line_parse(argv, shorts, myoptions, NULL,
                              results, helpfile);

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -69,6 +69,7 @@ PRTE_EXPORT prte_process_info_t prte_process_info = {
     .my_uri = NULL,
     .my_port = 0,
     .tmpdir_base = NULL,
+    .sessdir_prefix = NULL,
     .top_session_dir = NULL,
     .cpuset = NULL,
     .shared_fs = false
@@ -245,6 +246,11 @@ int prte_proc_info_finalize(void)
     if (NULL != prte_process_info.tmpdir_base) {
         free(prte_process_info.tmpdir_base);
         prte_process_info.tmpdir_base = NULL;
+    }
+
+    if (NULL != prte_process_info.sessdir_prefix) {
+        free(prte_process_info.sessdir_prefix);
+        prte_process_info.sessdir_prefix = NULL;
     }
 
     if (NULL != prte_process_info.top_session_dir) {

--- a/src/util/proc_info.h
+++ b/src/util/proc_info.h
@@ -88,6 +88,7 @@ typedef struct prte_process_info_t {
      * environmental variables, or else a default location.
      */
     char *tmpdir_base;        /**< Base directory of the session dir tree */
+    char *sessdir_prefix;     /**< starting string for top session dir name */
     char *top_session_dir;    /**< Top-most directory of the session tree */
     bool rm_session_dirs;     /**< Session directories will be cleaned up by RM */
 


### PR DESCRIPTION
There apparently is a performance advantage associated with reducing the length of the top session directory name in cases where the shared memory backing file is in the session directory tree. Removing the nodename would be a major factor in accomplishing that, but raises problems in those rare cases where we are operating with a shared filesystem under the temp dir.

Resolve this by checking for the shared fs early, and then:

* if tmpdir is on a shared fs, include the nodename in the top session directory name

* if tmpdir is _not_ on a shared fs, then leave the nodename out

Also remove the user ID from the name to save an additional few characters since we really don't need it, and set the prefix of the name to something more indicative of the source - e.g., use "ompi" when executing as "mpirun", and differentiate when operating under "prterun" from operating under "prun", etc.