### PR TITLE
Ensure cmd line MCA params are recognized

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1601,7 +1601,6 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     unsigned long num_procs;
     bool ignore;
     char *skips[] = {
-        "plm",
         "rmaps",
         "ras",
         NULL
@@ -1687,7 +1686,8 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
             tmpv = PMIx_Argv_split(environ[i], '=');
             ignore = false;
             for (j=0; NULL != skips[j]; j++) {
-                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j]))) {
+                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j])) ||
+                    0 == strcmp(&tmpv[0][offset], "plm")) {
                     ignore = true;;
                     break;
                 }
@@ -1744,7 +1744,8 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
          */
         ignore = false;
         for (j=0; NULL != skips[j]; j++) {
-            if (0 == strncmp(prted_cmd_line[i + 1], skips[j], strlen(skips[j]))) {
+            if (0 == strncmp(prted_cmd_line[i + 1], skips[j], strlen(skips[j])) ||
+                0 == strcmp(prted_cmd_line[i + 1], "plm")) {
                 ignore = true;;
                 break;
             }

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -303,15 +303,6 @@ int prte(int argc, char *argv[])
         }
     }
 
-    /* do a minimal setup of key infrastructure, including
-     * parsing the install-level and user-level PRRTE param
-     * files
-     */
-    rc = prte_init_minimum();
-    if (PRTE_SUCCESS != rc) {
-        return rc;
-    }
-
     /* because we have to use the schizo framework and init our hostname
      * prior to parsing the incoming argv for cmd line options, do a hacky
      * search to support passing of impacted options (e.g., verbosity for schizo) */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -209,11 +209,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    ret = prte_init_minimum();
-    if (PRTE_SUCCESS != ret) {
-        return ret;
-    }
-
     /* we always need the prrte and pmix params */
     ret = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
     if (PRTE_SUCCESS != ret) {


### PR DESCRIPTION
We need to parse the cmd line MCA params and push
them into the environment prior to registering
any params so the values will be recognized. Also
need to pass plm framework params to the prted's
as they can open that framework.