### PR TITLE
 Add logic to serve ras_slurm_module release requests 

### DIFF
--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -268,9 +268,16 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     pmix_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    /* don't kill if a node or prted dies */
-    pmix_argv_append(&argc, &argv, "--no-kill");
-    pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
+    if (!prte_get_attribute(&state->jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL) &&
+        !prte_get_attribute(&state->jdata->attributes, PRTE_JOB_CONTINUOUS, NULL, PMIX_BOOL) &&
+        !prte_elastic_mode) {
+        /* kill the job if any prteds die */
+        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit");
+    } else {
+        /* don't kill if a node or prted dies */
+        pmix_argv_append(&argc, &argv, "--no-kill");
+        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
+    }
 
     /* our daemons are not an MPI task */
     pmix_argv_append(&argc, &argv, "--mpi=none");

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -268,15 +268,9 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     pmix_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    if (!prte_get_attribute(&state->jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL) &&
-        !prte_get_attribute(&state->jdata->attributes, PRTE_JOB_CONTINUOUS, NULL, PMIX_BOOL)) {
-        /* kill the job if any prteds die */
-        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit");
-    } else {
-        /* don't kill if a node or prted dies */
-        pmix_argv_append(&argc, &argv, "--no-kill");
-        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
-    }
+    /* don't kill if a node or prted dies */
+    pmix_argv_append(&argc, &argv, "--no-kill");
+    pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
 
     /* our daemons are not an MPI task */
     pmix_argv_append(&argc, &argv, "--mpi=none");

--- a/src/mca/ras/base/ras_base_select.c
+++ b/src/mca/ras/base/ras_base_select.c
@@ -12,6 +12,8 @@
  * Copyright (c) 2019      Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -87,6 +89,18 @@ int prte_ras_base_select(void)
 
         /* If we got a module, keep it */
         nmodule = (prte_ras_base_module_t *) module;
+
+        /* Initialize the module */
+        if (NULL != nmodule->init) {
+            rc = nmodule->init();
+            if (PRTE_SUCCESS != rc) {
+                pmix_output_verbose(5, prte_ras_base_framework.framework_output,
+                                    "mca:ras:select: Skipping component [%s]. Module init failed",
+                                    component->pmix_mca_component_name);
+                continue;
+            }
+        }
+
         /* add to the list of selected modules */
         newmodule = PMIX_NEW(prte_ras_base_selected_module_t);
         newmodule->pri = priority;

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -132,6 +132,18 @@ enum record_job_data_field {
     PRTE_JOB_DATA_COUNT
 };
 
+/* Stack item type for our session stack */
+
+typedef struct {
+    pmix_list_item_t super;
+    prte_session_t *session;
+} prte_session_stack_item_t;
+PMIX_CLASS_DECLARATION(prte_session_stack_item_t);
+
+/* Stack to keep track of our Slurm allocations in LIFO order */
+
+extern pmix_list_t *prte_slurm_session_stack;
+
 END_C_DECLS
 
 #endif

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -36,8 +36,9 @@
 #include "src/mca/ras/base/base.h"
 #include "src/mca/ras/ras.h"
 
-#define PRTE_SLURM_ERR_STR_MAX_SIZE 256
+#define PRTE_SLURM_ERR_STR_MAX_LEN 256
 #define PRTE_SLURM_JOB_ID_MAX_LEN 20
+#define PRTE_SLURM_HOSTNAME_MAX_LEN 256
 
 /* Markers to indicate a given Slurm JSON-format number is set or infinite */
 #define PRTE_SLURM_UNSET_NUM_MARKER "prte_slurm_unset"
@@ -61,11 +62,13 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req);
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req);
 
 /* Common modify extend/release features */
-int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg);
+int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg, size_t err_msg_size);
 int prte_ras_slurm_token_has_control_chars(const char *s, size_t len, bool *has_control_chars);
+int prte_ras_slurm_drain_cmd_output(FILE *fp, char *output, size_t output_size);
 
 /* Common features for the module */
 int prte_ras_slurm_validate_jobid(const char *slurm_jobid);
+int prte_ras_slurm_validate_hostname(const char *hostname);
 int prte_ras_slurm_convert_jobid(const char *slurm_jobid, uint32_t *slurm_jobid_numeric);
 int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_refid, pmix_list_t *node_list);
 int prte_ras_slurm_tag_node_allocation(const char *slurm_jobid, pmix_list_t *node_list);

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -51,6 +51,7 @@ bool prte_ras_slurm_have_jansson(void);
 /* Features requiring JSON parser */
 int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table);
 int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *node_list);
+int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session, pmix_pointer_array_t *removed_nodes);
 int prte_ras_slurm_check_resources(const char *slurm_jobid);
 
 /* Features to serve request extension */
@@ -137,6 +138,7 @@ enum record_job_data_field {
 typedef struct {
     pmix_list_item_t super;
     prte_session_t *session;
+    int nodes_in_session;
 } prte_session_stack_item_t;
 PMIX_CLASS_DECLARATION(prte_session_stack_item_t);
 

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -755,6 +755,181 @@ int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *
     return err;
 }
 
+/**
+ * Synchronize a session's node list with a reduced Slurm allocation.
+ *
+ * Nodes no longer present in the allocation are appended to
+ * removed_nodes.
+ *
+ * @param[in] slurm_jobid Slurm job identifier.
+ * @param[in,out] session Session to update.
+ * @param[out] removed_nodes Receives detached nodes; must be empty.
+ */
+int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session, pmix_pointer_array_t *removed_nodes)
+{
+    if (NULL == slurm_jobid || NULL == removed_nodes ||
+        NULL == session || NULL == session->nodes || 
+        0 != removed_nodes->size) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int err = PRTE_SUCCESS;
+
+    err = prte_ras_slurm_validate_jobid(slurm_jobid);
+
+    if(PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    pmix_pointer_array_t matched_nodes, unmatched_nodes;
+    PMIX_CONSTRUCT(&matched_nodes, pmix_pointer_array_t);
+    PMIX_CONSTRUCT(&unmatched_nodes, pmix_pointer_array_t);
+
+    json_t *root = NULL;
+
+    err = prte_ras_slurm_get_jobinfo_json(slurm_jobid, &root);
+
+    if(PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+    json_t *job_resources = json_object_get(root, "job_resources");
+
+    if(NULL == job_resources || !json_is_object(job_resources)) {
+        err = PRTE_ERR_JSON_PARSE_FAILURE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    json_t *nodes = json_object_get(job_resources, "nodes");
+
+    if(NULL == nodes || !json_is_object(nodes)) {
+        err = PRTE_ERR_JSON_PARSE_FAILURE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    json_t *allocation = json_object_get(nodes, "allocation");
+
+    if (NULL == allocation || !json_is_array(allocation)) {
+        err = PRTE_ERR_JSON_PARSE_FAILURE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    size_t new_alloc_size = json_array_size(allocation);
+    size_t session_nodes_size = 0;
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *node_ptr = (prte_node_t *)pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL != node_ptr) {
+            pmix_pointer_array_add(&unmatched_nodes, node_ptr);
+            session_nodes_size++;
+        }
+    }
+
+    /* sanity checks, as we rely on these assumptions implicitly later */
+    if (0 == new_alloc_size || 0 == session_nodes_size 
+        || new_alloc_size >= session_nodes_size) {
+        err = PRTE_ERR_BAD_PARAM;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    /* retrieve surviving nodes in Slurm-provided order */
+
+    for (size_t i = 0; i < new_alloc_size; i++) {
+        json_t *node_obj = json_array_get(allocation, i);
+
+        if (!json_is_object(node_obj)) {
+            err = PRTE_ERR_JSON_PARSE_FAILURE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        json_t *nodename = json_object_get(node_obj, "name");
+
+        if (NULL == nodename || !json_is_string(nodename)) {
+            err = PRTE_ERR_JSON_PARSE_FAILURE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        const char *nodename_string = json_string_value(nodename);
+
+        if (NULL == nodename_string || '\0' == nodename_string[0]) {
+            err = PRTE_ERR_JSON_PARSE_FAILURE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        int session_node_idx = (int)i;
+        bool found = false;
+
+        /* find the equivalent node in the list of unmatched nodes. 
+         * We expect (but do not strictly require) the ordering here
+         * to be favorable; i.e. node at index i should be the
+         * one we are looking for */
+        for (int j = 0; j < unmatched_nodes.size; j++) {
+            prte_node_t *curr = (prte_node_t *)pmix_pointer_array_get_item(&unmatched_nodes, (int)session_node_idx);
+            
+            if (NULL != curr && NULL != curr->name &&
+                0 == strcmp(curr->name, nodename_string)) {
+                found = true;
+                pmix_pointer_array_add(&matched_nodes, curr);
+                pmix_pointer_array_set_item(&unmatched_nodes, session_node_idx, NULL);
+                break;
+            }
+            
+            if(++session_node_idx >= unmatched_nodes.size) {
+                session_node_idx = 0;
+            }
+        }
+
+        if(!found) {
+            err = PRTE_ERR_NOT_FOUND;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+    }
+
+    /* success, clear out old entries and reconstruct the node list*/
+
+    pmix_pointer_array_remove_all(session->nodes);
+
+    for (int i = 0; i < matched_nodes.size; i++) {
+        prte_node_t *curr = (prte_node_t *)pmix_pointer_array_get_item(&matched_nodes, i);
+        if(NULL != curr) {
+            pmix_pointer_array_set_item(session->nodes, i, curr);
+        }
+    }
+
+    pmix_pointer_array_remove_all(&matched_nodes);
+
+    for (int i = 0; i < unmatched_nodes.size; i++) {
+        prte_node_t *curr = (prte_node_t *)pmix_pointer_array_get_item(&unmatched_nodes, i);
+        if(NULL != curr) {
+            pmix_pointer_array_add(removed_nodes, curr);
+        }
+    }
+
+    pmix_pointer_array_remove_all(&unmatched_nodes);
+
+cleanup:
+
+    if(NULL != root) {
+        json_decref(root);
+    }
+
+    PMIX_DESTRUCT(&matched_nodes);
+    PMIX_DESTRUCT(&unmatched_nodes);
+
+    return err;
+}
+
 /*
  * Check the state of a Slurm job against RUNNING and PENDING.
  *

--- a/src/mca/ras/slurm/ras_slurm_jansson_stub.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson_stub.c
@@ -47,6 +47,15 @@ int prte_ras_slurm_add_modified_resources(const char *slurm_jobid,
     return PRTE_ERR_NOT_AVAILABLE;
 }
 
+int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session, pmix_pointer_array_t *removed_nodes)
+{
+    PRTE_HIDE_UNUSED_PARAMS(slurm_jobid, session, removed_nodes);
+
+    pmix_output(0, "ras:slurm:detach_nodes: "
+                "Jansson support is required but not enabled in this build");
+    return PRTE_ERR_NOT_AVAILABLE;
+}
+
 /**
  * Wait for SLURM job resources; returns PRTE_ERR_NOT_AVAILABLE if built without Jansson.
  */

--- a/src/mca/ras/slurm/ras_slurm_modify_common.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_common.c
@@ -22,11 +22,11 @@
  * If scancel returns an error, the first line of stderr/stdout output is copied
  * into err_msg. On success, err_msg is cleared.
  *
- * @param[in]  slurm_jobid  Null-terminated Slurm job ID string to cancel.
- * @param[out] err_msg      Writable buffer of size PRTE_SLURM_ERR_STR_MAX_SIZE
- *                          for Slurm output on failure, or NULL if not required.
+ * @param[in]  slurm_jobid   Null-terminated Slurm job ID string to cancel.
+ * @param[out] err_msg       Buffer for error message, or NULL.
+ * @param[in]  err_msg_size  Size of err_msg buffer, if applicable
  */
-int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg) {
+int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg, size_t err_msg_size) {
 
     if(NULL == slurm_jobid) {
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
@@ -72,19 +72,11 @@ int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg) {
         goto cleanup;
     }
 
-    if(NULL != err_msg) {
-        char *buf = fgets(err_msg, PRTE_SLURM_ERR_STR_MAX_SIZE, fp);
+    err = prte_ras_slurm_drain_cmd_output(fp, err_msg, err_msg_size);
 
-        /* Copy output into provided memory, truncating if necessary */
-        if(NULL != buf) {
-            size_t len = strcspn(buf, "\n");
-
-            if (buf[len] == '\n') {
-                buf[len] = '\0';
-            } else if (len == PRTE_SLURM_ERR_STR_MAX_SIZE - 1) {
-                memcpy(buf + PRTE_SLURM_ERR_STR_MAX_SIZE - 4, "...", 3);
-            }
-        } 
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
     }
 
     int status = pclose(fp);
@@ -138,6 +130,73 @@ int prte_ras_slurm_token_has_control_chars(const char *s, size_t len, bool *has_
             *has_control_chars = true;
             break;
         }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Drain command output and optionally capture it.
+ *
+ * Consumes all data from a popen() stream. When provided, output is
+ * populated with command output, potentially truncated to fit the buffer.
+ *
+ * @param[in] fp Stream returned by popen().
+ * @param[out] output Optional output buffer.
+ * @param[in] output_size Size of output buffer.
+ */
+int prte_ras_slurm_drain_cmd_output(FILE *fp, char *output, size_t output_size)
+{
+    if (NULL == fp) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (NULL != output && 0 == output_size) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    char buf[256];
+    size_t used = 0;
+    bool truncated = false;
+
+    if (NULL != output) {
+        output[0] = '\0';
+    }
+
+    while (NULL != fgets(buf, sizeof(buf), fp)) {
+        if (NULL == output || truncated) {
+            continue;
+        }
+
+        if (used >= output_size - 1) {
+            truncated = true;
+            continue;
+        }
+
+        size_t len = strlen(buf);
+        size_t avail = output_size - used - 1;
+
+        if (len > avail) {
+            memcpy(output + used, buf, avail);
+            used += avail;
+            output[used] = '\0';
+            truncated = true;
+        } else {
+            memcpy(output + used, buf, len);
+            used += len;
+            output[used] = '\0';
+        }
+    }
+
+    if (ferror(fp)) {
+        PRTE_ERROR_LOG(PRTE_ERR_FILE_READ_FAILURE);
+        return PRTE_ERR_FILE_READ_FAILURE;
+    }
+
+    if (NULL != output && truncated && output_size >= 4) {
+        strcpy(output + output_size - 4, "...");
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/ras/slurm/ras_slurm_modify_common.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_common.c
@@ -47,6 +47,10 @@ int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg) {
         return err;
     }
 
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                        "%s ras:slurm:kill_job: killing job %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), slurm_jobid));
+
     static const char *cmd_format = "scancel %s 2>&1";
 
     char *cmd = NULL;

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -572,7 +572,7 @@ static int prte_ras_slurm_launch_expander_job(pmix_hash_table_t *fields)
 
     if(PRTE_SUCCESS != err && job_id[0] != '\0') {
         /* Prevent hanging resources if failed */
-        prte_ras_slurm_kill_job(job_id, NULL);
+        prte_ras_slurm_kill_job(job_id, NULL, 0);
     }
 
     if(NULL != job_id_dyn) {

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -680,6 +680,8 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
         goto complete;
     }
 
+    prte_num_allocated_nodes += pmix_list_get_size(&added_nodes);
+
     complete:
 
     if(have_added_nodes) {

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -137,7 +137,8 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
 
             pmix_list_remove_last(prte_slurm_session_stack);
             
-            /* TODO: take nodes in session and remove them */
+            /* TODO: nodes in session need to be detached
+             * from PRRTE. */
 
             nodes_removed += session_item->nodes_in_session;
 
@@ -162,8 +163,6 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
                 goto cleanup;
             }
 
-            /* Magic needs to happen to remove nodes from PRRTE */
-
             pmix_pointer_array_t nodes_in_removal;
             PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
 
@@ -175,7 +174,8 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
                 goto cleanup;
             }
             
-            /* TODO: use nodes_in_removal to remove from PRRTE node lists */
+            /* TODO: use nodes_in_removal 
+             * to detach removed nodes from PRRTE */
 
             PMIX_DESTRUCT(&nodes_in_removal);
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -18,7 +18,8 @@
 
 /* Local functions */
 static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
-static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count, char *err_msg);
+static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
+static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
 
 /**
  * @brief Process a PMIx resource release request.
@@ -95,6 +96,12 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         return PRTE_ERR_REQUEST;
     }
 
+    char *launching_jobid;
+    if (NULL == (launching_jobid = getenv("SLURM_JOBID"))) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
     int nodes_removed = 0;
 
     do {
@@ -117,16 +124,31 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
 
         int nodes_left_to_rem = nodes_to_remove-nodes_removed;
 
-        char err_msg[PRTE_SLURM_ERR_STR_MAX_SIZE+1] = {0};
+        bool contains_invoker = false;
+        
+        if(0 == strcmp(session->alloc_refid, launching_jobid)) {
+            contains_invoker = true;
+        }
+
+        char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
 
         if(nodes_left_to_rem >= session_item->nodes_in_session) {
 
-            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg);
+            /* we'd be trying cancel ourselves. probably a bad idea */
+            if(contains_invoker) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_count: refusing to kill job %s "
+                               "because it contains the invoking process", session->alloc_refid);
+                err = PRTE_ERR_BAD_PARAM;
+                PRTE_ERROR_LOG(err);
+                goto cleanup;
+            }
+
+            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
 
             if (PRTE_SUCCESS != err) {
 
                 if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_resources: failed to kill job %s: %s.",
+                    pmix_output(0, "ras:slurm:remove_nodes_by_count: failed to kill job %s: %s.",
                                     session->alloc_refid, err_msg);
                 } else {
                     PRTE_ERROR_LOG(err);
@@ -149,12 +171,29 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
 
             int new_node_count = session_item->nodes_in_session-nodes_left_to_rem;
 
-            err = prte_ras_slurm_shrink_job(session->alloc_refid, new_node_count, err_msg);
+            char *whitelist_node = NULL;
+
+            if(contains_invoker) {
+                whitelist_node = getenv("SLURMD_NODENAME");
+
+                if (NULL == whitelist_node) {
+                    pmix_output(0,
+                                "ras:slurm:remove_nodes_by_count: SLURMD_NODENAME is not set. "
+                                "Refusing to shrink job %s because the current node cannot be "
+                                "excluded from the resize operation.",
+                                session->alloc_refid);
+                    err = PRTE_ERR_BAD_PARAM;
+                    PRTE_ERROR_LOG(err);
+                    goto cleanup; 
+                }
+            }
+
+            err = prte_ras_slurm_shrink_job(session->alloc_refid, whitelist_node, new_node_count, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
 
             if (PRTE_SUCCESS != err) {
 
                 if(PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_resources: failed to shrink job %s" 
+                    pmix_output(0, "ras:slurm:remove_nodes_by_count: failed to shrink job %s" 
                                     ": %s.", session->alloc_refid, err_msg);
                 } else {
                     PRTE_ERROR_LOG(err);
@@ -199,13 +238,16 @@ cleanup:
  * @brief Shrink a Slurm job to a new node count.
  *
  * Runs scontrol to resize the given Slurm job. On Slurm resize failure,
- * err_msg is populated with the command output when provided.
+ * err_msg is populated with the command output when provided. This failure
+ * mode is indicated by a return of PRTE_ERR_SLURM_SHRINK_FAILURE.
  *
  * @param[in] slurm_jobid Slurm job ID to resize.
+ * @param[in] exclude_hostname Hostname to exclude from resize.
  * @param[in] new_node_count New number of nodes for the job.
  * @param[out] err_msg Optional buffer for Slurm error output.
+ * @param[in] err_msg_size Size of err_msg buffer, if applicable.
  */
-static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count, char *err_msg) {
+static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size) {
 
     if(NULL == slurm_jobid || 0 >= new_node_count) {
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
@@ -233,18 +275,60 @@ static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count
     char *resize_script_sh = NULL;
     char *resize_script_csh = NULL;
 
-    static const char *cmd_format = "scontrol update job %s NumNodes=%d 2>&1";
+    char *req_nodes_arg = NULL; 
+    char *num_nodes_arg = NULL;
 
     char *cmd = NULL;
 
+    static const char *cmd_format = "scontrol update job %s %s 2>&1";
+
     FILE *fp = NULL;
 
-    if(0 > asprintf(&cmd, cmd_format, slurm_jobid, new_node_count)) {
-        cmd = NULL;
-        err = PRTE_ERR_OUT_OF_RESOURCE;
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
+    /* if we want to exclude a node from the shrink,
+     * then we have to specify all nodes to keep explicitly */
+    if(NULL != exclude_hostname) {
+
+        err = prte_ras_slurm_build_req_nodelist(slurm_jobid, exclude_hostname, new_node_count, &req_nodes_arg);
+
+        if (err != PRTE_SUCCESS) {
+            goto cleanup;
+        }
+
+        if(0 > asprintf(&cmd, cmd_format, slurm_jobid, req_nodes_arg)) {
+            cmd = NULL;
+            err = PRTE_ERR_OUT_OF_RESOURCE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        free(req_nodes_arg);
+        req_nodes_arg = NULL;
+
+    } else {
+
+        static const char *num_nodes_format = "NumNodes=%d";
+
+        if(0 > asprintf(&num_nodes_arg, num_nodes_format, new_node_count)) {
+            num_nodes_arg = NULL;
+            err = PRTE_ERR_OUT_OF_RESOURCE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        if(0 > asprintf(&cmd, cmd_format, slurm_jobid, num_nodes_arg)) {
+            cmd = NULL;
+            err = PRTE_ERR_OUT_OF_RESOURCE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        free(num_nodes_arg);
+        num_nodes_arg = NULL;
     }
+
+    PMIX_OUTPUT_VERBOSE((20, prte_ras_base_framework.framework_output,
+                        "%s ras:slurm:shrink_job: shrink command is:\n%s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cmd));
 
     fp = popen(cmd, "r");
 
@@ -254,19 +338,11 @@ static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count
         goto cleanup;
     }
 
-    if(NULL != err_msg) {
-        char *buf = fgets(err_msg, PRTE_SLURM_ERR_STR_MAX_SIZE, fp);
+    err = prte_ras_slurm_drain_cmd_output(fp, err_msg, err_msg_size);
 
-        /* Copy output into provided memory, truncating if necessary */
-        if(NULL != buf) {
-            size_t len = strcspn(buf, "\n");
-
-            if (buf[len] == '\n') {
-                buf[len] = '\0';
-            } else if (len == PRTE_SLURM_ERR_STR_MAX_SIZE - 1) {
-                memcpy(buf + PRTE_SLURM_ERR_STR_MAX_SIZE - 4, "...", 3);
-            }
-        } 
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
     }
 
     int status = pclose(fp);
@@ -296,7 +372,8 @@ static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count
     int rc = asprintf(&resize_script_sh, resize_script_format, slurm_jobid, "sh");
 
     if(0 > rc) {
-        pmix_output(0, "ras:slurm:shrink_job: asprintf failed during cleanup.");
+        pmix_output(0, "ras:slurm:shrink_job: asprintf failed after successful shrink.");
+        resize_script_sh = NULL;
         goto cleanup;
     }
 
@@ -312,7 +389,8 @@ static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count
     rc = asprintf(&resize_script_csh, resize_script_format, slurm_jobid, "csh");
 
     if(0 > rc) {
-        pmix_output(0, "ras:slurm:shrink_job: asprintf failed during cleanup.");
+        pmix_output(0, "ras:slurm:shrink_job: asprintf failed after successful shrink.");
+        resize_script_csh = NULL;
         goto cleanup;
     }
 
@@ -338,6 +416,167 @@ cleanup:
     free(cmd);
     free(resize_script_sh);
     free(resize_script_csh);
+    free(req_nodes_arg);
+    free(num_nodes_arg);
+
+    return err;
+}
+
+/**
+ * Build a required-node list for a Slurm shrink operation.
+ *
+ * Ensures that protected_hostname is included in the resulting
+ * comma-separated node list. Validates each hostname before it is
+ * included in the output string.
+ *
+ * @param[in]  slurm_jobid         Slurm job ID.
+ * @param[in]  protected_hostname  Hostname to preserve.
+ * @param[out] req_nodes_arg       Allocated string of the form
+ *                                 "ReqNodeList=node0,node1,...".
+ */
+static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg)
+{
+    if(!slurm_jobid || !protected_hostname || !req_nodes_arg) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    static const char *req_nodes_prefix = "ReqNodeList=";
+
+    *req_nodes_arg = NULL;
+
+    int err = prte_ras_slurm_validate_hostname(protected_hostname);
+
+    if(PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    err = prte_ras_slurm_validate_jobid(slurm_jobid);
+
+    if(PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    prte_session_t *session = prte_get_session_object_from_id(slurm_jobid);
+
+    if (NULL == session) {
+        err = PRTE_ERR_NOT_FOUND;
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    /* estimate the required size for the nodes */
+    size_t size_for_nodes = strlen(protected_hostname) * new_node_count;
+    const size_t prefix_size = strlen(req_nodes_prefix);
+
+    /* prefix, commas, and nullchar */
+    const size_t size_additional = prefix_size + new_node_count;
+
+    const size_t max_size_for_nodes = PRTE_SLURM_HOSTNAME_MAX_LEN * new_node_count;
+
+    size_t curr_size = size_for_nodes + size_additional;
+    size_t curr_occupied = size_additional; /* pre-reserve space for non-node content */
+
+    *req_nodes_arg = malloc(curr_size);
+    if (NULL == *req_nodes_arg) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    char *req_nodes_ptr = *req_nodes_arg;
+
+    /* append the prefix */
+    memcpy(*req_nodes_arg, req_nodes_prefix, prefix_size);
+    req_nodes_ptr += prefix_size;
+
+    bool found_protected = false;
+    int nodecount = 0;
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *curr = pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL == curr || NULL == curr->name) {
+            continue;
+        }
+
+        /* must be included on the list */
+        if (!found_protected && 
+            0 == strcmp(curr->name, protected_hostname)) {
+            found_protected = true;
+        } else if (!found_protected && nodecount >= new_node_count-1) {
+            /* we have enough nodes, only look for node to protect */
+            continue;   
+        }
+
+        err = prte_ras_slurm_validate_hostname(curr->name);
+
+        if(PRTE_SUCCESS != err) {
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+        
+        size_t item_size = strlen(curr->name);
+
+        if(curr_occupied+item_size > curr_size) {
+            size_t new_size = curr_size * 2;
+            size_t req_nodes_ptr_offset = req_nodes_ptr - *req_nodes_arg; 
+
+            if(new_size > max_size_for_nodes + size_additional) {
+                new_size = max_size_for_nodes + size_additional;
+            }
+
+            if(curr_occupied+item_size > new_size) {
+                err = PRTE_ERR_OUT_OF_RESOURCE;
+                PRTE_ERROR_LOG(err);
+                goto cleanup;                    
+            }
+
+            char *new_req_nodes_arg = realloc(*req_nodes_arg, new_size);
+
+            if (NULL == new_req_nodes_arg) {
+                err = PRTE_ERR_OUT_OF_RESOURCE;
+                PRTE_ERROR_LOG(err);
+                goto cleanup;
+            }
+
+            *req_nodes_arg = new_req_nodes_arg;
+            req_nodes_ptr = new_req_nodes_arg + req_nodes_ptr_offset;
+            curr_size = new_size;
+        }
+
+        /* insert a comma if not first item */
+        if(nodecount > 0) {
+            *req_nodes_ptr = ',';
+            req_nodes_ptr++;
+        }
+
+        memcpy(req_nodes_ptr, curr->name, item_size);
+
+        req_nodes_ptr += item_size;
+        curr_occupied += item_size;
+
+        if(++nodecount >= new_node_count) {
+            break;
+        }
+    }
+
+    if (nodecount != new_node_count || !found_protected) {
+        err = PRTE_ERR_NOT_FOUND;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    *req_nodes_ptr = '\0';
+
+cleanup:
+
+    if (PRTE_SUCCESS != err) {
+        free(*req_nodes_arg);
+        *req_nodes_arg = NULL;
+    }
 
     return err;
 }

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -16,8 +16,328 @@
 #include "ras_slurm.h"
 #include "src/mca/ras/base/base.h"
 
+/* Local functions */
+static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
+static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count, char *err_msg);
+
+/**
+ * @brief Process a PMIx resource release request.
+ */
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
 {
-    PRTE_HIDE_UNUSED_PARAMS(req);
-    return PRTE_ERR_NOT_IMPLEMENTED;
+    if(!prte_ras_slurm_have_jansson()) {
+        pmix_output(0, "ras:slurm:modify: "
+            "Jansson support is required but not enabled in this build");
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    int err = PRTE_SUCCESS;
+
+    uint64_t num_nodes = 0;
+    bool found = false;
+
+    for (size_t i = 0; i < req->ninfo; i++) {
+        if (0 != strcmp(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
+            continue;
+        }
+
+        if (PMIX_UINT64 != req->info[i].value.type) {
+            err = PRTE_ERR_BAD_PARAM;
+            goto cleanup;
+        }
+    
+        num_nodes = req->info[i].value.data.uint64;
+        found = true;
+        break;
+    }
+
+    if(!found) {
+        pmix_output(0, "ras:slurm:modify: modify request invalid or unsupported.\n"
+                       "Supported options: PMIX_ALLOC_NUM_NODES");
+        err = PRTE_ERR_REQUEST;
+        goto cleanup;
+    }
+
+    err = prte_ras_slurm_remove_nodes_by_count(num_nodes);
+
+    if(err != PRTE_SUCCESS) {
+        goto cleanup;
+    }
+
+cleanup:
+
+    return err;
+}
+
+/**
+ * @brief Remove nodes from Slurm allocations by count.
+ *
+ * Removes nodes from the most recently added Slurm allocation first. Whole
+ * allocations are cancelled when possible; otherwise the newest allocation is
+ * shrunk.
+ *
+ * @param[in] node_count Number of nodes to remove.
+ */
+static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
+
+    if(0 == node_count || node_count > INT_MAX) {
+        pmix_output(0, "ras:slurm:remove_nodes_by_count: invalid node count.");
+        return PRTE_ERR_REQUEST;
+    }
+
+    int err = PRTE_SUCCESS;
+
+    int nodes_initial = prte_num_allocated_nodes;
+    int nodes_to_remove = (int)node_count;
+    
+    if(nodes_to_remove >= nodes_initial) {
+        pmix_output(0, "ras:slurm:remove_nodes_by_count: cannot remove all allocated nodes or more.");
+        return PRTE_ERR_REQUEST;
+    }
+
+    int nodes_removed = 0;
+
+    do {
+        if (0 == pmix_list_get_size(prte_slurm_session_stack)) {
+            err = PRTE_ERR_NOT_FOUND;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        /* get the most recently added allocation to remove from */
+        prte_session_stack_item_t *session_item = (prte_session_stack_item_t *) pmix_list_get_last(prte_slurm_session_stack);
+
+        if(NULL == session_item || NULL == session_item->session) {
+            err = PRTE_ERR_NOT_FOUND;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;   
+        }
+
+        prte_session_t *session = session_item->session;
+
+        int nodes_left_to_rem = nodes_to_remove-nodes_removed;
+
+        char err_msg[PRTE_SLURM_ERR_STR_MAX_SIZE+1] = {0};
+
+        if(nodes_left_to_rem >= session_item->nodes_in_session) {
+
+            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg);
+
+            if (PRTE_SUCCESS != err) {
+
+                if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
+                    pmix_output(0, "ras:slurm:remove_resources: failed to kill job %s: %s.",
+                                    session->alloc_refid, err_msg);
+                } else {
+                    PRTE_ERROR_LOG(err);
+                }
+
+                goto cleanup;
+            }
+
+            pmix_list_remove_last(prte_slurm_session_stack);
+            
+            /* TODO: take nodes in session and remove them */
+
+            nodes_removed += session_item->nodes_in_session;
+
+            /* This also removes from prte_sessions */
+            PMIX_RELEASE(session);
+            PMIX_RELEASE(session_item);
+        } else {
+
+            int new_node_count = session_item->nodes_in_session-nodes_left_to_rem;
+
+            err = prte_ras_slurm_shrink_job(session->alloc_refid, new_node_count, err_msg);
+
+            if (PRTE_SUCCESS != err) {
+
+                if(PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
+                    pmix_output(0, "ras:slurm:remove_resources: failed to shrink job %s" 
+                                    ": %s.", session->alloc_refid, err_msg);
+                } else {
+                    PRTE_ERROR_LOG(err);
+                }
+
+                goto cleanup;
+            }
+
+            /* Magic needs to happen to remove nodes from PRRTE */
+
+            pmix_pointer_array_t nodes_in_removal;
+            PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
+
+            /* Remove target nodes from session and add to nodes_in_removal */
+            err = prte_ras_slurm_detach_nodes(session->alloc_refid, session, &nodes_in_removal);
+
+            if (PRTE_SUCCESS != err) {
+                PMIX_DESTRUCT(&nodes_in_removal);
+                goto cleanup;
+            }
+            
+            /* TODO: use nodes_in_removal to remove from PRRTE node lists */
+
+            PMIX_DESTRUCT(&nodes_in_removal);
+
+            session_item->nodes_in_session = new_node_count;
+            nodes_removed += nodes_left_to_rem;
+        }
+    } while (nodes_to_remove > nodes_removed);
+
+cleanup:
+
+    prte_num_allocated_nodes-=nodes_removed;
+
+    if(PRTE_SUCCESS != err && nodes_removed > 0) {
+        err = PRTE_ERR_PARTIAL_SUCCESS;
+    }
+
+    return err;
+}
+
+/**
+ * @brief Shrink a Slurm job to a new node count.
+ *
+ * Runs scontrol to resize the given Slurm job. On Slurm resize failure,
+ * err_msg is populated with the command output when provided.
+ *
+ * @param[in] slurm_jobid Slurm job ID to resize.
+ * @param[in] new_node_count New number of nodes for the job.
+ * @param[out] err_msg Optional buffer for Slurm error output.
+ */
+static int prte_ras_slurm_shrink_job(const char *slurm_jobid, int new_node_count, char *err_msg) {
+
+    if(NULL == slurm_jobid || 0 >= new_node_count) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if(NULL != err_msg) {
+        err_msg[0] = '\0';
+    }
+
+    int err = PRTE_SUCCESS;
+
+    /* Make sure the job ID given is something reasonable */
+    err = prte_ras_slurm_validate_jobid(slurm_jobid);
+
+    if(PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                        "%s ras:slurm:shrink_job: shrink job %s to %d nodes",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), slurm_jobid, new_node_count));
+
+    char *resize_script_sh = NULL;
+    char *resize_script_csh = NULL;
+
+    static const char *cmd_format = "scontrol update job %s NumNodes=%d 2>&1";
+
+    char *cmd = NULL;
+
+    FILE *fp = NULL;
+
+    if(0 > asprintf(&cmd, cmd_format, slurm_jobid, new_node_count)) {
+        cmd = NULL;
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    fp = popen(cmd, "r");
+
+    if(NULL == fp) {
+        err = PRTE_ERR_FILE_OPEN_FAILURE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    if(NULL != err_msg) {
+        char *buf = fgets(err_msg, PRTE_SLURM_ERR_STR_MAX_SIZE, fp);
+
+        /* Copy output into provided memory, truncating if necessary */
+        if(NULL != buf) {
+            size_t len = strcspn(buf, "\n");
+
+            if (buf[len] == '\n') {
+                buf[len] = '\0';
+            } else if (len == PRTE_SLURM_ERR_STR_MAX_SIZE - 1) {
+                memcpy(buf + PRTE_SLURM_ERR_STR_MAX_SIZE - 4, "...", 3);
+            }
+        } 
+    }
+
+    int status = pclose(fp);
+    fp = NULL;
+
+    if (-1 == status) {
+        pmix_output(0, "ras:slurm:shrink_job: pclose failed: %s.", strerror(errno));
+        err = PRTE_ERR_IN_ERRNO;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+        err = PRTE_ERR_SLURM_SHRINK_FAILURE;
+        goto cleanup;
+    }
+
+    /* On success, the resize operation creates some helper 
+     * scripts to update environment variables which
+     * we do not want cluttering the user environment.
+     * 
+     * NOTE: return success even if we fail here, as the
+     * shrink itself succeeded and the resources are gone. */
+
+    static const char *resize_script_format = "slurm_job_%s_resize.%s";
+
+    int rc = asprintf(&resize_script_sh, resize_script_format, slurm_jobid, "sh");
+
+    if(0 > rc) {
+        pmix_output(0, "ras:slurm:shrink_job: asprintf failed during cleanup.");
+        goto cleanup;
+    }
+
+    if (0 != remove(resize_script_sh)) {
+        int saved_errno = errno;
+        if (ENOENT != saved_errno) {
+            pmix_output(0,
+                        "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
+                        resize_script_sh, strerror(saved_errno));
+        }
+    }
+
+    rc = asprintf(&resize_script_csh, resize_script_format, slurm_jobid, "csh");
+
+    if(0 > rc) {
+        pmix_output(0, "ras:slurm:shrink_job: asprintf failed during cleanup.");
+        goto cleanup;
+    }
+
+    if (0 != remove(resize_script_csh)) {
+        int saved_errno = errno;
+        if (ENOENT != saved_errno) {
+            pmix_output(0,
+                        "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
+                        resize_script_csh, strerror(saved_errno));
+        }
+    }
+
+cleanup:
+
+    if(NULL != err_msg && PRTE_ERR_SLURM_SHRINK_FAILURE != err) {
+        err_msg[0] = '\0';
+    }
+
+    if(NULL != fp) {
+        pclose(fp);
+    }
+
+    free(cmd);
+    free(resize_script_sh);
+    free(resize_script_csh);
+
+    return err;
 }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -86,6 +86,13 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
 static int prte_ras_slurm_parse_ranges(char *base, char *ranges, char ***nodelist);
 static int prte_ras_slurm_parse_range(char *base, char *range, char ***nodelist);
 
+pmix_list_t *prte_slurm_session_stack = NULL;
+
+PMIX_CLASS_INSTANCE(prte_session_stack_item_t,
+                    pmix_list_item_t,
+                    NULL,
+                    NULL);
+
 static bool check_taint(char *name, char *evar)
 {
     int n;
@@ -104,6 +111,8 @@ static bool check_taint(char *name, char *evar)
 /* init the module */
 static int init(void)
 {
+    PMIX_CONSTRUCT(prte_slurm_session_stack, pmix_list_t);
+
     return PRTE_SUCCESS;
 }
 
@@ -270,6 +279,8 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
 
 static int prte_ras_slurm_finalize(void)
 {
+    PMIX_LIST_DESTRUCT(prte_slurm_session_stack);
+
     return PRTE_SUCCESS;
 }
 
@@ -703,7 +714,7 @@ int prte_ras_slurm_convert_jobid(const char *slurm_jobid, uint32_t *slurm_jobid_
  *
  * Creates a new prte_session_t using slurm_jobid as the session ID,
  * associates the nodes in node_list with the session, and adds it to
- * the global session table.
+ * the global session table and the internal session tracker list.
  * 
  * @note Nodes in the list are duplicates of the originals
  *
@@ -719,6 +730,7 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
     }
 
     int err = PRTE_SUCCESS;
+    int pmix_err = PMIX_SUCCESS;
 
     err = prte_ras_slurm_validate_jobid(slurm_jobid);
 
@@ -788,10 +800,9 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
             goto cleanup;
         }
 
-        int idx = pmix_pointer_array_add(session->nodes, node_cpy);
-        if (0 > idx) {
-            /* Negative returned idx indicates PMIX error */
-            err = prte_pmix_convert_status(idx);
+        pmix_err = pmix_pointer_array_add(session->nodes, node_cpy);
+        if (0 > pmix_err) {
+            err = prte_pmix_convert_status(pmix_err);
             PMIX_RELEASE(node);
             PRTE_ERROR_LOG(err);
             goto cleanup;
@@ -803,6 +814,11 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
         PRTE_ERROR_LOG(err);
         goto cleanup;
     }
+
+    prte_session_stack_item_t *item = PMIX_NEW(prte_session_stack_item_t);
+    item->session = session;
+
+    pmix_list_append(prte_slurm_session_stack, &item->super);
 
     cleanup:
 

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -112,6 +112,12 @@ static bool check_taint(char *name, char *evar)
 static int init(void)
 {
     prte_slurm_session_stack = PMIX_NEW(pmix_list_t);
+
+    if(NULL == prte_slurm_session_stack) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
     return PRTE_SUCCESS;
 }
 
@@ -671,6 +677,40 @@ int prte_ras_slurm_validate_jobid(const char *slurm_jobid) {
 }
 
 /*
+ * Validate that a Slurm hostname does not contain unexpected characters.
+ *
+ * A valid Slurm hostname must be non-NULL, non-empty, must not exceed
+ * PRTE_SLURM_HOSTNAME_MAX_LEN characters, and may contain only characters
+ * from a restricted allowlist.
+ *
+ * @param[in] hostname  Null-terminated Slurm hostname string to validate.
+ */
+int prte_ras_slurm_validate_hostname(const char *hostname)
+{
+    if (NULL == hostname) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    size_t len = strnlen(hostname, PRTE_SLURM_HOSTNAME_MAX_LEN + 1);
+    if (0 == len || len > PRTE_SLURM_HOSTNAME_MAX_LEN) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        unsigned char c = (unsigned char) hostname[i];
+
+        if (!(isalnum(c) ||
+              c == '-' || c == '_' || c == '.' ||
+              c == '+' || c == ':' || c == '@' ||
+              c == '%' || c == '=')) {
+            return PRTE_ERR_BAD_PARAM;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/*
  * Convert a Slurm job ID string to uint32_t.
  *
  * Expects a strictly decimal, non-negative string.
@@ -811,6 +851,12 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
     }
 
     prte_session_stack_item_t *item = PMIX_NEW(prte_session_stack_item_t);
+
+    if(NULL == item) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
 
     item->session = session;
     item->nodes_in_session = pmix_list_get_size(node_list);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -111,8 +111,7 @@ static bool check_taint(char *name, char *evar)
 /* init the module */
 static int init(void)
 {
-    PMIX_CONSTRUCT(prte_slurm_session_stack, pmix_list_t);
-
+    prte_slurm_session_stack = PMIX_NEW(pmix_list_t);
     return PRTE_SUCCESS;
 }
 
@@ -276,8 +275,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
 
 static int prte_ras_slurm_finalize(void)
 {
-    PMIX_LIST_DESTRUCT(prte_slurm_session_stack);
-
+    PMIX_RELEASE(prte_slurm_session_stack);
     return PRTE_SUCCESS;
 }
 
@@ -813,6 +811,7 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
     }
 
     prte_session_stack_item_t *item = PMIX_NEW(prte_session_stack_item_t);
+
     item->session = session;
     item->nodes_in_session = pmix_list_get_size(node_list);
 

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -262,18 +262,15 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     int err = PRTE_SUCCESS;
 
     if(PMIX_ALLOC_EXTEND == req->allocdir) {
-
-       err = prte_ras_slurm_serve_extend_req(req);
-
+        err = prte_ras_slurm_serve_extend_req(req);
+        req->pstatus = prte_pmix_convert_rc(err);
     } else if(PMIX_ALLOC_RELEASE == req->allocdir) {
-
         err = prte_ras_slurm_serve_release_req(req);
-
-        req->status = PMIX_ERR_NOT_SUPPORTED;
-        return PMIX_ERR_NOT_SUPPORTED;;
+        req->pstatus = prte_pmix_convert_rc(err);
+    } else {
+        req->pstatus = PMIX_ERR_NOT_SUPPORTED;
     }
 
-    req->pstatus = prte_pmix_convert_rc(err);
     return req->pstatus;
 }
 
@@ -817,6 +814,7 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
 
     prte_session_stack_item_t *item = PMIX_NEW(prte_session_stack_item_t);
     item->session = session;
+    item->nodes_in_session = pmix_list_get_size(node_list);
 
     pmix_list_append(prte_slurm_session_stack, &item->super);
 


### PR DESCRIPTION
Overview
- Add required Slurm interactions to serve PMIX_ALLOC_RELEASE modify requests
- Supported option: PMIX_ALLOC_NUM_NODES
- Release in LIFO order; newer allocations are removed first
- Protect own SLURMD_NODE from release

Limitations
- Identifies nodes to be removed and cuts them off using Slurm commands, but does not handle PRRTE-side removal of resources. Lines 162 and 216 in ras_slurm_modify_release.c contain placeholders for this.

@rhc54 please check especially: 
1. ras_base_select.c: I added logic to always call a module's init function as I needed to use it for the Slurm module
2. plm_slurm_module.c: I edited it to just always insert --no-kill and --kill-on-bad-exit=0 flags. Not sure if it's the ideal solution