### PR TITLE
Extend testbuild launchers support

### DIFF
--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -297,10 +297,15 @@ static int hnp_pull(const pmix_proc_t *dst_name, prte_iof_tag_t src_tag, int fd)
      */
     if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
         pmix_output(prte_iof_base_framework.framework_output,
-                    "[%s:%d]: fcntl(F_GETFL) failed with errno=%d\n", __FILE__, __LINE__, errno);
+                    "[%s:%d]: fcntl(F_GETFL) failed with errno=%d\n",
+                    __FILE__, __LINE__, errno);
     } else {
         flags |= O_NONBLOCK;
-        fcntl(fd, F_SETFL, flags);
+        if (fcntl(fd, F_SETFL, flags) < 0) {
+            pmix_output(prte_iof_base_framework.framework_output,
+                        "[%s:%d]: fcntl(F_SETFL) failed with errno=%d\n",
+                        __FILE__, __LINE__, errno);
+        }
     }
 
     /* do we already have this process in our list? */

--- a/src/mca/ras/gridengine/configure.m4
+++ b/src/mca/ras/gridengine/configure.m4
@@ -16,6 +16,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -28,7 +29,10 @@
 AC_DEFUN([MCA_prte_ras_gridengine_CONFIG],[
     AC_CONFIG_FILES([src/mca/ras/gridengine/Makefile])
 
-    PRTE_CHECK_GRIDENGINE([ras_gridengine], [ras_gridengine_happy="yes"], [ras_gridengine_happy="no"])
+    PRTE_CHECK_GRIDENGINE([ras_gridengine],
+                          [ras_gridengine_happy="yes"],
+                          [ras_gridengine_happy="no"])
 
-    AS_IF([test "$ras_gridengine_happy" = "yes"], [$1], [$2])
+    AS_IF([test "$ras_gridengine_happy" = "yes" || test "$prte_testbuild_launchers" = "1"],
+          [$1], [$2])
 ])dnl

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -70,6 +70,7 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
     FILE *fp;
     prte_node_t *node;
     bool found;
+    PRTE_HIDE_UNUSED_PARAMS(jdata);
 
     /* show the Grid Engine's JOB_ID */
     if (prte_mca_ras_gridengine_component.show_jobid || prte_mca_ras_gridengine_component.verbose != -1) {
@@ -88,7 +89,8 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
     /* parse the pe_hostfile for hostname, slots, etc, then compare the
      * current node with a list of hosts in the nodelist, if the current
      * node is not found in nodelist, add it in */
-    pmix_output(prte_mca_ras_gridengine_component.verbose, "ras:gridengine: PE_HOSTFILE: %s",
+    pmix_output(prte_mca_ras_gridengine_component.verbose,
+                "ras:gridengine: PE_HOSTFILE: %s",
                 pe_hostfile);
 
     while (fgets(buf, sizeof(buf), fp)) {
@@ -120,7 +122,8 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
             node->slots_max = 0;
             node->slots = (int) strtol(num, (char **) NULL, 10);
             pmix_output(prte_mca_ras_gridengine_component.verbose,
-                        "ras:gridengine: %s: PE_HOSTFILE shows slots=%d", node->name, node->slots);
+                        "ras:gridengine: %s: PE_HOSTFILE shows slots=%d queue=%s arch=%s",
+                        node->name, node->slots, queue, arch);
             pmix_list_append(nodelist, &node->super);
         }
     } /* finished reading the $PE_HOSTFILE */
@@ -141,47 +144,6 @@ cleanup:
     return PRTE_SUCCESS;
 }
 
-#if 0
-/**
- * This function is not used currently, but may be used eventually.
- * Parse the PE_HOSTFILE to determine the number of process
- * slots/processors available on the node.
- */
-static int get_slot_count(char* node_name, int* slot_cnt)
-{
-    char buf[1024], *tok, *name, *num, *queue, *arch;
-    char *pe_hostfile = getenv("PE_HOSTFILE");
-    FILE *fp;
-
-    /* check the PE_HOSTFILE before continuing on */
-    if (!(fp = fopen(pe_hostfile, "r"))) {
-        pmix_show_help("help-ras-gridengine.txt", "cannot-read-pe-hostfile",
-            true, pe_hostfile, strerror(errno));
-        PRTE_ERROR_LOG(PRTE_ERROR);
-        return(PRTE_ERROR);
-    }
-
-    while (fgets(buf, sizeof(buf), fp)) {
-        name = strtok_r(buf, " \n", &tok);
-        num = strtok_r(NULL, " \n", &tok);
-        queue = strtok_r(NULL, " \n", &tok);
-        arch = strtok_r(NULL, " \n", &tok);
-
-        if(strcmp(node_name,name) == 0) {
-            *slot_cnt = (int) strtol(num, (char **)NULL, 10);
-            pmix_output(prte_mca_ras_gridengine_component.verbose,
-                "ras:gridengine: %s: PE_HOSTFILE shows slots=%d",
-                node_name, *slot_cnt);
-            fclose(fp);
-            return PRTE_SUCCESS;
-        }
-    }
-
-    /* when there is no match */
-    fclose(fp);
-    return PRTE_ERROR;
-}
-#endif
 
 /**
  * finalize

--- a/src/mca/ras/lsf/configure.m4
+++ b/src/mca/ras/lsf/configure.m4
@@ -14,6 +14,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +31,7 @@ AC_DEFUN([MCA_prte_ras_lsf_CONFIG],[
 
     # if check worked, set wrapper flags if so.
     # Evaluate succeed / fail
-    AS_IF([test "$ras_lsf_good" = "1"],
+    AS_IF([test "$ras_lsf_good" = "1" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/ras/lsf/ras_lsf_component.c
+++ b/src/mca/ras/lsf/ras_lsf_component.c
@@ -27,7 +27,11 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#if PRTE_TESTBUILD_LAUNCHERS
+#include "testbuild_lsf.h"
+#else
 #include <lsf/lsbatch.h>
+#endif
 
 #include "src/mca/base/pmix_base.h"
 

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -29,7 +29,11 @@
 #include <unistd.h>
 
 #define SR1_PJOBS
+#if PRTE_TESTBUILD_LAUNCHERS
+#include "testbuild_lsf.h"
+#else
 #include <lsf/lsbatch.h>
+#endif
 
 #include "src/hwloc/hwloc-internal.h"
 #include "src/util/pmix_argv.h"
@@ -60,8 +64,9 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 {
     char **nodelist;
     prte_node_t *node;
-    int i, num_nodes, rc;
+    int i, num_nodes;
     char *ptr;
+    PRTE_HIDE_UNUSED_PARAMS(jdata);
 
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {

--- a/src/mca/ras/lsf/testbuild_lsf.h
+++ b/src/mca/ras/lsf/testbuild_lsf.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2020 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_RAS_LSF_TESTBUILD_H
+#define PRTE_RAS_LSF_TESTBUILD_H
+
+#include "prte_config.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/ras/ras.h"
+
+BEGIN_C_DECLS
+
+int lsb_init(char *str);
+int lsb_getalloc(char ***hostlist);
+
+END_C_DECLS
+
+#endif /* PRTE_RAS_LSF_TESTBUILD_H */

--- a/src/mca/ras/pbs/configure.m4
+++ b/src/mca/ras/pbs/configure.m4
@@ -14,7 +14,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
-# Copyright (c) 2022      Nanook Consulting.  All rights reserved.
+# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2022      Research Organization for Information Science
 #                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2022      Amazon.com, Inc. or its affiliates.
@@ -62,7 +62,7 @@ AC_DEFUN([MCA_prte_ras_pbs_CONFIG],[
 
     PRTE_SUMMARY_ADD([Resource Managers], [PBS], [], [$prte_check_pbs_happy (scheduler)])
 
-    AS_IF([test "$prte_check_pbs_happy" = "yes"],
+    AS_IF([test "$prte_check_pbs_happy" = "yes" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 

--- a/src/mca/ras/slurm/configure.m4
+++ b/src/mca/ras/slurm/configure.m4
@@ -14,6 +14,7 @@
 # Copyright (c) 2011-2013 Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# Copyright (c) 2025      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +31,7 @@ AC_DEFUN([MCA_prte_ras_slurm_CONFIG],[
 
     # if check worked, set wrapper flags if so.
     # Evaluate succeed / fail
-    AS_IF([test "$ras_slurm_good" = "1"],
+    AS_IF([test "$ras_slurm_good" = "1" || test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
 


### PR DESCRIPTION
Check RAS components for compile errors by shimming the environment-specific functions