### PR TITLE
Perform sanity check on cmd line

### DIFF
--- a/src/mca/schizo/base/help-schizo-base.txt
+++ b/src/mca/schizo/base/help-schizo-base.txt
@@ -103,8 +103,8 @@ We cannot determine which value was intended, and therefore are unable to procee
 Please correct your command line.
 #
 [multi-instances]
-ERROR: The "%s" command line option was listed more than once on the command line.
-Only one instance of this option is permitted.
+ERROR: The "%s" command line option was listed more than once on
+the command line. Only one instance of this option is permitted.
 Please correct your command line.
 #
 [no-proxy]

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -315,6 +315,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   MAP-BY   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAPBY)) {
+            if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
+                /* not allowed to provide multiple mapping policies */
+                pmix_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "mapping",
+                               info->value.data.string,
+                               prte_rmaps_base_print_mapping(jdata->map->mapping));
+                return PRTE_ERR_BAD_PARAM;
+            }
             rc = prte_rmaps_base_set_mapping_policy(jdata, info->value.data.string);
             if (PRTE_SUCCESS != rc) {
                 return rc;
@@ -338,6 +345,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   RANK-BY   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_RANKBY)) {
+            if (PRTE_RANKING_POLICY_IS_SET(jdata->map->ranking)) {
+                /* not allowed to provide multiple mapping policies */
+                pmix_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "ranking",
+                               info->value.data.string,
+                               prte_rmaps_base_print_ranking(jdata->map->ranking));
+                return PRTE_ERR_BAD_PARAM;
+            }
             rc = prte_rmaps_base_set_ranking_policy(jdata, info->value.data.string);
             if (PRTE_SUCCESS != rc) {
                 return rc;
@@ -345,6 +359,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   BIND-TO   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_BINDTO)) {
+            if (PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
+                /* not allowed to provide multiple mapping policies */
+                pmix_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "binding",
+                               info->value.data.string,
+                               prte_hwloc_base_print_binding(jdata->map->binding));
+                return PRTE_ERR_BAD_PARAM;
+            }
             rc = prte_hwloc_base_set_binding_policy(jdata, info->value.data.string);
             if (PRTE_SUCCESS != rc) {
                 return rc;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -399,12 +399,39 @@ int prte(int argc, char *argv[])
         return rc;
     }
 
-    /* look for any personality specification */
+    /* look for any personality specification and do a quick sanity check */
     personality = NULL;
+    bool mapby_found = false;
+    bool rankby_found = false;
+    bool bindto_found = false;
     for (i = 0; NULL != argv[i]; i++) {
         if (0 == strcmp(argv[i], "--personality")) {
             personality = argv[i + 1];
-            break;
+            continue;
+        }
+        if (0 == strcmp(argv[i], "--map-by")) {
+            if (mapby_found) {
+                pmix_show_help("help-schizo-base.txt", "multi-instances", true, "map-by");
+                return PRTE_ERR_BAD_PARAM;
+            }
+            mapby_found = true;
+            continue;
+        }
+        if (0 == strcmp(argv[i], "--rank-by")) {
+            if (rankby_found) {
+                pmix_show_help("help-schizo-base.txt", "multi-instances", true, "rank-by");
+                return PRTE_ERR_BAD_PARAM;
+            }
+            rankby_found = true;
+            continue;
+        }
+        if (0 == strcmp(argv[i], "--bind-to")) {
+            if (bindto_found) {
+                pmix_show_help("help-schizo-base.txt", "multi-instances", true, "bind-to");
+                return PRTE_ERR_BAD_PARAM;
+            }
+            bindto_found = true;
+            continue;
         }
     }
 

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -439,7 +439,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         }
     }
 #endif
-    
+
 #ifdef PMIX_CLI_SET_ENVAR
     opt = pmix_cmd_line_get_param(&results, PMIX_CLI_SET_ENVAR);
     if (NULL != opt) {


### PR DESCRIPTION
We do not support multiple map/rank/bind policies per job. More specifically, you cannot specify them on a per-app basis as those policies apply to the entire job. So check it and error out if given.