### PR TITLE
Multiple commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,395 @@
+# AGENTS.md — Orientation for AI Coding Agents and Human Contributors
+
+This document is an orientation guide for AI coding agents and their human operators working in the PRRTE code base.
+This file is an *orientation map*, not the
+full rulebook: the authoritative, human-maintained documentation lives
+under [`docs/developers/`](docs/developers/) and
+[`docs/contributing.rst`](docs/contributing.rst) (rendered at
+<https://docs.prrte.org/>). When this file and those docs disagree,
+**the docs win** — and please fix this file.
+
+AI-assisted contributions are welcome. But PRRTE runs on the largest
+supercomputers in the world and across a huge range of operating
+systems and hardware. It is also used by numerous research groups
+looking at developments such as elastic environments. We want careful,
+portable code — not plausible-looking code that solves one problem in
+one environment or use-case at the expense of others. Hold yourself to
+the same bar as a thoughtful human contributor.
+
+---
+
+## What is PRRTE?
+
+PRRTE (PMIx Reference RunTime Environment) is an open-source, production
+runtime system for launching and managing parallel jobs in HPC environments.
+Unlike a library, PRRTE exposes no public API for callers — it is a
+collection of executable tools that users invoke directly.  PRRTE acts as a
+reference implementation of the PMIx-defined runtime services, and it relies
+heavily on the PMIx project for its internal infrastructure: MCA
+(Modular Component Architecture), utility routines, data structures, and
+threading primitives.  Many PMIx symbols and headers PRRTE uses are internal
+PMIx interfaces, **not** the PMIx public library API.
+
+Source repository: https://github.com/openpmix/prrte
+Documentation: https://docs.prrte.org/
+
+---
+
+## Terminology
+
+Understanding PRRTE's vocabulary is essential before reading or modifying
+code.
+
+| Term | Meaning |
+|------|---------|
+| **DVM** | Distributed Virtual Machine — a persistent set of PRRTE daemons spread across an allocation, ready to launch jobs on demand. |
+| **HNP** | Head Node Process — the `prte` process that acts as the DVM controller.  Also called the DVM master. |
+| **prted** | PRRTE daemon — one instance runs on each node in the DVM and manages local processes. |
+| **job** | A set of processes launched together under a single `prun` invocation.  Each job has a unique namespace. |
+| **namespace** | A string that uniquely identifies a job within a DVM session (inherited from PMIx). |
+| **rank** | A process's integer identifier within its namespace (global rank), within its node (node rank), or within the local set of processes on a node (local rank). |
+| **app context** | A description of one executable to run: path, argv, environment, and process count.  A single `prun` may specify multiple app contexts. |
+| **session** | The lifetime of a DVM — from `prte` startup through `pterm` shutdown. |
+| **schizo** | The "personality" framework.  Schizo components translate between PRRTE's internal model and the command-line conventions of specific launchers (e.g., Open MPI's `mpirun`, SLURM's `srun`). |
+| **MCA** | Modular Component Architecture — the plugin system, inherited from PMIx, that PRRTE uses for every swappable subsystem. |
+| **framework** | An MCA abstraction layer that defines the interface for one functional area (e.g., `plm`, `rmaps`). |
+| **component** | A plugin that implements a framework's interface for a specific environment or algorithm (e.g., `plm/slurm`). |
+| **module** | The active instance of a component, returned after it wins selection. |
+
+---
+
+## User-Facing Tools
+
+PRRTE provides no linkable library.  All user interaction is through
+executables.
+
+| Tool | Source | Purpose |
+|------|--------|---------|
+| `prte` | `src/tools/prte/` | Start a DVM (the HNP process).  Allocates and connects daemons across an allocation. |
+| `prun` | `src/tools/prun/` | Submit and manage a job within a running DVM.  The everyday launch command. |
+| `pterm` | `src/tools/pterm/` | Terminate a running DVM cleanly. |
+| `prted` | `src/tools/prted/` | The per-node daemon, normally launched by the HNP — not invoked directly by users. |
+| `prte_info` | `src/tools/prte_info/` | Query build configuration, list available MCA components, and display version information. |
+| `pcc` | `src/tools/pcc/` | Compiler wrapper for applications that directly embed PMIx (not PRRTE — PRRTE has no linkable library). |
+
+---
+
+## Source Layout
+
+```
+src/
+  tools/          # Executable entry points (prte, prun, pterm, prted, prte_info, pcc)
+  mca/            # All MCA frameworks and their components
+  runtime/        # Global state, init/finalize, job/node/proc data structures
+  rml/            # Runtime Messaging Layer (point-to-point communication between daemons)
+  util/           # Internal utilities (hostfile parsing, name formatting, attributes, ...)
+  include/        # Internal header files (types.h, constants.h, ...)
+  pmix/           # Thin shim connecting PRRTE to its PMIx dependency
+  event/          # Libevent integration
+  hwloc/          # hwloc integration (topology, binding)
+```
+
+The three central data structures — `prte_job_t`, `prte_node_t`, and
+`prte_proc_t` — are defined in `src/runtime/prte_globals.h` and carry
+all runtime state for a running job.  Code throughout the tree reaches
+for these; understand them before touching launch, mapping, or error
+handling paths.
+
+---
+
+## MCA Frameworks
+
+Every swappable PRRTE subsystem is an MCA framework.  The framework
+directory contains a `base/` subdirectory (selection, default behaviors,
+utility stubs) and one or more component subdirectories.
+
+| Framework | Location | Responsibility |
+|-----------|----------|----------------|
+| `ess` | `src/mca/ess/` | Environment-Specific Services — init/finalize for each process role (HNP, daemon, tool). |
+| `plm` | `src/mca/plm/` | Process Launch Manager — spawns prted daemons across the system. Components: `ssh`, `slurm`, `lsf`, `pals`. |
+| `ras` | `src/mca/ras/` | Resource Allocation Subsystem — discovers nodes and slots. Components: `slurm`, `pbs`, `lsf`, `flux`, `gridengine`, `hosts`. |
+| `rmaps` | `src/mca/rmaps/` | Resource Mapping — assigns processes to nodes/slots. Components: `round_robin`, `ppr`, `rank_file`, `seq`. |
+| `odls` | `src/mca/odls/` | PRRTE Daemon Local Launch Subsystem — the per-node daemon (prted) forks/execs application processes. |
+| `iof` | `src/mca/iof/` | I/O Forwarding — routes stdout/stderr/stdin between daemons and the HNP. |
+| `grpcomm` | `src/mca/grpcomm/` | Group Communication — collective operations among daemons (broadcast, barrier). |
+| `errmgr` | `src/mca/errmgr/` | Error Manager — handles process faults, abnormal exits, and propagation of errors. |
+| `state` | `src/mca/state/` | State Machine — drives the DVM and job lifecycle through defined states/transitions. |
+| `schizo` | `src/mca/schizo/` | Personality layer — parses CLI options and environment for specific launcher personalities (prte, ompi). |
+| `filem` | `src/mca/filem/` | File Management — pre-positions files across nodes before launch. |
+| `prtereachable` | `src/mca/prtereachable/` | Reachability — determines which network interfaces can reach each node. |
+| `prtebacktrace` | `src/mca/prtebacktrace/` | Backtrace support for crash diagnostics. |
+| `prtedl` | `src/mca/prtedl/` | Dynamic linker abstraction (dlopen/dlclose). |
+| `prteinstalldirs` | `src/mca/prteinstalldirs/` | Installation directory queries. |
+
+### MCA component structure
+
+Each component directory must contain:
+- `<component>.h` — component struct (`prte_<fw>_<name>_component_t`)
+- `<component>.c` — component registration, open, query, close
+- `<name>_module.c` (or similar) — module implementation
+- `Makefile.am`
+
+The component's `query` function returns a priority; the highest-priority
+component that successfully opens wins selection.
+
+---
+
+## PRRTE's Relationship with PMIx
+
+PRRTE depends on PMIx (minimum version `6.1.0`) and uses PMIx internals
+extensively.  This is not the same as calling the PMIx public library API.
+
+**What PRRTE takes from PMIx:**
+
+- **MCA infrastructure** (`src/mca/base/`, `src/mca/mca.h`) — the entire
+  plugin/component system is PMIx's code, not PRRTE's.
+- **Data structures and classes** — `pmix_list_t`, `pmix_pointer_array_t`,
+  `pmix_hash_table_t`, `pmix_ring_buffer_t`, `pmix_value_array_t`.
+- **Threading primitives** — `pmix_mutex_t`, `pmix_condition_t`,
+  `pmix_threads_*`.
+- **Utility functions** — `pmix_argv_*`, `pmix_environ_*`,
+  `pmix_output_*`, `pmix_cmd_line_*`.
+- **Event loop** — PMIx's libevent integration and progress threads.
+- **Data packing/unpacking** — PMIx's buffer and bfrops subsystem.
+
+Include paths for these symbols come from PMIx's installed headers (found
+via `pkg-config` or `--with-pmix=`).  The shim at `src/pmix/pmix-internal.h`
+and `src/pmix/pmix.c` is PRRTE's integration point — consult it before
+reaching for PMIx symbols elsewhere.
+
+### Check capability flags
+
+PRRTE uses the `AC_PREPROC_IFELSE` idiom in its configure script to test for PMIx capability flags at build time.  PRRTE's `config/prte_setup_pmix.m4` defines a helper macro `PRTE_CHECK_PMIX_CAP` that reduces the check to:
+
+```m4
+PRTE_CHECK_PMIX_CAP([MY_NEW_FEATURE],
+    [action if supported],
+    [action if not supported])
+```
+
+The macro succeeds when `PMIX_CAP_MY_NEW_FEATURE` is defined in the installed `pmix_version.h`; it fails (and triggers the third argument) when the definition is absent, meaning the running PMIx predates the feature.
+
+Code requiring a specific PMIx feature that is covered by a capability flag must be protected by an appropriate `#if FOO` clause.
+
+---
+
+## Coding Rules
+
+These rules apply to **all** PRRTE C source files without exception.
+
+### Mandatory header order
+
+`prte_config.h` **must be the first `#include`** in every `.c` file.
+Nothing comes before it — not system headers, not other PRRTE headers.
+
+```c
+#include "prte_config.h"
+
+#include <stdio.h>          /* system headers follow */
+...
+#include "src/util/name_fns.h"  /* then PRRTE/PMIx headers */
+```
+
+### Symbol prefixes
+
+| Scope | Prefix |
+|-------|--------|
+| Exported (tools, public data) | `PRTE_` (macros) / `prte_` (functions, types) |
+| Internal only | `prte_` with no `PRTE_EXPORT` annotation |
+| MCA component | `prte_<framework>_<component>_` |
+
+Do not use `PMIX_` or `pmix_` prefixes for new PRRTE symbols.
+
+### New files need the standard copyright/license header.
+
+Copy the multi-institution BSD header block — including the `$COPYRIGHT$` and
+`$HEADER$` tokens — from a neighboring file. If you substantially
+change an existing file, add your copyright line to its block.
+
+### `#define` logical macros to `0` or `1`; never `#undef` them.
+
+Test with `#if FOO`, not `#ifdef FOO`, so a misspelling is a compiler
+error, not a silent false.
+
+### Constant-on-left comparisons
+
+Always put the constant or NULL on the left side of an equality test:
+
+```c
+if (NULL == ptr)    /* correct */
+if (ptr == NULL)    /* wrong — easy to mistype as assignment */
+
+if (PRTE_SUCCESS == rc)   /* correct */
+```
+
+### Always brace blocks
+
+Use `{ }` around every conditional or loop body, even single-line ones.
+
+### Indentation
+
+4 spaces, never tab characters.
+
+
+### Stay compiler-warning-free
+
+PRRTE strives to build with zero compiler warnings. Do not introduce
+code that adds new warnings. `--enable-devel-check` is implied when
+building from a git repo with `--enable-debug`; it instructs the compiler
+to treat all warnings as errors and enables maximum warning coverage
+(e.g., unused variables). CI runs with this setting, so your code must
+be warning-free before submitting.
+
+### No hand-editing of generated files
+
+Do not modify files produced by autotools (`configure`, `Makefile.in`, etc.), pre-rendered documentation, or third-party vendored code. Edit the source code instead.
+
+
+### Error handling
+
+Functions that can fail return `int`.  Check every return value.  Use
+`PRTE_ERROR_LOG(rc)` to record unexpected errors.  Use
+`PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_*)` to trigger state
+transitions rather than handling errors inline in launch paths.
+
+### Thread model
+
+PRRTE is event-driven and single-threaded on the progress thread.  Use
+the PRRTE event loop (`prte_event_base`) for deferred work.  Do not block on
+the progress thread.
+
+### Thread-shifting with caddies
+
+A **caddy** is a short-lived heap object whose sole job is to carry a request's parameters across states within the progress thread.  Every caddy struct must contain at minimum:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| ev | `pmix_event_t` | Required by Libevent to queue the caddy; **must be named `ev`** |
+| lock | `pmix_lock_t` | Thread synchronization (blocking operations wait on this; handlers wake it) |
+| cbdata | `void *` | Opaque pointer passed through to the callback |
+| callback pointer(s) | function pointer(s) | Cache the caller-supplied callback function(s) |
+
+The pattern:
+
+1. Allocate a caddy with `PMIX_NEW(caddy_type_t)`.
+2. Assign the caddy's fields to point at the caller's parameters — **do not copy the data**.
+3. Call `PRTE_PMIX_THREADSHIFT(cd, evbase, handler_fn)` to post the caddy to the progress thread's event queue.
+4. The progress thread fires `handler_fn(cd)`, which performs the actual work.
+
+Never read or write shared library state outside of the progress thread; do it only inside the handler that runs on the progress thread.
+Do not allocate a caddy on the stack — it must outlive the function that creates it.
+
+
+### Memory management
+
+Use `PMIX_NEW` / `PMIX_RELEASE` (PMIx's reference-counted object system)
+for all PRRTE objects that embed `pmix_object_t`.  Raw allocations use
+`malloc`/`free` directly — avoid `PMIX_MALLOC`/`PMIX_FREE` for plain
+buffers unless interfacing with PMIx routines that require it.
+
+### C standard
+
+PRRTE targets C11.  Do not add `-Wno-*` flags to suppress warnings —
+fix the underlying issue.
+
+---
+
+## Build System
+
+PRRTE uses GNU Autotools.  The generated `configure` script is **not** in
+the git repository; it is produced by running:
+
+```sh
+./autogen.pl
+```
+
+This must be re-run whenever `configure.ac`, any `Makefile.am`, or any
+`*.m4` file under `config/` is modified.  After `autogen.pl`:
+
+```sh
+./configure [options]
+make -j$(nproc)
+make install
+```
+
+Common configure options:
+
+| Option | Purpose |
+|--------|---------|
+| `--with-pmix=<path>` | Path to PMIx installation (required if not in default search path) |
+| `--with-hwloc=<path>` | Path to hwloc installation |
+| `--with-libevent=<path>` | Path to libevent installation |
+| `--with-slurm` | Enable SLURM support |
+| `--with-lsf=<path>` | Enable LSF support |
+| `--with-pbs` | Enable PBS/Torque support |
+| `--with-flux=<dir>` | Enable Flux support |
+| `--enable-debug` | Build with debug symbols and extra assertions |
+| `--enable-devel-check` | Enable strict compiler warnings (treat warnings as errors); on by default when `--enable-debug` is used in a git repo build |
+
+Version requirements: PMIx ≥ 6.1.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
+
+---
+
+## State Machines
+
+PRRTE drives both the DVM lifecycle and individual job lifecycles through
+explicit state machines defined in `src/mca/state/`.  Process and job
+states are declared in `src/mca/state/state_types.h`.  When debugging
+launch or termination problems, enable framework verbosity to trace
+state transitions:
+
+```sh
+prte --prtemca state_base_verbose 5 ...   # trace job state transitions
+prte --prtemca plm_base_verbose 5 ...     # trace daemon launch
+prte --prtemca rmaps_base_verbose 5 ...   # trace process mapping
+```
+
+Key job states in order: `PRTE_JOB_STATE_INIT` →
+`PRTE_JOB_STATE_ALLOCATE` → `PRTE_JOB_STATE_MAP` →
+`PRTE_JOB_STATE_LAUNCH_DAEMONS` → `PRTE_JOB_STATE_RUNNING` →
+`PRTE_JOB_STATE_TERMINATED`.
+
+---
+
+## Contributing
+
+### Commit messages
+
+Write prose commit messages, not bullet lists.  The subject line should
+complete the sentence "If applied, this commit will …".  The body must
+explain **why** the change is needed, not just what it does.  Keep the
+subject line under 72 characters.
+
+All commits require a `Signed-off-by:` line (DCO):
+
+```
+git commit -s
+```
+
+### Pull requests
+
+- Open PRs against the `master` branch (development trunk).
+- One logical change per PR.  Split unrelated fixes.
+- Describe the problem being solved in the PR description, not just the
+  solution.
+- Documentation updates (`docs/`) are required for user-visible changes.
+
+### Testing
+
+PRRTE does not have a standalone unit test suite.  Integration-level
+testing is done by running actual parallel jobs through the DVM.  When
+modifying launch, mapping, or I/O forwarding paths, test with:
+
+```sh
+prte --daemonize                    # start DVM
+prun -n 4 hostname                  # basic launch smoke test
+pterm                               # shut down DVM
+```
+
+For resource manager integration (SLURM, PBS, LSF), test within an actual
+allocation on the relevant system.
+
+### Reporting bugs
+
+File issues at https://github.com/openpmix/prrte/issues.  Include the
+output of `prte_info --all` and a minimal reproduction case.

--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -95,7 +95,7 @@ AC_ARG_ENABLE(debug-symbols,
 AC_MSG_CHECKING([if want developer-level compiler pickyness])
 AC_ARG_ENABLE(devel-check,
     AS_HELP_STRING([--enable-devel-check],
-                   [enable developer-level compiler pickyness when building PRRTE (default: disabled)]))
+                   [enable developer-level compiler pickyness when building PRRTE (default: enabled for git repo debug builds, disabled otherwise)]))
 if test "$enable_devel_check" = "yes"; then
     AC_MSG_RESULT([yes])
     WANT_PICKY_COMPILER=1

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -222,6 +222,16 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                          AC_MSG_WARN([PMIx installation with the required capability.])
                          AC_MSG_ERROR([Cannot continue.])])
 
+    AC_MSG_CHECKING([for PMIx regex2 API support])
+    PRTE_CHECK_PMIX_CAP([REGEX2],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_have_regex2=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_have_regex2=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_HAVE_REGEX2],
+                       [$prte_pmix_have_regex2],
+                       [Whether or not PMIx supports the PMIx_generate_regex2 API])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,8 +64,8 @@ on the remaining system nodes.
 on the other system nodes.
 
 ``DVMNodes=<regex of DVM nodes> (default: none)`` provides a regular expression
-identifying the nodes that upon which user applications can run. IP addresses can
-be provided in place of hostnames if desired.The regular expression can consist of
+identifying the nodes upon which user applications can run. IP addresses can
+be provided in place of hostnames if desired. The regular expression can consist of
 a simple comma-delimited list of hostnames, or a comma-delimited list of hostname
 ranges (e.g., "linux0,linux[2-10]"), or a PMIx "native" regular expression.
 

--- a/docs/developers/git-github.rst
+++ b/docs/developers/git-github.rst
@@ -18,7 +18,7 @@ PRRTE's Git repositories are `hosted at GitHub
       shell$ git clone --recursive https://github.com/openpmix/prrte.git
 
 Note that Git is natively capable of using many forms of web
-proxies. If your network setup requires the user of a web proxy,
+proxies. If your network setup requires the use of a web proxy,
 `consult the Git documentation for more details
 <https://git-scm.com/>`_.
 

--- a/docs/developers/gnu-autotools.rst
+++ b/docs/developers/gnu-autotools.rst
@@ -1,6 +1,6 @@
 .. _developers-installing-autotools-label:
 
-Manually installing the GNU Autootools
+Manually installing the GNU Autotools
 ======================================
 
 There is enough detail in building the GNU Autotools that it warrants
@@ -223,7 +223,7 @@ Installing the GNU Autotools from source
           Autotools manually if you can't use your operating system
           packaging system to install them for you.
 
-The GNU Autotools sources can be can be downloaded from:
+The GNU Autotools sources can be downloaded from:
 
 * https://ftp.gnu.org/gnu/autoconf/
 * https://ftp.gnu.org/gnu/automake/

--- a/docs/developers/prerequisites.rst
+++ b/docs/developers/prerequisites.rst
@@ -111,7 +111,7 @@ still have both the HTML documentation and man pages installed as part
 of the normal configure / build / install process.
 
 However, the HTML documentation and man pages are *not* stored in PRRTE's
-Git repository; only the ReStructred Text source code of the
+Git repository; only the ReStructured Text source code of the
 documentation is in the Git repository.  Hence, if you are building
 PRRTE from a Git clone, you will need Sphinx (and some Python
 modules) in order to build the HTML documentation and man pages.

--- a/docs/developers/rst-for-markdown-expats.rst
+++ b/docs/developers/rst-for-markdown-expats.rst
@@ -76,9 +76,9 @@ Chapter and section delimiters
 * RST: Have a single line of text, underlined by non-ASCII
   characters.
 
-  * The length of the underlying *must* be at least as long as the
+  * The length of the underline *must* be at least as long as the
     line of text
-  * Which non-ASCII character is used for the underlying does not
+  * Which non-ASCII character is used for the underline does not
     matter, but the order in which they are used denotes chapters
     / sections / subsections / etc.
 
@@ -152,7 +152,7 @@ Multi-line code/fixed-width font
     case, the example code block will be rendered in the bulleted
     item.
 
-Whereas this parargraph and code block will be outside of the
+Whereas this paragraph and code block will be outside of the
 above bulleted list:
 
 .. code-block:: sh

--- a/docs/developers/sphinx.rst
+++ b/docs/developers/sphinx.rst
@@ -226,7 +226,7 @@ after running ``make install``:
 
       shell$ open $prefix/share/doc/prte/html/index.html
 
-#. The man pages are installed (by default) to ``$preix/share/man``.
+#. The man pages are installed (by default) to ``$prefix/share/man``.
    If your man page search path includes this location, you can invoke
    commands similar to the following to see the same content that you
    see in these HTML pages:

--- a/docs/how-things-work/schedulers/overview.rst
+++ b/docs/how-things-work/schedulers/overview.rst
@@ -3,6 +3,6 @@ Overview
 
 While PRRTE does not itself contain a scheduler, it does support scheduler-related
 operations as a means of providing users and researchers with an environment within
-which they can investigate/explore dynamic operations. It will , of course, interact
+which they can investigate/explore dynamic operations. It will, of course, interact
 with any PMIx-based scheduler to support allocation requests and directives for
 executing jobs within an allocation.

--- a/docs/how-things-work/schedulers/structures.rst
+++ b/docs/how-things-work/schedulers/structures.rst
@@ -205,7 +205,7 @@ with the following fields:
 * num_daemons_reported: bookkeeping counter of number of daemons
   spawned in support of the job that have reported "ready"
 
-* num_ready_for_debug: bookkeeping counter of number of processed
+* num_ready_for_debug: bookkeeping counter of number of processes
   that have registered as ready for debug
 
 * originator: ID of process that requested spawn of this job

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,7 +82,7 @@ VPATH builds are fully supported.  For example:
 
 Parallel builds are also supported (although some versions of ``make``,
 such as GNU make, will only use the first target listed on the command
-line when executable parallel builds).  For example (assume GNU make):
+line when executing parallel builds).  For example (assume GNU make):
 
 .. code-block:: sh
 

--- a/docs/launching-apps/gridengine.rst
+++ b/docs/launching-apps/gridengine.rst
@@ -7,7 +7,7 @@ Grid Engine, Open Cluster Scheduler (OCS), Gridware Cluster Scheduler (GCS)
 and others.
 
 This documentation will collectively refer to all of them as "Grid
-Engine", unless a referring to a specific flavor of the Grid Engine
+Engine", unless referring to a specific flavor of the Grid Engine
 family.
 
 Verify Grid Engine support
@@ -34,7 +34,7 @@ When Grid Engine support is included, PRRTE will automatically
 detect when it is running inside SGE and will just "do the Right
 Thing."
 
-Specifically, if you execute an ``prterun`` command in a Grid Engine
+Specifically, if you execute a ``prterun`` command in a Grid Engine
 job, it will automatically use the Grid Engine mechanisms to launch
 and kill processes.  There is no need to specify what nodes to run on
 |mdash| PRRTE will obtain this information directly from Grid

--- a/docs/launching-apps/localhost.rst
+++ b/docs/launching-apps/localhost.rst
@@ -13,7 +13,7 @@ example:
 .. code-block:: sh
 
    shell$ prterun -n 6 mpi-hello-world
-   Hello world, I am 0 of 6 (running on my-laptop))
+   Hello world, I am 0 of 6 (running on my-laptop)
    Hello world, I am 1 of 6 (running on my-laptop)
    ...
    Hello world, I am 5 of 6 (running on my-laptop)

--- a/docs/launching-apps/lsf.rst
+++ b/docs/launching-apps/lsf.rst
@@ -28,7 +28,7 @@ Launching
 When properly configured, PRRTE obtains both the list of hosts and
 how many processes to start on each host from LSF directly.  Hence, it
 is unnecessary to specify the ``--hostfile``, ``--host``, or ``-n``
-options to ``mpirun``.  PRRTE will use LSF-native mechanisms
+options to ``prterun``.  PRRTE will use LSF-native mechanisms
 to launch and kill processes (``ssh`` is not required).
 
 For example:

--- a/docs/launching-apps/prerequisites.rst
+++ b/docs/launching-apps/prerequisites.rst
@@ -194,7 +194,7 @@ There are some situations where you cannot modify the ``PATH`` or
 all parallelism from the user, and therefore do not want to make the
 user modify their shell startup files.
 
-In such cases, you can use the ``prterun````--prefix`` command line
+In such cases, you can use the ``prterun`` ``--prefix`` command line
 option, which takes as an argument the
 top-level directory where PRRTE was installed.  While relative
 directory names are possible, they can become ambiguous depending on

--- a/docs/launching-apps/quickstart.rst
+++ b/docs/launching-apps/quickstart.rst
@@ -75,7 +75,7 @@ option:
 .. code-block:: sh
 
    shell$ prterun -n 6 mpi-hello-world
-   Hello world, I am 0 of 6 (running on my-laptop))
+   Hello world, I am 0 of 6 (running on my-laptop)
    Hello world, I am 1 of 6 (running on my-laptop)
    ...
    Hello world, I am 5 of 6 (running on my-laptop)
@@ -87,7 +87,7 @@ If you do not specify the ``-n`` option, ``prterun`` will
 default to launching as many processes as
 there are processor cores (not hyperthreads) on the machine.
 
-Launching in a non-scheduled environments (via ``ssh``)
+Launching in non-scheduled environments (via ``ssh``)
 -------------------------------------------------------
 
 In general, PRRTE requires the following to launch and run
@@ -141,7 +141,7 @@ each node:
 * node1: 16, because no ``slots`` was specified
 * node2: 16, because no ``slots`` was specified
 * node3: 2, because ``slots=2`` was specified
-* node2: 10, because ``slots=10`` was specified
+* node4: 10, because ``slots=10`` was specified
 
 Note, however, that not all environments require a hostfile.  For
 example, PRRTE will automatically detect when it is running in
@@ -155,7 +155,7 @@ Launching in scheduled environments
 -----------------------------------
 
 In scheduled environments (e.g., in a Slurm job, or PBS/Pro, or LSF,
-or any other schedule), the user tells the scheduler how many MPI
+or any other scheduler), the user tells the scheduler how many MPI
 processes to launch, and the scheduler decides which hosts to use.
 The scheduler then passes both pieces of information (the number of
 processes and the hosts to use) to PRRTE.

--- a/docs/launching-apps/slurm.rst
+++ b/docs/launching-apps/slurm.rst
@@ -4,7 +4,7 @@ Launching with Slurm
 PRRTE supports two modes of launching parallel jobs under
 Slurm:
 
-#. Using PRRTE's full-features ``prterun`` launcher.
+#. Using PRRTE's full-featured ``prterun`` launcher.
 #. Using Slurm's "direct launch" capability.
 
 Unless there is a strong reason to use ``srun`` for direct launch, the

--- a/docs/launching-apps/ssh.rst
+++ b/docs/launching-apps/ssh.rst
@@ -9,15 +9,15 @@ following:
 
 #. You must be able to non-interactively login |mdash| without
    entering a password or passphrase |mdash| to all remote nodes from
-   all remotes nodes.
-#. PRRTE's daemon executablesmust be findable (e.g., in your ``PATH``).
+   all remote nodes.
+#. PRRTE's daemon executables must be findable (e.g., in your ``PATH``).
 #. PRRTE's libraries must be findable (e.g., in your
    ``LD_LIBRARY_PATH``).
 
 Specifying the hosts for a job
 ------------------------------
 
-There are three mechanisms for specifying the hosts that an job will run on:
+There are three mechanisms for specifying the hosts that a job will run on:
 
 #. The ``--hostfile`` option to ``prterun``.
 
@@ -35,7 +35,7 @@ There are three mechanisms for specifying the hosts that an job will run on:
    If you are running in a scheduled environment (e.g., in a Slurm,
    Torque, or LSF job), PRRTE will automatically get the lists of
    hosts from the scheduler.  See the next subsections for details about
-   launching jobs in supported scheduled environements.
+   launching jobs in supported scheduled environments.
 
 .. important:: The specification of hosts using any of the above
                methods has nothing to do with the network interfaces
@@ -152,7 +152,7 @@ Consider the case where PRRTE was configured with:
 
    shell$ ./configure --prefix=$HOME/my-prrte ...
 
-In this cause, PRRTE will be installed into ``$HOME/my-prrte``.
+In this case, PRRTE will be installed into ``$HOME/my-prrte``.
 This path is almost certainly not in any system-default search paths,
 so it must be added to the ``$PATH`` and ``$LD_LIBRARY_PATH``
 environment variables.
@@ -177,7 +177,7 @@ Ensure that you do not see any errors about libraries that cannot be
 found.
 
 All shells have some kind of script file that is executed at login
-time perform environmental setup tasks.  This startup file is the one
+time to perform environmental setup tasks.  This startup file is the one
 that needs to be edited to:
 
 #. Add PRRTE's daemon executable path (which is likely ``$prefix/bin``, or

--- a/docs/launching-apps/troubleshooting.rst
+++ b/docs/launching-apps/troubleshooting.rst
@@ -115,7 +115,7 @@ them across multiple hosts, try the following:
    :ref:`this section <running-prerequisites-label>` for
    the correct values.  Keep in mind that it is fine to have multiple
    PRRTE installations installed on a machine; the *first* PRRTE
-   installation found by ``PATH`` and ``LD_LIBARY_PATH`` is the one
+   installation found by ``PATH`` and ``LD_LIBRARY_PATH`` is the one
    that matters.
 
 #. Run a simple operating system job across multiple hosts.  This verifies

--- a/docs/launching-apps/unusual.rst
+++ b/docs/launching-apps/unusual.rst
@@ -121,7 +121,7 @@ Connecting independent MPI applications
 ---------------------------------------
 
 In certain environments, Open MPI supports connecting multiple,
-independent MPI applications using mechanism defined in the MPI
+independent MPI applications using mechanisms defined in the MPI
 specification such as ``MPI_Comm_connect() / MPI_Comm_accept()`` and
 publishing connection information using ``MPI_Publish_name() /
 MPI_Lookup_name()``. These mechanisms require a centralized service

--- a/docs/news/news-v4.x.rst
+++ b/docs/news/news-v4.x.rst
@@ -20,8 +20,18 @@ series, in reverse chronological order.
                  have uniform nodes and do not wish to use the new logic
                  may add the --uniform-nodes cmd line option. Note that
                  the --hetero-nodes option has been removed.
+               * STOP_ON_EXEC support has been fixed and is now available
 
 Detailed changes include:
+ - PR #2467: Multiple commits
+    - Update NEWS
+    - Fix show-help backslash escaping and remove committed build artifact
+    -  pmix: use PMIx_generate_regex2 API when available for node/proc maps
+    -  examples/debugger: add STOP_ON_EXEC support to indirect + daemon
+    -  odls: fix STOP_ON_EXEC race between do_parent and wait_signal_callback
+    -  Add AGENTS.md orientation guide for AI agents and contributors
+    -  PMIX_QUERY_ALLOCATION add results to correct array
+    -  Fix spelling and grammatical errors in docs
  - PR #2450: Multiple commits
     - Ensure cmd line MCA params are recognized
     - Ignore irrelevant MCA params for prted cmd line

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -73,7 +73,7 @@ Supported process events include:
   include the process ID that was killed and the corresponding
   reported signal.
 
-* ``PMIX_ERR_PROC_REQUESTED_ABORT:`` indicates that the specified
+* ``PMIX_ERR_PROC_REQUESTED_ABORT``: indicates that the specified
   process has aborted by calling the ``PMIx_Abort``
   function. Notification will include the process ID that called abort
   and its exit status.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ indicating the installation directory on the command line:
 
 Note that there are many, many configuration options to the
 ``./configure`` step.  Some of them may be needed for your particular
-environmnet; see below for desciptions of the options available.
+environment; see below for descriptions of the options available.
 
 If your installation prefix path is not writable by a regular user,
 you may need to use ``sudo`` or ``su`` to run the ``make install``

--- a/docs/session-directory.rst
+++ b/docs/session-directory.rst
@@ -14,7 +14,7 @@ More detail on session directories is provided in the How Things Work
 Directory location
 ------------------
 
-PRRTE decides where to located the root of the session directory by
+PRRTE decides where to locate the root of the session directory by
 examining the following (in precedence order):
 
 #. If the value of the ``prte_top_session_dir`` MCA parameter is not

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -25,5 +25,5 @@ execution contexts within a job.
 
 ``Client`` refers to a process that was registered with the PMIx server prior to being started, and connects to that PMIx server via ``PMIx_Init`` using its assigned namespace and rank with the information required to connect to that server being provided to the process at time of start of execution.
 
-``Tool`` refers to a process that may or may not have been registered with the PMIx server prior to being started and intializes using ``PMIx_tool_init``.
+``Tool`` refers to a process that may or may not have been registered with the PMIx server prior to being started and initializes using ``PMIx_tool_init``.
 

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -14,7 +14,7 @@ major, minor, release, and an optional quantifier.
 
 * Minor: The minor number is the second integer in the version
   string (e.g., v1.2.3). Changes in the minor number typically
-  indicate a incremental change in the code base and/or end-user
+  indicate an incremental change in the code base and/or end-user
   functionality. The minor number is always included in the version
   number:
 

--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -26,11 +26,14 @@
  */
 
 #define _GNU_SOURCE
+#include <errno.h>
 #include <libgen.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -216,10 +219,12 @@ int main(int argc, char **argv)
     int i;
     pmix_data_array_t darray;
     int cospawned_namespace = 0;
+    bool stop_on_exec;
     char hostname[256];
 
     pid = getpid();
     gethostname(hostname, sizeof hostname);
+    stop_on_exec = (NULL != getenv("PRTE_DBG_STOP_ON_EXEC"));
 
     /* Initialize this daemon - since we were launched by the RM, our
      * connection info * will have been provided at startup. */
@@ -414,34 +419,55 @@ int main(int argc, char **argv)
      */
     (void) strncpy(proc.nspace, target_namespace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    // Since we are using the 'wildcard' only one daemon should send
-    // the release message.
-    // If we are 'cospawned' then the daemons are not ranked separately
-    // from the application (this is a bug) so just have everyone
-    // send the release.
-    if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        PMIX_INFO_LIST_START(dirs);
-        /* Send release notification to application namespace */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
-        /* Don't send notification to default event handlers */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
-        PMIX_INFO_LIST_RELEASE(dirs);
-        info = darray.array;
-        ninfo = darray.size;
+    if (stop_on_exec) {
+        /* Processes were stopped at exec with SIGSTOP before connecting to PMIx.
+         * Each daemon releases only its own local processes via SIGCONT; no
+         * rank-0 gating needed since every daemon operates on its own proctable. */
+        for (i = 0; i < (int) myquery_data.info[0].value.data.darray->size; i++) {
+            printf("[%s:%u:%lu] Sending SIGCONT to pid %lu (rank %u)\n",
+                   myproc.nspace, myproc.rank, (unsigned long) pid,
+                   (unsigned long) proctable[i].pid, proctable[i].proc.rank);
+            if (-1 == kill(proctable[i].pid, SIGCONT)) {
+                fprintf(stderr, "[%s:%u:%lu] kill(%lu, SIGCONT) failed: %s\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        (unsigned long) proctable[i].pid, strerror(errno));
+            }
+        }
+    } else {
+        /* Processes are stopped inside PMIx_Init / MPI_Init and have a PMIx
+         * event handler registered.  Send a single wildcard release; only one
+         * daemon needs to send it to avoid duplicate deliveries. */
+        // Since we are using the 'wildcard' only one daemon should send
+        // the release message.
+        // If we are 'cospawned' then the daemons are not ranked separately
+        // from the application (this is a bug) so just have everyone
+        // send the release.
+        if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        // Todo: Move this to the main tool
-        // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
-        sleep(1);
-        printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
-        rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo, NULL,
-                               NULL);
-        PMIX_DATA_ARRAY_DESTRUCT(&darray);
-        if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n", myproc.nspace,
-                    myproc.rank, (unsigned long) pid, PMIx_Error_string(rc), rc);
-            goto done;
+            PMIX_INFO_LIST_START(dirs);
+            /* Send release notification to application namespace */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
+            /* Don't send notification to default event handlers */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+            PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
+            PMIX_INFO_LIST_RELEASE(dirs);
+            info = darray.array;
+            ninfo = darray.size;
+
+            // Todo: Move this to the main tool
+            // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
+            sleep(1);
+            printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
+            rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo,
+                                   NULL, NULL);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        PMIx_Error_string(rc), rc);
+                goto done;
+            }
         }
     }
 

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -115,6 +115,15 @@ static void spawn_cbfunc(size_t evhdlr_registration_id, pmix_status_t status,
 {
     size_t n;
 
+    /* PMIX_READY_FOR_DEBUG fires once per job (all nodes coalesced), but guard
+     * against any future change that could deliver it more than once. */
+    if (NULL != appnspace) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NSPACE)) {
             appnspace = strdup(info[n].value.data.string);
@@ -139,7 +148,7 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     size_t ninfo, napps;
     char *requested_launcher;
-    int timeout;
+    int timeout, c;
     size_t n;
     char cwd[1024];
     pmix_status_t code = PMIX_EVENT_JOB_END;
@@ -147,7 +156,7 @@ int main(int argc, char **argv)
     pid_t pid;
     char *launchers[] = {"prun", "mpirun", "mpiexec", "prterun", NULL};
     pmix_proc_t proc, target_proc;
-    bool found;
+    bool found, stop_on_exec = false;
     pmix_data_array_t darray, darray2;
     pmix_nspace_t clientspace, dbnspace;
     pmix_value_t *val;
@@ -156,16 +165,32 @@ int main(int argc, char **argv)
     myquery_data_t *mydata = NULL;
     pmix_rank_t rank;
 
-    /* need to provide args */
-    if (2 > argc) {
-        fprintf(stderr, "Usage: %s [launcher] [app]\n", argv[0]);
+    /* parse options */
+    {
+        static struct option long_opts[] = {
+            { "stop-on-exec", no_argument, NULL, 'e' },
+            { NULL, 0, NULL, 0 }
+        };
+        while (-1 != (c = getopt_long(argc, argv, "+e", long_opts, NULL))) {
+            switch (c) {
+            case 'e':
+                stop_on_exec = true;
+                break;
+            default:
+                fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
+                exit(1);
+            }
+        }
+    }
+    if (optind >= argc) {
+        fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
         exit(0);
     }
 
     /* check to see if we are using an intermediate launcher - we only
      * support those we recognize */
     found = false;
-    requested_launcher = basename(argv[1]);
+    requested_launcher = basename(argv[optind]);
     for (n = 0; NULL != launchers[n]; n++) {
         if (0 == strcmp(requested_launcher, launchers[n])) {
             found = true;
@@ -243,11 +268,11 @@ int main(int argc, char **argv)
     napps = 1;
     PMIX_APP_CREATE(app, napps);
     /* setup the executable */
-    app[0].cmd = strdup(argv[1]);
-    PMIX_ARGV_APPEND(rc, app[0].argv, argv[1]);
+    app[0].cmd = strdup(argv[optind]);
+    PMIX_ARGV_APPEND(rc, app[0].argv, argv[optind]);
     /* pass it the rest of the cmd line as we don't know
      * how to parse it */
-    for (n = 2; n < argc; n++) {
+    for (n = (size_t) optind + 1; n < (size_t) argc; n++) {
         PMIX_ARGV_APPEND(rc, app[0].argv, argv[n]);
     }
     if (NULL == getcwd(cwd, 1024)) { // point us to our current directory
@@ -274,8 +299,10 @@ int main(int argc, char **argv)
      * to do with the app it is going to spawn for us */
     PMIX_INFO_LIST_START(linfo);
     rank = PMIX_RANK_WILDCARD;
-    if (NULL != strstr(argv[1], "mpi")) {
-        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL); // stop all procs in MPI_Init
+    if (NULL != strstr(argv[optind], "mpi")) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL);   // stop all procs in MPI_Init
+    } else if (stop_on_exec) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);  // stop all procs at first exec
     } else {
         PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // stop all procs in PMIx_Init
     }
@@ -417,6 +444,10 @@ int main(int argc, char **argv)
     }
     mydata->apps[0].cwd = strdup(cwd);
     mydata->apps[0].maxprocs = 1;
+    if (stop_on_exec) {
+        /* tell the daemon which release mechanism to use */
+        PMIX_SETENV(rc, "PRTE_DBG_STOP_ON_EXEC", "1", &mydata->apps[0].env);
+    }
     PMIX_LOAD_PROCID(&target_proc, (void *) appnspace, PMIX_RANK_WILDCARD);
     /* provide directives so the daemons go where we want, and
      * let the RM know these are debugger daemons */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -45,6 +45,9 @@
 #include <pmix_server.h>
 #include <signal.h>
 #include <time.h>
+#ifdef HAVE_SYS_PTRACE_H
+#    include <sys/ptrace.h>
+#endif
 
 #include "prte_stdint.h"
 #include "src/hwloc/hwloc-internal.h"
@@ -1753,6 +1756,46 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
         goto MOVEON;
     }
+
+#if PRTE_HAVE_STOP_ON_EXEC
+    /* If the child stopped due to the ptrace TRACEME+exec SIGTRAP, this is the
+     * stop-on-exec debug-attach point.  The wait_signal_callback consumed the
+     * ptrace-stop notification before do_parent could see it; handle it here
+     * instead.  Detach with SIGSTOP injected so the child stays stopped for
+     * the debugger, re-register for its eventual exit, and fire READY_FOR_DEBUG.
+     * Do NOT fall through to the exit-handling logic below. */
+    if (WIFSTOPPED(proc->exit_code) && WSTOPSIG(proc->exit_code) == SIGTRAP) {
+        if (NULL != jobdat &&
+            prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+            PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                 "%s odls:waitpid_fired ptrace-stop for %s, detaching with SIGSTOP",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(&proc->name)));
+            errno = 0;
+#    if PRTE_HAVE_LINUX_PTRACE
+            ptrace(PRTE_DETACH, proc->pid, 0, (void *) SIGSTOP);
+#    else
+            ptrace(PRTE_DETACH, proc->pid, 0, SIGSTOP);
+#    endif
+            if (0 != errno) {
+                PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                     "%s odls:waitpid_fired ptrace detach failed for %s: %s",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                     PRTE_NAME_PRINT(&proc->name), strerror(errno)));
+                state = PRTE_PROC_STATE_FAILED_TO_START;
+                PRTE_FLAG_UNSET(proc, PRTE_PROC_FLAG_ALIVE);
+                goto MOVEON;
+            }
+            proc->state = PRTE_PROC_STATE_RUNNING;
+            PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_ALIVE);
+            /* re-register to catch the child's eventual exit after the debugger releases it */
+            prte_wait_cb(proc, prte_odls_base_default_wait_local_proc, NULL);
+            PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
+            PMIX_RELEASE(t2);
+            return;
+        }
+    }
+#endif
 
     /* determine the state of this process */
     if (WIFEXITED(proc->exit_code)) {

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -375,7 +375,6 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     set_handler_default(SIGHUP);
     set_handler_default(SIGPIPE);
     set_handler_default(SIGCHLD);
-    set_handler_default(SIGTRAP);
 
     /* Unblock all signals, for many of the same reasons that we
        set the default handlers, above.  This is noticable on
@@ -428,7 +427,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
 
 static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
 {
-    int rc, status;
+    int rc;
     prte_odls_pipe_err_msg_t msg;
     char file[PRTE_ODLS_MAX_FILE_LEN + 1], topic[PRTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
@@ -437,51 +436,6 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
     }
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
-
-#if PRTE_HAVE_STOP_ON_EXEC
-    if (NULL != cd->child) {
-        if (prte_get_attribute(&cd->jdata->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
-            rc = waitpid(cd->child->pid, &status, WUNTRACED);
-            if (-1 == rc) {
-                /* doomed */
-                cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                close(read_fd);
-                return PRTE_ERR_FAILED_TO_START;
-            }
-            /* tell the child to stop */
-            if (WIFSTOPPED(status)) {
-                rc = kill(cd->child->pid, SIGSTOP);
-                if (-1 == rc) {
-                    /* doomed */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                errno = 0;
-#    if PRTE_HAVE_LINUX_PTRACE
-                ptrace(PRTE_DETACH, cd->child->pid, 0, (void *) SIGSTOP);
-#    else
-                ptrace(PRTE_DETACH, cd->child->pid, 0, SIGSTOP);
-#    endif
-                if (0 != errno) {
-                    /* couldn't detach */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                /* record that this proc is ready for debug */
-                PRTE_ACTIVATE_PROC_STATE(&cd->child->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
-            }
-            cd->child->state = PRTE_PROC_STATE_RUNNING;
-            PRTE_FLAG_SET(cd->child, PRTE_PROC_FLAG_ALIVE);
-            close(read_fd);
-            return PRTE_SUCCESS;
-        }
-    }
-#endif
 
     /* Block reading a message from the pipe */
     while (1) {

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -761,7 +761,7 @@ static void _query(int sd, short args, void *cbdata)
                 PMIX_INFO_LIST_CONVERT(rc, nodelist, &dry);
                 PMIX_INFO_LIST_RELEASE(nodelist);
                 /* add to results */
-                PMIX_INFO_LIST_ADD(rc, nodelist, PMIX_QUERY_ALLOCATION, &dry, PMIX_DATA_ARRAY);
+                PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_ALLOCATION, &dry, PMIX_DATA_ARRAY);
                 PMIX_DATA_ARRAY_DESTRUCT(&dry);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -239,6 +239,19 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         tmp = PMIx_Argv_join(list, ',');
         PMIx_Argv_free(list);
         list = NULL;
+#if PRTE_PMIX_HAVE_REGEX2
+        pmix_regex2_t nregex = PMIX_REGEX2_STATIC_INIT;
+        if (PMIX_SUCCESS != (ret = PMIx_generate_regex2(tmp, NULL, 0, &nregex))) {
+            PMIX_ERROR_LOG(ret);
+            free(tmp);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            return rc;
+        }
+        free(tmp);
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, &nregex, PMIX_REGEX2);
+        PMIx_Regex2_destruct(&nregex);
+#else
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
@@ -249,6 +262,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, regex, PMIX_REGEX);
         free(regex);
+#endif
     }
 
     /* let the PMIx server generate the procmap regex */
@@ -256,6 +270,19 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         tmp = PMIx_Argv_join(procs, ';');
         PMIx_Argv_free(procs);
         procs = NULL;
+#if PRTE_PMIX_HAVE_REGEX2
+        pmix_regex2_t pregex = PMIX_REGEX2_STATIC_INIT;
+        if (PMIX_SUCCESS != (ret = PMIx_generate_regex2(tmp, NULL, 0, &pregex))) {
+            PMIX_ERROR_LOG(ret);
+            free(tmp);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            return rc;
+        }
+        free(tmp);
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, &pregex, PMIX_REGEX2);
+        PMIx_Regex2_destruct(&pregex);
+#else
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
@@ -266,6 +293,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, regex, PMIX_REGEX);
         free(regex);
+#endif
     }
 
     /* pass the number of nodes in the job */

--- a/src/util/prte-convert-help.py
+++ b/src/util/prte-convert-help.py
@@ -411,7 +411,7 @@ def generate_c_code(parsed_data):
         for section, content_list in sections.items():
             entry = "    { .topic = \"" + section + "\",\n      .content = (const char *[]){\n"
             for content in content_list:
-                c_content = content.replace('"','\\"').replace("\n", '\\n"\n"').replace("\\;", ";")
+                c_content = content.replace("\\;", ";").replace('\\', '\\\\').replace('"','\\"').replace("\n", '\\n"\n"')
                 entry += "                 \"" + c_content + "\",\n"
             entry += "                 NULL}\n    },\n"
             ini_entries.append(entry)


### PR DESCRIPTION
[Fix spelling and grammatical errors in docs](https://github.com/openpmix/prrte/commit/e31252508e0154f3df6704d5b9971d6a69d344e7)

Signed-off-by: Ralph Castain <rhc@pmix.org>
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
(cherry picked from commit https://github.com/openpmix/prrte/commit/fb1bd73e7548986bee8e52bf44e6aa9163bc0a05)

[PMIX_QUERY_ALLOCATION add results to correct array](https://github.com/openpmix/prrte/commit/a6a95c82a07f62c40c3b2a089be2a043d1d67255)

Credits: AccelCom @ Barcelona Supercomputing Center

Signed-off-by: Petter Sandås <petter.sandas@bsc.es>
(cherry picked from commit https://github.com/openpmix/prrte/commit/59c75ef2a04f384e1ae636773928f79a98a85c3f)

[Add AGENTS.md orientation guide for AI agents and contributors](https://github.com/openpmix/prrte/commit/1c62faa1b8ec5d93efc50871940ff153599fc147)

PRRTE has grown complex enough that AI coding agents and new human
contributors benefit from a structured orientation document. Add
AGENTS.md modeled on the equivalent file in the OpenPMIx repository,
adapted for the fact that PRRTE is a runtime (not a library): it
exposes no public API, only user-facing tools (prte, prun, pterm,
prted, prte_info, pcc).

The document covers terminology (DVM, HNP, prted, job, namespace,
rank, schizo, MCA), the source layout, all MCA frameworks and their
components, PRRTE's relationship with PMIx internals, coding rules
(header order, symbol prefixes, constant-on-left comparisons, thread
model, caddy pattern, memory management), the build system and
configure options, state machine debugging, and contributing guidelines.

Also clarify the --enable-devel-check help string in
prte_configure_options.m4 to make explicit that the flag is
automatically enabled for git repo builds when --enable-debug is given.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/1c8b2d23b0b73b3a7465800c945ebf449e3498ca)

[odls: fix STOP_ON_EXEC race between do_parent and wait_signal_callback](https://github.com/openpmix/prrte/commit/8c03e4d2767d623aa8729d13ce4c742eedb54892)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/2c82be0cbf2305f0f12b83af6a24656ec64cfa94)

[examples/debugger: add STOP_ON_EXEC support to indirect + daemon](https://github.com/openpmix/prrte/commit/8e4028e21504412935a420dccfb58c6b9ce8238c)

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/929946d2fca69863d1e42aa6a153d07a3d333595)

[pmix: use PMIx_generate_regex2 API when available for node/proc maps](https://github.com/openpmix/prrte/commit/b8e4ddfb52a49ee201be3b284bd52f9d0f871f4e)

When the installed PMIx has PMIX_CAP_REGEX2, use the new
PMIx_generate_regex2() API to generate PMIX_NODE_MAP and PMIX_PROC_MAP
when registering nspaces, storing the result as PMIX_REGEX2 rather than
the deprecated PMIX_REGEX type.  The old PMIx_generate_regex /
PMIx_generate_ppn path is retained under #else for backward
compatibility with PMIx installations that predate the capability flag.

A new PRTE_CHECK_PMIX_CAP([REGEX2], ...) check in prte_setup_pmix.m4
defines PRTE_PMIX_HAVE_REGEX2 at configure time so the C code can
select the right path at compile time.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/42d75b065c861475f36c9ec20721dc161328b44d)

[Fix show-help backslash escaping and remove committed build artifact](https://github.com/openpmix/prrte/commit/c564aa9943577d46a6bf9c1c99d6d0f440663bf4)

Escape backslashes in help file content before generating C string
literals, so lines ending with \ (e.g. shell line continuations in
examples) do not produce unterminated strings in the generated
prte_show_help_content.c.  The \; -> ; special case is handled first
to preserve that substitution.

Also remove the accidentally committed libtool wrapper script
test/unit/rmaps/test_rmaps, which is a build artifact already listed
in .gitignore.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/034b25b9547b2de9fab2b6901ce14b303f3e586d)
bot:notacherrypick