### PR TITLE
 Add logic to serve ras_slurm_module cancel requests

### DIFF
--- a/src/mca/ras/slurm/Makefile.am
+++ b/src/mca/ras/slurm/Makefile.am
@@ -32,6 +32,7 @@ sources = \
         ras_slurm_component.c \
         ras_slurm_module.c \
         ras_slurm_modify_common.c \
+        ras_slurm_modify_cancel.c \
         ras_slurm_modify_extend.c \
         ras_slurm_modify_release.c 
 

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -56,7 +56,7 @@ int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session
 int prte_ras_slurm_check_resources(const char *slurm_jobid);
 
 /* Features to serve cancel requests */
-int prte_ras_slurm_add_pending_req(const char *request_id);
+int prte_ras_slurm_add_pending_req(const char *request_id, const char *slurm_job_id);
 int prte_ras_slurm_remove_pending_req(const char *request_id);
 bool prte_ras_slurm_pending_req_exists(const char *request_id);
 int prte_ras_slurm_cancel_pending_req(const char *request_id);

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -55,10 +55,19 @@ int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *
 int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session, pmix_pointer_array_t *removed_nodes);
 int prte_ras_slurm_check_resources(const char *slurm_jobid);
 
-/* Features to serve request extension */
+/* Features to serve cancel requests */
+int prte_ras_slurm_add_pending_req(const char *request_id);
+int prte_ras_slurm_remove_pending_req(const char *request_id);
+bool prte_ras_slurm_pending_req_exists(const char *request_id);
+int prte_ras_slurm_cancel_pending_req(const char *request_id);
+int prte_ras_slurm_modify_cancel_init(void);
+int prte_ras_slurm_modify_cancel_finalize(void);
+int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req);
+
+/* Features to serve extension requests */
 int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req);
 
-/* Features to serve request release */
+/* Features to serve release requests */
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req);
 
 /* Common modify extend/release features */

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -953,6 +953,7 @@ int prte_ras_slurm_check_resources(const char *slurm_jobid)
 
     bool running = false;
     bool pending = false;
+    bool cancelled = false;
 
     err = prte_ras_slurm_get_jobinfo_json(slurm_jobid, &job_info);
 
@@ -989,19 +990,27 @@ int prte_ras_slurm_check_resources(const char *slurm_jobid)
         else if (strcmp(state, "PENDING") == 0) {
             pending = true;
         }
+
+        else if (strcmp(state, "CANCELLED") == 0) {
+            cancelled = true;
+        }
     }
 
     json_decref(job_info);
     job_info = NULL;
 
-    /* Should be mutually exclusive */
-    if ((running && pending) || (!running && !pending)) {
+    /* Exactly one recognized Slurm state is expected here. */
+    int recognized_states = (running ? 1 : 0) + (pending ? 1 : 0) + (cancelled ? 1 : 0);
+
+    if (1 != recognized_states) {
         err = PRTE_ERR_SLURM_BAD_JOB_STATUS;
         PRTE_ERROR_LOG(err);
         goto cleanup;
     }
 
-    if(!running) {
+    if(cancelled) {
+        err = PRTE_ERR_JOB_CANCELLED;
+    } else if(!running) {
         err = PRTE_ERR_RESOURCE_BUSY;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_cancel.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_cancel.c
@@ -23,7 +23,13 @@
 static pmix_pointer_array_t pending_reqs;
 static bool initialized = false;
 
+typedef struct {
+    char *request_id;
+    char *slurm_job_id;
+} prte_ras_slurm_pending_req_t;
+
 /* Local functions */
+static void prte_ras_slurm_pending_req_free(prte_ras_slurm_pending_req_t *pending_req);
 static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx);
 
 /**
@@ -32,7 +38,7 @@ static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx);
  * Cancels a previously registered pending Slurm request identified by
  * PMIX_ALLOC_REQ_ID.
  *
- * @param[in] req PMIx server request containing a Slurm job ID as PMIX_ALLOC_REQ_ID.
+ * @param[in] req PMIx server request containing PMIX_ALLOC_REQ_ID.
  */
 int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req)
 {
@@ -76,18 +82,21 @@ cleanup:
 /**
  * @brief Add a pending request to the cancellable request list.
  *
- * Stores a copy of the provided request ID string. Duplicate additions are
- * treated as success.
+ * Stores copies of the PMIx-visible request ID and the Slurm job ID needed to
+ * cancel the scheduler request. Duplicate additions are treated as success if
+ * they refer to the same Slurm job.
  *
- * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ * @param[in] request_id PMIx request identifier.
+ * @param[in] slurm_job_id Slurm job ID backing the request.
  */
-int prte_ras_slurm_add_pending_req(const char *request_id)
+int prte_ras_slurm_add_pending_req(const char *request_id, const char *slurm_job_id)
 {
     if (!initialized) {
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
-    if (NULL == request_id || '\0' == request_id[0]) {
+    if (NULL == request_id || '\0' == request_id[0]
+        || NULL == slurm_job_id || '\0' == slurm_job_id[0]) {
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
         return PRTE_ERR_BAD_PARAM;
     }
@@ -96,7 +105,13 @@ int prte_ras_slurm_add_pending_req(const char *request_id)
     int err = prte_ras_slurm_find_pending_req(request_id, &idx);
 
     if (PRTE_SUCCESS == err) {
-        return PRTE_SUCCESS;
+        prte_ras_slurm_pending_req_t *pending_req =
+            (prte_ras_slurm_pending_req_t *) pmix_pointer_array_get_item(&pending_reqs, idx);
+        if (NULL != pending_req && 0 == strcmp(pending_req->slurm_job_id, slurm_job_id)) {
+            return PRTE_SUCCESS;
+        }
+        PRTE_ERROR_LOG(PRTE_EXISTS);
+        return PRTE_EXISTS;
     }
 
     if (PRTE_ERR_NOT_FOUND != err) {
@@ -104,17 +119,26 @@ int prte_ras_slurm_add_pending_req(const char *request_id)
         return err;
     }
 
-    char *request_copy = strdup(request_id);
+    prte_ras_slurm_pending_req_t *pending_req = calloc(1, sizeof(*pending_req));
 
-    if (NULL == request_copy) {
+    if (NULL == pending_req) {
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
-    int pmix_err = pmix_pointer_array_add(&pending_reqs, request_copy);
+    pending_req->request_id = strdup(request_id);
+    pending_req->slurm_job_id = strdup(slurm_job_id);
+
+    if (NULL == pending_req->request_id || NULL == pending_req->slurm_job_id) {
+        prte_ras_slurm_pending_req_free(pending_req);
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    int pmix_err = pmix_pointer_array_add(&pending_reqs, pending_req);
 
     if (0 > pmix_err) {
-        free(request_copy);
+        prte_ras_slurm_pending_req_free(pending_req);
         err = prte_pmix_convert_status(pmix_err);
         PRTE_ERROR_LOG(err);
         return err;
@@ -126,7 +150,7 @@ int prte_ras_slurm_add_pending_req(const char *request_id)
 /**
  * @brief Remove a pending request from the cancellable request list.
  *
- * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ * @param[in] request_id PMIx request identifier.
  */
 int prte_ras_slurm_remove_pending_req(const char *request_id)
 {
@@ -146,8 +170,9 @@ int prte_ras_slurm_remove_pending_req(const char *request_id)
         return err;
     }
 
-    char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, idx);
-    free(stored_req);
+    prte_ras_slurm_pending_req_t *pending_req =
+        (prte_ras_slurm_pending_req_t *) pmix_pointer_array_get_item(&pending_reqs, idx);
+    prte_ras_slurm_pending_req_free(pending_req);
     pmix_pointer_array_set_item(&pending_reqs, idx, NULL);
 
     return PRTE_SUCCESS;
@@ -156,7 +181,7 @@ int prte_ras_slurm_remove_pending_req(const char *request_id)
 /**
  * @brief Check whether a request is still pending cancellation.
  *
- * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ * @param[in] request_id PMIx request identifier.
  */
 bool prte_ras_slurm_pending_req_exists(const char *request_id)
 {
@@ -171,7 +196,7 @@ bool prte_ras_slurm_pending_req_exists(const char *request_id)
  * Invokes Slurm cancellation for the matching pending request and removes it
  * from the list.
  *
- * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ * @param[in] request_id PMIx request identifier.
  */
 int prte_ras_slurm_cancel_pending_req(const char *request_id)
 {
@@ -191,19 +216,37 @@ int prte_ras_slurm_cancel_pending_req(const char *request_id)
         return err;
     }
 
-    prte_ras_slurm_kill_job(request_id, NULL, 0);
+    prte_ras_slurm_pending_req_t *pending_req =
+        (prte_ras_slurm_pending_req_t *) pmix_pointer_array_get_item(&pending_reqs, idx);
 
-    char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, idx);
-    free(stored_req);
+    prte_ras_slurm_kill_job(pending_req->slurm_job_id, NULL, 0);
+
+    prte_ras_slurm_pending_req_free(pending_req);
     pmix_pointer_array_set_item(&pending_reqs, idx, NULL);
 
     return PRTE_SUCCESS;
 }
 
 /**
+ * @brief Free a pending request mapping.
+ *
+ * @param[in] pending_req Pending request entry.
+ */
+static void prte_ras_slurm_pending_req_free(prte_ras_slurm_pending_req_t *pending_req)
+{
+    if (NULL == pending_req) {
+        return;
+    }
+
+    free(pending_req->request_id);
+    free(pending_req->slurm_job_id);
+    free(pending_req);
+}
+
+/**
  * @brief Find a pending request in the cancellable request list.
  *
- * @param[in] request_id Pending request identifier.
+ * @param[in] request_id PMIx request identifier.
  * @param[out] idx Array index containing the request.
  */
 static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx)
@@ -218,9 +261,10 @@ static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx)
     }
 
     for (int i = 0; i < pending_reqs.size; i++) {
-        char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, i);
+        prte_ras_slurm_pending_req_t *pending_req =
+            (prte_ras_slurm_pending_req_t *) pmix_pointer_array_get_item(&pending_reqs, i);
 
-        if (NULL != stored_req && 0 == strcmp(stored_req, request_id)) {
+        if (NULL != pending_req && 0 == strcmp(pending_req->request_id, request_id)) {
             *idx = i;
             return PRTE_SUCCESS;
         }
@@ -266,7 +310,7 @@ int prte_ras_slurm_modify_cancel_finalize(void)
     for (int i = 0; i < pending_reqs.size; i++) {
         void *ptr = pmix_pointer_array_get_item(&pending_reqs, i);
         if (NULL != ptr) {
-            free(ptr);
+            prte_ras_slurm_pending_req_free((prte_ras_slurm_pending_req_t *) ptr);
             pmix_pointer_array_set_item(&pending_reqs, i, NULL);
         }
     }

--- a/src/mca/ras/slurm/ras_slurm_modify_cancel.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_cancel.c
@@ -1,0 +1,278 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ras_slurm.h"
+#include "src/mca/ras/base/base.h"
+
+static pmix_pointer_array_t pending_reqs;
+static bool initialized = false;
+
+/* Local functions */
+static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx);
+
+/**
+ * @brief Process a PMIx pending resource cancellation request.
+ *
+ * Cancels a previously registered pending Slurm request identified by
+ * PMIX_ALLOC_REQ_ID.
+ *
+ * @param[in] req PMIx server request containing a Slurm job ID as PMIX_ALLOC_REQ_ID.
+ */
+int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req)
+{
+    if(!prte_ras_slurm_have_jansson()) {
+        pmix_output(0, "ras:slurm:modify: "
+            "Jansson support is required but not enabled in this build");
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    int err = PRTE_SUCCESS;
+    const char *request_id = NULL;
+
+    for (size_t i = 0; i < req->ninfo; i++) {
+        if (0 != strcmp(req->info[i].key, PMIX_ALLOC_REQ_ID)) {
+            continue;
+        }
+
+        if (PMIX_STRING != req->info[i].value.type) {
+            err = PRTE_ERR_BAD_PARAM;
+            goto cleanup;
+        }
+
+        request_id = req->info[i].value.data.string;
+        break;
+    }
+
+    if (NULL == request_id || '\0' == request_id[0]) {
+        pmix_output(0, "ras:slurm:modify: cancel request invalid or unsupported.\n"
+                       "Supported options: PMIX_ALLOC_REQ_ID");
+        err = PRTE_ERR_REQUEST;
+        goto cleanup;
+    }
+
+    err = prte_ras_slurm_cancel_pending_req(request_id);
+
+cleanup:
+
+    return err;
+}
+
+/**
+ * @brief Add a pending request to the cancellable request list.
+ *
+ * Stores a copy of the provided request ID string. Duplicate additions are
+ * treated as success.
+ *
+ * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ */
+int prte_ras_slurm_add_pending_req(const char *request_id)
+{
+    if (!initialized) {
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    if (NULL == request_id || '\0' == request_id[0]) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int idx;
+    int err = prte_ras_slurm_find_pending_req(request_id, &idx);
+
+    if (PRTE_SUCCESS == err) {
+        return PRTE_SUCCESS;
+    }
+
+    if (PRTE_ERR_NOT_FOUND != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    char *request_copy = strdup(request_id);
+
+    if (NULL == request_copy) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    int pmix_err = pmix_pointer_array_add(&pending_reqs, request_copy);
+
+    if (0 > pmix_err) {
+        free(request_copy);
+        err = prte_pmix_convert_status(pmix_err);
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Remove a pending request from the cancellable request list.
+ *
+ * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ */
+int prte_ras_slurm_remove_pending_req(const char *request_id)
+{
+    if (!initialized) {
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    if (NULL == request_id || '\0' == request_id[0]) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int idx;
+    int err = prte_ras_slurm_find_pending_req(request_id, &idx);
+
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, idx);
+    free(stored_req);
+    pmix_pointer_array_set_item(&pending_reqs, idx, NULL);
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Check whether a request is still pending cancellation.
+ *
+ * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ */
+bool prte_ras_slurm_pending_req_exists(const char *request_id)
+{
+    int idx;
+
+    return PRTE_SUCCESS == prte_ras_slurm_find_pending_req(request_id, &idx);
+}
+
+/**
+ * @brief Cancel a pending request.
+ *
+ * Invokes Slurm cancellation for the matching pending request and removes it
+ * from the list.
+ *
+ * @param[in] request_id Pending request identifier; must be a Slurm job ID.
+ */
+int prte_ras_slurm_cancel_pending_req(const char *request_id)
+{
+    if (!initialized) {
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    if (NULL == request_id || '\0' == request_id[0]) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int idx;
+    int err = prte_ras_slurm_find_pending_req(request_id, &idx);
+
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    prte_ras_slurm_kill_job(request_id, NULL, 0);
+
+    char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, idx);
+    free(stored_req);
+    pmix_pointer_array_set_item(&pending_reqs, idx, NULL);
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Find a pending request in the cancellable request list.
+ *
+ * @param[in] request_id Pending request identifier.
+ * @param[out] idx Array index containing the request.
+ */
+static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx)
+{
+    if (!initialized) {
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    if (NULL == request_id || '\0' == request_id[0] || NULL == idx) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0; i < pending_reqs.size; i++) {
+        char *stored_req = (char *) pmix_pointer_array_get_item(&pending_reqs, i);
+
+        if (NULL != stored_req && 0 == strcmp(stored_req, request_id)) {
+            *idx = i;
+            return PRTE_SUCCESS;
+        }
+    }
+
+    return PRTE_ERR_NOT_FOUND;
+}
+
+/**
+ * @brief Initialize required data structures for record keeping.
+ */
+int prte_ras_slurm_modify_cancel_init(void)
+{
+    if(initialized || !prte_ras_slurm_have_jansson()) {
+        return PRTE_SUCCESS;
+    }
+
+    int err = PRTE_SUCCESS;
+
+    PMIX_CONSTRUCT(&pending_reqs, pmix_pointer_array_t);
+
+    err = pmix_pointer_array_init(&pending_reqs, 0, INT_MAX, 16);
+    
+    if (PMIX_SUCCESS != err) {
+        PMIX_DESTRUCT(&pending_reqs);
+        return prte_pmix_convert_status(err);
+    }
+
+    initialized = true;
+
+    return err;
+}
+
+/**
+ * @brief Destroy required data structures for record keeping.
+ */
+int prte_ras_slurm_modify_cancel_finalize(void)
+{
+    if (!initialized) {
+        return PRTE_SUCCESS;
+    }
+
+    for (int i = 0; i < pending_reqs.size; i++) {
+        void *ptr = pmix_pointer_array_get_item(&pending_reqs, i);
+        if (NULL != ptr) {
+            free(ptr);
+            pmix_pointer_array_set_item(&pending_reqs, i, NULL);
+        }
+    }
+
+    PMIX_DESTRUCT(&pending_reqs);
+    initialized = false;
+
+    return PRTE_SUCCESS;
+}

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -730,6 +730,25 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     req->pstatus = prte_pmix_convert_rc(err);
 
+    /* Report back: job ID and resource manager used */
+    if (PMIX_SUCCESS == req->pstatus) {
+        pmix_info_t *result_info = NULL;
+
+        PMIX_INFO_CREATE(result_info, 2);
+        if (NULL == result_info) {
+            req->pstatus = PMIX_ERR_NOMEM;
+        } else {
+            if (req->copy && NULL != req->info) {
+                PMIX_INFO_FREE(req->info, req->ninfo);
+            }
+            PMIX_INFO_LOAD(&result_info[0], PMIX_ALLOC_ID, job_id, PMIX_STRING);
+            PMIX_INFO_LOAD(&result_info[1], PMIX_RM_NAME, "slurm", PMIX_STRING);
+            req->info = result_info;
+            req->ninfo = 2;
+            req->copy = true;
+        }
+    }
+
     /* Launch daemons on the newly secured resources */
     if (PMIX_SUCCESS == req->pstatus) {
         prte_job_t *daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -626,6 +626,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
  
     pmix_list_t added_nodes;
     bool have_added_nodes = false;
+    bool resources_added = false;
     
     prte_slurm_wait_tracker_t *trk = cbdata;
     prte_pmix_server_req_t *req = trk->req;
@@ -676,13 +677,40 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     err = prte_ras_base_node_insert(&added_nodes, NULL);
 
     if(PRTE_SUCCESS != err) {
+        prte_session_t *session = prte_get_session_object_from_id(job_id);
+
+        /* Roll back session changes to avoid inconsistent state */
+        if (NULL != session) {
+            prte_session_stack_item_t *item, *next;
+            PMIX_LIST_FOREACH_SAFE(item, next, prte_slurm_session_stack, prte_session_stack_item_t) {
+                if (item->session == session) {
+                    pmix_list_remove_item(prte_slurm_session_stack, &item->super);
+                    PMIX_RELEASE(item);
+                    break;
+                }
+            }
+            PMIX_RELEASE(session);
+        }
+
         PRTE_ERROR_LOG(err);
         goto complete;
     }
 
     prte_num_allocated_nodes += pmix_list_get_size(&added_nodes);
+    resources_added = true;
+
+    int pending_err = prte_ras_slurm_remove_pending_req(job_id);
+    if(PRTE_SUCCESS != pending_err) {
+        pmix_output(0, "ras:slurm:modify: failed to remove completed request %s "
+                       "from the pending cancellation list: %s",
+                       job_id, prte_strerror(pending_err));
+    }
 
     complete:
+
+    if(PRTE_SUCCESS != err && PRTE_ERR_JOB_CANCELLED != err && !resources_added) {
+        prte_ras_slurm_cancel_pending_req(job_id);
+    }
 
     if(have_added_nodes) {
         PMIX_DESTRUCT(&added_nodes);
@@ -729,6 +757,13 @@ static void slurm_wait_poll_cb(int fd, short args, void *cbdata)
 
     int err;
 
+    /* While waiting, this request was cancelled */
+    if (!prte_ras_slurm_pending_req_exists(trk->job_id)) {
+        trk->err = PRTE_ERR_JOB_CANCELLED;
+        prte_ras_slurm_extend_wait_complete(-1, 0, trk);
+        return;
+    }
+
     err = prte_ras_slurm_check_resources(trk->job_id);
 
     if (PRTE_ERR_RESOURCE_BUSY == err) {
@@ -750,6 +785,12 @@ static void slurm_wait_poll_cb(int fd, short args, void *cbdata)
         }
 
         return;
+    }
+
+    if (PRTE_ERR_JOB_CANCELLED == err) {
+        PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                            "%s ras:slurm:extend_wait: request %s was cancelled",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), trk->job_id));
     }
 
     trk->err = err;
@@ -779,8 +820,10 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 
     pmix_hash_table_t slurm_jobfields;
     bool have_slurm_jobfields = false;
+    bool pending_req_added = false;
     
     char *nodes_string = NULL;
+    char *job_id = NULL;
 
     uint64_t num_nodes;
     bool found = false;
@@ -851,7 +894,6 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
         goto cleanup;
     }
 
-    char *job_id;
     pmix_err = pmix_hash_table_get_value_ptr(&slurm_jobfields, record_job_data_fields[PRTE_JOB_DATA_JOB_ID],
                     strlen(record_job_data_fields[PRTE_JOB_DATA_JOB_ID]), (void**)&job_id);
 
@@ -861,12 +903,28 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
         goto cleanup;
     }
 
-    /* Wait for resources by polling every 5 seconds,
+    err = prte_ras_slurm_add_pending_req(job_id);
+
+    if(PRTE_SUCCESS != err) {
+        prte_ras_slurm_kill_job(job_id, NULL, 0);
+        goto cleanup;
+    }
+
+    pending_req_added = true;
+
+    /* Wait for resources by polling intermittently,
      * since this could take a long time */
 
     prte_slurm_wait_tracker_t *trk;
     
     trk = PMIX_NEW(prte_slurm_wait_tracker_t);
+
+    if(NULL == trk) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
     trk->req = req;
     PMIX_RETAIN(req);
 
@@ -896,6 +954,10 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     err = PRTE_ERR_OP_IN_PROGRESS;
 
     cleanup:
+
+    if(PRTE_SUCCESS != err && PRTE_ERR_OP_IN_PROGRESS != err && pending_req_added) {
+        prte_ras_slurm_cancel_pending_req(job_id);
+    }
 
     free(nodes_string);
 

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -38,6 +38,8 @@ typedef struct {
     pmix_object_t super;
     prte_event_t ev;
     prte_pmix_server_req_t *req;
+    char *request_id;
+    bool user_request_id_provided;
     char *job_id;
     int err;
     uint64_t poll_delay_usec;
@@ -107,6 +109,8 @@ static const char *threads_per_core_format = "--threads-per-core=%s";
 static void swt_con(prte_slurm_wait_tracker_t *p)
 {
     p->req = NULL;
+    p->request_id = NULL;
+    p->user_request_id_provided = false;
     p->job_id = NULL;
     p->err = PRTE_SUCCESS;
 }
@@ -118,6 +122,10 @@ static void swt_des(prte_slurm_wait_tracker_t *p)
 {
     if (NULL != p->job_id) {
         free(p->job_id);
+    }
+
+    if (NULL != p->request_id) {
+        free(p->request_id);
     }
 
     if (NULL != p->req) {
@@ -632,6 +640,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     prte_pmix_server_req_t *req = trk->req;
 
     char *job_id = trk->job_id;
+    char *request_id = trk->request_id;
 
     int err = trk->err;
 
@@ -667,7 +676,9 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     }
 
     /* Create a session  */
-    err = prte_ras_slurm_assign_new_session(job_id, NULL, &added_nodes);
+    err = prte_ras_slurm_assign_new_session(job_id,
+                                            trk->user_request_id_provided ? request_id : NULL,
+                                            &added_nodes);
 
     if(PRTE_SUCCESS != err) {
         goto complete;
@@ -699,17 +710,17 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     prte_num_allocated_nodes += pmix_list_get_size(&added_nodes);
     resources_added = true;
 
-    int pending_err = prte_ras_slurm_remove_pending_req(job_id);
+    int pending_err = prte_ras_slurm_remove_pending_req(request_id);
     if(PRTE_SUCCESS != pending_err) {
         pmix_output(0, "ras:slurm:modify: failed to remove completed request %s "
                        "from the pending cancellation list: %s",
-                       job_id, prte_strerror(pending_err));
+                       request_id, prte_strerror(pending_err));
     }
 
     complete:
 
     if(PRTE_SUCCESS != err && PRTE_ERR_JOB_CANCELLED != err && !resources_added) {
-        prte_ras_slurm_cancel_pending_req(job_id);
+        prte_ras_slurm_cancel_pending_req(request_id);
     }
 
     if(have_added_nodes) {
@@ -758,7 +769,7 @@ static void slurm_wait_poll_cb(int fd, short args, void *cbdata)
     int err;
 
     /* While waiting, this request was cancelled */
-    if (!prte_ras_slurm_pending_req_exists(trk->job_id)) {
+    if (!prte_ras_slurm_pending_req_exists(trk->request_id)) {
         trk->err = PRTE_ERR_JOB_CANCELLED;
         prte_ras_slurm_extend_wait_complete(-1, 0, trk);
         return;
@@ -824,6 +835,8 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     
     char *nodes_string = NULL;
     char *job_id = NULL;
+    char *request_id = NULL;
+    bool user_request_id_provided = false;
 
     uint64_t num_nodes;
     bool found = false;
@@ -839,7 +852,13 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
         
             num_nodes = req->info[i].value.data.uint64;
             found = true;
-            break;
+        } else if (0 == strcmp(req->info[i].key, PMIX_ALLOC_REQ_ID)) {
+            if (req->info[i].value.type != PMIX_STRING) {
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+            request_id = req->info[i].value.data.string;
+            user_request_id_provided = (NULL != request_id && '\0' != request_id[0]);
         }
     }
 
@@ -903,7 +922,11 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
         goto cleanup;
     }
 
-    err = prte_ras_slurm_add_pending_req(job_id);
+    if (NULL == request_id || '\0' == request_id[0]) {
+        request_id = job_id;
+    }
+
+    err = prte_ras_slurm_add_pending_req(request_id, job_id);
 
     if(PRTE_SUCCESS != err) {
         prte_ras_slurm_kill_job(job_id, NULL, 0);
@@ -927,6 +950,17 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 
     trk->req = req;
     PMIX_RETAIN(req);
+
+    trk->request_id = strdup(request_id);
+
+    if(NULL == trk->request_id) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        PMIX_RELEASE(trk);
+        goto cleanup;
+    }
+
+    trk->user_request_id_provided = user_request_id_provided;
 
     trk->job_id = strdup(job_id);
 
@@ -956,7 +990,7 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     cleanup:
 
     if(PRTE_SUCCESS != err && PRTE_ERR_OP_IN_PROGRESS != err && pending_req_added) {
-        prte_ras_slurm_cancel_pending_req(job_id);
+        prte_ras_slurm_cancel_pending_req(request_id);
     }
 
     free(nodes_string);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -111,14 +111,29 @@ static bool check_taint(char *name, char *evar)
 /* init the module */
 static int init(void)
 {
+    int err = PRTE_SUCCESS;
+
     prte_slurm_session_stack = PMIX_NEW(pmix_list_t);
 
     if(NULL == prte_slurm_session_stack) {
-        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-        return PRTE_ERR_OUT_OF_RESOURCE;
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
     }
 
-    return PRTE_SUCCESS;
+    err = prte_ras_slurm_modify_cancel_init();
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+cleanup:
+
+    if (PRTE_SUCCESS != err) {
+        PMIX_RELEASE(prte_slurm_session_stack);
+        prte_slurm_session_stack = NULL;
+    }
+
+    return err;
 }
 
 /**
@@ -272,6 +287,9 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     } else if(PMIX_ALLOC_RELEASE == req->allocdir) {
         err = prte_ras_slurm_serve_release_req(req);
         req->pstatus = prte_pmix_convert_rc(err);
+    } else if(PMIX_ALLOC_REQ_CANCEL == req->allocdir) {
+        err = prte_ras_slurm_serve_cancel_req(req);
+        req->pstatus = prte_pmix_convert_rc(err);
     } else {
         req->pstatus = PMIX_ERR_NOT_SUPPORTED;
     }
@@ -281,6 +299,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
 
 static int prte_ras_slurm_finalize(void)
 {
+    prte_ras_slurm_modify_cancel_finalize();
     PMIX_RELEASE(prte_slurm_session_stack);
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -294,6 +294,14 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
         req->pstatus = PMIX_ERR_NOT_SUPPORTED;
     }
 
+    /* Success at this stage means the request was served atomically.
+    * Return PMIX_OPERATION_SUCCEEDED so the RAS base completes the
+    * request instead of waiting for an asynchronous callback.
+    */
+    if (PMIX_SUCCESS == req->pstatus) {
+        return PMIX_OPERATION_SUCCEEDED;
+    }
+
     return req->pstatus;
 }
 


### PR DESCRIPTION
Serve requests to cancel pending requests made to the ras Slurm module + adjacent improvements

* Allow assigning ID for allocation extension requests and using that ID to cancel requests
* Detect when a pending expander job was cancelled externally (e.g. using Slurm commands) and handle gracefully
* Once secured, return ID of new resources from Slurm in info

Credits: AccelCom @ Barcelona Supercomputing Center