### PR TITLE
Move prte function into library

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 #
-# Copyright (c) 2021      Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/src/prted/Makefile.am
+++ b/src/prted/Makefile.am
@@ -13,7 +13,7 @@
 # Copyright (c) 2014-2020 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2018      IBM Corporation.  All rights reserved.
-# Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -26,10 +26,11 @@
 
 headers += \
 	prted/prted.h
-
+        
 libprrte_la_SOURCES += \
         prted/prted_comm.c \
         prted/prte_app_parse.c \
-        prted/prun_common.c
+        prted/prun_common.c \
+        prted/prte.c
 
 include prted/pmix/Makefile.am

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -104,10 +104,10 @@
 #include "src/runtime/prte_wait.h"
 #include "src/runtime/runtime.h"
 
-#include "include/prte.h"
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/prted/prted.h"
+#include "include/prte.h"
 
 typedef struct {
     prte_pmix_lock_t lock;
@@ -256,7 +256,7 @@ static char *pmix_getline(FILE *fp)
 }
 #endif
 
-int main(int argc, char *argv[])
+int prte(int argc, char *argv[])
 {
     int rc = 1, i;
     char *param, *tpath, *cptr;

--- a/src/tools/prte/Makefile.am
+++ b/src/tools/prte/Makefile.am
@@ -39,8 +39,8 @@ AM_CFLAGS = \
 
 bin_PROGRAMS = prte
 
-prte_SOURCES = \
-        prte.c
+prte_SOURCES =  \
+        main.c
 
 prte_LDADD = \
     $(prte_libevent_LIBS) \
@@ -53,3 +53,4 @@ install-exec-hook:
 
 uninstall-local:
 	rm -f $(DESTDIR)$(bindir)/prterun$(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/prte$(EXEEXT)

--- a/src/tools/prte/main.c
+++ b/src/tools/prte/main.c
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *                                                                         *
+ *          PRTE: PMIx Reference RunTime Environment (PRTE)              *
+ *                                                                         *
+ *                   https://github.com/openpmix/prte                     *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "include/prte.h"
+
+int main(int argc, char *argv[])
+{
+    return prte(argc, argv);
+}
+
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2021 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2007-2009 Sun Microsystems, Inc. All rights reserved.
+ * Copyright (c) 2007-2017 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
+ * Copyright (c) 2020      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
+ *                         reserved.
+ * Copyright (c) 2022-2023 Triad National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+


### PR DESCRIPTION
Take the "main" function in the "prte" tool and move it into libprte so that it can be called by external tools. Cover it with a splash shield so that debuggers see the splash when starting "prte" or "prterun".