### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-ompi-external.yaml
+++ b/.github/workflows/build-ompi-external.yaml
@@ -2,6 +2,9 @@ name: OMPI External
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-ompi.yaml
+++ b/.github/workflows/build-ompi.yaml
@@ -2,6 +2,9 @@ name: OMPI Internal
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -2,6 +2,9 @@ name: Build tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   macos:
     runs-on: macos-latest

--- a/.github/workflows/dvm.yaml
+++ b/.github/workflows/dvm.yaml
@@ -2,6 +2,9 @@ name: DVM
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   pub-lookup:
     runs-on: ubuntu-22.04

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -2,6 +2,9 @@ name: GROUP
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   group-testsuite:
     runs-on: ubuntu-22.04

--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -15,6 +15,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To fix the problem, explicitly define a permissions block so that the GITHUB_TOKEN has only the minimum required scopes. This workflow only checks out code and builds/tests it; it does not need to write to repository contents, issues, or pull requests. Therefore contents: read is sufficient and matches the minimal starting point suggested by CodeQL.

The single best fix without changing existing functionality is to add a workflow-level permissions section right after the on: block in .github/workflows/build-ompi.yaml. This will apply to all jobs in the workflow (there is only test) unless overridden. Concretely, insert:

permissions:
  contents: read

between the existing on: [pull_request] and jobs: lines (i.e., after line 3 and before line 5 in the provided snippet). No additional methods, imports, or other definitions are needed; this is purely a YAML configuration change.