### PR TITLE
Fix debugger daemon rendezvous on remote nodes

### DIFF
--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -837,7 +837,6 @@ release:
         PMIX_LIST_FOREACH(jptr, &jdata->children, prte_job_t)
         {
             if (prte_get_attribute(&jptr->attributes, PRTE_JOB_CHILD_SEP, (void**)&sepptr, PMIX_BOOL) && !sep) {
-                pmix_output(0, "TERMINATING CHILD");
                 proc = PMIX_NEW(prte_proc_t);
                 PMIX_LOAD_PROCID(&proc->name, jptr->nspace, PMIX_RANK_WILDCARD);
                 pmix_pointer_array_add(&procs, proc);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -576,7 +576,7 @@ static void _toolconn(int sd, short args, void *cbdata)
         PMIX_ERROR_LOG(rc);
     }
     // if we do, then pass along the rank so they have it
-    if (nspace_given) {
+    if (!nspace_given) {
         rc = PMIx_Data_pack(NULL, buf, &cd->target.rank, 1, PMIX_PROC_RANK);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
When the tool connects to the local prted, it will already have a valid procID if it was started by the DVM. Properly communicate that to the DVM controller so we don't create a duplicate job entry in the tracking system.

Fixes [#3746](https://github.com/openpmix/openpmix/issues/3746)