### PR TITLE
PMIX_QUERY_ALLOCATION add results to correct list

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -761,7 +761,7 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_INFO_LIST_CONVERT(rc, nodelist, &dry);
                 PMIX_INFO_LIST_RELEASE(nodelist);
                 /* add to results */
-                PMIX_INFO_LIST_ADD(rc, nodelist, PMIX_QUERY_ALLOCATION, &dry, PMIX_DATA_ARRAY);
+                PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_ALLOCATION, &dry, PMIX_DATA_ARRAY);
                 PMIX_DATA_ARRAY_DESTRUCT(&dry);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
In serving PMIX_QUERY_ALLOCATION requests, the results are added to nodelist, which is already destroyed. Adjust to add to the "results" list.

Credits: AccelCom @ Barcelona Supercomputing Center