### PR TITLE
Potential use after free (alerts 10-12)

### DIFF
--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -264,6 +264,10 @@ static int raw_preposition_files(prte_job_t *jdata,
             cptr = pmix_basename(app->app);
             free(app->app);
             pmix_asprintf(&app->app, "./%s", cptr);
+            if (NULL == app->app) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                return PRTE_ERR_OUT_OF_RESOURCE;
+            }
             free(app->argv[0]);
             app->argv[0] = strdup(app->app);
             fs->remote_target = strdup(app->app);


### PR DESCRIPTION
This rule finds accesses through a pointer of a memory location that has already been freed (i.e. through a dangling pointer). Such memory blocks have already been released to the dynamic memory manager, and modifying them can lead to anything from a segfault to memory corruption that would cause subsequent calls to the dynamic memory manager to behave erratically, to a possible security vulnerability.