### PR TITLE
Multiple commits

### DIFF
--- a/.github/workflows/build-ompi-external.yaml
+++ b/.github/workflows/build-ompi-external.yaml
@@ -20,7 +20,7 @@ jobs:
         sudo apt install -y --no-install-recommends wget software-properties-common hwloc libhwloc-dev libevent-2.1-7 libevent-dev
 
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -35,7 +35,7 @@ jobs:
         make install
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             path: prrte
@@ -49,7 +49,7 @@ jobs:
         make install
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi

--- a/.github/workflows/build-ompi.yaml
+++ b/.github/workflows/build-ompi.yaml
@@ -20,7 +20,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi
@@ -38,7 +38,7 @@ jobs:
         git pull
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         path: 3rd-party/prrte

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: brew install libevent hwloc autoconf automake libtool
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -38,7 +38,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -102,7 +102,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -116,7 +116,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -164,7 +164,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev clang
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -178,7 +178,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false
@@ -217,7 +217,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev python3 python3-pip
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -231,7 +231,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/dvm.yaml
+++ b/.github/workflows/dvm.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
             submodules: recursive
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -31,7 +31,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
             submodules: recursive
     - name: Git clone PMIx
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             repository: openpmix/openpmix
@@ -31,7 +31,7 @@ jobs:
         make -j
         make install
     - name: Git clone PRRTE
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
             submodules: recursive
             clean: false

--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -35,7 +35,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
 
     - name: Git clone OpenPMIx
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: openpmix/openpmix
@@ -51,7 +51,7 @@ jobs:
         make install
 
     - name: Git clone PRRTE
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         clean: false
@@ -67,7 +67,7 @@ jobs:
         make install
 
     - name: Checkout Open MPI
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
         repository: open-mpi/ompi

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -175,10 +175,6 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
         caddy->jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
     }
 
-    if (prte_get_attribute(&caddy->jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
-        prte_ras_base_display_alloc(caddy->jdata);
-    }
-
     /* progress the job */
     caddy->jdata->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
     PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_VM_READY);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -170,7 +170,11 @@ void prte_ras_base_display_alloc(prte_job_t *jdata)
                     "%s=================================================================\n", tmp);
     }
     free(tmp);
-    prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+    if (prte_persistent) {
+        fprintf(stdout, "%s", tmp2);
+    } else {
+        prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+    }
     prte_set_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
 }
 
@@ -705,7 +709,8 @@ addlocal:
 
 DISPLAY:
     /* shall we display the results? */
-    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
+    if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) &&
+        0 == strcmp(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         prte_ras_base_display_alloc(jdata);
     }
 

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -50,7 +50,7 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
     int32_t num_nodes;
     int rc, i;
     prte_node_t *node, *hnp_node, *nptr;
-    bool skiphnp = false;
+    bool skiphnp = false, found;
     prte_attribute_t *kv;
     prte_proc_t *daemon;
     prte_job_t *djob;
@@ -178,19 +178,34 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                                  "%s ras:base:node_insert node %s slots %d",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  (NULL == node->name) ? "NULL" : node->name, node->slots));
-            if (prte_managed_allocation) {
-                /* the slots are always treated as sacred
-                 * in managed allocations
-                 */
-                PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+            // see if we already have this node
+            found = false;
+            for (i=0; i < prte_node_pool->size; i++) {
+                nptr = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, i);
+                if (NULL == nptr) {
+                    continue;
+                }
+                if (prte_nptr_match(nptr, node)) {
+                    found = true;
+                    break;
+                }
             }
-            /* insert it into the array */
-            node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
-            if (PRTE_SUCCESS > (rc = node->index)) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
+            if (!found) {
+                if (prte_managed_allocation) {
+                    /* the slots are always treated as sacred
+                     * in managed allocations
+                     */
+                    PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+                }
+                /* insert it into the array */
+                node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
+                if (PRTE_SUCCESS > (rc = node->index)) {
+                    PRTE_ERROR_LOG(rc);
+                    return rc;
+                }
             }
-            if (prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+            if (prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
+                NULL == node->daemon) {
                 /* create a daemon for this node since we won't be launching
                  * and the mapper needs to see a daemon - this is used solely
                  * for testing the mappers */

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -14,7 +14,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2021 IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -41,6 +41,9 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/ess.h"
+#include "src/mca/iof/base/base.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/dash_host/dash_host.h"
 #include "src/util/hostfile/hostfile.h"
@@ -516,14 +519,57 @@ complete:
     /* check for prior bookmark */
     prte_rmaps_base_get_starting_point(allocated_nodes, jdata);
 
-    if (4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
-        pmix_output(0, "AVAILABLE NODES FOR MAPPING:");
-        for (item = pmix_list_get_first(allocated_nodes);
-             item != pmix_list_get_end(allocated_nodes); item = pmix_list_get_next(item)) {
-            node = (prte_node_t *) item;
-            pmix_output(0, "    node: %s daemon: %s slots_available: %d", node->name,
-                        (NULL == node->daemon) ? "NULL" : PRTE_VPID_PRINT(node->daemon->name.rank),
-                        node->slots_available);
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL) ||
+        4 < pmix_output_get_verbosity(prte_rmaps_base_framework.framework_output)) {
+        bool parsable;
+        char *tmp = NULL, *tmp2, *tmp3;
+        prte_node_t *alloc;
+        pmix_proc_t source;
+
+        if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, NULL, PMIX_BOOL)) {
+
+            parsable = prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
+            PMIX_LOAD_PROCID(&source, jdata->nspace, PMIX_RANK_WILDCARD);
+
+            if (parsable) {
+                pmix_asprintf(&tmp, "<allocation>\n");
+            } else {
+                pmix_asprintf(&tmp,
+                              "\n============   ALLOCATED NODES FOR JOB %s APP %d ============\n",
+                              jdata->nspace, app->idx);
+            }
+            for (item = pmix_list_get_first(allocated_nodes);
+                 item != pmix_list_get_end(allocated_nodes); item = pmix_list_get_next(item)) {
+                alloc = (prte_node_t *) item;
+                if (parsable) {
+                    /* need to create the output in XML format */
+                    pmix_asprintf(&tmp2,
+                                  "\t<host name=\"%s\" slots=\"%d\" max_slots=\"%d\" slots_inuse=\"%d\">\n",
+                                  (NULL == alloc->name) ? "UNKNOWN" : alloc->name, (int) alloc->slots_available,
+                                  (int) alloc->slots_max, (int) alloc->slots_inuse);
+                } else {
+                    pmix_asprintf(&tmp2, "    %s: slots=%d max_slots=%d slots_inuse=%d\n",
+                                  (NULL == alloc->name) ? "UNKNOWN" : alloc->name, (int) alloc->slots_available,
+                                  (int) alloc->slots_max, (int) alloc->slots_inuse);
+                }
+                if (NULL == tmp) {
+                    tmp = tmp2;
+                } else {
+                    pmix_asprintf(&tmp3, "%s%s", tmp, tmp2);
+                    free(tmp);
+                    free(tmp2);
+                    tmp = tmp3;
+                }
+            }
+            if (parsable) {
+                pmix_asprintf(&tmp2, "%s</allocation>\n", tmp);
+            } else {
+                pmix_asprintf(&tmp2,
+                            "%s=================================================================================\n", tmp);
+            }
+            free(tmp);
+            prte_iof_base_output(&source, PMIX_FWD_STDOUT_CHANNEL, tmp2);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_ALLOC_DISPLAYED, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
         }
     }
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -680,16 +680,16 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     return ret;
                 }
 
-            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAPDEV)) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAP)) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIx_Argv_free(targv);
                     return ret;
                 }
 
-            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAP)) {
-                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP, NULL, PMIX_BOOL);
+            } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MAPDEV)) {
+                PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_DISPLAY_MAP_DETAILED, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIx_Argv_free(targv);


### PR DESCRIPTION
[Bump actions/checkout to v6](https://github.com/openpmix/prrte/commit/4982b73a95cbb8652ff4b587b0959982d7524e80)

Node 20 will be deprecated in June, actions/checkout@6 uses Node 24.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/fc334eb4cdbb9705481035b2d7a94a2cb3166bd8)

[Fix --host processing](https://github.com/openpmix/prrte/commit/ef3354e42e35891a9b033cba932e31d2bedcdf31)

Properly handle the number of slot assignments when the first
host in the --host list is the same as the one where we are
executing. Correctly display map vs map-dev options. Display
allocations for jobs after node allocations have been made
for the job. Need eventually to expand this to the app level.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/355769016e60c713ca1a9b5ff81d06d12cb1b0b5)
