### PR TITLE
Tweak the forwarding of signals 

### DIFF
--- a/src/mca/ess/base/base.h
+++ b/src/mca/ess/base/base.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -68,7 +68,7 @@ PRTE_EXPORT int prte_ess_base_std_prolog(void);
 PRTE_EXPORT int prte_ess_base_prted_setup(void);
 PRTE_EXPORT int prte_ess_base_prted_finalize(void);
 
-PRTE_EXPORT int prte_ess_base_setup_signals(char *signals);
+PRTE_EXPORT pmix_status_t prte_ess_base_setup_signals(char *signals);
 
 /* Detect whether or not this proc is bound - if not,
  * see if it should bind itself

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -735,7 +735,7 @@ int prte(int argc, char *argv[])
     } else {
         param = NULL;
     }
-    if (PRTE_SUCCESS != (rc = prte_ess_base_setup_signals(param))) {
+    if (PMIX_SUCCESS != (rc = prte_ess_base_setup_signals(param))) {
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
     }

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -359,14 +359,13 @@ int prun_common(pmix_cli_result_t *results,
     }
 
     /** setup callbacks for signals we should forward */
-    PMIX_CONSTRUCT(&prte_ess_base_signals, pmix_list_t);
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_FWD_SIGNALS);
     if (NULL != opt) {
         param = opt->values[0];
     } else {
         param = NULL;
     }
-    if (PRTE_SUCCESS != (rc = prte_ess_base_setup_signals(param))) {
+    if (PMIX_SUCCESS != (rc = prte_ess_base_setup_signals(param))) {
         return rc;
     }
     PMIX_LIST_FOREACH(sig, &prte_ess_base_signals, prte_ess_base_signal_t)


### PR DESCRIPTION
Update the MCA param help message to clarify what the param
does and what values it supports. Cleanup an error where we
would overwrite the resulting list of signals to forward.
Cleanup the return value so we don't generate spurious
error log output. Provide verbose output showing the
signals being forwarded.