### PR TITLE
Error out when asymmetric topologies cannot support ppr requests

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -399,3 +399,16 @@ A %s was given that defines a value multiple times:
   Given:   %s
 
 Please provide only one value for this policy, or remove it.
+#
+[not-enough-cpus]
+A request was made to map a specified number of processes to
+each object of a given type, and to bind each process to a given
+number of CPUs with that object. Unfortunately, at least one
+such object lacks enough CPUs to meet that combination of
+requirements:
+
+  #procs/obj:   %d
+  Object type:  %s
+  cpus/proc:    %d
+
+Please adjust the request and try again.

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -370,6 +370,12 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
     }
     hwloc_bitmap_list_asprintf(&proc->cpuset, result);
     hwloc_bitmap_free(result);
+    if (NULL == proc->cpuset || 0 == strlen(proc->cpuset)) {
+        pmix_show_help("help-prte-rmaps-base.txt", "not-enough-cpus", true,
+                       options->pprn, hwloc_obj_type_string(options->maptype),
+                       options->cpus_per_rank);
+        return PRTE_ERR_SILENT;
+    }
     return PRTE_SUCCESS;
 }
 


### PR DESCRIPTION
PPR placement policy requests are uniform - i.e., the specified number of procs must be placed on every object of the directed type. When the request includes a cpu/proc directive, then there must also be enough CPUs to meet the request on every object.

When that isn't the case, then we need to error out and not just place the proc without binding it.