### PR TITLE
Inherit env directives if requested

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -233,11 +233,18 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 // mapped by us
                 inherit = false;
                 parent = NULL;
+
             } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
                 inherit = true;
+                // if they didn't specifically direct it not inherit, then pass this on to the child
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_ATTR_GLOBAL, PRTE_JOB_INHERIT, NULL, PMIX_BOOL);
+                }
+
             } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
                 inherit = false;
                 parent = NULL;
+
             } else {
                 inherit = prte_rmaps_base.inherit;
             }


### PR DESCRIPTION
If someone specifies that child jobs inherit from their parents, then have them inherit any env directives as well as job-level directives.

Have children inherit their parent's inheritance directive, unless directed not to do so.


(cherry picked from commit eb577d4883340310927c2ee97405feaddb9f43ba)