### PR TITLE
Allow setting default cpus/rank

### DIFF
--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,8 +75,12 @@ typedef struct {
     /* default file for use in sequential and rankfile mapping
      * when the directive comes thru MCA param */
     char *file;
+    // default number of pe's per proc
+    uint16_t default_pes;
+    // some general storage values
     hwloc_cpuset_t available, baseset;  // scratch for binding calculation
     char *default_mapping_policy;
+    char *default_ranking_policy;
     /* whether or not to require hwtcpus due to topology limitations */
     bool require_hwtcpus;
 } prte_rmaps_base_t;

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -284,6 +284,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 /* get the parent job's pes/proc, if it had one */
                 if (prte_get_attribute(&parent->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                } else if (0 < prte_rmaps_base.default_pes) {
+                    u16 = prte_rmaps_base.default_pes;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
                 }
             }
             /* if not already assigned, inherit the parent's cpu designation */
@@ -388,6 +391,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                 pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps mapping given by MCA param");
                 jdata->map->mapping = prte_rmaps_base.mapping;
+                if (0 < prte_rmaps_base.default_pes) {
+                    u16 = prte_rmaps_base.default_pes;
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    options.cpus_per_rank = u16;
+                }
                 if (PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
                     tmp = strchr(prte_rmaps_base.default_mapping_policy, ':');
                     ++tmp;


### PR DESCRIPTION
No reason not to allow specifying a default cpus/rank value. Note that this will not be inherited by default.


(cherry picked from commit 7e3b847ae2eb47ac01e21db352546b9e3a90d8ba)