### PR TITLE
Multiple commits

### DIFF
--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -7,7 +7,7 @@
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -350,6 +350,7 @@ PRTE_EXPORT int prte_hwloc_base_memory_set(prte_hwloc_base_memory_segment_t *seg
  */
 PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
                                            bool use_hwthread_cpus,
+                                           bool physical,
                                            hwloc_topology_t topo);
 
 PRTE_EXPORT void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Inria.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +64,9 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
     int nobjs, n;
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                        "mca:rmaps: bind %s with policy %s",
+                        "mca:rmaps: bind %s to %s with policy %s",
                         PRTE_NAME_PRINT(&proc->name),
+                        hwloc_obj_type_string(options->maptype),
                         prte_hwloc_base_print_binding(jdata->map->binding));
     /* initialize */
     if (NULL == obj) {
@@ -147,7 +148,8 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
     hwloc_bitmap_list_asprintf(&proc->cpuset, tgtcpus); // bind to the entire target object
     if (4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
         char *tmp1;
-        tmp1 = prte_hwloc_base_cset2str(trg_obj->cpuset, options->use_hwthreads, node->topology->topo);
+        tmp1 = prte_hwloc_base_cset2str(trg_obj->cpuset, options->use_hwthreads,
+                                        false, node->topology->topo);
         pmix_output(prte_rmaps_base_framework.framework_output, "%s BOUND PROC %s[%s] TO %s",
                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name),
                     node->name, tmp1);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      UT-Battelle, LLC. All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -1042,6 +1042,7 @@ void prte_rmaps_base_report_bindings(prte_job_t *jdata,
             hwloc_bitmap_list_sscanf(prte_rmaps_base.available, proc->cpuset);
             tmp = prte_hwloc_base_cset2str(prte_rmaps_base.available,
                                            options->use_hwthreads,
+                                           false,
                                            proc->node->topology->topo);
             pmix_asprintf(&out, "Proc %s Node %s bound to %s",
                           PRTE_NAME_PRINT(&proc->name),

--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -355,7 +355,7 @@ static int lsf_map(prte_job_t *jdata,
                 rc = prte_hwloc_base_cpu_list_parse(slots, node->topology->topo, options->use_hwthreads, proc_bitmap);
                 if (PRTE_ERR_NOT_FOUND == rc) {
                     char *tmp = prte_hwloc_base_cset2str(hwloc_topology_get_allowed_cpuset(node->topology->topo),
-                                                         options->use_hwthreads, node->topology->topo);
+                                                         options->use_hwthreads, false, node->topology->topo);
                     pmix_show_help("help-rmaps_lsf.txt", "missing-cpu", true,
                                    prte_tool_basename, slots, tmp);
                     free(tmp);

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -383,7 +383,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 rc = prte_hwloc_base_cpu_list_parse(slots, node->topology->topo, options->use_hwthreads, proc_bitmap);
                 if (PRTE_ERR_NOT_FOUND == rc) {
                     char *tmp = prte_hwloc_base_cset2str(hwloc_topology_get_allowed_cpuset(node->topology->topo),
-                                                         false, node->topology->topo);
+                                                         false, false, node->topology->topo);
                     pmix_show_help("help-rmaps_rank_file.txt", "missing-cpu", true,
                                    prte_tool_basename, slots, tmp);
                     free(tmp);

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -491,6 +491,7 @@ pass:
                 hwloc_bitmap_free(options->job_cpuset);
                 options->job_cpuset = NULL;
             }
+            options->cpuset = strdup(savecpuset);
             if (NULL != savecpuset) {
                 free(savecpuset);
             }

--- a/src/mca/rtc/hwloc/rtc_hwloc.c
+++ b/src/mca/rtc/hwloc/rtc_hwloc.c
@@ -286,7 +286,7 @@ static void report_binding(prte_job_t *jobdat, int rank)
     if (hwloc_get_cpubind(prte_hwloc_topology, mycpus, HWLOC_CPUBIND_PROCESS) < 0) {
         pmix_output(0, "Rank %d is not bound", rank);
     } else {
-        tmp1 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, prte_hwloc_topology);
+        tmp1 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, false, prte_hwloc_topology);
         pmix_output(0, "Rank %d bound to %s", rank, tmp1);
         free(tmp1);
     }

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -387,7 +387,7 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
             mycpus = hwloc_bitmap_alloc();
             hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
             str = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus,
-                                           src->node->topology->topo);
+                                           false, src->node->topology->topo);
             if (NULL == str) {
                 str = strdup("UNBOUND");
             }
@@ -419,7 +419,7 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
     if (NULL != src->cpuset) {
         mycpus = hwloc_bitmap_alloc();
         hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
-        tmp2 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, src->node->topology->topo);
+        tmp2 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, false, src->node->topology->topo);
         hwloc_bitmap_free(mycpus);
     } else {
         tmp2 = strdup("UNBOUND");

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
             if (!hwloc_bitmap_iszero(ours)) {
                 (void) hwloc_set_cpubind(prte_hwloc_topology, ours, 0);
                 if (prte_debug_daemons_flag) {
-                    tmp = prte_hwloc_base_cset2str(ours, false, prte_hwloc_topology);
+                    tmp = prte_hwloc_base_cset2str(ours, false, false, prte_hwloc_topology);
                     pmix_output(0, "Daemon %s is bound to cores %s",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), tmp);
                     free(tmp);


### PR DESCRIPTION
[Revert back to explicitly setting hwloc support for xml import](https://github.com/openpmix/prrte/commit/a214a4746c0c48d01aefadb21da2d33c871ba3e6)

The import support feature doesn't seem to be reliable at this time.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/452c1f6dbcf57842974424a4b65eb6a29a4cdab4)

[Cleanup bind output when partial allocations exist](https://github.com/openpmix/prrte/commit/e2398ade91009e437f8bbf766821ab1b9ddb71fb)

When someone does a partial allocation, the topology switches
to bits-as-cores and things get confused. Try to handle that
situation a little better without messing up the more
common scenario.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/32f590df9d8cabaecf2d205c7f454cfc588d58fe)
