### PR TITLE
Ensure we have HNP node aliases

### DIFF
--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -43,6 +43,7 @@
 #include "src/event/event-internal.h"
 #include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
+#include "src/util/pmix_if.h"
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_environ.h"
 
@@ -298,6 +299,10 @@ int prte_ess_base_prted_setup(void)
         error = "pmix_server_init";
         goto error;
     }
+
+    /* add network aliases to our list of alias hostnames - must
+     * wait until after we init PMIx before getting them */
+    pmix_ifgetaliases(&prte_process_info.aliases);
 
     /* Setup the communication infrastructure */
     if (PRTE_SUCCESS

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -221,8 +221,6 @@ static int rte_init(int argc, char **argv)
     node->daemon = proc;
     PRTE_FLAG_SET(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
     node->state = PRTE_NODE_STATE_UP;
-    /* get our aliases - will include all the interface aliases captured in prte_init */
-    node->aliases = PMIX_ARGV_COPY_COMPAT(prte_process_info.aliases);
     /* record that the daemon job is running */
     jdata->num_procs = 1;
     jdata->state = PRTE_JOB_STATE_RUNNING;
@@ -251,6 +249,13 @@ static int rte_init(int argc, char **argv)
         error = "pmix_server_init";
         goto error;
     }
+
+    /* add network aliases to our list of alias hostnames - must
+     * wait until after we init PMIx before getting them */
+    pmix_ifgetaliases(&prte_process_info.aliases);
+
+    /* get our aliases - will include all the interface aliases captured in prte_init */
+    node->aliases = PMIX_ARGV_COPY_COMPAT(prte_process_info.aliases);
 
     /* if we are using xml for output, put a start tag */
     if (prte_xml_output) {

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -476,8 +476,6 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
         error = "prte_ess_init";
         goto error;
     }
-    /* add network aliases to our list of alias hostnames */
-    pmix_ifgetaliases(&prte_process_info.aliases);
 
     /* initialize the cache */
     prte_cache = PMIX_NEW(pmix_pointer_array_t);

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -573,9 +573,9 @@ int main(int argc, char *argv[])
 
     /* include any non-loopback aliases for this node */
     for (n = 0; NULL != prte_process_info.aliases[n]; n++) {
-        if (0 != strcmp(prte_process_info.aliases[n], "localhost")
-            && 0 != strcmp(prte_process_info.aliases[n], "127.0.0.1")
-            && 0 != strcmp(prte_process_info.aliases[n], prte_process_info.nodename)) {
+        if (0 != strcmp(prte_process_info.aliases[n], "localhost") &&
+            0 != strcmp(prte_process_info.aliases[n], "127.0.0.1") &&
+            0 != strcmp(prte_process_info.aliases[n], prte_process_info.nodename)) {
             PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nonlocal, prte_process_info.aliases[n]);
         }
     }

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -50,11 +50,6 @@ static bool quickmatch(prte_node_t *nd, char *name)
     if (0 == strcmp(nd->name, name)) {
         return true;
     }
-    if (0 == strcmp(nd->name, prte_process_info.nodename) &&
-        (0 == strcmp(name, "localhost") ||
-         0 == strcmp(name, "127.0.0.1"))) {
-        return true;
-    }
     if (NULL != nd->aliases) {
         for (n=0; NULL != nd->aliases[n]; n++) {
             if (0 == strcmp(nd->aliases[n], name)) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -94,6 +94,11 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         als = NULL;
         if (NULL != nptr->aliases) {
             for (m=0; NULL != nptr->aliases[m]; m++) {
+                // skip any localhost entries
+                if (0 == strcmp(nptr->aliases[m], "localhost") ||
+                    0 == strcmp(nptr->aliases[m], "127.0.0.1")) {
+                    continue;
+                }
                 PMIX_ARGV_APPEND_NOSIZE_COMPAT(&als, nptr->aliases[m]);
             }
             raw = PMIX_ARGV_JOIN_COMPAT(als, ',');

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -154,15 +154,16 @@ void prte_setup_hostname(void)
         }
     }
 
+    // add the localhost names
+    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, "localhost");
+    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, "127.0.0.1");
 }
 
 bool prte_check_host_is_local(const char *name)
 {
     int i;
 
-    if (0 == strcmp(name, prte_process_info.nodename) ||
-        0 == strcmp(name, "localhost") ||
-        0 == strcmp(name, "127.0.0.1")) {
+    if (0 == strcmp(name, prte_process_info.nodename)) {
         return true;
     }
 


### PR DESCRIPTION
We captured the HNP's aliases in prte_process_info, but that happened _after_ we had already copied them to the HNP's node object. So when we then checked the node aliases, they were missing from that node.

Ensure we capture the HNP's aliases on the node object. Simplify the check for local node by including the "localhost" and "127.0.0.1" aliases, being sure not to include them in the nidmap. Correct the check in dash-host for matching node names.

Thanks to Alexey Novikov for the report