### PR TITLE
Update the directive list in check_multi

### DIFF
--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -30,6 +30,7 @@
 #include "src/util/pmix_basename.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/prte_cmd_line.h"
 
 prte_schizo_base_module_t *prte_schizo_base_detect_proxy(char *cmdpath)
 {
@@ -70,10 +71,10 @@ PRTE_EXPORT void prte_schizo_base_root_error_msg(void)
 static bool check_multi(const char *target)
 {
     char *multi_dirs[] = {
-        "display",
-        "output",
-        "tune",
-        "runtime-options",
+        PRTE_CLI_DISPLAY,
+        PRTE_CLI_OUTPUT,
+        PRTE_CLI_TUNE,
+        PRTE_CLI_RTOS,
         NULL
     };
     int n;


### PR DESCRIPTION
When checking for multiple directives, need to use the "rtos" directive instead of "runtime-options". Change to using the definitions for the directives to ensure this follows along.

Fixes #2375 