### PR TITLE
Fix map-by pe-list when using core CPUs

### DIFF
--- a/src/hwloc/help-prte-hwloc-base.txt
+++ b/src/hwloc/help-prte-hwloc-base.txt
@@ -83,3 +83,16 @@ but will not be able to output the binding locations.
 At least one process in your application is bound to too many sites
 for us to report in a string. There will be no impact to your application
 so we will continue but will not be able to output the binding locations.
+#
+[unfound-cpu]
+The CPU list provided on your cmd line contains at least one ID that was
+not found:
+
+  CPU list:  %s
+  CPU ID:    %u (%s)
+  CPU type:  %s
+
+The most common reason for this is specifying the CPU list in terms of
+HWTs while failing to request that we treat HWTs as independent CPUs
+(which means we default to treating the CPU IDs as cores).
+Please correct your input and try again.

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -262,7 +262,8 @@ PRTE_EXPORT int prte_hwloc_base_set_topology(char *topofile);
 PRTE_EXPORT void prte_hwloc_base_setup_summary(hwloc_topology_t topo);
 
 PRTE_EXPORT hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
-                                                           bool use_hwthread_cpus, char *cpulist);
+                                                           bool use_hwthread_cpus,
+                                                           char **cpulist);
 
 PRTE_EXPORT hwloc_cpuset_t prte_hwloc_base_filter_cpus(hwloc_topology_t topo);
 

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -109,7 +109,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     }
     topo = t->topo;
     if (NULL != job_cpuset) {
-        available = prte_hwloc_base_generate_cpuset(topo, use_hwthread_cpus, job_cpuset);
+        available = prte_hwloc_base_generate_cpuset(topo, use_hwthread_cpus, &job_cpuset);
     } else {
         available = prte_hwloc_base_filter_cpus(topo);
     }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -744,7 +744,7 @@ void prte_rmaps_base_get_cpuset(prte_job_t *jdata,
     if (NULL != options->cpuset) {
         options->job_cpuset = prte_hwloc_base_generate_cpuset(node->topology->topo,
                                                               options->use_hwthreads,
-                                                              options->cpuset);
+                                                              &options->cpuset);
     } else {
         options->job_cpuset = hwloc_bitmap_dup(node->available);
     }

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -186,6 +186,11 @@ static int ppr_mapper(prte_job_t *jdata,
         PMIX_LIST_FOREACH_SAFE(node, nd, &node_list, prte_node_t) {
             options->nobjs = 0;
             prte_rmaps_base_get_cpuset(jdata, node, options);
+            if (NULL == options->job_cpuset) {
+                // the prior function will have printed out the error
+                rc = PRTE_ERR_SILENT;
+                goto error;
+            }
 
             if (!options->donotlaunch) {
                 rc = prte_rmaps_base_check_support(jdata, node, options);

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -330,6 +330,11 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 }
             }
             prte_rmaps_base_get_cpuset(jdata, node, options);
+            if (NULL == options->job_cpuset) {
+                // the prior function will have printed out the error
+                rc = PRTE_ERR_SILENT;
+                goto error;
+            }
             if (!prte_rmaps_base_check_avail(jdata, app, node, &node_list, NULL, options)) {
                 pmix_show_help("help-rmaps_rank_file.txt", "bad-host", true, rfmap->node_name);
                 rc = PRTE_ERR_SILENT;

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -378,6 +378,11 @@ process:
             }
             /* check availability */
             prte_rmaps_base_get_cpuset(jdata, node, options);
+            if (NULL == options->job_cpuset) {
+                // the prior function will have printed out the error
+                rc = PRTE_ERR_SILENT;
+                goto error;
+            }
             if (!prte_rmaps_base_check_avail(jdata, app, node, seq_list, NULL, options)) {
                 continue;
             }


### PR DESCRIPTION
Ensure the IDs provided are interpreted as core and not hwt values. Properly error out when an ID is provided that does not exist on the node, and note that this usually is because the IDs address hwt's while we are treating cores as CPUs.