### PR TITLE
Create a custom signature if asymmetric topology found

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -952,6 +952,13 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
+
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_DO_NOT_SPAWN, NULL, PMIX_BOOL)) {
+        // if we aren't spawning the apps, then just mark them as
+        // terminated and return
+        PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_TERMINATED);
+        return;
+    }
 
     /* ensure we clear any prior info regarding state or exit status in
      * case this is a restart

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -457,6 +457,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     char *rtos[] = {
         PRTE_CLI_ERROR_NZ,
         PRTE_CLI_NOLAUNCH,
+        PRTE_CLI_NOSPAWN,
         PRTE_CLI_SHOW_PROGRESS,
         PRTE_CLI_RECOVERABLE,
         PRTE_CLI_CONTINUOUS,

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -224,6 +224,18 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                                        &flag, PMIX_BOOL);
                 }
 
+            } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_NOSPAWN)) {
+                flag = PMIX_CHECK_TRUE(&value);
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_SPAWN, PRTE_ATTR_GLOBAL,
+                                   &flag, PMIX_BOOL);
+                /* if we are not in a persistent DVM, then make sure we also
+                 * apply this to the daemons */
+                if (!prte_persistent) {
+                    djob = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+                    prte_set_attribute(&djob->attributes, PRTE_JOB_DO_NOT_SPAWN, PRTE_ATTR_GLOBAL,
+                                       &flag, PMIX_BOOL);
+                }
+
             } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_SHOW_PROGRESS)) {
                 flag = PMIX_CHECK_TRUE(&value);
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_SHOW_PROGRESS, PRTE_ATTR_GLOBAL,

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2020 Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -525,6 +525,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "REPORT PHYSICAL CPUS";
         case PRTE_JOB_ALLOC_DISPLAYED:
             return "ALLOCATION DISPLAYED";
+        case PRTE_JOB_DO_NOT_SPAWN:
+            return "DO_NOT_SPAWN";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      The University of Tennessee and The University
  *                         of Tennessee Research Foundation.  All rights
  *                         reserved.
@@ -243,6 +243,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_FWD_ENVIRONMENT            (PRTE_JOB_START_KEY + 120) // bool - forward local environment to procs in this job
 #define PRTE_JOB_REPORT_PHYSICAL_CPUS       (PRTE_JOB_START_KEY + 121) // bool - report using physical (vs logical) cpu IDs
 #define PRTE_JOB_ALLOC_DISPLAYED            (PRTE_JOB_START_KEY + 122) // bool - allocation has been displayed
+#define PRTE_JOB_DO_NOT_SPAWN               (PRTE_JOB_START_KEY + 123) // bool - do not spawn app procs
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -204,6 +204,7 @@ BEGIN_C_DECLS
 // Runtime directives
 #define PRTE_CLI_ERROR_NZ           "error-nonzero-status"          // optional arg
 #define PRTE_CLI_NOLAUNCH           "donotlaunch"                   // no arg
+#define PRTE_CLI_NOSPAWN            "donotspawn"                    // no arg
 #define PRTE_CLI_SHOW_PROGRESS      "show-progress"                 // optional arg
 #define PRTE_CLI_RECOVERABLE        "recoverable"                   // optional arg
 #define PRTE_CLI_AUTORESTART        "autorestart"                   // optional arg


### PR DESCRIPTION
If we hit an asymmetric topology, then generate our own custom signature - may help with Azure's setup.

Add a runtime option "donotspawn" that allows us to launch daemons with alternate topologies, but not attempt to fork/exec application procs as that would fail.