### PR TITLE
update-my-copyright.py: properly support git workspaces

### DIFF
--- a/contrib/update-my-copyright.pl
+++ b/contrib/update-my-copyright.pl
@@ -1,19 +1,20 @@
 #!/usr/bin/env perl
 #
 # Copyright (c) 2010-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2017      IBM Corporation. All rights reserved.
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 
 # Short version:
 #
 # This script automates the tedious task of updating copyright notices
-# in the tops of OMPI/PRTE/OPAL source files before committing back to
+# in the tops of PRRTE source files before committing back to
 # the respository.  Set the environment variable
-# OMPI_COPYRIGHT_SEARCH_NAME to a short (case-insensitive) name that
+# PRTE_COPYRIGHT_SEARCH_NAME to a short (case-insensitive) name that
 # indicates your copyright line (e.g., "cisco"), and set the env
-# variable OMPI_COPYRIGHT_FORMAL_NAME with your organization's formal
+# variable PRTE_COPYRIGHT_FORMAL_NAME with your organization's formal
 # name and copyright statement (e.g., "Cisco Systems, Inc.  All rights
 # reserved.") before running the script.
 
@@ -54,7 +55,7 @@ use Getopt::Long;
 # Will exit with status 111 if there are out of date copyrights which this
 # script can correct.
 my $CHECK_ONLY = 0;
-# used by $CHECK_ONLY logic for bookeeping
+# used by $CHECK_ONLY logic for bookkeeping
 my $would_replace = 0;
 
 # Set to true to suppress most informational messages.  Only out of date files
@@ -65,25 +66,14 @@ my $QUIET = 0;
 my $HELP = 0;
 
 # Defaults
-my $my_search_name = "Cisco";
-my $my_formal_name = "Cisco Systems, Inc.  All rights reserved.";
-my $my_manual_list = "";
-
-# Protected directories
-my @protected = qw(
-    opal\\/mca\\/pmix\\/pmix.+?\\/pmix\\/
-    opal\\/mca\\/hwloc\\/hwloc.+?\\/hwloc\\/
-    opal\\/mca\\/event\\/libevent.+?\\/libevent\\/
-    contrib\\/update-my-copyright.pl
-);
+my $my_search_name = "Nanook";
+my $my_formal_name = "Nanook Consulting.  All rights reserved.";
 
 # Override the defaults if some values are set in the environment
-$my_search_name = $ENV{OMPI_COPYRIGHT_SEARCH_NAME}
-    if (defined($ENV{OMPI_COPYRIGHT_SEARCH_NAME}));
-$my_formal_name = $ENV{OMPI_COPYRIGHT_FORMAL_NAME}
-    if (defined($ENV{OMPI_COPYRIGHT_FORMAL_NAME}));
-$my_manual_list = $ENV{OMPI_COPYRIGHT_MANUAL_LIST}
-    if (defined($ENV{OMPI_COPYRIGHT_MANUAL_LIST}));
+$my_search_name = $ENV{PRTE_COPYRIGHT_SEARCH_NAME}
+    if (defined($ENV{PRTE_COPYRIGHT_SEARCH_NAME}));
+$my_formal_name = $ENV{PRTE_COPYRIGHT_FORMAL_NAME}
+    if (defined($ENV{PRTE_COPYRIGHT_FORMAL_NAME}));
 
 GetOptions(
     "help" => \$HELP,
@@ -128,31 +118,13 @@ quiet_print "==> This year: $year\n";
 
 # Find the top-level source tree dir in a git repo
 my $start = cwd();
-my $top = $start;
-while (! -d "$top/.git") {
-    chdir("..");
-    $top = cwd();
-    die "Can't find top-level repository directory"
-        if ($top eq "/");
-}
-chdir($start);
+my $top = `git rev-parse --show-toplevel`;
+chomp($top);
 
 quiet_print "==> Top-level repository dir: $top\n";
 quiet_print "==> Current directory: $start\n";
 
-# Select VCS used to obtain modification info.  Choose in increasing priority
-# order (last hit wins).
-my $vcs;
-$vcs = "git"
-    if (-d "$top/.git");
-$vcs = "hg"
-    if (-d "$top/.hg");
-$vcs = "svn"
-    if (-d "$top/.svn");
-$vcs = "manual"
-    if ("$my_manual_list" ne "");
-
-my @files = find_modified_files($vcs);
+my @files = find_modified_files();
 
 if ($#files < 0) {
     quiet_print "No added / changed files -- nothing to do\n";
@@ -284,98 +256,65 @@ if ($CHECK_ONLY and $would_replace) {
 
 #-------------------------------------------------------------------------------
 
-# Takes two arguments, the top level directory and the VCS method.  Returns a
-# list of file names (relative to pwd) which the VCS considers to be modified.
+# Returns a list of file names (relative to pwd) which git considers
+# to be modified.
 sub find_modified_files {
-    my $vcs = shift;
     my @files = ();
 
-    if ($vcs eq "git") {
-        # Number of path entries to remove from ${top}-relative paths.
-        # (--show-cdup either returns the empty string or sequence of "../"
-        # entries, always ending in a "/")
-        my $n_strip = scalar(split(m!/!, scalar(`git rev-parse --show-cdup`))) - 1;
+    # Number of path entries to remove from ${top}-relative paths.
+    # (--show-cdup either returns the empty string or sequence of "../"
+    # entries, always ending in a "/")
+    my $n_strip = scalar(split(m!/!, scalar(`git rev-parse --show-cdup`))) - 1;
 
-        # "." restricts scope, but does not get us relative path names
-        my $cmd = "git status -z --porcelain --untracked-files=no .";
-        quiet_print "==> Running: \"$cmd\"\n";
-        my $lines = `$cmd`;
+    # "." restricts scope, but does not get us relative path names
+    my $cmd = "git status -z --porcelain --untracked-files=no .";
+    quiet_print "==> Running: \"$cmd\"\n";
+    my $lines = `$cmd`;
 
-        # From git-status(1):
-        # X          Y     Meaning
-        # -------------------------------------------------
-        #           [MD]   not updated
-        # M        [ MD]   updated in index
-        # A        [ MD]   added to index
-        # D         [ M]   deleted from index
-        # R        [ MD]   renamed in index
-        # C        [ MD]   copied in index
-        # [MARC]           index and work tree matches
-        # [ MARC]     M    work tree changed since index
-        # [ MARC]     D    deleted in work tree
-        # -------------------------------------------------
-        # D           D    unmerged, both deleted
-        # A           U    unmerged, added by us
-        # U           D    unmerged, deleted by them
-        # U           A    unmerged, added by them
-        # D           U    unmerged, deleted by us
-        # A           A    unmerged, both added
-        # U           U    unmerged, both modified
-        # -------------------------------------------------
-        # ?           ?    untracked
-        # -------------------------------------------------
-        foreach my $line (split /\x{00}/, $lines) {
-            my $keep = 0;
-            my ($s1, $s2, $fullname) = $line =~ m/^(.)(.) (.*)$/;
+    # From git-status(1):
+    # X          Y     Meaning
+    # -------------------------------------------------
+    #           [MD]   not updated
+    # M        [ MD]   updated in index
+    # A        [ MD]   added to index
+    # D         [ M]   deleted from index
+    # R        [ MD]   renamed in index
+    # C        [ MD]   copied in index
+    # [MARC]           index and work tree matches
+    # [ MARC]     M    work tree changed since index
+    # [ MARC]     D    deleted in work tree
+    # -------------------------------------------------
+    # D           D    unmerged, both deleted
+    # A           U    unmerged, added by us
+    # U           D    unmerged, deleted by them
+    # U           A    unmerged, added by them
+    # D           U    unmerged, deleted by us
+    # A           A    unmerged, both added
+    # U           U    unmerged, both modified
+    # -------------------------------------------------
+    # ?           ?    untracked
+    # -------------------------------------------------
+    foreach my $line (split /\x{00}/, $lines) {
+        my $keep = 0;
+        my ($s1, $s2, $fullname) = $line =~ m/^(.)(.) (.*)$/;
 
-            # ignore all merge cases
-            next if ($s1 eq "D" and $s2 eq "D");
-            next if ($s1 eq "A" and $s2 eq "A");
-            next if ($s1 eq "U" or $s2 eq "U");
+        # ignore all merge cases
+        next if ($s1 eq "D" and $s2 eq "D");
+        next if ($s1 eq "A" and $s2 eq "A");
+        next if ($s1 eq "U" or $s2 eq "U");
 
-            # only update for actually added/modified cases, no copies,
-            # renames, etc.
-            $keep = 1 if ($s1 eq "M" or $s2 eq "M");
-            $keep = 1 if ($s1 eq "A");
+        # only update for actually added/modified cases, no copies,
+        # renames, etc.
+        $keep = 1 if ($s1 eq "M" or $s2 eq "M");
+        $keep = 1 if ($s1 eq "A");
 
-            if ($keep) {
-                my $relname = $fullname;
-                $relname =~ s!^([^/]*/){$n_strip}!!g;
+        if ($keep) {
+            my $relname = $fullname;
+            $relname =~ s!^([^/]*/){$n_strip}!!g;
 
-                push @files, $relname
-                    if (-f $relname);
-            }
+            push @files, $relname
+                if (-f $relname);
         }
-    }
-    elsif ($vcs eq "hg" or $vcs eq "svn") {
-        my $cmd = "$vcs st .";
-
-        # Run the command, parsing the output.  Make a list of files that are
-        # added or modified.
-        quiet_print "==> Running: \"$cmd\"\n";
-        open(CMD, "$cmd|") || die "Can't run command";
-        while (<CMD>) {
-            chomp;
-            if ($_ =~ /^M/ || $_ =~ /^A/) {
-                my @tokens = split(/\s+/, $_);
-                # Handle output of both forms:
-                # M       filenameA
-                # A  +    filenameB
-                my $filename = $tokens[1];
-                $filename = $tokens[2]
-                if ($tokens[1] =~ /\+/);
-                # Don't bother saving directory names
-                push(@files, $filename)
-                    if (-f $filename);
-            }
-        }
-        close(CMD);
-    }
-    elsif ($vcs eq "manual") {
-        @files = split(/\n/, `cat $my_manual_list`);
-    }
-    else {
-        die "unknown VCS '$vcs', stopped";
     }
 
     return @files;


### PR DESCRIPTION
Ported from an OMPI contribution by Jeff Squyres (part of https://github.com/open-mpi/ompi/pull/13599):

```text
update-my-copyright.py: properly support git workspaces

Don't search for a .git directory; it might not exist.

Also, remove unnecessary Mercurial and Subversion support; we haven't
used these for years.

```