### PR TITLE
ras: support dynamic DVM shrink/grow via scheduler allocation requests

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -22,7 +22,7 @@ release=0
 # PRRTE required dependency versions.
 # List in x.y.z format.
 
-pmix_min_version=6.1.0
+pmix_min_version=6.1.1
 hwloc_min_version=2.1.0
 pmix_max_version=1000.0.0
 hwloc_min_version=1.11.0

--- a/src/mca/odls/odls_types.h
+++ b/src/mca/odls/odls_types.h
@@ -88,6 +88,8 @@ typedef uint8_t prte_daemon_cmd_flag_t;
 /* tell DVM daemons to cleanup resources from job */
 #define PRTE_DAEMON_DVM_CLEANUP_JOB_CMD (prte_daemon_cmd_flag_t) 34
 
+#define PRTE_DAEMON_SHRINK_CMD (prte_daemon_cmd_flag_t) 35
+
 /*
  * Struct written up the pipe from the child to the parent.
  */

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -112,7 +112,11 @@ int prte_plm_base_comm_stop(void)
     return PRTE_SUCCESS;
 }
 
-/* process incoming messages in order of receipt */
+/* process incoming messages in order of receipt
+ *
+ * NOTE: THIS OCCURS INSIDE OF AN EVENT AND IS
+ * THEREFORE THREAD-SAFE
+ */
 void prte_plm_base_recv(int status, pmix_proc_t *sender,
                         pmix_data_buffer_t *buffer,
                         prte_rml_tag_t tag, void *cbdata)

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -89,6 +89,8 @@ PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
 
 PRTE_EXPORT char *prte_ras_base_flag_string(prte_node_t *node);
 
+PRTE_EXPORT void prte_ras_base_complete_request(prte_pmix_server_req_t *req);
+
 END_C_DECLS
 
 #endif

--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2019      Intel, Inc.  All rights reserved.
 # Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2023-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2023-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,17 +43,13 @@ file could not be opened for reading:
 
 Please check the filename and try again.
 #
-[ras-base:nonuniform-slots]
-A request was made to add hosts from a hostfile while operating
-in a managed allocation. In this case, either the slots must be
-specified in the given hostfile, or the number of slots assigned
-by the resource manager on the existing nodes must be uniform.
+[negative-slots]
+A host was provided in an add-hostfile that is unknown
+to the DVM but was given a negative number of slots:
 
-The current allocation does not conform to that requirement:
+  Host:  %s
+  Slots: %d
 
-   Base number of slots: %d
-   Node: %s
-   Number of slots: %d
-
-Please assign a number of slots for each node to be added to the
-allocation.
+We cannot subtract slots from an unknown host. Please
+correct the file or ensure that we are allocated the
+host in advance.

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -36,10 +36,12 @@
 #include "src/class/pmix_list.h"
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/mca.h"
+#include "src/mca/preg/preg.h"
 #include "src/pmix/pmix-internal.h"
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/iof/base/base.h"
+#include "src/mca/odls/odls_types.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
@@ -527,7 +529,6 @@ static void localrelease(void *cbdata)
 void prte_ras_base_modify(int fd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-    prte_job_t *daemons;
     prte_ras_base_selected_module_t *mod;
     pmix_status_t rc;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
@@ -537,6 +538,10 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
 
     // cycle across the modules and give each a chance to execute request
     PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t) {
+        if (NULL != req->key &&
+            0 != strcasecmp(req->key, mod->component->pmix_mca_component_name)) {
+            continue;
+        }
         if (NULL != mod->module->modify) {
             rc = mod->module->modify(req);
             if (PMIX_SUCCESS == rc ||
@@ -560,10 +565,11 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
         }
     }
 
-    // if we met the request, then we need to launch any new daemons
+    // get here if the module isn't handling the results itself
+
+    // if we met the request, then process the results
     if (PMIX_SUCCESS == req->pstatus) {
-        daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
+        prte_ras_base_complete_request(req);
     }
 
     // execute the callback
@@ -577,20 +583,200 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
     PMIX_RELEASE(req);
 }
 
+void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
+{
+    prte_job_t *daemons;
+    pmix_status_t rc;
+    pmix_data_buffer_t msg;
+    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+    size_t n;
+    char **nodes, *ndstring;
+    int32_t cnt=0, m;
+    int ret;
+    prte_node_t *node;
+    pmix_rank_t *ranks;
+    pmix_list_t ndlist;
+    bool found;
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (PMIX_ALLOC_EXTEND == req->allocdir ||
+        PMIX_ALLOC_NEW == req->allocdir) {
+        found = false;
+        for (n=0; n < req->ninfo; n++) {
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
+                if (PMIX_STRING == req->info[n].value.type ||
+                    PMIX_REGEX == req->info[n].value.type) {
+                    rc = pmix_preg.parse_nodes(req->info[n].value.data.string, &nodes);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        req->pstatus = rc;
+                        return;
+                    }
+                    ndstring = PMIx_Argv_join(nodes, ',');
+                    PMIx_Argv_free(nodes);
+
+#if PRTE_PMIX_HAVE_REGEX2
+                } else if (PMIX_REGEX2 == req->info[n].value.type) {
+                    // this is a regex value identifying the nodes that were
+                    // allocated by the scheduler (may match what we requested)
+                    rc = PMIx_parse_regex2(req->info[n].value.data.regex2, NULL, 0, &ndstring);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        req->pstatus = rc;
+                        return;
+                    }
+#endif
+
+                } else {
+                    // we only support those options
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    req->pstatus = PMIX_ERR_BAD_PARAM;
+                    return;
+                }
+                // add these nodes to our node pool
+                PMIX_CONSTRUCT(&ndlist, pmix_list_t);
+                ret = prte_util_add_dash_host_nodes(&ndlist, ndstring, true);
+                if (PRTE_SUCCESS != ret) {
+                    PRTE_ERROR_LOG(ret);
+                    req->pstatus = prte_pmix_convert_rc(ret);
+                    free(ndstring);
+                    PMIX_LIST_DESTRUCT(&ndlist);
+                    return;
+                }
+                free(ndstring);
+                ret = prte_ras_base_node_insert(&ndlist, NULL);
+                if (PRTE_SUCCESS != ret) {
+                    PRTE_ERROR_LOG(ret);
+                    PMIX_LIST_DESTRUCT(&ndlist);
+                    req->pstatus = prte_pmix_convert_rc(ret);
+                    return;
+                }
+                PMIX_LIST_DESTRUCT(&ndlist);
+                found = true;
+            }
+        }
+        if (found) {
+            // mark that we need to extend the DVM
+            prte_set_attribute(&daemons->attributes, PRTE_JOB_EXTEND_DVM, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+            /* mark that an updated nidmap must be communicated to existing daemons */
+            prte_nidmap_communicated = false;
+            PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
+        }
+
+    } else if (PMIX_ALLOC_RELEASE == req->allocdir) {
+
+        // create the request
+        PMIX_DATA_BUFFER_CONSTRUCT(&msg);
+        /* pack the command */
+        rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&msg);
+            req->pstatus = rc;
+            return;
+        }
+        // pack the daemon ranks to be removed from DVM
+        for (n=0; n < req->ninfo; n++) {
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
+                if (PMIX_STRING == req->info[n].value.type ||
+                    PMIX_REGEX == req->info[n].value.type) {
+                    rc = pmix_preg.parse_nodes(req->info[n].value.data.string, &nodes);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        req->pstatus = rc;
+                        return;
+                    }
+                    ndstring = PMIx_Argv_join(nodes, ',');
+                    PMIx_Argv_free(nodes);
+
+#if PRTE_PMIX_HAVE_REGEX2
+                } else if (PMIX_REGEX2 == req->info[n].value.type) {
+                    // this is a regex value identifying the nodes that were
+                    // allocated by the scheduler (may match what we requested)
+                    rc = PMIx_parse_regex2(req->info[n].value.data.regex2, NULL, 0, &ndstring);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        req->pstatus = prte_pmix_convert_rc(rc);
+                        return;
+                    }
+#endif
+
+                } else {
+                    // we only support those two options
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    req->pstatus = PMIX_ERR_BAD_PARAM;
+                    return;
+                }
+                nodes = PMIx_Argv_split(ndstring, ',');
+                free(ndstring);
+                cnt = PMIx_Argv_count(nodes);
+                break;
+            }
+        }
+        if (0 == cnt) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+            PMIX_DATA_BUFFER_DESTRUCT(&msg);
+            req->pstatus = PMIX_ERR_NOT_FOUND;
+            return;
+        }
+        // setup the array of ranks
+        ranks = (pmix_rank_t*)malloc(cnt * sizeof(pmix_rank_t));
+        m = 0;
+        for (n=0; NULL != nodes[n]; n++) {
+            // find this node in our global resource pool
+            node = prte_node_match(NULL, nodes[n]);
+            if (NULL == node) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+                PMIX_DATA_BUFFER_DESTRUCT(&msg);
+                PMIx_Argv_free(nodes);
+                free(ranks);
+                req->pstatus = PMIX_ERR_NOT_FOUND;
+                return;
+            }
+            if (NULL == node->daemon) {
+                // node doesn't have a daemon yet
+                continue;
+            }
+            ranks[m] = node->daemon->name.rank;
+            ++m;
+        }
+        PMIx_Argv_free(nodes);
+        rc = PMIx_Data_pack(NULL, &msg, &m, 1, PMIX_INT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&msg);
+            free(ranks);
+            req->pstatus = rc;
+            return;
+        }
+        rc = PMIx_Data_pack(NULL, &msg, ranks, m, PMIX_PROC_RANK);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&msg);
+            free(ranks);
+            req->pstatus = rc;
+            return;
+        }
+        free(ranks);
+
+        /* goes to all daemons */
+        if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+            PRTE_ERROR_LOG(rc);
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&msg);
+    }
+
+}
+
 int prte_ras_base_add_hosts(prte_job_t *jdata)
 {
-    int rc;
-    pmix_list_t nodes;
-    int i, k, m, n, slots;
+    int i;
     prte_app_context_t *app;
-    prte_node_t *node, *next, *nptr;
-    char *hosts, *line, *cptr, *ptr, **hostfiles, *nm;
-    FILE *fp;
-    bool addslots, found;
-    bool extend = false;
-    int default_slots = -1;
+    char *hosts, **hostfiles, **addhosts, *tmp;
+    prte_pmix_server_req_t *req;
 
-    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    hostfiles = NULL;
+    addhosts = NULL;
 
     // see if we have any add-hostfile or add-host directives
     for (i = 0; i < jdata->apps->size; i++) {
@@ -602,317 +788,63 @@ int prte_ras_base_add_hosts(prte_job_t *jdata)
                        (void **) &hosts, PMIX_STRING) &&
             NULL != hosts) {
             // found one
+            PMIx_Argv_append_nosize(&hostfiles, hosts);
             free(hosts);
-            goto proceed;
         }
         hosts = NULL;
         if (prte_get_attribute(&app->attributes, PRTE_APP_ADD_HOST,
                                (void **) &hosts, PMIX_STRING) &&
             NULL != hosts) {
             // found one
-            free(hosts);
-            goto proceed;
-        }
-    }
-    // if we get here, then there were no directives
-    return PRTE_SUCCESS;
-
-proceed:
-    /* Individual add-hostfile names, if given, are included
-     * in the app_contexts for this job. We therefore need to
-     * retrieve the app_contexts for the job, and then cycle
-     * through them to see if anything is there. The parser will
-     * add the nodes found in each add-hostfile to our list - i.e.,
-     * the resulting list contains the UNION of all nodes specified
-     * in add-hostfiles from across all app_contexts
-     *
-     * Note that any relative node syntax found in the add-hostfiles will
-     * generate an error in this scenario, so only non-relative syntax
-     * can be present
-     */
-
-    /* if we are in a managed allocation, the best we can do for nodes
-     * that do not include a specific slot assignment is to (a) check
-     * to see if there is a uniform assignment on existing nodes and
-     * use that, or (b) generate an error as we cannot know what the
-     * host environment might have set
-     */
-    if (prte_managed_allocation) {
-        for (n = 0; n < prte_node_pool->size; n++) {
-            nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
-            if (NULL == nptr) {
-                continue;
-            }
-            if (-1 == default_slots) {
-                default_slots = nptr->slots;
-                continue;
-            }
-            if (default_slots != nptr->slots) {
-                // generate an error message
-                pmix_show_help("help-ras-base.txt", "ras-base:nonuniform-slots", true,
-                               default_slots, nptr->name, nptr->slots);
-                PMIX_LIST_DESTRUCT(&nodes);
-                return PRTE_ERR_SILENT;
-            }
-        }
-    }
-
-    for (i = 0; i < jdata->apps->size; i++) {
-        if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i))) {
-            continue;
-        }
-        hosts = NULL;
-        if (prte_get_attribute(&app->attributes, PRTE_APP_ADD_HOSTFILE,
-                               (void **) &hosts, PMIX_STRING) &&
-            NULL != hosts) {
-            PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
-                                 "%s ras:base:add_hosts checking add-hostfile %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), hosts));
-
-            prte_remove_attribute(&app->attributes, PRTE_APP_ADD_HOSTFILE);
-
-            hostfiles = PMIx_Argv_split(hosts, ',');
-            free(hosts);
-
-            for (k=0; NULL != hostfiles[k]; k++) {
-                /* hostfile was specified - parse it and add it to the list. We
-                 * don't use the hostfile parsing code in src/util because it
-                 * uses flex and that has problems handling the range of allowed
-                 * syntax here */
-                fp = fopen(hostfiles[k], "r");
-                if (NULL == fp) {
-                    pmix_show_help("help-ras-base.txt", "ras-base:addhost-not-found", true, hostfiles[k]);
-                    PMIx_Argv_free(hostfiles);
-                    PMIX_LIST_DESTRUCT(&nodes);
-                    return PRTE_ERR_SILENT;
-                }
-
-                while (NULL != (line = pmix_getline(fp))) {
-                    // ignore comments and blank lines
-                    if (0 == strlen(line)) {
-                        free(line);
-                        continue;
-                    }
-                    // remove leading whitespace
-                    cptr = line;
-                    while (isspace(*cptr)) {
-                        ++cptr;
-                    }
-                    if ('#' == *cptr) {
-                        free(line);
-                        continue;
-                    }
-                    addslots = false;
-                    // because there can be arbitrary whitespace around keywords,
-                    // we manually parse the line to get the directives
-                    ptr = cptr;
-                    while ('\0' != *ptr && !isspace(*ptr)) {
-                        ++ptr;
-                    }
-                    if ('\0' == *ptr) {
-                        // end of the line - just the node name was given
-                        slots = default_slots;
-                        goto process;
-                    }
-                    *ptr = '\0'; // terminate the name
-                    // find the '=' sign
-                    ++ptr;
-                    while ('\0' != *ptr && ('=' != *ptr || isspace(*ptr))) {
-                        ++ptr;
-                    }
-                    if ('\0' == *ptr) {
-                        // didn't specify slots - use the default value
-                        slots = default_slots;
-                        goto process;
-                    }
-                    // find the value
-                    ++ptr;
-                    while ('\0' != *ptr && isspace(*ptr)) {
-                        ++ptr;
-                    }
-                    if ('\0' == *ptr) {
-                        // bad syntax
-                        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-                        fclose(fp);
-                        free(line);
-                        PMIx_Argv_free(hostfiles);
-                        PMIX_LIST_DESTRUCT(&nodes);
-                        return PRTE_ERR_SILENT;
-                    }
-                    // if it is a '+' or '-', then we are adjusting
-                    // the #slots
-                    if ('+' == *ptr || '-' == *ptr) {
-                        addslots = true;
-                    }
-                    slots = strtol(ptr, NULL, 10);
-
-            process:
-                    // see if we have this node
-                    found = false;
-                    // does the name refer to me?
-                        if (prte_check_host_is_local(cptr)) {
-                            nm = prte_process_info.nodename;
-                        } else {
-                            nm = cptr;
-                        }
-
-                    for (n = 0; !found && n < prte_node_pool->size; n++) {
-                        nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
-                        if (NULL == nptr) {
-                            continue;
-                        }
-                        if (0 == strcmp(nm, nptr->name)) {
-                            // we have the node
-                            if (addslots) {
-                                nptr->slots += slots;
-                                if (0 > nptr->slots) {
-                                    nptr->slots = 0;
-                                }
-                            }
-                            found = true;
-                            break;
-                        } else if (NULL != nptr->aliases) {
-                            /* no choice but an exhaustive search - fortunately, these lists are short! */
-                            for (m = 0; NULL != nptr->aliases[m]; m++) {
-                                if (0 == strcmp(cptr, nptr->aliases[m])) {
-                                    if (addslots) {
-                                        nptr->slots += slots;
-                                        if (0 > nptr->slots) {
-                                            nptr->slots = 0;
-                                        }
-                                    }
-                                    found = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if (!found) {
-                        // this is a new node - add it
-                        node = PMIX_NEW(prte_node_t);
-                        node->name = strdup(cptr);
-                        node->slots = slots;
-                        node->state = PRTE_NODE_STATE_ADDED;
-                        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
-                        pmix_list_append(&nodes, &node->super);
-                    }
-                    free(line);
-                }
-                fclose(fp);
-            }
-            PMIx_Argv_free(hostfiles);
-        }
-    }
-    if (!pmix_list_is_empty(&nodes)) {
-        /* store the results in the global resource pool - this removes the
-         * list items
-         */
-        if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
-            PRTE_ERROR_LOG(rc);
-        }
-        /* mark that an updated nidmap must be communicated to existing daemons */
-        prte_nidmap_communicated = false;
-        extend = true;
-    }
-
-    /* We next check for and add any add-host options. Note this is
-     * a -little- different than dash-host in that (a) we add these
-     * nodes to the global pool (avoiding duplication),
-     * and (b) as a result, any job and/or app_context can access them.
-     *
-     * Note that any relative node syntax found in the add-host lists will
-     * generate an error in this scenario, so only non-relative syntax
-     * can be present
-     */
-    for (i = 0; i < jdata->apps->size; i++) {
-        if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i))) {
-            continue;
-        }
-        hosts = NULL;
-        if (prte_get_attribute(&app->attributes, PRTE_APP_ADD_HOST,
-                               (void **) &hosts, PMIX_STRING) &&
-            NULL != hosts) {
-            pmix_output_verbose(5, prte_ras_base_framework.framework_output,
-                                "%s ras:base:add_hosts checking add-host %s",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), hosts);
-            if (PRTE_SUCCESS != (rc = prte_util_add_dash_host_nodes(&nodes, hosts, true))) {
-                PRTE_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&nodes);
-                free(hosts);
-                return rc;
-            }
-            prte_remove_attribute(&app->attributes, PRTE_APP_ADD_HOST);
+            PMIx_Argv_append_nosize(&addhosts, hosts);
             free(hosts);
         }
     }
-
-    /* if something was found, we add that to our global pool */
-    if (!pmix_list_is_empty(&nodes)) {
-        /* the node insert code doesn't check for uniqueness, so we will
-         * do so here - yes, this is an ugly, non-scalable loop, but this
-         * is the exception case and so we can do it here */
-        PMIX_LIST_FOREACH_SAFE(node, next, &nodes, prte_node_t)
-        {
-            node->state = PRTE_NODE_STATE_ADDED;
-            found = false;
-            for (n = 0; !found && n < prte_node_pool->size; n++) {
-                nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
-                if (NULL == nptr) {
-                    continue;
-                }
-                if (0 == strcmp(node->name, nptr->name)) {
-                    if (prte_get_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS, NULL, PMIX_BOOL)) {
-                        nptr->slots += node->slots;
-                        prte_remove_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS);
-                    } else {
-                        nptr->slots = node->slots;
-                    }
-                    pmix_list_remove_item(&nodes, &node->super);
-                    PMIX_RELEASE(node);
-                    found = true;
-                } else if (NULL != nptr->aliases) {
-                    /* no choice but an exhaustive search - fortunately, these lists are short! */
-                    for (m = 0; !found && NULL != nptr->aliases[m]; m++) {
-                        if (0 == strcmp(node->name, nptr->aliases[m])) {
-                            if (prte_get_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS, NULL, PMIX_BOOL)) {
-                                nptr->slots += node->slots;
-                                prte_remove_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS);
-                            } else {
-                                nptr->slots = node->slots;
-                            }
-                            pmix_list_remove_item(&nodes, &node->super);
-                            PMIX_RELEASE(node);
-                            found = true;
-                        }
-                    }
-                }
-            }
-        }
-        if (!pmix_list_is_empty(&nodes)) {
-            /* store the results in the global resource pool - this removes the
-             * list items
-             */
-            if (PRTE_SUCCESS != (rc = prte_ras_base_node_insert(&nodes, jdata))) {
-                PRTE_ERROR_LOG(rc);
-            }
-            /* mark that an updated nidmap must be communicated to existing daemons */
-            prte_nidmap_communicated = false;
-            extend = true;
-        }
-    }
-    /* cleanup */
-    PMIX_LIST_DESTRUCT(&nodes);
-
-    if (extend) {
-        // mark that we need to extend the DVM
-        prte_set_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+    if (NULL == hostfiles && NULL == addhosts) {
+        // there were no directives
+        return PRTE_SUCCESS;
     }
 
-    /* shall we display the results? */
-    if (0 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output) ||
-        prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_ALLOC, NULL, PMIX_BOOL)) {
-        prte_ras_base_display_alloc(jdata);
+    // create an allocation request tracker
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    req->key = strdup("hosts");
+    req->operation = strdup("ADDHOSTS");
+    req->allocdir = PMIX_ALLOC_EXTEND;
+    req->jdata = jdata;
+    if (NULL != hostfiles) {
+        req->ninfo++;
     }
+    if (NULL != addhosts) {
+        req->ninfo++;
+    }
+    req->copy = true;
+    req->info = PMIx_Info_create(req->ninfo);
+    i = 0;
+    if (NULL != hostfiles) {
+        tmp = PMIx_Argv_join(hostfiles, ',');
+        PMIX_INFO_LOAD(&req->info[i], PMIX_ADD_HOSTFILE, tmp, PMIX_STRING);
+        free(tmp);
+        ++i;
+        PMIx_Argv_free(hostfiles);
+    }
+    if (NULL != addhosts) {
+        tmp = PMIx_Argv_join(addhosts, ',');
+        PMIX_INFO_LOAD(&req->info[i], PMIX_ADD_HOST, tmp, PMIX_STRING);
+        free(tmp);
+        ++i;
+        PMIx_Argv_free(addhosts);
+    }
+    /* add this request to our local request tracker array */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    // pass this to the RAS framework for handling
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, prte_ras_base_modify, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+
+    // mark that the DVM is not ready so the launch does not continue
+    // until we have processed the nodes
+    prte_dvm_ready = false;
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -128,8 +128,17 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
             /* update the total slots in the job */
             prte_ras_base.total_slots_alloc += node->slots;
             /* copy the allocation data to that node's info */
-            hnp_node->slots = node->slots;
             hnp_node->slots_max = node->slots_max;
+            if (prte_get_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS, NULL, PMIX_BOOL)) {
+                hnp_node->slots += node->slots;
+                if (0 > hnp_node->slots) {
+                    hnp_node->slots = 0;
+                } else if (hnp_node->slots > hnp_node->slots_max && hnp_node->slots_max > 0) {
+                    hnp_node->slots = hnp_node->slots_max;
+                }
+            } else {
+                hnp_node->slots = node->slots;
+            }
             /* copy across any attributes */
             PMIX_LIST_FOREACH(kv, &node->attributes, prte_attribute_t)
             {
@@ -173,7 +182,7 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 node->index = pmix_pointer_array_add(prte_node_pool, node);
             }
         } else {
-            /* insert the object onto the prte_nodes global array */
+            /* insert the object into the prte_nodes global array */
             PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
                                  "%s ras:base:node_insert node %s slots %d",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
@@ -187,6 +196,14 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 }
                 if (prte_nptr_match(nptr, node)) {
                     found = true;
+                    if (prte_get_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS, NULL, PMIX_BOOL)) {
+                        nptr->slots += node->slots;
+                        if (0 > nptr->slots) {
+                            nptr->slots = 0;
+                        } else if (nptr->slots > nptr->slots_max && nptr->slots_max > 0) {
+                            nptr->slots = nptr->slots_max;
+                        }
+                    }
                     break;
                 }
             }

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -17,6 +17,8 @@
 #include "types.h"
 
 #include "src/class/pmix_list.h"
+#include "src/util/pmix_show_help.h"
+#include "src/util/pmix_string_copy.h"
 
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/mca/state/state.h"
@@ -191,8 +193,196 @@ static int finalize(void)
     return PRTE_SUCCESS;
 }
 
+static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
+{
+    FILE *fp;
+    char *line, *cptr, *ptr, *nm;
+    bool addslots, found;
+    int slots, m, n;
+    prte_node_t *nptr, *node;
+
+    /* We don't use the hostfile parsing code in src/util because it
+     * uses flex and that has problems handling the range of allowed
+     * syntax here */
+    fp = fopen(hostfile, "r");
+    if (NULL == fp) {
+        pmix_show_help("help-ras-base.txt", "ras-base:addhost-not-found", true, hostfile);
+        return PMIX_ERR_SILENT;
+    }
+
+    while (NULL != (line = pmix_getline(fp))) {
+        // ignore comments and blank lines
+        if (0 == strlen(line)) {
+            free(line);
+            continue;
+        }
+        // remove leading whitespace
+        cptr = line;
+        while (isspace(*cptr)) {
+            ++cptr;
+        }
+        if ('#' == *cptr) {
+            free(line);
+            continue;
+        }
+        addslots = false;
+        // because there can be arbitrary whitespace around keywords,
+        // we manually parse the line to get the directives
+        ptr = cptr;
+        while ('\0' != *ptr && !isspace(*ptr)) {
+            ++ptr;
+        }
+        if ('\0' == *ptr) {
+            // end of the line - just the node name was given
+            slots = -1;
+            goto process;
+        }
+        *ptr = '\0'; // terminate the name
+        // find the '=' sign
+        ++ptr;
+        while ('\0' != *ptr && ('=' != *ptr || isspace(*ptr))) {
+            ++ptr;
+        }
+        if ('\0' == *ptr) {
+            // didn't specify slots - use the default value
+            slots = -1;
+            goto process;
+        }
+        // find the value
+        ++ptr;
+        while ('\0' != *ptr && isspace(*ptr)) {
+            ++ptr;
+        }
+        if ('\0' == *ptr) {
+            // bad syntax
+            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+            fclose(fp);
+            free(line);
+            return PMIX_ERR_SILENT;
+        }
+        // if it is a '+' or '-', then we are adjusting
+        // the #slots
+        if ('+' == *ptr || '-' == *ptr) {
+            addslots = true;
+        }
+        slots = strtol(ptr, NULL, 10);
+
+process:
+        // see if we have this node
+        found = false;
+        // does the name refer to me?
+        if (prte_check_host_is_local(cptr)) {
+            nm = prte_process_info.nodename;
+        } else {
+            nm = cptr;
+        }
+
+        for (n = 0; !found && n < prte_node_pool->size; n++) {
+            nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
+            if (NULL == nptr) {
+                continue;
+            }
+            if (0 == strcmp(nm, nptr->name)) {
+                // we have the node
+                if (addslots) {
+                    nptr->slots += slots;
+                    if (0 > nptr->slots) {
+                        nptr->slots = 0;
+                    }
+                }
+                found = true;
+                break;
+            } else if (NULL != nptr->aliases) {
+                /* no choice but an exhaustive search - fortunately, these lists are short! */
+                for (m = 0; NULL != nptr->aliases[m]; m++) {
+                    if (0 == strcmp(cptr, nptr->aliases[m])) {
+                        if (addslots) {
+                            nptr->slots += slots;
+                            if (0 > nptr->slots) {
+                                nptr->slots = 0;
+                            }
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!found) {
+            // this is a new node - add it
+            node = PMIX_NEW(prte_node_t);
+            node->name = strdup(cptr);
+            node->state = PRTE_NODE_STATE_ADDED;
+            if (0 < slots) {
+                // if they gave us the number of slots, then just
+                // set it - otherwise, we'll compute them once
+                // the daemon reports back the topology
+                node->slots = slots;
+                PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+            } else if (0 > slots && -1 != slots) {
+                // cannot have a new node with negative slots - the -1
+                // is a marker for a node without slots being specified
+                pmix_show_help("help-ras-base.txt", "negative-slots", true,
+                               hostfile, cptr);
+                PMIX_RELEASE(node);
+                free(line);
+                fclose(fp);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            pmix_list_append(nodes, &node->super);
+        }
+        free(line);
+    }
+    fclose(fp);
+    return PMIX_SUCCESS;
+}
+
 static pmix_status_t modify(prte_pmix_server_req_t *req)
 {
-    req->status = PMIX_ERR_NOT_SUPPORTED;
-    return PMIX_ERR_TAKE_NEXT_OPTION;
+    int rc;
+    pmix_list_t nodes;
+    size_t n, k;
+    char **hostfiles;
+
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+
+    // look for applicable directives
+    for (n=0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOSTFILE)) {
+            // comma-delimited list of hostfiles to add or delete
+            hostfiles = PMIx_Argv_split(req->info[n].value.data.string, ',');
+            for (k=0; NULL != hostfiles[k]; k++) {
+                rc = process_hostfile(hostfiles[k], &nodes);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_LIST_DESTRUCT(&nodes);
+                    PMIx_Argv_free(hostfiles);
+                    req->pstatus = rc;
+                    return rc;
+                }
+            }
+            PMIx_Argv_free(hostfiles);
+        }
+        if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOST)) {
+            // comma-delimited list of hosts to add or delete
+            rc = prte_util_add_dash_host_nodes(&nodes, req->info[n].value.data.string, true);
+            if (PRTE_SUCCESS != rc) {
+                PRTE_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&nodes);
+                req->pstatus = prte_pmix_convert_rc(rc);
+                return req->pstatus;
+            }
+        }
+    }
+
+    if (0 < pmix_list_get_size(&nodes)) {
+        /* mark that an updated nidmap must be communicated to existing daemons */
+        prte_nidmap_communicated = false;
+        rc = prte_ras_base_node_insert(&nodes, req->jdata);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            req->pstatus = prte_pmix_convert_rc(rc);
+            return req->pstatus;
+        }
+    }
+    return PMIX_OPERATION_SUCCEEDED;
 }

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -61,24 +61,23 @@ static int finalize(void)
 static void passthru(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-    prte_job_t *daemons;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    // if we met the request, then we need to process it
+    if (PMIX_SUCCESS == req->pstatus) {
+        prte_ras_base_complete_request(req);
+    }
 
     if (NULL != req->infocbfunc) {
         // call the requestor's callback with the returned info
-        req->infocbfunc(req->status, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
-    } else {
+        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
+    } else if (NULL != req->rlcbfunc) {
         // let them cleanup
         req->rlcbfunc(req->rlcbdata);
     }
     // cleanup our request
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
 
-    // if we met the request, then we need to launch any new daemons
-    if (PMIX_SUCCESS == req->status) {
-        daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
-    }
 
     PMIX_RELEASE(req);
 }
@@ -112,6 +111,19 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     pmix_status_t rc;
     pmix_info_t *xfer;
     size_t n;
+
+    if (prte_mca_ras_pmix_component.simulate) {
+        // pretend we are attached to a scheduler
+        xfer = PMIx_Info_create(1);
+        PMIX_INFO_LOAD(xfer, PMIX_ALLOC_NODE_LIST, prte_mca_ras_pmix_component.simulate_nodelist, PMIX_STRING);
+        req->pstatus = PMIX_SUCCESS;
+        req->info = xfer;
+        req->ninfo = 1;
+        prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
+        PMIX_POST_OBJECT(req);
+        prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+        return PMIX_SUCCESS;
+    }
 
     // check if scheduler is attached and try to
     // attach if not

--- a/src/mca/ras/pmix/ras_pmix.h
+++ b/src/mca/ras/pmix/ras_pmix.h
@@ -22,6 +22,8 @@ BEGIN_C_DECLS
 
 struct prte_ras_pmix_component_t {
     prte_ras_base_component_t super;
+    bool simulate;
+    char *simulate_nodelist;
     bool connect_to_system_scheduler;
     pmix_proc_t server;
     char *uri;

--- a/src/mca/ras/pmix/ras_pmix_component.c
+++ b/src/mca/ras/pmix/ras_pmix_component.c
@@ -67,6 +67,18 @@ static int ras_pmix_register(void)
 {
     pmix_mca_base_component_t *component = &prte_mca_ras_pmix_component.super;
 
+    prte_mca_ras_pmix_component.simulate = false;
+    (void) pmix_mca_base_component_var_register(component, "simulate",
+                                                "Simulate a scheduler interaction",
+                                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                                &prte_mca_ras_pmix_component.simulate);
+
+    prte_mca_ras_pmix_component.simulate_nodelist = NULL;
+    (void) pmix_mca_base_component_var_register(component, "simulate_nodelist",
+                                                "Comma-delimited list of nodes to use in simulation",
+                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                &prte_mca_ras_pmix_component.simulate_nodelist);
+
     prte_mca_ras_pmix_component.uri = NULL;
     (void) pmix_mca_base_component_var_register(component, "uri",
                                                 "Specify the URI of the scheduler to which we are to connect, "

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -81,7 +81,7 @@
 /*
  * Globals
  */
-static char *get_prted_comm_cmd_str(int command);
+static const char *get_prted_comm_cmd_str(int command);
 
 static void _notify_release(pmix_status_t status, void *cbdata)
 {
@@ -121,6 +121,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
     pmix_byte_object_t pbo;
     char *tmp;
     pmix_info_t info[4];
+    pmix_rank_t *ranks;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     /* unpack the command */
@@ -131,12 +132,10 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         return;
     }
 
-    cmd_str = get_prted_comm_cmd_str(command);
     PMIX_OUTPUT_VERBOSE((1, prte_debug_output,
                          "%s prted:comm:process_commands() Processing Command: %s",
-                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cmd_str));
-    free(cmd_str);
-    cmd_str = NULL;
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         get_prted_comm_cmd_str(command)));
 
     /* now process the command locally */
     switch (command) {
@@ -466,6 +465,55 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         }
         return;
 
+        /****    SHRINK DVM    ****/
+    case PRTE_DAEMON_SHRINK_CMD:
+        // get number of daemon ranks to be terminated
+        n = 1;
+        ret = PMIx_Data_unpack(NULL, buffer, &num_procs, &n, PMIX_INT32);
+        if (PMIX_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            goto CLEANUP;
+        }
+        // create space for them
+        ranks = (pmix_rank_t*)malloc(num_procs * sizeof(pmix_rank_t));
+        if (NULL == ranks) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            goto CLEANUP;
+        }
+        // unpack the targets
+        n = num_procs;
+        ret = PMIx_Data_unpack(NULL, buffer, ranks, &n, PMIX_PROC_RANK);
+        if (PMIX_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            free(ranks);
+            goto CLEANUP;
+        }
+        // see if we are one of them
+        for (i=0; i < num_procs; i++) {
+            if (ranks[i] == PRTE_PROC_MY_NAME->rank) {
+                /* this is an abnormal termination */
+                prte_abnormal_term_ordered = true;
+                /* any tools attached to us will have done so via PMIx, so
+                 * let's provide them with a friendly "job end" notification */
+                PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+                PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &prte_process_info.myproc, PMIX_PROC);
+                PMIX_INFO_LOAD(&info[2], "prte.notify.donotloop", NULL, PMIX_BOOL);
+                PMIX_INFO_LOAD(&info[3], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
+                PRTE_PMIX_CONSTRUCT_LOCK(&lk);
+                ret = PMIx_Notify_event(PMIX_EVENT_JOB_END, &prte_process_info.myproc,
+                                        PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
+                PRTE_PMIX_WAIT_THREAD(&lk);
+                PRTE_PMIX_DESTRUCT_LOCK(&lk);
+                // mark abnormal exit status
+                PRTE_UPDATE_EXIT_STATUS(-1);
+                // do a clean exit
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+                break;
+            }
+        }
+        free(ranks);
+        break;
+
         /****     DVM CLEANUP JOB COMMAND    ****/
     case PRTE_DAEMON_DVM_CLEANUP_JOB_CMD:
         /* unpack the jobid */
@@ -625,74 +673,94 @@ CLEANUP:
     return;
 }
 
-static char *get_prted_comm_cmd_str(int command)
+static const char *get_prted_comm_cmd_str(int command)
 {
     switch (command) {
     case PRTE_DAEMON_CONTACT_QUERY_CMD:
-        return strdup("PRTE_DAEMON_CONTACT_QUERY_CMD");
+        return "PRTE_DAEMON_CONTACT_QUERY_CMD";
+
     case PRTE_DAEMON_KILL_LOCAL_PROCS:
-        return strdup("PRTE_DAEMON_KILL_LOCAL_PROCS");
+        return "PRTE_DAEMON_KILL_LOCAL_PROCS";
+
     case PRTE_DAEMON_SIGNAL_LOCAL_PROCS:
-        return strdup("PRTE_DAEMON_SIGNAL_LOCAL_PROCS");
+        return "PRTE_DAEMON_SIGNAL_LOCAL_PROCS";
+
     case PRTE_DAEMON_ADD_LOCAL_PROCS:
-        return strdup("PRTE_DAEMON_ADD_LOCAL_PROCS");
+        return "PRTE_DAEMON_ADD_LOCAL_PROCS";
+
     case PRTE_DAEMON_HEARTBEAT_CMD:
-        return strdup("PRTE_DAEMON_HEARTBEAT_CMD");
+        return "PRTE_DAEMON_HEARTBEAT_CMD";
+
     case PRTE_DAEMON_EXIT_CMD:
-        return strdup("PRTE_DAEMON_EXIT_CMD");
+        return "PRTE_DAEMON_EXIT_CMD";
+
     case PRTE_DAEMON_PROCESS_AND_RELAY_CMD:
-        return strdup("PRTE_DAEMON_PROCESS_AND_RELAY_CMD");
+        return "PRTE_DAEMON_PROCESS_AND_RELAY_CMD";
+
     case PRTE_DAEMON_NULL_CMD:
-        return strdup("NULL");
+        return "NULL";
 
     case PRTE_DAEMON_REPORT_JOB_INFO_CMD:
-        return strdup("PRTE_DAEMON_REPORT_JOB_INFO_CMD");
+        return "PRTE_DAEMON_REPORT_JOB_INFO_CMD";
+
     case PRTE_DAEMON_REPORT_NODE_INFO_CMD:
-        return strdup("PRTE_DAEMON_REPORT_NODE_INFO_CMD");
+        return "PRTE_DAEMON_REPORT_NODE_INFO_CMD";
+
     case PRTE_DAEMON_REPORT_PROC_INFO_CMD:
-        return strdup("PRTE_DAEMON_REPORT_PROC_INFO_CMD");
+        return "PRTE_DAEMON_REPORT_PROC_INFO_CMD";
+
     case PRTE_DAEMON_SPAWN_JOB_CMD:
-        return strdup("PRTE_DAEMON_SPAWN_JOB_CMD");
+        return "PRTE_DAEMON_SPAWN_JOB_CMD";
+
     case PRTE_DAEMON_TERMINATE_JOB_CMD:
-        return strdup("PRTE_DAEMON_TERMINATE_JOB_CMD");
+        return "PRTE_DAEMON_TERMINATE_JOB_CMD";
+
     case PRTE_DAEMON_HALT_VM_CMD:
-        return strdup("PRTE_DAEMON_HALT_VM_CMD");
+        return "PRTE_DAEMON_HALT_VM_CMD";
+
     case PRTE_DAEMON_HALT_DVM_CMD:
-        return strdup("PRTE_DAEMON_HALT_DVM_CMD");
+        return "PRTE_DAEMON_HALT_DVM_CMD";
+
     case PRTE_DAEMON_REPORT_JOB_COMPLETE:
-        return strdup("PRTE_DAEMON_REPORT_JOB_COMPLETE");
+        return "PRTE_DAEMON_REPORT_JOB_COMPLETE";
+
     case PRTE_DAEMON_DEFINE_PSET:
-        return strdup("PRTE_DAEMON_DEFINE_PSET");
+        return "PRTE_DAEMON_DEFINE_PSET";
 
     case PRTE_DAEMON_TOP_CMD:
-        return strdup("PRTE_DAEMON_TOP_CMD");
+        return "PRTE_DAEMON_TOP_CMD";
 
     case PRTE_DAEMON_NAME_REQ_CMD:
-        return strdup("PRTE_DAEMON_NAME_REQ_CMD");
+        return "PRTE_DAEMON_NAME_REQ_CMD";
+
     case PRTE_DAEMON_CHECKIN_CMD:
-        return strdup("PRTE_DAEMON_CHECKIN_CMD");
+        return "PRTE_DAEMON_CHECKIN_CMD";
+
     case PRTE_TOOL_CHECKIN_CMD:
-        return strdup("PRTE_TOOL_CHECKIN_CMD");
+        return "PRTE_TOOL_CHECKIN_CMD";
 
     case PRTE_DAEMON_PROCESS_CMD:
-        return strdup("PRTE_DAEMON_PROCESS_CMD");
+        return "PRTE_DAEMON_PROCESS_CMD";
 
     case PRTE_DAEMON_ABORT_PROCS_CALLED:
-        return strdup("PRTE_DAEMON_ABORT_PROCS_CALLED");
+        return "PRTE_DAEMON_ABORT_PROCS_CALLED";
 
     case PRTE_DAEMON_DVM_ADD_PROCS:
-        return strdup("PRTE_DAEMON_DVM_ADD_PROCS");
+        return "PRTE_DAEMON_DVM_ADD_PROCS";
 
     case PRTE_DAEMON_GET_STACK_TRACES:
-        return strdup("PRTE_DAEMON_GET_STACK_TRACES");
+        return "PRTE_DAEMON_GET_STACK_TRACES";
 
     case PRTE_DAEMON_GET_MEMPROFILE:
-        return strdup("PRTE_DAEMON_GET_MEMPROFILE");
+        return "PRTE_DAEMON_GET_MEMPROFILE";
 
     case PRTE_DAEMON_DVM_CLEANUP_JOB_CMD:
-        return strdup("PRTE_DAEMON_DVM_CLEANUP_JOB_CMD");
+        return "PRTE_DAEMON_DVM_CLEANUP_JOB_CMD";
+
+    case PRTE_DAEMON_SHRINK_CMD:
+        return "PRTE_DAEMON_SHRINK_CMD";
 
     default:
-        return strdup("Unknown Command!");
+        return "Unknown Command!";
     }
 }


### PR DESCRIPTION
## What

Route `add-host`/`add-hostfile` directives and scheduler allocation responses through a common RAS "modify" pathway so the DVM can **grow and shrink at runtime**, and add a daemon-side command that lets released nodes terminate themselves.

## Why

Previously `add-host` handling inline-parsed hostfiles and mutated the node pool directly, and there was no mechanism to release nodes back from a running DVM. This unifies grow/shrink under the RAS modify framework and adds the missing shrink path, including support for a scheduler interaction (real or simulated).

## What changed

**Resource allocation (`ras/base/ras_base_allocate.c`)**
- Split the monolithic `prte_ras_base_add_hosts()` into a thin collector that packages directives into a `prte_pmix_server_req_t` and dispatches asynchronously via the RAS modify framework, plus a new `prte_ras_base_complete_request()` that applies the result.
- Completion handles **EXTEND/NEW** (insert nodes, flag `PRTE_JOB_EXTEND_DVM`, relaunch daemons) and **RELEASE** (xcast a `SHRINK` command carrying the daemon ranks to terminate).
- `prte_ras_base_modify()` now filters modules by `req->key` and funnels every success through the new completion routine.

**Hostfile handling (`ras/hosts/ras_hosts.c`)**
- Implemented the `hosts` module `modify()` entry (`process_hostfile` helper). A host given without a slot count is left for the daemon to compute from topology (`-1` marker) rather than erroring; an unknown host with negative slots reports the new `negative-slots` help (replacing `nonuniform-slots`).

**Slot accounting (`ras/base/ras_base_node.c`)**
- Honors `PRTE_NODE_ADD_SLOTS` for incremental `host:+N`/`-N` adjustments, clamping to `[0, slots_max]` only when `slots_max > 0` (0 = unlimited).

**Daemon shrink (`prted/prted_comm.c`, `odls/odls_types.h`)**
- New `PRTE_DAEMON_SHRINK_CMD`: each daemon checks the unpacked rank list and, if listed, emits a `JOB_END` event and exits cleanly.
- Constified `get_prted_comm_cmd_str()` to return literals, dropping the per-call `strdup`/`free`.

**Scheduler simulation (`ras/pmix`)**
- New `ras_pmix_simulate` / `simulate_nodelist` MCA params to exercise grow/shrink without a live scheduler; `passthru` completes via `prte_ras_base_complete_request()` and keys callbacks off `req->pstatus`.

**`VERSION`:** requires PMIx >= 6.1.1.

## Reviewer notes

- The `SHRINK` xcast packs only daemon ranks that actually have a daemon assigned (separate fill counter), so the count and array stay consistent.
- Slot clamping deliberately skips the upper bound when `slots_max == 0` since that value means "unlimited".