### PR TITLE
Add CodeQL workflow for static analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# CodeQL configuration for PRRTE.  Push / PR scans load this file
+# locally from the checked-out branch.  The scheduled cross-branch scan
+# loads this same file from the default branch via CodeQL's remote
+# config-file syntax, so the release-branch scans do not require a local
+# copy of this file to already exist.
+
+name: "PRRTE CodeQL config"
+
+paths-ignore:
+  - '**/test'
+  # OpenPMIx is cloned here during the manual build; exclude it so
+  # CodeQL only reports results for PRRTE source code.
+  - 'openpmix/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,268 @@
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# CodeQL (GitHub code scanning / static analysis) configuration for
+# PRRTE.
+#
+# What this workflow does:
+#
+#   1. Runs CodeQL analysis on every pull request and on every push
+#      (i.e., merge) to master and the supported release branches.  This
+#      catches newly-introduced problems at the moment code changes.
+#
+#   2. Runs a periodic (weekly, Monday morning UTC) CodeQL scan of master
+#      *and* the active release branches.
+#
+# Why run periodic scans in addition to the per-PR / per-merge scans?
+#
+#   The PR/merge scans only ever examine code at the moment it changes.
+#   But CodeQL's query packs and analysis engine are continually
+#   updated as new classes of vulnerabilities (and new CVEs) are
+#   discovered.  The weekly scan re-analyzes the *existing* code base
+#   with the latest queries, so a vulnerability pattern that was
+#   unknown when a piece of code was merged can still be found later --
+#   even though that code has not changed and therefore would never be
+#   re-examined by a push/PR scan.  Release branches in particular tend
+#   to go quiet between point releases, so the periodic scan is often
+#   the only thing that keeps their results current.
+#
+# A note on branches and where this file must live:
+#
+#   - push and pull_request workflows always run from the copy of this
+#     file on the branch receiving the push / targeted by the PR (not
+#     from master).  So to get PR and merge analysis on a release branch
+#     (e.g., v4.0.x), this file must also be committed on that branch.
+#
+#   - The schedule (cron) event is special: it only ever fires from the
+#     default branch (master).  To periodically scan the release branches
+#     as well, the scheduled job below explicitly checks out each branch
+#     and tells the analyze action which ref/sha to attribute the results
+#     to.  The scheduled job is therefore inert on the release branches
+#     (it never fires there); only the copy on master drives the weekly
+#     scans.
+#
+# A note on building PRRTE:
+#
+#   PRRTE requires OpenPMIx to be installed before it can be configured
+#   and built.  The manual build steps therefore clone and install the
+#   OpenPMIx master branch before building PRRTE itself.
+
+name: "CodeQL Advanced"
+
+on:
+  push:
+    # Defined once here (&scan_branches) and reused by pull_request
+    # below via a YAML alias, so the two trigger lists cannot drift.
+    branches: &scan_branches
+      - master
+      - 'v[1-9].*'          # Matches v1.0.x, v2.0, v4.1, etc.
+      - 'v[1-9][0-9]+.*'    # Matches v10.0 and higher (double digits+)
+  pull_request:
+    branches: *scan_branches
+  schedule:
+    # Monday morning (UTC).  The off-the-hour minute avoids GitHub's
+    # top-of-the-hour scheduling congestion.
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
+# Cancel a superseded in-progress run when a newer commit is pushed to
+# the same pull request, to avoid stacking up expensive C/C++ builds.
+# The group includes the event name so push/schedule runs live in
+# separate groups, and cancellation is enabled only for pull_request
+# runs -- never the weekly scheduled scan or pushes to a branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # -------------------------------------------------------------------
+  # Event-driven analysis: scans the ref that triggered the push / PR.
+  # -------------------------------------------------------------------
+  analyze:
+    if: >-
+      github.event_name != 'schedule' &&
+      github.event_name != 'workflow_dispatch'
+    name: Analyze ${{ matrix.language }} (${{ github.ref_name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
+
+      - name: Clone and build OpenPMIx
+        if: matrix.build-mode == 'manual'
+        uses: actions/checkout@v6
+        with:
+          repository: openpmix/openpmix
+          ref: master
+          path: openpmix/master
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install OpenPMIx
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          cd openpmix/master
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+          make install
+
+      - name: Build PRRTE
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/prteinstall \
+            --with-pmix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  # -------------------------------------------------------------------
+  # Scheduled/manual analysis: explicitly scans master and each release
+  # branch. The schedule only fires from the default branch (master);
+  # see the header comment. workflow_dispatch intentionally runs this
+  # same matrix so the scheduled path can be tested without waiting for
+  # the next cron event.
+  # -------------------------------------------------------------------
+  analyze-scheduled:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+    name: Scheduled analysis - ${{ matrix.language }} (${{ matrix.branch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Concrete branch names only: this matrix drives
+        # 'actions/checkout', so (unlike the on.push.branches globs)
+        # these cannot be globs or regexes. New release branches must be
+        # added here, too.
+        branch:
+          - master
+          - v4.0
+          - v4.1
+        language:
+          - actions
+          - c-cpp
+          - python
+        include:
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Resolve commit SHA
+        id: commit
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: >-
+            ${{ github.repository }}/.github/codeql/codeql-config.yml@${{ github.event.repository.default_branch }}
+
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libhwloc-dev libevent-dev \
+            autoconf automake libtool
+
+      - name: Clone and build OpenPMIx
+        if: matrix.build-mode == 'manual'
+        uses: actions/checkout@v6
+        with:
+          repository: openpmix/openpmix
+          ref: master
+          path: openpmix/master
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Install OpenPMIx
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          cd openpmix/master
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+          make install
+
+      - name: Build PRRTE
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          ./autogen.pl
+          ./configure --prefix=$RUNNER_TEMP/prteinstall \
+            --with-pmix=$RUNNER_TEMP/pmixinstall
+          make -j $(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"
+          # Attribute results to the checked-out branch rather than to
+          # master (which is what a schedule event would otherwise report
+          # against).
+          ref: refs/heads/${{ matrix.branch }}
+          sha: ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
Adds GitHub CodeQL scanning for C/C++, Python, and Actions on every PR/push to master and release branches, plus a weekly scheduled scan of master, v4.0, and v4.1.  PRRTE's manual build clones and installs OpenPMIx/master as a prerequisite before building PRRTE itself.