### PR TITLE
Fix --host processing

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -175,10 +175,6 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
         caddy->jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
     }
 
-    if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
-        prte_ras_base_display_alloc(caddy->jdata);
-    }
-
     /* progress the job */
     caddy->jdata->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
     PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_VM_READY);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -172,7 +172,11 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
                     "%s=================================================================\n", tmp);
     }
     free(tmp);
-    prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+    if (prte_persistent) {
+        fprintf(stdout, "%s", tmp2);
+    } else {
+        prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+    }
     prte_set_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
 }
 
@@ -424,7 +428,8 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
+    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) &&
+        0 == strcmp(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -50,7 +50,7 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
     int32_t num_nodes;
     int rc, i;
     prte_node_t *node, *hnp_node, *nptr;
-    bool skiphnp = false;
+    bool skiphnp = false, found;
     prte_attribute_t *kv;
     prte_proc_t *daemon;
     prte_job_t *djob;
@@ -178,19 +178,34 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                                  "%s ras:base:node_insert node %s slots %d",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  (NULL == node->name) ? "NULL" : node->name, node->slots));
-            if (prte_managed_allocation) {
-                /* the slots are always treated as sacred
-                 * in managed allocations
-                 */
-                PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+            // see if we already have this node
+            found = false;
+            for (i=0; i < prte_node_pool->size; i++) {
+                nptr = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, i);
+                if (NULL == nptr) {
+                    continue;
+                }
+                if (prte_nptr_match(nptr, node)) {
+                    found = true;
+                    break;
+                }
             }
-            /* insert it into the array */
-            node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
-            if (PRTE_SUCCESS > (rc = node->index)) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
+            if (!found) {
+                if (prte_managed_allocation) {
+                    /* the slots are always treated as sacred
+                     * in managed allocations
+                     */
+                    PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+                }
+                /* insert it into the array */
+                node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
+                if (PRTE_SUCCESS > (rc = node->index)) {
+                    PRTE_ERROR_LOG(rc);
+                    return rc;
+                }
             }
-            if (prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+            if (prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
+                NULL == node->daemon) {
                 /* create a daemon for this node since we won't be launching
                  * and the mapper needs to see a daemon - this is used solely
                  * for testing the mappers */

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -67,19 +67,9 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         free(hosts);
     }
 
-    /* if something was found in the rankfile, we add those resources to
-     * our global pool, use that as our global
-     * pool - set it and we are done
+    /* if something was found in the rankfile, then we are done
      */
     if (!pmix_list_is_empty(nodes)) {
-        /* store the results in the global resource pool - this removes the
-         * list items
-         */
-        rc = prte_ras_base_node_insert(nodes, jdata);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            return rc;
-        }
         /* Record that the rankfile mapping policy has been selected */
         if (NULL == jdata->map) {
             jdata->map = PMIX_NEW(prte_job_map_t);
@@ -116,18 +106,9 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         }
     }
 
-    /* if something was found in the dash-host(s), we use that as our global
-     * pool - set it and we are done
-     */
+    /* if something was found in the dash-host(s), then we are done */
     if (!pmix_list_is_empty(nodes)) {
-        /* store the results in the global resource pool - this removes the
-         * list items
-         */
-        if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(nodes, jdata))) {
-            PRTE_ERROR_LOG(rc);
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-        }
-        return rc;
+        return PRTE_SUCCESS;
     }
 
     /* Our next option is to look for a hostfile and assign our global
@@ -171,18 +152,10 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         }
     }
 
-    /* if something was found in the hosthosts(s), we use that as our global
-     * pool - set it and we are done
+    /* if something was found in the hosthosts(s), then we are done
      */
     if (!pmix_list_is_empty(nodes)) {
-        /* store the results in the global resource pool - this removes the
-         * list items
-         */
-        if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(nodes, jdata))) {
-            PRTE_ERROR_LOG(rc);
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-        }
-        return rc;
+        return PRTE_SUCCESS;
     }
 
     /* if nothing was found so far, then look for a default hostfile */
@@ -198,18 +171,9 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         }
     }
 
-    /* if something was found in the default hostfile, we use that as our global
-     * pool - set it and we are done
-     */
+    /* if something was found in the default hostfile, then we are done */
     if (!pmix_list_is_empty(nodes)) {
-        /* store the results in the global resource pool - this removes the
-         * list items
-         */
-        if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(nodes, jdata))) {
-            PRTE_ERROR_LOG(rc);
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
-        }
-        return rc;
+        return PRTE_SUCCESS;
     }
 
     PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +41,9 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/ess.h"
+#include "src/mca/iof/base/base.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/dash_host/dash_host.h"
 #include "src/util/hostfile/hostfile.h"
@@ -516,14 +519,57 @@ complete:
     /* check for prior bookmark */
     prte_rmaps_base_get_starting_point(allocated_nodes, jdata);
 
-    if (4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
-        pmix_output(0, "AVAILABLE NODES FOR MAPPING:");
-        for (item = pmix_list_get_first(allocated_nodes);
-             item != pmix_list_get_end(allocated_nodes); item = pmix_list_get_next(item)) {
-            node = (prte_node_t *) item;
-            pmix_output(0, "    node: %s daemon: %s slots_available: %d", node->name,
-                        (NULL == node->daemon) ? "NULL" : PRTE_VPID_PRINT(node->daemon->name.rank),
-                        node->slots_available);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL) ||
+        4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
+        bool parsable;
+        char *tmp = NULL, *tmp2, *tmp3;
+        prte_node_t *alloc;
+        pmix_proc_t source;
+
+        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, NULL, PMIX_BOOL)) {
+
+            parsable = prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
+            PMIX_LOAD_PROCID(&source, jdata->nspace, PMIX_RANK_WILDCARD);
+
+            if (parsable) {
+                pmix_asprintf(&tmp, "<allocation>\n");
+            } else {
+                pmix_asprintf(&tmp,
+                              "\n============   ALLOCATED NODES FOR JOB %s APP %d ============\n",
+                              jdata->nspace, app->idx);
+            }
+            for (item = pmix_list_get_first(allocated_nodes);
+                 item != pmix_list_get_end(allocated_nodes); item = pmix_list_get_next(item)) {
+                alloc = (prte_node_t *) item;
+                if (parsable) {
+                    /* need to create the output in XML format */
+                    pmix_asprintf(&tmp2,
+                                  "\t<host name=\"%s\" slots=\"%d\" max_slots=\"%d\" slots_inuse=\"%d\">\n",
+                                  (NULL == alloc->name) ? "UNKNOWN" : alloc->name, (int) alloc->slots_available,
+                                  (int) alloc->slots_max, (int) alloc->slots_inuse);
+                } else {
+                    pmix_asprintf(&tmp2, "    %s: slots=%d max_slots=%d slots_inuse=%d\n",
+                                  (NULL == alloc->name) ? "UNKNOWN" : alloc->name, (int) alloc->slots_available,
+                                  (int) alloc->slots_max, (int) alloc->slots_inuse);
+                }
+                if (NULL == tmp) {
+                    tmp = tmp2;
+                } else {
+                    pmix_asprintf(&tmp3, "%s%s", tmp, tmp2);
+                    free(tmp);
+                    free(tmp2);
+                    tmp = tmp3;
+                }
+            }
+            if (parsable) {
+                pmix_asprintf(&tmp2, "%s</allocation>\n", tmp);
+            } else {
+                pmix_asprintf(&tmp2,
+                            "%s=================================================================================\n", tmp);
+            }
+            free(tmp);
+            prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
         }
     }
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -681,16 +681,16 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     return ret;
                 }
 
-            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAPDEV)) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAP)) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIx_Argv_free(targv);
                     return ret;
                 }
 
-            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAP)) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAPDEV)) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIx_Argv_free(targv);


### PR DESCRIPTION
Properly handle the number of slot assignments when the first host in the --host list is the same as the one where we are executing. Correctly display map vs map-dev options. Display allocations for jobs after node allocations have been made for the job. Need eventually to expand this to the app level.

Fixes problem reported in #2446 