### PR TITLE
Inherit env directives if requested

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1252,14 +1252,15 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
     int j, idx;
     int total_num_local_procs = 0;
     prte_odls_launch_local_t *caddy = (prte_odls_launch_local_t *) cbdata;
-    prte_job_t *jobdat;
+    prte_job_t *jobdat, *parent;
     pmix_nspace_t job;
     prte_odls_base_fork_local_proc_fn_t fork_local = caddy->fork_local;
-    bool index_argv;
+    bool index_argv, inherit;
     char *msg, **xfer;
     prte_odls_spawn_caddy_t *cd;
     prte_event_base_t *evb;
     prte_schizo_base_module_t *schizo;
+    pmix_proc_t *nptr;
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -1352,6 +1353,20 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         }
     }
 
+    // see if we have a parent in case of inheritance
+    nptr = NULL;
+    prte_get_attribute(&jobdat->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC);
+    if (NULL != nptr) {
+        parent = prte_get_job_data_object(nptr->nspace);
+        if (NULL != parent) {
+            inherit = prte_get_attribute(&parent->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL);
+        } else {
+            inherit = false;
+        }
+    } else {
+        inherit = false;
+    }
+
     for (j = 0; j < jobdat->apps->size; j++) {
         app = (prte_app_context_t *) pmix_pointer_array_get_item(jobdat->apps, j);
         if (NULL == app) {
@@ -1395,6 +1410,10 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         }
 
         // process any provided env directives
+        if (inherit) {
+            // start with the parent's directives
+            process_envars(parent, app);
+        }
         process_envars(jobdat, app);
 
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -241,11 +241,18 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 // mapped by us
                 inherit = false;
                 parent = NULL;
+
             } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
                 inherit = true;
+                // if they didn't specifically direct it not inherit, then pass this on to the child
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_ATTR_GLOBAL, PRTE_JOB_INHERIT, NULL, PMIX_BOOL);
+                }
+
             } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
                 inherit = false;
                 parent = NULL;
+
             } else {
                 inherit = prte_rmaps_base.inherit;
             }


### PR DESCRIPTION
If someone specifies that child jobs inherit from their parents, then have them inherit any env directives as well as job-level directives.

Have children inherit their parent's inheritance directive, unless directed not to do so.