### PR TITLE
Fix CodeQL security alerts: narrow-type comparison and double-free

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -304,8 +304,7 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
     hwloc_obj_type_t type;
     hwloc_cpuset_t result, tgtcpus;
     hwloc_obj_t target, tmp_obj, pkg;
-    uint16_t n;
-    unsigned npkgs, ncpus;
+    unsigned n, npkgs, ncpus;
     bool moveon = false;
     PRTE_HIDE_UNUSED_PARAMS(jdata);
 

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -151,6 +151,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         return rc;
     }
     free(bo.bytes);
+    bo.bytes = NULL;
 
     /* construct the string of aliases for compression */
     raw = PMIx_Argv_join(aliases, ';');
@@ -183,6 +184,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         return rc;
     }
     free(bo.bytes);
+    bo.bytes = NULL;
 
     /* compress the vpids */
     if (PMIx_Data_compress((uint8_t *) vpids, nbytes, (uint8_t **) &bo.bytes, &sz)) {


### PR DESCRIPTION
Alert #18 (CWE-190/835): in bind_multiple(), loop variable n was declared uint16_t while npkgs is unsigned int, risking overflow in the loop condition. Merge into a single unsigned declaration.

Alerts #16/#17 (CWE-415): in prte_util_nidmap_create(), two intermediate free(bo.bytes) calls on the success path left bo.bytes holding a stale pointer that CodeQL could not prove was overwritten before the next error-path free. Set bo.bytes = NULL immediately after each success-path free to make the state unambiguous.