### PR TITLE
Multiple commits

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -39,7 +39,7 @@ python_min_version=3.6
 # requirement is that it must be entirely printable ASCII characters
 # and have no white space.
 
-greek=rc1
+greek=rc2
 
 # If repo_rev is empty, then the repository version number will be
 # obtained during "make dist" via the "git describe --tags --always"

--- a/config/prte_find_type.m4
+++ b/config/prte_find_type.m4
@@ -12,6 +12,7 @@ dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2020 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2026      Nanook Consulting  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -34,7 +35,11 @@ AC_DEFUN([PRTE_FIND_TYPE],[
          AS_IF([test "$oft_target_size" != ""],
              [m4_foreach(oft_type, [$2],
                   [if test -z "$oft_real_type"; then
-                       if test "[$ac_cv_sizeof_]m4_bpatsubst(oft_type, [[^a-zA-Z0-9_]], [_])" = "$oft_target_size" ; then
+                       dnl AS_TR_SH expands literals via m4_translit, which is
+                       dnl locale-independent; m4_bpatsubst regex character
+                       dnl classes are not (e.g. cs_CZ.UTF-8 collates "ch" as
+                       dnl one element, mangling "char" -> "_ar").
+                       if test "[$ac_cv_sizeof_]AS_TR_SH(oft_type)" = "$oft_target_size" ; then
                            oft_real_type="oft_type"
                        fi
                    fi

--- a/docs/news/news-v4.x.rst
+++ b/docs/news/news-v4.x.rst
@@ -22,6 +22,12 @@ series, in reverse chronological order.
                  the --hetero-nodes option has been removed.
 
 Detailed changes include:
+ - PR #2450: Multiple commits
+    - Ensure cmd line MCA params are recognized
+    - Ignore irrelevant MCA params for prted cmd line
+    - Transfer the default mapby modifiers to jobs
+    - config: make m4 type-name sanitization locale-independen
+    - Update NEWS and VERSION
  - PR #2437: Multiple commits
     - Default no-arg prun case to --help
     - Improve hetero node handling

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1600,6 +1600,12 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     prte_job_t *jdata;
     unsigned long num_procs;
     bool ignore;
+    char *skips[] = {
+        "plm",
+        "rmaps",
+        "ras",
+        NULL
+    };
 
     /* check for debug flags */
     if (prte_debug_flag) {
@@ -1679,6 +1685,17 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
         if (0 == strncmp(environ[i], "PMIX_MCA_", offset) ||
             0 == strncmp(environ[i], "PRTE_MCA_", offset)) {
             tmpv = PMIx_Argv_split(environ[i], '=');
+            ignore = false;
+            for (j=0; NULL != skips[j]; j++) {
+                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j]))) {
+                    ignore = true;;
+                    break;
+                }
+            }
+            if (ignore) {
+                continue;
+            }
+
             /* check for duplicate */
             ignore = false;
             for (j = 0; j < *argc; j++) {
@@ -1722,11 +1739,20 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
          * end. Only a few environments allow this, so the daemon
          * only opens the PLM -if- it is specifically told to do
          * so by giving it a specific PLM module. To ensure we avoid
-         * confusion, do not include any directives here
+         * confusion, do not include any directives here, and ignore
+         * any frameworks the daemons do not use
          */
-        if (0 == strcmp(prted_cmd_line[i + 1], "plm")) {
+        ignore = false;
+        for (j=0; NULL != skips[j]; j++) {
+            if (0 == strncmp(prted_cmd_line[i + 1], skips[j], strlen(skips[j]))) {
+                ignore = true;;
+                break;
+            }
+        }
+        if (ignore) {
             continue;
         }
+
         /* check for duplicate */
         ignore = false;
         for (j = 0; j < *argc; j++) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1601,7 +1601,6 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     unsigned long num_procs;
     bool ignore;
     char *skips[] = {
-        "plm",
         "rmaps",
         "ras",
         NULL
@@ -1687,7 +1686,8 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
             tmpv = PMIx_Argv_split(environ[i], '=');
             ignore = false;
             for (j=0; NULL != skips[j]; j++) {
-                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j]))) {
+                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j])) ||
+                    0 == strcmp(&tmpv[0][offset], "plm")) {
                     ignore = true;;
                     break;
                 }
@@ -1744,7 +1744,8 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
          */
         ignore = false;
         for (j=0; NULL != skips[j]; j++) {
-            if (0 == strncmp(prted_cmd_line[i + 1], skips[j], strlen(skips[j]))) {
+            if (0 == strncmp(prted_cmd_line[i + 1], skips[j], strlen(skips[j])) ||
+                0 == strcmp(prted_cmd_line[i + 1], "plm")) {
                 ignore = true;;
                 break;
             }

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -65,6 +65,8 @@ typedef struct {
     /* default mapping/ranking directives */
     prte_mapping_policy_t mapping;
     prte_ranking_policy_t ranking;
+    // default ppr setting
+    char *ppr;
     /* default device for dist mapping */
     char *device;
     /* whether or not child jobs should inherit mapping/ranking/binding directives from their parent

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -57,6 +57,7 @@ prte_rmaps_base_t prte_rmaps_base = {
     .selected_modules = PMIX_LIST_STATIC_INIT,
     .mapping = 0,
     .ranking = 0,
+    .ppr = NULL,
     .device = NULL,
     .inherit = false,
     .hwthread_cpus = false,
@@ -492,9 +493,12 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
              * ck[2] contains the string that describes
              * the object and ck[3] is either NULL or contains any
              * modifiers (i.e., "#:obj:mod1,mod2") */
-            if (NULL != jdata) {
-                /* save the pattern */
-                pmix_asprintf(&cptr, "%s:%s", ck[1], ck[2]);
+
+            /* save the pattern */
+            pmix_asprintf(&cptr, "%s:%s", ck[1], ck[2]);
+            if (NULL == jdata) {
+                prte_rmaps_base.ppr = cptr;
+            } else {
                 prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, cptr, PMIX_STRING);
                 free(cptr);
             }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -277,77 +277,148 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         inherit = true;
     }
 
-    if (inherit) {
-        if (NULL != parent) {
-            /* if not already assigned, inherit the parent's ppr */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING)) {
-                /* get the parent job's ppr, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
-                    free(tmp);
+    pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
+                        "mca:rmaps: setting mapping policies for job %s inherit %s hwtcpus %s",
+                        PRTE_JOBID_PRINT(jdata->nspace),
+                        inherit ? "TRUE" : "FALSE",
+                        options.use_hwthreads ? "TRUE" : "FALSE");
+
+    /* set the default mapping policy IFF it wasn't provided */
+    if (!PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
+        if (inherit) {
+            if (NULL != parent) {
+                // copy across the mapping policy
+                jdata->map->mapping = parent->map->mapping;
+
+                /* if not already assigned, inherit the parent's ppr */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING)) {
+                    /* get the parent job's ppr, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
+                        free(tmp);
+                    } else if (NULL != prte_rmaps_base.ppr) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, prte_rmaps_base.ppr, PMIX_STRING);
+                    }
                 }
-            }
-            /* if not already assigned, inherit the parent's pes/proc */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16)) {
-                /* get the parent job's pes/proc, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
-                } else if (0 < prte_rmaps_base.default_pes) {
+                /* if not already assigned, inherit the parent's pes/proc */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16)) {
+                    /* get the parent job's pes/proc, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    } else if (0 < prte_rmaps_base.default_pes) {
+                        u16 = prte_rmaps_base.default_pes;
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    }
+                }
+                /* if not already assigned, inherit the parent's cpu designation */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                    /* get the parent job's designation, if it had one */
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else {
+                        /* default */
+                        if (prte_rmaps_base.hwthread_cpus) {
+                            prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                        } else {
+                            prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                        }
+                    }
+                }
+                /* if not already assigned, inherit the parent's GPU support directive */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_GPU_SUPPORT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                /* if not already assigned, inherit the parent's output directives */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_TAG_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
+                    if (prte_get_attribute(&parent->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void **) &fptr, PMIX_BOOL)) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
+                    }
+                }
+
+                // copy over any env directives, but do not overwrite anything already specified
+                inherit_env_directives(jdata, parent, nptr);
+
+            } else {
+                // bring over the MCA param defaults, where set and not already specified for this job
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, NULL, PMIX_STRING) &&
+                    NULL != prte_rmaps_base.ppr) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, prte_rmaps_base.ppr, PMIX_STRING);
+                }
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, NULL, PMIX_UINT16) &&
+                    0 < prte_rmaps_base.default_pes) {
                     u16 = prte_rmaps_base.default_pes;
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
+                    options.cpus_per_rank = u16;
                 }
-            }
-            /* if not already assigned, inherit the parent's cpu designation */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
-                !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                /* get the parent job's designation, if it had one */
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else if (prte_get_attribute(&parent->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else {
-                    /* default */
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
                     if (prte_rmaps_base.hwthread_cpus) {
                         prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                     } else {
                         prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                     }
                 }
-            }
-            /* if not already assigned, inherit the parent's GPU support directive */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_GPU_SUPPORT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_GPU_SUPPORT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            /* if not already assigned, inherit the parent's output directives */
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TAG_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_TIMESTAMP_OUTPUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL)) {
-                if (prte_get_attribute(&parent->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void **) &fptr, PMIX_BOOL)) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, PRTE_ATTR_GLOBAL, fptr, PMIX_BOOL);
-                }
-            }
 
-            // copy over any env directives, but do not overwrite anything already specified
-            inherit_env_directives(jdata, parent, nptr);
-        } else {
-            if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
-                !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                /* inherit the base defaults */
-                if (prte_rmaps_base.hwthread_cpus) {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                } else {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
+                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
+                    /* inherit the base defaults */
+                    if (prte_rmaps_base.hwthread_cpus) {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    } else {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+                    }
                 }
+
+                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING) &&
+                    NULL != prte_rmaps_base.file) {
+                    prte_set_attribute(&jdata->attributes, PRTE_JOB_FILE, PRTE_ATTR_GLOBAL,
+                                       prte_rmaps_base.file, PMIX_STRING);
+                }
+
+                if (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping)) {
+                    jdata->map->mapping = prte_rmaps_base.mapping;
+                } else {
+                    // let the job's personality set the default mapping behavior
+                    if (NULL != schizo->set_default_mapping) {
+                        rc = schizo->set_default_mapping(jdata, &options);
+                    } else {
+                        rc = prte_rmaps_base_set_default_mapping(jdata, &options);
+                    }
+                    if (PRTE_SUCCESS != rc) {
+                        // the error message should have been printed
+                        jdata->exit_code = rc;
+                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                        goto cleanup;
+                    }
+                }
+            }
+        } else {
+            // let the job's personality set the default mapping behavior
+            if (NULL != schizo->set_default_mapping) {
+                rc = schizo->set_default_mapping(jdata, &options);
+            } else {
+                rc = prte_rmaps_base_set_default_mapping(jdata, &options);
+            }
+            if (PRTE_SUCCESS != rc) {
+                // the error message should have been printed
+                jdata->exit_code = rc;
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+                goto cleanup;
             }
         }
     }
@@ -414,53 +485,6 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PROCESSORS, (void*)&tmp, PMIX_STRING)) {
         prte_ras_base_display_cpus(jdata, tmp);
         free(tmp);
-    }
-
-    pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                        "mca:rmaps: setting mapping policies for job %s inherit %s hwtcpus %s",
-                        PRTE_JOBID_PRINT(jdata->nspace),
-                        inherit ? "TRUE" : "FALSE",
-                        options.use_hwthreads ? "TRUE" : "FALSE");
-
-    /* set the default mapping policy IFF it wasn't provided */
-    if (!PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
-        did_map = false;
-        if (inherit) {
-            if (NULL != parent) {
-                jdata->map->mapping = parent->map->mapping;
-                did_map = true;
-            } else if (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(prte_rmaps_base.mapping)) {
-                pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                                    "mca:rmaps mapping given by MCA param");
-                jdata->map->mapping = prte_rmaps_base.mapping;
-                if (0 < prte_rmaps_base.default_pes) {
-                    u16 = prte_rmaps_base.default_pes;
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL, u16ptr, PMIX_UINT16);
-                    options.cpus_per_rank = u16;
-                }
-                if (PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(jdata->map->mapping)) {
-                    tmp = strchr(prte_rmaps_base.default_mapping_policy, ':');
-                    ++tmp;
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_PPR,
-                                       PRTE_ATTR_GLOBAL, tmp, PMIX_STRING);
-                }
-                did_map = true;
-            }
-        }
-        if (!did_map) {
-            // let the job's personality set the default mapping behavior
-            if (NULL != schizo->set_default_mapping) {
-                rc = schizo->set_default_mapping(jdata, &options);
-            } else {
-                rc = prte_rmaps_base_set_default_mapping(jdata, &options);
-            }
-            if (PRTE_SUCCESS != rc) {
-                // the error message should have been printed
-                jdata->exit_code = rc;
-                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-                goto cleanup;
-            }
-        }
     }
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PPR, (void **) &tmp, PMIX_STRING)) {

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -303,15 +303,6 @@ int prte(int argc, char *argv[])
         }
     }
 
-    /* do a minimal setup of key infrastructure, including
-     * parsing the install-level and user-level PRRTE param
-     * files
-     */
-    rc = prte_init_minimum();
-    if (PRTE_SUCCESS != rc) {
-        return rc;
-    }
-
     /* because we have to use the schizo framework and init our hostname
      * prior to parsing the incoming argv for cmd line options, do a hacky
      * search to support passing of impacted options (e.g., verbosity for schizo) */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -209,11 +209,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    ret = prte_init_minimum();
-    if (PRTE_SUCCESS != ret) {
-        return ret;
-    }
-
     /* we always need the prrte and pmix params */
     ret = prte_schizo_base_parse_prte(pargc, 0, pargv, NULL);
     if (PRTE_SUCCESS != ret) {


### PR DESCRIPTION
[config: make m4 type-name sanitization locale-independen](https://github.com/openpmix/prrte/commit/653d582401bd8e954891879d732abcb234c2efcb)

Port of https://github.com/open-mpi/ompi/pull/13869

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/c7290c2e862ed7672f140737c344c3e577c82597)

[Transfer the default mapby modifiers to jobs](https://github.com/openpmix/prrte/commit/4319133516cfb09fc37ac6b6eb1cd0e2fcab6b5b)

If someone doesn't specify a mapping policy but does
specify mapby modifiers using the MCA param, then we
need to transfer those modifiers across to jobs. Ensure
we transfer _all_ the modifiers across.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5cb36418f3136dda08e6ac885d2e49cda7032f67)

[Ignore irrelevant MCA params for prted cmd line](https://github.com/openpmix/prrte/commit/c75322783fa853f2db7d0cca2f70097a5b7b1c7b)

The prted doesn't load some frameworks such as rmaps
and ras, so no point in passing MCA params for those
targets.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/6a626f3d61e907b1fc33957e6d40423f8eb4f93d)

[Ensure cmd line MCA params are recognized](https://github.com/openpmix/prrte/commit/e0908ab36cd6d44c9bfdc139687156c7af0e6f31)

We need to parse the cmd line MCA params and push
them into the environment prior to registering
any params so the values will be recognized. Also
need to pass plm framework params to the prted's
as they can open that framework.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/c1bf949913491610dc4a2843a398064fc2fd981e)

[Update NEWS and VERSION](https://github.com/openpmix/prrte/commit/d7f9f6787ce8e0ca81bb32c8afa29be7f148a36c)

Signed-off-by: Ralph Castain <rhc@pmix.org>
bot:notacherrypick