### PR TITLE
Fix typo and add MCA param for default output options

### DIFF
--- a/src/mca/schizo/base/base.h
+++ b/src/mca/schizo/base/base.h
@@ -50,6 +50,7 @@ typedef struct {
     bool test_proxy_launch;
     char *default_display_options;
     char *default_runtime_options;
+    char *default_output_options;
     char *default_personality;
 } prte_schizo_base_t;
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -46,6 +46,7 @@ prte_schizo_base_t prte_schizo_base = {
     .test_proxy_launch = false,
     .default_display_options = NULL,
     .default_runtime_options = NULL,
+    .default_output_options = NULL,
     .default_personality = NULL
 };
 
@@ -82,6 +83,19 @@ static int prte_schizo_base_register(pmix_mca_base_register_flag_t flags)
                                      "to represent \"MAP-DEVEL\" (though \"MAP-D\" would suffice).",
                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
                                      &prte_schizo_base.default_display_options);
+
+    prte_schizo_base.default_output_options = NULL;
+    (void)pmix_mca_base_var_register("prte", NULL, NULL, "output",
+                                     "Comma-delimited list of case-insensitive options that control how "
+                                     "output is generated. The full directive need not be provided — only "
+                                     "enough characters are required to uniquely identify the directive. For "
+                                     "example, \"MERGE\" is sufficient to represent the \"MERGE-STDERR-TO-STDOUT\" "
+                                     "directive — while \"TAG\" can not be used to represent \"TAG-DETAILED\" "
+                                     "(though \"TAG-D\" would suffice). Supported values include: [tag | "
+                                     "tag-detailed | tag-fullname | timestamp | xml | dir=[dirname] | "
+                                     "file=[filename]. Supported qualifiers include [nocopy | raw]",
+                                     PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                     &prte_schizo_base.default_output_options);
 
     prte_schizo_base.default_runtime_options = NULL;
     ret = pmix_mca_base_var_register("prte", NULL, NULL, "rtos",

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -783,7 +783,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         }
 
         /* --output-filename DIR  ->  --output file=file */
-        else if (0 == strcmp(option, "--output-filename")) {
+        else if (0 == strcmp(option, "output-filename")) {
             pmix_asprintf(&p2, "file=%s", opt->values[0]);
             rc = prte_schizo_base_add_directive(results, option,
                                                 PRTE_CLI_OUTPUT, p2,

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -792,10 +792,16 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
         ret = prte_schizo_base_parse_output(opt, jinfo);
-        if (PRTE_SUCCESS != ret) {
-            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-            return ret;
-        }
+    } else if (NULL != prte_schizo_base.default_output_options) {
+        PMIX_CONSTRUCT(&opt2, pmix_cli_item_t);
+        opt2.key = strdup(PRTE_CLI_OUTPUT);
+        PMIx_Argv_append_nosize(&opt2.values, prte_schizo_base.default_output_options);
+        ret = prte_schizo_base_parse_output(&opt2, jinfo);
+        PMIX_DESTRUCT(&opt2);
+    }
+    if (PRTE_SUCCESS != ret) {
+        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+        return ret;
     }
 
     /* check for runtime options */


### PR DESCRIPTION
Fix a typo in the prte personality that caused output-filename to be ignored. Add an MCA param `PRTE_MCA_output` to set default output options.