### PR TITLE
Transfer the default mapby modifiers to jobs

### DIFF
--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,8 @@ typedef struct {
     /* default mapping/ranking directives */
     prte_mapping_policy_t mapping;
     prte_ranking_policy_t ranking;
+    // default ppr setting
+    char *ppr;
     /* default device for dist mapping */
     char *device;
     /* whether or not child jobs should inherit mapping/ranking/binding directives from their parent

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -57,6 +57,7 @@ prte_rmaps_base_t prte_rmaps_base = {
     .selected_modules = PMIX_LIST_STATIC_INIT,
     .mapping = 0,
     .ranking = 0,
+    .ppr = NULL,
     .device = NULL,
     .inherit = false,
     .hwthread_cpus = false,
@@ -494,9 +495,12 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
              * ck[2] contains the string that describes
              * the object and ck[3] is either NULL or contains any
              * modifiers (i.e., "#:obj:mod1,mod2") */
-            if (NULL != jdata) {
-                /* save the pattern */
-                pmix_asprintf(&cptr, "%s:%s", ck[1], ck[2]);
+
+            /* save the pattern */
+            pmix_asprintf(&cptr, "%s:%s", ck[1], ck[2]);
+            if (NULL == jdata) {
+                prte_rmaps_base.ppr = cptr;
+            } else {
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, cptr, PMIX_STRING);
                 free(cptr);
             }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -277,77 +277,148 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         inherit = true;
     }
 
-    if (inherit) {
-        if (NULL != parent) {
-            /* if not already assigned, inherit the parent's ppr */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING)) {
-                /* get the parent job's ppr, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
-                    free(tmp);
+    pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
+                        "mca:rmaps: setting mapping policies for job %s inherit %s hwtcpus %s",
+                        PRTE_JOBID_PRINT(jdata->nspace),
+                        inherit ? "TRUE" : "FALSE",
+                        options.use_hwthreads ? "TRUE" : "FALSE");
+
+    /* set the default mapping policy IFF it wasn't provided */
+    if (!PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
+        if (inherit) {
+            if (NULL != parent) {
+                // copy across the mapping policy
+                jdata->map->mapping = parent->map->mapping;
+
+                /* if not already assigned, inherit the parent's ppr */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING)) {
+                    /* get the parent job's ppr, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
+                        free(tmp);
+                    } else if (NULL != prte_rmaps_base.ppr) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, prte_rmaps_base.ppr, PMIX_STRING);
+                    }
                 }
-            }
-            /* if not already assigned, inherit the parent's pes/proc */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16)) {
-                /* get the parent job's pes/proc, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
-                } else if (0 < prte_rmaps_base.default_pes) {
+                /* if not already assigned, inherit the parent's pes/proc */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16)) {
+                    /* get the parent job's pes/proc, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    } else if (0 < prte_rmaps_base.default_pes) {
+                        u16 = prte_rmaps_base.default_pes;
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    }
+                }
+                /* if not already assigned, inherit the parent's cpu designation */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                    /* get the parent job's designation, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else {
+                        /* default */
+                        if (prte_rmaps_base.hwthread_cpus) {
+                            prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                        } else {
+                            prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                        }
+                    }
+                }
+                /* if not already assigned, inherit the parent's GPU support directive */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_GPU_SUPPORT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                /* if not already assigned, inherit the parent's output directives */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_TAG_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+
+                // copy over any env directives, but do not overwrite anything already specified
+                inherit_env_directives(jdata, parent, nptr);
+
+            } else {
+                // bring over the MCA param defaults, where set and not already specified for this job
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING) &&
+                    NULL != prte_rmaps_base.ppr) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, prte_rmaps_base.ppr, PMIX_STRING);
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16) &&
+                    0 < prte_rmaps_base.default_pes) {
                     u16 = prte_rmaps_base.default_pes;
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    options.cpus_per_rank = u16;
                 }
-            }
-            /* if not already assigned, inherit the parent's cpu designation */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
-                !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                /* get the parent job's designation, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else {
-                    /* default */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
                     if (prte_rmaps_base.hwthread_cpus) {
                         prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                     } else {
                         prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                     }
                 }
-            }
-            /* if not already assigned, inherit the parent's GPU support directive */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_GPU_SUPPORT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            /* if not already assigned, inherit the parent's output directives */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TAG_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
 
-            // copy over any env directives, but do not overwrite anything already specified
-            inherit_env_directives(jdata, parent, nptr);
-        } else {
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
-                !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                /* inherit the base defaults */
-                if (prte_rmaps_base.hwthread_cpus) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                    /* inherit the base defaults */
+                    if (prte_rmaps_base.hwthread_cpus) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    }
                 }
+
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING) &&
+                    NULL != prte_rmaps_base.file) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_FILE, PRTE_ATTR_GLOBAL,
+                                       prte_rmaps_base.file, PMIX_STRING);
+                }
+
+                if (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping)) {
+                    jdata->map->mapping = prte_rmaps_base.mapping;
+                } else {
+                    // let the job's personality set the default mapping behavior
+                    if (NULL != schizo->set_default_mapping) {
+                        rc = schizo->set_default_mapping(jdata, &options);
+                    } else {
+                        rc = prte_rmaps_base_set_default_mapping(jdata, &options);
+                    }
+                    if (PRTE_SUCCESS != rc) {
+                        // the error message should have been printed
+                        jdata->exit_code = rc;
+                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                        goto cleanup;
+                    }
+                }
+            }
+        } else {
+            // let the job's personality set the default mapping behavior
+            if (NULL != schizo->set_default_mapping) {
+                rc = schizo->set_default_mapping(jdata, &options);
+            } else {
+                rc = prte_rmaps_base_set_default_mapping(jdata, &options);
+            }
+            if (PRTE_SUCCESS != rc) {
+                // the error message should have been printed
+                jdata->exit_code = rc;
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                goto cleanup;
             }
         }
     }
@@ -414,53 +485,6 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS, (void*)&tmp, PMIX_STRING)) {
         prte_ras_base_display_cpus(jdata, tmp);
         free(tmp);
-    }
-
-    pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                        "mca:rmaps: setting mapping policies for job %s inherit %s hwtcpus %s",
-                        PRTE_JOBID_PRINT(jdata->nspace),
-                        inherit ? "TRUE" : "FALSE",
-                        options.use_hwthreads ? "TRUE" : "FALSE");
-
-    /* set the default mapping policy IFF it wasn't provided */
-    if (!PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
-        did_map = false;
-        if (inherit) {
-            if (NULL != parent) {
-                jdata->map->mapping = parent->map->mapping;
-                did_map = true;
-            } else if (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping)) {
-                pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                                    "mca:rmaps mapping given by MCA param");
-                jdata->map->mapping = prte_rmaps_base.mapping;
-                if (0 < prte_rmaps_base.default_pes) {
-                    u16 = prte_rmaps_base.default_pes;
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
-                    options.cpus_per_rank = u16;
-                }
-                if (PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
-                    tmp = strchr(prte_rmaps_base.default_mapping_policy, ':');
-                    ++tmp;
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR,
-                                       PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
-                }
-                did_map = true;
-            }
-        }
-        if (!did_map) {
-            // let the job's personality set the default mapping behavior
-            if (NULL != schizo->set_default_mapping) {
-                rc = schizo->set_default_mapping(jdata, &options);
-            } else {
-                rc = prte_rmaps_base_set_default_mapping(jdata, &options);
-            }
-            if (PRTE_SUCCESS != rc) {
-                // the error message should have been printed
-                jdata->exit_code = rc;
-                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-                goto cleanup;
-            }
-        }
     }
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {


### PR DESCRIPTION
If someone doesn't specify a mapping policy but does specify mapby modifiers using the MCA param, then we need to transfer those modifiers across to jobs. Ensure we transfer _all_ the modifiers across.