### PR TITLE
Check only for existence of PMIx capability flag

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -39,10 +39,7 @@ AC_DEFUN([PRTE_CHECK_PMIX_CAP],[
                           #error This PMIx does not have any capability flags
                           #endif
                           #if !defined(PMIX_CAP_$1)
-                          #error This PMIx does not have the PMIX_CAP_$1 capability flag at all
-                          #endif
-                          #if (PMIX_CAPABILITIES & PMIX_CAP_$1) == 0
-                          #error This PMIx does not have the PMIX_CAP_$1 capability flag set
+                          #error This PMIx does not have the PMIX_CAP_$1 capability flag
                           #endif
                          ]
                         )


### PR DESCRIPTION
There was an initial thought that we would generate some uber-list of defined flags for capabilities across all PMIx versions, and then indicate which ones were supported by this particular version by OR'ing them together into some more general value. This has proven unworkable as you get into a giant game of bit-counting to create the definitions. Instead, we only define flags that this specific version supports - thus, the value of the individual flag is irrelevant and no general value is required.