### PR TITLE
Use session_dir_finalize to preserve output files

### DIFF
--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1541,7 +1541,7 @@ static void abort_signal_callback(int fd)
         second = false;
     } else {
         surekill();  // ensure we attempt to kill everything
-        pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, NULL);
+        prte_job_session_dir_finalize(NULL);
         exit(1);
     }
 }

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -46,6 +46,7 @@
 #include "src/runtime/runtime.h"
 #include "src/util/name_fns.h"
 #include "src/util/proc_info.h"
+#include "src/util/session_dir.h"
 
 int prte_finalize(void)
 {
@@ -79,7 +80,7 @@ int prte_finalize(void)
     prte_finalizing = true;
 
     // we always must cleanup the session directory tree
-    pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, NULL);
+    prte_job_session_dir_finalize(NULL);
 
 #ifdef PRTE_PICKY_COMPILERS
     /* release the cache */

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -293,6 +293,7 @@ void prte_job_session_dir_finalize(prte_job_t *jdata)
         if (prte_finalizing) {
             if (NULL != prte_process_info.top_session_dir) {
                 pmix_os_dirpath_destroy(prte_process_info.top_session_dir, true, _check_file);
+                /* if the top session dir is now empty, remove it */
                 rmdir(prte_process_info.top_session_dir);
                 free(prte_process_info.top_session_dir);
                 prte_process_info.top_session_dir = NULL;


### PR DESCRIPTION
Don't hard-destroy the session dir tree - ensure we preserve any output files.