### PR TITLE
Minor updates to slurm support

### DIFF
--- a/config/prte_check_slurm.m4
+++ b/config/prte_check_slurm.m4
@@ -27,7 +27,7 @@
 # PRTE_CHECK_SLURM(prefix, [action-if-found], [action-if-not-found])
 # --------------------------------------------------------
 AC_DEFUN([PRTE_CHECK_SLURM],[
-    if test -z "$prte_check_slurm_happy" ; then
+
 	AC_ARG_WITH([slurm],
            [AS_HELP_STRING([--with-slurm],
                            [Build SLURM scheduler component (default: yes)])])
@@ -53,27 +53,26 @@ AC_DEFUN([PRTE_CHECK_SLURM],[
                     AC_MSG_RESULT([$prte_check_slurm_happy])
                     ;;
             esac
-        else
-            prte_check_slurm_happy="yes"
-        fi
+      else
+          prte_check_slurm_happy="yes"
+      fi
 
-        AS_IF([test "$prte_check_slurm_happy" = "yes"],
-              [AC_CHECK_FUNC([fork],
-                             [prte_check_slurm_happy="yes"],
-                             [prte_check_slurm_happy="no"])])
+      AS_IF([test "$prte_check_slurm_happy" = "yes"],
+            [AC_CHECK_FUNC([fork],
+                           [prte_check_slurm_happy="yes"],
+                           [prte_check_slurm_happy="no"])])
 
-        AS_IF([test "$prte_check_slurm_happy" = "yes"],
-              [AC_CHECK_FUNC([execve],
-                             [prte_check_slurm_happy="yes"],
-                             [prte_check_slurm_happy="no"])])
+      AS_IF([test "$prte_check_slurm_happy" = "yes"],
+            [AC_CHECK_FUNC([execve],
+                           [prte_check_slurm_happy="yes"],
+                           [prte_check_slurm_happy="no"])])
 
-        AS_IF([test "$prte_check_slurm_happy" = "yes"],
-              [AC_CHECK_FUNC([setpgid],
-                             [prte_check_slurm_happy="yes"],
-                             [prte_check_slurm_happy="no"])])
+      AS_IF([test "$prte_check_slurm_happy" = "yes"],
+            [AC_CHECK_FUNC([setpgid],
+                           [prte_check_slurm_happy="yes"],
+                           [prte_check_slurm_happy="no"])])
 
-        PRTE_SUMMARY_ADD([Resource Managers], [Slurm], [], [$prte_check_slurm_happy])
-    fi
+      PRTE_SUMMARY_ADD([Resource Managers], [Slurm], [], [$prte_check_slurm_happy])
 
     AS_IF([test "$prte_check_slurm_happy" = "yes"],
           [$2],

--- a/src/mca/plm/slurm/configure.m4
+++ b/src/mca/plm/slurm/configure.m4
@@ -35,9 +35,7 @@ AC_DEFUN([MCA_prte_plm_slurm_CONFIG],[
           [$1],
           [$2])
 
-    # set build flags to use in makefile
-    AC_SUBST([plm_slurm_CPPFLAGS])
-    AC_SUBST([plm_slurm_LDFLAGS])
-    AC_SUBST([plm_slurm_LIBS])
+    # there are no libraries to add to the Makefile as we don't
+    # link against any Slurm libs
 
 ])dnl

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -280,14 +280,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
      */
     pmix_argv_append(&argc, &argv, "--cpu-bind=none");
 
-    /* protect against launchers that forward the entire environment */
-    if (NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
-        unsetenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL");
-    }
-    if (NULL != getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE")) {
-        unsetenv("PMIX_LAUNCHER_RENDEZVOUS_FILE");
-    }
-
     /* Append user defined arguments to srun */
     if (NULL != prte_mca_plm_slurm_component.custom_args) {
         custom_strings = PMIx_Argv_split(prte_mca_plm_slurm_component.custom_args, ' ');

--- a/src/mca/ras/slurm/configure.m4
+++ b/src/mca/ras/slurm/configure.m4
@@ -37,9 +37,6 @@ AC_DEFUN([MCA_prte_ras_slurm_CONFIG],[
           [$2])
 
     # set build flags to use in makefile
-    AC_SUBST([ras_slurm_CPPFLAGS])
-    AC_SUBST([ras_slurm_LDFLAGS])
-    AC_SUBST([ras_slurm_LIBS])
     AC_SUBST([ras_slurm_jansson_CPPFLAGS])
     AC_SUBST([ras_slurm_jansson_LDFLAGS])
     AC_SUBST([ras_slurm_jansson_LIBS])


### PR DESCRIPTION
We don't link against Slurm libraries due to license incompatibilities, so remove the lib integration from the m4 configure logic