### PR TITLE
Bump actions/checkout to v6

### DIFF
--- a/.github/workflows/build-ompi-external.yaml
+++ b/.github/workflows/build-ompi-external.yaml
@@ -20,7 +20,7 @@ jobs:
         sudo apt install -y --no-install-recommends wget software-properties-common hwloc libhwloc-dev libevent-2.1-7 libevent-dev
 
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -35,7 +35,7 @@ jobs:
         make install
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             path: prrte
@@ -49,7 +49,7 @@ jobs:
         make install
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi

--- a/.github/workflows/build-ompi.yaml
+++ b/.github/workflows/build-ompi.yaml
@@ -20,7 +20,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi
@@ -38,7 +38,7 @@ jobs:
         git pull
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         path: 3rd-party/prrte

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: brew install libevent hwloc autoconf automake libtool
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -38,7 +38,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -102,7 +102,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -116,7 +116,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -164,7 +164,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev clang
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -178,7 +178,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -217,7 +217,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev python3 python3-pip
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -231,7 +231,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/dvm.yaml
+++ b/.github/workflows/dvm.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
             submodules: recursive
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -31,7 +31,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
             submodules: recursive
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -31,7 +31,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
 
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: openpmix/openpmix
@@ -51,7 +51,7 @@ jobs:
         make install
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         clean: false
@@ -67,7 +67,7 @@ jobs:
         make install
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi


### PR DESCRIPTION
Node 20 will be deprecated in June, actions/checkout@6 uses Node 24.