### PR TITLE
Centralize quickmatch to ensure consistency

### DIFF
--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -87,28 +87,6 @@ PMIX_CLASS_INSTANCE(seq_node_t, pmix_list_item_t, sn_con, sn_des);
 
 static int process_file(char *path, pmix_list_t *list);
 
-static bool quickmatch(prte_node_t *nd, char *name)
-{
-    int n;
-
-    if (0 == strcmp(nd->name, name)) {
-        return true;
-    }
-    if (0 == strcmp(nd->name, prte_process_info.nodename) &&
-        (0 == strcmp(name, "localhost") ||
-         0 == strcmp(name, "127.0.0.1"))) {
-        return true;
-    }
-    if (NULL != nd->aliases) {
-        for (n=0; NULL != nd->aliases[n]; n++) {
-            if (0 == strcmp(nd->aliases[n], name)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 #if PMIX_NUMERIC_VERSION < 0x00040205
 static char *pmix_getline(FILE *fp)
 {
@@ -339,7 +317,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
                 if (NULL == node) {
                     continue;
                 }
-                if (quickmatch(node, sq->hostname)) {
+                if (prte_quickmatch(node, sq->hostname)) {
                     match = true;
                     break;
                 }

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -43,23 +43,6 @@
 
 #include "dash_host.h"
 
-static bool quickmatch(prte_node_t *nd, char *name)
-{
-    int n;
-
-    if (0 == strcmp(nd->name, name)) {
-        return true;
-    }
-    if (NULL != nd->aliases) {
-        for (n=0; NULL != nd->aliases[n]; n++) {
-            if (0 == strcmp(nd->aliases[n], name)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
 {
     char **specs, *cptr;
@@ -77,7 +60,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
         } else {
             cptr = NULL;
         }
-        if (quickmatch(node, specs[n])) {
+        if (prte_quickmatch(node, specs[n])) {
             if (NULL != cptr) {
                 if ('*' == *cptr || 0 == strcmp(cptr, "auto")) {
                     slots += node->slots - node->slots_inuse;
@@ -698,7 +681,7 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
                         test = (lmn == lst) ? 0 : 1;
                     }
                 } else {
-                    test = (quickmatch(node, mapped_nodes[i])) ? 0 : 1;
+                    test = (prte_quickmatch(node, mapped_nodes[i])) ? 0 : 1;
                 }
                 if (0 == test) {
                     if (remove) {


### PR DESCRIPTION
Use the centralized prte_quickmatch instead of the various file-specific versions.


(cherry picked from commit a4b81526f172ec559c1b54b184606f2f226e67ca)