### PR TITLE
Add MCA param to control "elastic" mode

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -79,6 +79,7 @@ bool prte_fwd_environment = false;
 bool prte_show_launch_progress = false;
 bool prte_bootstrap_setup = false;
 bool prte_xml_output = false;
+bool prte_elastic_mode = false;
 
 /* PRTE OOB port flags */
 bool prte_static_ports = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -77,6 +77,7 @@ PRTE_EXPORT extern bool prte_show_launch_progress;
 PRTE_EXPORT extern bool prte_bootstrap_setup;
 PRTE_EXPORT extern bool prte_silence_shared_fs;
 PRTE_EXPORT extern pmix_show_help_file_t prte_show_help_data[];
+PRTE_EXPORT extern bool prte_elastic_mode;
 
 /**
  * Global indicating where this process was bound to at launch (will

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -564,6 +564,11 @@ int prte_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_bootstrap_setup);
 
+    (void) pmix_mca_base_var_register("prte", "prte", "elastic", "mode",
+                                      "Allow DVM to expand and contract as directed (default: false)",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_elastic_mode);
+
     /* pickup the RML params */
     prte_rml_register();
 


### PR DESCRIPTION
Define a new MCA param prte_elastic_mode=true|false to control DVM behavior. Defaults to false. Setting to true allows the DVM to grow/contract per application directive.