### PR TITLE
Enable MCA param support for display and runtime-options

### DIFF
--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -160,15 +160,22 @@ int prte_hwloc_base_register(void)
      *                     generate an error if it cannot be done
      */
     prte_hwloc_base_binding_policy = NULL;
-    ret = pmix_mca_base_var_register("prte", "hwloc", "default", "binding_policy",
+    ret = pmix_mca_base_var_register("prte", NULL, NULL, "bindto",
                                      "Default policy for binding processes. Allowed values: none, hwthread, core, l1cache, "
                                      "l2cache, "
                                      "l3cache, numa, package, (\"none\" is the default when oversubscribed, \"core\" is "
                                      "the default otherwise). Allowed "
                                      "colon-delimited qualifiers: "
-                                     "overload-allowed, if-supported, limit",
+                                     "overload-allowed, if-supported, limit. For more details, see \"prterun --help bind-to\""
+                                     "The full directive need not be provided — "
+                                      "only enough characters are required to uniquely identify the "
+                                      "directive. Directive values are case insensitive",
                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                      &prte_hwloc_base_binding_policy);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", NULL, NULL, "bind_to",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", "hwloc", "default", "binding_policy",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
     if (NULL == prte_hwloc_base_binding_policy) {
         if (bind_to_core) {
             prte_hwloc_base_binding_policy = "core";

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -20,7 +20,7 @@
  *                         All rights reserved.
  * Copyright (c) 2018      Amazon.com, Inc. or its affiliates.  All Rights reserved.
  * Copyright (c) 2019-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -377,7 +377,7 @@ int prte_hwloc_base_get_topology(void)
         pmix_output_verbose(1, prte_hwloc_base_output,
                             "hwloc:base discovering topology");
         if (0 != hwloc_topology_init(&prte_hwloc_topology) ||
-            0 != prte_hwloc_base_topology_set_flags(prte_hwloc_topology, 0, true) ||
+            0 != prte_hwloc_base_topology_set_flags(prte_hwloc_topology, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM, true) ||
             0 != hwloc_topology_load(prte_hwloc_topology)) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_SUPPORTED);
             return PRTE_ERR_NOT_SUPPORTED;
@@ -403,11 +403,12 @@ int prte_hwloc_base_get_topology(void)
 
 int prte_hwloc_base_set_topology(char *topofile)
 {
-    struct hwloc_topology_support *support;
     hwloc_obj_t obj;
     unsigned j, k;
+    int rc;
 
-    PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output, "hwloc:base:set_topology %s", topofile));
+    PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output,
+                        "hwloc:base:set_topology %s", topofile));
 
     if (NULL != prte_hwloc_topology) {
         hwloc_topology_destroy(prte_hwloc_topology);
@@ -423,11 +424,30 @@ int prte_hwloc_base_set_topology(char *topofile)
     /* since we are loading this from an external source, we have to
      * explicitly set a flag so hwloc sets things up correctly
      */
-    if (0 != prte_hwloc_base_topology_set_flags(prte_hwloc_topology,
-                                                HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM, true)) {
+#ifdef HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT
+    rc = prte_hwloc_base_topology_set_flags(prte_hwloc_topology,
+                                            HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT, true);
+    if (0 != rc) {
         hwloc_topology_destroy(prte_hwloc_topology);
         return PRTE_ERR_NOT_SUPPORTED;
     }
+#else
+    struct hwloc_topology_support *support;
+    rc = prte_hwloc_base_topology_set_flags(prte_hwloc_topology, 0, true);
+    if (0 != rc) {
+        hwloc_topology_destroy(prte_hwloc_topology);
+        return PRTE_ERR_NOT_SUPPORTED;
+    }
+    /* unfortunately, early hwloc does not include support info in its
+     * xml output :-(( We default to assuming it is present as
+     * systems that use this option are likely to provide
+     * binding support
+     */
+    support = (struct hwloc_topology_support *) hwloc_topology_get_support(prte_hwloc_topology);
+    support->cpubind->set_thisproc_cpubind = true;
+    support->membind->set_thisproc_membind = true;
+#endif
+
     if (0 != hwloc_topology_load(prte_hwloc_topology)) {
         hwloc_topology_destroy(prte_hwloc_topology);
         PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output, "hwloc:base:set_topology failed to load"));
@@ -459,15 +479,6 @@ int prte_hwloc_base_set_topology(char *topofile)
             break;
         }
     }
-
-    /* unfortunately, hwloc does not include support info in its
-     * xml output :-(( We default to assuming it is present as
-     * systems that use this option are likely to provide
-     * binding support
-     */
-    support = (struct hwloc_topology_support *) hwloc_topology_get_support(prte_hwloc_topology);
-    support->cpubind->set_thisproc_cpubind = true;
-    support->membind->set_thisproc_membind = true;
 
     /* fill prte_cache_line_size global with the smallest L1 cache
        line size */

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -175,9 +175,10 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
     char *msg;
 
     pmix_output_verbose(2, prte_odls_base_framework.framework_output,
-                        "%s hwloc:set on child %s",
+                        "%s hwloc:set on child %s cpuset %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        (NULL == child) ? "NULL" : PRTE_NAME_PRINT(&child->name));
+                        (NULL == child) ? "NULL" : PRTE_NAME_PRINT(&child->name),
+                        (NULL == child->cpuset) ? "NULL" : child->cpuset);
 
     if (NULL == jobdat || NULL == child) {
         /* nothing for us to do */
@@ -254,8 +255,8 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
             if (NULL == msg) {
                 msg = "failed to convert bitmap list to hwloc bitmap";
             }
-            if (PRTE_BINDING_REQUIRED(jobdat->map->binding)
-                && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+            if (PRTE_BINDING_REQUIRED(jobdat->map->binding) &&
+                PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
                 /* If binding is required and a binding directive was explicitly
                  * given (i.e., we are not binding due to a default policy),
                  * send an error up the pipe (which exits -- it doesn't return).

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -21,7 +21,7 @@
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -475,11 +475,11 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
                 /* record that this proc is ready for debug */
                 PRTE_ACTIVATE_PROC_STATE(&cd->child->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
             }
+            cd->child->state = PRTE_PROC_STATE_RUNNING;
+            PRTE_FLAG_SET(cd->child, PRTE_PROC_FLAG_ALIVE);
+            close(read_fd);
+            return PRTE_SUCCESS;
         }
-        cd->child->state = PRTE_PROC_STATE_RUNNING;
-        PRTE_FLAG_SET(cd->child, PRTE_PROC_FLAG_ALIVE);
-        close(read_fd);
-        return PRTE_SUCCESS;
     }
 #endif
 
@@ -586,7 +586,7 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
                 PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
             }
             close(read_fd);
-            return PRTE_ERR_FAILED_TO_START;
+            return PRTE_ERR_SILENT;
         }
     }
 

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -71,27 +71,43 @@ prte_rmaps_base_t prte_rmaps_base = {
 
 static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
 {
+    int ret;
     PRTE_HIDE_UNUSED_PARAMS(flags);
 
     /* define default mapping policy */
     prte_rmaps_base.default_mapping_policy = NULL;
-    (void) pmix_mca_base_var_register("prte", "rmaps", "default", "mapping_policy",
-                                      "Default mapping Policy [slot | hwthread | core | l1cache | "
+    ret = pmix_mca_base_var_register("prte", NULL, NULL, "mapby",
+                                     "Default mapping Policy [slot | hwthread | core | l1cache | "
                                       "l2cache | l3cache | numa | package | node | seq | dist | ppr | "
                                       "rankfile | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
                                       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
                                       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
                                       "DEVICE=dev (for dist policy), INHERIT, NOINHERIT, ORDERED, FILE=%s (path to file containing sequential "
-                                      "or rankfile entries)",
-                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                      &prte_rmaps_base.default_mapping_policy);
+                                      "or rankfile entries). For more details, see \"prterun --help map-by\". "
+                                      "The full directive need not be provided — "
+                                      "only enough characters are required to uniquely identify the "
+                                      "directive. Directive values are case insensitive",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_rmaps_base.default_mapping_policy);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", NULL, NULL, "map_by",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", "rmaps", "default", "mapping_policy",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     /* define default ranking policy */
     prte_rmaps_base.default_ranking_policy = NULL;
-    (void) pmix_mca_base_var_register("prte", "rmaps", "default", "ranking_policy",
-                                      "Default ranking Policy [slot | node | span | fill]",
-                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                      &prte_rmaps_base.default_ranking_policy);
+    ret = pmix_mca_base_var_register("prte", NULL, NULL, "rankby",
+                                     "Default ranking Policy [slot | node | span | fill]. "
+                                     "For more details, see \"prterun --help rank-by\". The full "
+                                     "directive need not be provided — only enough characters are "
+                                     "required to uniquely identify the directive. Directive values "
+                                     "are case insensitive",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_rmaps_base.default_ranking_policy);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", NULL, NULL, "rank_by",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", "rmaps", "default", "ranking_policy",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     prte_rmaps_base.inherit = false;
     (void) pmix_mca_base_var_register("prte", "rmaps", "default", "inherit",

--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,6 +48,8 @@ typedef struct {
     /* list of active modules */
     pmix_list_t active_modules;
     bool test_proxy_launch;
+    char *default_display_options;
+    char *default_runtime_options;
 } prte_schizo_base_t;
 
 /**

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,19 +43,57 @@
  */
 prte_schizo_base_t prte_schizo_base = {
     .active_modules = PMIX_LIST_STATIC_INIT,
-    .test_proxy_launch = false
+    .test_proxy_launch = false,
+    .default_display_options = NULL,
+    .default_runtime_options = NULL
 };
 
 static int prte_schizo_base_register(pmix_mca_base_register_flag_t flags)
 {
+    int ret;
     PRTE_HIDE_UNUSED_PARAMS(flags);
 
     /* test proxy launch */
     prte_schizo_base.test_proxy_launch = false;
-    pmix_mca_base_var_register("prte", "schizo", "base", "test_proxy_launch",
-                               "Test proxy launches",
-                               PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                               &prte_schizo_base.test_proxy_launch);
+    (void)pmix_mca_base_var_register("prte", "schizo", "base", "test_proxy_launch",
+                                     "Test proxy launches",
+                                     PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                     &prte_schizo_base.test_proxy_launch);
+
+    prte_schizo_base.default_display_options = NULL;
+    (void)pmix_mca_base_var_register("prte", NULL, NULL, "display",
+                                     "Comma-delimited list of values about the job and/or allocation "
+                                     "that are to be displayed. Supported values include: [allocation | bindings "
+                                     "| map | map-devel | topo[=semi-colon delimited list of nodes whose topology is to be displayed] "
+                                     "| cpus[=semi-colon delimited list of nodes whose cpus are to be displayed], with supported colon-delimited "
+                                     "modifiers: [parseable | physical]. For more details, see \"prterun --help display\". "
+                                     "The full directive need not be provided — "
+                                     "only enough characters are required to uniquely identify the "
+                                     "directive. For example, \"ALL\" is sufficient to represent "
+                                     "the \"ALLOCATION\" directive — while \"MAP\" can not be used "
+                                     "to represent \"MAP-DEVEL\" (though \"MAP-D\" would suffice).",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_schizo_base.default_display_options);
+
+    prte_schizo_base.default_runtime_options = NULL;
+    ret = pmix_mca_base_var_register("prte", NULL, NULL, "rtos",
+                                     "Comma-delimited list of options specifying desired behavior of "
+                                     "the runtime itself. Supported values include: [error-nonzero-status, donotlaunch, "
+                                     "show-progress, notifyerrors, recoverable, autorestart, continuous, max-restarts, "
+                                     "exec-agent, default-exec-agent, output-proctable, stop-on-exec, stop-in-init, "
+                                     "stop-in-app, timeout, spawn-timeout, report-state-on-timeout, get-stack-traces, "
+                                     "report-child-jobs-seperately, aggregate-help-messages, fwd-environment]. "
+                                     "For more details, see \"prterun --help runtime-options\". "
+                                     "The full directive need not be provided — "
+                                     "only enough characters are required to uniquely identify the "
+                                     "directive. For example, \"donot\" is sufficient to represent "
+                                     "the \"donotlaunch\" directive — while \"STOP\" can not be used "
+                                     "to represent \"STOP-ON-EXEC\" (though \"STOP-ON-E\" would suffice).",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_schizo_base.default_runtime_options);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", NULL, NULL, "runtime_options",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/state/base/base.h
+++ b/src/mca/state/base/base.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,9 +57,6 @@ PRTE_EXPORT int prte_state_base_select(void);
 PRTE_EXPORT void prte_state_base_print_job_state_machine(void);
 
 PRTE_EXPORT void prte_state_base_print_proc_state_machine(void);
-
-PRTE_EXPORT int prte_state_base_set_default_rto(prte_job_t *jdata,
-                                                prte_rmaps_options_t *options);
 
 PRTE_EXPORT int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec);
 

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,16 +48,6 @@
 #include "src/util/pmix_show_help.h"
 
 #include "src/mca/state/base/base.h"
-
-int prte_state_base_set_default_rto(prte_job_t *jdata,
-                                    prte_rmaps_options_t *options)
-{
-    int rc;
-    PRTE_HIDE_UNUSED_PARAMS(options);
-
-    rc = prte_state_base_set_runtime_options(jdata, NULL);
-    return rc;
-}
 
 /* this function is called if pmix_server_dyn receives a
  * PMIX_RUNTIME_OPTIONS info struct */

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -116,12 +116,12 @@ BEGIN_C_DECLS
 #define PRTE_CLI_GPU_SUPPORT			"gpu-support"				// required
 
 // Placement options
-#define PRTE_CLI_MAPBY                  "map-by"                    // required
-#define PRTE_CLI_RANKBY                 "rank-by"                   // required
-#define PRTE_CLI_BINDTO                 "bind-to"                   // required
+#define PRTE_CLI_MAPBY                  "mapby"                     // required
+#define PRTE_CLI_RANKBY                 "rankby"                    // required
+#define PRTE_CLI_BINDTO                 "bindto"                    // required
 
 // Runtime options
-#define PRTE_CLI_RTOS                   "runtime-options"           // required
+#define PRTE_CLI_RTOS                   "rtos"           			// required
 
 // Debug options
 #define PRTE_CLI_DO_NOT_LAUNCH          "do-not-launch"             // none


### PR DESCRIPTION
Users sometimes find it helpful to provide cmd line options as MCA params - e.g., when using the same script for different MPI implementations. We already provided it for map, rank, and bind options, but not for display and runtime-options. So add support for those two as well.

Users also note that the param names are painfully long and involve PRRTE-internal pieces - e.g., "rmaps_base_default_mapping_policy". This puts the user in the position of having to know something about PRRTE's code organization, which is less than desirable. So shorten the names and make them code-agnostic:

map-by  becomes PRTE_MCA_mapby
rank-by becomes PRTE_MCA_rankby
bind-to becomes PRTE_MCA_bindto
display becomes PRTE_MCA_display
runtime-options becomes PRTE_MCA_rtos

Preserve backward compatibility through synonyms for the old param names.

Apply the same principle to the cmd line options as well, removing the hyphens and replacing runtime-options with a simple rtos. Translate the old options under-the-covers so users don't see the change - basically we now accept both spellings for the cmd line.