### PR TITLE
Add MCA param to set personality

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -50,6 +50,7 @@ typedef struct {
     bool test_proxy_launch;
     char *default_display_options;
     char *default_runtime_options;
+    char *default_personality;
 } prte_schizo_base_t;
 
 /**

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -45,7 +45,8 @@ prte_schizo_base_t prte_schizo_base = {
     .active_modules = PMIX_LIST_STATIC_INIT,
     .test_proxy_launch = false,
     .default_display_options = NULL,
-    .default_runtime_options = NULL
+    .default_runtime_options = NULL,
+    .default_personality = NULL
 };
 
 static int prte_schizo_base_register(pmix_mca_base_register_flag_t flags)
@@ -59,6 +60,13 @@ static int prte_schizo_base_register(pmix_mca_base_register_flag_t flags)
                                      "Test proxy launches",
                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                      &prte_schizo_base.test_proxy_launch);
+    prte_schizo_base.default_personality = NULL;
+    ret = pmix_mca_base_var_register("prte", NULL, NULL, "personality",
+                                     "Default personality to use",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_schizo_base.default_personality);
+    (void) pmix_mca_base_var_register_synonym(ret, "prte", NULL, "schizo", "proxy",
+                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
 
     prte_schizo_base.default_display_options = NULL;
     (void)pmix_mca_base_var_register("prte", NULL, NULL, "display",

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -602,7 +602,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         free(caught_positions);
         caught_positions = NULL;
     }
- 
+
     PMIX_ARGV_FREE_COMPAT(pargv);
     /* check for deprecated options - warn and convert them */
     rc = convert_deprecated_cli(results, silent);
@@ -2163,7 +2163,8 @@ static int detect_proxy(char *personalities)
     }
 
     /* if we were told the proxy, then use it */
-    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
+    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy")) ||
+        NULL != (evar = getenv("PRTE_MCA_personality"))) {
         if (0 == strcmp(evar, "ompi")) {
             return 100;
         } else {

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1068,7 +1068,8 @@ static int detect_proxy(char *personalities)
     }
 
     /* if we were told the proxy, then use it */
-    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy"))) {
+    if (NULL != (evar = getenv("PRTE_MCA_schizo_proxy")) ||
+        NULL != (evar = getenv("PRTE_MCA_personality"))) {
         if (0 == strcmp(evar, "prte")) {
             /* they asked exclusively for us */
             return 100;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -471,6 +471,7 @@ int prte(int argc, char *argv[])
     /* ensure we don't confuse any downstream PRRTE tools on
      * choice of proxy since some environments forward their envars */
     unsetenv("PRTE_MCA_schizo_proxy");
+    unsetenv("PRTE_MCA_personality");
 
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (rc = prte_register_params())) {

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2022      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -212,6 +212,7 @@ int main(int argc, char *argv[])
     /* ensure we aren't misdirected on choice of proxy since
      * some environments forward their envars */
     unsetenv("PRTE_MCA_schizo_proxy");
+    unsetenv("PRTE_MCA_personality");
 
     /* initialize the globals */
     PMIX_DATA_BUFFER_CREATE(bucket);


### PR DESCRIPTION
We already have an envar (PRTE_MCA_schizo_proxy) that _looks_ like an MCA param, but it is never registered as one. Do that, and add a simpler one (PRTE_MCA_personality).