### PR TITLE
Update handling of log requests

### DIFF
--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -18,7 +18,7 @@
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -287,6 +287,10 @@ PRTE_EXPORT extern pmix_status_t pmix_server_log2_fn(const pmix_proc_t *client, 
                                                      size_t ndata, const pmix_info_t directives[],
                                                      size_t ndirs, pmix_op_cbfunc_t cbfunc, void *cbdata);
 #endif
+
+PRTE_EXPORT extern void pmix_server_logging_resp(int status, pmix_proc_t *sender,
+                                                 pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                                 void *cbdata);
 
 PRTE_EXPORT extern pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
                                                       pmix_alloc_directive_t directive,

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -161,6 +161,7 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 
 /* pmix log requests */
 #define PRTE_RML_TAG_LOGGING              65
+#define PRTE_RML_TAG_LOGGING_RESP         66
 
 /* scheduler requests */
 #define PRTE_RML_TAG_SCHED                72


### PR DESCRIPTION
Threadshift out of the PMIx progress thread before touching PRRTE globals. Have the DVM controller respond with an "ack" message once the log has been completed.