### PR TITLE
Extend control over client connections

### DIFF
--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -406,7 +406,7 @@ void pmix_server_register_params(void)
     /* whether or not to support tool connections */
     prte_pmix_server_globals.tool_support = true;
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "tool_support",
-                                      "Whether or not to support tool connectionst",
+                                      "Whether or not to support tool connections",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_pmix_server_globals.tool_support);
 
@@ -428,6 +428,20 @@ void pmix_server_register_params(void)
           }
           remote_connections_specified = true;
      }
+
+    /* whether or not to require client pid to match */
+    prte_pmix_server_globals.require_pid_match = false;
+    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "require_pid_match",
+                                      "Whether or not to require client pid to match",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_pmix_server_globals.require_pid_match);
+
+    /* whether or not to allow multiple clients with same ID to connect */
+    prte_pmix_server_globals.allow_client_clones = false;
+    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "allow_client_clones",
+                                      "Whether or not to allow client clones",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_pmix_server_globals.allow_client_clones);
 
     /* whether or not to drop a session-level tool rendezvous point */
     prte_pmix_server_globals.session_server = false;
@@ -865,6 +879,16 @@ int pmix_server_init(void)
              return rc;
          }
     }
+
+#ifdef PMIX_ALLOW_CLIENT_CLONES
+    PMIX_INFO_LIST_ADD(prc, ilist, PMIX_ALLOW_CLIENT_CLONES,
+                      (void*)&prte_pmix_server_globals.allow_client_clones, PMIX_BOOL);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_INFO_LIST_RELEASE(ilist);
+        rc = prte_pmix_convert_status(prc);
+        return rc;
+    }
+#endif
 
     /* if we were launched by a debugger, then we need to have
      * notification of our termination sent */

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -134,23 +134,25 @@ static void _client_conn(int sd, short args, void *cbdata)
             }
             continue;
         }
-        if (PMIx_Check_key(cd->info[n].key, PMIX_PROC_PID)) {
-            rc = PMIx_Value_get_number(&cd->info[n].value, (void*)&pid, PMIX_PID);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                goto complete;
-            }
-            if (singleton) {
-                // we didn't know the pid initially, so update it here
-                p->pid = pid;
-            } else {
-                if (p->pid != pid) {
-                    rc = PMIX_ERR_NOT_SUPPORTED;
+        if (prte_pmix_server_globals.require_pid_match) {
+            if (PMIx_Check_key(cd->info[n].key, PMIX_PROC_PID)) {
+                rc = PMIx_Value_get_number(&cd->info[n].value, (void*)&pid, PMIX_PID);
+                if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto complete;
                 }
+                if (singleton) {
+                    // we didn't know the pid initially, so update it here
+                    p->pid = pid;
+                } else {
+                    if (p->pid != pid) {
+                        rc = PMIX_ERR_NOT_SUPPORTED;
+                        PMIX_ERROR_LOG(rc);
+                        goto complete;
+                    }
+                }
+                continue;
             }
-            continue;
         }
     }
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -382,6 +382,8 @@ typedef struct {
     bool scheduler_connected;
     bool remote_connections;
     bool tool_support;
+    bool require_pid_match;
+    bool allow_client_clones;
     pmix_proc_t scheduler;
     bool scheduler_set_as_server;
     char *report_uri;


### PR DESCRIPTION
Provide MCA params to control the ability for a client to connect even if it has a different pid than what we started. This happens when an intermediate script or executable is being used to fork the client - e.g., in the case of a debugger. Set this to not require pid match by default.

Also provide a switch to enable/disable client clones - i.e., for a client process to fork a child that also connects back to the PMIx server since it will use the same nspace/rank as its parent. This is currently an unusual use-case, but allowed by the Standard. Set this to not allow clones by default.

Fixes #2256 