### PR TITLE
Provide skeleton for passing allocation requests through RAS

### DIFF
--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -810,7 +810,7 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
     pmix_data_array_t darray;
     pmix_info_t *grpinfo = NULL;
     pmix_info_t *endpts = NULL;
-    pmix_server_pset_t *pset;
+    prte_pmix_server_pset_t *pset;
     void *ilist;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
 
@@ -844,7 +844,7 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
      * further to unpack */
     if (PMIX_GROUP_DESTRUCT == sig->op) {
         /* find this group ID on our list of groups */
-        PMIX_LIST_FOREACH(pset, &prte_pmix_server_globals.groups, pmix_server_pset_t)
+        PMIX_LIST_FOREACH(pset, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
         {
             if (0 == strcmp(pset->name, sig->groupID)) {
                 pmix_list_remove_item(&prte_pmix_server_globals.groups, &pset->super);
@@ -970,7 +970,7 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
 
     if (PMIX_SUCCESS == st) {
        /* add it to our list of known groups */
-        pset = PMIX_NEW(pmix_server_pset_t);
+        pset = PMIX_NEW(prte_pmix_server_pset_t);
         pset->name = strdup(sig->groupID);
         if (NULL != finalmembership) {
             pset->num_members = nfinal;

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -13,7 +13,7 @@
  *                         reserved.
  * Copyright (c) 2016-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -67,6 +67,8 @@ PRTE_EXPORT void prte_ras_base_display_alloc(prte_job_t *jdata);
 PRTE_EXPORT void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist);
 
 PRTE_EXPORT void prte_ras_base_allocate(int fd, short args, void *cbdata);
+
+PRTE_EXPORT void prte_ras_base_modify(int fd, short args, void *cbdata);
 
 PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
 

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -53,8 +53,10 @@ static int get_slot_count(char* node_name, int* slot_cnt);
 /*
  * Global variable
  */
-prte_ras_base_module_t prte_ras_gridengine_module = {NULL, prte_ras_gridengine_allocate, NULL,
-                                                     prte_ras_gridengine_finalize};
+prte_ras_base_module_t prte_ras_gridengine_module = {
+    .allocate = prte_ras_gridengine_allocate,
+    .finalize = prte_ras_gridengine_finalize
+};
 
 /**
  *  Discover available (pre-allocated) nodes. Allocate the

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -58,7 +58,11 @@ static int finalize(void);
 /*
  * Global variable
  */
-prte_ras_base_module_t prte_ras_lsf_module = {NULL, allocate, NULL, finalize};
+prte_ras_base_module_t prte_ras_lsf_module = {
+    .init = NULL,
+    .allocate = allocate,
+    .finalize = finalize
+};
 
 static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 {

--- a/src/mca/ras/ras.h
+++ b/src/mca/ras/ras.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,7 +63,7 @@
 #include "src/event/event-internal.h"
 #include "src/mca/mca.h"
 #include "src/pmix/pmix-internal.h"
-
+#include "src/prted/pmix/pmix_server_internal.h"
 #include "src/runtime/prte_globals.h"
 
 BEGIN_C_DECLS
@@ -89,6 +89,9 @@ typedef int (*prte_ras_base_module_allocate_fn_t)(prte_job_t *jdata, pmix_list_t
 /* deallocate resources */
 typedef void (*prte_ras_base_module_dealloc_fn_t)(prte_job_t *jdata, prte_app_context_t *app);
 
+/* modify allocation */
+typedef void (*prte_ras_base_module_modify_fn_t)(prte_pmix_server_req_t *req);
+
 /**
  * Cleanup module resources.
  */
@@ -99,12 +102,13 @@ typedef int (*prte_ras_base_module_finalize_fn_t)(void);
  */
 struct prte_ras_base_module_2_0_0_t {
     /** init */
-    prte_ras_base_module_init_fn_t init;
+    prte_ras_base_module_init_fn_t      init;
     /** Allocation function pointer */
-    prte_ras_base_module_allocate_fn_t allocate;
-    prte_ras_base_module_dealloc_fn_t deallocate;
+    prte_ras_base_module_allocate_fn_t  allocate;
+    prte_ras_base_module_dealloc_fn_t   deallocate;
+    prte_ras_base_module_modify_fn_t    modify;
     /** Finalization function pointer */
-    prte_ras_base_module_finalize_fn_t finalize;
+    prte_ras_base_module_finalize_fn_t  finalize;
 };
 /** Convenience typedef */
 typedef struct prte_ras_base_module_2_0_0_t prte_ras_base_module_2_0_0_t;

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -39,7 +39,13 @@ static int finalize(void);
 /*
  * Global variable
  */
-prte_ras_base_module_t prte_ras_sim_module = {NULL, allocate, NULL, finalize};
+prte_ras_base_module_t prte_ras_sim_module = {
+    .init = NULL,
+    .allocate = allocate,
+    .deallocate = NULL,
+    .modify = NULL,
+    .finalize = finalize
+};
 
 static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 {

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -67,6 +67,7 @@
 static int init(void);
 static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes);
 static void deallocate(prte_job_t *jdata, prte_app_context_t *app);
+static void modify(prte_pmix_server_req_t *req);
 static int prte_ras_slurm_finalize(void);
 
 /*
@@ -76,6 +77,7 @@ prte_ras_base_module_t prte_ras_slurm_module = {
     .init = init,
     .allocate = prte_ras_slurm_allocate,
     .deallocate = deallocate,
+    .modify = modify,
     .finalize = prte_ras_slurm_finalize
 };
 
@@ -220,6 +222,12 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
 static void deallocate(prte_job_t *jdata, prte_app_context_t *app)
 {
     PRTE_HIDE_UNUSED_PARAMS(jdata, app);
+    return;
+}
+
+static void modify(prte_pmix_server_req_t *req)
+{
+    req->status = PMIX_ERR_NOT_SUPPORTED;
     return;
 }
 

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -594,7 +594,7 @@ void prte_state_base_check_all_complete(int fd, short args, void *cbdata)
     int32_t i32, *i32ptr;
     prte_pmix_lock_t lock;
     prte_app_context_t *app;
-    pmix_server_pset_t *pst, *pst2;
+    prte_pmix_server_pset_t *pst, *pst2;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -748,7 +748,7 @@ CHECK_DAEMONS:
         jdata->map = NULL;
     }
     // if this job has apps that named a pset, then remove them
-    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, pmix_server_pset_t) {
+    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, prte_pmix_server_pset_t) {
         if (pst->jdata == jdata) {
             pmix_list_remove_item(&prte_pmix_server_globals.psets, &pst->super);
             PMIX_RELEASE(pst);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -517,7 +517,7 @@ static void check_complete(int fd, short args, void *cbdata)
     hwloc_obj_type_t type;
     hwloc_cpuset_t boundcpus, tgt;
     bool takeall, sep, *sepptr = &sep;
-    pmix_server_pset_t *pst, *pst2;
+    prte_pmix_server_pset_t *pst, *pst2;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -815,7 +815,7 @@ release:
         jdata->map = NULL;
     }
     // if this job has apps that named a pset, then remove them
-    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, pmix_server_pset_t) {
+    PMIX_LIST_FOREACH_SAFE(pst, pst2, &prte_pmix_server_globals.psets, prte_pmix_server_pset_t) {
         if (pst->jdata == jdata) {
             pmix_list_remove_item(&prte_pmix_server_globals.psets, &pst->super);
             PMIX_RELEASE(pst);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -95,7 +95,7 @@ static void pmix_server_sched(int status, pmix_proc_t *sender, pmix_data_buffer_
 
 #define PRTE_PMIX_SERVER_MIN_ROOMS 4096
 
-pmix_server_globals_t prte_pmix_server_globals = {0};
+prte_pmix_server_globals_t prte_pmix_server_globals = {0};
 static pmix_topology_t mytopology = {0};
 
 static pmix_server_module_t pmix_server = {
@@ -502,7 +502,7 @@ void pmix_server_register_params(void)
 
 static void timeout_cbfunc(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
@@ -545,10 +545,10 @@ static void timeout_cbfunc(int sd, short args, void *cbdata)
 void prte_pmix_server_clear(pmix_proc_t *pname)
 {
     int n;
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
 
     for (n = 0; n < prte_pmix_server_globals.remote_reqs.size; n++) {
-        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, n);
+        req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, n);
         if (NULL != req) {
             if (!PMIX_CHECK_NSPACE(req->tproc.nspace, pname->nspace) ||
                 !PMIX_CHECK_RANK(req->tproc.rank, pname->rank)) {
@@ -1108,15 +1108,15 @@ void pmix_server_finalize(void)
     prte_data_server_finalize();
 
     /* cleanup collectives */
-    pmix_server_req_t *cd;
+    prte_pmix_server_req_t *cd;
     for (int i = 0; i < prte_pmix_server_globals.local_reqs.size; i++) {
-      cd = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, i);
+      cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, i);
       if (NULL != cd) {
           PMIX_RELEASE(cd);
       }
     }
     for (int i = 0; i < prte_pmix_server_globals.remote_reqs.size; i++) {
-      cd = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, i);
+      cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, i);
       if (NULL != cd) {
           PMIX_RELEASE(cd);
       }
@@ -1169,7 +1169,7 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
 
 static void _mdxresp(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
     pmix_data_buffer_t *reply;
     pmix_status_t prc;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
@@ -1239,7 +1239,7 @@ error:
  * access our global data */
 static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
 
     PMIX_ACQUIRE_OBJECT(req);
 
@@ -1275,7 +1275,7 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
 
 static void dmdx_check(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     prte_job_t *jdata;
     prte_proc_t *proc;
     struct timeval tv = {2, 0};
@@ -1364,7 +1364,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     struct timeval tv = {0, 0};
     prte_job_t *jdata;
     prte_proc_t *proc;
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     pmix_proc_t pproc;
     pmix_status_t prc;
     pmix_info_t *info = NULL, *iptr;
@@ -1470,7 +1470,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         pmix_output_verbose(2, prte_pmix_server_globals.output,
                             "%s dmdx:recv request cannot find job object - delaying",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        req = PMIX_NEW(pmix_server_req_t);
+        req = PMIX_NEW(prte_pmix_server_req_t);
         pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
         req->proxy = *sender;
         memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
@@ -1533,7 +1533,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
                                 "%s dmdx:recv key %s not found - delaying",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), key);
             /* we don't - wait for awhile */
-            req = PMIX_NEW(pmix_server_req_t);
+            req = PMIX_NEW(prte_pmix_server_req_t);
             pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
             req->proxy = *sender;
             memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
@@ -1577,7 +1577,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
 
     /* track the request since the call down to the PMIx server
      * is asynchronous */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
     req->proxy = *sender;
     memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
@@ -1651,7 +1651,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
 {
     int index, n;
     int32_t cnt;
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     datacaddy_t *d;
     pmix_proc_t pproc;
     size_t psz;
@@ -1713,7 +1713,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
     }
 
     /* get the request out of the tracking array */
-    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, index);
+    req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, index);
     /* return the returned data to the requestor */
     if (NULL != req) {
         if (NULL != req->mdxcbfunc) {
@@ -1730,7 +1730,7 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
 
     /* now see if anyone else was waiting for data from this target */
     for (n = 0; n < prte_pmix_server_globals.local_reqs.size; n++) {
-        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, n);
+        req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, n);
         if (NULL == req) {
             continue;
         }
@@ -1910,7 +1910,7 @@ static void send_alloc_resp(pmix_status_t status,
                             pmix_release_cbfunc_t release_fn,
                             void *release_cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     pmix_data_buffer_t *buf;
     pmix_status_t rc;
 
@@ -1973,7 +1973,7 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     uint32_t sessionID;
     pmix_info_t *info = NULL;
     pmix_proc_t source;
-    pmix_server_req_t *req = NULL;
+    prte_pmix_server_req_t *req = NULL;
     int refid;
     PRTE_HIDE_UNUSED_PARAMS(status, tg, cbdata);
 
@@ -2057,6 +2057,32 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
    }
 #endif
 
+    if (PRTE_PMIX_ALLOC_REQ == cmd) {
+        req = PMIX_NEW(prte_pmix_server_req_t);
+        pmix_asprintf(&req->operation, "ALLOCATE: %s",
+                      PMIx_Alloc_directive_string(allocdir));
+        req->allocdir = allocdir;
+        req->remote_index = refid;
+        req->copy = true;
+        req->info = info;
+        req->ninfo = ninfo;
+        PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
+        PMIX_PROC_LOAD(&req->tproc, source.nspace, source.rank);
+        /* add this request to our local request tracker array */
+        PMIX_RETAIN(req);
+        req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+        // point to the proper callback function
+        req->infocbfunc = send_alloc_resp;
+        req->cbdata = req;  // so the callback function finds it correctly
+        // pass this to the RAS framework for handling
+        prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, prte_ras_base_modify, req);
+        PMIX_POST_OBJECT(req);
+        prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+        return;
+    }
+
+    // session control request
+
     /* we are the DVM master, so handle this ourselves - start
      * by ensuring the scheduler is connected to us */
     rc = prte_pmix_set_scheduler();
@@ -2068,27 +2094,24 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
         goto reply;
     }
 
-    /* track the request */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    pmix_asprintf(&req->operation, "SESSIONCTRL: %u", sessionID);
     req->remote_index = refid;
     req->copy = true;
     req->info = info;
     req->ninfo = ninfo;
     PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
     PMIX_PROC_LOAD(&req->tproc, source.nspace, source.rank);
-    if (PRTE_PMIX_ALLOC_REQ == cmd) {
-        pmix_asprintf(&req->operation, "ALLOCATE: %u", allocdir);
-        rc = PMIx_Allocation_request_nb(allocdir, req->info, req->ninfo,
-                                        send_alloc_resp, req);
-    } else {
-        pmix_asprintf(&req->operation, "SESSIONCTRL: %u", sessionID);
+    /* add this request to our local request tracker array */
+    PMIX_RETAIN(req);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
 #if PMIX_NUMERIC_VERSION < 0x00050000
-        rc = PMIX_ERR_NOT_SUPPORTED;
+    rc = PMIX_ERR_NOT_SUPPORTED;
 #else
-        rc = PMIx_Session_control(sessionID, req->info, req->ninfo,
-                                  send_alloc_resp, req);
+    rc = PMIx_Session_control(sessionID, req->info, req->ninfo,
+                              send_alloc_resp, req);
 #endif
-    }
     if (PMIX_SUCCESS != rc) {
         goto reply;
     }
@@ -2156,7 +2179,7 @@ PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t,
                     pmix_object_t,
                     opcon, NULL);
 
-static void rqcon(pmix_server_req_t *p)
+static void rqcon(prte_pmix_server_req_t *p)
 {
     p->event_active = false;
     p->cycle_active = false;
@@ -2205,7 +2228,7 @@ static void rqcon(pmix_server_req_t *p)
     p->cbdata = NULL;
     p->rlcbdata = NULL;
 }
-static void rqdes(pmix_server_req_t *p)
+static void rqdes(prte_pmix_server_req_t *p)
 {
     if (NULL != p->operation) {
         free(p->operation);
@@ -2230,18 +2253,18 @@ static void rqdes(pmix_server_req_t *p)
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->msg);
 }
-PMIX_CLASS_INSTANCE(pmix_server_req_t,
+PMIX_CLASS_INSTANCE(prte_pmix_server_req_t,
                     pmix_object_t,
                     rqcon, rqdes);
 
-static void pscon(pmix_server_pset_t *p)
+static void pscon(prte_pmix_server_pset_t *p)
 {
     p->name = NULL;
     p->jdata = NULL;
     p->members = NULL;
     p->num_members = 0;
 }
-static void psdes(pmix_server_pset_t *p)
+static void psdes(prte_pmix_server_pset_t *p)
 {
     if (NULL != p->name) {
         free(p->name);
@@ -2253,6 +2276,6 @@ static void psdes(pmix_server_pset_t *p)
         free(p->members);
     }
 }
-PMIX_CLASS_INSTANCE(pmix_server_pset_t,
+PMIX_CLASS_INSTANCE(prte_pmix_server_pset_t,
                     pmix_list_item_t,
                     pscon, psdes);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -59,7 +59,7 @@
 
 void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     prte_job_t *jdata;
 
     jdata = prte_get_job_data_object(jobid);
@@ -70,7 +70,7 @@ void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret)
     }
 
     /* retrieve the request */
-    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
+    req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
     if (NULL == req) {
         /* we are hosed */
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
@@ -137,7 +137,7 @@ void pmix_server_launch_resp(int status, pmix_proc_t *sender,
 
 static void spawn(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
     int rc;
     pmix_data_buffer_t *buf;
     prte_plm_cmd_flag_t command;
@@ -1006,7 +1006,7 @@ static void connect_release(pmix_status_t status,
                             void *cbdata,
                             pmix_release_cbfunc_t rel, void *relcbdata)
 {
-    pmix_server_req_t *md = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *md = (prte_pmix_server_req_t*)cbdata;
     pmix_byte_object_t bo;
     pmix_data_buffer_t pbkt;
     pmix_info_t *info = NULL, infostat;
@@ -1089,7 +1089,7 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                      const pmix_info_t info[], size_t ninfo,
                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *cd;
+    prte_pmix_server_req_t *cd;
     size_t n;
     pmix_status_t rc;
 
@@ -1106,7 +1106,7 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
      * nodes, and (b) send along any endpt information posted by the participants
      * for "remote" scope */
 
-    cd = PMIX_NEW(pmix_server_req_t);
+    cd = PMIX_NEW(prte_pmix_server_req_t);
     for (n=0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_DATA) ||
             PMIX_CHECK_KEY(&info[n], PMIX_JOB_INFO_ARRAY)) {

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,8 +72,8 @@ pmix_status_t pmix_server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 
 static void dmodex_req(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) cbdata;
-    pmix_server_req_t *r;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *r;
     prte_job_t *jdata;
     prte_proc_t *proct, *dmn;
     int rc, rnum;
@@ -131,7 +131,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
     /* has anyone already requested data for this target? If so,
      * then the data is already on its way */
     for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
-        r = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
+        r = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
         if (NULL == r) {
             continue;
         }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -348,7 +348,7 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
                               pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                               void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     int rc, room;
     int32_t ret, cnt;
     pmix_nspace_t jobid;
@@ -372,7 +372,7 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
     }
 
     /* retrieve the request */
-    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
+    req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room);
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, room, NULL);
 
     if (NULL == req) {
@@ -407,7 +407,7 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
 
 static void _toolconn(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *cd = (pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *cd = (prte_pmix_server_req_t *) cbdata;
     int rc;
     char *tmp;
     size_t n;
@@ -626,14 +626,14 @@ void pmix_tool_connected_fn(pmix_info_t *info, size_t ninfo,
                             pmix_tool_connection_cbfunc_t cbfunc,
                             void *cbdata)
 {
-    pmix_server_req_t *cd;
+    prte_pmix_server_req_t *cd;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s TOOL CONNECTION REQUEST RECVD",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* need to threadshift this request */
-    cd = PMIX_NEW(pmix_server_req_t);
+    cd = PMIX_NEW(prte_pmix_server_req_t);
     cd->toolcbfunc = cbfunc;
     cd->cbdata = cbdata;
     cd->target.rank = 0; // set default for tool
@@ -651,14 +651,14 @@ pmix_status_t pmix_tool_connected2_fn(pmix_info_t *info, size_t ninfo,
                                       pmix_tool_connection_cbfunc_t cbfunc,
                                       void *cbdata)
 {
-    pmix_server_req_t *cd;
+    prte_pmix_server_req_t *cd;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s TOOL CONNECTION2 REQUEST RECVD",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* need to threadshift this request */
-    cd = PMIX_NEW(pmix_server_req_t);
+    cd = PMIX_NEW(prte_pmix_server_req_t);
     cd->toolcbfunc = cbfunc;
     cd->cbdata = cbdata;
     cd->target.rank = 0; // set default for tool

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -107,8 +107,8 @@ typedef struct {
     pmix_info_cbfunc_t infocbfunc;
     void *cbdata;
     void *rlcbdata;
-} pmix_server_req_t;
-PMIX_CLASS_DECLARATION(pmix_server_req_t);
+} prte_pmix_server_req_t;
+PMIX_CLASS_DECLARATION(prte_pmix_server_req_t);
 
 /* object for thread-shifting server operations */
 typedef struct {
@@ -158,8 +158,8 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
 
 #define PRTE_DMX_REQ(p, i, ni, cf, ocf, ocd)                                         \
     do {                                                                             \
-        pmix_server_req_t *_req;                                                     \
-        _req = PMIX_NEW(pmix_server_req_t);                                          \
+        prte_pmix_server_req_t *_req;                                                \
+        _req = PMIX_NEW(prte_pmix_server_req_t);                                     \
         pmix_asprintf(&_req->operation, "DMDX: %s:%d", __FILE__, __LINE__);          \
         memcpy(&_req->tproc, (p), sizeof(pmix_proc_t));                              \
         _req->info = (pmix_info_t *) (i);                                            \
@@ -173,8 +173,8 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
 
 #define PRTE_SPN_REQ(j, cf, ocf, ocd)                                                \
     do {                                                                             \
-        pmix_server_req_t *_req;                                                     \
-        _req = PMIX_NEW(pmix_server_req_t);                                          \
+        prte_pmix_server_req_t *_req;                                                \
+        _req = PMIX_NEW(prte_pmix_server_req_t);                                     \
         pmix_asprintf(&_req->operation, "SPAWN: %s:%d", __FILE__, __LINE__);         \
         _req->jdata = (j);                                                           \
         _req->spcbfunc = (ocf);                                                      \
@@ -199,7 +199,7 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);
 
-#define PRTE_SERVER_PMIX_THREADSHIFT(p, s, st, m, pl, pn, fn, cf, cb)                     \
+#define PRTE_SERVER_PMIX_THREADSHIFT(p, s, st, m, pl, pn, fn, cf, cb)              \
     do {                                                                           \
         prte_pmix_server_op_caddy_t *_cd;                                          \
         _cd = PMIX_NEW(prte_pmix_server_op_caddy_t);                               \
@@ -342,7 +342,7 @@ PRTE_EXPORT extern void pmix_server_tconn_return(int status, pmix_proc_t *sender
                                                  pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                                  void *cbdata);
 
-PRTE_EXPORT extern int prte_pmix_server_register_tool(pmix_server_req_t *cd);
+PRTE_EXPORT extern int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 
@@ -358,7 +358,7 @@ PRTE_EXPORT extern void pmix_server_alloc_request_resp(int status, pmix_proc_t *
 
 PRTE_EXPORT extern pmix_status_t prte_pmix_set_scheduler(void);
 
-PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, pmix_server_req_t *req);
+PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req);
 
 PRTE_EXPORT extern void prte_server_lost_connection(size_t evhdlr_registration_id,
                                                     pmix_status_t status,
@@ -398,8 +398,8 @@ typedef struct {
     prte_job_t *jdata;
     pmix_proc_t *members;
     size_t num_members;
-} pmix_server_pset_t;
-PMIX_CLASS_DECLARATION(pmix_server_pset_t);
+} prte_pmix_server_pset_t;
+PMIX_CLASS_DECLARATION(prte_pmix_server_pset_t);
 
 typedef struct {
     bool initialized;
@@ -428,9 +428,9 @@ typedef struct {
     pmix_device_type_t generate_dist;
     pmix_list_t psets;
     pmix_list_t groups;
-} pmix_server_globals_t;
+} prte_pmix_server_globals_t;
 
-extern pmix_server_globals_t prte_pmix_server_globals;
+extern prte_pmix_server_globals_t prte_pmix_server_globals;
 
 END_C_DECLS
 

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -68,7 +68,7 @@
 
 static void rlfn(void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
 
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
@@ -76,7 +76,7 @@ static void rlfn(void *cbdata)
 
 static void mfn(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     pmix_data_buffer_t msg;
     pmix_status_t rc;
     int ret;
@@ -170,7 +170,7 @@ pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *requestor,
                                      const pmix_info_t directives[], size_t ndirs,
                                      pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     PRTE_HIDE_UNUSED_PARAMS(error);
 
     // protection
@@ -179,7 +179,7 @@ pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *requestor,
     }
 
     // create a tracking object
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     memcpy(&req->target, requestor, sizeof(pmix_proc_t));
     req->monitor = (pmix_info_t*)monitor;
     req->pstatus = error;
@@ -199,8 +199,8 @@ pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *requestor,
 
 static void mycbfn(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *rq2 = (pmix_server_req_t*)cbdata;
-    pmix_server_req_t *req = (pmix_server_req_t*)rq2->cbdata;
+    prte_pmix_server_req_t *rq2 = (prte_pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)rq2->cbdata;
     pmix_data_buffer_t *msg;
     pmix_status_t rc;
     int ret;
@@ -275,10 +275,10 @@ errorout:
 static void mycb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
                  pmix_release_cbfunc_t release_fn, void *release_cbdata)
 {
-    pmix_server_req_t *rq2;
+    prte_pmix_server_req_t *rq2;
 
     // need to threadshift this into our progress thread
-    rq2 = PMIX_NEW(pmix_server_req_t);
+    rq2 = PMIX_NEW(prte_pmix_server_req_t);
     rq2->pstatus = status;
     rq2->info = info;
     rq2->ninfo = ninfo;
@@ -302,7 +302,7 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
     pmix_info_t *monitor;
     size_t ndirs;
     pmix_info_t *directives = NULL;
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     pmix_data_buffer_t *msg;
     pmix_proc_t requestor;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
@@ -384,7 +384,7 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
     ++ndirs;
 
     // cache this request
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     PMIx_Load_procid(&req->proxy, prte_process_info.myproc.nspace, dvpid);
     req->monitor = monitor;
     req->moncopy = true;
@@ -449,7 +449,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     pmix_status_t rc, rstatus;
     pmix_rank_t dvpid;
     int local_index;
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     pmix_info_t *info=NULL, *results;
     size_t ninfo=0, sz, m, n;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
@@ -471,7 +471,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     }
 
     // lookup the request
-    req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, local_index);
+    req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, local_index);
     if (NULL == req) {
         // bad index, or we no longer have this request
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -138,7 +138,7 @@ static int init_server(void)
 
 static void execute(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t *) cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
     int rc;
     pmix_data_buffer_t *xfer;
     pmix_proc_t *target;
@@ -218,7 +218,7 @@ callback:
 pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t info[],
                                      size_t ninfo, pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     pmix_status_t rc;
     int ret;
     uint8_t cmd = PRTE_PMIX_PUBLISH_CMD;
@@ -228,7 +228,7 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* create the caddy */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "PUBLISH: %s:%d", __FILE__, __LINE__);
     req->opcbfunc = cbfunc;
     req->cbdata = cbdata;
@@ -284,7 +284,7 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
 pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_info_t info[],
                                     size_t ninfo, pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     int ret;
     uint8_t cmd = PRTE_PMIX_LOOKUP_CMD;
     size_t m, n;
@@ -295,7 +295,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     }
 
     /* create the caddy */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "LOOKUP: %s:%d", __FILE__, __LINE__);
     req->lkcbfunc = cbfunc;
     req->cbdata = cbdata;
@@ -369,7 +369,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
                                        const pmix_info_t info[], size_t ninfo,
                                        pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
     int ret;
     uint8_t cmd;
     size_t m, n;
@@ -378,7 +378,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
     // check for a "purge" command
     if (NULL == keys) {
         /* create the caddy */
-        req = PMIX_NEW(pmix_server_req_t);
+        req = PMIX_NEW(prte_pmix_server_req_t);
         pmix_asprintf(&req->operation, "PURGE: %s:%d", __FILE__, __LINE__);
         req->opcbfunc = cbfunc;
         req->cbdata = cbdata;
@@ -409,7 +409,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
 
 
     /* create the caddy */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "UNPUBLISH: %s:%d", __FILE__, __LINE__);
     req->opcbfunc = cbfunc;
     req->cbdata = cbdata;
@@ -487,7 +487,7 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
     uint8_t command;
     int rc, room_num = -1;
     int32_t cnt;
-    pmix_server_req_t *req = NULL;
+    prte_pmix_server_req_t *req = NULL;
     pmix_byte_object_t bo;
     pmix_data_buffer_t pbkt;
     pmix_status_t ret = PMIX_SUCCESS;
@@ -603,7 +603,7 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
 
 release:
     if (0 <= room_num) {
-        req = (pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room_num);
+        req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, room_num);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, room_num, NULL);
     }
 

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -165,8 +165,8 @@ static void _query(int sd, short args, void *cbdata)
                      */
                     /* Make sure the qualifier group exists */
                     matched = 0;
-                    pmix_server_pset_t *ps;
-                    PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, pmix_server_pset_t)
+                    prte_pmix_server_pset_t *ps;
+                    PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
                     {
                         if (PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string, ps->name)) {
                             matched = 1;
@@ -587,9 +587,9 @@ static void _query(int sd, short args, void *cbdata)
                 }
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_PSET_NAMES)) {
-                pmix_server_pset_t *ps;
+                prte_pmix_server_pset_t *ps;
                 ans = NULL;
-                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, pmix_server_pset_t)
+                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, prte_pmix_server_pset_t)
                 {
                     PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
                 }
@@ -610,7 +610,7 @@ static void _query(int sd, short args, void *cbdata)
                 }
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_PSET_MEMBERSHIP)) {
-                pmix_server_pset_t *ps, *psptr;
+                prte_pmix_server_pset_t *ps, *psptr;
                 /* must have provided us with a pset name qualifier */
                 if (NULL == psetname) {
                     ret = PMIX_ERR_BAD_PARAM;
@@ -619,7 +619,7 @@ static void _query(int sd, short args, void *cbdata)
                 ans = NULL;
                 /* find the referenced pset */
                 psptr = NULL;
-                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, pmix_server_pset_t) {
+                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, prte_pmix_server_pset_t) {
                     if (0 == strcmp(psetname, ps->name)) {
                         psptr = ps;
                         break;
@@ -665,9 +665,9 @@ static void _query(int sd, short args, void *cbdata)
                 }
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_GROUP_NAMES)) {
-                pmix_server_pset_t *ps;
+                prte_pmix_server_pset_t *ps;
                 ans = NULL;
-                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, pmix_server_pset_t)
+                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
                 {
                     PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
                 }
@@ -683,8 +683,8 @@ static void _query(int sd, short args, void *cbdata)
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_GROUP_MEMBERSHIP)) {
                 /* construct a list of values with pmix_proc_t
                  * entries for each proc in the indicated group */
-                pmix_server_pset_t *ps, *grp = NULL;
-                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, pmix_server_pset_t)
+                prte_pmix_server_pset_t *ps, *grp = NULL;
+                PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
                 {
                     if (PMIX_CHECK_NSPACE(ps->name, jobid)) {
                         grp = ps;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -86,7 +86,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     pmix_list_t local_procs, members;
     prte_namelist_t *nm;
     size_t nmsize;
-    pmix_server_pset_t *pset;
+    prte_pmix_server_pset_t *pset;
     pmix_cpuset_t cpuset;
     uint32_t ui32, *ui32_ptr;
     prte_job_t *parent = NULL;
@@ -391,7 +391,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             && NULL != tmp) {
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_PSET_NAME, tmp, PMIX_STRING);
             /* register it */
-            pset = PMIX_NEW(pmix_server_pset_t);
+            pset = PMIX_NEW(prte_pmix_server_pset_t);
             pset->name = strdup(tmp);
             PMIX_RETAIN(jdata);
             pset->jdata = jdata;
@@ -723,7 +723,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
 }
 
 /* add any info that the tool couldn't self-assign */
-int prte_pmix_server_register_tool(pmix_server_req_t *cd)
+int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd)
 {
     pmix_status_t ret;
     prte_pmix_lock_t lock;

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -21,14 +21,14 @@
 
 static void localrelease(void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
 
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
 }
 
 /* Process the session control directive from the scheduler */
-static int process_directive(pmix_server_req_t *req)
+static int process_directive(prte_pmix_server_req_t *req)
 {
     char *user_refid = NULL, *alloc_refid = NULL;
     pmix_info_t *personality = NULL, *iptr;
@@ -281,7 +281,7 @@ ANSWER:
  */
 static void passthru(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     if (NULL != req->infocbfunc) {
@@ -301,7 +301,7 @@ static void infocbfunc(pmix_status_t status,
                        void *cbdata,
                        pmix_release_cbfunc_t rel, void *relcbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
 
     // need to pass this into our progress thread for processing
     // since we touch the global request array
@@ -322,7 +322,7 @@ static void infocbfunc(pmix_status_t status,
 
 static void pass_request(int sd, short args, void *cbdata)
 {
-    pmix_server_req_t *req = (pmix_server_req_t*)cbdata;
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     pmix_status_t rc;
     size_t n;
     pmix_info_t *xfer;
@@ -396,14 +396,14 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                                           const pmix_info_t directives[], size_t ndirs,
                                           pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *req;
+    prte_pmix_server_req_t *req;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s session ctrl upcalled on behalf of proc %s:%u with %" PRIsize_t " directives",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), requestor->nspace, requestor->rank, ndirs);
 
     /* create a request tracker for this operation */
-    req = PMIX_NEW(pmix_server_req_t);
+    req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "SESSIONCTRL: %u", sessionID);
     PMIX_PROC_LOAD(&req->tproc, requestor->nspace, requestor->rank);
     req->sessionID = sessionID;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -161,14 +161,14 @@ static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
                            pmix_info_t results[], size_t nresults,
                            pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
-    pmix_server_req_t *cd;
+    prte_pmix_server_req_t *cd;
     PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, info, ninfo, results, nresults);
 
     // allow the pmix event base to continue
     cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
 
     // shift this into our event base
-    cd = PMIX_NEW(pmix_server_req_t);
+    cd = PMIX_NEW(prte_pmix_server_req_t);
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, clean_abort, cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }


### PR DESCRIPTION
As part of extending PRRTE to be fully elastic, we need to pass the allocation requests that come up to the DVM through the controller's active RAS components since they will know how to interact with the local host scheduler. Provide an initial skeleton for this purpose so others can start working on the components themselves.