### PR TITLE
Clarify help messages

### DIFF
--- a/src/tools/prun/help-prun.txt
+++ b/src/tools/prun/help-prun.txt
@@ -257,8 +257,8 @@ Node: %s
 while attempting to start process rank %lu.
 #
 [prun:wdir-not-accessible]
-%s was unable to launch the specified application as it lacks
-permissions to change to the specified working directory:
+%s was unable to launch the specified application as it could not
+access the specified working directory:
 
 Working directory: %s
 Node: %s
@@ -278,8 +278,8 @@ Node:       %s
 Executable: %s
 #
 [prun:exe-not-accessible]
-%s was unable to launch the specified application as it lacked
-permissions to execute an executable:
+%s was unable to launch the specified application as it could not
+access an executable:
 
 Executable: %s
 Node: %s


### PR DESCRIPTION
This error is also displayed in cases where files or directories do not exist and is not only caused by missing permissions.