### PR TITLE
odls: pin STOP_ON_EXEC children to prte_event_base (ptrace tracer-thr…

### DIFF
--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1555,12 +1555,28 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  PRTE_NAME_PRINT(&child->name)));
 
-            /* determine the thread that will handle this child */
-            ++prte_odls_globals.next_base;
-            if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-                prte_odls_globals.next_base = 0;
+            /* determine the thread that will handle this child.
+             *
+             * STOP_ON_EXEC requires that the SAME thread which calls fork()
+             * (and thereby becomes the ptrace(2) tracer of the child) also
+             * performs the later ptrace(PTRACE_DETACH) call - ptrace control
+             * operations are only permitted from the exact tracer thread,
+             * even though waitpid() for the same status is visible to any
+             * thread in the process.  Our STOP_ON_EXEC detach happens in
+             * wait_local_proc(), which always runs on prte_event_base, so
+             * force the fork onto that same base instead of handing it to
+             * one of the odls worker threads - otherwise the PTRACE_DETACH
+             * call fails (ESRCH) once the local proc count reaches the
+             * worker-thread-pool cutoff. */
+            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+                evb = prte_event_base;
+            } else {
+                ++prte_odls_globals.next_base;
+                if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
+                    prte_odls_globals.next_base = 0;
+                }
+                evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
             }
-            evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
 
             /* set the waitpid callback here for thread protection and
              * to ensure we can capture the callback on shortlived apps */
@@ -2260,11 +2276,17 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
             goto CLEANUP;
         }
     }
-    ++prte_odls_globals.next_base;
-    if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-        prte_odls_globals.next_base = 0;
+    /* see comment in launch_local_procs() regarding STOP_ON_EXEC + ptrace
+     * tracer-thread affinity */
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+        evb = prte_event_base;
+    } else {
+        ++prte_odls_globals.next_base;
+        if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
+            prte_odls_globals.next_base = 0;
+        }
+        evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
     }
-    evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
     prte_wait_cb(child, prte_odls_base_default_wait_local_proc, NULL);
 
     PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output, "%s restarting app %s",


### PR DESCRIPTION
…ead affinity)

Problem
-------
After the previous race fix (commit 57c247a9f6), STOP_ON_EXEC still fails - but only once the local proc count crosses the odls worker thread pool cutoff (MCA param odls_base_cutoff, default 32).  4 local procs work; 48 do not, with explicit FAILED_TO_START errors for the affected processes rather than a silent hang or runaway.

Root cause
----------
prte_odls_base_start_threads() (odls_base_frame.c) only uses prte_event_base directly when num_local_procs is below the cutoff. At or above the cutoff, it spins up num_local_procs/8 (capped at odls_base_max_threads, default 16) dedicated "PRTE-ODLS-N" progress threads, and launch_local_procs() / prte_odls_base_default_restart_proc() round-robin each child's fork onto one of those worker threads via prte_odls_globals.ev_bases[next_base].

fork() executes on whichever thread is selected.  The forked child's subsequent ptrace(PTRACE_TRACEME) call establishes ITS PARENT'S CURRENT THREAD as the ptrace tracer - not the process as a whole.

waitpid() is thread-group-wide: the kernel's do_wait() walks every thread in the caller's thread group, so wait_signal_callback() on prte_event_base correctly observes the ptrace-stop status regardless of which worker thread did the fork.  This is why the previous fix (moving the WIFSTOPPED handling into wait_local_proc(), which always runs on prte_event_base) was necessary and correct as far as it went.

However, ptrace(2) CONTROL operations - PTRACE_DETACH, PTRACE_CONT, etc. - are restricted to the exact tracer thread; the kernel returns ESRCH if any other thread in the process attempts one, even though that other thread can see the tracee's status via waitpid().

wait_local_proc()'s ptrace(PRTE_DETACH, proc->pid, 0, SIGSTOP) call always executes on prte_event_base (that is where SIGCHLD is handled). When the child was forked on a worker thread (local proc count at or above the cutoff), prte_event_base is not the tracer thread, so this PTRACE_DETACH call fails.  errno is checked and the code correctly reports PRTE_PROC_STATE_FAILED_TO_START - which is the "error report" users are seeing - rather than silently leaving the child stuck.  The child itself remains attached and stopped in kernel ptrace-stop since the failed detach never released it, and the job aborts for that proc.

Fix
---
In both call sites that round-robin a child's fork onto a worker thread - launch_local_procs() and prte_odls_base_default_restart_proc()
- check PRTE_JOB_STOP_ON_EXEC on the job's attributes first.  If set, force evb = prte_event_base, bypassing the worker-thread pool entirely for that job's children.  This guarantees the thread that calls fork() (and thus becomes the ptrace tracer) is the same thread that later calls ptrace(PTRACE_DETACH) in wait_local_proc(), regardless of how many local procs are being launched.

This serializes the fork/exec of STOP_ON_EXEC jobs on the main event thread instead of parallelizing across the odls worker pool.  That is an acceptable trade-off: debug-launch jobs are not a high-throughput hot path, and correctness of the stop-on-exec handshake takes priority. Parallelizing this case while staying correct would require dispatching the PTRACE_DETACH call back to the same worker thread that performed the fork (e.g., tracking the originating event base per proc and posting the detach there) - left as a follow-on if large-scale debug launches need the throughput.


(cherry picked from commit 5c34b862ec48c6fc1713d575b084cf6dc2f20a3b)