### PR TITLE
Debugger-related commits

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -26,11 +26,14 @@
  */
 
 #define _GNU_SOURCE
+#include <errno.h>
 #include <libgen.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -216,10 +219,12 @@ int main(int argc, char **argv)
     int i;
     pmix_data_array_t darray;
     int cospawned_namespace = 0;
+    bool stop_on_exec;
     char hostname[256];
 
     pid = getpid();
     gethostname(hostname, sizeof hostname);
+    stop_on_exec = (NULL != getenv("PRTE_DBG_STOP_ON_EXEC"));
 
     /* Initialize this daemon - since we were launched by the RM, our
      * connection info * will have been provided at startup. */
@@ -414,34 +419,55 @@ int main(int argc, char **argv)
      */
     (void) strncpy(proc.nspace, target_namespace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    // Since we are using the 'wildcard' only one daemon should send
-    // the release message.
-    // If we are 'cospawned' then the daemons are not ranked separately
-    // from the application (this is a bug) so just have everyone
-    // send the release.
-    if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        PMIX_INFO_LIST_START(dirs);
-        /* Send release notification to application namespace */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
-        /* Don't send notification to default event handlers */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
-        PMIX_INFO_LIST_RELEASE(dirs);
-        info = darray.array;
-        ninfo = darray.size;
+    if (stop_on_exec) {
+        /* Processes were stopped at exec with SIGSTOP before connecting to PMIx.
+         * Each daemon releases only its own local processes via SIGCONT; no
+         * rank-0 gating needed since every daemon operates on its own proctable. */
+        for (i = 0; i < (int) myquery_data.info[0].value.data.darray->size; i++) {
+            printf("[%s:%u:%lu] Sending SIGCONT to pid %lu (rank %u)\n",
+                   myproc.nspace, myproc.rank, (unsigned long) pid,
+                   (unsigned long) proctable[i].pid, proctable[i].proc.rank);
+            if (-1 == kill(proctable[i].pid, SIGCONT)) {
+                fprintf(stderr, "[%s:%u:%lu] kill(%lu, SIGCONT) failed: %s\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        (unsigned long) proctable[i].pid, strerror(errno));
+            }
+        }
+    } else {
+        /* Processes are stopped inside PMIx_Init / MPI_Init and have a PMIx
+         * event handler registered.  Send a single wildcard release; only one
+         * daemon needs to send it to avoid duplicate deliveries. */
+        // Since we are using the 'wildcard' only one daemon should send
+        // the release message.
+        // If we are 'cospawned' then the daemons are not ranked separately
+        // from the application (this is a bug) so just have everyone
+        // send the release.
+        if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        // Todo: Move this to the main tool
-        // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
-        sleep(1);
-        printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
-        rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo, NULL,
-                               NULL);
-        PMIX_DATA_ARRAY_DESTRUCT(&darray);
-        if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n", myproc.nspace,
-                    myproc.rank, (unsigned long) pid, PMIx_Error_string(rc), rc);
-            goto done;
+            PMIX_INFO_LIST_START(dirs);
+            /* Send release notification to application namespace */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
+            /* Don't send notification to default event handlers */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+            PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
+            PMIX_INFO_LIST_RELEASE(dirs);
+            info = darray.array;
+            ninfo = darray.size;
+
+            // Todo: Move this to the main tool
+            // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
+            sleep(1);
+            printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
+            rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo,
+                                   NULL, NULL);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        PMIx_Error_string(rc), rc);
+                goto done;
+            }
         }
     }
 

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -115,6 +115,15 @@ static void spawn_cbfunc(size_t evhdlr_registration_id, pmix_status_t status,
 {
     size_t n;
 
+    /* PMIX_READY_FOR_DEBUG fires once per job (all nodes coalesced), but guard
+     * against any future change that could deliver it more than once. */
+    if (NULL != appnspace) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NSPACE)) {
             appnspace = strdup(info[n].value.data.string);
@@ -139,7 +148,7 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     size_t ninfo, napps;
     char *requested_launcher;
-    int timeout;
+    int timeout, c;
     size_t n;
     char cwd[1024];
     pmix_status_t code = PMIX_EVENT_JOB_END;
@@ -147,7 +156,7 @@ int main(int argc, char **argv)
     pid_t pid;
     char *launchers[] = {"prun", "mpirun", "mpiexec", "prterun", NULL};
     pmix_proc_t proc, target_proc;
-    bool found;
+    bool found, stop_on_exec = false;
     pmix_data_array_t darray, darray2;
     pmix_nspace_t clientspace, dbnspace;
     pmix_value_t *val;
@@ -156,16 +165,32 @@ int main(int argc, char **argv)
     myquery_data_t *mydata = NULL;
     pmix_rank_t rank;
 
-    /* need to provide args */
-    if (2 > argc) {
-        fprintf(stderr, "Usage: %s [launcher] [app]\n", argv[0]);
+    /* parse options */
+    {
+        static struct option long_opts[] = {
+            { "stop-on-exec", no_argument, NULL, 'e' },
+            { NULL, 0, NULL, 0 }
+        };
+        while (-1 != (c = getopt_long(argc, argv, "+e", long_opts, NULL))) {
+            switch (c) {
+            case 'e':
+                stop_on_exec = true;
+                break;
+            default:
+                fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
+                exit(1);
+            }
+        }
+    }
+    if (optind >= argc) {
+        fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
         exit(0);
     }
 
     /* check to see if we are using an intermediate launcher - we only
      * support those we recognize */
     found = false;
-    requested_launcher = basename(argv[1]);
+    requested_launcher = basename(argv[optind]);
     for (n = 0; NULL != launchers[n]; n++) {
         if (0 == strcmp(requested_launcher, launchers[n])) {
             found = true;
@@ -243,11 +268,11 @@ int main(int argc, char **argv)
     napps = 1;
     PMIX_APP_CREATE(app, napps);
     /* setup the executable */
-    app[0].cmd = strdup(argv[1]);
-    PMIX_ARGV_APPEND(rc, app[0].argv, argv[1]);
+    app[0].cmd = strdup(argv[optind]);
+    PMIX_ARGV_APPEND(rc, app[0].argv, argv[optind]);
     /* pass it the rest of the cmd line as we don't know
      * how to parse it */
-    for (n = 2; n < argc; n++) {
+    for (n = (size_t) optind + 1; n < (size_t) argc; n++) {
         PMIX_ARGV_APPEND(rc, app[0].argv, argv[n]);
     }
     if (NULL == getcwd(cwd, 1024)) { // point us to our current directory
@@ -274,8 +299,10 @@ int main(int argc, char **argv)
      * to do with the app it is going to spawn for us */
     PMIX_INFO_LIST_START(linfo);
     rank = PMIX_RANK_WILDCARD;
-    if (NULL != strstr(argv[1], "mpi")) {
-        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL); // stop all procs in MPI_Init
+    if (NULL != strstr(argv[optind], "mpi")) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL);   // stop all procs in MPI_Init
+    } else if (stop_on_exec) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);  // stop all procs at first exec
     } else {
         PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // stop all procs in PMIx_Init
     }
@@ -417,6 +444,10 @@ int main(int argc, char **argv)
     }
     mydata->apps[0].cwd = strdup(cwd);
     mydata->apps[0].maxprocs = 1;
+    if (stop_on_exec) {
+        /* tell the daemon which release mechanism to use */
+        PMIX_SETENV(rc, "PRTE_DBG_STOP_ON_EXEC", "1", &mydata->apps[0].env);
+    }
     PMIX_LOAD_PROCID(&target_proc, (void *) appnspace, PMIX_RANK_WILDCARD);
     /* provide directives so the daemons go where we want, and
      * let the RM know these are debugger daemons */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -45,6 +45,9 @@
 #include <pmix_server.h>
 #include <signal.h>
 #include <time.h>
+#ifdef HAVE_SYS_PTRACE_H
+#    include <sys/ptrace.h>
+#endif
 
 #include "prte_stdint.h"
 #include "src/hwloc/hwloc-internal.h"
@@ -1753,6 +1756,46 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
         goto MOVEON;
     }
+
+#if PRTE_HAVE_STOP_ON_EXEC
+    /* If the child stopped due to the ptrace TRACEME+exec SIGTRAP, this is the
+     * stop-on-exec debug-attach point.  The wait_signal_callback consumed the
+     * ptrace-stop notification before do_parent could see it; handle it here
+     * instead.  Detach with SIGSTOP injected so the child stays stopped for
+     * the debugger, re-register for its eventual exit, and fire READY_FOR_DEBUG.
+     * Do NOT fall through to the exit-handling logic below. */
+    if (WIFSTOPPED(proc->exit_code) && WSTOPSIG(proc->exit_code) == SIGTRAP) {
+        if (NULL != jobdat &&
+            prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+            PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                 "%s odls:waitpid_fired ptrace-stop for %s, detaching with SIGSTOP",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(&proc->name)));
+            errno = 0;
+#    if PRTE_HAVE_LINUX_PTRACE
+            ptrace(PRTE_DETACH, proc->pid, 0, (void *) SIGSTOP);
+#    else
+            ptrace(PRTE_DETACH, proc->pid, 0, SIGSTOP);
+#    endif
+            if (0 != errno) {
+                PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                     "%s odls:waitpid_fired ptrace detach failed for %s: %s",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                     PRTE_NAME_PRINT(&proc->name), strerror(errno)));
+                state = PRTE_PROC_STATE_FAILED_TO_START;
+                PRTE_FLAG_UNSET(proc, PRTE_PROC_FLAG_ALIVE);
+                goto MOVEON;
+            }
+            proc->state = PRTE_PROC_STATE_RUNNING;
+            PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_ALIVE);
+            /* re-register to catch the child's eventual exit after the debugger releases it */
+            prte_wait_cb(proc, prte_odls_base_default_wait_local_proc, NULL);
+            PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
+            PMIX_RELEASE(t2);
+            return;
+        }
+    }
+#endif
 
     /* determine the state of this process */
     if (WIFEXITED(proc->exit_code)) {

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -375,7 +375,6 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     set_handler_default(SIGHUP);
     set_handler_default(SIGPIPE);
     set_handler_default(SIGCHLD);
-    set_handler_default(SIGTRAP);
 
     /* Unblock all signals, for many of the same reasons that we
        set the default handlers, above.  This is noticable on
@@ -428,7 +427,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
 
 static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
 {
-    int rc, status;
+    int rc;
     prte_odls_pipe_err_msg_t msg;
     char file[PRTE_ODLS_MAX_FILE_LEN + 1], topic[PRTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
@@ -437,51 +436,6 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
     }
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
-
-#if PRTE_HAVE_STOP_ON_EXEC
-    if (NULL != cd->child) {
-        if (prte_get_attribute(&cd->jdata->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
-            rc = waitpid(cd->child->pid, &status, WUNTRACED);
-            if (-1 == rc) {
-                /* doomed */
-                cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                close(read_fd);
-                return PRTE_ERR_FAILED_TO_START;
-            }
-            /* tell the child to stop */
-            if (WIFSTOPPED(status)) {
-                rc = kill(cd->child->pid, SIGSTOP);
-                if (-1 == rc) {
-                    /* doomed */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                errno = 0;
-#    if PRTE_HAVE_LINUX_PTRACE
-                ptrace(PRTE_DETACH, cd->child->pid, 0, (void *) SIGSTOP);
-#    else
-                ptrace(PRTE_DETACH, cd->child->pid, 0, SIGSTOP);
-#    endif
-                if (0 != errno) {
-                    /* couldn't detach */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                /* record that this proc is ready for debug */
-                PRTE_ACTIVATE_PROC_STATE(&cd->child->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
-            }
-            cd->child->state = PRTE_PROC_STATE_RUNNING;
-            PRTE_FLAG_SET(cd->child, PRTE_PROC_FLAG_ALIVE);
-            close(read_fd);
-            return PRTE_SUCCESS;
-        }
-    }
-#endif
 
     /* Block reading a message from the pipe */
     while (1) {


### PR DESCRIPTION
[odls: fix STOP_ON_EXEC race between do_parent and wait_signal_callback](https://github.com/openpmix/prrte/commit/57c247a9f617ef1e609341f4572e5a94c1c428f3)

Background
----------
When PRTE_JOB_STOP_ON_EXEC is set the daemon forks each child, the child
calls ptrace(PTRACE_TRACEME) immediately before execve(), and the kernel
delivers SIGTRAP to the new process before any user code runs, placing it
in a ptrace-stop.  The parent is then expected to observe the stop, detach
with SIGSTOP injected (so the process stays stopped for a debugger to
attach), and fire PRTE_PROC_STATE_READY_FOR_DEBUG.

The race
--------
Linux guarantees that waitpid(-1, WNOHANG) returns ptrace-stops for traced
children even without WUNTRACED.  The daemon's global SIGCHLD handler
(wait_signal_callback in prte_wait.c) calls exactly that in a loop on
every SIGCHLD.  Each child launch is dispatched to a worker thread; by the
time the worker calls waitpid(child->pid, WUNTRACED) inside do_parent(), the
SIGCHLD handler running on the main event thread may have already consumed
the ptrace-stop notification.

When the race is lost:

1. wait_signal_callback consumes the ptrace-stop and dispatches
   prte_odls_base_default_wait_local_proc() with the stopped status.

2. wait_local_proc() has no WIFSTOPPED branch.  It falls through to the
   else clause, misidentifies the stopped child as having been killed by a
   signal (PRTE_PROC_STATE_ABORTED_BY_SIG), and the error manager tears
   down the job.  WTERMSIG() on a stopped-status value is undefined
   behaviour; the resulting garbage exit code makes diagnosis harder.

3. Meanwhile the worker thread's waitpid(child->pid, WUNTRACED) blocks
   indefinitely: the only state change it was waiting for was already
   consumed.  The child itself is frozen in ptrace-stop with no tracer
   willing to release it.  Eventually the job-teardown SIGKILL unblocks
   the worker, which then marks the (now dead) child RUNNING|ALIVE.

The failure is intermittent because the race window is narrow for any
single child; at 128 processes the cumulative probability of hitting it
at least once becomes significant (confirmed in issue https://github.com/openpmix/prrte/issues/2453).

Additional bugs fixed
---------------------
* set_handler_default(SIGTRAP) was called in do_child() before
  ptrace(PTRACE_TRACEME).  SIG_DFL for SIGTRAP terminates the process.
  Although the kernel intercepts the post-exec SIGTRAP at the ptrace layer
  regardless of user-space disposition, any spurious SIGTRAP between the
  TRACEME call and the return from execve() would silently kill the child
  with no error written to the pipe.  Removed.

* do_parent() sent kill(SIGSTOP) to the ptrace-stopped child before
  calling ptrace(PTRACE_DETACH, SIGSTOP).  PTRACE_DETACH with an injected
  signal is the atomic, correct idiom; the preceding kill() queued a
  second SIGSTOP that would re-stop the process after the debugger's first
  SIGCONT, confusing debuggers.  The entire do_parent STOP_ON_EXEC block
  is removed, so this is gone with it.

Fix
---
Move all STOP_ON_EXEC post-fork work into the event-driven path that
already owns the waitpid(-1) calls, eliminating the race entirely.

odls_pdefault_module.c / do_parent():
  Remove the #if PRTE_HAVE_STOP_ON_EXEC block.  do_parent() now falls
  straight through to the pipe-read loop for all children.  The pipe's
  write end is close-on-exec, so it closes as soon as execve() succeeds;
  the parent reads EOF, which is already the correct "exec succeeded"
  signal regardless of whether the child then enters ptrace-stop.

odls_base_default_fns.c / wait_local_proc():
  Add #include <sys/ptrace.h> and insert a #if PRTE_HAVE_STOP_ON_EXEC
  block before the WIFEXITED branch.  When the status is
  WIFSTOPPED && WSTOPSIG == SIGTRAP and the job has STOP_ON_EXEC set:
    - Call ptrace(PTRACE_DETACH, pid, 0, SIGSTOP) to atomically release
      the child and leave it stopped under job-control.
    - Set proc->state = RUNNING and PRTE_PROC_FLAG_ALIVE.
    - Re-register prte_wait_cb() so the child's eventual exit (after the
      debugger releases it) is caught by the normal callback path.
    - Fire PRTE_PROC_STATE_READY_FOR_DEBUG.
    - Return early without going through MOVEON (no ABORTED_BY_SIG,
      no prte_wait_cb_cancel()).
  On ptrace(PTRACE_DETACH) failure the child is marked FAILED_TO_START
  and falls through to MOVEON as usual.

Fixes: https://github.com/openpmix/prrte/issues/2453

Signed-off-by: Ralph Castain <rhc@pmix.org>


[examples/debugger: add STOP_ON_EXEC support to indirect + daemon](https://github.com/openpmix/prrte/commit/1adc4611b4c7aec1f48cddc120ff5f4f45133a25)

indirect.c
----------
Add a -e / --stop-on-exec flag (getopt_long).  When given, the launch
directive sent to the intermediate launcher is PMIX_DEBUG_STOP_ON_EXEC
instead of PMIX_DEBUG_STOP_IN_INIT.  Application processes will be
stopped with SIGSTOP by the PRRTE daemon immediately after exec, before
any user code runs, and the PMIX_READY_FOR_DEBUG event will fire once
all processes across all nodes have stopped (two-level coalescing in the
state machine confirmed: per-node in state_prted, global in
plm_base_receive + state_dvm).

When stop-on-exec mode is active, the env var PRTE_DBG_STOP_ON_EXEC=1
is injected into the debugger daemon's environment so daemon.c knows
which release mechanism to use.

Also fix spawn_cbfunc: add an early-return guard so repeated calls
(possible if PMIX_READY_FOR_DEBUG were ever delivered more than once)
do not leak the strdup'd nspace string or re-enter the wakeup logic.

argv indexing is updated throughout to use optind so that -e may appear
before the launcher name on the command line.

daemon.c
--------
Add #include <errno.h>, <signal.h>, and <string.h>.

Detect stop-on-exec mode via getenv("PRTE_DBG_STOP_ON_EXEC") at
startup.

In the release section, branch on the mode:

  stop-on-exec: iterate the local proctable obtained from
    PMIX_QUERY_LOCAL_PROC_TABLE and send SIGCONT to each local process
    PID.  Each daemon operates on its own local processes so no
    rank-0 gating is required.  Processes stopped with SIGSTOP before
    PMIx_Init have no PMIx connection and cannot receive
    PMIX_DEBUGGER_RELEASE events; SIGCONT is the correct OS-level
    release.

  stop-in-init / stop-in-app: existing PMIX_DEBUGGER_RELEASE path,
    unchanged.

The "wait for job termination" logic (PMIX_EVENT_JOB_END handler and
DEBUG_WAIT_THREAD) is common to both paths and requires no changes.

Signed-off-by: Ralph Castain <rhc@pmix.org>
