### PR TITLE
Extend support for specifying tool connection parameters

### DIFF
--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -380,6 +380,8 @@ typedef struct {
     bool no_foreign_tools;
     bool system_controller;
     bool scheduler_connected;
+    bool remote_connections;
+    bool tool_support;
     pmix_proc_t scheduler;
     bool scheduler_set_as_server;
     char *report_uri;

--- a/src/tools/prte/prte.c
+++ b/src/tools/prte/prte.c
@@ -87,6 +87,7 @@
 #include "src/util/pmix_getcwd.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
+#include "src/util/session_dir.h"
 
 #include "src/class/pmix_pointer_array.h"
 #include "src/runtime/prte_progress_threads.h"
@@ -685,6 +686,9 @@ int main(int argc, char *argv[])
     /* setup PRTE infrastructure */
     if (PRTE_SUCCESS != (ret = prte_init(&pargc, &pargv, PRTE_PROC_MASTER))) {
         PRTE_ERROR_LOG(ret);
+        // ensure we cleanup any session dir we might have dropped
+        prte_finalizing = true;
+        prte_job_session_dir_finalize(NULL);
         return ret;
     }
     /* get my proc ID */

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -283,13 +283,9 @@ void prte_job_session_dir_finalize(prte_job_t *jdata)
         return;
     }
 
-    if (NULL == jdata->session_dir) {
-        return;
-    }
-
     /* if this is the DVM job, then we destroy the top-level
      * session directory, but only if we are finalizing */
-    if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
+    if (NULL == jdata || PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
         if (prte_finalizing) {
             if (NULL != prte_process_info.top_session_dir) {
                 pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, _check_file);
@@ -298,6 +294,10 @@ void prte_job_session_dir_finalize(prte_job_t *jdata)
                 prte_process_info.top_session_dir = NULL;
             }
         }
+        return;
+    }
+
+    if (NULL == jdata || NULL == jdata->session_dir) {
         return;
     }
 


### PR DESCRIPTION
Make the remote connection and foreign tool settings be via MCA param so they can be globally set. Don't set the remote connection option unless someone specified it so that PMIx can use the default behavior if necessary.