### PR TITLE
Support multi-app map-by specifications

### DIFF
--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -23,12 +23,6 @@
 #
 # This is the US/English general help file for PRRTE's prun.
 #
-[multi-apps-and-zero-np]
-PRTE found multiple applications to be launched, with
-at least one that failed to specify the number of processes to execute.
-When specifying multiple applications, you must specify how many processes
-of each to launch via the -np argument.
-#
 [prte-rmaps-base:alloc-error]
 There are not enough slots available in the system to satisfy the %d
 slots that were requested by the application:

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -532,101 +532,55 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         PRTE_FLAG_SET(app, PRTE_APP_FLAG_COMPUTED);
 
         if (PRTE_MAPPING_SEQ == PRTE_GET_MAPPING_POLICY(jdata->map->mapping) ||
-            PRTE_MAPPING_BYUSER == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
+            PRTE_MAPPING_BYUSER == PRTE_GET_MAPPING_POLICY(jdata->map->mapping) ||
+            PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
             // these mappers compute their #procs as they go
             continue;
         }
 
-        if (1 < jdata->num_apps && 0 == app->num_procs) {
-            pmix_show_help("help-prte-rmaps-base.txt",
-                           "multi-apps-and-zero-np", true,
-                           jdata->num_apps, NULL);
-            jdata->exit_code = PRTE_ERR_BAD_PARAM;
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-            goto cleanup;
-        }
-        /*
-         * get the target nodes for this app - the base function
-         * will take any host or hostfile directive into account
-         */
-        PMIX_CONSTRUCT(&nodes, pmix_list_t);
-        rc = prte_rmaps_base_get_target_nodes(&nodes, &slots,
-                                              jdata, app, jdata->map->mapping,
-                                              true, true, false);
-        if (PRTE_SUCCESS != rc) {
-            PMIX_LIST_DESTRUCT(&nodes);
-            jdata->exit_code = rc;
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-            goto cleanup;
-        }
-        if (0 < options.pprn) {
-            if (HWLOC_OBJ_MACHINE == options.maptype) {
-                app->num_procs = options.pprn * pmix_list_get_size(&nodes);
-            } else if (HWLOC_OBJ_PACKAGE == options.maptype) {
-                /* add in #packages for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                              HWLOC_OBJ_PACKAGE);
-                }
-            } else if (HWLOC_OBJ_NUMANODE== options.maptype) {
-                /* add in #numa for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                              HWLOC_OBJ_NUMANODE);
-                }
-            } else if (HWLOC_OBJ_L1CACHE == options.maptype ||
-                       HWLOC_OBJ_L2CACHE == options.maptype ||
-                       HWLOC_OBJ_L3CACHE == options.maptype) {
-                /* add in #cache for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                              options.maptype);
-                }
-            } else if (HWLOC_OBJ_CORE == options.maptype) {
-                /* add in #cores for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                              HWLOC_OBJ_CORE);
-                }
-            } else if (HWLOC_OBJ_PU == options.maptype) {
-                /* add in #hwt for each node */
-                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                    app->num_procs += options.pprn * prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                              HWLOC_OBJ_PU);
-                }
-            }
-
+       if (NULL != options.cpuset) {
+            ck = PMIX_ARGV_SPLIT_COMPAT(options.cpuset, ',');
+            app->num_procs = PMIX_ARGV_COUNT_COMPAT(ck);
+            PMIX_ARGV_FREE_COMPAT(ck);
         } else {
-           if (NULL != options.cpuset) {
-                ck = PMIX_ARGV_SPLIT_COMPAT(options.cpuset, ',');
-                app->num_procs = PMIX_ARGV_COUNT_COMPAT(ck);
-                PMIX_ARGV_FREE_COMPAT(ck);
-            } else {
-                if (1 < options.cpus_per_rank) {
-                    // compute the number of cpus on each node
-                    len = 0;
-                    PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
-                        if (options.use_hwthreads) {
-                            len += prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                      HWLOC_OBJ_PU) / options.cpus_per_rank;
-                        } else {
-                            len += prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                                                      HWLOC_OBJ_CORE) / options.cpus_per_rank;
-                        }
+            if (1 < options.cpus_per_rank) {
+                /*
+                 * get the target nodes for this app - the base function
+                 * will take any host or hostfile directive into account
+                 */
+                PMIX_CONSTRUCT(&nodes, pmix_list_t);
+                rc = prte_rmaps_base_get_target_nodes(&nodes, &slots,
+                                                      jdata, app, jdata->map->mapping,
+                                                      true, true, false);
+                if (PRTE_SUCCESS != rc) {
+                    PMIX_LIST_DESTRUCT(&nodes);
+                    jdata->exit_code = rc;
+                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                    goto cleanup;
+                }
+                // compute the number of cpus on each node
+                len = 0;
+                PMIX_LIST_FOREACH (node, &nodes, prte_node_t) {
+                    if (options.use_hwthreads) {
+                        len += prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
+                                                                  HWLOC_OBJ_PU) / options.cpus_per_rank;
+                    } else {
+                        len += prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
+                                                                  HWLOC_OBJ_CORE) / options.cpus_per_rank;
                     }
-                    app->num_procs = len;
-                    // ensure we always wind up with at least one proc
-                    if (0 == app->num_procs) {
-                        app->num_procs = 1;
-                    } else if (slots < app->num_procs) {
-                        app->num_procs = slots;
-                    }
-                } else {
+                }
+                PMIX_LIST_DESTRUCT(&nodes);
+                app->num_procs = len;
+                // ensure we always wind up with at least one proc
+                if (0 == app->num_procs) {
+                    app->num_procs = 1;
+                } else if (slots < app->num_procs) {
                     app->num_procs = slots;
                 }
+            } else {
+                app->num_procs = slots;
             }
         }
-        PMIX_LIST_DESTRUCT(&nodes);
         options.nprocs += app->num_procs;
     }
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -410,6 +410,7 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
     }
 
     nprocs_mapped = 0;
+    pmix_output(0, "CPUSET %s", (NULL == options->cpuset) ? "NULL" : options->cpuset);
     savecpuset = strdup(options->cpuset);
 
 pass:

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -401,20 +401,11 @@ int prte(int argc, char *argv[])
 
     /* look for any personality specification and do a quick sanity check */
     personality = NULL;
-    bool mapby_found = false;
     bool rankby_found = false;
     bool bindto_found = false;
     for (i = 0; NULL != argv[i]; i++) {
         if (0 == strcmp(argv[i], "--personality")) {
             personality = argv[i + 1];
-            continue;
-        }
-        if (0 == strcmp(argv[i], "--map-by")) {
-            if (mapby_found) {
-                pmix_show_help("help-schizo-base.txt", "multi-instances", true, "map-by");
-                return PRTE_ERR_BAD_PARAM;
-            }
-            mapby_found = true;
             continue;
         }
         if (0 == strcmp(argv[i], "--rank-by")) {

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -520,6 +520,14 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PREFIX, NULL, PMIX_STRING);
     }
 
+    // check for a mapping directive - we don't allow you to change the base
+    // mapper (e.g., from ppr to map-by core), but you could change the pe=N
+    // value or the ppr number itself
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_MAPBY);
+    if (NULL != opt) {
+        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_MAPBY, opt->values[0], PMIX_STRING);
+    }
+
     *app_ptr = app;
     app = NULL;
     *made_app = true;

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -273,6 +273,10 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_ADD_ENVAR";
         case PRTE_APP_PSET_NAME:
             return "PRTE_APP_PSET_NAME";
+        case PRTE_APP_PES_PER_PROC:
+            return "PRTE_APP_PES_PER_PROC";
+        case PRTE_APP_PPR:
+            return "PRTE_APP_PPR";
 
         case PRTE_NODE_USERNAME:
             return "NODE-USERNAME";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -64,6 +64,9 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_ADD_ENVAR          21 // prte_envar_t - add envar, do not override pre-existing one
 #define PRTE_APP_PSET_NAME          23 // string - user-assigned name for the process
                                        //          set containing the given process
+#define PRTE_APP_PES_PER_PROC       24 // uint16_t - number of cpus to be assigned to each process
+#define PRTE_APP_PPR                25 // uint16_t - number of procs to place on the resource specified
+                                       //           in the job ppr string
 
 #define PRTE_APP_MAX_KEY 100
 


### PR DESCRIPTION
We do not support changing the base mapping policy (i.e., you cannot swtich from ppr to round-robin), but we can allow you to change some of the parameters between apps. In particular, allow specifying pe=N and ppr values for each app.

Will extend to other mappers.