### PR TITLE
Fix prte_info to output correct version

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -61,7 +61,7 @@ tarball_version=gitclone
 
 # The date when this release was created
 
-date="Nov 24, 2018"
+date="N/A"
 
 # The shared library version of each of PRRTE's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/src/tools/prte_info/version.c
+++ b/src/tools/prte_info/version.c
@@ -15,7 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -70,7 +70,7 @@ void prte_info_show_prte_version(const char *scope)
     pmix_asprintf(&tmp, "%s:version:full", prte_info_type_prte);
     tmp2 = prte_util_make_version_string(scope, PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
                                          PRTE_RELEASE_VERSION,
-                                         PRTE_GREEK_VERSION, PRTE_REPO_REV);
+                                         PRTE_GREEK_VERSION, NULL);
     prte_info_out("PRTE", tmp, tmp2);
     free(tmp);
     free(tmp2);
@@ -78,7 +78,7 @@ void prte_info_show_prte_version(const char *scope)
     prte_info_out("PRTE repo revision", tmp, PRTE_REPO_REV);
     free(tmp);
     pmix_asprintf(&tmp, "%s:version:release_date", prte_info_type_prte);
-    prte_info_out("PRTE release date", tmp, PMIX_RELEASE_DATE);
+    prte_info_out("PRTE release date", tmp, PRTE_RELEASE_DATE);
     free(tmp);
 
     prte_info_out("PMIx", "pmix:version:full", PMIx_Get_version());


### PR DESCRIPTION
Don't append the repo version to the version as the result is confusing - just output the current version triplet. Set the release date of the master branch to "N/A" as it has never been released