### PR TITLE
Some cleanup on hostfile parsing

### DIFF
--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -124,6 +124,11 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
     bool parsable;
     pmix_proc_t source;
 
+
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, NULL, PMIX_BOOL)) {
+        return;
+    }
+
     parsable = prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
     PMIX_LOAD_PROCID(&source, jdata->nspace, PMIX_RANK_WILDCARD);
 
@@ -131,7 +136,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
         pmix_asprintf(&tmp, "<allocation>\n");
     } else {
         pmix_asprintf(&tmp,
-                      "\n======================   ALLOCATED NODES   ======================\n");
+                      "\n======================   ALLOCATED NODES FOR JOB %s  ======================\n", jdata->nspace);
     }
     if (prte_hnp_is_allocated) {
         istart = 0;
@@ -184,6 +189,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
     }
     free(tmp);
     prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
 }
 
 static void display_cpus(prte_topology_t *t,

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -146,7 +146,15 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 PRTE_FLAG_UNSET(hnp_node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             }
             /* if the node name is different, store it as an alias */
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->name);
+            if (0 != strcmp(hnp_node->name, node->name)) {
+                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->name);
+            }
+             // transfer across any new aliases
+            if (NULL != node->aliases) {
+                for (i=0; NULL != node->aliases[i]; i++) {
+                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->aliases[i]);
+                }
+            }
             if (NULL != node->rawname) {
                 if (NULL != hnp_node->rawname) {
                     free(hnp_node->rawname);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -519,6 +519,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "FWD ENVIRONMENT";
         case PRTE_JOB_REPORT_PHYSICAL_CPUS:
             return "REPORT PHYSICAL CPUS";
+        case PRTE_JOB_ALLOC_DISPLAYED:
+            return "ALLOCATION DISPLAYED";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -239,6 +239,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_PMIX_PREFIX                (PRTE_JOB_START_KEY + 119) // string - PMIX_PREFIX for daemons
 #define PRTE_JOB_FWD_ENVIRONMENT            (PRTE_JOB_START_KEY + 120) // bool - forward local environment to procs in this job
 #define PRTE_JOB_REPORT_PHYSICAL_CPUS       (PRTE_JOB_START_KEY + 121) // bool - report using physical (vs logical) cpu IDs
+#define PRTE_JOB_ALLOC_DISPLAYED            (PRTE_JOB_START_KEY + 122) // bool - allocation has been displayed
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -270,14 +270,17 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         /* check for local name and compute non-fqdn name */
         shortname = NULL;
         rawname = NULL;
+
         if (prte_check_host_is_local(mini_map[i])) {
             ndname = prte_process_info.nodename;
         } else {
             ndname = mini_map[i];
-            /* compute the non-fqdn version */
-            if (!prte_keep_fqdn_hostnames &&
-                !pmix_net_isaddr(ndname)) {
-                cptr = strchr(ndname, '.');
+        }
+
+        if (!prte_keep_fqdn_hostnames) {
+            // Strip off the FQDN if present, ignore IP addresses
+            if (!pmix_net_isaddr(mini_map[i])) {
+                 cptr = strchr(ndname, '.');
                 if (NULL != cptr) {
                     rawname = strdup(ndname);
                     *cptr = '\0';
@@ -286,6 +289,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                 }
             }
         }
+
         /* see if a node of this name is already on the list */
         node = prte_node_match(&adds, ndname);
         if (NULL == node && NULL != shortname) {

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -142,12 +142,14 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         }
         PMIX_ARGV_FREE_COMPAT(argv);
 
-        // Strip off the FQDN if present, ignore IP addresses
-        if (!pmix_net_isaddr(node_name)) {
-            char *ptr;
-            alias = strdup(node_name);
-            if (NULL != (ptr = strchr(alias, '.'))) {
-                *ptr = '\0';
+        if (!prte_keep_fqdn_hostnames) {
+            // Strip off the FQDN if present, ignore IP addresses
+            if (!pmix_net_isaddr(node_name)) {
+                char *ptr;
+                alias = strdup(node_name);
+                if (NULL != (ptr = strchr(node_name, '.'))) {
+                    *ptr = '\0';
+                }
             }
         }
 
@@ -220,9 +222,17 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
          */
 
         PMIX_OUTPUT_VERBOSE((3, prte_ras_base_framework.framework_output,
-                             "%s hostfile: node %s is being included - keep all is %s",
+                             "%s hostfile: node %s is being included - keep all is %s alias %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node_name,
-                             keep_all ? "TRUE" : "FALSE"));
+                             keep_all ? "TRUE" : "FALSE",
+                             (NULL == alias) ? "NULL" : alias));
+
+        /* see if this is another name for us */
+        if (prte_check_host_is_local(node_name)) {
+            /* Nodename has been allocated, that is for sure */
+            free(node_name);
+            node_name = strdup(prte_process_info.nodename);
+        }
 
         /* Do we need to make a new node object? */
         if (keep_all || NULL == (node = prte_node_match(updates, node_name))) {
@@ -230,9 +240,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             if (prte_keep_fqdn_hostnames || NULL == alias) {
                 node->name = strdup(node_name);
             } else {
-                node->name = strdup(alias);
-                node->rawname = strdup(node_name);
+                node->name = strdup(node_name);
+                node->rawname = strdup(alias);
             }
+            free(node_name);
             node->slots = 1;
             if (NULL != username) {
                 prte_set_attribute(&node->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_LOCAL, username,
@@ -376,7 +387,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         }
         free(node_name);
         return PRTE_SUCCESS;
-        
+
     } else {
         hostfile_parse_error(token);
         return PRTE_ERROR;

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -139,14 +139,9 @@ void prte_setup_hostname(void)
     }
 
     // if we are not keeping FQDN, then strip it off if not an IP address
-    if (!pmix_net_isaddr(prte_process_info.nodename) &&
-        NULL != (ptr = strchr(prte_process_info.nodename, '.'))) {
-        if (prte_keep_fqdn_hostnames) {
-            /* retain the non-fqdn name as an alias */
-            *ptr = '\0';
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
-            *ptr = '.';
-        } else {
+    if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(prte_process_info.nodename)) {
+        ptr = strchr(prte_process_info.nodename, '.');
+        if (NULL != ptr) {
             /* add the fqdn name as an alias */
             PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
             /* retain the non-fqdn name as the node's name */


### PR DESCRIPTION
Ensure we retain all aliases for the HNP. Avoid
output of allocation for the same job multiple
times. Check to see if we are keeping FQDN during
hostfile parsing.