### PR TITLE
Match IP addresses of local interfaces in --host

### DIFF
--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -43,24 +43,36 @@
 
 #include "dash_host.h"
 
+static inline bool is_str_in_arr(char *arr[], char *str)
+{
+    if (NULL == arr) {
+        return false;
+    }
+    while (NULL != *arr) {
+        if (0 == strcmp(*arr, str)) {
+            return true;
+        }
+        arr++;
+    }
+    return false;
+}
+
 static bool quickmatch(prte_node_t *nd, char *name)
 {
-    int n;
-
     if (0 == strcmp(nd->name, name)) {
         return true;
     }
-    if (0 == strcmp(nd->name, prte_process_info.nodename) &&
-        (0 == strcmp(name, "localhost") ||
-         0 == strcmp(name, "127.0.0.1"))) {
-        return true;
-    }
-    if (NULL != nd->aliases) {
-        for (n=0; NULL != nd->aliases[n]; n++) {
-            if (0 == strcmp(nd->aliases[n], name)) {
-                return true;
-            }
+    if (0 == strcmp(nd->name, prte_process_info.nodename)) {
+        if ((0 == strcmp(name, "localhost") ||
+             0 == strcmp(name, "127.0.0.1"))) {
+            return true;
         }
+        if (is_str_in_arr(prte_process_info.aliases, name)) {
+            return true;
+        }
+    }
+    if (is_str_in_arr(nd->aliases, name)) {
+        return true;
     }
     return false;
 }


### PR DESCRIPTION
We have noticed a simple use case `mpirun --host <my IP address>` does not work anymore with OpenMPI v5.x. It works with OpenMPI v4.x without any issue.

Example:
```
[ec2-user@ip-10-0-0-184 ~]$ /home/ec2-user/ompi-5.0.6-/bin/mpirun -N 1 -n 1 -H 10.0.0.184 hostname
--------------------------------------------------------------------------
There are not enough slots available in the system to satisfy the 1
slots that were requested by the application:

  hostname

Either request fewer procs for your application, or make more slots
available for use.
...
```

Turns out function [prte_util_dash_host_compute_slots()](https://github.com/openpmix/prrte/blob/ce2f0c2e286d66b3a99913544c7ff134971a4707/src/util/dash_host/dash_host.c#L68-L99) returns 0 slots for localhost if it had been specified with `--host` using  a local IP address other that 127.0.0.1, therefore OpenMPI thinks no slots are available.

The issue is the IP addresses of the local interface are not added to node aliases during initialization. They are added  to `prte_process_info.aliases` however. 

I think we should check if `--host` argument is on `prte_process_info.aliases` list for the local node case.

I suggest adding that functionality to [quickmatch()](https://github.com/openpmix/prrte/blob/ce2f0c2e286d66b3a99913544c7ff134971a4707/src/util/dash_host/dash_host.c#L46-L47) function. 