### PR TITLE
Initialize ESS before prterun fallback to prun_common()

### DIFF
--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -630,7 +630,19 @@ int prte(int argc, char *argv[])
                 return 1;
             }
         }
+
+        // open the ess framework so it can init the signal forwarding
+        // list - we don't actually need the components
+        rc = pmix_mca_base_framework_open(&prte_ess_base_framework,
+                                        PMIX_MCA_BASE_OPEN_DEFAULT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
+            exit(rc);
+        }
         rc = prun_common(&results, schizo, argc, argv);
+
+        (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
         exit(rc);
     }
 


### PR DESCRIPTION
Fix for https://github.com/openpmix/prrte/issues/2364

The root cause was found with the help from DeepWiki - https://deepwiki.com/search/i-cant-run-anything-on-a-preex_1862a831-88d6-4520-8b2c-13bd1237119b?mode=deep

Works as expected with pre-existing DVM after applying the fix.

What's not clear to me though is which change had actually caused the problem (haven't seen it in e.g. mpi-bundled version of prrte)