### PR TITLE
Correct the nprocs check to support moving to next node

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -96,19 +96,29 @@ mapping operation.
 
 #
 [span-packages-multiple]
-Your job failed to map because the resulting process placement
-would cause the process to be bound to CPUs in more than one
-package:
+Your job failed to map because either a package with sufficient
+available cpus could not be found on the node, or the resulting
+process placement would cause the process to be bound to CPUs in
+more than one package on the node:
 
   Mapping policy:  %s
   Binding policy:  %s
   CPUs/rank:       %d
+  Node:            %s
 
-This configuration almost always results in a loss of performance
-that can significantly impact applications. Either alter the
-mapping, binding, and/or cpus/rank policies so that each process
-can fit into a single package, or consider using an alternative
-mapper that can handle this configuration (e.g., the rankfile mapper).
+If we couldn't find a package on the node that had sufficient
+available cpus, then you may need to alter your mapping request.
+For example, your ppr request may include more procs than the
+node can support.
+
+If we failed to map due to cross-package placement, then you may
+need to alter your policy. A configuration that causes a single
+process to operate across multiple packages almost always results
+in a loss of performance that can significantly impact applications.
+Either alter the mapping, binding, and/or cpus/rank policies so
+that each process can fit into a single package, or consider using
+an alternative mapper that can handle this configuration (e.g., the
+rankfile mapper).
 #
 [span-packages-cpuset]
 Your job failed to map because the resulting process placement

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -352,7 +352,8 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
             pmix_show_help("help-prte-rmaps-base.txt", "span-packages-multiple", true,
                            prte_rmaps_base_print_mapping(jdata->map->mapping),
                            prte_hwloc_base_print_binding(jdata->map->binding),
-                           options->cpus_per_rank);
+                           options->cpus_per_rank,
+                           node->name);
             return PRTE_ERR_SILENT;
         }
     } else {

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -712,12 +712,12 @@ bool prte_rmaps_base_check_avail(prte_job_t *jdata,
     options->target = hwloc_bitmap_dup(prte_rmaps_base.available);
 
     nprocs = options->ncpus / options->cpus_per_rank;
-    if (options->nprocs < nprocs) {
+    if (options->nprocs <= nprocs) {
         avail = true;
     } else if (options->overload) {
         /* doesn't matter how many cpus are in use */
         avail = true;
-    } else if (0 < nprocs) {
+    } else if (0 == options->pprn && 0 < nprocs) {
         options->nprocs = nprocs;
         avail = true;
     }


### PR DESCRIPTION
If we are ppr mapping, then there must be enough cpus available to allow us to meet the ppr directive. Improve the error message for binding to multiple cpus as failure isn't always due to cross-package binding.