### PR TITLE
pmix: use PMIx_generate_regex2 API when available for node/proc maps

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -222,6 +222,16 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                          AC_MSG_WARN([PMIx installation with the required capability.])
                          AC_MSG_ERROR([Cannot continue.])])
 
+    AC_MSG_CHECKING([for PMIx regex2 API support])
+    PRTE_CHECK_PMIX_CAP([REGEX2],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_have_regex2=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_have_regex2=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_HAVE_REGEX2],
+                       [$prte_pmix_have_regex2],
+                       [Whether or not PMIx supports the PMIx_generate_regex2 API])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -239,6 +239,19 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         tmp = PMIx_Argv_join(list, ',');
         PMIx_Argv_free(list);
         list = NULL;
+#if PRTE_PMIX_HAVE_REGEX2
+        pmix_regex2_t nregex = PMIX_REGEX2_STATIC_INIT;
+        if (PMIX_SUCCESS != (ret = PMIx_generate_regex2(tmp, NULL, 0, &nregex))) {
+            PMIX_ERROR_LOG(ret);
+            free(tmp);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            return rc;
+        }
+        free(tmp);
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, &nregex, PMIX_REGEX2);
+        PMIx_Regex2_destruct(&nregex);
+#else
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
@@ -249,6 +262,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, regex, PMIX_REGEX);
         free(regex);
+#endif
     }
 
     /* let the PMIx server generate the procmap regex */
@@ -256,6 +270,19 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         tmp = PMIx_Argv_join(procs, ';');
         PMIx_Argv_free(procs);
         procs = NULL;
+#if PRTE_PMIX_HAVE_REGEX2
+        pmix_regex2_t pregex = PMIX_REGEX2_STATIC_INIT;
+        if (PMIX_SUCCESS != (ret = PMIx_generate_regex2(tmp, NULL, 0, &pregex))) {
+            PMIX_ERROR_LOG(ret);
+            free(tmp);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            return rc;
+        }
+        free(tmp);
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, &pregex, PMIX_REGEX2);
+        PMIx_Regex2_destruct(&pregex);
+#else
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
@@ -266,6 +293,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, regex, PMIX_REGEX);
         free(regex);
+#endif
     }
 
     /* pass the number of nodes in the job */


### PR DESCRIPTION
When the installed PMIx has PMIX_CAP_REGEX2, use the new PMIx_generate_regex2() API to generate PMIX_NODE_MAP and PMIX_PROC_MAP when registering nspaces, storing the result as PMIX_REGEX2 rather than the deprecated PMIX_REGEX type.  The old PMIx_generate_regex / PMIx_generate_ppn path is retained under #else for backward compatibility with PMIx installations that predate the capability flag.

A new PRTE_CHECK_PMIX_CAP([REGEX2], ...) check in prte_setup_pmix.m4 defines PRTE_PMIX_HAVE_REGEX2 at configure time so the C code can select the right path at compile time.