### PR TITLE
Correct ordering of macro variables

### DIFF
--- a/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
+++ b/src/mca/rmaps/rank_file/help-rmaps_rank_file.txt
@@ -4,7 +4,7 @@
 # Copyright (c) 2013      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,7 +18,7 @@
   Filename: %s
 Check to make sure the path and filename are correct.
 
-usage:  %s -mca rmaps_rankfile_path rankfile ./app
+usage:  %s --map-by rankfile:file=<path> ./app
 
 Examples of proper syntax include:
   cat hostfile

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -112,7 +112,7 @@ bool prte_schizo_base_check_qualifiers(char *directive,
     char *v;
 
     for (n=0; NULL != valid[n]; n++) {
-        if (PMIX_CHECK_CLI_OPTION(valid[n], qual)) {
+        if (PMIX_CHECK_CLI_OPTION(qual, valid[n])) {
             return true;
         }
     }


### PR DESCRIPTION
The option provided by the user should come first, followed by the option definition. Also, correct the suggested cmd line syntax in the ranfile hlp output