### PR TITLE
Do not assign DVM's bookmark to the application job

### DIFF
--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -446,7 +446,8 @@ moveon:
             goto ANSWER_LAUNCH;
         }
 
-        if (NULL != parent && !PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
+        if (NULL != parent && !PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL) &&
+            !PMIX_CHECK_NSPACE(parent->nspace, PRTE_PROC_MY_NAME->nspace)) {
             if (NULL == parent->bookmark) {
                 /* find the sender's node in the job map */
                 proc = (prte_proc_t *) pmix_pointer_array_get_item(parent->procs, sender->rank);

--- a/src/mca/schizo/prte/help-prterun.txt
+++ b/src/mca/schizo/prte/help-prterun.txt
@@ -162,6 +162,9 @@ option to the help request as "--help <option>".
 | "--machinefile       | Provide a hostfile (synonym for "--hostfile") |
 | <file>"              |                                               |
 +----------------------+-----------------------------------------------+
+| "--default-hostfile  | Provide a default hostfile                    |
+| <file>"              |                                               |
++----------------------+-----------------------------------------------+
 | "--path <path>"      | PATH to be used to look for executables to    |
 |                      | start processes                               |
 +----------------------+-----------------------------------------------+
@@ -723,6 +726,12 @@ Output a brief periodic report on launch progress
 
 User-specified name assigned to the processes in their given
 application
+#
+[default-hostfile]
+
+Specify a default hostfile.
+
+Also see "--help hostfile".
 #
 [hostfile]
 
@@ -2699,3 +2708,11 @@ Then 81 processes are mapped to the first package and 80 to the second
 package.  At binding time we have an overloading scenario because
 there are only 80 CPUs (hwthreads) available in the package at the
 hardware level.  So the first package is overloaded.
+#
+[multiple-default-hostfiles]
+Multiple default hostfile values were provided:
+
+  Values:  %s
+
+Only one default hostfile can be specified. Please correct the input
+and try again.


### PR DESCRIPTION
Allow the target node list to follow the ordering inside a provided hostfile
and dash-host specification by not assigning a bookmark based on the DVM job.

Add support for missing default-hostfile cmd line option We have the support
for the user to specify it via MCA param, but somehow we lost the integration
to pick it up off of the prte and prterun cmd lines.

Fixes https://github.com/openpmix/prrte/issues/2292