### PR TITLE
Allow PMIx group construct caller to specify the order of the final membership

### DIFF
--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +62,8 @@ typedef struct {
     bool follower;
     pmix_proc_t *addmembers;  // procs supplied as add-members
     size_t naddmembers;
+    pmix_proc_t *final_order;
+    size_t nfinal;
 } prte_grpcomm_direct_group_signature_t;
 PRTE_MODULE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_direct_group_signature_t);
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -82,6 +82,8 @@ static void sgcon(prte_grpcomm_direct_group_signature_t *p)\
     p->follower = false;
     p->addmembers = NULL;
     p->naddmembers = 0;
+    p->final_order = NULL;
+    p->nfinal = 0;
 }
 static void sgdes(prte_grpcomm_direct_group_signature_t *p)
 {

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -33,7 +33,6 @@
 #include "src/util/name_fns.h"
 #include "src/util/nidmap.h"
 #include "src/util/proc_info.h"
-#include "src/util/pmix_show_help.h"
 
 #include "grpcomm_direct.h"
 #include "src/mca/grpcomm/base/base.h"

--- a/src/runtime/help-prte-runtime.txt
+++ b/src/runtime/help-prte-runtime.txt
@@ -122,3 +122,10 @@ other nodes using the "prte_remote_tmpdir_base" param.
 This is only a warning advisory and your job will continue. You can
 disable this warning in the future by setting the
 "prte_silence_shared_fs" MCA param to "1".
+#
+[bad-final-order]
+A PMIx group construct operation was provided with a final order
+directive that caused some group members to be dropped - i.e., the
+provided final order does not cover some of the final group members.
+Please revise your final order directive so that all final group
+members can be included in the returned final membership.


### PR DESCRIPTION
The PMIx_Group_construct API itself is not order sensitive in the provided proc array - i.e., we ignore that order when executing the operation. This allows each caller to provide the proc array in arbitrary order - which is advantageous for most libraries.

However, some users may need us to return a specific order of the procs in the final membership. Allow them to specify the order in a new attribute, This can be specified by individual processes or by namespace (with a wildcard rank). If multiple participants provide this attribute, then the values must match - i.e., the desired final membership order must be identical.