### PR TITLE
Do not override user-specified num procs

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -619,6 +619,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         }
         PMIX_LIST_DESTRUCT(&nodes);
         options.nprocs += app->num_procs;
+        PRTE_FLAG_SET(app, PRTE_APP_FLAG_COMPUTED);
     }
 
     /* check for oversubscribe directives */

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -223,11 +223,13 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
         initial_map = false;
 
         /* set the number of procs to the number of entries in that rankfile */
-        app->num_procs = num_ranks;
-        if (0 == app->num_procs) {
-            pmix_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
-            rc = PRTE_ERR_SILENT;
-            goto error;
+        if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_COMPUTED)) {
+            app->num_procs = num_ranks;
+            if (0 == app->num_procs) {
+                pmix_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                rc = PRTE_ERR_SILENT;
+                goto error;
+            }
         }
         for (k = 0; k < app->num_procs; k++) {
             rank = vpid_start + k;

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -1023,6 +1023,33 @@ char* prte_print_node_flags(struct prte_node_t *ptr)
     return ans;
 }
 
+char* prte_print_app_flags(struct prte_app_context_t *ptr)
+{
+    prte_app_context_t *p = (prte_app_context_t*)ptr;
+    char **tmp = NULL;
+    char *ans;
+
+    // start with the app command
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, p->app);
+    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+
+    if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_USED_ON_NODE)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "USED-LOCAL-NODE");
+    }
+
+    if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_TOOL)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TOOL");
+    }
+
+    if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_COMPUTED)) {
+        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "NPROCS-COMPUTED");
+    }
+
+    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
+    PMIX_ARGV_FREE_COMPAT(tmp);
+    return ans;
+}
+
 char* prte_print_job_flags(struct prte_job_t *ptr)
 {
     prte_job_t *p = (prte_job_t*)ptr;

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -36,6 +36,9 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_FLAG_TOOL          0x02    // this app describes daemons to be co-launched
                                             //    with the application procs in the other apps
                                             //    and does not count against allocation
+#define PRTE_APP_FLAG_COMPUTED      0x04    // num procs for this app were computed and not
+                                            //    given by the user
+
 
 /* APP_CONTEXT ATTRIBUTE KEYS */
 #define PRTE_APP_HOSTFILE            1  // string  - hostfile
@@ -345,8 +348,10 @@ PRTE_EXPORT int prte_attr_register(const char *project, prte_attribute_key_t key
 // forward declarations
 struct prte_proc_t;
 struct prte_node_t;
+struct prte_app_context_t;
 struct prte_job_t;
 
 PRTE_EXPORT char* prte_print_proc_flags(struct prte_proc_t *p);
 PRTE_EXPORT char* prte_print_node_flags(struct prte_node_t *p);
+PRTE_EXPORT char* prte_print_app_flags(struct prte_app_context_t *p);
 PRTE_EXPORT char* prte_print_job_flags(struct prte_job_t *p);


### PR DESCRIPTION
If we are using an LSF rankfile, then we don't declare map-by rankfile - we just let the LSF envar override any mapping directive. Don't ask why - it's what IBM did. So mark if the user specified nprocs, and only use the computed number if they didn't.