### PR TITLE
Extend timeout to child jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ test/iostress
 test/spawn_multiple
 test/clichk
 test/chkfs
+test/spawn_timeout
 
 test/mpi/spawn_multiple
 test/mpi/create_comm_from_group

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -343,8 +343,9 @@ static void spawn_timeout_cb(int fd, short event, void *cbdata)
     }
 }
 
-static void stack_trace_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
-                             prte_rml_tag_t tag, void *cbdata)
+void prte_plm_base_stack_trace_recv(int status, pmix_proc_t *sender,
+                                    pmix_data_buffer_t *buffer,
+                                    prte_rml_tag_t tag, void *cbdata)
 {
     pmix_byte_object_t pbo;
     pmix_data_buffer_t blob;
@@ -494,13 +495,101 @@ static void stack_trace_timeout(int sd, short args, void *cbdata)
     PMIX_DESTRUCT(&parray);
 }
 
+static void dump_job(prte_job_t *jdata)
+{
+    pmix_proc_t pc;
+    prte_proc_t *proc;
+    pmix_byte_object_t bo;
+    char *st;
+    int i;
+
+    PMIX_LOAD_PROCID(&pc, jdata->nspace, PMIX_RANK_WILDCARD);
+    pmix_asprintf(&st, "DATA FOR JOB: %s\n", PRTE_JOBID_PRINT(jdata->nspace));
+    bo.bytes = st;
+    bo.size = strlen(st);
+    PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+    free(st);
+    pmix_asprintf(&st, "\tNum apps: %d\tNum procs: %d\tJobState: %s\tAbort: %s\n",
+                  (int) jdata->num_apps, (int) jdata->num_procs, prte_job_state_to_str(jdata->state),
+                  (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) ? "True" : "False");
+    bo.bytes = st;
+    bo.size = strlen(st);
+    PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+    free(st);
+    pmix_asprintf(&st, "\tNum launched: %ld\tNum reported: %ld\tNum terminated: %ld\n\n\tProcs:\n",
+                  (long) jdata->num_launched, (long) jdata->num_reported,
+                  (long) jdata->num_terminated);
+    bo.bytes = st;
+    bo.size = strlen(st);
+    PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+    free(st);
+    for (i = 0; i < jdata->procs->size; i++) {
+        if (NULL != (proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, i))) {
+            pmix_asprintf(&st, "\t\tRank: %s\tNode: %s\tPID: %u\tState: %s\tExitCode %d\n",
+                          PRTE_VPID_PRINT(proc->name.rank),
+                          (NULL == proc->node) ? "UNKNOWN" : proc->node->name,
+                          (unsigned int) proc->pid, prte_proc_state_to_str(proc->state),
+                          proc->exit_code);
+            bo.bytes = st;
+            bo.size = strlen(st);
+            PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+            free(st);
+        }
+    }
+    st = "\n";
+    bo.bytes = st;
+    bo.size = strlen(st);
+    PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+}
+
+static int get_traces(prte_job_t *jdata)
+{
+    prte_daemon_cmd_flag_t command = PRTE_DAEMON_GET_STACK_TRACES;
+    pmix_data_buffer_t buffer;
+    pmix_byte_object_t bo;
+    pmix_proc_t pc;
+    pmix_status_t rc;
+
+    PMIX_LOAD_PROCID(&pc, jdata->nspace, PMIX_RANK_WILDCARD);
+    bo.bytes = "Waiting for stack traces (this may take a few moments)...\n";
+    bo.size = strlen(bo.bytes);
+    PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+
+
+    /* setup the buffer */
+    PMIX_DATA_BUFFER_CONSTRUCT(&buffer);
+    /* pack the command */
+    rc = PMIx_Data_pack(NULL, &buffer, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+        return PRTE_ERROR;
+    }
+    /* pack the jobid */
+    rc = PMIx_Data_pack(NULL, &buffer, &jdata->nspace, 1, PMIX_PROC_NSPACE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+        return PRTE_ERROR;
+    }
+    /* goes to all daemons */
+    if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &buffer))) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+        return PRTE_ERROR;
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+    return PRTE_SUCCESS;
+}
+
 static void job_timeout_cb(int fd, short event, void *cbdata)
 {
     prte_job_t *jdata = (prte_job_t *) cbdata;
     prte_timer_t *timer = NULL;
-    prte_proc_t *proc, prc;
+    prte_proc_t *prc;
+    prte_job_t *child;
     pmix_proc_t pc;
-    int i, rc, timeout, *tp;
+    int rc, timeout, *tp, i;
     pmix_pointer_array_t parray;
     pmix_byte_object_t bo;
     char *st;
@@ -534,83 +623,31 @@ static void job_timeout_cb(int fd, short event, void *cbdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_STATE, NULL, PMIX_BOOL)) {
         /* output the results - note that the output might need to go to a
          * tool instead of just to stderr, so we use the PMIx IOF deliver
-         * function to ensure it gets where it needs to go */
-        pmix_asprintf(&st, "DATA FOR JOB: %s\n", PRTE_JOBID_PRINT(jdata->nspace));
-        bo.bytes = st;
-        bo.size = strlen(st);
-        PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
-        free(st);
-        pmix_asprintf(&st, "\tNum apps: %d\tNum procs: %d\tJobState: %s\tAbort: %s\n",
-                      (int) jdata->num_apps, (int) jdata->num_procs, prte_job_state_to_str(jdata->state),
-                      (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) ? "True" : "False");
-        bo.bytes = st;
-        bo.size = strlen(st);
-        PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
-        free(st);
-        pmix_asprintf(&st, "\tNum launched: %ld\tNum reported: %ld\tNum terminated: %ld\n\n\tProcs:\n",
-                      (long) jdata->num_launched, (long) jdata->num_reported,
-                      (long) jdata->num_terminated);
-        bo.bytes = st;
-        bo.size = strlen(st);
-        PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
-        free(st);
-        for (i = 0; i < jdata->procs->size; i++) {
-            if (NULL != (proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, i))) {
-                pmix_asprintf(&st, "\t\tRank: %s\tNode: %s\tPID: %u\tState: %s\tExitCode %d\n",
-                              PRTE_VPID_PRINT(proc->name.rank),
-                              (NULL == proc->node) ? "UNKNOWN" : proc->node->name,
-                              (unsigned int) proc->pid, prte_proc_state_to_str(proc->state),
-                              proc->exit_code);
-                bo.bytes = st;
-                bo.size = strlen(st);
-                PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
-                free(st);
-            }
-        }
-        st = "\n";
-        bo.bytes = st;
-        bo.size = strlen(st);
-        PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
+         * function to ensure it gets where it needs to go. */
+        dump_job(jdata);
+    }
+
+    /* Do this for all its child jobs, if any */
+    PMIX_LIST_FOREACH(child, &jdata->children, prte_job_t) {
+        dump_job(child);
     }
 
     /* see if they want stacktraces */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_STACKTRACES, NULL, PMIX_BOOL)) {
         /* if they asked for stack_traces, attempt to get them, but timeout
          * if we cannot do so */
-        prte_daemon_cmd_flag_t command = PRTE_DAEMON_GET_STACK_TRACES;
-        pmix_data_buffer_t buffer;
-
-        bo.bytes = "Waiting for stack traces (this may take a few moments)...\n";
-        bo.size = strlen(bo.bytes);
-        PMIx_server_IOF_deliver(&pc, PMIX_FWD_STDERR_CHANNEL, &bo, NULL, 0, NULL, NULL);
-
-        /* set the recv */
-        PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_STACK_TRACE,
-                      PRTE_RML_PERSISTENT, stack_trace_recv, NULL);
-
-        /* setup the buffer */
-        PMIX_DATA_BUFFER_CONSTRUCT(&buffer);
-        /* pack the command */
-        rc = PMIx_Data_pack(NULL, &buffer, &command, 1, PMIX_UINT8);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+        rc = get_traces(jdata);
+        if (PRTE_SUCCESS != rc) {
             goto giveup;
         }
-        /* pack the jobid */
-        rc = PMIx_Data_pack(NULL, &buffer, &jdata->nspace, 1, PMIX_PROC_NSPACE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&buffer);
-            goto giveup;
+        // get traces for child jobs too
+        PMIX_LIST_FOREACH(child, &jdata->children, prte_job_t) {
+            rc = get_traces(child);
+            if (PRTE_SUCCESS != rc) {
+                goto giveup;
+            }
         }
-        /* goes to all daemons */
-        if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &buffer))) {
-            PRTE_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&buffer);
-            goto giveup;
-        }
-        PMIX_DATA_BUFFER_DESTRUCT(&buffer);
+
         /* we will terminate after we get the stack_traces, but set a timeout
          * just in case we never hear back from everyone */
         if (prte_stack_trace_wait_timeout > 0) {
@@ -629,10 +666,29 @@ static void job_timeout_cb(int fd, short event, void *cbdata)
 giveup:
     /* abort the job */
     PMIX_CONSTRUCT(&parray, pmix_pointer_array_t);
-    PMIX_LOAD_PROCID(&prc.name, jdata->nspace, PMIX_RANK_WILDCARD);
-    pmix_pointer_array_add(&parray, &prc);
+    pmix_pointer_array_init(&parray,
+                            PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
+                            PRTE_GLOBAL_ARRAY_MAX_SIZE,
+                            PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+
+    prc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&prc->name, jdata->nspace, PMIX_RANK_WILDCARD);
+    pmix_pointer_array_add(&parray, prc);
+    PMIX_LIST_FOREACH(child, &jdata->children, prte_job_t) {
+        prc = PMIX_NEW(prte_proc_t);
+        PMIX_LOAD_PROCID(&prc->name, child->nspace, PMIX_RANK_WILDCARD);
+        pmix_pointer_array_add(&parray, prc);
+    }
     if (PRTE_SUCCESS != (rc = prte_plm.terminate_procs(&parray))) {
         PRTE_ERROR_LOG(rc);
+    }
+    for (i=0; i < parray.size; i++) {
+        prc = (prte_proc_t *) pmix_pointer_array_get_item(&parray, i);
+        if (NULL == prc) {
+            continue;
+        }
+        pmix_pointer_array_set_item(&parray, i, NULL);
+        PMIX_RELEASE(prc);
     }
     PMIX_DESTRUCT(&parray);
 }

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -86,6 +86,8 @@ int prte_plm_base_comm_start(void)
                       PRTE_RML_PERSISTENT, prte_plm_base_daemon_failed, NULL);
         PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_TOPOLOGY_REPORT,
                       PRTE_RML_PERSISTENT, prte_plm_base_daemon_topology, NULL);
+        PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_STACK_TRACE,
+                      PRTE_RML_PERSISTENT, prte_plm_base_stack_trace_recv, NULL);
     }
     recv_issued = true;
 
@@ -106,6 +108,7 @@ int prte_plm_base_comm_stop(void)
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_PRTED_CALLBACK);
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_REPORT_REMOTE_LAUNCH);
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_TOPOLOGY_REPORT);
+        PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_STACK_TRACE);
     }
     recv_issued = false;
 

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -89,6 +89,9 @@ PRTE_EXPORT void prte_plm_base_daemon_failed(int status, pmix_proc_t *sender,
 PRTE_EXPORT void prte_plm_base_daemon_topology(int status, pmix_proc_t *sender,
                                                pmix_data_buffer_t *buffer, prte_rml_tag_t tag,
                                                void *cbdata);
+PRTE_EXPORT void prte_plm_base_stack_trace_recv(int status, pmix_proc_t *sender,
+                                                pmix_data_buffer_t *buffer,
+                                                prte_rml_tag_t tag, void *cbdata);
 
 PRTE_EXPORT int prte_plm_base_create_jobid(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_set_hnp_name(void);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -317,6 +317,23 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
                 }
             }
+            /* if not already assigned, inherit the parent's output directives */
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
+                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TAG_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                }
+            }
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
+                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                }
+            }
+            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+                if (prte_get_attribute(&parent->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void **) &fptr, PMIX_BOOL)) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                }
+            }
+
             // copy over any env directives, but do not overwrite anything already specified
             inherit_env_directives(jdata, parent, nptr);
         } else {

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.  All rights reserved.
 # Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
 # $COPYRIGHT$
 #
@@ -52,7 +52,8 @@ TESTS = \
 	iostress \
 	filegen \
 	clichk \
-	chkfs
+	chkfs \
+	spawn_timeout
 
 all: $(TESTS)
 

--- a/test/spawn_timeout.c
+++ b/test/spawn_timeout.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2016      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdbool.h>
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "examples.h"
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    int rc, exitcode;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    char nsp2[PMIX_MAX_NSLEN + 1];
+    pmix_app_t *app;
+    char hostname[1024], dir[1024];
+
+    if (0 > gethostname(hostname, sizeof(hostname))) {
+        exit(1);
+    }
+    if (NULL == getcwd(dir, 1024)) {
+        exit(1);
+    }
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank,
+                rc);
+        exit(rc);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        // we are the parent
+        PMIX_APP_CREATE(app, 1);
+        if (0 > asprintf(&app->cmd, "%s/%s", dir, argv[0])) {
+            exitcode = 1;
+            goto done;
+        }
+        app->maxprocs = 1;
+        PMIX_ARGV_APPEND(rc, app->argv, app->cmd);
+
+        fprintf(stderr, "Client ns %s rank %d: calling PMIx_Spawn\n", myproc.nspace, myproc.rank);
+        if (PMIX_SUCCESS != (rc = PMIx_Spawn(NULL, 0, app, 1, nsp2))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Spawn failed: %s(%d)\n", myproc.nspace,
+                    myproc.rank, PMIx_Error_string(rc), rc);
+            exitcode = rc;
+            goto done;
+        } else {
+          fprintf(stderr, "Spawn success.\n");
+        }
+        PMIX_APP_FREE(app, 1);
+    }
+
+    sleep(15);
+
+done:
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace,
+                myproc.rank, rc);
+    }
+    fflush(stderr);
+    printf("exit\n");
+    return (exitcode);
+}


### PR DESCRIPTION
When a timeout is specified and the primary job is timed-out, then we need to ensure we also report and kill any child jobs it started. This includes reporting any requested stack traces.

Also all inheritance of output directives like tag and timestamp.