### PR TITLE
Remove the "compat" macro definitions

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -366,14 +366,14 @@ int main(int argc, char **argv)
         goto done;
     }
     /* split the returned string to get the rank of each local peer */
-    peers = PMIX_ARGV_SPLIT_COMPAT(val->data.string, ',');
+    peers = PMIx_Argv_split(val->data.string, ',');
     PMIX_VALUE_RELEASE(val);
-    nlocal = PMIX_ARGV_COUNT_COMPAT(peers);
+    nlocal = PMIx_Argv_count(peers);
     if (nprocs == nlocal) {
         all_local = true;
     } else {
         all_local = false;
-        locals = (pmix_rank_t *) malloc(PMIX_ARGV_COUNT_COMPAT(peers) * sizeof(pmix_rank_t));
+        locals = (pmix_rank_t *) malloc(PMIx_Argv_count(peers) * sizeof(pmix_rank_t));
         for (n = 0; NULL != peers[n]; n++) {
             locals[n] = strtoul(peers[n], NULL, 10);
         }

--- a/examples/debugger/debugger.h
+++ b/examples/debugger/debugger.h
@@ -94,30 +94,3 @@ typedef struct {
     int exit_code;
     bool exit_code_given;
 } myrel_t;
-
-#define PMIX_ARGV_JOIN_COMPAT(a, b) \
-        PMIx_Argv_join(a, b)
-
-#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
-        PMIx_Argv_split(a, b)
-
-#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
-        PMIx_Argv_split_with_empty(a, b)
-
-#define PMIX_ARGV_COUNT_COMPAT(a) \
-        PMIx_Argv_count(a)
-
-#define PMIX_ARGV_FREE_COMPAT(a) \
-        PMIx_Argv_free(a)
-
-#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
-        PMIx_Argv_append_unique_nosize(a, b)
-
-#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
-        PMIx_Argv_append_nosize(a, b)
-
-#define PMIX_ARGV_COPY_COMPAT(a) \
-        PMIx_Argv_copy(a)
-
-#define PMIX_SETENV_COMPAT(a, b, c, d) \
-        PMIx_Setenv(a, b, c, d)

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
         }
     }
     if (!found) {
-        char *tmp = PMIX_ARGV_JOIN_COMPAT(launchers, ',');
+        char *tmp = PMIx_Argv_join(launchers, ',');
         fprintf(stderr, "Wrong test, dude - unknown launcher\n");
         fprintf(stderr, "Known launchers: %s\n", tmp);
         free(tmp);

--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
@@ -131,14 +131,14 @@ int main(int argc, char **argv)
         goto done;
     }
     /* split the returned string to get the rank of each local peer */
-    peers = PMIX_ARGV_SPLIT_COMPAT(val->data.string, ',');
+    peers = PMIx_Argv_split(val->data.string, ',');
     PMIX_VALUE_RELEASE(val);
-    nlocal = PMIX_ARGV_COUNT_COMPAT(peers);
+    nlocal = PMIx_Argv_count(peers);
     if (nprocs == nlocal) {
         all_local = true;
     } else {
         all_local = false;
-        locals = (pmix_rank_t *) malloc(PMIX_ARGV_COUNT_COMPAT(peers) * sizeof(pmix_rank_t));
+        locals = (pmix_rank_t *) malloc(PMIx_Argv_count(peers) * sizeof(pmix_rank_t));
         for (n = 0; NULL != peers[n]; n++) {
             locals[n] = strtoul(peers[n], NULL, 10);
         }

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -138,30 +138,3 @@ static inline void examples_hide_unused_params(int x, ...)
     va_start(ap, x);
     va_end(ap);
 }
-
-#define PMIX_ARGV_JOIN_COMPAT(a, b) \
-        PMIx_Argv_join(a, b)
-
-#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
-        PMIx_Argv_split(a, b)
-
-#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
-        PMIx_Argv_split_with_empty(a, b)
-
-#define PMIX_ARGV_COUNT_COMPAT(a) \
-        PMIx_Argv_count(a)
-
-#define PMIX_ARGV_FREE_COMPAT(a) \
-        PMIx_Argv_free(a)
-
-#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
-        PMIx_Argv_append_unique_nosize(a, b)
-
-#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
-        PMIx_Argv_append_nosize(a, b)
-
-#define PMIX_ARGV_COPY_COMPAT(a) \
-        PMIx_Argv_copy(a)
-
-#define PMIX_SETENV_COMPAT(a, b, c, d) \
-        PMIx_Setenv(a, b, c, d)

--- a/examples/server.c
+++ b/examples/server.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -274,14 +274,14 @@ int main(int argc, char **argv)
         PMIX_ARGV_APPEND_COMPAT(&atmp, tmp);
         free(tmp);
     }
-    tmp = PMIX_ARGV_JOIN_COMPAT(atmp, ',');
-    PMIX_ARGV_FREE_COMPAT(atmp);
+    tmp = PMIx_Argv_join(atmp, ',');
+    PMIx_Argv_free(atmp);
     /* register the nspace */
     x = PMIX_NEW(myxfer_t);
     set_namespace(nprocs, tmp, "foobar", opcbfunc, x);
 
     /* set common argv and env */
-    client_env = PMIX_ARGV_COPY_COMPAT(environ);
+    client_env = PMIx_Argv_copy(environ);
     pmix_argv_prepend_nosize(&client_argv, executable);
 
     wakeup = nprocs;
@@ -345,8 +345,8 @@ int main(int argc, char **argv)
         }
     }
     free(executable);
-    PMIX_ARGV_FREE_COMPAT(client_argv);
-    PMIX_ARGV_FREE_COMPAT(client_env);
+    PMIx_Argv_free(client_argv);
+    PMIx_Argv_free(client_env);
 
     /* hang around until the client(s) finalize */
     while (0 < wakeup) {

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -581,7 +581,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
     if (NULL != ptr) {
         *ptr = '\0';
         ++ptr;
-        quals = PMIX_ARGV_SPLIT_COMPAT(ptr, ':');
+        quals = PMIx_Argv_split(ptr, ':');
         for (i = 0; NULL != quals[i]; i++) {
             if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_IF_SUPP)) {
                 tmp |= PRTE_BIND_IF_SUPPORTED;
@@ -616,7 +616,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                     /* missing the value or value is invalid */
                     pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                    "binding limit", "LIMIT", quals[i]);
-                    PMIX_ARGV_FREE_COMPAT(quals);
+                    PMIx_Argv_free(quals);
                     return PRTE_ERR_SILENT;
                 }
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_BINDING_LIMIT, PRTE_ATTR_GLOBAL,
@@ -625,12 +625,12 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
             } else {
                 /* unknown option */
                 pmix_show_help("help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
-                PMIX_ARGV_FREE_COMPAT(quals);
+                PMIx_Argv_free(quals);
                 free(myspec);
                 return PRTE_ERR_BAD_PARAM;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(quals);
+        PMIx_Argv_free(quals);
     }
 
     if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NONE)) {

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -135,14 +135,14 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
     char tmp[256];
 
     /* find the specified logical cpus */
-    ranges = PMIX_ARGV_SPLIT_COMPAT(*cpulist, ',');
+    ranges = PMIx_Argv_split(*cpulist, ',');
     avail = hwloc_bitmap_alloc();
     hwloc_bitmap_zero(avail);
     res = hwloc_bitmap_alloc();
     pucpus = hwloc_bitmap_alloc();
-    for (idx = 0; idx < PMIX_ARGV_COUNT_COMPAT(ranges); idx++) {
-        range = PMIX_ARGV_SPLIT_COMPAT(ranges[idx], '-');
-        switch (PMIX_ARGV_COUNT_COMPAT(range)) {
+    for (idx = 0; idx < PMIx_Argv_count(ranges); idx++) {
+        range = PMIx_Argv_split(ranges[idx], '-');
+        switch (PMIx_Argv_count(range)) {
         case 1:
             /* only one cpu given - get that object */
             cpu = strtoul(range[0], NULL, 10);
@@ -151,9 +151,9 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
                 pmix_show_help("help-prte-hwloc-base.txt", "unfound-cpu", true,
                                *cpulist, cpu, "logical",
                                use_hwthread_cpus ? "hwthread" : "core");
-                PMIX_ARGV_FREE_COMPAT(ranges);
-                PMIX_ARGV_FREE_COMPAT(range);
-                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIx_Argv_free(ranges);
+                PMIx_Argv_free(range);
+                PMIx_Argv_free(cache);
                 hwloc_bitmap_free(avail);
                 hwloc_bitmap_free(res);
                 hwloc_bitmap_free(pucpus);
@@ -163,7 +163,7 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
             hwloc_bitmap_or(res, avail, pucpus);
             hwloc_bitmap_copy(avail, res);
             // cache the cpu
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, range[0]);
+            PMIx_Argv_append_nosize(&cache, range[0]);
             break;
         case 2:
             /* range given */
@@ -175,9 +175,9 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
                     pmix_show_help("help-prte-hwloc-base.txt", "unfound-cpu", true,
                                    cpulist, cpu, "logical",
                                    use_hwthread_cpus ? "hwthread" : "core");
-                    PMIX_ARGV_FREE_COMPAT(ranges);
-                    PMIX_ARGV_FREE_COMPAT(range);
-                    PMIX_ARGV_FREE_COMPAT(cache);
+                    PMIx_Argv_free(ranges);
+                    PMIx_Argv_free(range);
+                    PMIx_Argv_free(cache);
                     hwloc_bitmap_free(avail);
                     hwloc_bitmap_free(res);
                     hwloc_bitmap_free(pucpus);
@@ -188,23 +188,23 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
                 hwloc_bitmap_copy(avail, res);
                 // cache the cpu
                 snprintf(tmp, 256, "%d", cpu);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, tmp);
+                PMIx_Argv_append_nosize(&cache, tmp);
             }
             break;
         default:
             break;
         }
-        PMIX_ARGV_FREE_COMPAT(range);
+        PMIx_Argv_free(range);
     }
     if (NULL != ranges) {
-        PMIX_ARGV_FREE_COMPAT(ranges);
+        PMIx_Argv_free(ranges);
     }
     hwloc_bitmap_free(res);
     hwloc_bitmap_free(pucpus);
     // update the cpulist in case it was expanded
     free(*cpulist);
-    *cpulist = PMIX_ARGV_JOIN_COMPAT(cache, ',');
-    PMIX_ARGV_FREE_COMPAT(cache);
+    *cpulist = PMIx_Argv_join(cache, ',');
+    PMIx_Argv_free(cache);
 
     return avail;
 }
@@ -682,8 +682,8 @@ static int package_to_cpu_set(char *cpus, hwloc_topology_t topo, hwloc_bitmap_t 
         return PRTE_SUCCESS;
     }
 
-    range = PMIX_ARGV_SPLIT_COMPAT(cpus, '-');
-    range_cnt = PMIX_ARGV_COUNT_COMPAT(range);
+    range = PMIx_Argv_split(cpus, '-');
+    range_cnt = PMIx_Argv_count(range);
     switch (range_cnt) {
     case 1: /* no range was present, so just one package given */
         package_id = atoi(range[0]);
@@ -703,10 +703,10 @@ static int package_to_cpu_set(char *cpus, hwloc_topology_t topo, hwloc_bitmap_t 
         }
         break;
     default:
-        PMIX_ARGV_FREE_COMPAT(range);
+        PMIx_Argv_free(range);
         return PRTE_ERROR;
     }
-    PMIX_ARGV_FREE_COMPAT(range);
+    PMIx_Argv_free(range);
 
     return PRTE_SUCCESS;
 }
@@ -725,13 +725,13 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
     unsigned int npus;
     bool hwthreadcpus = false;
 
-    package_core = PMIX_ARGV_SPLIT_COMPAT(package_core_list, ':');
+    package_core = PMIx_Argv_split(package_core_list, ':');
     package_id = atoi(package_core[0]);
 
     /* get the object for this package id */
     package = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, package_id);
     if (NULL == package) {
-        PMIX_ARGV_FREE_COMPAT(package_core);
+        PMIx_Argv_free(package_core);
         return PRTE_ERR_NOT_FOUND;
     }
 
@@ -759,12 +759,12 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
             rc = PRTE_SUCCESS;
             break;
         } else {
-            range = PMIX_ARGV_SPLIT_COMPAT(corestr, '-');
-            range_cnt = PMIX_ARGV_COUNT_COMPAT(range);
+            range = PMIx_Argv_split(corestr, '-');
+            range_cnt = PMIx_Argv_count(range);
             /* see if a range was set or not */
             switch (range_cnt) {
             case 1: /* only one core, or a list of cores, specified */
-                list = PMIX_ARGV_SPLIT_COMPAT(range[0], ',');
+                list = PMIx_Argv_split(range[0], ',');
                 for (j = 0; NULL != list[j]; j++) {
                     /* get the indexed core from this package */
                     core_id = atoi(list[j]) + npus;
@@ -777,7 +777,7 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
                     /* get the cpus */
                     hwloc_bitmap_or(cpumask, cpumask, core->cpuset);
                 }
-                PMIX_ARGV_FREE_COMPAT(list);
+                PMIx_Argv_free(list);
                 break;
 
             case 2: /* range of core id's was given */
@@ -800,14 +800,14 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
                 break;
 
             default:
-                PMIX_ARGV_FREE_COMPAT(range);
-                PMIX_ARGV_FREE_COMPAT(package_core);
+                PMIx_Argv_free(range);
+                PMIx_Argv_free(package_core);
                 return PRTE_ERROR;
             }
-            PMIX_ARGV_FREE_COMPAT(range);
+            PMIx_Argv_free(range);
         }
     }
-    PMIX_ARGV_FREE_COMPAT(package_core);
+    PMIx_Argv_free(package_core);
 
     return rc;
 }
@@ -833,7 +833,7 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
     pmix_output_verbose(5, prte_hwloc_base_output, "slot assignment: slot_list == %s", slot_str);
 
     /* split at ';' */
-    item = PMIX_ARGV_SPLIT_COMPAT(slot_str, ';');
+    item = PMIx_Argv_split(slot_str, ';');
 
     /* start with a clean mask */
     hwloc_bitmap_zero(cpumask);
@@ -853,15 +853,15 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                  * it could specify multiple packages
                  * Skip the P and look for ranges
                  */
-                rngs = PMIX_ARGV_SPLIT_COMPAT(&item[i][1], ',');
+                rngs = PMIx_Argv_split(&item[i][1], ',');
                 for (j = 0; NULL != rngs[j]; j++) {
                     if (PRTE_SUCCESS != (rc = package_to_cpu_set(rngs[j], topo, cpumask))) {
-                        PMIX_ARGV_FREE_COMPAT(rngs);
-                        PMIX_ARGV_FREE_COMPAT(item);
+                        PMIx_Argv_free(rngs);
+                        PMIx_Argv_free(item);
                         return rc;
                     }
                 }
-                PMIX_ARGV_FREE_COMPAT(rngs);
+                PMIx_Argv_free(rngs);
             } else {
                 if ('P' == item[i][0] || 'p' == item[i][0] || 'S' == item[i][0]
                     || 's' == item[i][0]) {
@@ -870,34 +870,34 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                     lst = item[i];
                 }
                 if (PRTE_SUCCESS != (rc = package_core_to_cpu_set(lst, topo, cpumask))) {
-                    PMIX_ARGV_FREE_COMPAT(item);
+                    PMIx_Argv_free(item);
                     return rc;
                 }
             }
         } else {
-            rngs = PMIX_ARGV_SPLIT_COMPAT(item[i], ',');
+            rngs = PMIx_Argv_split(item[i], ',');
             for (k = 0; NULL != rngs[k]; k++) {
                 /* just a core specification - see if one or a range was given */
-                range = PMIX_ARGV_SPLIT_COMPAT(rngs[k], '-');
-                range_cnt = PMIX_ARGV_COUNT_COMPAT(range);
+                range = PMIx_Argv_split(rngs[k], '-');
+                range_cnt = PMIx_Argv_count(range);
                 /* see if a range was set or not */
                 switch (range_cnt) {
                 case 1: /* only one core, or a list of cores, specified */
-                    list = PMIX_ARGV_SPLIT_COMPAT(range[0], ',');
+                    list = PMIx_Argv_split(range[0], ',');
                     for (j = 0; NULL != list[j]; j++) {
                         core_id = atoi(list[j]);
                         /* find the specified available cpu */
                         if (NULL == (pu = prte_hwloc_base_get_pu(topo, use_hwthread_cpus, core_id))) {
-                            PMIX_ARGV_FREE_COMPAT(range);
-                            PMIX_ARGV_FREE_COMPAT(item);
-                            PMIX_ARGV_FREE_COMPAT(rngs);
-                            PMIX_ARGV_FREE_COMPAT(list);
+                            PMIx_Argv_free(range);
+                            PMIx_Argv_free(item);
+                            PMIx_Argv_free(rngs);
+                            PMIx_Argv_free(list);
                             return PRTE_ERR_NOT_FOUND;
                         }
                         /* get the cpus for that object and set them in the massk*/
                         hwloc_bitmap_or(cpumask, cpumask, pu->cpuset);
                     }
-                    PMIX_ARGV_FREE_COMPAT(list);
+                    PMIx_Argv_free(list);
                     break;
 
                 case 2: /* range of core id's was given */
@@ -906,9 +906,9 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                     for (core_id = lower_range; core_id <= upper_range; core_id++) {
                         /* find the specified logical available cpu */
                         if (NULL == (pu = prte_hwloc_base_get_pu(topo, use_hwthread_cpus, core_id))) {
-                            PMIX_ARGV_FREE_COMPAT(range);
-                            PMIX_ARGV_FREE_COMPAT(item);
-                            PMIX_ARGV_FREE_COMPAT(rngs);
+                            PMIx_Argv_free(range);
+                            PMIx_Argv_free(item);
+                            PMIx_Argv_free(rngs);
                             return PRTE_ERR_NOT_FOUND;
                         }
                         /* get the cpus for that object and set them in the mask*/
@@ -917,17 +917,17 @@ int prte_hwloc_base_cpu_list_parse(const char *slot_str, hwloc_topology_t topo,
                     break;
 
                 default:
-                    PMIX_ARGV_FREE_COMPAT(range);
-                    PMIX_ARGV_FREE_COMPAT(item);
-                    PMIX_ARGV_FREE_COMPAT(rngs);
+                    PMIx_Argv_free(range);
+                    PMIx_Argv_free(item);
+                    PMIx_Argv_free(rngs);
                     return PRTE_ERROR;
                 }
-                PMIX_ARGV_FREE_COMPAT(range);
+                PMIx_Argv_free(range);
             }
-            PMIX_ARGV_FREE_COMPAT(rngs);
+            PMIx_Argv_free(rngs);
         }
     }
-    PMIX_ARGV_FREE_COMPAT(item);
+    PMIx_Argv_free(item);
     return PRTE_SUCCESS;
 }
 
@@ -1085,15 +1085,15 @@ char *prte_hwloc_base_find_coprocessors(hwloc_topology_t topo)
                     PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output,
                                          "hwloc:base:find_coprocessors: coprocessor %s found",
                                          osdev->infos[i].value));
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cps, osdev->infos[i].value);
+                    PMIx_Argv_append_nosize(&cps, osdev->infos[i].value);
                 }
             }
         }
         osdev = osdev->next_cousin;
     }
     if (NULL != cps) {
-        cpstring = PMIX_ARGV_JOIN_COMPAT(cps, ',');
-        PMIX_ARGV_FREE_COMPAT(cps);
+        cpstring = PMIx_Argv_join(cps, ',');
+        PMIx_Argv_free(cps);
     }
     PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output,
                          "hwloc:base:find_coprocessors: hosting coprocessors %s",
@@ -1622,16 +1622,16 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
             if (PRTE_SUCCESS == complete) {
                 snprintf(ans, 4096, "package[%d][%s]", n, tmp);
             } else {
-                PMIX_ARGV_FREE_COMPAT(output);
+                PMIx_Argv_free(output);
                 return NULL;
             }
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&output, ans);
+        PMIx_Argv_append_nosize(&output, ans);
     }
 
     if (NULL != output) {
-        result = PMIX_ARGV_JOIN_COMPAT(output, ' ');
-        PMIX_ARGV_FREE_COMPAT(output);
+        result = PMIx_Argv_join(output, ' ');
+        PMIx_Argv_free(output);
     } else {
         result = NULL;
     }
@@ -1651,10 +1651,10 @@ static char* construct_range(char **vals)
     for (n=0; NULL != vals[n]; n++) {
         if (NULL == vals[n+1]) {
             if (1 == cnt) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, vals[n]);
+                PMIx_Argv_append_nosize(&ans, vals[n]);
             } else {
                 snprintf(buf, 4096, "%d:%s", cnt, vals[n]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, buf);
+                PMIx_Argv_append_nosize(&ans, buf);
             }
             break;
         }
@@ -1662,16 +1662,16 @@ static char* construct_range(char **vals)
             cnt++;
         } else {
             if (1 == cnt) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, vals[n]);
+                PMIx_Argv_append_nosize(&ans, vals[n]);
             } else {
                 snprintf(buf, 4096, "%d:%s", cnt, vals[n]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, buf);
+                PMIx_Argv_append_nosize(&ans, buf);
             }
             cnt = 1;
         }
     }
 
-    str = PMIX_ARGV_JOIN_COMPAT(ans, ',');
+    str = PMIx_Argv_join(ans, ',');
     return str;
 }
 
@@ -1697,13 +1697,13 @@ char *prte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
             hwloc_bitmap_and(available, avail, obj->cpuset);
             ncpus = hwloc_bitmap_weight(available);
             snprintf(buffer, 4096, "%u", ncpus);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&scratch, buffer);
+            PMIx_Argv_append_nosize(&scratch, buffer);
         }
         sig = construct_range(scratch);
         snprintf(buffer, 4096, "PKG[%s]", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(scratch);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&answer, buffer);
+        PMIx_Argv_free(scratch);
+        PMIx_Argv_append_nosize(&answer, buffer);
         // now account for NUMA
         scratch = NULL;
         nobjs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_NUMANODE);
@@ -1712,13 +1712,13 @@ char *prte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
             hwloc_bitmap_and(available, avail, obj->cpuset);
             ncpus = hwloc_bitmap_weight(available);
             snprintf(buffer, 4096, "%u", ncpus);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&scratch, buffer);
+            PMIx_Argv_append_nosize(&scratch, buffer);
         }
         sig = construct_range(scratch);
         snprintf(buffer, 4096, "NUMA[%s]", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(scratch);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&answer, buffer);
+        PMIx_Argv_free(scratch);
+        PMIx_Argv_append_nosize(&answer, buffer);
         // L3caches
         scratch = NULL;
         nobjs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_L3CACHE);
@@ -1727,13 +1727,13 @@ char *prte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
             hwloc_bitmap_and(available, avail, obj->cpuset);
             ncpus = hwloc_bitmap_weight(available);
             snprintf(buffer, 4096, "%u", ncpus);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&scratch, buffer);
+            PMIx_Argv_append_nosize(&scratch, buffer);
         }
         sig = construct_range(scratch);
         snprintf(buffer, 4096, "L3[%s]", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(scratch);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&answer, buffer);
+        PMIx_Argv_free(scratch);
+        PMIx_Argv_append_nosize(&answer, buffer);
         // L2caches
         scratch = NULL;
         nobjs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_L2CACHE);
@@ -1742,13 +1742,13 @@ char *prte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
             hwloc_bitmap_and(available, avail, obj->cpuset);
             ncpus = hwloc_bitmap_weight(available);
             snprintf(buffer, 4096, "%u", ncpus);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&scratch, buffer);
+            PMIx_Argv_append_nosize(&scratch, buffer);
         }
         sig = construct_range(scratch);
         snprintf(buffer, 4096, "L2[%s]", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(scratch);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&answer, buffer);
+        PMIx_Argv_free(scratch);
+        PMIx_Argv_append_nosize(&answer, buffer);
         // L1caches
         scratch = NULL;
         nobjs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_L1CACHE);
@@ -1757,18 +1757,18 @@ char *prte_hwloc_base_get_topo_signature(hwloc_topology_t topo)
             hwloc_bitmap_and(available, avail, obj->cpuset);
             ncpus = hwloc_bitmap_weight(available);
             snprintf(buffer, 4096, "%u", ncpus);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&scratch, buffer);
+            PMIx_Argv_append_nosize(&scratch, buffer);
         }
         sig = construct_range(scratch);
         snprintf(buffer, 4096, "L1[%s]", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(scratch);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&answer, buffer);
+        PMIx_Argv_free(scratch);
+        PMIx_Argv_append_nosize(&answer, buffer);
         // setup the signature
-        sig = PMIX_ARGV_JOIN_COMPAT(answer, ';');
+        sig = PMIx_Argv_join(answer, ';');
         snprintf(buffer, 4096, "%s", sig);
         free(sig);
-        PMIX_ARGV_FREE_COMPAT(answer);
+        PMIx_Argv_free(answer);
         hwloc_bitmap_free(avail);
     }
 
@@ -1994,14 +1994,14 @@ char *prte_hwloc_base_get_location(char *locality, hwloc_obj_type_t type, unsign
     default:
         return NULL;
     }
-    loc = PMIX_ARGV_SPLIT_COMPAT(locality, ':');
+    loc = PMIx_Argv_split(locality, ':');
     for (n = 0; NULL != loc[n]; n++) {
         if (0 == strncmp(loc[n], srch, 2)) {
             ans = strdup(&loc[n][2]);
             break;
         }
     }
-    PMIX_ARGV_FREE_COMPAT(loc);
+    PMIx_Argv_free(loc);
 
     return ans;
 }
@@ -2024,8 +2024,8 @@ prte_hwloc_locality_t prte_hwloc_compute_relative_locality(char *loc1, char *loc
         return locality;
     }
 
-    set1 = PMIX_ARGV_SPLIT_COMPAT(loc1, ':');
-    set2 = PMIX_ARGV_SPLIT_COMPAT(loc2, ':');
+    set1 = PMIx_Argv_split(loc1, ':');
+    set2 = PMIx_Argv_split(loc2, ':');
     bit1 = hwloc_bitmap_alloc();
     bit2 = hwloc_bitmap_alloc();
 
@@ -2064,8 +2064,8 @@ prte_hwloc_locality_t prte_hwloc_compute_relative_locality(char *loc1, char *loc
             }
         }
     }
-    PMIX_ARGV_FREE_COMPAT(set1);
-    PMIX_ARGV_FREE_COMPAT(set2);
+    PMIx_Argv_free(set1);
+    PMIx_Argv_free(set2);
     hwloc_bitmap_free(bit1);
     hwloc_bitmap_free(bit2);
     return locality;

--- a/src/mca/ess/base/ess_base_bootstrap.c
+++ b/src/mca/ess/base/ess_base_bootstrap.c
@@ -234,7 +234,7 @@ cleanup:
         free(dvmnodes);
     }
     if (NULL != nodes) {
-        PMIX_ARGV_FREE_COMPAT(nodes);
+        PMIx_Argv_free(nodes);
     }
     if (NULL != dvmtmpdir) {
         free(dvmtmpdir);
@@ -384,7 +384,7 @@ static pmix_status_t regex_extract_nodes(char *regexp, char ***names)
             }
         } else {
             /* If we didn't find a range, just add the value */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(names, base);
+            PMIx_Argv_append_nosize(names, base);
             /* step over the comma */
             i++;
             /* set base equal to the (possible) next base to look at */
@@ -546,7 +546,7 @@ static pmix_status_t regex_parse_value_range(char *base, char *range, int num_di
         if (NULL != suffix) {
             strcat(str, suffix);
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(names, str);
+        PMIx_Argv_append_nosize(names, str);
     }
     free(str);
 
@@ -569,7 +569,7 @@ static pmix_status_t read_file(char *regexp, char ***names)
             free(line);
             continue;
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(names, line);
+        PMIx_Argv_append_nosize(names, line);
         free(line);
     }
     fclose(fp);

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -229,7 +229,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
     }
 
     /* see what they asked for - ignore any duplicates */
-    signals = PMIX_ARGV_SPLIT_COMPAT(mysignals, ',');
+    signals = PMIx_Argv_split(mysignals, ',');
     for (i = 0; NULL != signals[i]; i++) {
         sval = 0;
         if (0 != strncasecmp(signals[i], "SIG", 3)) {
@@ -239,7 +239,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
             if (0 != errno || '\0' != *tmp) {
                 pmix_show_help("help-ess-base.txt", "ess-base:unknown-signal", true,
                                signals[i], mysignals);
-                PMIX_ARGV_FREE_COMPAT(signals);
+                PMIx_Argv_free(signals);
                 return PMIX_ERR_SILENT;
             }
             // see if it's a known signal number
@@ -262,7 +262,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
                     if (!known_signals[j].can_forward) {
                         pmix_show_help("help-ess-base.txt", "ess-base:cannot-forward", true,
                                        known_signals[j].signame, mysignals);
-                        PMIX_ARGV_FREE_COMPAT(signals);
+                        PMIx_Argv_free(signals);
                         return PMIX_ERR_SILENT;
                     }
                     found = true;
@@ -274,7 +274,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
             if (!found) {
                 pmix_show_help("help-ess-base.txt", "ess-base:unknown-signal", true,
                                signals[i], mysignals);
-                PMIX_ARGV_FREE_COMPAT(signals);
+                PMIx_Argv_free(signals);
                 return PMIX_ERR_SILENT;
             }
         }
@@ -298,7 +298,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
         ESS_ADDSIGNAL(sval, sname);
     }
 
-    PMIX_ARGV_FREE_COMPAT(signals);
+    PMIx_Argv_free(signals);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -191,7 +191,7 @@ static int rte_init(int argc, char **argv)
     /* every job requires at least one app */
     app = PMIX_NEW(prte_app_context_t);
     app->app = strdup(argv[0]);
-    app->argv = PMIX_ARGV_COPY_COMPAT(argv);
+    app->argv = PMIx_Argv_copy(argv);
     app->job = (struct prte_job_t*)jdata;
     pmix_pointer_array_set_item(jdata->apps, 0, app);
     jdata->num_apps++;
@@ -255,7 +255,7 @@ static int rte_init(int argc, char **argv)
     pmix_ifgetaliases(&prte_process_info.aliases);
 
     /* get our aliases - will include all the interface aliases captured in prte_init */
-    node->aliases = PMIX_ARGV_COPY_COMPAT(prte_process_info.aliases);
+    node->aliases = PMIx_Argv_copy(prte_process_info.aliases);
 
     /* if we are using xml for output, put a start tag */
     if (prte_xml_output) {

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -280,7 +280,7 @@ static int raw_preposition_files(prte_job_t *jdata,
         if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES,
                                (void **) &filestring, PMIX_STRING) &&
             NULL != filestring) {
-            files = PMIX_ARGV_SPLIT_COMPAT(filestring, ',');
+            files = PMIx_Argv_split(filestring, ',');
             free(filestring);
             for (j = 0; NULL != files[j]; j++) {
                 fs = PMIX_NEW(prte_filem_base_file_set_t);
@@ -369,11 +369,11 @@ static int raw_preposition_files(prte_job_t *jdata,
             /* replace the app's file list with the revised one so we
              * can find them on the remote end
              */
-            filestring = PMIX_ARGV_JOIN_COMPAT(files, ',');
+            filestring = PMIx_Argv_join(files, ',');
             prte_set_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES, PRTE_ATTR_GLOBAL,
                                filestring, PMIX_STRING);
             /* cleanup for the next app */
-            PMIX_ARGV_FREE_COMPAT(files);
+            PMIx_Argv_free(files);
             free(filestring);
         }
     }
@@ -622,13 +622,13 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
     if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_FILES,
                            (void **) &filestring, PMIX_STRING) &&
         NULL != filestring) {
-        files = PMIX_ARGV_SPLIT_COMPAT(filestring, ',');
+        files = PMIx_Argv_split(filestring, ',');
         free(filestring);
     }
     if (prte_get_attribute(&app->attributes, PRTE_APP_PRELOAD_BIN, NULL, PMIX_BOOL)) {
         /* add the app itself to the list */
         bname = pmix_basename(app->app);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&files, bname);
+        PMIx_Argv_append_nosize(&files, bname);
         free(bname);
     }
 
@@ -708,7 +708,7 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
         }
         free(path);
     }
-    PMIX_ARGV_FREE_COMPAT(files);
+    PMIx_Argv_free(files);
     return PRTE_SUCCESS;
 }
 
@@ -895,7 +895,7 @@ static int link_archive(prte_filem_raw_incoming_t *inbnd)
         PMIX_OUTPUT_VERBOSE((10, prte_filem_base_framework.framework_output,
                              "%s filem:raw: adding path %s to link points",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), path));
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&inbnd->link_pts, path);
+        PMIx_Argv_append_nosize(&inbnd->link_pts, path);
     }
     /* close */
     pclose(fp);
@@ -1097,7 +1097,7 @@ static void write_handler(int fd, short event, void *cbdata)
                 /* just link to the top as this will be the
                  * name we will want in each proc's session dir
                  */
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&sink->link_pts, sink->top);
+                PMIx_Argv_append_nosize(&sink->link_pts, sink->top);
                 send_complete(sink->file, PRTE_SUCCESS);
             } else {
                 /* unarchive the file */
@@ -1264,7 +1264,7 @@ static void in_destruct(prte_filem_raw_incoming_t *ptr)
     if (NULL != ptr->fullpath) {
         free(ptr->fullpath);
     }
-    PMIX_ARGV_FREE_COMPAT(ptr->link_pts);
+    PMIx_Argv_free(ptr->link_pts);
     PMIX_LIST_DESTRUCT(&ptr->outputs);
 }
 PMIX_CLASS_INSTANCE(prte_filem_raw_incoming_t,

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -138,7 +138,7 @@ void prte_odls_base_harvest_threads(void)
         prte_odls_globals.ev_bases[0] = prte_event_base;
         prte_odls_globals.num_threads = 0;
         if (NULL != prte_odls_globals.ev_threads) {
-            PMIX_ARGV_FREE_COMPAT(prte_odls_globals.ev_threads);
+            PMIx_Argv_free(prte_odls_globals.ev_threads);
             prte_odls_globals.ev_threads = NULL;
         }
     }
@@ -196,7 +196,7 @@ startup:
         for (i = 0; i < prte_odls_globals.num_threads; i++) {
             pmix_asprintf(&tmp, "PRTE-ODLS-%d", i);
             prte_odls_globals.ev_bases[i] = prte_progress_thread_init(tmp);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.ev_threads, tmp);
+            PMIx_Argv_append_nosize(&prte_odls_globals.ev_threads, tmp);
             free(tmp);
         }
     }
@@ -264,7 +264,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
         /* construct a list of ranks to be displayed */
         xterm_hold = false;
         pmix_util_parse_range_options(prte_xterm, &ranks);
-        for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ranks); i++) {
+        for (i = 0; i < PMIx_Argv_count(ranks); i++) {
             if (0 == strcmp(ranks[i], "BANG")) {
                 xterm_hold = true;
                 continue;
@@ -288,21 +288,21 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
             }
             pmix_list_append(&prte_odls_globals.xterm_ranks, &nm->super);
         }
-        PMIX_ARGV_FREE_COMPAT(ranks);
+        PMIx_Argv_free(ranks);
         /* construct the xtermcmd */
         prte_odls_globals.xtermcmd = NULL;
         tmp = pmix_find_absolute_path("xterm");
         if (NULL == tmp) {
             return PRTE_ERROR;
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, tmp);
+        PMIx_Argv_append_nosize(&prte_odls_globals.xtermcmd, tmp);
         free(tmp);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-T");
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "save");
+        PMIx_Argv_append_nosize(&prte_odls_globals.xtermcmd, "-T");
+        PMIx_Argv_append_nosize(&prte_odls_globals.xtermcmd, "save");
         if (xterm_hold) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-hold");
+            PMIx_Argv_append_nosize(&prte_odls_globals.xtermcmd, "-hold");
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_odls_globals.xtermcmd, "-e");
+        PMIx_Argv_append_nosize(&prte_odls_globals.xtermcmd, "-e");
     }
 
     /* Open up all available components */
@@ -347,10 +347,10 @@ static void scdes(prte_odls_spawn_caddy_t *p)
         free(p->wdir);
     }
     if (NULL != p->argv) {
-        PMIX_ARGV_FREE_COMPAT(p->argv);
+        PMIx_Argv_free(p->argv);
     }
     if (NULL != p->env) {
-        PMIX_ARGV_FREE_COMPAT(p->env);
+        PMIx_Argv_free(p->env);
     }
 }
 PMIX_CLASS_INSTANCE(prte_odls_spawn_caddy_t,

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -409,14 +409,14 @@ void prte_plm_base_stack_trace_recv(int status, pmix_proc_t *sender,
         pmix_asprintf(&st, "STACK TRACE FOR PROC %s (%s, PID %lu)\n",
                       PRTE_NAME_PRINT(&name), hostname,
                       (unsigned long) pid);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->traces, st);
+        PMIx_Argv_append_nosize(&jdata->traces, st);
         free(hostname);
         free(st);
         /* unpack the stack_trace until complete */
         cnt = 1;
         while (PRTE_SUCCESS == (rc = PMIx_Data_unpack(NULL, &blob, &st, &cnt, PMIX_STRING))) {
             pmix_asprintf(&st2, "\t%s", st); // has its own newline
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->traces, st2);
+            PMIx_Argv_append_nosize(&jdata->traces, st2);
             free(st);
             free(st2);
             cnt = 1;
@@ -972,7 +972,7 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
                 free(name);
             }
             /* pass the argv from each app */
-            name = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
+            name = PMIx_Argv_join(app->argv, ' ');
             PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_APP_ARGV, name, PMIX_STRING);
             free(name);
         }
@@ -1468,7 +1468,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             NULL != (ptr = strchr(nodename, '.'))) {
             /* retain the non-fqdn name as an alias */
             *ptr = '\0';
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&daemon->node->aliases, nodename);
+            PMIx_Argv_append_unique_nosize(&daemon->node->aliases, nodename);
             *ptr = '.';
         }
 
@@ -1490,7 +1490,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
          * and apps may refer to the host by that name
          */
         if (0 != strcmp(nodename, daemon->node->name)) {
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&daemon->node->aliases, daemon->node->name);
+            PMIx_Argv_append_unique_nosize(&daemon->node->aliases, daemon->node->name);
             free(daemon->node->name);
             daemon->node->name = strdup(nodename);
         }
@@ -2006,14 +2006,14 @@ int prte_plm_base_setup_prted_cmd(int *argc, char ***argv)
      */
     loc = 0;
     /* split the command apart in case it is multi-word */
-    tmpv = PMIX_ARGV_SPLIT_COMPAT(prte_launch_agent, ' ');
+    tmpv = PMIx_Argv_split(prte_launch_agent, ' ');
     for (i = 0; NULL != tmpv && NULL != tmpv[i]; ++i) {
         if (0 == strcmp(tmpv[i], "prted")) {
             loc = i;
         }
         pmix_argv_append(argc, argv, tmpv[i]);
     }
-    PMIX_ARGV_FREE_COMPAT(tmpv);
+    PMIx_Argv_free(tmpv);
 
     return loc;
 }
@@ -2106,7 +2106,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     for (i=0; NULL != environ[i]; i++) {
         if (0 == strncmp(environ[i], "PMIX_MCA_", offset) ||
             0 == strncmp(environ[i], "PRTE_MCA_", offset)) {
-            tmpv = PMIX_ARGV_SPLIT_COMPAT(environ[i], '=');
+            tmpv = PMIx_Argv_split(environ[i], '=');
             /* check for duplicate */
             ignore = false;
             for (j = 0; j < *argc; j++) {
@@ -2125,7 +2125,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
                 pmix_argv_append(argc, argv, &tmpv[0][offset]);
                 pmix_argv_append(argc, argv, tmpv[1]);
             }
-            PMIX_ARGV_FREE_COMPAT(tmpv);
+            PMIx_Argv_free(tmpv);
         }
     }
 
@@ -2133,7 +2133,7 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
      * being sure to "purge" any that would cause problems
      * on backend nodes and ignoring all duplicates
      */
-    cnt = PMIX_ARGV_COUNT_COMPAT(prted_cmd_line);
+    cnt = PMIx_Argv_count(prted_cmd_line);
     for (i = 0; i < cnt; i += 3) {
         /* if the specified option is more than one word, we don't
          * have a generic way of passing it as some environments ignore

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -312,9 +312,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
 
         /* assign a schizo module */
         if (NULL == jdata->personality) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jdata->personality, "prte");
+            PMIx_Argv_append_nosize(&jdata->personality, "prte");
         }
-        tmp = PMIX_ARGV_JOIN_COMPAT(jdata->personality, ',');
+        tmp = PMIx_Argv_join(jdata->personality, ',');
         jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(tmp);
         if (NULL == jdata->schizo) {
             pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, tmp);

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -18,7 +18,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -299,7 +299,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_wrap_args(argv);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        param = PMIx_Argv_join(argv, ' ');
         if (NULL != param) {
             pmix_output(0, "plm:lsf: final top-level argv:");
             pmix_output(0, "plm:lsf:     %s", param);
@@ -309,7 +309,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* setup environment - this is the pristine version that PRRTE
      * has already stripped of all PRTE_ and PMIX_ prefixed values */
-    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
+    env = PMIx_Argv_copy(prte_launch_environ);
 
     /*
      * Any prefix was installed in the DAEMON job object, so
@@ -331,7 +331,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:lsf: resetting PATH: %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
-        PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
+        PMIx_Setenv("PATH", newenv, true, &env);
         free(newenv);
         // set the library path
         param = getenv("LD_LIBRARY_PATH");
@@ -343,10 +343,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:lsf: resetting LD_LIBRARY_PATH: %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
-        PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+        PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
         free(newenv);
         // add the prefix itself to the environment
-        PMIX_SETENV_COMPAT("PRTE_PREFIX", cur_prefix, true, &env);
+        PMIx_Setenv("PRTE_PREFIX", cur_prefix, true, &env);
         free(cur_prefix);
         free(bin_base);
         free(lib_base);
@@ -365,10 +365,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:lsf: resetting LD_LIBRARY_PATH: %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), newenv));
-        PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+        PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
         free(newenv);
         // add the prefix itself to the environment
-        PMIX_SETENV_COMPAT("PMIX_PREFIX", pmix_prefix, true, &env);
+        PMIx_Setenv("PMIX_PREFIX", pmix_prefix, true, &env);
         free(pmix_prefix);
         free(lib_base);
     }
@@ -389,9 +389,9 @@ static void launch_daemons(int fd, short args, void *cbdata)
     if ((rc = lsb_launch(nodelist_argv, argv, LSF_DJOB_REPLACE_ENV | LSF_DJOB_NOWAIT, env)) < 0) {
         PRTE_ERROR_LOG(PRTE_ERR_FAILED_TO_START);
         char *flattened_nodelist = NULL;
-        flattened_nodelist = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, '\n');
+        flattened_nodelist = PMIx_Argv_join(nodelist_argv, '\n');
         pmix_show_help("help-plm-lsf.txt", "lsb_launch-failed", true, rc, lsberrno, lsb_sysmsg(),
-                       PMIX_ARGV_COUNT_COMPAT(nodelist_argv), flattened_nodelist);
+                       PMIx_Argv_count(nodelist_argv), flattened_nodelist);
         free(flattened_nodelist);
         rc = PRTE_ERR_FAILED_TO_START;
         prte_wait_enable(); /* re-enable our SIGCHLD handler */
@@ -408,10 +408,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
 cleanup:
     if (NULL != argv) {
-        PMIX_ARGV_FREE_COMPAT(argv);
+        PMIx_Argv_free(argv);
     }
     if (NULL != env) {
-        PMIX_ARGV_FREE_COMPAT(env);
+        PMIx_Argv_free(env);
     }
 
     /* check for failed launch - if so, force terminate */

--- a/src/mca/plm/pals/plm_pals_module.c
+++ b/src/mca/plm/pals/plm_pals_module.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023-2024 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -254,12 +254,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* Append user defined arguments to aprun */
     if (NULL != prte_mca_plm_pals_component.custom_args) {
-        custom_strings = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_pals_component.custom_args, ' ');
-        num_args = PMIX_ARGV_COUNT_COMPAT(custom_strings);
+        custom_strings = PMIx_Argv_split(prte_mca_plm_pals_component.custom_args, ' ');
+        num_args = PMIx_Argv_count(custom_strings);
         for (i = 0; i < num_args; ++i) {
             pmix_argv_append(&argc, &argv, custom_strings[i]);
         }
-        PMIX_ARGV_FREE_COMPAT(custom_strings);
+        PMIx_Argv_free(custom_strings);
     }
 
     /* number of processors needed */
@@ -298,13 +298,13 @@ static void launch_daemons(int fd, short args, void *cbdata)
              */
             pmix_argv_append(&nodelist_argc, &nodelist_argv, node->name);
         }
-        if (0 == PMIX_ARGV_COUNT_COMPAT(nodelist_argv)) {
+        if (0 == PMIx_Argv_count(nodelist_argv)) {
             pmix_show_help("help-plm-pals.txt", "no-hosts-in-list", true);
             rc = PRTE_ERR_FAILED_TO_START;
             goto cleanup;
         }
-        nodelist_flat = PMIX_ARGV_JOIN_COMPAT(nodelist_argv, ',');
-        PMIX_ARGV_FREE_COMPAT(nodelist_argv);
+        nodelist_flat = PMIx_Argv_join(nodelist_argv, ',');
+        PMIx_Argv_free(nodelist_argv);
 
         pmix_argv_append(&argc, &argv, "-L");
         pmix_argv_append(&argc, &argv, nodelist_flat);
@@ -336,7 +336,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     free(vpid_string);
 
     if (prte_mca_plm_pals_component.debug) {
-        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        param = PMIx_Argv_join(argv, ' ');
         if (NULL != param) {
             pmix_output(0, "plm:pals: final top-level argv:");
             pmix_output(0, "plm:pals:     %s", param);
@@ -363,10 +363,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     /* setup environment - this is the pristine version that PRRTE
      * has already stripped of all PRTE_ and PMIX_ prefixed values */
-    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
+    env = PMIx_Argv_copy(prte_launch_environ);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        param = PMIx_Argv_join(argv, ' ');
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:pals: final top-level argv:\n\t%s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (NULL == param) ? "NULL" : param));
@@ -389,10 +389,10 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
 cleanup:
     if (NULL != argv) {
-        PMIX_ARGV_FREE_COMPAT(argv);
+        PMIx_Argv_free(argv);
     }
     if (NULL != env) {
-        PMIX_ARGV_FREE_COMPAT(env);
+        PMIx_Argv_free(env);
     }
 
     /* check for failed launch - if so, force terminate */
@@ -550,7 +550,7 @@ static int plm_pals_start_proc(int argc, char **argv, char **env,
             } else {
                 pmix_asprintf(&newenv, "%s/%s", prefix, bin_base);
             }
-            PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
+            PMIx_Setenv("PATH", newenv, true, &env);
             if (prte_mca_plm_pals_component.debug) {
                 pmix_output(0, "plm:pals: reset PATH: %s", newenv);
             }
@@ -563,13 +563,13 @@ static int plm_pals_start_proc(int argc, char **argv, char **env,
             } else {
                 pmix_asprintf(&newenv, "%s/%s", prefix, lib_base);
             }
-            PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+            PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
             if (prte_mca_plm_pals_component.debug) {
                 pmix_output(0, "plm:pals: reset LD_LIBRARY_PATH: %s", newenv);
             }
             free(newenv);
             // add the prefix itself to the environment
-            PMIX_SETENV_COMPAT("PRTE_PREFIX", prefix, true, &env);
+            PMIx_Setenv("PRTE_PREFIX", prefix, true, &env);
         }
 
         /* for pmix_prefix, we only have to modify the library path.
@@ -585,13 +585,13 @@ static int plm_pals_start_proc(int argc, char **argv, char **env,
                 pmix_asprintf(&newenv, "%s/%s", pmix_prefix, p);
             }
             free(p);
-            PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+            PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
             if (prte_mca_plm_pals_component.debug) {
                 pmix_output(0, "plm:pals: reset LD_LIBRARY_PATH: %s", newenv);
             }
             free(newenv);
             // add the prefix itself to the environment
-            PMIX_SETENV_COMPAT("PMIX_PREFIX", pmix_prefix, true, &env);
+            PMIx_Setenv("PMIX_PREFIX", pmix_prefix, true, &env);
         }
 
         fd = open("/dev/null", O_CREAT | O_WRONLY | O_TRUNC, 0666);

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -20,7 +20,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -350,9 +350,9 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
         pmix_string_copy(cwd, path, PRTE_PATH_MAX);
     }
     if (NULL == agent_list) {
-        lines = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_ssh_component.agent, ':');
+        lines = PMIx_Argv_split(prte_mca_plm_ssh_component.agent, ':');
     } else {
-        lines = PMIX_ARGV_SPLIT_COMPAT(agent_list, ':');
+        lines = PMIx_Argv_split(agent_list, ':');
     }
     for (i = 0; NULL != lines[i]; ++i) {
         line = lines[i];
@@ -369,23 +369,23 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
         }
 
         /* Split it */
-        tokens = PMIX_ARGV_SPLIT_COMPAT(line, ' ');
+        tokens = PMIx_Argv_split(line, ' ');
 
         /* Look for the first token in the PATH */
         tmp = pmix_path_findv(tokens[0], X_OK, environ, cwd);
         if (NULL != tmp) {
             free(tokens[0]);
             tokens[0] = tmp;
-            PMIX_ARGV_FREE_COMPAT(lines);
+            PMIx_Argv_free(lines);
             return tokens;
         }
 
         /* Didn't find it */
-        PMIX_ARGV_FREE_COMPAT(tokens);
+        PMIx_Argv_free(tokens);
     }
 
     /* Doh -- didn't find anything */
-    PMIX_ARGV_FREE_COMPAT(lines);
+    PMIx_Argv_free(lines);
     return NULL;
 }
 
@@ -424,7 +424,7 @@ static int ssh_launch_agent_lookup(const char *agent_list, char *path)
     if (0 == strcmp(bname, "ssh")) {
         /* if xterm option was given, add '-X', ensuring we don't do it twice */
         if (NULL != prte_xterm) {
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_mca_plm_ssh_component.agent_argv, "-X");
+            PMIx_Argv_append_unique_nosize(&prte_mca_plm_ssh_component.agent_argv, "-X");
         } else if (0 >= pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
             /* if debug was not specified, and the user didn't explicitly
              * specify X11 forwarding/non-forwarding, add "-x" if it
@@ -436,7 +436,7 @@ static int ssh_launch_agent_lookup(const char *agent_list, char *path)
                 }
             }
             if (NULL == prte_mca_plm_ssh_component.agent_argv[i]) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_mca_plm_ssh_component.agent_argv, "-x");
+                PMIx_Argv_append_nosize(&prte_mca_plm_ssh_component.agent_argv, "-x");
             }
         }
     }

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,7 +129,7 @@ static void caddy_const(prte_plm_ssh_caddy_t *ptr)
 static void caddy_dest(prte_plm_ssh_caddy_t *ptr)
 {
     if (NULL != ptr->argv) {
-        PMIX_ARGV_FREE_COMPAT(ptr->argv);
+        PMIx_Argv_free(ptr->argv);
     }
     if (NULL != ptr->daemon) {
         PMIX_RELEASE(ptr->daemon);
@@ -191,14 +191,14 @@ static int ssh_init(void)
         }
         free(tmp);
         /* automatically add -inherit and grid engine PE related flags */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-inherit");
+        PMIx_Argv_append_nosize(&ssh_agent_argv, "-inherit");
         /* Don't use the "-noshell" flag as qrsh would have a problem
          * swallowing a long command */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-nostdin");
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-V");
+        PMIx_Argv_append_nosize(&ssh_agent_argv, "-nostdin");
+        PMIx_Argv_append_nosize(&ssh_agent_argv, "-V");
         if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-verbose");
-            tmp = PMIX_ARGV_JOIN_COMPAT(ssh_agent_argv, ' ');
+            PMIx_Argv_append_nosize(&ssh_agent_argv, "-verbose");
+            tmp = PMIx_Argv_join(ssh_agent_argv, ' ');
             pmix_output_verbose(1, prte_plm_base_framework.framework_output,
                                 "%s plm:ssh: using \"%s\" for launching\n",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), tmp);
@@ -395,16 +395,16 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     /*
      * Build argv array
      */
-    argv = PMIX_ARGV_COPY_COMPAT(ssh_agent_argv);
-    argc = PMIX_ARGV_COUNT_COMPAT(argv);
+    argv = PMIx_Argv_copy(ssh_agent_argv);
+    argc = PMIx_Argv_count(argv);
     /* if any ssh args were provided, now is the time to add them */
     if (NULL != prte_mca_plm_ssh_component.ssh_args) {
         char **ssh_argv;
-        ssh_argv = PMIX_ARGV_SPLIT_COMPAT(prte_mca_plm_ssh_component.ssh_args, ' ');
+        ssh_argv = PMIx_Argv_split(prte_mca_plm_ssh_component.ssh_args, ' ');
         for (i = 0; NULL != ssh_argv[i]; i++) {
             pmix_argv_append(&argc, &argv, ssh_argv[i]);
         }
-        PMIX_ARGV_FREE_COMPAT(ssh_argv);
+        PMIx_Argv_free(ssh_argv);
     }
     *node_name_index1 = argc;
     pmix_argv_append(&argc, &argv, "<template>");
@@ -454,21 +454,21 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
          * However, we don't need/want a prefix as nothing precedes the orted
          * cmd itself
          */
-        orted_cmd = PMIX_ARGV_JOIN_COMPAT(orted_argv, ' ');
+        orted_cmd = PMIx_Argv_join(orted_argv, ' ');
         orted_prefix = NULL;
     } else {
         /* okay, so the "orted" cmd is somewhere in this array, with
          * something preceding it and perhaps things following it.
          */
         orted_prefix = pmix_argv_join_range(orted_argv, 0, orted_index, ' ');
-        orted_cmd = pmix_argv_join_range(orted_argv, orted_index, PMIX_ARGV_COUNT_COMPAT(orted_argv), ' ');
+        orted_cmd = pmix_argv_join_range(orted_argv, orted_index, PMIx_Argv_count(orted_argv), ' ');
     }
-    PMIX_ARGV_FREE_COMPAT(orted_argv); /* done with this */
+    PMIx_Argv_free(orted_argv); /* done with this */
 
     /* if they asked us to change directory, do so */
     if (NULL != prte_mca_plm_ssh_component.chdir) {
         pmix_asprintf(&tmp, "cd %s", prte_mca_plm_ssh_component.chdir);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+        PMIx_Argv_append_nosize(&final_argv, tmp);
         free(tmp);
     }
 
@@ -481,13 +481,13 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             PRTE_PLM_SSH_SHELL_BASH == remote_shell) {
             if (NULL != prefix_dir) {
                 pmix_asprintf(&tmp, "PRTE_PREFIX=%s", prefix_dir);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export PRTE_PREFIX");
+                PMIx_Argv_append_nosize(&final_argv, tmp);
+                PMIx_Argv_append_nosize(&final_argv, "export PRTE_PREFIX");
                 free(tmp);
                 if (NULL != pmix_prefix) {
                     pmix_asprintf(&tmp, "PMIX_PREFIX=%s", pmix_prefix);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export PMIX_PREFIX");
+                    PMIx_Argv_append_nosize(&final_argv, tmp);
+                    PMIx_Argv_append_nosize(&final_argv, "export PMIX_PREFIX");
                     free(tmp);
                     pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s/%s:%s/%s:$LD_LIBRARY_PATH",
                                   prefix_dir, value, pmix_prefix, value2);
@@ -498,14 +498,14 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             } else {
                 // pmix_prefix must not be NULL
                 pmix_asprintf(&tmp, "PMIX_PREFIX=%s", pmix_prefix);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export PMIX_PREFIX");
+                PMIx_Argv_append_nosize(&final_argv, tmp);
+                PMIx_Argv_append_nosize(&final_argv, "export PMIX_PREFIX");
                 free(tmp);
                 pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s/%s:$LD_LIBRARY_PATH",
                               pmix_prefix, value2);
             }
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export LD_LIBRARY_PATH");
+            PMIx_Argv_append_nosize(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, "export LD_LIBRARY_PATH");
             free(tmp);
             if (NULL != prefix_dir) {
                 if (NULL != pmix_prefix) {
@@ -520,8 +520,8 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "DYLD_LIBRARY_PATH=%s/%s:$DYLD_LIBRARY_PATH",
                               pmix_prefix, value2);
             }
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export DYLD_LIBRARY_PATH");
+            PMIx_Argv_append_nosize(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, "export DYLD_LIBRARY_PATH");
             free(tmp);
         } else {
             /* [t]csh is a bit more challenging -- we
@@ -538,20 +538,20 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
              */
             if (NULL != prefix_dir) {
                 pmix_asprintf(&tmp, "setenv PRTE_PREFIX %s", prefix_dir);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+                PMIx_Argv_append_nosize(&final_argv, tmp);
                 free(tmp);
                 if (NULL != pmix_prefix) {
                     pmix_asprintf(&tmp, "setenv PMIX_PREFIX %s", pmix_prefix);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+                    PMIx_Argv_append_nosize(&final_argv, tmp);
                     free(tmp);
                 }
             } else {
                 // pmix_prefix must not be NULL
                 pmix_asprintf(&tmp, "setenv PMIX_PREFIX %s", pmix_prefix);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+                PMIx_Argv_append_nosize(&final_argv, tmp);
                 free(tmp);
             }
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
+            PMIx_Argv_append_nosize(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
             if (NULL != prefix_dir) {
                 if (NULL != pmix_prefix) {
                     pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s/%s:%s/%s",
@@ -565,7 +565,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s/%s",
                               pmix_prefix, value2);
             }
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, tmp);
             free(tmp);
             if (NULL != prefix_dir) {
                 if (NULL != pmix_prefix) {
@@ -580,7 +580,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
                 pmix_asprintf(&tmp, "if ( $?PRTE_have_llp == 1 ) setenv LD_LIBRARY_PATH %s/%s:$LD_LIBRARY_PATH",
                               pmix_prefix, value2);
             }
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, tmp);
             free(tmp);
         }
         free(value);
@@ -596,12 +596,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
             PRTE_PLM_SSH_SHELL_ZSH == remote_shell ||
             PRTE_PLM_SSH_SHELL_BASH == remote_shell) {
             pmix_asprintf(&tmp, "LD_LIBRARY_PATH=%s:$LD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export LD_LIBRARY_PATH");
+            PMIx_Argv_append_nosize(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, "export LD_LIBRARY_PATH");
             free(tmp);
             pmix_asprintf(&tmp, "DYLD_LIBRARY_PATH=%s:$DYLD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "export DYLD_LIBRARY_PATH");
+            PMIx_Argv_append_nosize(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, "export DYLD_LIBRARY_PATH");
             free(tmp);
         } else {
             /* [t]csh is a bit more challenging -- we
@@ -616,12 +616,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
              * assemble the cmd with the orted_cmd at the end. Otherwise,
              * we have to insert the orted_prefix in the right place
              */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
+            PMIx_Argv_append_nosize(&final_argv, "if ( $?LD_LIBRARY_PATH == 1 ) set PRTE_have_llp");
             pmix_asprintf(&tmp, "if ( $?LD_LIBRARY_PATH == 0 ) setenv LD_LIBRARY_PATH %s", prte_mca_plm_ssh_component.pass_libpath);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, tmp);
             free(tmp);
             pmix_asprintf(&tmp, "if ( $?PRTE_have_llp == 1 ) setenv LD_LIBRARY_PATH %s:$LD_LIBRARY_PATH", prte_mca_plm_ssh_component.pass_libpath);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+            PMIx_Argv_append_nosize(&final_argv, tmp);
             free(tmp);
         }
     }
@@ -672,12 +672,12 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     } else {
         tmp = strdup(full_orted_cmd);
     }
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&final_argv, tmp);
+    PMIx_Argv_append_nosize(&final_argv, tmp);
     free(full_orted_cmd);
 
     /* now add the final cmd to the argv array */
-    final_cmd = PMIX_ARGV_JOIN_COMPAT(final_argv, ';');
-    PMIX_ARGV_FREE_COMPAT(final_argv);
+    final_cmd = PMIx_Argv_join(final_argv, ';');
+    PMIx_Argv_free(final_argv);
     pmix_argv_append(&argc, &argv, final_cmd);
     free(final_cmd); /* done with this */
 
@@ -719,7 +719,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     /* protect the params */
     prte_plm_base_wrap_args(argv);
 
-    value = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+    value = PMIx_Argv_join(argv, ' ');
     if (sysconf(_SC_ARG_MAX) < (int) strlen(value)) {
         pmix_show_help("help-plm-ssh.txt", "cmd-line-too-long", true, strlen(value),
                        sysconf(_SC_ARG_MAX));
@@ -733,7 +733,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     }
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        param = PMIx_Argv_join(argv, ' ');
         pmix_output(prte_plm_base_framework.framework_output,
                     "%s plm:ssh: final template argv:\n\t%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                     (NULL == param) ? "NULL" : param);
@@ -759,7 +759,7 @@ static void ssh_child(int argc, char **argv)
     PRTE_HIDE_UNUSED_PARAMS(argc);
 
     /* setup environment */
-    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
+    env = PMIx_Argv_copy(prte_launch_environ);
 
     /* We don't need to sense an oversubscribed condition and set the sched_yield
      * for the node as we are only launching the daemons at this time. The daemons
@@ -811,7 +811,7 @@ static void ssh_child(int argc, char **argv)
     sigprocmask(SIG_UNBLOCK, &sigs, 0);
 
     /* exec the daemon */
-    var = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+    var = PMIx_Argv_join(argv, ' ');
     PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                          "%s plm:ssh: executing: (%s) [%s]", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          exec_path, (NULL == var) ? "NULL" : var));
@@ -907,7 +907,7 @@ static int remote_spawn(void)
         /* we are in an event, so no need to protect the list */
         caddy = PMIX_NEW(prte_plm_ssh_caddy_t);
         caddy->argc = argc;
-        caddy->argv = PMIX_ARGV_COPY_COMPAT(argv);
+        caddy->argv = PMIx_Argv_copy(argv);
         /* fake a proc structure for the new daemon - will be released
          * upon startup
          */
@@ -931,7 +931,7 @@ static int remote_spawn(void)
 
 cleanup:
     if (NULL != argv) {
-        PMIX_ARGV_FREE_COMPAT(argv);
+        PMIx_Argv_free(argv);
     }
 
     /* check for failed launch */
@@ -1274,7 +1274,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         /* we are in an event, so no need to protect the list */
         caddy = PMIX_NEW(prte_plm_ssh_caddy_t);
         caddy->argc = argc;
-        caddy->argv = PMIX_ARGV_COPY_COMPAT(argv);
+        caddy->argv = PMIx_Argv_copy(argv);
         /* insert the alternate port if any */
         portptr = &port;
         if (prte_get_attribute(&node->attributes, PRTE_NODE_PORT, (void **) &portptr, PMIX_INT)) {
@@ -1307,7 +1307,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
      * function determine they are all alive and trigger the next stage
      */
     PMIX_RELEASE(state);
-    PMIX_ARGV_FREE_COMPAT(argv);
+    PMIx_Argv_free(argv);
     return;
 
 cleanup:
@@ -1373,8 +1373,8 @@ static int ssh_finalize(void)
     }
     free(prte_mca_plm_ssh_component.agent_path);
     free(ssh_agent_path);
-    PMIX_ARGV_FREE_COMPAT(prte_mca_plm_ssh_component.agent_argv);
-    PMIX_ARGV_FREE_COMPAT(ssh_agent_argv);
+    PMIx_Argv_free(prte_mca_plm_ssh_component.agent_argv);
+    PMIx_Argv_free(ssh_agent_argv);
 
     return rc;
 }
@@ -1436,7 +1436,7 @@ static int launch_agent_setup(const char *agent, char *path)
                          (NULL == path) ? "NULL" : path));
     ssh_agent_argv = prte_plm_ssh_search(agent, path);
 
-    if (0 == PMIX_ARGV_COUNT_COMPAT(ssh_agent_argv)) {
+    if (0 == PMIx_Argv_count(ssh_agent_argv)) {
         /* nothing was found */
         return PRTE_ERR_NOT_FOUND;
     }
@@ -1446,7 +1446,7 @@ static int launch_agent_setup(const char *agent, char *path)
 
     if (NULL == ssh_agent_path) {
         /* not an error - just report not found */
-        PMIX_ARGV_FREE_COMPAT(ssh_agent_argv);
+        PMIx_Argv_free(ssh_agent_argv);
         return PRTE_ERR_NOT_FOUND;
     }
 
@@ -1454,7 +1454,7 @@ static int launch_agent_setup(const char *agent, char *path)
     if (NULL != bname && 0 == strcmp(bname, "ssh")) {
         /* if xterm option was given, add '-X', ensuring we don't do it twice */
         if (NULL != prte_xterm) {
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&ssh_agent_argv, "-X");
+            PMIx_Argv_append_unique_nosize(&ssh_agent_argv, "-X");
         } else if (0 >= pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
             /* if debug was not specified, and the user didn't explicitly
              * specify X11 forwarding/non-forwarding, add "-x" if it
@@ -1466,7 +1466,7 @@ static int launch_agent_setup(const char *agent, char *path)
                 }
             }
             if (NULL == ssh_agent_argv[i]) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ssh_agent_argv, "-x");
+                PMIx_Argv_append_nosize(&ssh_agent_argv, "-x");
             }
         }
     }
@@ -1513,8 +1513,8 @@ static int ssh_probe(char *nodename, prte_plm_ssh_shell_t *shell)
             exit(01);
         }
         /* Build argv array */
-        argv = PMIX_ARGV_COPY_COMPAT(prte_mca_plm_ssh_component.agent_argv);
-        argc = PMIX_ARGV_COUNT_COMPAT(prte_mca_plm_ssh_component.agent_argv);
+        argv = PMIx_Argv_copy(prte_mca_plm_ssh_component.agent_argv);
+        argc = PMIx_Argv_count(prte_mca_plm_ssh_component.agent_argv);
         pmix_argv_append(&argc, &argv, nodename);
         pmix_argv_append(&argc, &argv, "echo $SHELL");
 
@@ -1652,14 +1652,14 @@ static int setup_shell(prte_plm_ssh_shell_t *sshell, prte_plm_ssh_shell_t *lshel
     if (PRTE_PLM_SSH_SHELL_SH == remote_shell || PRTE_PLM_SSH_SHELL_KSH == remote_shell) {
         int i;
         char **tmp;
-        tmp = PMIX_ARGV_SPLIT_COMPAT("( test ! -r ./.profile || . ./.profile;", ' ');
+        tmp = PMIx_Argv_split("( test ! -r ./.profile || . ./.profile;", ' ');
         if (NULL == tmp) {
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         for (i = 0; NULL != tmp[i]; ++i) {
             pmix_argv_append(argc, argv, tmp[i]);
         }
-        PMIX_ARGV_FREE_COMPAT(tmp);
+        PMIx_Argv_free(tmp);
     }
 
     /* pass results back */

--- a/src/mca/plm/tm/plm_tm_component.c
+++ b/src/mca/plm/tm/plm_tm_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -104,7 +104,7 @@ static int plm_tm_open(void)
 static int plm_tm_close(void)
 {
     if (NULL != prte_mca_plm_tm_component.checked_paths) {
-        PMIX_ARGV_FREE_COMPAT(prte_mca_plm_tm_component.checked_paths);
+        PMIx_Argv_free(prte_mca_plm_tm_component.checked_paths);
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/plm/tm/plm_tm_module.c
+++ b/src/mca/plm/tm/plm_tm_module.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -262,7 +262,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     prte_plm_base_prted_append_basic_args(&argc, &argv, "tm", &proc_vpid_index);
 
     if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-        param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+        param = PMIx_Argv_join(argv, ' ');
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:tm: final top-level argv:\n\t%s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (NULL == param) ? "NULL" : param));
@@ -292,16 +292,16 @@ static void launch_daemons(int fd, short args, void *cbdata)
     bin_base = pmix_basename(prte_install_dirs.bindir);
 
     /* setup environment */
-    env = PMIX_ARGV_COPY_COMPAT(prte_launch_environ);
+    env = PMIx_Argv_copy(prte_launch_environ);
 
     /* enable local launch by the orteds */
-    PMIX_SETENV_COMPAT("PRTE_MCA_plm", "ssh", true, &env);
+    PMIx_Setenv("PRTE_MCA_plm", "ssh", true, &env);
 
     /* add our umask -- see big note in orted.c */
     current_umask = umask(0);
     umask(current_umask);
     pmix_asprintf(&var, "0%o", current_umask);
-    PMIX_SETENV_COMPAT("PRTE_DAEMON_UMASK_VALUE", var, true, &env);
+    PMIx_Setenv("PRTE_DAEMON_UMASK_VALUE", var, true, &env);
     free(var);
 
     /*
@@ -322,7 +322,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         } else {
             pmix_asprintf(&newenv, "%s/%s", prefix_dir, bin_base);
         }
-        PMIX_SETENV_COMPAT("PATH", newenv, true, &env);
+        PMIx_Setenv("PATH", newenv, true, &env);
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "plm:tm: reset PATH: %s", newenv));
         free(newenv);
@@ -334,12 +334,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
         } else {
             pmix_asprintf(&newenv, "%s/%s", prefix_dir, lib_base);
         }
-        PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+        PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
         free(newenv);
         // add the prefix itself to the environment
-        PMIX_SETENV_COMPAT("PRTE_PREFIX", prefix_dir, true, &env);
+        PMIx_Setenv("PRTE_PREFIX", prefix_dir, true, &env);
         free(prefix_dir);
     }
 
@@ -357,12 +357,12 @@ static void launch_daemons(int fd, short args, void *cbdata)
             pmix_asprintf(&newenv, "%s/%s", pmix_prefix, p);
         }
         free(p);
-        PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", newenv, true, &env);
+        PMIx_Setenv("LD_LIBRARY_PATH", newenv, true, &env);
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "plm:tm: reset LD_LIBRARY_PATH: %s", newenv));
         free(newenv);
         // add the prefix itself to the environment
-        PMIX_SETENV_COMPAT("PMIX_PREFIX", pmix_prefix, true, &env);
+        PMIx_Setenv("PMIX_PREFIX", pmix_prefix, true, &env);
         free(pmix_prefix);
     }
 
@@ -395,7 +395,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
         /* exec the daemon */
         if (0 < pmix_output_get_verbosity(prte_plm_base_framework.framework_output)) {
-            param = PMIX_ARGV_JOIN_COMPAT(argv, ' ');
+            param = PMIx_Argv_join(argv, ' ');
             PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                  "%s plm:tm: executing:\n\t%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  (NULL == param) ? "NULL" : param));

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_component.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_component.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2019-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +80,7 @@ static int dlopen_component_register(void)
         return ret;
     }
     prte_mca_prtedl_dlopen_component.filename_suffixes
-        = PMIX_ARGV_SPLIT_COMPAT(prte_mca_prtedl_dlopen_component.filename_suffixes_mca_storage, ',');
+        = PMIx_Argv_split(prte_mca_prtedl_dlopen_component.filename_suffixes_mca_storage, ',');
 
     return PRTE_SUCCESS;
 }
@@ -93,7 +93,7 @@ static int dlopen_component_open(void)
 static int dlopen_component_close(void)
 {
     if (NULL != prte_mca_prtedl_dlopen_component.filename_suffixes) {
-        PMIX_ARGV_FREE_COMPAT(prte_mca_prtedl_dlopen_component.filename_suffixes);
+        PMIx_Argv_free(prte_mca_prtedl_dlopen_component.filename_suffixes);
         prte_mca_prtedl_dlopen_component.filename_suffixes = NULL;
     }
 

--- a/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
+++ b/src/mca/prtedl/dlopen/prtedl_dlopen_module.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -169,7 +169,7 @@ static int dlopen_foreachfile(const char *search_path,
     char **dirs = NULL;
     char **good_files = NULL;
 
-    dirs = PMIX_ARGV_SPLIT_COMPAT(search_path, PRTE_ENV_SEP);
+    dirs = PMIx_Argv_split(search_path, PRTE_ENV_SEP);
     for (int i = 0; NULL != dirs && NULL != dirs[i]; ++i) {
 
         dp = opendir(dirs[i]);
@@ -227,7 +227,7 @@ static int dlopen_foreachfile(const char *search_path,
             }
 
             if (!found) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&good_files, abs_name);
+                PMIx_Argv_append_nosize(&good_files, abs_name);
             }
             free(abs_name);
         }
@@ -252,10 +252,10 @@ error:
         closedir(dp);
     }
     if (NULL != dirs) {
-        PMIX_ARGV_FREE_COMPAT(dirs);
+        PMIx_Argv_free(dirs);
     }
     if (NULL != good_files) {
-        PMIX_ARGV_FREE_COMPAT(good_files);
+        PMIx_Argv_free(good_files);
     }
 
     return ret;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -69,28 +69,28 @@ char *prte_ras_base_flag_string(prte_node_t *node)
     }
 
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "DAEMON_LAUNCHED");
+        PMIx_Argv_append_nosize(&t2, "DAEMON_LAUNCHED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_LOC_VERIFIED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "LOCATION_VERIFIED");
+        PMIx_Argv_append_nosize(&t2, "LOCATION_VERIFIED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "OVERSUBSCRIBED");
+        PMIx_Argv_append_nosize(&t2, "OVERSUBSCRIBED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_MAPPED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "MAPPED");
+        PMIx_Argv_append_nosize(&t2, "MAPPED");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "SLOTS_GIVEN");
+        PMIx_Argv_append_nosize(&t2, "SLOTS_GIVEN");
     }
     if (PRTE_FLAG_TEST(node, PRTE_NODE_NON_USABLE)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&t2, "NONUSABLE");
+        PMIx_Argv_append_nosize(&t2, "NONUSABLE");
     }
     if (NULL != t2) {
-        t3 = PMIX_ARGV_JOIN_COMPAT(t2, ':');
+        t3 = PMIx_Argv_join(t2, ':');
         pmix_asprintf(&tmp, "Flags: %s", t3);
         free(t3);
-        PMIX_ARGV_FREE_COMPAT(t2);
+        PMIx_Argv_free(t2);
     } else {
         tmp = strdup("Flags: NONE");
     }
@@ -140,7 +140,7 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
             flgs = prte_ras_base_flag_string(alloc);
             /* build the aliases string */
             if (NULL != alloc->aliases) {
-                aliases = PMIX_ARGV_JOIN_COMPAT(alloc->aliases, ',');
+                aliases = PMIx_Argv_join(alloc->aliases, ',');
             } else {
                 aliases = NULL;
             }
@@ -280,7 +280,7 @@ void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist)
         return;
     }
 
-    nodes = PMIX_ARGV_SPLIT_COMPAT(nodelist, ';');
+    nodes = PMIx_Argv_split(nodelist, ';');
     for (j=0; NULL != nodes[j]; j++) {
         moveon = false;
         for (i=0; i < prte_node_pool->size && !moveon; i++) {
@@ -306,7 +306,7 @@ void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist)
             }
         }
     }
-    PMIX_ARGV_FREE_COMPAT(nodes);
+    PMIx_Argv_free(nodes);
 }
 
 
@@ -435,11 +435,11 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
                 if (prte_keep_fqdn_hostnames) {
                     /* retain the non-fqdn name as an alias */
                     *ptr = '\0';
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node->name);
+                    PMIx_Argv_append_unique_nosize(&node->aliases, node->name);
                     *ptr = '.';
                 } else {
                     /* add the fqdn name as an alias */
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node->name);
+                    PMIx_Argv_append_unique_nosize(&node->aliases, node->name);
                     /* retain the non-fqdn name as the node's name */
                     *ptr = '\0';
                 }
@@ -592,11 +592,11 @@ parsehostfile:
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), hosts));
 
             /* hostfile was specified - parse it and add it to the list */
-            hostlist = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
+            hostlist = PMIx_Argv_split(hosts, ',');
             free(hosts);
             for (j=0; NULL != hostlist[j]; j++) {
                 if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&nodes, hostlist[j]))) {
-                    PMIX_ARGV_FREE_COMPAT(hostlist);
+                    PMIx_Argv_free(hostlist);
                     PMIX_DESTRUCT(&nodes);
                     /* set an error event */
                     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
@@ -604,7 +604,7 @@ parsehostfile:
                     return;
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(hostlist);
+            PMIx_Argv_free(hostlist);
         }
     }
 
@@ -731,7 +731,7 @@ next_state:
     hosts = NULL;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_TOPO, (void**)&hosts, PMIX_STRING)) {
         if (NULL != hosts) {
-            hostlist = PMIX_ARGV_SPLIT_COMPAT(hosts, ';');
+            hostlist = PMIx_Argv_split(hosts, ';');
             free(hosts);
             for (j=0; NULL != hostlist[j]; j++) {
                 node = prte_node_match(NULL, hostlist[j]);
@@ -747,7 +747,7 @@ next_state:
                 pmix_output(prte_clean_output,
                             "=================================================================\n");
             }
-            PMIX_ARGV_FREE_COMPAT(hostlist);
+            PMIx_Argv_free(hostlist);
         } else {
             for (j=0; j < prte_node_pool->size; j++) {
                 node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, j);
@@ -895,7 +895,7 @@ proceed:
 
             prte_remove_attribute(&app->attributes, PRTE_APP_ADD_HOSTFILE);
 
-            hostfiles = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
+            hostfiles = PMIx_Argv_split(hosts, ',');
             free(hosts);
 
             for (k=0; NULL != hostfiles[k]; k++) {
@@ -906,7 +906,7 @@ proceed:
                 fp = fopen(hostfiles[k], "r");
                 if (NULL == fp) {
                     pmix_show_help("help-ras-base.txt", "ras-base:addhost-not-found", true, hostfiles[k]);
-                    PMIX_ARGV_FREE_COMPAT(hostfiles);
+                    PMIx_Argv_free(hostfiles);
                     PMIX_LIST_DESTRUCT(&nodes);
                     return PRTE_ERR_SILENT;
                 }
@@ -959,7 +959,7 @@ proceed:
                         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                         fclose(fp);
                         free(line);
-                        PMIX_ARGV_FREE_COMPAT(hostfiles);
+                        PMIx_Argv_free(hostfiles);
                         PMIX_LIST_DESTRUCT(&nodes);
                         return PRTE_ERR_SILENT;
                     }
@@ -1024,7 +1024,7 @@ proceed:
                 }
                 fclose(fp);
             }
-            PMIX_ARGV_FREE_COMPAT(hostfiles);
+            PMIx_Argv_free(hostfiles);
         }
     }
     if (!pmix_list_is_empty(&nodes)) {

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -147,12 +147,12 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
             }
             /* if the node name is different, store it as an alias */
             if (0 != strcmp(hnp_node->name, node->name)) {
-                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->name);
+                PMIx_Argv_append_unique_nosize(&hnp_node->aliases, node->name);
             }
              // transfer across any new aliases
             if (NULL != node->aliases) {
                 for (i=0; NULL != node->aliases[i]; i++) {
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&hnp_node->aliases, node->aliases[i]);
+                    PMIx_Argv_append_unique_nosize(&hnp_node->aliases, node->aliases[i]);
                 }
             }
             if (NULL != node->rawname) {

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2022 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,7 +105,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     }
 
     /* release the nodelist from lsf */
-    PMIX_ARGV_FREE_COMPAT(nodelist);
+    PMIx_Argv_free(nodelist);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,32 +62,32 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     bool use_hwthread_cpus = false;
     hwloc_cpuset_t available;
 
-    node_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.num_nodes, ',');
-    num_nodes = PMIX_ARGV_COUNT_COMPAT(node_cnt);
+    node_cnt = PMIx_Argv_split(prte_mca_ras_simulator_component.num_nodes, ',');
+    num_nodes = PMIx_Argv_count(node_cnt);
 
     if (NULL != prte_mca_ras_simulator_component.slots) {
-        slot_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.slots, ',');
+        slot_cnt = PMIx_Argv_split(prte_mca_ras_simulator_component.slots, ',');
         /* if they didn't provide a slot count for each node, then
          * backfill the slot_cnt so every node has a cnt */
-        nslots = PMIX_ARGV_COUNT_COMPAT(slot_cnt);
+        nslots = PMIx_Argv_count(slot_cnt);
         if (nslots < num_nodes) {
             // take the last one given and extend it to cover remaining nodes
             tmp = slot_cnt[nslots - 1];
             for (n = nslots; n < num_nodes; n++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&slot_cnt, tmp);
+                PMIx_Argv_append_nosize(&slot_cnt, tmp);
             }
         }
     }
     if (NULL != prte_mca_ras_simulator_component.slots_max) {
-        max_slot_cnt = PMIX_ARGV_SPLIT_COMPAT(prte_mca_ras_simulator_component.slots_max, ',');
+        max_slot_cnt = PMIx_Argv_split(prte_mca_ras_simulator_component.slots_max, ',');
         /* if they didn't provide a max slot count for each node, then
          * backfill the slot_cnt so every node has a cnt */
-        nslots = PMIX_ARGV_COUNT_COMPAT(max_slot_cnt);
+        nslots = PMIx_Argv_count(max_slot_cnt);
          if (nslots < num_nodes) {
             // take the last one given and extend it to cover remaining nodes
             tmp = max_slot_cnt[nslots - 1];
             for (n = nslots; n < num_nodes; n++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&max_slot_cnt, tmp);
+                PMIx_Argv_append_nosize(&max_slot_cnt, tmp);
             }
         }
     }
@@ -169,12 +169,12 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
                        NULL, PMIX_BOOL);
 
     if (NULL != max_slot_cnt) {
-        PMIX_ARGV_FREE_COMPAT(max_slot_cnt);
+        PMIx_Argv_free(max_slot_cnt);
     }
     if (NULL != slot_cnt) {
-        PMIX_ARGV_FREE_COMPAT(slot_cnt);
+        PMIx_Argv_free(slot_cnt);
     }
-    PMIX_ARGV_FREE_COMPAT(node_cnt);
+    PMIx_Argv_free(node_cnt);
     if (NULL != job_cpuset) {
         free(job_cpuset);
     }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -341,7 +341,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
                                  "%s ras:slurm:allocate:discover: found node %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), base));
 
-            if (PRTE_SUCCESS != (ret = PMIX_ARGV_APPEND_NOSIZE_COMPAT(&names, base))) {
+            if (PRTE_SUCCESS != (ret = PMIx_Argv_append_nosize(&names, base))) {
                 PRTE_ERROR_LOG(ret);
                 free(orig);
                 return ret;
@@ -353,7 +353,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
 
     free(orig);
 
-    num_nodes = PMIX_ARGV_COUNT_COMPAT(names);
+    num_nodes = PMIx_Argv_count(names);
 
     /* Find the number of slots per node */
 
@@ -439,7 +439,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         pmix_list_append(nodelist, &node->super);
     }
     free(slots);
-    PMIX_ARGV_FREE_COMPAT(names);
+    PMIx_Argv_free(names);
 
     /* All done */
     return ret;
@@ -585,7 +585,7 @@ static int prte_ras_slurm_parse_range(char *base, char *range, char ***names)
             str[j] = '\0';
         }
         strcat(str, temp1);
-        ret = PMIX_ARGV_APPEND_NOSIZE_COMPAT(names, str);
+        ret = PMIx_Argv_append_nosize(names, str);
         if (PRTE_SUCCESS != ret) {
             PRTE_ERROR_LOG(ret);
             free(str);

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -220,7 +220,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
         /* not enough cpus were specified */
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
-    cpus = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
+    cpus = PMIx_Argv_split(options->cpuset, ',');
     /* take the first one */
     idx = strtoul(cpus[0], NULL, 10);
     if (options->use_hwthreads) {
@@ -243,7 +243,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
         tset = root->cpuset;
         obj = hwloc_get_obj_inside_cpuset_by_type(node->topology->topo, tset, type, idx);
         if (NULL == obj) {
-            PMIX_ARGV_FREE_COMPAT(cpus);
+            PMIx_Argv_free(cpus);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         tset = obj->cpuset;
@@ -269,7 +269,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
                        prte_rmaps_base_print_mapping(jdata->map->mapping),
                        prte_hwloc_base_print_binding(jdata->map->binding),
                        options->cpuset);
-        PMIX_ARGV_FREE_COMPAT(cpus);
+        PMIx_Argv_free(cpus);
         return PRTE_ERR_SILENT;
     }
     /* bind to the specified cpuset */
@@ -281,9 +281,9 @@ static int bind_to_cpuset(prte_job_t *jdata,
     if (NULL == cpus[1]) {
         options->cpuset = NULL;
     } else {
-        options->cpuset = PMIX_ARGV_JOIN_COMPAT(&cpus[1], ',');
+        options->cpuset = PMIx_Argv_join(&cpus[1], ',');
     }
-    PMIX_ARGV_FREE_COMPAT(cpus);
+    PMIx_Argv_free(cpus);
 
     /* mark that we used ONE of these cpus - we do this each time we
      * the cpuset is assigned to a proc. When all the cpus in the

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -194,7 +194,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
         return PRTE_SUCCESS;
     }
 
-    ck2 = PMIX_ARGV_SPLIT_COMPAT(ck, ':');
+    ck2 = PMIx_Argv_split(ck, ':');
     for (i = 0; NULL != ck2[i]; i++) {
         if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_SPAN)) {
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_SPAN);
@@ -205,7 +205,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             PRTE_UNSET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_OVERSUBSCRIBE);
@@ -217,7 +217,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_OVERSUBSCRIBE);
@@ -242,7 +242,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* missing the value or value is invalid */
                 pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                "PE", ck2[i]);
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -257,7 +257,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -273,7 +273,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -288,7 +288,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             if (core_cpus_given) {
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -303,7 +303,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             if (hwthread_cpus_given) {
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (prte_rmaps_base.require_hwtcpus) {
@@ -328,7 +328,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 /* missing the value */
                 pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true, "mapping policy",
                                "FILE", ck2[i]);
-                PMIX_ARGV_FREE_COMPAT(ck2);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == jdata) {
@@ -336,7 +336,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                     // cannot specify it twice
                     pmix_show_help("help-prte-rmaps-base.txt", "multiply-defined", true, "mapping policy",
                                    "FILE", prte_rmaps_base.file, ck2[i]);
-                    PMIX_ARGV_FREE_COMPAT(ck2);
+                    PMIx_Argv_free(ck2);
                     return PRTE_ERR_SILENT;
                 }
                 prte_rmaps_base.file = strdup(&ck2[i][5]);
@@ -347,11 +347,11 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
 
         } else {
             /* unrecognized modifier */
-            PMIX_ARGV_FREE_COMPAT(ck2);
+            PMIx_Argv_free(ck2);
             return PRTE_ERR_BAD_PARAM;
         }
     }
-    PMIX_ARGV_FREE_COMPAT(ck2);
+    PMIx_Argv_free(ck2);
     return PRTE_SUCCESS;
 }
 
@@ -464,8 +464,8 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
     }
 
     /* see if a colon was included - if so, then we have a modifier */
-    ck = PMIX_ARGV_SPLIT_COMPAT(inspec, ':');
-    if (1 < PMIX_ARGV_COUNT_COMPAT(ck)) {
+    ck = PMIx_Argv_split(inspec, ':');
+    if (1 < PMIx_Argv_count(ck)) {
         if (0 == strcasecmp(ck[0], "ppr")) {
             if (4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
                 pmix_asprintf(&cptr, "%s:%s", ck[1], ck[2]);
@@ -480,12 +480,12 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
              * specifying #pe's/proc or oversubscribe - so check for modifiers. if
              * they are present, the rest of ck will look like "N:obj:mod1,mod2,mod3"
              */
-            if (3 > PMIX_ARGV_COUNT_COMPAT(ck)) {
+            if (3 > PMIx_Argv_count(ck)) {
                 /* this is an error - there had to be at least one
                  * colon to delimit the number from the object type
                  */
                 pmix_show_help("help-prte-rmaps-base.txt", "invalid-pattern", true, inspec);
-                PMIX_ARGV_FREE_COMPAT(ck);
+                PMIx_Argv_free(ck);
                 return PRTE_ERR_SILENT;
             }
             /* at this point, ck[1] contains the number of procs/resource,
@@ -503,7 +503,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
             ppr = true;
             if (NULL == ck[3]) {
                 /* there are no modifiers, so we are done */
-                PMIX_ARGV_FREE_COMPAT(ck);
+                PMIx_Argv_free(ck);
                 goto setpolicy;
             }
             PMIX_ARGV_JOIN(cptr, &ck[3], ':');
@@ -519,13 +519,13 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
                 rc = PRTE_ERR_SILENT;
             }
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(cptr);
             return rc;
         }
         if (ppr) {
             /* we are done */
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             goto setpolicy;
         }
     }
@@ -542,10 +542,10 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
                 rc = PRTE_ERR_SILENT;
             }
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             return rc;
         }
-        PMIX_ARGV_FREE_COMPAT(ck);
+        PMIx_Argv_free(ck);
         goto setpolicy;
     }
 
@@ -560,7 +560,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
             /* malformed option */
             pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(cptr);
             return PRTE_ERR_SILENT;
         }
@@ -609,7 +609,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         if ((NULL == jdata && NULL == prte_rmaps_base.file) ||
             (NULL != jdata && !prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING))) {
             pmix_show_help("help-prte-rmaps-base.txt", "rankfile-no-filename", true);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(cptr);
             if (NULL != val) {
                 free(val);
@@ -623,7 +623,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                 if (NULL == prte_rmaps_base.file) {
                     /* also not allowed */
                     pmix_show_help("help-prte-rmaps-base.txt", "rankfile-no-filename", true);
-                    PMIX_ARGV_FREE_COMPAT(ck);
+                    PMIx_Argv_free(ck);
                     free(cptr);
                     if (NULL != val) {
                         free(val);
@@ -652,7 +652,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         if (NULL == jdata) {
             pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-policy", true,
                            "mapping", cptr);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(cptr);
             if (NULL != val) {
                 free(val);
@@ -663,7 +663,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
             /* malformed option */
             pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(cptr);
             return PRTE_ERR_SILENT;
         }
@@ -671,13 +671,13 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         temp_token = strtok(val, ",");
         while (NULL != temp_token) {
             // check for range
-            range = PMIX_ARGV_SPLIT_COMPAT(temp_token, '-');
-            if (2 < PMIX_ARGV_COUNT_COMPAT(range)) {
+            range = PMIx_Argv_split(temp_token, '-');
+            if (2 < PMIx_Argv_count(range)) {
                 // can only have one '-' delimiter
                 pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                "mapping", "PE-LIST", ck[0]);
-                PMIX_ARGV_FREE_COMPAT(ck);
-                PMIX_ARGV_FREE_COMPAT(range);
+                PMIx_Argv_free(ck);
+                PMIx_Argv_free(range);
                 free(cptr);
                 if (NULL != val) {
                     free(val);
@@ -689,8 +689,8 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                 if ('\0' != *parm_delimiter) {
                     pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                    "mapping", "PE-LIST", val);
-                    PMIX_ARGV_FREE_COMPAT(ck);
-                    PMIX_ARGV_FREE_COMPAT(range);
+                    PMIx_Argv_free(ck);
+                    PMIx_Argv_free(range);
                     free(cptr);
                     if (NULL != val) {
                         free(val);
@@ -698,7 +698,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                     return PRTE_ERR_SILENT;
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(range);
+            PMIx_Argv_free(range);
             temp_token = strtok(NULL, ",");
         }
         prte_set_attribute(&jdata->attributes, PRTE_JOB_CPUSET, PRTE_ATTR_GLOBAL,
@@ -709,14 +709,14 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
     } else {
         pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
                        true, "mapping", cptr);
-        PMIX_ARGV_FREE_COMPAT(ck);
+        PMIx_Argv_free(ck);
         free(cptr);
         if (NULL != val) {
             free(val);
         }
         return PRTE_ERR_SILENT;
     }
-    PMIX_ARGV_FREE_COMPAT(ck);
+    PMIx_Argv_free(ck);
     free(cptr);
     if (NULL != val) {
         free(val);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -376,7 +376,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     continue;
                 }
                 env = pmix_environ_merge(prte_launch_environ, app->env);
-                PMIX_ARGV_FREE_COMPAT(app->env);
+                PMIx_Argv_free(app->env);
                 app->env = env;
             }
         }
@@ -393,7 +393,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                         continue;
                     }
                     env = pmix_environ_merge(prte_launch_environ, app->env);
-                    PMIX_ARGV_FREE_COMPAT(app->env);
+                    PMIx_Argv_free(app->env);
                     app->env = env;
                 }
             }
@@ -464,11 +464,11 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     }
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {
-        ck = PMIX_ARGV_SPLIT_COMPAT(tmp, ':');
-        if (2 != PMIX_ARGV_COUNT_COMPAT(ck)) {
+        ck = PMIx_Argv_split(tmp, ':');
+        if (2 != PMIx_Argv_count(ck)) {
             /* must provide a specification */
             pmix_show_help("help-prte-rmaps-ppr.txt", "invalid-ppr", true, tmp);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             free(tmp);
             jdata->exit_code = PRTE_ERR_BAD_PARAM;
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
@@ -510,13 +510,13 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             pmix_show_help("help-prte-rmaps-ppr.txt", "unrecognized-ppr-option", true,
                            ck[1], tmp);
             free(tmp);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            PMIx_Argv_free(ck);
             jdata->exit_code = PRTE_ERR_BAD_PARAM;
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
             goto cleanup;
         }
         free(tmp);
-        PMIX_ARGV_FREE_COMPAT(ck);
+        PMIx_Argv_free(ck);
     }
 
     /* add up all the expected procs */
@@ -539,9 +539,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         }
 
        if (NULL != options.cpuset) {
-            ck = PMIX_ARGV_SPLIT_COMPAT(options.cpuset, ',');
-            app->num_procs = PMIX_ARGV_COUNT_COMPAT(ck);
-            PMIX_ARGV_FREE_COMPAT(ck);
+            ck = PMIx_Argv_split(options.cpuset, ',');
+            app->num_procs = PMIx_Argv_count(ck);
+            PMIx_Argv_free(ck);
         } else {
             /*
              * get the target nodes for this app - the base function
@@ -1038,7 +1038,7 @@ void prte_rmaps_base_report_bindings(prte_job_t *jdata,
                           proc->node->name, tmp);
             free(tmp);
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, out);
+        PMIx_Argv_append_nosize(&cache, out);
         free(out);
     }
 
@@ -1046,9 +1046,9 @@ void prte_rmaps_base_report_bindings(prte_job_t *jdata,
         out = strdup("Error: job has no procs");
     } else {
         /* add a blank line with \n on it so IOF will output the last line */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, "");
-        out = PMIX_ARGV_JOIN_COMPAT(cache, '\n');
-        PMIX_ARGV_FREE_COMPAT(cache);
+        PMIx_Argv_append_nosize(&cache, "");
+        out = PMIx_Argv_join(cache, '\n');
+        PMIx_Argv_free(cache);
     }
     PMIX_LOAD_PROCID(&source, jdata->nspace, PMIX_RANK_WILDCARD);
     prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, out);

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2018-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,23 +168,23 @@ char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping)
     }
 
     if (PRTE_MAPPING_NO_USE_LOCAL & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "NO_USE_LOCAL");
+        PMIx_Argv_append_nosize(&qls, "NO_USE_LOCAL");
     }
     if (PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "NOOVERSUBSCRIBE");
+        PMIx_Argv_append_nosize(&qls, "NOOVERSUBSCRIBE");
     } else if (PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "OVERSUBSCRIBE");
+        PMIx_Argv_append_nosize(&qls, "OVERSUBSCRIBE");
     }
     if (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "SPAN");
+        PMIx_Argv_append_nosize(&qls, "SPAN");
     }
     if (PRTE_MAPPING_ORDERED & PRTE_GET_MAPPING_DIRECTIVE(mapping)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&qls, "ORDERED");
+        PMIx_Argv_append_nosize(&qls, "ORDERED");
     }
 
     if (NULL != qls) {
-        tmp = PMIX_ARGV_JOIN_COMPAT(qls, ':');
-        PMIX_ARGV_FREE_COMPAT(qls);
+        tmp = PMIx_Argv_join(qls, ':');
+        PMIx_Argv_free(qls);
         pmix_asprintf(&mymap, "%s:%s", map, tmp);
         free(tmp);
     } else {

--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -552,12 +552,12 @@ static int file_parse(const char *affinity_file)
         }
 
         if (NULL != sep) {
-            cpus = PMIX_ARGV_SPLIT_COMPAT(sep, ',');
+            cpus = PMIx_Argv_split(sep, ',');
             for(i = 0; NULL != cpus[i]; ++i) {
                 // get the specified object
                 obj = hwloc_get_pu_obj_by_os_index(nptr->topology->topo, strtol(cpus[i], NULL, 10)) ;
                 if (NULL == obj) {
-                    PMIX_ARGV_FREE_COMPAT(cpus);
+                    PMIx_Argv_free(cpus);
                     fclose(fp);
                     free(hstname);
                     return PRTE_ERROR;
@@ -567,8 +567,8 @@ static int file_parse(const char *affinity_file)
                 cpus[i] = (char*)malloc(sizeof(char) * 10);
                 snprintf(cpus[i], 10, "%d", obj->logical_index);
             }
-            sep = PMIX_ARGV_JOIN_COMPAT(cpus, ',');
-            PMIX_ARGV_FREE_COMPAT(cpus);
+            sep = PMIx_Argv_join(cpus, ',');
+            PMIx_Argv_free(cpus);
             pmix_output_verbose(20, prte_rmaps_base_framework.framework_output,
                                 "mca:rmaps:lsf: (lsf) Convert Physical CPUSET to   <%s>", sep);
         }

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -555,8 +555,8 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                 } else {
                     value = prte_rmaps_rank_file_value.sval;
                 }
-                argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
-                cnt = PMIX_ARGV_COUNT_COMPAT(argv);
+                argv = PMIx_Argv_split(value, '@');
+                cnt = PMIx_Argv_count(argv);
                 if (NULL != node_name) {
                     free(node_name);
                 }
@@ -568,11 +568,11 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                     pmix_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                     rc = PRTE_ERR_BAD_PARAM;
                     PRTE_ERROR_LOG(rc);
-                    PMIX_ARGV_FREE_COMPAT(argv);
+                    PMIx_Argv_free(argv);
                     node_name = NULL;
                     goto unlock;
                 }
-                PMIX_ARGV_FREE_COMPAT(argv);
+                PMIx_Argv_free(argv);
 
                 // Strip off the FQDN if present, ignore IP addresses
                 if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(node_name)) {

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -437,9 +437,9 @@ pass:
             }
         } else  if (options->ordered || !options->overload) {
             // see how many PEs we were given
-            tmp = PMIX_ARGV_SPLIT_COMPAT(options->cpuset, ',');
-            ntomap = PMIX_ARGV_COUNT_COMPAT(tmp);
-            PMIX_ARGV_FREE_COMPAT(tmp);
+            tmp = PMIx_Argv_split(options->cpuset, ',');
+            ntomap = PMIx_Argv_count(tmp);
+            PMIx_Argv_free(tmp);
             options->nprocs = ntomap;
         } else {
             /* assign a number of procs equal to the number of available slots */

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -176,7 +176,7 @@ bool prte_schizo_base_check_qualifiers(char *directive,
             return true;
         }
     }
-    v = PMIX_ARGV_JOIN_COMPAT(valid, ',');
+    v = PMIx_Argv_join(valid, ',');
     pmix_show_help("help-prte-rmaps-base.txt",
                    "unrecognized-qualifier", true,
                    directive, qual, v);
@@ -209,14 +209,14 @@ bool prte_schizo_base_check_directives(char *directive,
 
     /* if it starts with a ':', then these are just qualifiers */
     if (':' == dir[0]) {
-        qls = PMIX_ARGV_SPLIT_COMPAT(&dir[1], ':');
+        qls = PMIx_Argv_split(&dir[1], ':');
         for (m=0; NULL != qls[m]; m++) {
             if (!prte_schizo_base_check_qualifiers(directive, quals, qls[m])) {
-                PMIX_ARGV_FREE_COMPAT(qls);
+                PMIx_Argv_free(qls);
                 return false;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(qls);
+        PMIx_Argv_free(qls);
         return true;
     }
 
@@ -227,7 +227,7 @@ bool prte_schizo_base_check_directives(char *directive,
         return true;
     }
 
-    args = PMIX_ARGV_SPLIT_COMPAT(dir, ':');
+    args = PMIx_Argv_split(dir, ':');
     /* remove any '=' in the directive */
     if (NULL != (v = strchr(args[0], '='))) {
         *v = '\0';
@@ -241,7 +241,7 @@ bool prte_schizo_base_check_directives(char *directive,
                     /* unfortunately, this is a special case that
                      * must be checked separately due to the format
                      * of the qualifier */
-                    if (3 > PMIX_ARGV_COUNT_COMPAT(args)) {
+                    if (3 > PMIx_Argv_count(args)) {
                         /* this is an error as there must be at least
                          * the "ppr" directive, a number, and then the
                          * resource type. There may also be additional
@@ -251,7 +251,7 @@ bool prte_schizo_base_check_directives(char *directive,
                         pmix_show_help("help-prte-rmaps-base.txt",
                                        "invalid-pattern", true,
                                        dir);
-                        PMIX_ARGV_FREE_COMPAT(args);
+                        PMIx_Argv_free(args);
                         return false;
                     }
                     v = NULL;
@@ -263,7 +263,7 @@ bool prte_schizo_base_check_directives(char *directive,
                                        "unrecognized-qualifier", true,
                                        directive, dir, v);
                         free(v);
-                        PMIX_ARGV_FREE_COMPAT(args);
+                        PMIx_Argv_free(args);
                         return false;
                     }
                     found = false;
@@ -274,45 +274,45 @@ bool prte_schizo_base_check_directives(char *directive,
                         }
                     }
                     if (!found) {
-                        v = PMIX_ARGV_JOIN_COMPAT(pproptions, ':');
+                        v = PMIx_Argv_join(pproptions, ':');
                         pmix_asprintf(&q, "ppr:%s:[%s]", args[1], v);
                         free(v);
                         pmix_show_help("help-prte-rmaps-base.txt",
                                        "unrecognized-qualifier", true,
                                        directive, dir, q);
                         free(q);
-                        PMIX_ARGV_FREE_COMPAT(args);
+                        PMIx_Argv_free(args);
                         return false;
                     }
                     if (NULL != args[3]) {
-                        qls = PMIX_ARGV_SPLIT_COMPAT(args[3], ':');
+                        qls = PMIx_Argv_split(args[3], ':');
                     } else {
-                        PMIX_ARGV_FREE_COMPAT(args);
+                        PMIx_Argv_free(args);
                         return true;
                     }
                 } else {
-                    qls = PMIX_ARGV_SPLIT_COMPAT(args[1], ':');
+                    qls = PMIx_Argv_split(args[1], ':');
                 }
                for (m=0; NULL != qls[m]; m++) {
                     if (!prte_schizo_base_check_qualifiers(directive, quals, qls[m])) {
-                        PMIX_ARGV_FREE_COMPAT(qls);
-                        PMIX_ARGV_FREE_COMPAT(args);
+                        PMIx_Argv_free(qls);
+                        PMIx_Argv_free(args);
                         return false;
                     }
                 }
-                PMIX_ARGV_FREE_COMPAT(qls);
-                PMIX_ARGV_FREE_COMPAT(args);
+                PMIx_Argv_free(qls);
+                PMIx_Argv_free(args);
                 return true;
             }
-            PMIX_ARGV_FREE_COMPAT(args);
+            PMIx_Argv_free(args);
             return true;
         }
     }
-    v = PMIX_ARGV_JOIN_COMPAT(valid, ':');
+    v = PMIx_Argv_join(valid, ':');
     pmix_show_help("help-prte-rmaps-base.txt",
                    "unrecognized-directive", true,
                    directive, dir, v);
-    PMIX_ARGV_FREE_COMPAT(args);
+    PMIx_Argv_free(args);
     return false;
 }
 
@@ -355,9 +355,9 @@ static int check_ndirs(pmix_cli_item_t *opt)
 
     for (n=0; NULL != limits[n]; n++) {
         if (0 == strcmp(opt->key, limits[n])) {
-            count = PMIX_ARGV_COUNT_COMPAT(opt->values);
+            count = PMIx_Argv_count(opt->values);
             if (1 > count) {
-                param = PMIX_ARGV_JOIN_COMPAT(opt->values, ' ');
+                param = PMIx_Argv_join(opt->values, ' ');
                 pmix_show_help("help-schizo-base.txt", "too-many-instances", true,
                                param, opt->key, count, 1);
                 return PRTE_ERR_SILENT;
@@ -568,35 +568,35 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     /* the following have multiple directives */
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
-        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        vtmp = PMIx_Argv_split(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_OUTPUT, outputs, outquals, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(vtmp);
+        PMIx_Argv_free(vtmp);
     }
 
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_DISPLAY);
     if (NULL != opt) {
-        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        vtmp = PMIx_Argv_split(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_DISPLAY, displays, displayquals, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(vtmp);
+        PMIx_Argv_free(vtmp);
     }
 
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_RTOS);
     if (NULL != opt) {
-        vtmp = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        vtmp = PMIx_Argv_split(opt->values[0], ',');
         for (n=0; NULL != vtmp[n]; n++) {
             if (!prte_schizo_base_check_directives(PRTE_CLI_RTOS, rtos, NULL, vtmp[n])) {
                 return PRTE_ERR_SILENT;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(vtmp);
+        PMIx_Argv_free(vtmp);
     }
 
     // check too many values given to a single command line option
@@ -634,14 +634,14 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
     char **targv, *ptr, *cptr, **quals;
 
     for (n=0; NULL != opt->values[n]; n++) {
-        targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[n], ',');
+        targv = PMIx_Argv_split(opt->values[n], ',');
         for (idx = 0; NULL != targv[idx]; idx++) {
             /* check for qualifiers */
             cptr = strchr(targv[idx], ':');
             if (NULL != cptr) {
                 *cptr = '\0';
                 ++cptr;
-                quals = PMIX_ARGV_SPLIT_COMPAT(cptr, ':');
+                quals = PMIx_Argv_split(cptr, ':');
                 /* check qualifiers */
                 for (m=0; NULL != quals[m]; m++) {
                     if (PMIX_CHECK_CLI_OPTION(quals[m], PRTE_CLI_PARSEABLE) ||
@@ -649,8 +649,8 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIX_ARGV_FREE_COMPAT(quals);
-                            PMIX_ARGV_FREE_COMPAT(targv);
+                            PMIx_Argv_free(quals);
+                            PMIx_Argv_free(targv);
                             return ret;
                         }
 
@@ -658,15 +658,15 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_REPORT_PHYSICAL_CPUS, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIX_ARGV_FREE_COMPAT(quals);
-                            PMIX_ARGV_FREE_COMPAT(targv);
+                            PMIx_Argv_free(quals);
+                            PMIx_Argv_free(targv);
                             return ret;
                         }
 
                     } else {
                         pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-qualifier", true,
                                        "display", cptr, "PARSEABLE,PARSABLE");
-                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                 }
@@ -676,7 +676,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_ALLOCATION, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -684,7 +684,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -692,7 +692,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -700,7 +700,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_REPORT_BINDINGS, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -712,14 +712,14 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         /* missing the value or value is invalid */
                         pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                        "display", "PROCESSORS", targv[idx]);
-                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                 }
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_TOPOLOGY, ptr, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_CPUS)) {
@@ -730,19 +730,19 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                         /* missing the value or value is invalid */
                         pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
                                        "display", "PROCESSORS", targv[idx]);
-                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                 }
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_PROCESSORS, ptr, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
             }
         }
-        PMIX_ARGV_FREE_COMPAT(targv);
+        PMIx_Argv_free(targv);
     }
 
     return PRTE_SUCCESS;
@@ -757,7 +757,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
     pmix_status_t ret;
 
     for (n=0; NULL != opt->values[n]; n++) {
-        targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        targv = PMIx_Argv_split(opt->values[0], ',');
         for (idx = 0; NULL != targv[idx]; idx++) {
             /* check for qualifiers */
             cptr = strchr(targv[idx], ':');
@@ -765,15 +765,15 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 *cptr = '\0';
                 ++cptr;
                 /* could be multiple qualifiers, so separate them */
-                options = PMIX_ARGV_SPLIT_COMPAT(cptr, ',');
+                options = PMIx_Argv_split(cptr, ',');
                 for (m=0; NULL != options[m]; m++) {
 
                     if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_NOCOPY)) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIX_ARGV_FREE_COMPAT(targv);
-                            PMIX_ARGV_FREE_COMPAT(options);
+                            PMIx_Argv_free(targv);
+                            PMIx_Argv_free(options);
                             return ret;
                         }
 
@@ -781,8 +781,8 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIX_ARGV_FREE_COMPAT(targv);
-                            PMIX_ARGV_FREE_COMPAT(options);
+                            PMIx_Argv_free(targv);
+                            PMIx_Argv_free(options);
                             return ret;
                         }
 
@@ -790,13 +790,13 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIX_ARGV_FREE_COMPAT(targv);
-                            PMIX_ARGV_FREE_COMPAT(options);
+                            PMIx_Argv_free(targv);
+                            PMIx_Argv_free(options);
                             return ret;
                         }
                     }
                 }
-                PMIX_ARGV_FREE_COMPAT(options);
+                PMIx_Argv_free(options);
             }
             if (0 == strlen(targv[idx])) {
                 // only qualifiers were given
@@ -811,7 +811,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -819,7 +819,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -827,7 +827,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -835,7 +835,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -843,7 +843,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -851,7 +851,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -859,7 +859,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -868,12 +868,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "directory", "directory");
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return PRTE_ERR_FATAL;
                 }
                 if (NULL != outfile) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, ptr);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     free(outfile);
                     return PRTE_ERR_FATAL;
                 }
@@ -884,7 +884,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                     outdir = pmix_os_path(false, cwd, ptr, NULL);
@@ -894,7 +894,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
 
@@ -903,12 +903,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "filename", "filename");
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return PRTE_ERR_FATAL;
                 }
                 if (NULL != outdir) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, ptr, outdir);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return PRTE_ERR_FATAL;
                 }
                 /* If the given filename isn't an absolute path, then
@@ -918,7 +918,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        PMIX_ARGV_FREE_COMPAT(targv);
+                        PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                     outfile = pmix_os_path(false, cwd, ptr, NULL);
@@ -928,12 +928,12 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIX_ARGV_FREE_COMPAT(targv);
+                    PMIx_Argv_free(targv);
                     return ret;
                 }
             }
         }
-        PMIX_ARGV_FREE_COMPAT(targv);
+        PMIx_Argv_free(targv);
     }
     if (NULL != outdir) {
         free(outdir);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -101,8 +101,8 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
         // does it already have a value?
         if (NULL == opt->values) {
             // technically this should never happen, but...
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, directive);
-        } else if (1 < PMIX_ARGV_COUNT_COMPAT(opt->values)) {
+            PMIx_Argv_append_nosize(&opt->values, directive);
+        } else if (1 < PMIx_Argv_count(opt->values)) {
             // cannot use this function
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
@@ -119,7 +119,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
                 // do we allow multiple directives?
                 if (!check_multi(target)) {
                     // report the error
-                    tmp = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+                    tmp = PMIx_Argv_join(opt->values, ',');
                     ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-directives",
                                                 true, target, tmp, deprecated, directive);
                     free(tmp);
@@ -147,7 +147,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
         // add the new option
         opt = PMIX_NEW(pmix_cli_item_t);
         opt->key = strdup(target);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, directive);
+        PMIx_Argv_append_nosize(&opt->values, directive);
         pmix_list_append(&results->instances, &opt->super);
     }
 
@@ -178,9 +178,9 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
         if (NULL == opt->values) {
             // technically this should never happen, but...
             pmix_asprintf(&tmp, ":%s", qualifier);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, tmp);
+            PMIx_Argv_append_nosize(&opt->values, tmp);
             free(tmp);
-        } else if (1 < PMIX_ARGV_COUNT_COMPAT(opt->values)) {
+        } else if (1 < PMIx_Argv_count(opt->values)) {
             // cannot use this function
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
@@ -197,7 +197,7 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
         opt = PMIX_NEW(pmix_cli_item_t);
         opt->key = strdup(target);
         pmix_asprintf(&tmp, ":%s", qualifier);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt->values, tmp);
+        PMIx_Argv_append_nosize(&opt->values, tmp);
         free(tmp);
         pmix_list_append(&results->instances, &opt->super);
     }
@@ -275,9 +275,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                 setenv(param, p2, true);
                 free(param);
             } else {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
+                PMIx_Argv_append_nosize(target, "--prtemca");
+                PMIx_Argv_append_nosize(target, p1);
+                PMIx_Argv_append_nosize(target, p2);
             }
             free(p1);
             free(p2);
@@ -332,9 +332,9 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
                     pmix_output_verbose(1, prte_schizo_base_framework.framework_output,
                                         "%s schizo:prte:parse_cli adding %s to target",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), p1);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--prtemca");
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
+                    PMIx_Argv_append_nosize(target, "--prtemca");
+                    PMIx_Argv_append_nosize(target, p1);
+                    PMIx_Argv_append_nosize(target, p2);
                 }
                 i += 2;
             }
@@ -375,9 +375,9 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                 setenv(param, p2, true);
                 free(param);
             } else {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, argv[i]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
+                PMIx_Argv_append_nosize(target, argv[i]);
+                PMIx_Argv_append_nosize(target, p1);
+                PMIx_Argv_append_nosize(target, p2);
             }
             free(p1);
             free(p2);
@@ -411,12 +411,12 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                     setenv(param, p2, true);
                     free(param);
                 } else {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--pmixmca");
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--omca");
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
+                    PMIx_Argv_append_nosize(target, "--pmixmca");
+                    PMIx_Argv_append_nosize(target, p1);
+                    PMIx_Argv_append_nosize(target, p2);
+                    PMIx_Argv_append_nosize(target, "--omca");
+                    PMIx_Argv_append_nosize(target, p1);
+                    PMIx_Argv_append_nosize(target, p2);
                 }
                 free(p1);
                 free(p2);
@@ -455,9 +455,9 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
                     setenv(param, p2, true);
                     free(param);
                 } else {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, "--pmixmca");
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p1);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(target, p2);
+                    PMIx_Argv_append_nosize(target, "--pmixmca");
+                    PMIx_Argv_append_nosize(target, p1);
+                    PMIx_Argv_append_nosize(target, p2);
                 }
             }
             free(p1);
@@ -478,7 +478,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     prte_job_t *daemons;
 
     /* flag that we started this job */
-    PMIX_SETENV_COMPAT("PRTE_LAUNCHED", "1", true, &app->env);
+    PMIx_Setenv("PRTE_LAUNCHED", "1", true, &app->env);
 
     /* now process any envar attributes - we begin with the job-level
      * ones as the app-specific ones can override them. We have to
@@ -487,11 +487,11 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
     {
         if (PRTE_JOB_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+            PMIx_Setenv(attr->data.data.envar.envar,
                                attr->data.data.envar.value,
                                true, &app->env);
         } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+            PMIx_Setenv(attr->data.data.envar.envar,
                                attr->data.data.envar.value,
                                false, &app->env);
         } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
@@ -509,7 +509,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -519,7 +519,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                PMIx_Setenv(attr->data.data.envar.envar,
                                    attr->data.data.envar.value,
                                    true, &app->env);
             }
@@ -536,7 +536,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -546,7 +546,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                PMIx_Setenv(attr->data.data.envar.envar,
                                    attr->data.data.envar.value,
                                    true, &app->env);
             }
@@ -564,7 +564,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                 continue;
             }
             // need to set the prefix into the environment
-            PMIX_SETENV_COMPAT("PMIX_PREFIX",
+            PMIx_Setenv("PMIX_PREFIX",
                                attr->data.data.string,
                                true, &app->env);
             // and need to set LD_LIBRARY_PATH
@@ -579,7 +579,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     p = pmix_basename(pmix_pinstall_dirs.libdir);
                     pmix_asprintf(&p2, "%s/%s:%s", attr->data.data.string, p, param);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", p2, true, &app->env);
+                    PMIx_Setenv("LD_LIBRARY_PATH", p2, true, &app->env);
                     free(p2);
                     free(p);
                     exists = true;
@@ -592,7 +592,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                 /* just insert it */
                 param = pmix_basename(pmix_pinstall_dirs.libdir);
                 pmix_asprintf(&p2, "%s/%s", attr->data.data.string, param);
-                PMIX_SETENV_COMPAT("LD_LIBRARY_PATH",
+                PMIx_Setenv("LD_LIBRARY_PATH",
                                    p2,
                                    true, &app->env);
                 free(p2);
@@ -600,12 +600,12 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
 
         } else if (PRTE_APP_SET_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+            PMIx_Setenv(attr->data.data.envar.envar,
                                attr->data.data.envar.value,
                                true, &app->env);
 
         } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+            PMIx_Setenv(attr->data.data.envar.envar,
                                attr->data.data.envar.value,
                                false, &app->env);
 
@@ -625,7 +625,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
                                   attr->data.data.envar.separator, param);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -635,7 +635,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                PMIx_Setenv(attr->data.data.envar.envar,
                                    attr->data.data.envar.value,
                                    true, &app->env);
             }
@@ -653,7 +653,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
                                   attr->data.data.envar.value);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT(attr->data.data.envar.envar, p2, true, &app->env);
+                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
                     free(p2);
                     exists = true;
                     break;
@@ -663,7 +663,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
             }
             if (!exists) {
                 /* just insert it */
-                PMIX_SETENV_COMPAT(attr->data.data.envar.envar,
+                PMIx_Setenv(attr->data.data.envar.envar,
                                    attr->data.data.envar.value,
                                    true, &app->env);
             }
@@ -675,7 +675,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     if (!prefix_defined) {
         daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
         if (prte_get_attribute(&daemons->attributes, PRTE_JOB_PMIX_PREFIX, (void **)&defprefix, PMIX_STRING)) {
-            PMIX_SETENV_COMPAT("PMIX_PREFIX",
+            PMIx_Setenv("PMIX_PREFIX",
                                defprefix,
                                true, &app->env);
             // and need to set LD_LIBRARY_PATH
@@ -690,7 +690,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                     p = pmix_basename(pmix_pinstall_dirs.libdir);
                     pmix_asprintf(&p2, "%s/%s:%s", defprefix, p, param);
                     *saveptr = '='; // restore the current envar setting
-                    PMIX_SETENV_COMPAT("LD_LIBRARY_PATH", p2, true, &app->env);
+                    PMIx_Setenv("LD_LIBRARY_PATH", p2, true, &app->env);
                     free(p2);
                     free(p);
                     exists = true;
@@ -703,7 +703,7 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                 /* just insert it */
                 param = pmix_basename(pmix_pinstall_dirs.libdir);
                 pmix_asprintf(&p2, "%s/%s", defprefix, param);
-                PMIX_SETENV_COMPAT("LD_LIBRARY_PATH",
+                PMIx_Setenv("LD_LIBRARY_PATH",
                                    p2,
                                    true, &app->env);
                 free(p2);

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -438,7 +438,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     char **pargv;
 
     /* backup the argv */
-    pargv = PMIX_ARGV_COPY_COMPAT(argv);
+    pargv = PMIx_Argv_copy(argv);
 
     char **caught_single_dashes = NULL;
     int  *caught_positions = NULL;
@@ -512,7 +512,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     rc = pmix_cmd_line_parse(pargv, ompishorts, ompioptions, NULL,
                              results, "help-schizo-ompi.txt");
     if (PMIX_SUCCESS != rc) {
-        PMIX_ARGV_FREE_COMPAT(pargv);
+        PMIx_Argv_free(pargv);
         if (warn) {
             for(n = 0; n < cur_caught_pos; n++) {
                 free(caught_single_dashes[n]);
@@ -591,7 +591,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         caught_positions = NULL;
     }
 
-    PMIX_ARGV_FREE_COMPAT(pargv);
+    PMIx_Argv_free(pargv);
     /* check for deprecated options - warn and convert them */
     rc = convert_deprecated_cli(results, silent);
     if (PRTE_SUCCESS != rc) {
@@ -626,8 +626,8 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
             if (0 == strcmp(results->tail[0], argv[n])) {
                 /* this starts the tail - replace the rest of the
                  * tail with the original argv */
-                PMIX_ARGV_FREE_COMPAT(results->tail);
-                results->tail = PMIX_ARGV_COPY_COMPAT(&argv[n]);
+                PMIx_Argv_free(results->tail);
+                results->tail = PMIx_Argv_copy(&argv[n]);
                 break;
             }
         }
@@ -1100,7 +1100,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                     // add the output directive
                     opt2 = PMIX_NEW(pmix_cli_item_t);
                     opt2->key = strdup(PRTE_CLI_OUTPUT);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&opt2->values, ":raw");
+                    PMIx_Argv_append_nosize(&opt2->values, ":raw");
                     pmix_list_append(&results->instances, &opt2->super);
                 } else {
                     // see if the "raw" modifier is already present
@@ -1159,8 +1159,8 @@ static int check_cache(char ***c1, char ***c2, char *p1, char *p2)
 
     if (PRTE_SUCCESS == rc) {
         /* add them to the cache */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(c1, p1);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(c2, p2);
+        PMIx_Argv_append_nosize(c1, p1);
+        PMIx_Argv_append_nosize(c2, p2);
     }
     return rc;
 }
@@ -1270,7 +1270,7 @@ static int process_env_list(const char *env_list, char ***xparams, char ***xvals
     char **tokens;
     int rc = PRTE_SUCCESS;
 
-    tokens = PMIX_ARGV_SPLIT_COMPAT(env_list, (int) sep);
+    tokens = PMIx_Argv_split(env_list, (int) sep);
     if (NULL == tokens) {
         return PRTE_SUCCESS;
     }
@@ -1286,7 +1286,7 @@ static int process_env_list(const char *env_list, char ***xparams, char ***xvals
         }
     }
 
-    PMIX_ARGV_FREE_COMPAT(tokens);
+    PMIx_Argv_free(tokens);
     return rc;
 }
 
@@ -1298,7 +1298,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
     char **cache = NULL, **cachevals = NULL;
     char **xparams = NULL, **xvals = NULL;
 
-    tmp = PMIX_ARGV_SPLIT_COMPAT(filename, sep);
+    tmp = PMIx_Argv_split(filename, sep);
     if (NULL == tmp) {
         return PRTE_SUCCESS;
     }
@@ -1315,22 +1315,22 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 fp = fopen(p1, "r");
                 if (NULL == fp) {
                     pmix_show_help("help-schizo-base.txt", "missing-param-file-def", true, tmp[i], p1);;
-                    PMIX_ARGV_FREE_COMPAT(tmp);
-                    PMIX_ARGV_FREE_COMPAT(cache);
-                    PMIX_ARGV_FREE_COMPAT(cachevals);
-                    PMIX_ARGV_FREE_COMPAT(xparams);
-                    PMIX_ARGV_FREE_COMPAT(xvals);
+                    PMIx_Argv_free(tmp);
+                    PMIx_Argv_free(cache);
+                    PMIx_Argv_free(cachevals);
+                    PMIx_Argv_free(xparams);
+                    PMIx_Argv_free(xvals);
                     free(p1);
                     return PRTE_ERR_NOT_FOUND;
                 }
                 free(p1);
             } else {
                 pmix_show_help("help-schizo-base.txt", "missing-param-file", true, tmp[i]);;
-                PMIX_ARGV_FREE_COMPAT(tmp);
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
-                PMIX_ARGV_FREE_COMPAT(xparams);
-                PMIX_ARGV_FREE_COMPAT(xvals);
+                PMIx_Argv_free(tmp);
+                PMIx_Argv_free(cache);
+                PMIx_Argv_free(cachevals);
+                PMIx_Argv_free(xparams);
+                PMIx_Argv_free(xvals);
                 return PRTE_ERR_NOT_FOUND;
             }
         }
@@ -1339,15 +1339,15 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 free(line);
                 continue; /* skip empty lines */
             }
-            opts = PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(line, ' ');
+            opts = PMIx_Argv_split_with_empty(line, ' ');
             if (NULL == opts) {
                 pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i], line);
                 free(line);
-                PMIX_ARGV_FREE_COMPAT(tmp);
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
-                PMIX_ARGV_FREE_COMPAT(xparams);
-                PMIX_ARGV_FREE_COMPAT(xvals);
+                PMIx_Argv_free(tmp);
+                PMIx_Argv_free(cache);
+                PMIx_Argv_free(cachevals);
+                PMIx_Argv_free(xparams);
+                PMIx_Argv_free(xvals);
                 fclose(fp);
                 return PRTE_ERR_BAD_PARAM;
             }
@@ -1362,12 +1362,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1381,12 +1381,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                                            line);
                             free(line);
                             free(p1);
-                            PMIX_ARGV_FREE_COMPAT(tmp);
-                            PMIX_ARGV_FREE_COMPAT(opts);
-                            PMIX_ARGV_FREE_COMPAT(cache);
-                            PMIX_ARGV_FREE_COMPAT(cachevals);
-                            PMIX_ARGV_FREE_COMPAT(xparams);
-                            PMIX_ARGV_FREE_COMPAT(xvals);
+                            PMIx_Argv_free(tmp);
+                            PMIx_Argv_free(opts);
+                            PMIx_Argv_free(cache);
+                            PMIx_Argv_free(cachevals);
+                            PMIx_Argv_free(xparams);
+                            PMIx_Argv_free(xvals);
                             fclose(fp);
                             return PRTE_ERR_BAD_PARAM;
                         }
@@ -1401,12 +1401,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     free(p1);
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         free(line);
                         return rc;
                     }
@@ -1416,12 +1416,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1438,12 +1438,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     free(p2);
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         free(line);
                         return rc;
                     }
@@ -1455,12 +1455,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         fclose(fp);
                         return PRTE_ERR_BAD_PARAM;
                     }
@@ -1468,12 +1468,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     rc = process_env_list(p1, &xparams, &xvals, ';');
                     if (PRTE_SUCCESS != rc) {
                         fclose(fp);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         free(line);
                         return rc;
                     }
@@ -1483,12 +1483,12 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                         pmix_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         fclose(fp);
-                        PMIX_ARGV_FREE_COMPAT(tmp);
-                        PMIX_ARGV_FREE_COMPAT(opts);
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(xparams);
-                        PMIX_ARGV_FREE_COMPAT(xvals);
+                        PMIx_Argv_free(tmp);
+                        PMIx_Argv_free(opts);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(xparams);
+                        PMIx_Argv_free(xvals);
                         free(line);
                         return rc;
                     }
@@ -1499,30 +1499,30 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
         fclose(fp);
     }
 
-    PMIX_ARGV_FREE_COMPAT(tmp);
+    PMIx_Argv_free(tmp);
 
     if (NULL != cache) {
         /* add the results into dstenv */
         for (i = 0; NULL != cache[i]; i++) {
             if (0 != strncmp(cache[i], "OMPI_MCA_", strlen("OMPI_MCA_"))) {
                 pmix_asprintf(&p1, "OMPI_MCA_%s", cache[i]);
-                PMIX_SETENV_COMPAT(p1, cachevals[i], true, dstenv);
+                PMIx_Setenv(p1, cachevals[i], true, dstenv);
                 free(p1);
             } else {
-                PMIX_SETENV_COMPAT(cache[i], cachevals[i], true, dstenv);
+                PMIx_Setenv(cache[i], cachevals[i], true, dstenv);
             }
         }
-        PMIX_ARGV_FREE_COMPAT(cache);
-        PMIX_ARGV_FREE_COMPAT(cachevals);
+        PMIx_Argv_free(cache);
+        PMIx_Argv_free(cachevals);
     }
 
     /* add the -x values */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
+            PMIx_Setenv(xparams[i], xvals[i], true, dstenv);
         }
-        PMIX_ARGV_FREE_COMPAT(xparams);
-        PMIX_ARGV_FREE_COMPAT(xvals);
+        PMIx_Argv_free(xparams);
+        PMIx_Argv_free(xvals);
     }
 
     return PRTE_SUCCESS;
@@ -1597,7 +1597,7 @@ static void setup_ompi_frameworks(void)
 
     // If we found the env variable, it will be a comma-delimited list
     // of values.  Split it into an argv-style array.
-    char **tmp = PMIX_ARGV_SPLIT_COMPAT(env, ',');
+    char **tmp = PMIx_Argv_split(env, ',');
     if (NULL != tmp) {
         ompi_frameworks = tmp;
     }
@@ -1644,26 +1644,26 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != env_set_flag) {
         rc = process_env_list(env_set_flag, &xparams, &xvals, ';');
         if (PRTE_SUCCESS != rc) {
-            PMIX_ARGV_FREE_COMPAT(xparams);
-            PMIX_ARGV_FREE_COMPAT(xvals);
+            PMIx_Argv_free(xparams);
+            PMIx_Argv_free(xvals);
             return rc;
         }
     }
     /* process the resulting cache into the dstenv */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
+            PMIx_Setenv(xparams[i], xvals[i], true, dstenv);
         }
-        PMIX_ARGV_FREE_COMPAT(xparams);
+        PMIx_Argv_free(xparams);
         xparams = NULL;
-        PMIX_ARGV_FREE_COMPAT(xvals);
+        PMIx_Argv_free(xvals);
         xvals = NULL;
     }
 
     /* now process any tune file specification - the tune file processor
      * will police itself for duplicate values */
     if (NULL != (opt = pmix_cmd_line_get_param(results, "tune"))) {
-        p1 = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+        p1 = PMIx_Argv_join(opt->values, ',');
         rc = process_tune_files(p1, dstenv, ',');
         free(p1);
         if (PRTE_SUCCESS != rc) {
@@ -1674,8 +1674,8 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != (opt = pmix_cmd_line_get_param(results, "initial-errhandler"))) {
         rc = check_cache(&cache, &cachevals, "mpi_initial_errhandler", opt->values[0]);
         if (PRTE_SUCCESS != rc) {
-            PMIX_ARGV_FREE_COMPAT(cache);
-            PMIX_ARGV_FREE_COMPAT(cachevals);
+            PMIx_Argv_free(cache);
+            PMIx_Argv_free(cachevals);
             return rc;
         }
     }
@@ -1683,19 +1683,19 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != (opt = pmix_cmd_line_get_param(results, PRTE_CLI_MEM_ALLOC_KIND))) {
         rc = check_cache(&cache, &cachevals, "mpi_memory_alloc_kinds", opt->values[0]);
         if (PRTE_SUCCESS != rc) {
-            PMIX_ARGV_FREE_COMPAT(cache);
-            PMIX_ARGV_FREE_COMPAT(cachevals);
+            PMIx_Argv_free(cache);
+            PMIx_Argv_free(cachevals);
             return rc;
         }
     }
 
     if (pmix_cmd_line_is_taken(results, "display-comm") &&
         pmix_cmd_line_is_taken(results, "display-comm-finalize")) {
-        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_init,mpi_finalize", true, dstenv);
+        PMIx_Setenv("OMPI_MCA_ompi_display_comm", "mpi_init,mpi_finalize", true, dstenv);
     } else if (pmix_cmd_line_is_taken(results, "display-comm")) {
-        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_init", true, dstenv);
+        PMIx_Setenv("OMPI_MCA_ompi_display_comm", "mpi_init", true, dstenv);
     } else if (pmix_cmd_line_is_taken(results, "display-comm-finalize")) {
-        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
+        PMIx_Setenv("OMPI_MCA_ompi_display_comm", "mpi_finalize", true, dstenv);
     }
 
     /* --stream-buffering will be deprecated starting with Open MPI v5 */
@@ -1711,7 +1711,7 @@ static int parse_env(char **srcenv, char ***dstenv,
             /* bad value */
             pmix_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
         }
-        PMIX_SETENV_COMPAT("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
+        PMIx_Setenv("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
     }
 
     /* now look for any "--mca" options - note that it is an error
@@ -1728,13 +1728,13 @@ static int parse_env(char **srcenv, char ***dstenv,
             p1 = opt->values[i];
             /* treat mca_base_env_list as a special case */
             if (0 == strcmp(p1, "mca_base_env_list")) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
+                PMIx_Argv_append_nosize(&envlist, p3);
                 continue;
             }
             rc = check_cache(&cache, &cachevals, p1, p3);
             if (PRTE_SUCCESS != rc) {
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
+                PMIx_Argv_free(cache);
+                PMIx_Argv_free(cachevals);
                 return rc;
             }
         }
@@ -1750,13 +1750,13 @@ static int parse_env(char **srcenv, char ***dstenv,
             p1 = opt->values[i];
             /* treat mca_base_env_list as a special case */
             if (0 == strcmp(p1, "mca_base_env_list")) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
+                PMIx_Argv_append_nosize(&envlist, p3);
                 continue;
             }
             rc = check_cache(&cache, &cachevals, p1, p3);
             if (PRTE_SUCCESS != rc) {
-                PMIX_ARGV_FREE_COMPAT(cache);
-                PMIX_ARGV_FREE_COMPAT(cachevals);
+                PMIx_Argv_free(cache);
+                PMIx_Argv_free(cachevals);
                 return rc;
             }
         }
@@ -1774,14 +1774,14 @@ static int parse_env(char **srcenv, char ***dstenv,
             if (check_generic(p1)) {
                 /* treat mca_base_env_list as a special case */
                 if (0 == strcmp(p1, "mca_base_env_list")) {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
+                    PMIx_Argv_append_nosize(&envlist, p3);
                     continue;
                 }
                 rc = check_cache(&cache, &cachevals, p1, p3);
                 if (PRTE_SUCCESS != rc) {
-                    PMIX_ARGV_FREE_COMPAT(cache);
-                    PMIX_ARGV_FREE_COMPAT(cachevals);
-                    PMIX_ARGV_FREE_COMPAT(envlist);
+                    PMIx_Argv_free(cache);
+                    PMIx_Argv_free(cachevals);
+                    PMIx_Argv_free(envlist);
                     return rc;
                 }
             }
@@ -1800,14 +1800,14 @@ static int parse_env(char **srcenv, char ***dstenv,
             if (check_generic(p1)) {
                 /* treat mca_base_env_list as a special case */
                 if (0 == strcmp(p1, "mca_base_env_list")) {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&envlist, p3);
+                    PMIx_Argv_append_nosize(&envlist, p3);
                     continue;
                 }
                 rc = check_cache(&cache, &cachevals, p1, p3);
                 if (PRTE_SUCCESS != rc) {
-                    PMIX_ARGV_FREE_COMPAT(cache);
-                    PMIX_ARGV_FREE_COMPAT(cachevals);
-                    PMIX_ARGV_FREE_COMPAT(envlist);
+                    PMIx_Argv_free(cache);
+                    PMIx_Argv_free(cachevals);
+                    PMIx_Argv_free(envlist);
                     return rc;
                 }
             }
@@ -1817,7 +1817,7 @@ static int parse_env(char **srcenv, char ***dstenv,
     /* if we got any env lists, process them here */
     if (NULL != envlist) {
         for (i = 0; NULL != envlist[i]; i++) {
-            envtgt = PMIX_ARGV_SPLIT_COMPAT(envlist[i], ';');
+            envtgt = PMIx_Argv_split(envlist[i], ';');
             for (j = 0; NULL != envtgt[j]; j++) {
                 if (NULL == (p2 = strchr(envtgt[j], '='))) {
                     p1 = getenv(envtgt[j]);
@@ -1833,51 +1833,51 @@ static int parse_env(char **srcenv, char ***dstenv,
                     }
                     free(p1);
                     if (PRTE_SUCCESS != rc) {
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(envtgt);
-                        PMIX_ARGV_FREE_COMPAT(envlist);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(envtgt);
+                        PMIx_Argv_free(envlist);
                         return rc;
                     }
                 } else {
                     *p2 = '\0';
                     rc = check_cache(&xparams, &xvals, envtgt[j], p2 + 1);
                     if (PRTE_SUCCESS != rc) {
-                        PMIX_ARGV_FREE_COMPAT(cache);
-                        PMIX_ARGV_FREE_COMPAT(cachevals);
-                        PMIX_ARGV_FREE_COMPAT(envtgt);
-                        PMIX_ARGV_FREE_COMPAT(envlist);
+                        PMIx_Argv_free(cache);
+                        PMIx_Argv_free(cachevals);
+                        PMIx_Argv_free(envtgt);
+                        PMIx_Argv_free(envlist);
                         return rc;
                     }
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(envtgt);
+            PMIx_Argv_free(envtgt);
         }
     }
-    PMIX_ARGV_FREE_COMPAT(envlist);
+    PMIx_Argv_free(envlist);
 
     /* process the resulting cache into the dstenv */
     if (NULL != cache) {
         for (i = 0; NULL != cache[i]; i++) {
             if (0 != strncmp(cache[i], "OMPI_MCA_", strlen("OMPI_MCA_"))) {
                 pmix_asprintf(&p1, "OMPI_MCA_%s", cache[i]);
-                PMIX_SETENV_COMPAT(p1, cachevals[i], true, dstenv);
+                PMIx_Setenv(p1, cachevals[i], true, dstenv);
                 free(p1);
             } else {
-                PMIX_SETENV_COMPAT(cache[i], cachevals[i], true, dstenv);
+                PMIx_Setenv(cache[i], cachevals[i], true, dstenv);
             }
         }
     }
-    PMIX_ARGV_FREE_COMPAT(cache);
-    PMIX_ARGV_FREE_COMPAT(cachevals);
+    PMIx_Argv_free(cache);
+    PMIx_Argv_free(cachevals);
 
     /* add the -x values */
     if (NULL != xparams) {
         for (i = 0; NULL != xparams[i]; i++) {
-            PMIX_SETENV_COMPAT(xparams[i], xvals[i], true, dstenv);
+            PMIx_Setenv(xparams[i], xvals[i], true, dstenv);
         }
-        PMIX_ARGV_FREE_COMPAT(xparams);
-        PMIX_ARGV_FREE_COMPAT(xvals);
+        PMIx_Argv_free(xparams);
+        PMIx_Argv_free(xvals);
     }
 
     /* add a flag indicating that we did indeed check the tmpdir
@@ -1887,7 +1887,7 @@ static int parse_env(char **srcenv, char ***dstenv,
     } else {
         p1 = "FALSE";
     }
-    PMIX_SETENV_COMPAT("PRTE_SHARED_FS", p1, true, dstenv);
+    PMIx_Setenv("PRTE_SHARED_FS", p1, true, dstenv);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -909,13 +909,13 @@ void prte_state_base_check_fds(prte_job_t *jdata)
         }
         /* construct the list of capabilities */
         if (fdflags & FD_CLOEXEC) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "cloexec");
+            PMIx_Argv_append_nosize(&list, "cloexec");
         }
         if (flflags & O_APPEND) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "append");
+            PMIx_Argv_append_nosize(&list, "append");
         }
         if (flflags & O_NONBLOCK) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "nonblock");
+            PMIx_Argv_append_nosize(&list, "nonblock");
         }
         /* from the man page:
          *  Unlike the other values that can be specified in flags,
@@ -924,22 +924,22 @@ void prte_state_base_check_fds(prte_job_t *jdata)
          * the low order two bits of flags, and defined respectively
          * as 0, 1, and 2. */
         if (O_RDONLY == (flflags & 3)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdonly");
+            PMIx_Argv_append_nosize(&list, "rdonly");
         } else if (O_WRONLY == (flflags & 3)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "wronly");
+            PMIx_Argv_append_nosize(&list, "wronly");
         } else {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdwr");
+            PMIx_Argv_append_nosize(&list, "rdwr");
         }
         if (flk && F_UNLCK != fl.l_type) {
             if (F_WRLCK == fl.l_type) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "wrlock");
+                PMIx_Argv_append_nosize(&list, "wrlock");
             } else {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, "rdlock");
+                PMIx_Argv_append_nosize(&list, "rdlock");
             }
         }
         if (NULL != list) {
-            status = PMIX_ARGV_JOIN_COMPAT(list, ' ');
-            PMIX_ARGV_FREE_COMPAT(list);
+            status = PMIx_Argv_join(list, ' ');
+            PMIx_Argv_free(list);
             list = NULL;
             if (NULL == result) {
                 pmix_asprintf(&result, "    %d\t(%s)\t%s\n", i, info, status);

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -190,7 +190,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
         }
 
     } else {
-        options = PMIX_ARGV_SPLIT_COMPAT(spec, ',');
+        options = PMIx_Argv_split(spec, ',');
         for (n=0; NULL != options[n]; n++) {
             /* see if there is an '=' */
             ptr = strchr(options[n], '=');
@@ -201,7 +201,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                     /* missing the value */
                     pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
-                    PMIX_ARGV_FREE_COMPAT(options);
+                    PMIx_Argv_free(options);
                     return PRTE_ERR_BAD_PARAM;
                 }
             }
@@ -266,7 +266,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                     /* missing the value */
                     pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
-                    PMIX_ARGV_FREE_COMPAT(options);
+                    PMIx_Argv_free(options);
                     return PRTE_ERR_BAD_PARAM;
                 }
                 i32 = strtol(ptr, NULL, 10);
@@ -363,7 +363,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 return PRTE_ERR_SILENT;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(options);
+        PMIx_Argv_free(options);
     }
     /* if notify-error is set but neither recovery nor continuous were specified,
      * then notifications will not be given as we will terminate the job upon

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -4,7 +4,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -446,7 +446,7 @@ static void ready_for_debug(int fd, short args, void *cbdata)
            free(name);
         }
         /* pass the argv from each app */
-        name = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
+        name = PMIx_Argv_join(app->argv, ' ');
         PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_APP_ARGV, name, PMIX_STRING);
         free(name);
     }

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -270,32 +270,6 @@ PRTE_EXPORT int prte_pmix_register_cleanup(char *path, bool directory, bool igno
     PMIX_MCA_BASE_VERSION_2_1_0("prte", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION, \
                                 PRTE_RELEASE_VERSION, type, type_major, type_minor, type_release)
 
-#define PMIX_ARGV_JOIN_COMPAT(a, b) \
-        PMIx_Argv_join(a, b)
-
-#define PMIX_ARGV_SPLIT_COMPAT(a, b) \
-        PMIx_Argv_split(a, b)
-
-#define PMIX_ARGV_SPLIT_WITH_EMPTY_COMPAT(a, b) \
-        PMIx_Argv_split_with_empty(a, b)
-
-#define PMIX_ARGV_COUNT_COMPAT(a) \
-        PMIx_Argv_count(a)
-
-#define PMIX_ARGV_FREE_COMPAT(a) \
-        PMIx_Argv_free(a)
-
-#define PMIX_ARGV_APPEND_UNIQUE_COMPAT(a, b) \
-        PMIx_Argv_append_unique_nosize(a, b)
-
-#define PMIX_ARGV_APPEND_NOSIZE_COMPAT(a, b) \
-        PMIx_Argv_append_nosize(a, b)
-
-#define PMIX_ARGV_COPY_COMPAT(a) \
-        PMIx_Argv_copy(a)
-
-#define PMIX_SETENV_COMPAT(a, b, c, d) \
-        PMIx_Setenv(a, b, c, d)
 
 END_C_DECLS
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -477,7 +477,7 @@ void pmix_server_register_params(void)
                                       &generate_dist);
     prte_pmix_server_globals.generate_dist = 0;
     if (NULL != generate_dist) {
-        char **tmp = PMIX_ARGV_SPLIT_COMPAT(generate_dist, ',');
+        char **tmp = PMIx_Argv_split(generate_dist, ',');
         for (i=0; NULL != tmp[i]; i++) {
             if (0 == strcasecmp(tmp[i], "fabric")) {
                 prte_pmix_server_globals.generate_dist |= PMIX_DEVTYPE_OPENFABRICS;
@@ -487,7 +487,7 @@ void pmix_server_register_params(void)
                 prte_pmix_server_globals.generate_dist |= PMIX_DEVTYPE_NETWORK;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(tmp);
+        PMIx_Argv_free(tmp);
     }
 
     prte_pmix_server_globals.system_controller = false;
@@ -982,7 +982,7 @@ int pmix_server_init(void)
 
     // check for aliases
     if (NULL != prte_process_info.aliases) {
-        tmp = PMIX_ARGV_JOIN_COMPAT(prte_process_info.aliases, ',');
+        tmp = PMIx_Argv_join(prte_process_info.aliases, ',');
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_HOSTNAME_ALIASES, tmp, PMIX_STRING);
         free(tmp);
         if (PMIX_SUCCESS != rc) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -737,10 +737,10 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
         app->app = strdup(papp->argv[0]);
     }
     if (NULL != papp->argv) {
-        app->argv = PMIX_ARGV_COPY_COMPAT(papp->argv);
+        app->argv = PMIx_Argv_copy(papp->argv);
     }
     if (NULL != papp->env) {
-        app->env = PMIX_ARGV_COPY_COMPAT(papp->env);
+        app->env = PMIx_Argv_copy(papp->env);
     }
     if (NULL != papp->cwd) {
         app->cwd = strdup(papp->cwd);
@@ -809,9 +809,9 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 char **ck, *p;
                 uint16_t ppn, pes;
                 int n;
-                ck = PMIX_ARGV_SPLIT_COMPAT(info->value.data.string, ':');
-                if (3 > PMIX_ARGV_COUNT_COMPAT(ck)) {
-                    PMIX_ARGV_FREE_COMPAT(ck);
+                ck = PMIx_Argv_split(info->value.data.string, ':');
+                if (3 > PMIx_Argv_count(ck)) {
+                    PMIx_Argv_free(ck);
                     return PMIX_ERR_BAD_PARAM;
                 }
                 if (0 == strcasecmp(ck[0], "ppr")) {
@@ -833,14 +833,14 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                                            PRTE_ATTR_GLOBAL, &pes, PMIX_UINT16);
                     }
                 } 
-                PMIX_ARGV_FREE_COMPAT(ck);
+                PMIx_Argv_free(ck);
  
                 /***   MAP-BY   ***/
             } else if (PMIX_CHECK_KEY(info, PMIX_MAPBY)) {
                 char **ck, *p;
                 uint16_t ppn, pes;
                 int n;
-                ck = PMIX_ARGV_SPLIT_COMPAT(info->value.data.string, ':');
+                ck = PMIx_Argv_split(info->value.data.string, ':');
                 for (n=0; NULL != ck[n]; n++) {
                     if (0 == strcasecmp(ck[n], "ppr")) {
                         ppn =  strtoul(ck[1], NULL, 10);
@@ -853,7 +853,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                             /* missing the value or value is invalid */
                             pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                            "PE", ck[n]);
-                            PMIX_ARGV_FREE_COMPAT(ck);
+                            PMIx_Argv_free(ck);
                             return PRTE_ERR_SILENT;
                         }
                         ++p;
@@ -861,7 +861,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                             /* missing the value or value is invalid */
                             pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                            "PE", ck[n]);
-                            PMIX_ARGV_FREE_COMPAT(ck);
+                            PMIx_Argv_free(ck);
                             return PRTE_ERR_SILENT;
                         }
                         pes = strtol(p, NULL, 10);                
@@ -871,7 +871,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                         }
                     }
                 }
-                PMIX_ARGV_FREE_COMPAT(ck);
+                PMIx_Argv_free(ck);
 
                 /***   ENVIRONMENTAL VARIABLE DIRECTIVES   ***/
                 /* there can be multiple of these, so we add them to the attribute list */
@@ -979,7 +979,7 @@ static void interim(int sd, short args, void *cbdata)
      * option parsing */
     for (n=0; n < cd->ninfo; n++) {
         if (PMIX_CHECK_KEY(&cd->info[n], PMIX_PERSONALITY)) {
-            jdata->personality = PMIX_ARGV_SPLIT_COMPAT(cd->info[n].value.data.string, ',');
+            jdata->personality = PMIx_Argv_split(cd->info[n].value.data.string, ',');
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(cd->info[n].value.data.string);
             pmix_server_cache_job_info(jdata, &cd->info[n]);
             break;

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -18,7 +18,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -290,7 +290,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     size_t m, n;
     pmix_status_t rc;
 
-    if (NULL == keys || 0 == PMIX_ARGV_COUNT_COMPAT(keys)) {
+    if (NULL == keys || 0 == PMIx_Argv_count(keys)) {
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -325,7 +325,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     }
 
     /* pack the number of keys */
-    n = PMIX_ARGV_COUNT_COMPAT(keys);
+    n = PMIx_Argv_count(keys);
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, &req->msg, &n, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
@@ -440,7 +440,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
     }
 
     /* pack the number of keys */
-    n = PMIX_ARGV_COUNT_COMPAT(keys);
+    n = PMIx_Argv_count(keys);
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, &req->msg, &n, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -218,12 +218,12 @@ static void _query(int sd, short args, void *cbdata)
                     }
                     /* don't show the requestor's job */
                     if (!PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, jdata->nspace)) {
-                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nspaces, jdata->nspace);
+                        PMIx_Argv_append_nosize(&nspaces, jdata->nspace);
                     }
                 }
                 /* join the results into a single comma-delimited string */
-                tmp = PMIX_ARGV_JOIN_COMPAT(nspaces, ',');
-                PMIX_ARGV_FREE_COMPAT(nspaces);
+                tmp = PMIx_Argv_join(nspaces, ',');
+                PMIx_Argv_free(nspaces);
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_NAMESPACES, tmp, PMIX_STRING);
                 free(tmp);
                 if (PMIX_SUCCESS != rc) {
@@ -257,7 +257,7 @@ static void _query(int sd, short args, void *cbdata)
                         ret = PMIX_ERR_NOT_FOUND;
                         goto done;
                     }
-                    cmdline = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
+                    cmdline = PMIx_Argv_join(app->argv, ' ');
                     PMIX_INFO_LIST_ADD(rc, stack, PMIX_CMD_LINE, cmdline, PMIX_STRING);
                     free(cmdline);
                     /* add the job size */
@@ -337,21 +337,21 @@ static void _query(int sd, short args, void *cbdata)
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_SPAWN_SUPPORT)) {
                 ans = NULL;
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_HOST);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_HOSTFILE);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_ADD_HOST);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_ADD_HOSTFILE);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_PREFIX);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_WDIR);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_MAPPER);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_PPR);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_MAPBY);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_RANKBY);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_BINDTO);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_COSPAWN_APP);
+                PMIx_Argv_append_nosize(&ans, PMIX_HOST);
+                PMIx_Argv_append_nosize(&ans, PMIX_HOSTFILE);
+                PMIx_Argv_append_nosize(&ans, PMIX_ADD_HOST);
+                PMIx_Argv_append_nosize(&ans, PMIX_ADD_HOSTFILE);
+                PMIx_Argv_append_nosize(&ans, PMIX_PREFIX);
+                PMIx_Argv_append_nosize(&ans, PMIX_WDIR);
+                PMIx_Argv_append_nosize(&ans, PMIX_MAPPER);
+                PMIx_Argv_append_nosize(&ans, PMIX_PPR);
+                PMIx_Argv_append_nosize(&ans, PMIX_MAPBY);
+                PMIx_Argv_append_nosize(&ans, PMIX_RANKBY);
+                PMIx_Argv_append_nosize(&ans, PMIX_BINDTO);
+                PMIx_Argv_append_nosize(&ans, PMIX_COSPAWN_APP);
                 /* create the return kv */
-                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
-                PMIX_ARGV_FREE_COMPAT(ans);
+                tmp = PMIx_Argv_join(ans, ',');
+                PMIx_Argv_free(ans);
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_SPAWN_SUPPORT, tmp, PMIX_STRING);
                 free(tmp);
                 if (PMIX_SUCCESS != rc) {
@@ -361,15 +361,15 @@ static void _query(int sd, short args, void *cbdata)
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_DEBUG_SUPPORT)) {
                 ans = NULL;
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_IN_INIT);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_IN_APP);
+                PMIx_Argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_INIT);
+                PMIx_Argv_append_nosize(&ans, PMIX_DEBUG_STOP_IN_APP);
 #if PRTE_HAVE_STOP_ON_EXEC
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_STOP_ON_EXEC);
+                PMIx_Argv_append_nosize(&ans, PMIX_DEBUG_STOP_ON_EXEC);
 #endif
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, PMIX_DEBUG_TARGET);
+                PMIx_Argv_append_nosize(&ans, PMIX_DEBUG_TARGET);
                 /* create the return kv */
-                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
-                PMIX_ARGV_FREE_COMPAT(ans);
+                tmp = PMIx_Argv_join(ans, ',');
+                PMIx_Argv_free(ans);
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_DEBUG_SUPPORT, tmp, PMIX_STRING);
                 free(tmp);
                 if (PMIX_SUCCESS != rc) {
@@ -591,13 +591,13 @@ static void _query(int sd, short args, void *cbdata)
                 ans = NULL;
                 PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.psets, prte_pmix_server_pset_t)
                 {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
+                    PMIx_Argv_append_nosize(&ans, ps->name);
                 }
                 if (NULL == ans) {
                     tmp = NULL;;
                 } else {
-                    tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
-                    PMIX_ARGV_FREE_COMPAT(ans);
+                    tmp = PMIx_Argv_join(ans, ',');
+                    PMIx_Argv_free(ans);
                     ans = NULL;
                 }
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PSET_NAMES, tmp, PMIX_STRING);
@@ -669,10 +669,10 @@ static void _query(int sd, short args, void *cbdata)
                 ans = NULL;
                 PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
                 {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ans, ps->name);
+                    PMIx_Argv_append_nosize(&ans, ps->name);
                 }
-                tmp = PMIX_ARGV_JOIN_COMPAT(ans, ',');
-                PMIX_ARGV_FREE_COMPAT(ans);
+                tmp = PMIx_Argv_join(ans, ',');
+                PMIx_Argv_free(ans);
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_GROUP_NAMES, tmp, PMIX_STRING);
                 free(tmp);
                 if (PMIX_SUCCESS != rc) {
@@ -730,7 +730,7 @@ static void _query(int sd, short args, void *cbdata)
                     PMIX_INFO_LIST_ADD(rc, nodeinfolist, PMIX_HOSTNAME, node->name, PMIX_STRING);
                     /* add any aliases */
                     if (NULL != node->aliases) {
-                        str = PMIX_ARGV_JOIN_COMPAT(node->aliases, ',');
+                        str = PMIx_Argv_join(node->aliases, ',');
                         PMIX_INFO_LIST_ADD(rc, nodeinfolist, PMIX_HOSTNAME_ALIASES, str, PMIX_STRING);
                         free(str);
                     }

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -165,12 +165,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             tmp = NULL;
             vpid = PMIX_RANK_VALID;
             ui32 = 0;
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&list, node->name);
+            PMIx_Argv_append_nosize(&list, node->name);
             /* assemble all the ranks for this job that are on this node */
             for (k = 0; k < node->procs->size; k++) {
                 if (NULL != (pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, k))) {
                     if (PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
-                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&micro, PRTE_VPID_PRINT(pptr->name.rank));
+                        PMIx_Argv_append_nosize(&micro, PRTE_VPID_PRINT(pptr->name.rank));
                         if (pptr->name.rank < vpid) {
                             vpid = pptr->name.rank;
                         }
@@ -196,9 +196,9 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             }
             /* assemble the rank/node map */
             if (NULL != micro) {
-                tmp = PMIX_ARGV_JOIN_COMPAT(micro, ',');
-                PMIX_ARGV_FREE_COMPAT(micro);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&procs, tmp);
+                tmp = PMIx_Argv_join(micro, ',');
+                PMIx_Argv_free(micro);
+                PMIx_Argv_append_nosize(&procs, tmp);
             }
             /* construct the node info array */
             PMIX_INFO_LIST_START(iarray);
@@ -206,7 +206,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_HOSTNAME, node->name, PMIX_STRING);
             /* add any aliases */
             if (NULL != node->aliases) {
-                regex = PMIX_ARGV_JOIN_COMPAT(node->aliases, ',');
+                regex = PMIx_Argv_join(node->aliases, ',');
                 PMIX_INFO_LIST_ADD(ret, iarray, PMIX_HOSTNAME_ALIASES, regex, PMIX_STRING);
                 free(regex);
             }
@@ -236,8 +236,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     }
     /* let the PMIx server generate the nodemap regex */
     if (NULL != list) {
-        tmp = PMIX_ARGV_JOIN_COMPAT(list, ',');
-        PMIX_ARGV_FREE_COMPAT(list);
+        tmp = PMIx_Argv_join(list, ',');
+        PMIx_Argv_free(list);
         list = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -253,8 +253,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
 
     /* let the PMIx server generate the procmap regex */
     if (NULL != procs) {
-        tmp = PMIX_ARGV_JOIN_COMPAT(procs, ';');
-        PMIX_ARGV_FREE_COMPAT(procs);
+        tmp = PMIx_Argv_join(procs, ';');
+        PMIx_Argv_free(procs);
         procs = NULL;
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
@@ -379,7 +379,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         /* add the wdir */
         PMIX_INFO_LIST_ADD(ret, iarray, PMIX_WDIR, app->cwd, PMIX_STRING);
         /* add the argv */
-        tmp = PMIX_ARGV_JOIN_COMPAT(app->argv, ' ');
+        tmp = PMIx_Argv_join(app->argv, ' ');
         PMIX_INFO_LIST_ADD(ret, iarray, PMIX_APP_ARGV, tmp, PMIX_STRING);
         free(tmp);
         /* add the pset name */

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -130,7 +130,7 @@ static int process_directive(prte_pmix_server_req_t *req)
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_PERSONALITY)) {
             personality = &req->info[n];
             if (NULL != jdata && NULL == jdata->personality) {
-                jdata->personality = PMIX_ARGV_SPLIT_COMPAT(personality->value.data.string, ',');
+                jdata->personality = PMIx_Argv_split(personality->value.data.string, ',');
                 jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
                 pmix_server_cache_job_info(jdata, personality);
             }
@@ -235,7 +235,7 @@ static int process_directive(prte_pmix_server_req_t *req)
             /* use the default */
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(NULL);
         } else {
-            jdata->personality = PMIX_ARGV_SPLIT_COMPAT(personality->value.data.string, ',');
+            jdata->personality = PMIx_Argv_split(personality->value.data.string, ',');
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
             pmix_server_cache_job_info(jdata, personality);
         }

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -299,7 +299,7 @@ int prte(int argc, char *argv[])
     for (i=0; NULL != environ[i]; i++) {
         if (0 != strncmp(environ[i], "PMIX_", 5) &&
             0 != strncmp(environ[i], "PRTE_", 5)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_launch_environ, environ[i]);
+            PMIx_Argv_append_nosize(&prte_launch_environ, environ[i]);
         }
     }
 
@@ -489,14 +489,14 @@ int prte(int argc, char *argv[])
     // check if they asked for XML output from us
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_OUTPUT);
     if (NULL != opt) {
-        split = PMIX_ARGV_SPLIT_COMPAT(opt->values[0], ',');
+        split = PMIx_Argv_split(opt->values[0], ',');
         for (n = 0; NULL != split[n]; n++) {
             if (PMIX_CHECK_CLI_OPTION(split[n], PRTE_CLI_XML)) {
                 prte_xml_output = true;
                 break;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(split);
+        PMIx_Argv_free(split);
     }
 
    /* Did the user specify a default hostfile? */
@@ -547,16 +547,16 @@ int prte(int argc, char *argv[])
         while (NULL != (param = pmix_getline(fp))) {
             if (!first) {
                 // add a colon delimiter
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&pargv, ":");
+                PMIx_Argv_append_nosize(&pargv, ":");
                 ++pargc;
             }
             // break the line down into parts
-            split = PMIX_ARGV_SPLIT_COMPAT(param, ' ');
+            split = PMIx_Argv_split(param, ' ');
             for (n=0; NULL != split[n]; n++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&pargv, split[n]);
+                PMIx_Argv_append_nosize(&pargv, split[n]);
                 ++pargc;
             }
-            PMIX_ARGV_FREE_COMPAT(split);
+            PMIx_Argv_free(split);
             first = false;
         }
         fclose(fp);
@@ -638,7 +638,7 @@ int prte(int argc, char *argv[])
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_KEEPALIVE);
     if (NULL != opt) {
         keepalive = true;
-        PMIX_SETENV_COMPAT("PMIX_KEEPALIVE_PIPE", opt->values[0], true, &environ);
+        PMIx_Setenv("PMIX_KEEPALIVE_PIPE", opt->values[0], true, &environ);
     }
 
     /* check for debug options */
@@ -687,10 +687,10 @@ int prte(int argc, char *argv[])
 
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_SYSTEM_SERVER)) {
         /* we should act as system-level PMIx server */
-        PMIX_SETENV_COMPAT("PRTE_MCA_pmix_system_server", "1", true, &environ);
+        PMIx_Setenv("PRTE_MCA_pmix_system_server", "1", true, &environ);
     }
     /* always act as session-level PMIx server */
-    PMIX_SETENV_COMPAT("PRTE_MCA_pmix_session_server", "1", true, &environ);
+    PMIx_Setenv("PRTE_MCA_pmix_session_server", "1", true, &environ);
     /* if we were asked to report a uri, set the MCA param to do so */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_REPORT_URI);
     if (NULL != opt) {
@@ -1047,7 +1047,7 @@ int prte(int argc, char *argv[])
         char *tptr;
         int m;
         for (n=0; NULL != opt->values[n]; n++) {
-            targv = PMIX_ARGV_SPLIT_COMPAT(opt->values[n], ',');
+            targv = PMIx_Argv_split(opt->values[n], ',');
             for (i=0; NULL != targv[i]; i++) {
                 if (PMIX_CHECK_CLI_OPTION(targv[i], PRTE_CLI_ALLOC)) {
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC,
@@ -1059,12 +1059,12 @@ int prte(int argc, char *argv[])
                                        PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(targv);
+            PMIx_Argv_free(targv);
             /* check for qualifiers */
             tptr = strchr(opt->values[n], ':');
             if (NULL != tptr) {
                 ++tptr;
-                targv = PMIX_ARGV_SPLIT_COMPAT(tptr, ':');
+                targv = PMIx_Argv_split(tptr, ':');
                 /* check qualifiers */
                 for (m=0; NULL != targv[m]; m++) {
                     if (PMIX_CHECK_CLI_OPTION(targv[m], PRTE_CLI_PARSEABLE) ||
@@ -1074,7 +1074,7 @@ int prte(int argc, char *argv[])
                         break;
                     }
                 }
-                PMIX_ARGV_FREE_COMPAT(targv);
+                PMIx_Argv_free(targv);
             }
         }
 
@@ -1082,7 +1082,7 @@ int prte(int argc, char *argv[])
         char **targv;
         char *tptr;
         int m;
-        targv = PMIX_ARGV_SPLIT_COMPAT(prte_schizo_base.default_display_options, ',');
+        targv = PMIx_Argv_split(prte_schizo_base.default_display_options, ',');
         for (i=0; NULL != targv[i]; i++) {
             if (PMIX_CHECK_CLI_OPTION(targv[i], PRTE_CLI_ALLOC)) {
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC,
@@ -1093,12 +1093,12 @@ int prte(int argc, char *argv[])
                                    PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
             }
         }
-        PMIX_ARGV_FREE_COMPAT(targv);
+        PMIx_Argv_free(targv);
         /* check for qualifiers */
         tptr = strchr(prte_schizo_base.default_display_options, ':');
         if (NULL != tptr) {
             ++tptr;
-            targv = PMIX_ARGV_SPLIT_COMPAT(tptr, ':');
+            targv = PMIx_Argv_split(tptr, ':');
             /* check qualifiers */
             for (m=0; NULL != targv[m]; m++) {
                 if (PMIX_CHECK_CLI_OPTION(targv[m], PRTE_CLI_PARSEABLE) ||
@@ -1108,7 +1108,7 @@ int prte(int argc, char *argv[])
                     break;
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(targv);
+            PMIx_Argv_free(targv);
         }
     }
 
@@ -1140,7 +1140,7 @@ int prte(int argc, char *argv[])
     if (prte_persistent) {
         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOSTFILE);
         if (NULL != opt) {
-            tpath = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+            tpath = PMIx_Argv_join(opt->values, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_HOSTFILE,
                                PRTE_ATTR_GLOBAL, tpath, PMIX_STRING);
             free(tpath);
@@ -1150,7 +1150,7 @@ int prte(int argc, char *argv[])
         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOST);
         if (NULL != opt) {
             char *tval;
-            tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+            tval = PMIx_Argv_join(opt->values, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_DASH_HOST,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
@@ -1159,19 +1159,19 @@ int prte(int argc, char *argv[])
         /* the directives might be in the app(s) */
         if (NULL != hostfiles) {
             char *tval;
-            tval = PMIX_ARGV_JOIN_COMPAT(hostfiles, ',');
+            tval = PMIx_Argv_join(hostfiles, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_HOSTFILE,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
-            PMIX_ARGV_FREE_COMPAT(hostfiles);
+            PMIx_Argv_free(hostfiles);
         }
         if (NULL != hosts) {
             char *tval;
-            tval = PMIX_ARGV_JOIN_COMPAT(hosts, ',');
+            tval = PMIx_Argv_join(hosts, ',');
             prte_set_attribute(&dapp->attributes, PRTE_APP_DASH_HOST,
                                PRTE_ATTR_GLOBAL, tval, PMIX_STRING);
             free(tval);
-            PMIX_ARGV_FREE_COMPAT(hosts);
+            PMIx_Argv_free(hosts);
         }
     }
 
@@ -1303,8 +1303,8 @@ int prte(int argc, char *argv[])
     PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
     {
         papps[n].cmd = strdup(app->app.cmd);
-        papps[n].argv = PMIX_ARGV_COPY_COMPAT(app->app.argv);
-        papps[n].env = PMIX_ARGV_COPY_COMPAT(app->app.env);
+        papps[n].argv = PMIx_Argv_copy(app->app.argv);
+        papps[n].env = PMIx_Argv_copy(app->app.env);
         papps[n].cwd = strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);
@@ -1558,7 +1558,7 @@ static int prep_singleton(const char *name)
     app = PMIX_NEW(prte_app_context_t);
     app->app = strdup(jdata->nspace);
     app->num_procs = 1;
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->argv, app->app);
+    PMIx_Argv_append_nosize(&app->argv, app->app);
     pmix_getcwd(cwd, sizeof(cwd));
     app->cwd = strdup(cwd);
     pmix_pointer_array_set_item(jdata->apps, 0, app);

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -125,7 +125,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     }
     /* Setup application context */
     app = PMIX_NEW(prte_pmix_app_t);
-    app->app.argv = PMIX_ARGV_COPY_COMPAT(results.tail);
+    app->app.argv = PMIx_Argv_copy(results.tail);
     // app->app.cmd is setup below.
 
     /* get the cwd - we may need it in several places */
@@ -187,13 +187,13 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                 opt->values[i] = value;
             }
         }
-        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+        tval = PMIx_Argv_join(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_HOSTFILE,
                            tval, PMIX_STRING);
         free(tval);
         if (NULL != hostfiles) {
             for (i=0; NULL != opt->values[i]; i++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(hostfiles, opt->values[i]);
+                PMIx_Argv_append_nosize(hostfiles, opt->values[i]);
             }
         }
     }
@@ -208,7 +208,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                 opt->values[i] = value;
             }
         }
-        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+        tval = PMIx_Argv_join(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_ADD_HOSTFILE,
                            tval, PMIX_STRING);
         free(tval);
@@ -219,12 +219,12 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     /* Did the user specify any hosts? */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOST);
     if (NULL != opt) {
-        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+        tval = PMIx_Argv_join(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_HOST, tval, PMIX_STRING);
         free(tval);
         if (NULL != hosts) {
             for (i=0; NULL != opt->values[i]; i++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(hosts, opt->values[i]);
+                PMIx_Argv_append_nosize(hosts, opt->values[i]);
             }
         }
     }
@@ -232,7 +232,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     /* Did the user specify any add-hosts? */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_ADDHOST);
     if (NULL != opt) {
-        tval = PMIX_ARGV_JOIN_COMPAT(opt->values, ',');
+        tval = PMIx_Argv_join(opt->values, ',');
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_ADD_HOST, tval, PMIX_STRING);
         free(tval);
         // we don't add these to the hosts array as they
@@ -547,7 +547,7 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
 
     /* Make the apps */
     temp_argv = NULL;
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[0]);
+    PMIx_Argv_append_nosize(&temp_argv, argv[0]);
 
     /* NOTE: This bogus env variable is necessary in the calls to
      create_app(), below.  See comment immediately before the
@@ -557,9 +557,9 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     for (i = 1; NULL != argv[i]; ++i) {
         if (0 == strcmp(argv[i], ":")) {
             /* Make an app with this argv */
-            if (PMIX_ARGV_COUNT_COMPAT(temp_argv) > 1) {
+            if (PMIx_Argv_count(temp_argv) > 1) {
                 if (NULL != env) {
-                    PMIX_ARGV_FREE_COMPAT(env);
+                    PMIx_Argv_free(env);
                     env = NULL;
                 }
                 app = NULL;
@@ -568,7 +568,7 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                 if (PRTE_SUCCESS != rc) {
                     /* Assume that the error message has already been
                      printed; */
-                    PMIX_ARGV_FREE_COMPAT(temp_argv);
+                    PMIx_Argv_free(temp_argv);
                     return rc;
                 }
                 if (made_app) {
@@ -576,16 +576,16 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                 }
 
                 /* Reset the temps */
-                PMIX_ARGV_FREE_COMPAT(temp_argv);
+                PMIx_Argv_free(temp_argv);
                 temp_argv = NULL;
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[0]);
+                PMIx_Argv_append_nosize(&temp_argv, argv[0]);
             }
         } else {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&temp_argv, argv[i]);
+            PMIx_Argv_append_nosize(&temp_argv, argv[i]);
         }
     }
 
-    if (PMIX_ARGV_COUNT_COMPAT(temp_argv) > 1) {
+    if (PMIx_Argv_count(temp_argv) > 1) {
         app = NULL;
         rc = create_app(schizo, temp_argv, &app, &made_app, &env,
                         hostfiles, hosts, jobdata);
@@ -598,9 +598,9 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     }
 
     if (NULL != env) {
-        PMIX_ARGV_FREE_COMPAT(env);
+        PMIx_Argv_free(env);
     }
-    PMIX_ARGV_FREE_COMPAT(temp_argv);
+    PMIx_Argv_free(temp_argv);
 
     /* All done */
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -617,8 +617,8 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
     {
         papps[n].cmd = strdup(app->app.cmd);
-        papps[n].argv = PMIX_ARGV_COPY_COMPAT(app->app.argv);
-        papps[n].env = PMIX_ARGV_COPY_COMPAT(app->app.env);
+        papps[n].argv = PMIx_Argv_copy(app->app.argv);
+        papps[n].env = PMIx_Argv_copy(app->app.env);
         papps[n].cwd = strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);

--- a/src/rml/oob/oob_base_stubs.c
+++ b/src/rml/oob/oob_base_stubs.c
@@ -4,7 +4,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -177,9 +177,9 @@ void prte_oob_base_get_addr(char **uri)
 
     if (!prte_oob_base.disable_ipv4_family &&
         NULL != prte_oob_base.ipv4conns) {
-        tmp = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.ipv4conns, ',');
-        tp = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.ipv4ports, ',');
-        tm = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.if_masks, ',');
+        tmp = PMIx_Argv_join(prte_oob_base.ipv4conns, ',');
+        tp = PMIx_Argv_join(prte_oob_base.ipv4ports, ',');
+        tm = PMIx_Argv_join(prte_oob_base.if_masks, ',');
         pmix_asprintf(&cptr, "tcp://%s:%s:%s", tmp, tp, tm);
         free(tmp);
         free(tp);
@@ -201,9 +201,9 @@ void prte_oob_base_get_addr(char **uri)
          * an implementation may use an optional version flag to indicate such a format
          * explicitly rather than rely on heuristic determination.
          */
-        tmp = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.ipv6conns, ',');
-        tp = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.ipv6ports, ',');
-        tm = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.if_masks, ',');
+        tmp = PMIx_Argv_join(prte_oob_base.ipv6conns, ',');
+        tp = PMIx_Argv_join(prte_oob_base.ipv6ports, ',');
+        tm = PMIx_Argv_join(prte_oob_base.if_masks, ',');
         if (NULL == cptr) {
             /* no ipv4 stuff */
             pmix_asprintf(&cptr, "tcp6://[%s]:%s:%s", tmp, tp, tm);
@@ -336,7 +336,7 @@ static void set_addr(pmix_proc_t *peer, char **uris)
         }
         *masks_string = '\0';
         masks_string++;
-        masks = PMIX_ARGV_SPLIT_COMPAT(masks_string, ',');
+        masks = PMIx_Argv_split(masks_string, ',');
 
         /* separate the ports from the network addrs */
         ports = strrchr(tcpuri, ':');
@@ -364,7 +364,7 @@ static void set_addr(pmix_proc_t *peer, char **uris)
             }
         }
 #endif // PRTE_ENABLE_IPV6
-        addrs = PMIX_ARGV_SPLIT_COMPAT(hptr, ',');
+        addrs = PMIx_Argv_split(hptr, ',');
 
         /* cycle across the provided addrs */
         for (j = 0; NULL != addrs[j]; j++) {
@@ -426,7 +426,7 @@ static void set_addr(pmix_proc_t *peer, char **uris)
                                 (NULL == host) ? "NULL" : host, (NULL == ports) ? "NULL" : ports);
             pmix_list_append(&pr->addrs, &maddr->super);
         }
-        PMIX_ARGV_FREE_COMPAT(addrs);
+        PMIx_Argv_free(addrs);
         free(tcpuri);
     }
 }
@@ -471,7 +471,7 @@ static prte_oob_tcp_peer_t* process_uri(char *uri)
     }
 
     /* split the rest of the uri into component parts */
-    uris = PMIX_ARGV_SPLIT_COMPAT(cptr, ';');
+    uris = PMIx_Argv_split(cptr, ';');
 
     /* get the peer object for this process */
     pr = get_peer(&peer);
@@ -482,7 +482,7 @@ static prte_oob_tcp_peer_t* process_uri(char *uri)
     }
 
     set_addr(&pr->name, uris);
-    PMIX_ARGV_FREE_COMPAT(uris);
+    PMIx_Argv_free(uris);
     return pr;
 }
 

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -210,7 +210,7 @@ int prte_oob_open(void)
              */
             if (PRTE_ERR_NETWORK_NOT_PARSEABLE == rc) {
                 pmix_show_help("help-oob-tcp.txt", "not-parseable", true);
-                PMIX_ARGV_FREE_COMPAT(interfaces);
+                PMIx_Argv_free(interfaces);
                 return PRTE_ERR_BAD_PARAM;
             }
             /* if we are including, then ignore this if not present */
@@ -247,7 +247,7 @@ int prte_oob_open(void)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                 pmix_net_get_hostname((struct sockaddr *) &my_ss),
                                 (AF_INET == my_ss.ss_family) ? "V4" : "V6");
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_oob_base.ipv4conns,
+            PMIx_Argv_append_nosize(&prte_oob_base.ipv4conns,
                                            pmix_net_get_hostname((struct sockaddr *) &my_ss));
         } else if (AF_INET6 == my_ss.ss_family) {
 #if PRTE_ENABLE_IPV6
@@ -256,7 +256,7 @@ int prte_oob_open(void)
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                 pmix_net_get_hostname((struct sockaddr *) &my_ss),
                                 (AF_INET == my_ss.ss_family) ? "V4" : "V6");
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_oob_base.ipv6conns,
+            PMIx_Argv_append_nosize(&prte_oob_base.ipv6conns,
                                            pmix_net_get_hostname((struct sockaddr *) &my_ss));
 #endif // PRTE_ENABLE_IPV6
         } else {
@@ -288,16 +288,16 @@ int prte_oob_open(void)
         copied_interface->ifmtu = selected_interface->ifmtu;
         /* Add the if_mask to the list */
         snprintf(string, 50, "%d", selected_interface->if_mask);
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_oob_base.if_masks, string);
+        PMIx_Argv_append_nosize(&prte_oob_base.if_masks, string);
         pmix_list_append(&prte_oob_base.local_ifs, &(copied_interface->super));
     }
     if (NULL != interfaces) {
-        PMIX_ARGV_FREE_COMPAT(interfaces);
+        PMIx_Argv_free(interfaces);
     }
 
-    if (0 == PMIX_ARGV_COUNT_COMPAT(prte_oob_base.ipv4conns)
+    if (0 == PMIx_Argv_count(prte_oob_base.ipv4conns)
 #if PRTE_ENABLE_IPV6
-        && 0 == PMIX_ARGV_COUNT_COMPAT(prte_oob_base.ipv6conns)
+        && 0 == PMIx_Argv_count(prte_oob_base.ipv6conns)
 #endif
     ) {
         return PRTE_ERR_NOT_AVAILABLE;
@@ -331,22 +331,22 @@ void prte_oob_close(void)
     PMIX_LIST_DESTRUCT(&prte_oob_base.peers);
 
     if (NULL != prte_oob_base.ipv4conns) {
-        PMIX_ARGV_FREE_COMPAT(prte_oob_base.ipv4conns);
+        PMIx_Argv_free(prte_oob_base.ipv4conns);
     }
     if (NULL != prte_oob_base.ipv4ports) {
-        PMIX_ARGV_FREE_COMPAT(prte_oob_base.ipv4ports);
+        PMIx_Argv_free(prte_oob_base.ipv4ports);
     }
 
 #if PRTE_ENABLE_IPV6
     if (NULL != prte_oob_base.ipv6conns) {
-        PMIX_ARGV_FREE_COMPAT(prte_oob_base.ipv6conns);
+        PMIx_Argv_free(prte_oob_base.ipv6conns);
     }
     if (NULL != prte_oob_base.ipv6ports) {
-        PMIX_ARGV_FREE_COMPAT(prte_oob_base.ipv6ports);
+        PMIx_Argv_free(prte_oob_base.ipv6ports);
     }
 #endif
     if (NULL != prte_oob_base.if_masks) {
-        PMIX_ARGV_FREE_COMPAT(prte_oob_base.if_masks);
+        PMIx_Argv_free(prte_oob_base.if_masks);
     }
 
     if (0 <= prte_oob_base.output) {
@@ -401,7 +401,7 @@ int prte_oob_register(void)
     if (NULL != static_port_string) {
         pmix_util_parse_range_options(static_port_string, &prte_oob_base.tcp_static_ports);
         if (0 == strcmp(prte_oob_base.tcp_static_ports[0], "-1")) {
-            PMIX_ARGV_FREE_COMPAT(prte_oob_base.tcp_static_ports);
+            PMIx_Argv_free(prte_oob_base.tcp_static_ports);
             prte_oob_base.tcp_static_ports = NULL;
         }
     } else {
@@ -420,7 +420,7 @@ int prte_oob_register(void)
         pmix_util_parse_range_options(static_port_string6,
                                       &prte_oob_base.tcp6_static_ports);
         if (0 == strcmp(prte_oob_base.tcp6_static_ports[0], "-1")) {
-            PMIX_ARGV_FREE_COMPAT(prte_oob_base.tcp6_static_ports);
+            PMIx_Argv_free(prte_oob_base.tcp6_static_ports);
             prte_oob_base.tcp6_static_ports = NULL;
         }
     } else {
@@ -442,14 +442,14 @@ int prte_oob_register(void)
     if (NULL != dyn_port_string) {
         /* can't have both static and dynamic ports! */
         if (prte_static_ports) {
-            char *err = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.tcp_static_ports, ',');
+            char *err = PMIx_Argv_join(prte_oob_base.tcp_static_ports, ',');
             pmix_show_help("help-oob-tcp.txt", "static-and-dynamic", true, err, dyn_port_string);
             free(err);
             return PRTE_ERROR;
         }
         pmix_util_parse_range_options(dyn_port_string, &prte_oob_base.tcp_dyn_ports);
         if (0 == strcmp(prte_oob_base.tcp_dyn_ports[0], "-1")) {
-            PMIX_ARGV_FREE_COMPAT(prte_oob_base.tcp_dyn_ports);
+            PMIx_Argv_free(prte_oob_base.tcp_dyn_ports);
             prte_oob_base.tcp_dyn_ports = NULL;
         }
     } else {
@@ -468,10 +468,10 @@ int prte_oob_register(void)
         if (prte_static_ports) {
             char *err4 = NULL, *err6 = NULL;
             if (NULL != prte_oob_base.tcp_static_ports) {
-                err4 = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.tcp_static_ports, ',');
+                err4 = PMIx_Argv_join(prte_oob_base.tcp_static_ports, ',');
             }
             if (NULL != prte_oob_base.tcp6_static_ports) {
-                err6 = PMIX_ARGV_JOIN_COMPAT(prte_oob_base.tcp6_static_ports, ',');
+                err6 = PMIx_Argv_join(prte_oob_base.tcp6_static_ports, ',');
             }
             pmix_show_help("help-oob-tcp.txt", "static-and-dynamic-ipv6", true,
                            (NULL == err4) ? "N/A" : err4, (NULL == err6) ? "N/A" : err6,
@@ -486,7 +486,7 @@ int prte_oob_register(void)
         }
         pmix_util_parse_range_options(dyn_port_string6, &prte_oob_base.tcp6_dyn_ports);
         if (0 == strcmp(prte_oob_base.tcp6_dyn_ports[0], "-1")) {
-            PMIX_ARGV_FREE_COMPAT(prte_oob_base.tcp6_dyn_ports);
+            PMIx_Argv_free(prte_oob_base.tcp6_dyn_ports);
             prte_oob_base.tcp6_dyn_ports = NULL;
         }
     } else {
@@ -708,7 +708,7 @@ static void split_and_resolve(char **orig_str, char *name,
         return;
     }
 
-    argv = PMIX_ARGV_SPLIT_COMPAT(*orig_str, ',');
+    argv = PMIx_Argv_split(*orig_str, ',');
     if (NULL == argv) {
         return;
     }
@@ -728,7 +728,7 @@ static void split_and_resolve(char **orig_str, char *name,
                 pmix_output_verbose(20,
                                     prte_oob_base.output,
                                     "oob:tcp: Using interface: %s ", argv[i]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(interfaces, argv[i]);
+                PMIx_Argv_append_nosize(interfaces, argv[i]);
             }
             continue;
         }
@@ -798,7 +798,7 @@ static void split_and_resolve(char **orig_str, char *name,
                                         "oob:tcp: Found match: %s (%s)",
                                         pmix_net_get_hostname((struct sockaddr*) &if_inaddr),
                                         if_name);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(interfaces, if_name);
+                    PMIx_Argv_append_nosize(interfaces, if_name);
                 }
             }
         }
@@ -818,7 +818,7 @@ static void split_and_resolve(char **orig_str, char *name,
     free(argv);
     free(*orig_str);
     if (NULL != interfaces) {
-        *orig_str = PMIX_ARGV_JOIN_COMPAT(*interfaces, ',');
+        *orig_str = PMIx_Argv_join(*interfaces, ',');
     } else {
         *orig_str = NULL;
     }

--- a/src/rml/oob/oob_tcp_listener.c
+++ b/src/rml/oob/oob_tcp_listener.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -201,16 +201,16 @@ static int create_listen(void)
         /* if static ports were provided, take the
          * first entry in the list
          */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_oob_base.tcp_static_ports[0]);
+        PMIx_Argv_append_nosize(&ports, prte_oob_base.tcp_static_ports[0]);
         /* flag that we are using static ports */
         prte_static_ports = true;
     } else if (NULL != prte_oob_base.tcp_dyn_ports) {
         /* take the entire range */
-        ports = PMIX_ARGV_COPY_COMPAT(prte_oob_base.tcp_dyn_ports);
+        ports = PMIx_Argv_copy(prte_oob_base.tcp_dyn_ports);
         prte_static_ports = false;
     } else {
         /* flag the system to dynamically take any available port */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
+        PMIx_Argv_append_nosize(&ports, "0");
         prte_static_ports = false;
     }
 
@@ -230,7 +230,7 @@ static int create_listen(void)
      * one socket, but that prun and daemons will have multiple
      * sockets to support more flexible wireup protocols
      */
-    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ports); i++) {
+    for (i = 0; i < PMIx_Argv_count(ports); i++) {
         pmix_output_verbose(5, prte_oob_base.output,
                             "%s attempting to bind to IPv4 port %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ports[i]);
@@ -248,7 +248,7 @@ static int create_listen(void)
                 pmix_output(0, "prte_oob_create_listen: socket() failed: %s (%d)",
                             strerror(prte_socket_errno), prte_socket_errno);
             }
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERR_IN_ERRNO;
         }
 
@@ -264,7 +264,7 @@ static int create_listen(void)
                         "SO_REUSEADDR option (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -276,7 +276,7 @@ static int create_listen(void)
                         "listening socket to CLOEXEC (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -288,7 +288,7 @@ static int create_listen(void)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) ntohs(port),
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
         /* resolve assigned port */
@@ -296,7 +296,7 @@ static int create_listen(void)
             pmix_output(0, "prte_oob_create_listen: getsockname(): %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -305,7 +305,7 @@ static int create_listen(void)
             pmix_output(0, "prte_oob_create_listen: listen(): %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -314,7 +314,7 @@ static int create_listen(void)
             pmix_output(0, "prte_oob_create_listen init: fcntl(F_GETFL) failed: %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
         flags |= O_NONBLOCK;
@@ -322,7 +322,7 @@ static int create_listen(void)
             pmix_output(0, "prte_oob_create_listen init: fcntl(F_SETFL) failed: %s (%d)",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -337,7 +337,7 @@ static int create_listen(void)
         pmix_list_append(&prte_oob_base.listeners, &conn->item);
         /* and to our ports */
         pmix_asprintf(&tconn, "%d", ntohs(((struct sockaddr_in *) &inaddr)->sin_port));
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_oob_base.ipv4ports, tconn);
+        PMIx_Argv_append_nosize(&prte_oob_base.ipv4ports, tconn);
         free(tconn);
         if (OOB_TCP_DEBUG_CONNECT
             <= pmix_output_get_verbosity(prte_oob_base.output)) {
@@ -351,7 +351,7 @@ static int create_listen(void)
         }
     }
     /* done with this, so release it */
-    PMIX_ARGV_FREE_COMPAT(ports);
+    PMIx_Argv_free(ports);
 
     if (0 == pmix_list_get_size(&prte_oob_base.listeners)) {
         /* cleanup */
@@ -394,16 +394,16 @@ static int create_listen6(void)
             /* if static ports were provided, take the
              * first entry in the list
              */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_oob_base.tcp6_static_ports[0]);
+            PMIx_Argv_append_nosize(&ports, prte_oob_base.tcp6_static_ports[0]);
             /* flag that we are using static ports */
             prte_static_ports = true;
         } else if (NULL != prte_oob_base.tcp6_dyn_ports) {
             /* take the entire range */
-            ports = PMIX_ARGV_COPY_COMPAT(prte_oob_base.tcp6_dyn_ports);
+            ports = PMIx_Argv_copy(prte_oob_base.tcp6_dyn_ports);
             prte_static_ports = false;
         } else {
             /* flag the system to dynamically take any available port */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
+            PMIx_Argv_append_nosize(&ports, "0");
             prte_static_ports = false;
         }
     } else {
@@ -411,16 +411,16 @@ static int create_listen6(void)
             /* if static ports were provided, take the
              * first entry in the list
              */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, prte_oob_base.tcp6_static_ports[0]);
+            PMIx_Argv_append_nosize(&ports, prte_oob_base.tcp6_static_ports[0]);
             /* flag that we are using static ports */
             prte_static_ports = true;
         } else if (NULL != prte_oob_base.tcp6_dyn_ports) {
             /* take the entire range */
-            ports = PMIX_ARGV_COPY_COMPAT(prte_oob_base.tcp6_dyn_ports);
+            ports = PMIx_Argv_copy(prte_oob_base.tcp6_dyn_ports);
             prte_static_ports = false;
         } else {
             /* flag the system to dynamically take any available port */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&ports, "0");
+            PMIx_Argv_append_nosize(&ports, "0");
             prte_static_ports = false;
         }
     }
@@ -441,7 +441,7 @@ static int create_listen6(void)
      * one socket, but that prun and daemons will have multiple
      * sockets to support more flexible wireup protocols
      */
-    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(ports); i++) {
+    for (i = 0; i < PMIx_Argv_count(ports); i++) {
         pmix_output_verbose(5, prte_oob_base.output,
                             "%s attempting to bind to IPv6 port %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ports[i]);
@@ -469,7 +469,7 @@ static int create_listen6(void)
                         "listening socket to CLOEXEC (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -485,7 +485,7 @@ static int create_listen6(void)
                         "SO_REUSEADDR option (%s:%d)\n",
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
 
@@ -497,7 +497,7 @@ static int create_listen6(void)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) ntohs(port),
                         strerror(prte_socket_errno), prte_socket_errno);
             CLOSE_THE_SOCKET(sd);
-            PMIX_ARGV_FREE_COMPAT(ports);
+            PMIx_Argv_free(ports);
             return PRTE_ERROR;
         }
         /* resolve assigned port */
@@ -536,7 +536,7 @@ static int create_listen6(void)
         pmix_list_append(&prte_oob_base.listeners, &conn->item);
         /* and to our ports */
         pmix_asprintf(&tconn, "%d", ntohs(((struct sockaddr_in6 *) &inaddr)->sin6_port));
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_oob_base.ipv6ports, tconn);
+        PMIx_Argv_append_nosize(&prte_oob_base.ipv6ports, tconn);
         free(tconn);
         if (OOB_TCP_DEBUG_CONNECT
             <= pmix_output_get_verbosity(prte_oob_base.output)) {
@@ -552,12 +552,12 @@ static int create_listen6(void)
     if (0 == pmix_list_get_size(&prte_oob_base.listeners)) {
         /* cleanup */
         CLOSE_THE_SOCKET(sd);
-        PMIX_ARGV_FREE_COMPAT(ports);
+        PMIx_Argv_free(ports);
         return PRTE_ERR_SOCKET_NOT_AVAILABLE;
     }
 
     /* done with this, so release it */
-    PMIX_ARGV_FREE_COMPAT(ports);
+    PMIx_Argv_free(ports);
 
     return PRTE_SUCCESS;
 }

--- a/src/rml/rml_base_contact.c
+++ b/src/rml/rml_base_contact.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -57,7 +57,7 @@ int prte_rml_parse_uris(const char *uri, pmix_proc_t *peer, char ***uris)
 
     if (NULL != uris) {
         /* parse the remainder of the string into an array of uris */
-        *uris = PMIX_ARGV_SPLIT_COMPAT(ptr, ';');
+        *uris = PMIx_Argv_split(ptr, ';');
     }
     free(cinfo);
     return PRTE_SUCCESS;

--- a/src/runtime/data_server/ds_lookup.c
+++ b/src/runtime/data_server/ds_lookup.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -101,10 +101,10 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
         rc = PMIx_Data_unpack(NULL, buffer, &str, &count, PMIX_STRING);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_ARGV_FREE_COMPAT(keys);
+            PMIx_Argv_free(keys);
             return rc;
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&keys, str);
+        PMIx_Argv_append_nosize(&keys, str);
         free(str);
     }
 
@@ -113,7 +113,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &count, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        PMIX_ARGV_FREE_COMPAT(keys);
+        PMIx_Argv_free(keys);
         return rc;
     }
     if (0 < ninfo) {
@@ -123,7 +123,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_INFO_FREE(info, ninfo);
-            PMIX_ARGV_FREE_COMPAT(keys);
+            PMIx_Argv_free(keys);
             return rc;
         }
         /* scan the directives for things we care about */
@@ -201,7 +201,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
         } // loop over stored data
         if (!found) {
             // cache the key
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, keys[i]);
+            PMIx_Argv_append_nosize(&cache, keys[i]);
         }
     }     // loop over keys
 
@@ -213,8 +213,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_LIST_DESTRUCT(&answers);
-            PMIX_ARGV_FREE_COMPAT(keys);
-            PMIX_ARGV_FREE_COMPAT(cache);
+            PMIx_Argv_free(keys);
+            PMIx_Argv_free(cache);
             return rc;
         }
         /* loop thru and pack the individual responses - this is somewhat less
@@ -228,29 +228,29 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_LIST_DESTRUCT(&answers);
-                PMIX_ARGV_FREE_COMPAT(keys);
-                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIx_Argv_free(keys);
+                PMIx_Argv_free(cache);
                 return rc;
             }
             rc = PMIx_Data_pack(NULL, &pbkt, &rinfo->info, 1, PMIX_INFO);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_LIST_DESTRUCT(&answers);
-                PMIX_ARGV_FREE_COMPAT(keys);
-                PMIX_ARGV_FREE_COMPAT(cache);
+                PMIx_Argv_free(keys);
+                PMIx_Argv_free(cache);
                 return rc;
             }
         }
     }
     PMIX_LIST_DESTRUCT(&answers);
 
-    i = PMIX_ARGV_COUNT_COMPAT(cache);
+    i = PMIx_Argv_count(cache);
     if (0 < i) {
         if (wait) {
             pmix_output_verbose(1, prte_data_store.output,
                                 "%s data server:lookup: at least some data not found %d vs %d",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nanswers,
-                                (int) PMIX_ARGV_COUNT_COMPAT(keys));
+                                (int) PMIx_Argv_count(keys));
 
             req = PMIX_NEW(prte_data_req_t);
             req->room_number = room_number;
@@ -261,15 +261,15 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             req->keys = cache;
             cache = NULL;
             pmix_list_append(&prte_data_store.pending, &req->super);
-            PMIX_ARGV_FREE_COMPAT(keys);
+            PMIx_Argv_free(keys);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             return PMIX_SUCCESS; // do not return an answer
         } else {
-            PMIX_ARGV_FREE_COMPAT(cache);
+            PMIx_Argv_free(cache);
             if (0 == nanswers) {
                 /* nothing was found - indicate that situation */
                 rc = PMIX_ERR_NOT_FOUND;
-                PMIX_ARGV_FREE_COMPAT(keys);
+                PMIx_Argv_free(keys);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 return rc;
             } else {
@@ -277,7 +277,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             }
         }
     }
-    PMIX_ARGV_FREE_COMPAT(keys);
+    PMIx_Argv_free(keys);
 
     pmix_output_verbose(1, prte_data_store.output,
                         "%s data server:lookup: data found - status %s",

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -307,7 +307,7 @@ static void rqcon(prte_data_req_t *p)
 }
 static void rqdes(prte_data_req_t *p)
 {
-    PMIX_ARGV_FREE_COMPAT(p->keys);
+    PMIx_Argv_free(p->keys);
 }
 PMIX_CLASS_INSTANCE(prte_data_req_t,
                     pmix_list_item_t,

--- a/src/runtime/data_server/ds_publish.c
+++ b/src/runtime/data_server/ds_publish.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -192,12 +192,12 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
                 }
             }
             if (!found) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, req->keys[i]);
+                PMIx_Argv_append_nosize(&cache, req->keys[i]);
             }
         }
         // update the keys to remove all that have been resolved
-        if (0 < PMIX_ARGV_COUNT_COMPAT(cache)) {
-            PMIX_ARGV_FREE_COMPAT(req->keys);
+        if (0 < PMIx_Argv_count(cache)) {
+            PMIx_Argv_free(req->keys);
             req->keys = cache;
         } else {
             // if no keys are in the cache, then all keys were resolved
@@ -236,7 +236,7 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             return rc;
         }
         /* if we found all of the requested keys, then indicate so */
-        if (n == (size_t) PMIX_ARGV_COUNT_COMPAT(req->keys)) {
+        if (n == (size_t) PMIx_Argv_count(req->keys)) {
             rc = PMIX_SUCCESS;
         } else {
             rc = PMIX_ERR_PARTIAL_SUCCESS;

--- a/src/runtime/data_server/ds_unpublish.c
+++ b/src/runtime/data_server/ds_unpublish.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2025      Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
@@ -107,7 +107,7 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
             PMIX_DESTRUCT(&rq);
             return rc;
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&rq.keys, str);
+        PMIx_Argv_append_nosize(&rq.keys, str);
         free(str);
     }
 

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -97,8 +97,8 @@ int prte_app_copy(prte_app_context_t **dest, prte_app_context_t *src)
         (*dest)->app = strdup(src->app);
     }
     (*dest)->num_procs = src->num_procs;
-    (*dest)->argv = PMIX_ARGV_COPY_COMPAT(src->argv);
-    (*dest)->env = PMIX_ARGV_COPY_COMPAT(src->env);
+    (*dest)->argv = PMIx_Argv_copy(src->argv);
+    (*dest)->env = PMIx_Argv_copy(src->env);
     if (NULL != src->cwd) {
         (*dest)->cwd = strdup(src->cwd);
     }

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,7 +126,7 @@ int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job)
     }
 
     /* pack the personality */
-    count = PMIX_ARGV_COUNT_COMPAT(job->personality);
+    count = PMIx_Argv_count(job->personality);
     rc = PMIx_Data_pack(NULL, bkt, (void *) &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -470,7 +470,7 @@ int prte_app_pack(pmix_data_buffer_t *bkt, prte_app_context_t *app)
     }
 
     /* pack the number of entries in the argv array */
-    count = PMIX_ARGV_COUNT_COMPAT(app->argv);
+    count = PMIx_Argv_count(app->argv);
     rc = PMIx_Data_pack(NULL, bkt, &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -487,7 +487,7 @@ int prte_app_pack(pmix_data_buffer_t *bkt, prte_app_context_t *app)
     }
 
     /* pack the number of entries in the enviro array */
-    count = PMIX_ARGV_COUNT_COMPAT(app->env);
+    count = PMIx_Argv_count(app->env);
     rc = PMIx_Data_pack(NULL, bkt, &count, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -121,7 +121,7 @@ void prte_job_print(char **output, prte_job_t *src)
     /* set default result */
     *output = NULL;
 
-    tmp2 = PMIX_ARGV_JOIN_COMPAT(src->personality, ',');
+    tmp2 = PMIx_Argv_join(src->personality, ',');
     pmix_asprintf(&tmp,
                   "\nData for job: %s\tPersonality: %s\tRecovery: %s\n\tNum apps: %ld\tStdin "
                   "target: %s\tState: %s\tAbort: %s",
@@ -457,14 +457,14 @@ void prte_app_print(char **output, prte_job_t *jdata, prte_app_context_t *src)
                   (unsigned long) src->idx, (NULL == src->app) ? "NULL" : src->app,
                   (unsigned long) src->num_procs, PRTE_VPID_PRINT(src->first_rank));
 
-    count = PMIX_ARGV_COUNT_COMPAT(src->argv);
+    count = PMIx_Argv_count(src->argv);
     for (i = 0; i < count; i++) {
         pmix_asprintf(&tmp2, "%s\n\tArgv[%d]: %s", tmp, i, src->argv[i]);
         free(tmp);
         tmp = tmp2;
     }
 
-    count = PMIX_ARGV_COUNT_COMPAT(src->env);
+    count = PMIx_Argv_count(src->env);
     for (i = 0; i < count; i++) {
         pmix_asprintf(&tmp2, "%s\n\tEnv[%lu]: %s", tmp, (unsigned long) i, src->env[i]);
         free(tmp);

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -150,7 +150,7 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
             PMIX_RELEASE(jptr);
             return prte_pmix_convert_status(rc);
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&jptr->personality, tmp);
+        PMIx_Argv_append_nosize(&jptr->personality, tmp);
         free(tmp);
     }
 
@@ -560,7 +560,7 @@ int prte_app_unpack(pmix_data_buffer_t *bkt, prte_app_context_t **ap)
             PMIX_RELEASE(app);
             return prte_pmix_convert_status(rc);
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->argv, tmp);
+        PMIx_Argv_append_nosize(&app->argv, tmp);
         free(tmp);
     }
 
@@ -580,7 +580,7 @@ int prte_app_unpack(pmix_data_buffer_t *bkt, prte_app_context_t **ap)
             PMIX_RELEASE(app);
             return prte_pmix_convert_status(rc);
         }
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&app->env, tmp);
+        PMIx_Argv_append_nosize(&app->env, tmp);
         free(tmp);
     }
 

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -588,12 +588,12 @@ static void prte_app_context_destructor(prte_app_context_t *app_context)
 
     /* argv and env lists created by util/argv copy functions */
     if (NULL != app_context->argv) {
-        PMIX_ARGV_FREE_COMPAT(app_context->argv);
+        PMIx_Argv_free(app_context->argv);
         app_context->argv = NULL;
     }
 
     if (NULL != app_context->env) {
-        PMIX_ARGV_FREE_COMPAT(app_context->env);
+        PMIx_Argv_free(app_context->env);
         app_context->env = NULL;
     }
 
@@ -668,7 +668,7 @@ static void prte_job_destruct(prte_job_t *job)
     }
 
     if (NULL != job->personality) {
-        PMIX_ARGV_FREE_COMPAT(job->personality);
+        PMIx_Argv_free(job->personality);
     }
 
     for (n = 0; n < job->apps->size; n++) {
@@ -741,7 +741,7 @@ static void prte_job_destruct(prte_job_t *job)
         pmix_pointer_array_set_item(prte_job_data, job->index, NULL);
     }
     if (NULL != job->traces) {
-        PMIX_ARGV_FREE_COMPAT(job->traces);
+        PMIx_Argv_free(job->traces);
     }
     PMIX_DESTRUCT(&job->cli);
 }
@@ -792,7 +792,7 @@ static void prte_node_destruct(prte_node_t *node)
         node->rawname = NULL;
     }
     if (NULL != node->aliases) {
-        PMIX_ARGV_FREE_COMPAT(node->aliases);
+        PMIx_Argv_free(node->aliases);
         node->aliases = NULL;
     }
     if (NULL != node->daemon) {

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -267,7 +267,7 @@ static int start_progress_engine(prte_progress_tracker_t *trk)
     if (NULL != prte_progress_thread_cpus) {
         CPU_ZERO(&cpuset);
         // comma-delimited list of cpu ranges
-        ranges = PMIX_ARGV_SPLIT_COMPAT(prte_progress_thread_cpus, ',');
+        ranges = PMIx_Argv_split(prte_progress_thread_cpus, ',');
         for (n=0; NULL != ranges[n]; n++) {
             // look for '-'
             start = strtoul(ranges[n], &dash, 10);

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
     }
     // we do NOT accept arguments other than our own
     if (NULL != results.tail) {
-        str = PMIX_ARGV_JOIN_COMPAT(results.tail, ' ');
+        str = PMIx_Argv_join(results.tail, ' ');
         if (0 != strcmp(str, argv[0])) {
             ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
                                         prte_tool_basename, str, prte_tool_basename);

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
     for (i=0; NULL != environ[i]; i++) {
         if (0 != strncmp(environ[i], "PMIX_", 5) &&
             0 != strncmp(environ[i], "PRTE_", 5)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_launch_environ, environ[i]);
+            PMIx_Argv_append_nosize(&prte_launch_environ, environ[i]);
         }
     }
 
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
     }
 
     /* ensure we silence any compression warnings */
-    PMIX_SETENV_COMPAT("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
+    PMIx_Setenv("PMIX_MCA_compress_base_silence_warning", "1", true, &environ);
 
     /* check for bootstrap operation */
     if (pmix_cmd_line_is_taken(&results, PRTE_CLI_BOOTSTRAP)) {
@@ -427,7 +427,7 @@ int main(int argc, char *argv[])
             /* cleanup */
             hwloc_bitmap_free(ours);
             hwloc_bitmap_free(res);
-            PMIX_ARGV_FREE_COMPAT(cores);
+            PMIx_Argv_free(cores);
         }
     }
 
@@ -581,7 +581,7 @@ int main(int argc, char *argv[])
         if (0 != strcmp(prte_process_info.aliases[n], "localhost") &&
             0 != strcmp(prte_process_info.aliases[n], "127.0.0.1") &&
             0 != strcmp(prte_process_info.aliases[n], prte_process_info.nodename)) {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&nonlocal, prte_process_info.aliases[n]);
+            PMIx_Argv_append_nosize(&nonlocal, prte_process_info.aliases[n]);
         }
     }
     if (NULL == nonlocal) {
@@ -594,7 +594,7 @@ int main(int argc, char *argv[])
     if (NULL != aliases) {
         free(aliases);
     }
-    PMIX_ARGV_FREE_COMPAT(nonlocal);
+    PMIx_Argv_free(nonlocal);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(buffer);
@@ -765,9 +765,9 @@ int main(int argc, char *argv[])
                     }
                 }
                 if (!ignore) {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, "--"PRTE_CLI_PRTEMCA);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, opt->values[i]);
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, t);
+                    PMIx_Argv_append_nosize(&prted_cmd_line, "--"PRTE_CLI_PRTEMCA);
+                    PMIx_Argv_append_nosize(&prted_cmd_line, opt->values[i]);
+                    PMIx_Argv_append_nosize(&prted_cmd_line, t);
                 }
                 --t;
                 *t = '=';
@@ -780,9 +780,9 @@ int main(int argc, char *argv[])
                 char *t = strchr(opt->values[i], '=');
                 *t = '\0';
                 ++t;
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, "--"PRTE_CLI_PMIXMCA);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, opt->values[i]);
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prted_cmd_line, t);
+                PMIx_Argv_append_nosize(&prted_cmd_line, "--"PRTE_CLI_PMIXMCA);
+                PMIx_Argv_append_nosize(&prted_cmd_line, opt->values[i]);
+                PMIx_Argv_append_nosize(&prted_cmd_line, t);
                 --t;
                 *t = '=';
             }

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -311,16 +311,16 @@ int prun(int argc, char *argv[])
         while (NULL != (param = pmix_getline(fp))) {
             if (!first) {
                 // add a colon delimiter
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&pargv, ":");
+                PMIx_Argv_append_nosize(&pargv, ":");
                 ++pargc;
             }
             // break the line down into parts
-            split = PMIX_ARGV_SPLIT_COMPAT(param, ' ');
+            split = PMIx_Argv_split(param, ' ');
             for (n=0; NULL != split[n]; n++) {
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&pargv, split[n]);
+                PMIx_Argv_append_nosize(&pargv, split[n]);
                 ++pargc;
             }
-            PMIX_ARGV_FREE_COMPAT(split);
+            PMIx_Argv_free(split);
             first = false;
         }
         fclose(fp);

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -19,7 +19,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Geoffroy Vallee. All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2021      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
  * $COPYRIGHT$
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
 
     // we do NOT accept arguments other than our own
     if (NULL != results.tail) {
-        param = PMIX_ARGV_JOIN_COMPAT(results.tail, ' ');
+        param = PMIx_Argv_join(results.tail, ' ');
         if (0 != strcmp(param, argv[0])) {
             ptr = pmix_show_help_string("help-pterm.txt", "no-args", false,
                                         prte_tool_basename, param, prte_tool_basename);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -209,11 +209,11 @@ char *prte_attr_print_list(pmix_list_t *attributes)
 
     PMIX_LIST_FOREACH(attr, attributes, prte_attribute_t)
     {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&cache, prte_attr_key_to_str(attr->key));
+        PMIx_Argv_append_nosize(&cache, prte_attr_key_to_str(attr->key));
     }
     if (NULL != cache) {
-        out1 = PMIX_ARGV_JOIN_COMPAT(cache, '\n');
-        PMIX_ARGV_FREE_COMPAT(cache);
+        out1 = PMIx_Argv_join(cache, '\n');
+        PMIx_Argv_free(cache);
     } else {
         out1 = NULL;
     }
@@ -945,56 +945,56 @@ char* prte_print_proc_flags(struct prte_proc_t *ptr)
     char *ans;
 
     // start with the proc name
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, PRTE_NAME_PRINT(&p->name));
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+    PMIx_Argv_append_nosize(&tmp, PRTE_NAME_PRINT(&p->name));
+    PMIx_Argv_append_nosize(&tmp, ": ");
 
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_ALIVE)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ALIVE");
+        PMIx_Argv_append_nosize(&tmp, "ALIVE");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_ABORT)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ABORT");
+        PMIx_Argv_append_nosize(&tmp, "ABORT");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_UPDATED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "UPDATED");
+        PMIx_Argv_append_nosize(&tmp, "UPDATED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_LOCAL)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LOCAL");
+        PMIx_Argv_append_nosize(&tmp, "LOCAL");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_REPORTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "REPORTED");
+        PMIx_Argv_append_nosize(&tmp, "REPORTED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_REG)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "REGISTERED");
+        PMIx_Argv_append_nosize(&tmp, "REGISTERED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_HAS_DEREG)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DEREGISTERED");
+        PMIx_Argv_append_nosize(&tmp, "DEREGISTERED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_AS_MPI)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MPI");
+        PMIx_Argv_append_nosize(&tmp, "MPI");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_IOF_COMPLETE)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "IOF-COMPLETE");
+        PMIx_Argv_append_nosize(&tmp, "IOF-COMPLETE");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_WAITPID)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "WAITPID");
+        PMIx_Argv_append_nosize(&tmp, "WAITPID");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_RECORDED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RECORDED");
+        PMIx_Argv_append_nosize(&tmp, "RECORDED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_DATA_IN_SM)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DATA-IN-SM");
+        PMIx_Argv_append_nosize(&tmp, "DATA-IN-SM");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_DATA_RECVD)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DATA-RECVD");
+        PMIx_Argv_append_nosize(&tmp, "DATA-RECVD");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_SM_ACCESS)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "SM-ACCESS");
+        PMIx_Argv_append_nosize(&tmp, "SM-ACCESS");
     }
     if (PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_TERM_REPORTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TERMINATED");
+        PMIx_Argv_append_nosize(&tmp, "TERMINATED");
     }
-    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
-    PMIX_ARGV_FREE_COMPAT(tmp);
+    ans = PMIx_Argv_join(tmp, '|');
+    PMIx_Argv_free(tmp);
     return ans;
 }
 
@@ -1005,29 +1005,29 @@ char* prte_print_node_flags(struct prte_node_t *ptr)
     char *ans;
 
     // start with the node name
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, p->name);
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+    PMIx_Argv_append_nosize(&tmp, p->name);
+    PMIx_Argv_append_nosize(&tmp, ": ");
 
     if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DAEMON-LAUNCHED");
+        PMIx_Argv_append_nosize(&tmp, "DAEMON-LAUNCHED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_LOC_VERIFIED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LOCATION");
+        PMIx_Argv_append_nosize(&tmp, "LOCATION");
     }
     if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "OVERSUBSCRIBED");
+        PMIx_Argv_append_nosize(&tmp, "OVERSUBSCRIBED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_MAPPED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MAPPED");
+        PMIx_Argv_append_nosize(&tmp, "MAPPED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "SLOTS-GIVEN");
+        PMIx_Argv_append_nosize(&tmp, "SLOTS-GIVEN");
     }
     if (PRTE_FLAG_TEST(p, PRTE_NODE_NON_USABLE)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "NONUSABLE");
+        PMIx_Argv_append_nosize(&tmp, "NONUSABLE");
     }
-    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
-    PMIX_ARGV_FREE_COMPAT(tmp);
+    ans = PMIx_Argv_join(tmp, '|');
+    PMIx_Argv_free(tmp);
     return ans;
 }
 
@@ -1038,23 +1038,23 @@ char* prte_print_app_flags(struct prte_app_context_t *ptr)
     char *ans;
 
     // start with the app command
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, p->app);
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+    PMIx_Argv_append_nosize(&tmp, p->app);
+    PMIx_Argv_append_nosize(&tmp, ": ");
 
     if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_USED_ON_NODE)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "USED-LOCAL-NODE");
+        PMIx_Argv_append_nosize(&tmp, "USED-LOCAL-NODE");
     }
 
     if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_TOOL)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TOOL");
+        PMIx_Argv_append_nosize(&tmp, "TOOL");
     }
 
     if (PRTE_FLAG_TEST(p, PRTE_APP_FLAG_COMPUTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "NPROCS-COMPUTED");
+        PMIx_Argv_append_nosize(&tmp, "NPROCS-COMPUTED");
     }
 
-    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
-    PMIX_ARGV_FREE_COMPAT(tmp);
+    ans = PMIx_Argv_join(tmp, '|');
+    PMIx_Argv_free(tmp);
     return ans;
 }
 
@@ -1065,46 +1065,46 @@ char* prte_print_job_flags(struct prte_job_t *ptr)
     char *ans;
 
     // start with the job name
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, PRTE_JOBID_PRINT(p->nspace));
-    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, ": ");
+    PMIx_Argv_append_nosize(&tmp, PRTE_JOBID_PRINT(p->nspace));
+    PMIx_Argv_append_nosize(&tmp, ": ");
 
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_UPDATED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "UPDATED");
+        PMIx_Argv_append_nosize(&tmp, "UPDATED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_RESTARTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RESTARTED");
+        PMIx_Argv_append_nosize(&tmp, "RESTARTED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_ABORTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ABORTED");
+        PMIx_Argv_append_nosize(&tmp, "ABORTED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "FORWARD-OUTPUT");
+        PMIx_Argv_append_nosize(&tmp, "FORWARD-OUTPUT");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_DO_NOT_MONITOR)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "DO-NOT-MONITOR");
+        PMIx_Argv_append_nosize(&tmp, "DO-NOT-MONITOR");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_FORWARD_COMM)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "FWD-COM");
+        PMIx_Argv_append_nosize(&tmp, "FWD-COM");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_RESTART)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "RESTART");
+        PMIx_Argv_append_nosize(&tmp, "RESTART");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_PROCS_MIGRATING)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "MIGRATING");
+        PMIx_Argv_append_nosize(&tmp, "MIGRATING");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_OVERSUBSCRIBED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "OVERSUBSCRIBED");
+        PMIx_Argv_append_nosize(&tmp, "OVERSUBSCRIBED");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_TOOL)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "TOOL");
+        PMIx_Argv_append_nosize(&tmp, "TOOL");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_LAUNCHER)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "LAUNCHER");
+        PMIx_Argv_append_nosize(&tmp, "LAUNCHER");
     }
     if (PRTE_FLAG_TEST(p, PRTE_JOB_FLAG_ERR_REPORTED)) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&tmp, "ERROR-REPORTED");
+        PMIx_Argv_append_nosize(&tmp, "ERROR-REPORTED");
     }
-    ans = PMIX_ARGV_JOIN_COMPAT(tmp, '|');
-    PMIX_ARGV_FREE_COMPAT(tmp);
+    ans = PMIx_Argv_join(tmp, '|');
+    PMIx_Argv_free(tmp);
     return ans;
 }

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -49,7 +49,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
     int slots = 0;
     int n;
 
-    specs = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
+    specs = PMIx_Argv_split(hosts, ',');
 
     /* see if this node appears in the list */
     for (n = 0; NULL != specs[n]; n++) {
@@ -72,7 +72,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
             }
         }
     }
-    PMIX_ARGV_FREE_COMPAT(specs);
+    PMIx_Argv_free(specs);
     return slots;
 }
 
@@ -102,7 +102,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                          hosts));
 
     PMIX_CONSTRUCT(&adds, pmix_list_t);
-    host_argv = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
+    host_argv = PMIx_Argv_split(hosts, ',');
     if (0 < pmix_list_get_size(nodes)) {
         needcheck = true;
     } else {
@@ -110,24 +110,24 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
     }
 
     /* Accumulate all of the host name mappings */
-    for (j = 0; j < PMIX_ARGV_COUNT_COMPAT(host_argv); ++j) {
-        mini_map = PMIX_ARGV_SPLIT_COMPAT(host_argv[j], ',');
+    for (j = 0; j < PMIx_Argv_count(host_argv); ++j) {
+        mini_map = PMIx_Argv_split(host_argv[j], ',');
 
         if (mapped_nodes == NULL) {
             mapped_nodes = mini_map;
         } else {
             for (k = 0; NULL != mini_map[k]; ++k) {
-                rc = PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mapped_nodes, mini_map[k]);
+                rc = PMIx_Argv_append_nosize(&mapped_nodes, mini_map[k]);
                 if (PRTE_SUCCESS != rc) {
-                    PMIX_ARGV_FREE_COMPAT(host_argv);
-                    PMIX_ARGV_FREE_COMPAT(mini_map);
+                    PMIx_Argv_free(host_argv);
+                    PMIx_Argv_free(mini_map);
                     goto cleanup;
                 }
             }
-            PMIX_ARGV_FREE_COMPAT(mini_map);
+            PMIx_Argv_free(mini_map);
         }
     }
-    PMIX_ARGV_FREE_COMPAT(host_argv);
+    PMIx_Argv_free(host_argv);
     mini_map = NULL;
 
     /* Did we find anything? If not, then do nothing */
@@ -160,7 +160,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                         if (NULL
                             != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, k))) {
                             if (0 == node->num_procs) {
-                                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, node->name);
+                                PMIx_Argv_append_nosize(&mini_map, node->name);
                                 --j;
                             }
                         }
@@ -203,7 +203,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
                         goto cleanup;
                     }
                     /* add this node to the list */
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, node->name);
+                    PMIx_Argv_append_nosize(&mini_map, node->name);
                 } else {
                     /* invalid relative node syntax */
                     pmix_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
@@ -214,7 +214,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             }
         } else {
             /* just one node was given */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&mini_map, mapped_nodes[i]);
+            PMIx_Argv_append_nosize(&mini_map, mapped_nodes[i]);
         }
     }
     if (NULL == mini_map) {
@@ -308,7 +308,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             /* if we didn't find it, add it to the list */
             node = PMIX_NEW(prte_node_t);
             if (NULL == node) {
-                PMIX_ARGV_FREE_COMPAT(mapped_nodes);
+                PMIx_Argv_free(mapped_nodes);
                 if (NULL != shortname) {
                     free(shortname);
                 }
@@ -350,11 +350,11 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         }
         if (0 != strcmp(node->name, mini_map[i])) {
             // add the mini_map name to the list of aliases
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, mini_map[i]);
+            PMIx_Argv_append_unique_nosize(&node->aliases, mini_map[i]);
         }
         // ensure the non-fqdn version is saved
         if (NULL != shortname && 0 != strcmp(shortname, node->name)) {
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, shortname);
+            PMIx_Argv_append_unique_nosize(&node->aliases, shortname);
         }
         if (NULL != shortname) {
             free(shortname);
@@ -363,7 +363,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             free(rawname);
         }
     }
-    PMIX_ARGV_FREE_COMPAT(mini_map);
+    PMIx_Argv_free(mini_map);
 
     /* transfer across all unique nodes */
     while (NULL != (item = pmix_list_remove_first(&adds))) {
@@ -424,7 +424,7 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
 
 cleanup:
     if (NULL != mapped_nodes) {
-        PMIX_ARGV_FREE_COMPAT(mapped_nodes);
+        PMIx_Argv_free(mapped_nodes);
     }
     PMIX_LIST_DESTRUCT(&adds);
 
@@ -444,7 +444,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
     prte_node_t *node;
     char **host_argv = NULL;
 
-    host_argv = PMIX_ARGV_SPLIT_COMPAT(hosts, ',');
+    host_argv = PMIx_Argv_split(hosts, ',');
     if (prte_hnp_is_allocated) {
         start = 0;
     } else {
@@ -452,8 +452,8 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
     }
 
     /* Accumulate all of the host name mappings */
-    for (j = 0; j < PMIX_ARGV_COUNT_COMPAT(host_argv); ++j) {
-        mini_map = PMIX_ARGV_SPLIT_COMPAT(host_argv[j], ',');
+    for (j = 0; j < PMIx_Argv_count(host_argv); ++j) {
+        mini_map = PMIx_Argv_split(host_argv[j], ',');
 
         for (k = 0; NULL != mini_map[k]; ++k) {
             if ('+' == mini_map[k][0]) {
@@ -481,7 +481,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                             }
                             // if the node is empty, capture it
                             if (0 == node->num_procs) {
-                                PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, node->name);
+                                PMIx_Argv_append_nosize(mapped_nodes, node->name);
                                 ++p;
                             }
                         }
@@ -495,7 +495,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                         }
                     } else {
                         /* add a marker to the list */
-                        PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, "*");
+                        PMIx_Argv_append_nosize(mapped_nodes, "*");
                     }
                 } else if ('n' == mini_map[k][1] || 'N' == mini_map[k][1]) {
                     /* they want a specific relative node #, so
@@ -527,7 +527,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                         goto cleanup;
                     }
                     /* add this node to the list */
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, node->name);
+                    PMIx_Argv_append_nosize(mapped_nodes, node->name);
                 } else {
                     /* invalid relative node syntax */
                     pmix_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
@@ -542,22 +542,22 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                 }
                 /* check for local alias */
                 if (prte_check_host_is_local(mini_map[k])) {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, prte_process_info.nodename);
+                    PMIx_Argv_append_nosize(mapped_nodes, prte_process_info.nodename);
                 } else {
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(mapped_nodes, mini_map[k]);
+                    PMIx_Argv_append_nosize(mapped_nodes, mini_map[k]);
                 }
             }
         }
-        PMIX_ARGV_FREE_COMPAT(mini_map);
+        PMIx_Argv_free(mini_map);
         mini_map = NULL;
     }
 
 cleanup:
     if (NULL != host_argv) {
-        PMIX_ARGV_FREE_COMPAT(host_argv);
+        PMIx_Argv_free(host_argv);
     }
     if (NULL != mini_map) {
-        PMIX_ARGV_FREE_COMPAT(mini_map);
+        PMIx_Argv_free(mini_map);
     }
     return rc;
 }
@@ -597,7 +597,7 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
      * nodes list ONCE.
      */
 
-    len_mapped_node = PMIX_ARGV_COUNT_COMPAT(mapped_nodes);
+    len_mapped_node = PMIx_Argv_count(mapped_nodes);
     /* setup a working list so we can put the final list
      * of nodes in order. This way, if the user specifies a
      * set of nodes, we will use them in the order in which
@@ -771,6 +771,6 @@ int prte_util_get_ordered_dash_host_list(pmix_list_t *nodes, char *hosts)
     }
 
     /* cleanup */
-    PMIX_ARGV_FREE_COMPAT(mapped_nodes);
+    PMIx_Argv_free(mapped_nodes);
     return rc;
 }

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -127,9 +127,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         } else {
             value = prte_util_hostfile_value.sval;
         }
-        argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
+        argv = PMIx_Argv_split(value, '@');
 
-        cnt = PMIX_ARGV_COUNT_COMPAT(argv);
+        cnt = PMIx_Argv_count(argv);
         if (1 == cnt) {
             node_name = strdup(argv[0]);
         } else if (2 == cnt) {
@@ -137,10 +137,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             node_name = strdup(argv[1]);
         } else {
             pmix_output(0, "WARNING: Unhandled user@host-combination - %s\n", value); /* XXX */
-            PMIX_ARGV_FREE_COMPAT(argv);
+            PMIx_Argv_free(argv);
             return PRTE_ERROR;
         }
-        PMIX_ARGV_FREE_COMPAT(argv);
+        PMIx_Argv_free(argv);
 
         if (!prte_keep_fqdn_hostnames) {
             // Strip off the FQDN if present, ignore IP addresses
@@ -193,18 +193,18 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                 }
                 if (NULL != alias && 0 != strcmp(alias, node->name)) {
                     // new node object, so alias must be unique
-                    PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
+                    PMIx_Argv_append_nosize(&node->aliases, alias);
                 }
                 pmix_list_append(exclude, &node->super);
             } else {
                 /* the node name may not match the prior entry, so ensure we
                  * keep it if necessary */
                 if (0 != strcmp(node_name, node->name)) {
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
+                    PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
                 }
                 free(node_name);
                 if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
+                    PMIx_Argv_append_unique_nosize(&node->aliases, alias);
                 }
             }
             if (NULL != alias) {
@@ -251,7 +251,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             }
             if (NULL != alias && 0 != strcmp(alias, node->name)) {
                 // new node object, so alias must be unique
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
+                PMIx_Argv_append_nosize(&node->aliases, alias);
             }
             pmix_list_append(updates, &node->super);
         } else {
@@ -261,11 +261,11 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             /* the node name may not match the prior entry, so ensure we
              * keep it if necessary */
             if (0 != strcmp(node_name, node->name)) {
-                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
+                PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
             }
             free(node_name);
             if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
+                PMIx_Argv_append_unique_nosize(&node->aliases, alias);
             }
         }
         if (NULL != alias) {
@@ -295,7 +295,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         }
         if (NULL != alias && 0 != strcmp(alias, node->name)) {
             // new node object, so alias must be unique
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&node->aliases, alias);
+            PMIx_Argv_append_nosize(&node->aliases, alias);
         }
         pmix_list_append(updates, &node->super);
         if (NULL != alias) {
@@ -324,9 +324,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             value = prte_util_hostfile_value.sval;
         }
 
-        argv = PMIX_ARGV_SPLIT_COMPAT(value, '@');
+        argv = PMIx_Argv_split(value, '@');
 
-        cnt = PMIX_ARGV_COUNT_COMPAT(argv);
+        cnt = PMIx_Argv_count(argv);
         if (1 == cnt) {
             node_name = strdup(argv[0]);
         } else if (2 == cnt) {
@@ -334,10 +334,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             node_name = strdup(argv[1]);
         } else {
             pmix_output(0, "WARNING: Unhandled user@host-combination - %s\n", value); /* XXX */
-            PMIX_ARGV_FREE_COMPAT(argv);
+            PMIx_Argv_free(argv);
             return PRTE_ERROR;
         }
-        PMIX_ARGV_FREE_COMPAT(argv);
+        PMIx_Argv_free(argv);
 
         // Strip off the FQDN if present, ignore IP addresses
         if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(node_name)) {
@@ -364,11 +364,11 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             /* the node name may not match the prior entry, so ensure we
              * keep it if necessary */
             if (0 != strcmp(node_name, node->name)) {
-                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, node_name);
+                PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
             }
         }
         if (NULL != alias) {
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, alias);
+            PMIx_Argv_append_unique_nosize(&node->aliases, alias);
             free(alias);
             node->rawname = strdup(node_name);
             alias = NULL;
@@ -645,11 +645,11 @@ int prte_util_add_hostfile_nodes(pmix_list_t *nodes, char *hostfile)
         }
         if (found) {
             /* add this node name as alias */
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, nd->name);
+            PMIx_Argv_append_unique_nosize(&node->aliases, nd->name);
             /* ensure all other aliases are also transferred */
             if (NULL != nd->aliases) {
                 for (i=0; NULL != nd->aliases[i]; i++) {
-                    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&node->aliases, nd->aliases[i]);
+                    PMIx_Argv_append_unique_nosize(&node->aliases, nd->aliases[i]);
                 }
             }
            PMIX_RELEASE(item);

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2020      Triad National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -90,7 +90,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
             continue;
         }
         /* add the hostname to the argv */
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(&names, nptr->name);
+        PMIx_Argv_append_nosize(&names, nptr->name);
         als = NULL;
         if (NULL != nptr->aliases) {
             for (m=0; NULL != nptr->aliases[m]; m++) {
@@ -99,14 +99,14 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
                     0 == strcmp(nptr->aliases[m], "127.0.0.1")) {
                     continue;
                 }
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(&als, nptr->aliases[m]);
+                PMIx_Argv_append_nosize(&als, nptr->aliases[m]);
             }
-            raw = PMIX_ARGV_JOIN_COMPAT(als, ',');
-            PMIX_ARGV_FREE_COMPAT(als);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&aliases, raw);
+            raw = PMIx_Argv_join(als, ',');
+            PMIx_Argv_free(als);
+            PMIx_Argv_append_nosize(&aliases, raw);
             free(raw);
         } else {
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&aliases, "PRTENONE");
+            PMIx_Argv_append_nosize(&aliases, "PRTENONE");
         }
         /* store the vpid */
         vpids[ndaemons] = nptr->daemon->name.rank;
@@ -121,8 +121,8 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     }
 
     /* construct the string of node names for compression */
-    raw = PMIX_ARGV_JOIN_COMPAT(names, ',');
-    PMIX_ARGV_FREE_COMPAT(names);
+    raw = PMIx_Argv_join(names, ',');
+    PMIx_Argv_free(names);
     if (PMIx_Data_compress((uint8_t *) raw, strlen(raw) + 1, (uint8_t **) &bo.bytes, &sz)) {
         /* mark that this was compressed */
         compressed = true;
@@ -153,8 +153,8 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     free(bo.bytes);
 
     /* construct the string of aliases for compression */
-    raw = PMIX_ARGV_JOIN_COMPAT(aliases, ';');
-    PMIX_ARGV_FREE_COMPAT(aliases);
+    raw = PMIx_Argv_join(aliases, ';');
+    PMIx_Argv_free(aliases);
     if (PMIx_Data_compress((uint8_t *) raw, strlen(raw) + 1, (uint8_t **) &bo.bytes, &sz)) {
         /* mark that this was compressed */
         compressed = true;
@@ -286,7 +286,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pbo.size = 0;
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    names = PMIX_ARGV_SPLIT_COMPAT(raw, ',');
+    names = PMIx_Argv_split(raw, ',');
     free(raw);
 
     /* unpack compression flag for node aliases */
@@ -319,7 +319,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pbo.size = 0;
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    aliases = PMIX_ARGV_SPLIT_COMPAT(raw, ';');
+    aliases = PMIx_Argv_split(raw, ';');
     free(raw);
 
     /* unpack compression flag for daemon vpids */
@@ -384,9 +384,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
             }
             if (0 != strcmp(aliases[n], "PRTENONE")) {
                 if (NULL != nd->aliases) {
-                    PMIX_ARGV_FREE_COMPAT(nd->aliases);
+                    PMIx_Argv_free(nd->aliases);
                 }
-                nd->aliases = PMIX_ARGV_SPLIT_COMPAT(aliases[n], ',');
+                nd->aliases = PMIx_Argv_split(aliases[n], ',');
             }
             continue;
         }
@@ -397,7 +397,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         pmix_pointer_array_set_item(prte_node_pool, n, nd);
         /* add any aliases */
         if (0 != strcmp(aliases[n], "PRTENONE")) {
-            nd->aliases = PMIX_ARGV_SPLIT_COMPAT(aliases[n], ',');
+            nd->aliases = PMIx_Argv_split(aliases[n], ',');
         }
         /* set the topology - always default to homogeneous
          * as that is the most common scenario */
@@ -431,7 +431,7 @@ cleanup:
         free(vpid);
     }
     if (NULL != names) {
-        PMIX_ARGV_FREE_COMPAT(names);
+        PMIx_Argv_free(names);
     }
     return rc;
 }

--- a/src/util/parse_options.c
+++ b/src/util/parse_options.c
@@ -14,7 +14,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,11 +65,11 @@ void pmix_util_parse_range_options(char *inp, char ***output)
     }
 
     /* split on commas */
-    r1 = PMIX_ARGV_SPLIT_COMPAT(input, ',');
+    r1 = PMIx_Argv_split(input, ',');
     /* for each resulting element, check for range */
-    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(r1); i++) {
-        r2 = PMIX_ARGV_SPLIT_COMPAT(r1[i], '-');
-        if (1 < PMIX_ARGV_COUNT_COMPAT(r2)) {
+    for (i = 0; i < PMIx_Argv_count(r1); i++) {
+        r2 = PMIx_Argv_split(r1[i], '-');
+        if (1 < PMIx_Argv_count(r2)) {
             /* given range - get start and end */
             start = strtol(r2[0], NULL, 10);
             end = strtol(r2[1], NULL, 10);
@@ -79,10 +79,10 @@ void pmix_util_parse_range_options(char *inp, char ***output)
              */
             vint = strtol(r1[i], NULL, 10);
             if (-1 == vint) {
-                PMIX_ARGV_FREE_COMPAT(*output);
+                PMIx_Argv_free(*output);
                 *output = NULL;
-                PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, "-1");
-                PMIX_ARGV_FREE_COMPAT(r2);
+                PMIx_Argv_append_nosize(output, "-1");
+                PMIx_Argv_free(r2);
                 goto cleanup;
             }
             start = strtol(r2[0], NULL, 10);
@@ -90,17 +90,17 @@ void pmix_util_parse_range_options(char *inp, char ***output)
         }
         for (n = start; n <= end; n++) {
             snprintf(nstr, 32, "%d", n);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, nstr);
+            PMIx_Argv_append_nosize(output, nstr);
         }
-        PMIX_ARGV_FREE_COMPAT(r2);
+        PMIx_Argv_free(r2);
     }
 
 cleanup:
     if (bang_option) {
-        PMIX_ARGV_APPEND_NOSIZE_COMPAT(output, "BANG");
+        PMIx_Argv_append_nosize(output, "BANG");
     }
     free(input);
-    PMIX_ARGV_FREE_COMPAT(r1);
+    PMIx_Argv_free(r1);
 }
 
 void prte_util_get_ranges(char *inp, char ***startpts, char ***endpts)
@@ -118,28 +118,28 @@ void prte_util_get_ranges(char *inp, char ***startpts, char ***endpts)
     input = strdup(inp);
 
     /* split on commas */
-    r1 = PMIX_ARGV_SPLIT_COMPAT(input, ',');
+    r1 = PMIx_Argv_split(input, ',');
     /* for each resulting element, check for range */
-    for (i = 0; i < PMIX_ARGV_COUNT_COMPAT(r1); i++) {
-        r2 = PMIX_ARGV_SPLIT_COMPAT(r1[i], '-');
-        if (2 == PMIX_ARGV_COUNT_COMPAT(r2)) {
+    for (i = 0; i < PMIx_Argv_count(r1); i++) {
+        r2 = PMIx_Argv_split(r1[i], '-');
+        if (2 == PMIx_Argv_count(r2)) {
             /* given range - get start and end */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(startpts, r2[0]);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(endpts, r2[1]);
-        } else if (1 == PMIX_ARGV_COUNT_COMPAT(r2)) {
+            PMIx_Argv_append_nosize(startpts, r2[0]);
+            PMIx_Argv_append_nosize(endpts, r2[1]);
+        } else if (1 == PMIx_Argv_count(r2)) {
             /* only one value provided, so it is both the start
              * and the end
              */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(startpts, r2[0]);
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(endpts, r2[0]);
+            PMIx_Argv_append_nosize(startpts, r2[0]);
+            PMIx_Argv_append_nosize(endpts, r2[0]);
         } else {
             /* no idea how to parse this */
             pmix_output(0, "%s Unknown parse error on string: %s(%s)",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), inp, r1[i]);
         }
-        PMIX_ARGV_FREE_COMPAT(r2);
+        PMIx_Argv_free(r2);
     }
 
     free(input);
-    PMIX_ARGV_FREE_COMPAT(r1);
+    PMIx_Argv_free(r1);
 }

--- a/src/util/proc_info.c
+++ b/src/util/proc_info.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -107,7 +107,7 @@ void prte_setup_hostname(void)
      * the names exchanged in the modex match the names found locally
      */
     if (NULL != prte_strip_prefix && !pmix_net_isaddr(hostname)) {
-        prefixes = PMIX_ARGV_SPLIT_COMPAT(prte_strip_prefix, ',');
+        prefixes = PMIx_Argv_split(prte_strip_prefix, ',');
         match = false;
         for (i = 0; NULL != prefixes[i]; i++) {
             if (0 == strncmp(hostname, prefixes[i], strlen(prefixes[i]))) {
@@ -124,7 +124,7 @@ void prte_setup_hostname(void)
                     prte_process_info.nodename = strdup(&hostname[idx]);
                 }
                 /* add this to our list of aliases */
-                PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
+                PMIx_Argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
                 match = true;
                 break;
             }
@@ -133,7 +133,7 @@ void prte_setup_hostname(void)
         if (!match) {
             prte_process_info.nodename = strdup(hostname);
         }
-        PMIX_ARGV_FREE_COMPAT(prefixes);
+        PMIx_Argv_free(prefixes);
     } else {
         prte_process_info.nodename = strdup(hostname);
     }
@@ -143,15 +143,15 @@ void prte_setup_hostname(void)
         ptr = strchr(prte_process_info.nodename, '.');
         if (NULL != ptr) {
             /* add the fqdn name as an alias */
-            PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, prte_process_info.nodename);
+            PMIx_Argv_append_unique_nosize(&prte_process_info.aliases, prte_process_info.nodename);
             /* retain the non-fqdn name as the node's name */
             *ptr = '\0';
         }
     }
 
     // add the localhost names
-    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, "localhost");
-    PMIX_ARGV_APPEND_UNIQUE_COMPAT(&prte_process_info.aliases, "127.0.0.1");
+    PMIx_Argv_append_unique_nosize(&prte_process_info.aliases, "localhost");
+    PMIx_Argv_append_unique_nosize(&prte_process_info.aliases, "127.0.0.1");
 }
 
 bool prte_check_host_is_local(const char *name)
@@ -172,7 +172,7 @@ bool prte_check_host_is_local(const char *name)
     if (!prte_do_not_resolve) {
         if (pmix_ifislocal(name)) {
             /* add to our aliases */
-            PMIX_ARGV_APPEND_NOSIZE_COMPAT(&prte_process_info.aliases, name);
+            PMIx_Argv_append_nosize(&prte_process_info.aliases, name);
             return true;
         }
     }
@@ -266,7 +266,7 @@ int prte_proc_info_finalize(void)
 
     prte_process_info.proc_type = PRTE_PROC_TYPE_NONE;
 
-    PMIX_ARGV_FREE_COMPAT(prte_process_info.aliases);
+    PMIx_Argv_free(prte_process_info.aliases);
 
     init = false;
     return PRTE_SUCCESS;

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -203,8 +203,8 @@ static int setup_base(void)
         /* break the string into tokens - it should be
          * separated by ','
          */
-        list = PMIX_ARGV_SPLIT_COMPAT(prte_prohibited_session_dirs, ',');
-        len = PMIX_ARGV_COUNT_COMPAT(list);
+        list = PMIx_Argv_split(prte_prohibited_session_dirs, ',');
+        len = PMIx_Argv_count(list);
         /* cycle through the list */
         for (i = 0; i < len; i++) {
             /* check if prefix matches */
@@ -212,11 +212,11 @@ static int setup_base(void)
                 /* this is a prohibited location */
                 pmix_show_help("help-prte-runtime.txt", "prte:session:dir:prohibited", true,
                                prte_process_info.tmpdir_base, prte_prohibited_session_dirs);
-                PMIX_ARGV_FREE_COMPAT(list);
+                PMIx_Argv_free(list);
                 return PRTE_ERR_FATAL;
             }
         }
-        PMIX_ARGV_FREE_COMPAT(list); /* done with this */
+        PMIx_Argv_free(list); /* done with this */
     }
 
     rc = _setup_top_session_dir();

--- a/src/util/sys_limits.c
+++ b/src/util/sys_limits.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2020      NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -118,15 +118,15 @@ int prte_util_init_sys_limits(char **errmsg)
     }
 
     /* parse the requested limits to set */
-    lims = PMIX_ARGV_SPLIT_COMPAT(prte_set_max_sys_limits, ',');
+    lims = PMIx_Argv_split(prte_set_max_sys_limits, ',');
     if (NULL == lims) {
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
     /* each limit is expressed as a "param:value" pair */
     for (i = 0; NULL != lims[i]; i++) {
-        lim = PMIX_ARGV_SPLIT_COMPAT(lims[i], ':');
-        if (1 == PMIX_ARGV_COUNT_COMPAT(lim)) {
+        lim = PMIx_Argv_split(lims[i], ':');
+        if (1 == PMIx_Argv_count(lim)) {
             setlim = "max";
         } else {
             setlim = lim[1];
@@ -224,7 +224,7 @@ int prte_util_init_sys_limits(char **errmsg)
                                             lim[0], setlim);
             goto out;
         }
-        PMIX_ARGV_FREE_COMPAT(lim);
+        PMIx_Argv_free(lim);
         lim = NULL;
     }
 
@@ -234,9 +234,9 @@ int prte_util_init_sys_limits(char **errmsg)
     rc = PRTE_SUCCESS;
 
 out:
-    PMIX_ARGV_FREE_COMPAT(lims);
+    PMIx_Argv_free(lims);
     if (NULL != lim) {
-        PMIX_ARGV_FREE_COMPAT(lim);
+        PMIx_Argv_free(lim);
     }
 
     return rc;


### PR DESCRIPTION
Since we now require PMIx v6.1 or above, we don't need the compat macros