### PR TITLE
Protect against missing object types

### DIFF
--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1647,6 +1647,11 @@ static char* construct_range(char **vals)
     int n, cnt;
     char buf[4096], **ans = NULL, *str;
 
+    if (NULL == vals) {
+        str = strdup("-");
+        return str;
+    }
+
     cnt = 1;
     for (n=0; NULL != vals[n]; n++) {
         if (NULL == vals[n+1]) {


### PR DESCRIPTION
Indicate an object type isn't present by including a '-' in for the number of objects of that type in the signature.

Fixes #2416 