### PR TITLE
Fix ppr mapper

### DIFF
--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -266,11 +266,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
         // check for topology limitations
         prte_rmaps_base.require_hwtcpus = !prte_hwloc_base_core_cpus(node->topology->topo);
 
-        // display the allocation, if requested
-        if (prte_get_attribute(&state->jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
-            prte_ras_base_display_alloc(state->jdata);
-        }
-
         /* jump to mapping */
         state->jdata->state = PRTE_JOB_STATE_VM_READY;
         PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_DAEMONS_REPORTED);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -124,7 +124,6 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
     bool parsable;
     pmix_proc_t source;
 
-
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, NULL, PMIX_BOOL)) {
         return;
     }
@@ -722,8 +721,7 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) ||
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
+    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -712,15 +712,25 @@ bool prte_rmaps_base_check_avail(prte_job_t *jdata,
     /* the available cpus are in the scratch location */
     options->target = hwloc_bitmap_dup(prte_rmaps_base.available);
 
+    // compute how many procs we can support on this object
     nprocs = options->ncpus / options->cpus_per_rank;
-    if (options->nprocs <= nprocs) {
-        avail = true;
-    } else if (options->overload) {
-        /* doesn't matter how many cpus are in use */
-        avail = true;
-    } else if (0 == options->pprn && 0 < nprocs) {
-        options->nprocs = nprocs;
-        avail = true;
+
+    if (0 < options->pprn) {
+        // we are ppr mapping, so there must be enough cpus to
+        // support at least pprn procs on this object
+        if (options->pprn <= nprocs) {
+            avail = true;
+        }
+    } else {
+        if (options->nprocs <= nprocs) {
+            avail = true;
+        } else if (options->overload) {
+            /* doesn't matter how many cpus are in use */
+            avail = true;
+        } else if (0 < nprocs) {
+            options->nprocs = nprocs;
+            avail = true;
+        }
     }
 
 done:

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -207,13 +207,15 @@ static int ppr_mapper(prte_job_t *jdata,
 
             if (HWLOC_OBJ_MACHINE == options->maptype) {
                 options->nprocs = options->pprn;
-                /* if the number of procs is greater than the number of CPUs
-                 * on this node, but less or equal to the number of slots,
+                /* if the number of procs times the number of pes/proc
+                 * is greater than the number of CPUs
+                 * on this node, but the number of procs is less or equal
+                 * to the number of slots,
                  * then we are not oversubscribed but we are overloaded. If
                  * the user didn't specify a required binding, then we set
                  * the binding policy to do-not-bind for this node */
                 ncpus = prte_rmaps_base_get_ncpus(node, NULL, options);
-                if (options->nprocs > ncpus &&
+                if ((options->nprocs * options->cpus_per_rank) > ncpus &&
                     options->nprocs <= node->slots_available &&
                     !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
                     options->bind = PRTE_BIND_TO_NONE;
@@ -253,13 +255,15 @@ static int ppr_mapper(prte_job_t *jdata,
                     continue;
                 }
                 options->nprocs = options->pprn * nobjs;
-                /* if the number of procs is greater than the number of CPUs
-                 * on this node, but less or equal to the number of slots,
+                /* if the number of procs times the number of pes/proc
+                 * is greater than the number of CPUs
+                 * on this node, but the number of procs is less or equal
+                 * to the number of slots,
                  * then we are not oversubscribed but we are overloaded. If
                  * the user didn't specify a required binding, then we set
                  * the binding policy to do-not-bind for this node */
                 ncpus = prte_rmaps_base_get_ncpus(node, NULL, options);
-                if (options->nprocs > ncpus &&
+                if ((options->nprocs * options->cpus_per_rank) > ncpus &&
                     options->nprocs <= node->slots_available &&
                     !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
                     options->bind = PRTE_BIND_TO_NONE;
@@ -269,6 +273,7 @@ static int ppr_mapper(prte_job_t *jdata,
                 for (i = 0; i < nobjs && nprocs_mapped < app->num_procs; i++) {
                     obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
                                                           options->maptype, options->cmaplvl, i);
+                    // are there enough cpus on this obj to meet the request?
                     if (!prte_rmaps_base_check_avail(jdata, app, node, &node_list, obj, options)) {
                         continue;
                     }


### PR DESCRIPTION
When mapping ppr, we need to know if there are enough cpus to map the required ppn for just that object. So be a little more careful on the logic checking for availability.

Cleanup the display allocation a bit - need to ensure we had the opportunity to set slots before declaring the allocation as having been displayed.


(cherry picked from commit 7766e922903f2c3a557309cf14ae31ec03552692)