### PR TITLE
Silence warnings from gcc15

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -134,7 +134,7 @@ typedef struct {
 static inline void examples_hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1013,7 +1013,7 @@ PMIX_CLASS_INSTANCE(prte_session_t,
 void prte_hide_unused_params(int x, ...)
 {
     va_list ap;
-
+    (void)x;
     va_start(ap, x);
     va_end(ap);
 }


### PR DESCRIPTION
Apparently, using a param in va_start no longer qualifies as it having been "used".