### PR TITLE
Don't force map display for donotlaunch if bind display requested

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -748,7 +748,8 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
     // we will simply silently exit
     if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
         !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_MAP, NULL, PMIX_BOOL) &&
-        !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
+        !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL) &&
+        !prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL)) {
         // default to the devel map
         prte_set_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, PRTE_ATTR_GLOBAL,
                            NULL, PMIX_BOOL);


### PR DESCRIPTION
Let "display bind" be sufficient - we just want to ensure that _some_ output appears when we are not launching.


(cherry picked from commit 0cde5fb677ff6ac603f22f10e319cabd8ea653a7)