### PR TITLE
Properly implement the "abort" operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ examples/pset
 examples/nodeid
 examples/client-threaded
 examples/dynamic-dep
+examples/abort
 
 src/sys/powerpc/atomic-32.s
 src/sys/powerpc/atomic-64.s

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,7 +14,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -63,7 +63,8 @@ EXAMPLES = \
 	pset \
 	nodeid \
 	client-threaded \
-	dynamic-dep
+	dynamic-dep \
+	abort
 
 all: $(EXAMPLES)
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -15,7 +15,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -71,4 +71,5 @@ EXTRA_DIST += \
         examples/pset.c \
         examples/nodeid.c \
         examples/client-threaded.c \
-        examples/dynamic-dep.c
+        examples/dynamic-dep.c \
+        examples/abort.c

--- a/examples/abort.c
+++ b/examples/abort.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix_tool.h>
+
+static void cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                   pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    myquery_data_t *mq = (myquery_data_t *) cbdata;
+    size_t n;
+
+    mq->lock.status = status;
+
+    /* save the returned info - it will be
+     * released in the release_fn */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(mq->info, ninfo);
+        mq->ninfo = ninfo;
+        for (n = 0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&mq->info[n], &info[n]);
+        }
+    }
+
+    /* let the library release the data */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    /* release the block */
+    DEBUG_WAKEUP_THREAD(&mq->lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_proc_t myproc, target;
+    size_t ninfo = 0, n;
+    pmix_info_t *info = NULL;
+    char *nspace = NULL;
+    pid_t pid = -1;
+
+    for (n = 1; n < (size_t) argc; n++) {
+        if (0 == strcmp("-p", argv[n]) || 0 == strcmp("--pid", argv[n])) {
+            if (NULL == argv[n + 1]) {
+                fprintf(stderr, "Must provide PID argument to %s option\n", argv[n]);
+                exit(1);
+            }
+            pid = strtol(argv[n + 1], NULL, 10);
+        } else if (0 == strcmp("-nspace", argv[n]) || 0 == strcmp("--nspace", argv[n])) {
+            if (NULL == argv[n + 1]) {
+                fprintf(stderr, "Must provide nspace argument to %s option\n", argv[n]);
+                exit(1);
+            }
+            nspace = argv[n + 1];
+        }
+    }
+    if (NULL == nspace) {
+        fprintf(stderr, "Must provide nspace\n");
+        exit(1);
+    }
+
+    if (0 < pid) {
+        ninfo = 1;
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
+    }
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
+        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+        exit(rc);
+    }
+    if (NULL != info) {
+        PMIX_INFO_FREE(info, ninfo);
+    }
+
+    // abort the provided nspace
+    PMIx_Load_procid(&target, nspace, PMIX_RANK_WILDCARD);
+    fprintf(stderr, "Aborting %s:%u\n", target.nspace, target.rank);
+    rc = PMIx_Abort(PMIX_ERROR, "DIE HUMAN SCUM", &target, 1);
+    fprintf(stderr, "Abort returned: %s\n", PMIx_Error_string(rc));
+
+
+    /* finalize us */
+    PMIx_tool_finalize();
+    return (rc);
+}

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -13,7 +13,7 @@
  *                         reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021      Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -225,7 +225,7 @@ typedef uint8_t prte_plm_cmd_flag_t;
 #define PRTE_PLM_LAUNCH_JOB_CMD         1
 #define PRTE_PLM_UPDATE_PROC_STATE      2
 #define PRTE_PLM_REGISTERED_CMD         3
-#define PRTE_PLM_ALLOC_JOBID_CMD        4
+#define PRTE_PLM_TOOL_ATTACHED_CMD      4
 #define PRTE_PLM_READY_FOR_DEBUG_CMD    5
 #define PRTE_PLM_LOCAL_LAUNCH_COMP_CMD  6
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -130,15 +130,10 @@ typedef struct {
     pmix_info_cbfunc_t infocbfunc;
     pmix_tool_connection_cbfunc_t toolcbfunc;
     pmix_spawn_cbfunc_t spcbfunc;
+    pmix_event_notification_cbfunc_fn_t evcbfunc;
     void *cbdata;
 } prte_pmix_server_op_caddy_t;
 PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    pmix_proc_t name;
-} prte_pmix_tool_t;
-PMIX_CLASS_DECLARATION(prte_pmix_tool_t);
 
 #define PRTE_IO_OP(t, nt, b, fn, cfn, cbd)                                         \
     do {                                                                           \
@@ -314,11 +309,11 @@ PRTE_EXPORT extern void pmix_server_notify(int status, pmix_proc_t *sender,
                                            pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                            void *cbdata);
 
-PRTE_EXPORT extern void pmix_server_jobid_return(int status, pmix_proc_t *sender,
-                                           pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
-                                           void *cbdata);
+PRTE_EXPORT extern void pmix_server_tconn_return(int status, pmix_proc_t *sender,
+                                                 pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                                 void *cbdata);
 
-PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_nspace_t nspace);
+PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_server_req_t *cd);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 
@@ -335,6 +330,14 @@ PRTE_EXPORT extern void pmix_server_alloc_request_resp(int status, pmix_proc_t *
 PRTE_EXPORT extern pmix_status_t prte_pmix_set_scheduler(void);
 
 PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, pmix_server_req_t *req);
+
+PRTE_EXPORT extern void prte_server_lost_connection(size_t evhdlr_registration_id,
+                                                    pmix_status_t status,
+                                                    const pmix_proc_t *source,
+                                                    pmix_info_t info[], size_t ninfo,
+                                                    pmix_info_t *results, size_t nresults,
+                                                    pmix_event_notification_cbfunc_fn_t cbfunc,
+                                                    void *cbdata);
 
 
 #define PRTE_PMIX_ALLOC_REQ      0
@@ -382,7 +385,6 @@ typedef struct {
     char *report_uri;
     char *singleton;
     pmix_device_type_t generate_dist;
-    pmix_list_t tools;
     pmix_list_t psets;
     pmix_list_t groups;
 } pmix_server_globals_t;

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -115,7 +115,7 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 /* For FileM RSH Component */
 #define PRTE_RML_TAG_FILEM_RSH 23
 
-#define PRTE_RML_TAG_JOBID_RESP      24
+#define PRTE_RML_TAG_TCONN_RESP      24
 
 /* support data store/lookup */
 #define PRTE_RML_TAG_DATA_SERVER 27


### PR DESCRIPTION
When a tool or proc calls abort, we need to propagate that request to the HNP for proper execution. If the call comes from a tool, then we need to ensure we don't terminate the DVM until after the tool disconnects.