### PR TITLE
PLM: mark uncached daemons as reported

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1893,6 +1893,9 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                 }
                 continue;
             }
+            // Signature already found, we can mark this node as completed now
+            jdatorted->num_reported++;
+            jdatorted->num_daemons_reported++;
         }
 
     CLEANUP:


### PR DESCRIPTION
Fixes launching when prte_hetero_nodes isn't set