### PR TITLE
Extend inheritance to app level

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -655,8 +655,8 @@ next:
         /* add any cache'd values to the front of the job attributes  */
         for (m = 0; m < ninfo; m++) {
             if (0 == strcmp(info[m].key, PMIX_SET_ENVAR)) {
-                envt.envar = strdup(info[m].value.data.envar.envar);
-                envt.value = strdup(info[m].value.data.envar.value);
+                envt.envar = info[m].value.data.envar.envar;
+                envt.value = info[m].value.data.envar.value;
                 envt.separator = info[m].value.data.envar.separator;
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envt, PMIX_ENVAR);
@@ -1112,6 +1112,9 @@ static void process_envars(prte_job_t *jdata,
     bool found;
 
     PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t) {
+        if (PMIX_ENVAR != attr->data.type) {
+            continue;
+        }
         val = &attr->data;
         envar = &val->data.envar;
         if (attr->key == PRTE_JOB_SET_ENVAR) {
@@ -1186,6 +1189,9 @@ static void process_envars(prte_job_t *jdata,
 
     // app trumps job, so do it after the job
     PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t) {
+        if (PMIX_ENVAR != attr->data.type) {
+            continue;
+        }
         val = &attr->data;
         envar = &val->data.envar;
         if (attr->key == PRTE_APP_SET_ENVAR) {
@@ -1252,15 +1258,14 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
     int j, idx;
     int total_num_local_procs = 0;
     prte_odls_launch_local_t *caddy = (prte_odls_launch_local_t *) cbdata;
-    prte_job_t *jobdat, *parent;
+    prte_job_t *jobdat;
     pmix_nspace_t job;
     prte_odls_base_fork_local_proc_fn_t fork_local = caddy->fork_local;
-    bool index_argv, inherit;
+    bool index_argv;
     char *msg, **xfer;
     prte_odls_spawn_caddy_t *cd;
     prte_event_base_t *evb;
     prte_schizo_base_module_t *schizo;
-    pmix_proc_t *nptr;
     PRTE_HIDE_UNUSED_PARAMS(fd, sd);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -1353,20 +1358,6 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         }
     }
 
-    // see if we have a parent in case of inheritance
-    nptr = NULL;
-    prte_get_attribute(&jobdat->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC);
-    if (NULL != nptr) {
-        parent = prte_get_job_data_object(nptr->nspace);
-        if (NULL != parent) {
-            inherit = prte_get_attribute(&parent->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL);
-        } else {
-            inherit = false;
-        }
-    } else {
-        inherit = false;
-    }
-
     for (j = 0; j < jobdat->apps->size; j++) {
         app = (prte_app_context_t *) pmix_pointer_array_get_item(jobdat->apps, j);
         if (NULL == app) {
@@ -1410,10 +1401,6 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         }
 
         // process any provided env directives
-        if (inherit) {
-            // start with the parent's directives
-            process_envars(parent, app);
-        }
         process_envars(jobdat, app);
 
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -57,6 +57,10 @@ static int map_colocate(prte_job_t *jdata,
                         uint16_t procs_per_target,
                         prte_rmaps_options_t *options);
 
+static void inherit_env_directives(prte_job_t *jdata,
+                                   prte_job_t *parent,
+                                   pmix_proc_t *proxy);
+
 void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
@@ -70,7 +74,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     prte_job_t *parent = NULL;
     prte_app_context_t *app;
     bool inherit = false;
-    pmix_proc_t *nptr, *target_proc;
+    pmix_proc_t *nptr = NULL, *target_proc;
     char *tmp, **ck, **env;
     uint16_t u16 = 0, procs_per_target = 0;
     uint16_t *u16ptr = &u16;
@@ -229,6 +233,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     /* if this is a dynamic job launch and they didn't explicitly
      * request inheritance, then don't inherit the launch directives */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &nptr, PMIX_PROC)) {
+        if (NULL == nptr) {
+            PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+            goto cleanup;
+        }
         /* if the launch proxy is me, then this is the initial launch from
          * a proxy scenario, so we don't really have a parent */
         if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, nptr->nspace)) {
@@ -263,7 +272,6 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         } else {
             inherit = true;
         }
-        PMIX_PROC_RELEASE(nptr);
     } else {
         /* initial launch always takes on default MCA params for non-specified policies */
         inherit = true;
@@ -309,6 +317,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
                 }
             }
+            // copy over any env directives, but do not overwrite anything already specified
+            inherit_env_directives(jdata, parent, nptr);
         } else {
             if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
                 !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
@@ -320,6 +330,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 }
             }
         }
+    }
+    if (NULL != nptr) {
+        PMIX_PROC_RELEASE(nptr);
     }
 
     /* we always inherit a parent's oversubscribe flag unless the job assigned it */
@@ -1249,4 +1262,109 @@ done:
     }
     PMIX_LIST_DESTRUCT(&targets);
     return ret;
+}
+
+static void inherit_env_directives(prte_job_t *jdata,
+                                   prte_job_t *parent,
+                                   pmix_proc_t *proxy)
+{
+    prte_app_context_t *app, *app2;
+    prte_proc_t *p;
+    prte_attribute_t *attr, *attr2;
+    pmix_value_t *val, *val2;
+    pmix_envar_t *envar, *envar2;
+    int n;
+    bool exists;
+
+    // deal with job-level attributes first
+    PMIX_LIST_FOREACH(attr, &parent->attributes, prte_attribute_t) {
+        if (PMIX_ENVAR != attr->data.type) {
+            continue;
+        }
+        val = &attr->data;
+        envar = &val->data.envar;
+
+        // do we have a matching attribute in the new job?
+        exists = false;
+        PMIX_LIST_FOREACH(attr2, &jdata->attributes, prte_attribute_t) {
+            if (PMIX_ENVAR != attr->data.type) {
+                continue;
+            }
+            val2 = &attr2->data;
+            envar2 = &val2->data.envar;
+
+            if (attr->key == attr2->key) {
+                // operation is same - check if the target envars match
+                if (0 == strcmp(envar->envar, envar2->envar)) {
+                    // these match, so don't overwrite it
+                    exists = true;
+                    break;
+                }
+            }
+        }
+
+        if (exists) {
+            // leave this alone
+            continue;
+        }
+
+        // if it doesn't exist, then inherit it
+        prte_prepend_attribute(&jdata->attributes, attr->key, PRTE_ATTR_GLOBAL,
+                               envar, PMIX_ENVAR);
+    }
+
+    /* There is no one-to-one correlation between the apps, but we can
+     * inherit the directives from the proc that called spawn, so do that
+     * much here */
+    p = prte_get_proc_object(proxy);
+    if (NULL == p) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return;
+    }
+    app = (prte_app_context_t*)pmix_pointer_array_get_item(parent->apps, p->app_idx);
+    if (NULL == app) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return;
+    }
+    for (n=0; n < jdata->apps->size; n++) {
+        app2 = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, n);
+        if (NULL == app2) {
+            continue;
+        }
+        PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t) {
+            if (PMIX_ENVAR != attr->data.type) {
+                continue;
+            }
+            val = &attr->data;
+            envar = &val->data.envar;
+
+            exists = false;
+            PMIX_LIST_FOREACH(attr2, &app2->attributes, prte_attribute_t) {
+                if (PMIX_ENVAR != attr->data.type) {
+                    continue;
+                }
+                val2 = &attr2->data;
+                envar2 = &val2->data.envar;
+
+                if (attr->key == attr2->key) {
+                    // operation is same - check if the target envars match
+                    if (0 == strcmp(envar->envar, envar2->envar)) {
+                        // these match, so don't overwrite it
+                        exists = true;
+                        break;
+                    }
+                }
+            }
+
+            if (exists) {
+                // leave this alone
+                continue;
+            }
+
+            // if it doesn't exist, then inherit it
+            prte_prepend_attribute(&app2->attributes, attr->key, PRTE_ATTR_GLOBAL,
+                                   envar, PMIX_ENVAR);
+        }
+    }
+
 }

--- a/test/simple_spawn.c
+++ b/test/simple_spawn.c
@@ -18,6 +18,7 @@ int main(int argc, char *argv[])
     char hostname[1024];
     pmix_value_t *val = NULL;
     pmix_nspace_t nspace;
+    char *env;
 
     pid = getpid();
     gethostname(hostname, 1024);
@@ -122,6 +123,9 @@ int main(int argc, char *argv[])
         }
         printf("%s.%u: Disconnect complete!\n", myproc.nspace, myproc.rank);
     }
+
+    env = getenv("foo");
+    printf("%s.%u: FOO %s\n", myproc.nspace, myproc.rank, (NULL == env) ? "NULL" : env);
 
 done:
     PMIx_Finalize(NULL, 0);


### PR DESCRIPTION
If we are inheriting envar directives from our parent job, then extend that to inheriting envar directives for the application of the proc that spawned us. Shift processing of inheritance directives to the mapper, and ensure that the child inherits the inheritance directive so that the grandchildren will also inherit.