### PR TITLE
Implement DVM launch fence

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -249,6 +249,27 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        [$PRTE_PMIX_LTO_CAPABILITY],
                        [Whether or not PMIx has the LTO capability flag set])
 
+    dnl The elastic-DVM completion contract directs two PMIx events at the
+    dnl process that requested a DVM size change: PMIX_DVM_IS_READY on success
+    dnl and PMIX_ERR_DVM_MOD on failure.  These are plain #define'd status
+    dnl codes, not behavioral capability flags, so probe for the symbols
+    dnl themselves rather than a PMIX_CAP_* flag.  A PMIx that defines neither
+    dnl leaves the completion notification compiled out (see
+    dnl docs/plans/elastic_dvm/).
+    AC_MSG_CHECKING([for PMIx DVM modification event codes])
+    AC_PREPROC_IFELSE(
+        [AC_LANG_PROGRAM([[#include <pmix.h>
+#if !defined(PMIX_DVM_IS_READY) || !defined(PMIX_ERR_DVM_MOD)
+#error DVM modification event codes not present
+#endif
+]], [[]])],
+        [AC_MSG_RESULT([yes])
+         AC_DEFINE([PRTE_HAVE_DVM_MOD_EVENTS], [1],
+                   [Whether PMIx defines the DVM modification event codes])],
+        [AC_MSG_RESULT([no])
+         AC_DEFINE([PRTE_HAVE_DVM_MOD_EVENTS], [0],
+                   [Whether PMIx defines the DVM modification event codes])])
+
     # restore the global flags
     CPPFLAGS=$prte_external_pmix_save_CPPFLAGS
     LDFLAGS=$prte_external_pmix_save_LDFLAGS

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -12,3 +12,4 @@ find information on that subject here.
    session_dirs.rst
    per-app-mapping.rst
    schedulers/index.rst
+   state_machine.rst

--- a/docs/how-things-work/state_machine.rst
+++ b/docs/how-things-work/state_machine.rst
@@ -1,0 +1,717 @@
+.. _state-machine-label:
+
+Job Launch State Machine
+========================
+
+PRRTE drives the full lifecycle of a job — from daemon launch through
+application launch and termination — through an explicit, event-driven state
+machine.  Every transition is represented as an event posted to the PRRTE
+progress thread; the callback for each state runs single-threaded, performs
+its work, and posts the next event when done.  Nothing blocks the calling
+thread and there are no race conditions between state handlers.
+
+There are two cooperating state machines: one for **jobs** (tracking the
+lifecycle of an entire job or the DVM itself) and one for **processes**
+(tracking each individual application process).
+
+Architecture
+------------
+
+The state machine is implemented in ``src/mca/state/``.  The **DVM module**
+(``src/mca/state/dvm/state_dvm.c``) is used when ``prte`` runs as a
+persistent Distributed Virtual Machine; it owns the authoritative ordered
+table of states and callbacks.  The **prted module**
+(``src/mca/state/prted/state_prted.c``) runs inside each daemon and handles
+only the small set of states relevant to a daemon's local work.
+
+The state machine is a linked list (``prte_job_states``) of
+``(state, callback)`` pairs.  The macro ``PRTE_ACTIVATE_JOB_STATE(jdata,
+state)`` packages the job object and the target state into a *caddy* and
+posts it to the event loop.  The matching callback is looked up and invoked
+asynchronously.
+
+Job State Definitions
+---------------------
+
+All job-state constants are defined in
+``src/mca/plm/plm_types.h`` (lines 116–194).  The states relevant to daemon
+launch, in numeric order, are:
+
+.. list-table::
+   :widths: 35 10 55
+   :header-rows: 1
+
+   * - Name
+     - Value
+     - Meaning
+   * - ``PRTE_JOB_STATE_INIT``
+     - 1
+     - Job record created; ready to receive a job ID.
+   * - ``PRTE_JOB_STATE_INIT_COMPLETE``
+     - 2
+     - Job ID assigned; initial setup done.
+   * - ``PRTE_JOB_STATE_ALLOCATE``
+     - 3
+     - Ready to request resources from the scheduler/RAS.
+   * - ``PRTE_JOB_STATE_ALLOCATION_COMPLETE``
+     - 4
+     - Resource allocation finished.
+   * - ``PRTE_JOB_STATE_LAUNCH_DAEMONS``
+     - 8
+     - Ready to spawn ``prted`` processes.  *Not* in the DVM default table;
+       registered by each PLM component at startup.
+   * - ``PRTE_JOB_STATE_DAEMONS_LAUNCHED``
+     - 9
+     - The PLM has initiated daemon spawning; waiting for daemons to call home.
+   * - ``PRTE_JOB_STATE_DAEMONS_REPORTED``
+     - 10
+     - All expected daemons have connected and sent their contact information.
+   * - ``PRTE_JOB_STATE_VM_READY``
+     - 11
+     - The DVM is fully operational; node map and wireup info have been
+       broadcast to all daemons.
+   * - ``PRTE_JOB_STATE_MAP``
+     - 5
+     - Ready to map processes to nodes.
+   * - ``PRTE_JOB_STATE_MAP_COMPLETE``
+     - 6
+     - Process mapping finished.
+   * - ``PRTE_JOB_STATE_SYSTEM_PREP``
+     - 7
+     - Final sanity checks and environment setup before launch.
+   * - ``PRTE_JOB_STATE_LAUNCH_APPS``
+     - 12
+     - Ready to send launch directives to daemons.
+   * - ``PRTE_JOB_STATE_SEND_LAUNCH_MSG``
+     - 13
+     - Launch message being assembled and sent.
+   * - ``PRTE_JOB_STATE_STARTED``
+     - 20
+     - At least one application process has been forked.
+   * - ``PRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE``
+     - 18
+     - All local processes on a daemon have attempted to launch.
+   * - ``PRTE_JOB_STATE_READY_FOR_DEBUG``
+     - 19
+     - All local processes report ready for a debugger attach.
+   * - ``PRTE_JOB_STATE_RUNNING``
+     - 14
+     - All processes across all daemons have been forked.
+   * - ``PRTE_JOB_STATE_REGISTERED``
+     - 16
+     - All processes have registered with the PMIx server (called
+       ``PMIx_Init``).
+
+Termination states (values ≥ 30) and error states (values ≥ 51) are
+described at the bottom of this page.
+
+The Daemon Launch Sequence
+--------------------------
+
+The DVM module registers the following ordered table at startup
+(``src/mca/state/dvm/state_dvm.c``, ``launch_states[]`` /
+``launch_callbacks[]``):
+
+.. code-block:: text
+
+   State                          Callback
+   ─────────────────────────────────────────────────────────────────────
+   PRTE_JOB_STATE_INIT            prte_plm_base_setup_job
+   PRTE_JOB_STATE_INIT_COMPLETE   init_complete              (dvm-local)
+   PRTE_JOB_STATE_ALLOCATE        prte_ras_base_allocate
+   PRTE_JOB_STATE_ALLOCATION_COMPLETE  prte_plm_base_allocation_complete
+   PRTE_JOB_STATE_DAEMONS_LAUNCHED     prte_plm_base_daemons_launched
+   PRTE_JOB_STATE_DAEMONS_REPORTED     prte_plm_base_daemons_reported
+   PRTE_JOB_STATE_VM_READY        vm_ready                   (dvm-local)
+   PRTE_JOB_STATE_MAP             prte_rmaps_base_map_job
+   PRTE_JOB_STATE_MAP_COMPLETE    prte_plm_base_mapping_complete
+   PRTE_JOB_STATE_SYSTEM_PREP     prte_plm_base_complete_setup
+   PRTE_JOB_STATE_LAUNCH_APPS     prte_plm_base_launch_apps
+   PRTE_JOB_STATE_SEND_LAUNCH_MSG prte_plm_base_send_launch_msg
+   PRTE_JOB_STATE_STARTED         job_started                (dvm-local)
+   PRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE  prte_state_base_local_launch_complete
+   PRTE_JOB_STATE_READY_FOR_DEBUG ready_for_debug            (dvm-local)
+   PRTE_JOB_STATE_RUNNING         prte_plm_base_post_launch
+   PRTE_JOB_STATE_REGISTERED      prte_plm_base_registered
+   PRTE_JOB_STATE_TERMINATED      check_complete             (dvm-local)
+   PRTE_JOB_STATE_NOTIFY_COMPLETED dvm_notify               (dvm-local)
+   PRTE_JOB_STATE_NOTIFIED        cleanup_job                (dvm-local)
+   PRTE_JOB_STATE_ALL_JOBS_COMPLETE prte_quit
+
+   (plus DAEMONS_TERMINATED → prte_quit and FORCED_EXIT → force_quit,
+    registered separately)
+
+Note that ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` is **not** in this table.
+Each Process Launch Manager (PLM) component—ssh, slurm, pals, lsf—inserts
+its own ``launch_daemons`` callback for that state during its own ``init``.
+
+Step-by-step walk-through
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**1. INIT → prte_plm_base_setup_job**
+
+The job record is validated and initial app-context setup is performed.
+On success the callback posts ``INIT_COMPLETE``.
+
+**2. INIT_COMPLETE → init_complete**
+
+The DVM-local ``init_complete`` immediately posts ``ALLOCATE`` so that a
+potential DVM expansion can go through the allocation step.
+
+**3. ALLOCATE → prte_ras_base_allocate**
+
+The Resource Allocation Subsystem (RAS) queries the scheduler or hostfile
+for available nodes and records them in the node pool.  On completion it
+posts ``ALLOCATION_COMPLETE``.
+
+**4. ALLOCATION_COMPLETE → prte_plm_base_allocation_complete**
+
+Decision point (``src/mca/plm/base/plm_base_launch_support.c``:186):
+
+* If ``PRTE_JOB_DO_NOT_LAUNCH`` is set (e.g., ``--map-by :display``), skip
+  daemon spawning entirely and jump straight to ``DAEMONS_REPORTED``.
+* Otherwise, post ``LAUNCH_DAEMONS``.
+
+**5. LAUNCH_DAEMONS → <PLM launch_daemons>**
+
+This state is handled by the active PLM component, not by the DVM module.
+The ssh PLM's handler (``src/mca/plm/ssh/plm_ssh_module.c``:1077) is
+representative:
+
+a. Calls ``prte_plm_base_setup_virtual_machine()`` to compute which nodes
+   need new daemons (nodes already hosting a daemon from a prior job are
+   reused).
+b. If no new daemons are needed (``map->num_new_daemons == 0``), fast-paths
+   to ``DAEMONS_REPORTED``.
+c. Otherwise, builds the ``prted`` command line and spawns one daemon per
+   node via ssh (or pdsh, or the equivalent for slurm/pals/lsf).
+d. Registers ``prte_plm_base_daemon_callback`` on
+   ``PRTE_RML_TAG_DAEMON_REPORT`` to hear from daemons as they start.
+e. Posts ``DAEMONS_LAUNCHED`` to indicate spawning has been initiated.
+
+**6. DAEMONS_LAUNCHED → prte_plm_base_daemons_launched**
+
+This callback is intentionally a no-op
+(``src/mca/plm/base/plm_base_launch_support.c``:218).  The state machine
+parks here and waits for daemons to call home asynchronously.
+
+**7. Daemons call home (asynchronous)**
+
+As each ``prted`` process starts up it:
+
+a. Initializes via its ESS (Environment-Specific Services) component.
+b. Connects to the HNP (Head Node Process) via the RML.
+c. Sends a report containing its process name, RML contact URI, node name,
+   and hwloc topology to the HNP on ``PRTE_RML_TAG_DAEMON_REPORT``.
+
+The HNP receives these reports in ``prte_plm_base_daemon_callback``
+(``src/mca/plm/base/plm_base_launch_support.c``:1237).  For each arriving
+daemon it:
+
+* Records the daemon's contact URI (stored via ``PMIx_Store_internal`` as
+  ``PMIX_PROC_URI``).
+* Records the node name and hwloc topology.
+* Marks the node ``PRTE_NODE_STATE_UP``.
+* Increments ``jdatorted->num_reported``.
+* Calls ``progress_daemons()`` (line 1173), which fires
+  ``DAEMONS_REPORTED`` once ``num_reported == num_procs``.
+
+**8. DAEMONS_REPORTED → prte_plm_base_daemons_reported**
+
+(``src/mca/plm/base/plm_base_launch_support.c``:118)
+
+* If using an unmanaged allocation (e.g., a hostfile), sets the default
+  slot count on each node according to ``--set-slots`` (cores, sockets,
+  hwthreads, or a literal number).
+* Totals up ``jdata->total_slots_alloc``.
+* Posts ``VM_READY``.
+
+At this point every daemon is up and the HNP knows how to reach each of
+them.
+
+**9. VM_READY → vm_ready**
+
+(``src/mca/state/dvm/state_dvm.c``:261)
+
+If new daemons were actually launched (``PRTE_JOB_LAUNCHED_DAEMONS`` is
+set) and more than one daemon is running:
+
+* Serializes the node map via ``prte_util_nidmap_create()`` into a buffer.
+* Looks up each daemon's ``PMIX_PROC_URI`` and packs it into the same
+  buffer.
+* Broadcasts the combined nidmap + wireup buffer to all daemons via
+  ``prte_grpcomm.xcast(PRTE_RML_TAG_WIREUP, &buf)``.
+
+After the broadcast:
+
+* Sets ``prte_dvm_ready = true``.
+* If running as a persistent DVM (``prte`` without an immediate job),
+  prints ``"DVM ready\n"`` to stdout or writes a ``'K'`` byte on the
+  parent pipe so the caller knows the DVM is accepting work.
+* Dispatches any jobs that arrived and were cached while the DVM was
+  starting (``prte_cache``).
+
+**The DVM is now fully operational.**  For a standalone ``prterun``
+invocation the state machine continues immediately into the app-launch
+phase below.
+
+Application Launch (after the DVM is ready)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the DVM is ready, each new application job that arrives at the HNP
+(via ``PRTE_PLM_LAUNCH_JOB_CMD``) goes through a fast-path re-entry into
+the state machine (``plm_base_receive.c``:470).  If ``prte_dvm_ready`` is
+not yet true (initial DVM startup still in progress), the job is stashed in
+``prte_cache`` and flushed when ``vm_ready`` fires for the daemon job.
+Otherwise the job enters the state machine immediately via
+``prte_plm.spawn(jdata)``.
+
+A DVM can run many application jobs concurrently.  Each follows the same
+state machine independently.
+
+**10. MAP → prte_rmaps_base_map_job**
+
+(``src/mca/rmaps/base/``)
+
+The RMAPS framework assigns each application process to a specific node and
+slot.  The mapping policy (``--map-by slot``, ``--map-by node``,
+``--map-by core``, ``--map-by ppr:N:L``, etc.) determines how processes
+are distributed.
+
+Key actions:
+
+* Iterates over the node pool for the job's session.
+* For each app context, calls the selected RMAPS component
+  (e.g., ``rmaps_round_robin``, ``rmaps_ppr``, ``rmaps_rank_file``).
+* Each component calls ``prte_rmaps_base_claim_slot()`` to assign a process
+  to a node; this creates a ``prte_proc_t`` entry and links it to the node.
+* Sets ``jdata->num_procs``.
+* If ``--rank-by`` or ``--bind-to`` were specified, records those policies
+  in the map for use during launch.
+
+On completion, fires ``MAP_COMPLETE``.
+
+**11. MAP_COMPLETE → prte_plm_base_mapping_complete**
+
+(``plm_base_launch_support.c``:276)
+
+Posts ``SYSTEM_PREP``.
+
+**12. SYSTEM_PREP → prte_plm_base_complete_setup**
+
+(``plm_base_launch_support.c``)
+
+Performs pre-launch sanity checks and environment preparation:
+
+* Validates that there are enough slots for the requested process count.
+* Constructs the environment for each app context (inheriting the HNP
+  environment, applying ``-x VAR``, ``--env-merge``, and PMIx-standard
+  keys).
+* Calls ``prte_filem.preposition_files()`` to stage any required input
+  files to the compute nodes.  The ``files_ready`` callback fires on
+  completion; on success it activates ``MAP`` — **wait, this is actually
+  activated from** ``vm_ready`` **for the app-job path; see below**.
+
+.. note::
+   ``SYSTEM_PREP``'s callback ``prte_plm_base_complete_setup`` does the
+   environment/slot validation and then fires ``LAUNCH_APPS``.  File
+   staging happens earlier, inside ``vm_ready``, before MAP is activated.
+   The call chain is: ``vm_ready`` → ``preposition_files`` →
+   ``files_ready`` → ``MAP`` → ... → ``SYSTEM_PREP`` → ``LAUNCH_APPS``.
+
+**13. LAUNCH_APPS → prte_plm_base_launch_apps**
+
+(``plm_base_launch_support.c``)
+
+Prepares the per-daemon launch data and posts ``SEND_LAUNCH_MSG``.
+
+**14. SEND_LAUNCH_MSG → prte_plm_base_send_launch_msg**
+
+(``plm_base_launch_support.c``)
+
+Builds and sends an ODLS (On-node Daemon Launch Subsystem) launch message
+to each daemon that has local processes for this job.  The message contains:
+
+* The job's namespace and process list.
+* Per-process slot list (cpuset, binding directives).
+* Application argv and environment.
+* IOF (I/O Forwarding) channel setup — which file descriptors to forward
+  for each process.
+* Any PMIx server info that the processes will need at init time.
+
+Each daemon receives the message via ``PRTE_RML_TAG_LAUNCH_APPS`` and
+passes it to its ODLS component.  The ODLS ``launch_local_procs()`` entry
+point iterates over the local process list and ``fork``/``exec``'s each
+one.  After the exec, the child process calls ``PMIx_Init`` which connects
+it to the daemon's embedded PMIx server.
+
+**15. STARTED → job_started**
+
+Fires once the first process has been forked on any daemon (triggered by
+``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD`` receipt at the HNP—see step 16).
+Notifies the originating tool via a PMIx ``PMIX_EVENT_JOB_START`` event.
+
+**16. LOCAL_LAUNCH_COMPLETE**
+
+Each daemon sends ``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD`` back to the HNP when
+all of its local processes have attempted to start, carrying each process's
+PID and state.  The HNP handler (``plm_base_receive.c``:715) accumulates
+``jdata->num_launched``; when the first process is counted it posts
+``STARTED``; when all processes are counted it posts ``RUNNING``.
+
+**17. READY_FOR_DEBUG → ready_for_debug**
+
+Optional.  If the job was submitted with ``--stop-on-exec``,
+``--stop-in-init``, or ``--stop-in-app``, each daemon waits until all its
+local processes signal readiness and then sends
+``PRTE_PLM_READY_FOR_DEBUG_CMD`` to the HNP.  When the HNP has heard from
+all daemons it fires a ``PMIX_READY_FOR_DEBUG`` PMIx event to the
+originating tool.
+
+**18. RUNNING → prte_plm_base_post_launch**
+
+All processes across the entire job are running.  Post-launch cleanup:
+timeout timers, progress callbacks, and similar housekeeping.
+
+**19. REGISTERED → prte_plm_base_registered**
+
+All application processes have called ``PMIx_Init`` and registered with
+their local PMIx server.  Each daemon accumulates its local count and
+sends ``PRTE_PLM_REGISTERED_CMD`` to the HNP when all of its local
+processes have registered.  The HNP handler
+(``plm_base_receive.c``:675) increments ``jdata->num_reported``; when the
+count reaches ``jdata->num_procs`` it fires this state.
+
+Process State Machine
+---------------------
+
+The process state machine tracks individual application processes.  It
+runs on both the HNP (via the DVM module) and each daemon (via the prted
+module), with the same set of states and a single callback
+``prte_state_base_track_procs`` / ``track_procs``.
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Name
+     - Value
+     - Meaning
+   * - ``PRTE_PROC_STATE_INIT``
+     - 1
+     - Process entry created by RMAPS.
+   * - ``PRTE_PROC_STATE_RUNNING``
+     - 4
+     - Daemon has forked the process.
+   * - ``PRTE_PROC_STATE_REGISTERED``
+     - 5
+     - Process called ``PMIx_Init``.
+   * - ``PRTE_PROC_STATE_IOF_COMPLETE``
+     - 6
+     - All I/O forwarding pipes have closed.
+   * - ``PRTE_PROC_STATE_WAITPID_FIRED``
+     - 7
+     - ``waitpid`` detected the process has exited.
+   * - ``PRTE_PROC_STATE_READY_FOR_DEBUG``
+     - 9
+     - Process is stopped and awaiting a debugger.
+   * - ``PRTE_PROC_STATE_TERMINATED``
+     - 20
+     - Process is fully cleaned up.
+
+A process is considered still running if its state is less than
+``PRTE_PROC_STATE_UNTERMINATED`` (15).  States ≥
+``PRTE_PROC_STATE_ERROR`` (50) indicate abnormal exit.
+
+On the daemon side (``src/mca/state/prted/state_prted.c``:314,
+``track_procs``):
+
+* ``RUNNING``: increments ``jdata->num_launched``; when all local procs
+  are running, fires ``PRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE`` which
+  sends ``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD`` to the HNP.
+* ``REGISTERED``: increments ``jdata->num_reported``; when all local procs
+  have registered, sends ``PRTE_PLM_REGISTERED_CMD`` to the HNP.
+* ``IOF_COMPLETE`` / ``WAITPID_FIRED``: when both flags are set for a
+  process, marks it ``TERMINATED`` and triggers job-completion accounting.
+
+Termination and Error States
+----------------------------
+
+**Boundary markers** (job states):
+
+* ``PRTE_JOB_STATE_UNTERMINATED`` (30): any state below this means the job
+  is still running.
+* ``PRTE_JOB_STATE_ERROR`` (50): any state at or above this is an error.
+
+**Normal termination sequence**:
+
+``TERMINATED`` → ``NOTIFY_COMPLETED`` → ``NOTIFIED`` → ``ALL_JOBS_COMPLETE``
+→ ``prte_quit``
+
+**Selected error states**:
+
+.. list-table::
+   :widths: 50 10
+   :header-rows: 1
+
+   * - Name
+     - Value
+   * - ``PRTE_JOB_STATE_KILLED_BY_CMD``
+     - 51
+   * - ``PRTE_JOB_STATE_ABORTED``
+     - 52
+   * - ``PRTE_JOB_STATE_FAILED_TO_START``
+     - 53
+   * - ``PRTE_JOB_STATE_NEVER_LAUNCHED``
+     - 60
+   * - ``PRTE_JOB_STATE_ALLOC_FAILED``
+     - 68
+   * - ``PRTE_JOB_STATE_MAP_FAILED``
+     - 69
+   * - ``PRTE_JOB_STATE_CANNOT_LAUNCH``
+     - 70
+   * - ``PRTE_JOB_STATE_FORCED_EXIT``
+     - 64
+
+All error states ultimately route to ``force_quit`` or ``prte_quit`` which
+calls ``prte_plm.terminate_orteds()`` before exiting.
+
+Key Source Files
+----------------
+
+.. list-table::
+   :widths: 45 55
+   :header-rows: 1
+
+   * - File
+     - Role
+   * - ``src/mca/plm/plm_types.h``
+     - All state constant definitions.
+   * - ``src/mca/state/dvm/state_dvm.c``
+     - DVM job and proc state tables; ``vm_ready``, ``init_complete``,
+       ``check_complete``, ``dvm_notify``, ``cleanup_job``.
+   * - ``src/mca/state/prted/state_prted.c``
+     - Per-daemon job and proc state tables; ``track_procs``,
+       ``track_jobs``.
+   * - ``src/mca/state/base/state_base_fns.c``
+     - ``prte_state_base_activate_job_state`` — the core dispatch function.
+   * - ``src/mca/plm/base/plm_base_launch_support.c``
+     - Most PLM base callbacks: ``prte_plm_base_setup_job``,
+       ``prte_plm_base_allocation_complete``,
+       ``prte_plm_base_daemons_launched``,
+       ``prte_plm_base_daemons_reported``, ``progress_daemons``,
+       ``prte_plm_base_daemon_callback``.
+   * - ``src/mca/plm/base/plm_base_receive.c``
+     - HNP message handler: processes ``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD``
+       and ``PRTE_PLM_REGISTERED_CMD`` from daemons.
+   * - ``src/mca/plm/ssh/plm_ssh_module.c``
+     - SSH PLM ``launch_daemons`` callback (line 1077).
+   * - ``src/mca/plm/slurm/plm_slurm_module.c``
+     - SLURM PLM ``launch_daemons`` callback.
+   * - ``src/mca/plm/pals/plm_pals_module.c``
+     - PALS PLM ``launch_daemons`` callback.
+   * - ``src/mca/plm/lsf/plm_lsf_module.c``
+     - LSF PLM ``launch_daemons`` callback.
+   * - ``src/mca/ras/base/ras_base_allocate.c``
+     - ``prte_ras_base_add_hosts()`` (thin async wrapper, line 771);
+       ``prte_ras_base_complete_request()`` (grow/shrink completion, line
+       586); ``prte_ras_base_modify()`` (routes requests to RAS modules,
+       line 529).
+   * - ``src/mca/ras/hosts/ras_hosts.c``
+     - ``ras/hosts`` module ``modify()`` entry point: parses hostfiles and
+       host lists and inserts nodes into the pool (line 340).
+   * - ``src/mca/ras/slurm/ras_slurm_modify_extend.c``
+     - Slurm ``modify()`` entry for ``PMIX_ALLOC_EXTEND``; fires
+       ``LAUNCH_DAEMONS`` directly on the daemon job (line 752).
+   * - ``src/prted/prted_comm.c``
+     - ``PRTE_DAEMON_SHRINK_CMD`` handler (line 469): checks daemon rank
+       list and exits cleanly if listed.
+
+Debugging
+---------
+
+Verbose output for each subsystem is controlled at runtime:
+
+.. code-block:: sh
+
+   # Job state machine transitions
+   prte --prtemca state_base_verbose 5 ...
+
+   # PLM (daemon launch, message receive)
+   prte --prtemca plm_base_verbose 5 ...
+
+   # Process mapping
+   prte --prtemca rmaps_base_verbose 5 ...
+
+   # Resource allocation
+   prte --prtemca ras_base_verbose 5 ...
+
+At verbosity level 5 the state machine also prints its full table at
+startup via ``prte_state_base_print_job_state_machine()``.
+
+DVM Extension and the Daemon-Launch Race
+-----------------------------------------
+
+Background
+~~~~~~~~~~
+
+A persistent DVM can have its node pool expanded at runtime in two ways:
+
+1. **App-triggered** (``src/mca/ras/base/ras_base_allocate.c``:771):
+   A job submitted with ``--add-host`` or ``--add-hostfile`` causes the RAS
+   base ``add_hosts()`` function — now a thin asynchronous wrapper — to
+   collect the directives into a ``prte_pmix_server_req_t`` with
+   ``req->key = "hosts"`` and ``req->allocdir = PMIX_ALLOC_EXTEND``.  It
+   sets ``prte_dvm_ready = false`` to block concurrent job dispatch, then
+   posts the request to the event loop for ``prte_ras_base_modify()`` to
+   handle.  ``prte_ras_base_modify()`` routes the request to the ``ras/hosts``
+   module, whose ``modify()`` entry point
+   (``src/mca/ras/hosts/ras_hosts.c``:340) parses the hostfiles and host
+   lists and inserts new nodes into ``prte_node_pool``.  On success the
+   common completion function ``prte_ras_base_complete_request()`` (line 586)
+   marks ``PRTE_JOB_EXTEND_DVM`` on the **daemon job** and fires
+   ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` on the daemon job.  Any application
+   jobs that arrive while ``prte_dvm_ready`` is false are stashed in
+   ``prte_cache`` and flushed when ``vm_ready()`` fires.
+
+2. **Scheduler push** (``src/mca/ras/slurm/ras_slurm_modify_extend.c``:752):
+   When Slurm grants additional nodes (e.g., in response to a
+   ``PMIx_Allocate`` call from an application), the Slurm RAS component
+   adds the nodes to the pool and fires ``PRTE_JOB_STATE_LAUNCH_DAEMONS``
+   **directly on the daemon job**, setting ``PRTE_JOB_EXTEND_DVM`` on the
+   daemon job — bypassing ``prte_ras_base_complete_request()`` and leaving
+   ``prte_dvm_ready`` unchanged.
+
+In both cases ``setup_virtual_machine()`` is called (from within the PLM's
+``launch_daemons`` callback) and detects the extension via the
+``PRTE_JOB_EXTEND_DVM`` attribute on the daemon job.  If new daemons are
+needed it sets ``PRTE_JOB_LAUNCHED_DAEMONS`` on the daemon job and returns
+with ``map->num_new_daemons > 0``.  The PLM then spawns ``prted`` processes
+on the new nodes and the state machine parks at ``DAEMONS_LAUNCHED`` until
+they call home.
+
+DVM Shrink
+~~~~~~~~~~
+
+A DVM can also be **shrunk** at runtime by releasing nodes back to the
+scheduler.  The path runs through the same ``prte_ras_base_complete_request()``
+function, but with ``req->allocdir == PMIX_ALLOC_RELEASE``:
+
+1. The ``PMIX_ALLOC_RELEASE`` branch extracts the node list from
+   ``PMIX_ALLOC_NODE_LIST``, looks up each node's daemon rank in
+   ``prte_node_pool``, and packs the ranks into a
+   ``PRTE_DAEMON_SHRINK_CMD`` message.
+2. The message is broadcast to all daemons via
+   ``prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON)``.
+3. Each daemon that receives ``PRTE_DAEMON_SHRINK_CMD``
+   (``src/prted/prted_comm.c``:469) checks whether its own rank appears in
+   the unpacked list.  If listed, it:
+
+   a. Sets ``prte_abnormal_term_ordered = true``.
+   b. Fires a ``PMIX_EVENT_JOB_END`` PMIx event to notify any attached tools.
+   c. Sends a ``PRTE_PLM_SHRINK_ACK_CMD`` to the HNP on
+      ``PRTE_RML_TAG_PLM`` (**planned**; see below).
+   d. Activates ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and exits cleanly.
+
+Unlisted daemons silently discard the command and continue running.
+
+In addition, each RAS module may implement a ``release_allocation`` entry
+point (added in ``src/mca/ras/ras.h``).  The base function
+``prte_ras_base_release_allocation()`` cycles active modules in priority
+order (filtering by ``session->alloc_module`` when set) and is called
+automatically from the ``prte_session_t`` destructor so that allocations are
+released when their session object is destructed.
+
+Shrink Synchronisation Requirement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``PRTE_DAEMON_SHRINK_CMD`` xcast is fire-and-forget: targeted daemons
+exit on their own schedule, and the HNP currently has no signal for when all
+of them have terminated.  This creates two race windows that must be closed.
+
+**Race 1 — new job mapping onto a shrinking node**
+
+A job that reaches the ``VM_READY → MAP`` boundary while a shrink is in
+progress may have its processes mapped onto a node whose daemon has already
+received ``PRTE_DAEMON_SHRINK_CMD``.  By the time the launch message is
+sent the daemon may already have exited.
+
+**Race 2 — in-flight job at** ``LAUNCH_APPS``
+
+A job that was fully mapped *before* a shrink started and then reaches
+``LAUNCH_APPS`` (where launch data is packed and sent to each daemon) may
+send to a daemon that dies in the window between MAP and the actual send.
+
+Closing both races requires:
+
+1. **Daemon acknowledgement** before exit — each targeted daemon sends an
+   explicit ``PRTE_PLM_SHRINK_ACK_CMD`` to the HNP on ``PRTE_RML_TAG_PLM``
+   after its ``PMIX_EVENT_JOB_END`` notification completes but *before* it
+   activates ``PRTE_JOB_STATE_DAEMONS_TERMINATED``.  The HNP counts ACKs
+   and uses them to drive the fence counter down.
+
+2. **Second hold point at** ``LAUNCH_APPS`` — ``prte_plm_base_launch_apps()``
+   checks a dedicated ``prte_shrink_ntargets`` counter (nonzero only when a
+   shrink is in progress) and if nonzero parks the job in a second held-job
+   array (``prte_prelaunch_held_jobs``) rather than packing or sending any
+   launch data.  This hold uses ``prte_shrink_ntargets`` rather than the
+   general ``prte_dvm_launch_fence`` so that a concurrent DVM grow does not
+   unnecessarily stall jobs that have already been mapped to existing nodes.
+
+3. **Remap on release** — when ``prte_dvm_launch_fence`` returns to zero,
+   jobs in ``prte_prelaunch_held_jobs`` that were mapped to any of the now-dead
+   daemon nodes are reset to ``MAP`` state so they are remapped to the
+   surviving nodes; jobs whose entire mapping lies on surviving nodes are
+   re-activated at ``LAUNCH_APPS`` without remapping.
+
+The full implementation plan is in :ref:`dvm-launch-fence-label`,
+*DVM Shrink Fence*.
+
+The Race Condition
+~~~~~~~~~~~~~~~~~~
+
+The app-triggered path partially mitigates the race by setting
+``prte_dvm_ready = false`` in ``add_hosts()`` before the asynchronous
+request is posted: any job that arrives after that point is stashed in
+``prte_cache`` and is not dispatched until ``vm_ready()`` restores
+``prte_dvm_ready = true``.
+
+The scheduler-push path does **not** clear ``prte_dvm_ready``.  Because
+``prte_dvm_ready`` otherwise remains ``true`` throughout DVM operation (it
+is only cleared at shutdown), any application job that arrives while a
+scheduler-initiated daemon launch is in flight is dispatched immediately:
+
+.. code-block:: text
+
+   Thread of events (time →)
+
+   Slurm grants new nodes
+   ras_slurm_modify_extend fires LAUNCH_DAEMONS on daemon job
+   PLM starts spawning prted on new nodes    ← daemon launch in progress
+   App job B arrives, prte_dvm_ready==true, B is dispatched
+   B: INIT → ALLOCATE → VM_READY
+   B: MAP ← assigns procs to new nodes ← daemons NOT UP YET
+   B: SEND_LAUNCH_MSG → daemons fail to receive it
+
+The same race exists when multiple apps are running concurrently inside the
+DVM and one of them triggers an allocation expansion: the other apps'
+independent state machine progressions can interleave with the daemon launch
+events.
+
+Required Change: Gate at the VM_READY → MAP Boundary
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To eliminate the race, all application jobs must be held at the
+``VM_READY → MAP`` boundary whenever any daemon launch campaign is in
+progress, regardless of which path (app-triggered or scheduler push)
+initiated it.  Jobs that are already past ``MAP`` (i.e., already launching
+or running) are unaffected — their daemons are already up.
+
+The mechanism is a **global launch fence** — a counter
+(``prte_dvm_launch_fence``) that tracks the number of in-progress daemon
+launch campaigns.  An app job that reaches the ``VM_READY → MAP`` transition
+checks the fence; if it is nonzero the job parks itself in a held-job array
+(``prte_held_jobs``) and is released when the fence reaches zero.
+
+The step-by-step implementation plan is in
+:ref:`dvm-launch-fence-label`.

--- a/docs/how-things-work/state_machine.rst
+++ b/docs/how-things-work/state_machine.rst
@@ -609,9 +609,12 @@ function, but with ``req->allocdir == PMIX_ALLOC_RELEASE``:
 
    a. Sets ``prte_abnormal_term_ordered = true``.
    b. Fires a ``PMIX_EVENT_JOB_END`` PMIx event to notify any attached tools.
-   c. Sends a ``PRTE_PLM_SHRINK_ACK_CMD`` to the HNP on
-      ``PRTE_RML_TAG_PLM`` (**planned**; see below).
-   d. Activates ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and exits cleanly.
+   c. Activates ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and exits cleanly.
+
+   The HNP needs no acknowledgement from the daemon: it learns that the
+   daemon is gone through the normal daemon-loss (comm-failure) path, which
+   is also the only event that guarantees the daemon's routes and node state
+   have actually been torn down (see below).
 
 Unlisted daemons silently discard the command and continue running.
 
@@ -626,8 +629,8 @@ Shrink Synchronisation Requirement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``PRTE_DAEMON_SHRINK_CMD`` xcast is fire-and-forget: targeted daemons
-exit on their own schedule, and the HNP currently has no signal for when all
-of them have terminated.  This creates two race windows that must be closed.
+exit on their own schedule, and the HNP must determine when all of them have
+actually terminated.  This creates two race windows that must be closed.
 
 **Race 1 — new job mapping onto a shrinking node**
 
@@ -644,11 +647,18 @@ send to a daemon that dies in the window between MAP and the actual send.
 
 Closing both races requires:
 
-1. **Daemon acknowledgement** before exit — each targeted daemon sends an
-   explicit ``PRTE_PLM_SHRINK_ACK_CMD`` to the HNP on ``PRTE_RML_TAG_PLM``
-   after its ``PMIX_EVENT_JOB_END`` notification completes but *before* it
-   activates ``PRTE_JOB_STATE_DAEMONS_TERMINATED``.  The HNP counts ACKs
-   and uses them to drive the fence counter down.
+1. **Completion on actual daemon death** — the HNP records the targeted
+   daemon ranks in a ``prte_shrink_campaign_t`` and waits for each one to
+   leave the DVM.  Departure is detected through the existing daemon-loss
+   (comm-failure) path in the ``errmgr/dvm`` component, which matches the
+   dead daemon's rank against the campaign's target list, drives the fence
+   counter down, and releases the fence once every target is gone.  The
+   HNP does not rely on any acknowledgement from the daemon: the reason a
+   targeted daemon dies is irrelevant, and the comm-failure event is the
+   only signal that also guarantees the daemon's routes, ``num_daemons``
+   count, and node state have been cleaned up.  Each target slot is stamped
+   ``PMIX_RANK_INVALID`` once counted so a repeated comm event cannot
+   decrement the campaign twice.
 
 2. **Second hold point at** ``LAUNCH_APPS`` — ``prte_plm_base_launch_apps()``
    checks a dedicated ``prte_shrink_ntargets`` counter (nonzero only when a

--- a/docs/how-things-work/state_machine.rst
+++ b/docs/how-things-work/state_machine.rst
@@ -694,8 +694,8 @@ Closing both races requires:
    surviving nodes; jobs whose entire mapping lies on surviving nodes are
    re-activated at ``LAUNCH_APPS`` without remapping.
 
-The full implementation plan is in :ref:`dvm-launch-fence-label`,
-*DVM Shrink Fence*.
+The full implementation plan is in :ref:`dvm-shrink-campaign-label`; the
+shared fence mechanism it builds on is in :ref:`elastic-dvm-plan-label`.
 
 The Race Condition
 ~~~~~~~~~~~~~~~~~~
@@ -744,4 +744,5 @@ checks the fence; if it is nonzero the job parks itself in a held-job array
 (``prte_held_jobs``) and is released when the fence reaches zero.
 
 The step-by-step implementation plan is in
-:ref:`dvm-launch-fence-label`.
+:ref:`elastic-dvm-plan-label`, with the grow- and shrink-specific details
+in :ref:`dvm-grow-campaign-label` and :ref:`dvm-shrink-campaign-label`.

--- a/docs/how-things-work/state_machine.rst
+++ b/docs/how-things-work/state_machine.rst
@@ -522,7 +522,10 @@ Key Source Files
        host lists and inserts nodes into the pool (line 340).
    * - ``src/mca/ras/slurm/ras_slurm_modify_extend.c``
      - Slurm ``modify()`` entry for ``PMIX_ALLOC_EXTEND``; fires
-       ``LAUNCH_DAEMONS`` directly on the daemon job (line 752).
+       ``LAUNCH_DAEMONS`` directly on the daemon job (line 752) instead of
+       routing through ``prte_ras_base_complete_request()`` — see the
+       launch-fence warning under *DVM Extension and the Daemon-Launch
+       Race*.
    * - ``src/prted/prted_comm.c``
      - ``PRTE_DAEMON_SHRINK_CMD`` handler (line 469): checks daemon rank
        list and exits cleanly if listed.
@@ -589,6 +592,23 @@ needed it sets ``PRTE_JOB_LAUNCHED_DAEMONS`` on the daemon job and returns
 with ``map->num_new_daemons > 0``.  The PLM then spawns ``prted`` processes
 on the new nodes and the state machine parks at ``DAEMONS_LAUNCHED`` until
 they call home.
+
+.. warning::
+   A RAS component that handles a modification request (grow or shrink)
+   must route its result through ``prte_ras_base_complete_request()``
+   rather than activating ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` directly on the
+   daemon job.  ``prte_ras_base_complete_request()`` is the single point
+   that performs the bookkeeping the launch fence depends on: it sets
+   ``PRTE_JOB_EXTEND_DVM`` and resets ``prte_nidmap_communicated`` on the
+   grow path, and on the shrink path it records the
+   ``prte_shrink_campaign_t`` and raises ``prte_dvm_launch_fence`` *before*
+   any daemon is asked to leave.  A component that fires
+   ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` itself — as the Slurm scheduler-push
+   path historically does — skips this common handling and can leave the
+   fence out of step with the campaign it is supposed to gate, reopening
+   the daemon-launch race described below.  New RAS modules, and any
+   reworking of the existing ones, should hand their results to
+   ``prte_ras_base_complete_request()`` and let it activate the state.
 
 DVM Shrink
 ~~~~~~~~~~

--- a/docs/plans/elastic_dvm/dvm_launch_fence.rst
+++ b/docs/plans/elastic_dvm/dvm_launch_fence.rst
@@ -17,6 +17,12 @@ checks the fence; if it is nonzero the job parks itself in a held-job array
 The state machine is single-threaded on the progress thread, so no locking
 is required anywhere in this plan.
 
+The externally observable contract that this mechanism implements — the
+job-admission and placement guarantees a caller may rely on while the DVM
+grows or shrinks — is specified in :ref:`elastic-dvm-spec-label`; that
+document is authoritative for observable behavior, and this one describes
+the implementation that delivers it.
+
 .. note::
    The app-triggered expansion path (``--add-host`` / ``--add-hostfile``)
    already sets ``prte_dvm_ready = false`` in ``add_hosts()`` before posting

--- a/docs/plans/elastic_dvm/dvm_launch_fence.rst
+++ b/docs/plans/elastic_dvm/dvm_launch_fence.rst
@@ -1,0 +1,791 @@
+.. _dvm-launch-fence-label:
+
+DVM Launch-Fence Implementation Plan
+=====================================
+
+This document describes the implementation plan for eliminating the race
+condition between a DVM extension (new-daemon launch campaign) and
+concurrently-running application jobs.  For background on the race itself see
+:ref:`state-machine-label`, section *DVM Extension and the Daemon-Launch Race*.
+
+The mechanism is a **global launch fence** — a counter
+(``prte_dvm_launch_fence``) that tracks the number of in-progress daemon
+launch campaigns.  An app job that reaches the ``VM_READY → MAP`` transition
+checks the fence; if it is nonzero the job parks itself in a held-job array
+(``prte_held_jobs``) and is released when the fence reaches zero.
+
+The state machine is single-threaded on the progress thread, so no locking
+is required anywhere in this plan.
+
+.. note::
+   The app-triggered expansion path (``--add-host`` / ``--add-hostfile``)
+   already sets ``prte_dvm_ready = false`` in ``add_hosts()`` before posting
+   the asynchronous RAS modify request, which causes newly-arriving jobs to be
+   stashed in ``prte_cache`` rather than dispatched immediately.  The launch
+   fence is still required for the scheduler-push path (e.g., Slurm firing
+   ``LAUNCH_DAEMONS`` directly) where ``prte_dvm_ready`` is never cleared, and
+   to ensure full correctness when both paths can interleave.
+
+Step 1 — New state constant
+---------------------------
+
+In ``src/mca/plm/plm_types.h``, add:
+
+.. code-block:: c
+
+   /* value 17 is currently unused in the running-state band */
+   #define PRTE_JOB_STATE_WAITING_FOR_DAEMONS  17
+
+Add a corresponding string to ``src/util/error_strings.c``.
+
+This state is used purely as a marker so that debugging tools and verbose
+output show clearly why a job is parked; no callback is registered for it.
+
+Step 2 — New global fence and held-job arrays
+---------------------------------------------
+
+In ``src/runtime/prte_globals.c`` and ``src/runtime/prte_globals.h``, add:
+
+.. code-block:: c
+
+   /* counts in-progress daemon launch campaigns */
+   int prte_dvm_launch_fence = 0;
+
+   /* jobs parked at the VM_READY → MAP boundary */
+   pmix_pointer_array_t *prte_held_jobs;
+
+   /* jobs parked at the LAUNCH_APPS boundary during a shrink */
+   pmix_pointer_array_t *prte_prelaunch_held_jobs;
+
+Initialize both arrays in ``src/runtime/prte_init.c`` alongside the existing
+``prte_cache`` initialization:
+
+.. code-block:: c
+
+   prte_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+   pmix_pointer_array_init(prte_held_jobs, 1, INT_MAX, 1);
+
+   prte_prelaunch_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+   pmix_pointer_array_init(prte_prelaunch_held_jobs, 1, INT_MAX, 1);
+
+Destruct both in ``src/runtime/prte_finalize.c``.
+
+Step 3 — Increment the fence in setup_virtual_machine
+------------------------------------------------------
+
+In ``src/mca/plm/base/plm_base_launch_support.c``, inside
+``prte_plm_base_setup_virtual_machine()``, the block at line 2380 already
+sets ``PRTE_JOB_LAUNCHED_DAEMONS`` when ``map->num_new_daemons > 0``:
+
+.. code-block:: c
+
+   /* existing code */
+   if (0 < map->num_new_daemons) {
+       rc = prte_set_attribute(&jdata->attributes,
+                               PRTE_JOB_LAUNCHED_DAEMONS, true, NULL, PMIX_BOOL);
+       if (PRTE_SUCCESS != rc) { ... }
+       /* ADD: increment the fence */
+       prte_dvm_launch_fence++;
+   }
+
+This location is reached by all four PLM backends (ssh, slurm, pals, lsf)
+through a single common code path, so a single insertion covers every
+extension scenario.
+
+Both expansion paths ultimately fire ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` on
+the **daemon job** (app-triggered via ``prte_ras_base_complete_request()``;
+scheduler-push directly from the Slurm RAS module), so ``setup_virtual_machine()``
+always operates on the daemon job when an extension is in progress.  The
+``PRTE_JOB_EXTEND_DVM`` attribute is therefore set on the daemon job in both
+cases.
+
+Step 4 — Decrement the fence and release held jobs in vm_ready
+--------------------------------------------------------------
+
+In ``src/mca/state/dvm/state_dvm.c``, ``vm_ready()`` has an outer block
+conditioned on ``PRTE_JOB_LAUNCHED_DAEMONS`` (line 275).  Inside that block,
+a nested ``if (!PRTE_JOB_DO_NOT_LAUNCH && 1 < prte_process_info.num_daemons)``
+block (lines 278–331) sends the nidmap xcast; the outer block closes at
+line 332.
+
+The fence decrement must be placed **just before the closing ``}`` of the
+outer** ``PRTE_JOB_LAUNCHED_DAEMONS`` **block** (between the inner block and
+line 332).  This position is reached by both the xcast path and the
+``DO_NOT_LAUNCH`` / single-daemon path:
+
+.. code-block:: c
+
+   if (prte_get_attribute(...PRTE_JOB_LAUNCHED_DAEMONS...)) {
+       if (!DO_NOT_LAUNCH && 1 < prte_process_info.num_daemons) {
+           /* existing xcast code (lines 283–330) */
+           /* error exits within this block each need:
+            *   prte_dvm_launch_fence--;
+            *   if (0 == prte_dvm_launch_fence)
+            *       prte_plm_base_fence_release(false);
+            * before PRTE_ACTIVATE_JOB_STATE / return          */
+           PMIX_DATA_BUFFER_DESTRUCT(&buf);   /* line 330 */
+       }
+       /* ADD: success path (and DO_NOT_LAUNCH / single-daemon path) */
+       prte_dvm_launch_fence--;
+       if (0 == prte_dvm_launch_fence) {
+           prte_plm_base_fence_release(true);
+       }
+   }   /* line 332 */
+
+Error exits inside the inner block (the ``PRTE_ACTIVATE_JOB_STATE(NULL,
+PRTE_JOB_STATE_FORCED_EXIT)`` branches at lines 288, 302, 310, 317, 327)
+return without reaching the decrement above, so each one must do its own
+decrement + ``prte_plm_base_fence_release(false)`` before returning.
+
+The held jobs re-enter ``vm_ready``; at that point ``PRTE_JOB_LAUNCHED_DAEMONS``
+is not set on them and the fence is zero, so they fall through to the
+``preposition_files → MAP`` path normally.
+
+Step 5 — Park jobs at the VM_READY → MAP boundary
+--------------------------------------------------
+
+In ``vm_ready()``, the code at line 360 is reached only by app jobs (the
+daemon-job branch returns at line 357).  This is immediately before
+``prte_filem.preposition_files()`` which leads to ``files_ready → MAP``.
+Add the hold check here:
+
+.. code-block:: c
+
+   /* position any required files */
+   if (0 < prte_dvm_launch_fence) {
+       /* daemon launch in progress — park this job */
+       caddy->jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
+       PMIX_RETAIN(caddy->jdata);
+       pmix_pointer_array_add(prte_held_jobs, caddy->jdata);
+       PMIX_RELEASE(caddy);
+       return;
+   }
+   if (PRTE_SUCCESS !=
+           prte_filem.preposition_files(caddy->jdata, files_ready, caddy->jdata)) {
+       PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
+   }
+   PMIX_RELEASE(caddy);
+
+Step 6 — Handle daemon launch failure
+--------------------------------------
+
+If daemon launch fails, the normal ``vm_ready`` decrement path is never
+reached.  There are two distinct failure modes, each needing its own guard.
+
+**6a — xcast build/send errors inside** ``vm_ready``
+
+The error-exit paths inside the ``!DO_NOT_LAUNCH`` block (lines 288, 302,
+310, 317, 327) call ``PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT)``
+and return before reaching the common decrement at the bottom of the outer
+block.  Each of these branches must decrement and release explicitly, as
+described in Step 4.
+
+**6b — daemon crash after fence increment, before** ``vm_ready``
+
+A daemon might crash between ``setup_virtual_machine()`` (which increments
+the fence) and the ``DAEMONS_REPORTED → VM_READY`` transition.  In this case
+``vm_ready`` is never reached; the crash is routed to
+``errmgr_dvm.c:proc_errors()``.
+
+In ``src/mca/errmgr/dvm/errmgr_dvm.c``, inside the ``PMIX_CHECK_NSPACE``
+daemon block (line 252), within the ``PRTE_PROC_STATE_COMM_FAILED`` /
+``PRTE_PROC_STATE_HEARTBEAT_FAILED`` handler, add after the "mark daemon as
+gone" logic and before the early ``goto cleanup``:
+
+.. code-block:: c
+
+   /* if a grow campaign was in progress, fail the fence now so
+    * held jobs are not parked indefinitely */
+   if (0 < prte_dvm_launch_fence &&
+       prte_get_attribute(&jdata->attributes,
+                          PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL)) {
+       prte_dvm_launch_fence--;
+       if (0 == prte_dvm_launch_fence) {
+           prte_plm_base_fence_release(false);
+       }
+       /* remove the attribute so a second daemon crash in the same
+        * campaign does not decrement the fence again */
+       prte_remove_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS);
+   }
+
+**6c —** ``check_complete`` **safety net**
+
+If daemon launch fails through ``PRTE_JOB_STATE_TERMINATED`` on the daemon
+job (reached via the errmgr abort path), add a fence check **inside** the
+``if (NULL == jdata || PMIX_CHECK_NSPACE(...))`` block of ``check_complete``
+(line 539), before the early return at line 553:
+
+.. code-block:: c
+
+   if (NULL == jdata || PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
+       /* existing NULL / daemon-count checks ... */
+
+       /* ADD: if the daemon job held the grow fence, release it */
+       if (NULL != jdata &&
+           prte_get_attribute(&jdata->attributes,
+                              PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL) &&
+           0 < prte_dvm_launch_fence) {
+           prte_dvm_launch_fence--;
+           if (0 == prte_dvm_launch_fence) {
+               prte_plm_base_fence_release(false);
+           }
+       }
+       /* existing early return ... */
+
+Note: this block is the only path in ``check_complete`` that is reached by
+the daemon job.  The ``jdata->state > PRTE_JOB_STATE_UNTERMINATED`` check
+at line 566 is not reachable for the daemon job.
+
+----
+
+DVM Shrink Fence
+================
+
+Background
+----------
+
+The ``PRTE_DAEMON_SHRINK_CMD`` xcast is fire-and-forget: daemons exit
+asynchronously and the HNP has no built-in notification when all targeted
+daemons have terminated.  Two race windows must be closed:
+
+**Race 1 — new job maps onto a shrinking node.**  A job that checks the
+``VM_READY → MAP`` fence while a shrink is in progress may pass the fence
+(if it was raised after the check), get mapped to a node whose daemon is
+dying, and then send a launch message to a daemon that has already exited.
+
+**Race 2 — in-flight job at LAUNCH_APPS.**  A job that completed MAP before
+the shrink started and then enters ``prte_plm_base_launch_apps()`` may pack
+and send launch data to a daemon that dies between MAP and the send.  The
+existing VM_READY fence does not protect this window because the job already
+passed the fence before the shrink was initiated.
+
+Race 1 is covered by the existing grow-fence mechanism (the fence is also
+incremented for shrink — see Step 7).  Race 2 requires a second hold point
+guarded by checking the shrink campaign list (nonempty only during shrink)
+so that a concurrent grow does not unnecessarily hold jobs that have already
+been mapped to surviving nodes.
+
+Multiple concurrent shrink campaigns are supported: each campaign tracks its
+own pending-ACK count and is removed from the list when all its targets have
+confirmed exit.
+
+Step 7 — Shrink campaign type, list, and fence increment
+---------------------------------------------------------
+
+**7a — Campaign type**
+
+Add the following type to ``src/runtime/prte_globals.h`` and define the
+class instance in ``src/runtime/prte_globals.c``:
+
+.. code-block:: c
+
+   /* one entry per in-progress shrink campaign */
+   typedef struct {
+       pmix_list_item_t super;
+       pmix_rank_t     *targets;   /* daemon ranks being terminated */
+       int              ntargets;  /* initial count */
+       int              pending;   /* remaining ACKs expected */
+   } prte_shrink_campaign_t;
+   PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
+
+In ``src/runtime/prte_globals.c``:
+
+.. code-block:: c
+
+   static void campaign_destruct(prte_shrink_campaign_t *p)
+   {
+       free(p->targets);
+   }
+   PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
+                       NULL, campaign_destruct);
+
+**7b — Global list**
+
+In ``src/runtime/prte_globals.h`` declare, and in ``src/runtime/prte_globals.c``
+define:
+
+.. code-block:: c
+
+   pmix_list_t prte_shrink_campaigns;
+
+Initialize in ``src/runtime/prte_init.c``:
+
+.. code-block:: c
+
+   PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t);
+
+Destruct in ``src/runtime/prte_finalize.c``:
+
+.. code-block:: c
+
+   PMIX_LIST_DESTRUCT(&prte_shrink_campaigns);
+
+**7c — Populate campaign and increment fence**
+
+In ``src/mca/ras/base/ras_base_allocate.c``, the ``PMIX_ALLOC_RELEASE``
+branch of ``prte_ras_base_complete_request()`` builds the daemon rank array
+(``ranks``, count ``m``) and then calls ``free(ranks)`` at line 760 before
+the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
+(between lines 758 and 760):
+
+.. code-block:: c
+
+   /* record the campaign — must be before free(ranks) */
+   {
+       prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
+       _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
+       memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
+       _camp->ntargets = m;
+       _camp->pending  = m;
+       pmix_list_append(&prte_shrink_campaigns, &_camp->super);
+       prte_dvm_launch_fence += m;
+   }
+   free(ranks);   /* existing line 760 */
+
+   /* existing xcast */
+   if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+       /* clean up the campaign we just added */
+       prte_shrink_campaign_t *_camp =
+           (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
+       prte_dvm_launch_fence -= _camp->pending;
+       PMIX_RELEASE(_camp);
+       PRTE_ERROR_LOG(rc);
+   }
+
+Because the campaign is appended before the xcast, any ``VM_READY`` event
+that fires on the progress thread after this point will see a nonzero fence
+and park the job.
+
+Step 8 — Daemon shrink acknowledgement
+---------------------------------------
+
+A daemon that decides to exit in response to ``PRTE_DAEMON_SHRINK_CMD``
+must send an acknowledgement to the HNP **before** it activates
+``PRTE_JOB_STATE_DAEMONS_TERMINATED``, so the HNP can track completions.
+
+Add a new PLM command constant in ``src/mca/plm/plm_types.h``:
+
+.. code-block:: c
+
+   #define PRTE_PLM_SHRINK_ACK_CMD  7   /* daemon → HNP: I am exiting due to shrink */
+
+In ``src/prted/prted_comm.c``, in the ``PRTE_DAEMON_SHRINK_CMD`` handler
+(line 469), after ``PRTE_PMIX_WAIT_THREAD(&lk)`` completes the
+``PMIX_EVENT_JOB_END`` notification but *before*
+``PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED)``,
+insert:
+
+.. code-block:: c
+
+   {
+       pmix_data_buffer_t _ack;
+       prte_plm_cmd_flag_t _cmd = PRTE_PLM_SHRINK_ACK_CMD;
+       pmix_rank_t _myrank = PRTE_PROC_MY_NAME->rank;
+       PMIX_DATA_BUFFER_CONSTRUCT(&_ack);
+       PMIx_Data_pack(NULL, &_ack, &_cmd, 1, PMIX_UINT8);
+       PMIx_Data_pack(NULL, &_ack, &_myrank, 1, PMIX_PROC_RANK);
+       prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, &_ack,
+                               PRTE_RML_TAG_PLM,
+                               prte_rml_send_callback, NULL);
+   }
+
+The rank is packed so the HNP can match the ACK to the correct campaign
+entry.  The send is non-blocking; the daemon proceeds to shut down
+immediately after posting it.
+
+Step 9 — Second hold point at LAUNCH_APPS
+------------------------------------------
+
+In ``src/mca/plm/base/plm_base_launch_support.c``,
+``prte_plm_base_launch_apps()`` (line 817), add a check after the job-state
+guard but before packing any data:
+
+.. code-block:: c
+
+   /* if a shrink is in progress, hold this job until all targeted
+    * daemons have confirmed exit, to prevent sending launch data to
+    * a dying daemon */
+   if (!pmix_list_is_empty(&prte_shrink_campaigns)) {
+       jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
+       PMIX_RETAIN(jdata);
+       pmix_pointer_array_add(prte_prelaunch_held_jobs, jdata);
+       PMIX_RELEASE(caddy);
+       return;
+   }
+
+Using ``!pmix_list_is_empty(...)`` rather than a counter means the check
+automatically handles concurrent campaigns: the list is nonempty as long as
+any shrink is in progress.
+
+Step 10 — Fence-release helper
+--------------------------------
+
+Both grow completion (``vm_ready``) and shrink ACK receipt decrement the
+fence and, when it hits zero, must release two classes of held jobs.
+Extract this logic into a single helper declared in
+``src/mca/plm/base/plm_base_launch_support.h`` and defined in
+``plm_base_launch_support.c``:
+
+.. code-block:: c
+
+   void prte_plm_base_fence_release(bool success)
+   {
+       int _hi;
+       prte_job_t *_held;
+
+       /* --- pre-map held jobs (parked at VM_READY) --- */
+       for (_hi = 0; _hi < prte_held_jobs->size; _hi++) {
+           _held = (prte_job_t *)
+               pmix_pointer_array_get_item(prte_held_jobs, _hi);
+           if (NULL == _held) continue;
+           pmix_pointer_array_set_item(prte_held_jobs, _hi, NULL);
+           PRTE_ACTIVATE_JOB_STATE(_held,
+               success ? PRTE_JOB_STATE_VM_READY
+                       : PRTE_JOB_STATE_NEVER_LAUNCHED);
+           PMIX_RELEASE(_held);
+       }
+
+       /* --- pre-launch held jobs (parked at LAUNCH_APPS) --- */
+       for (_hi = 0; _hi < prte_prelaunch_held_jobs->size; _hi++) {
+           _held = (prte_job_t *)
+               pmix_pointer_array_get_item(prte_prelaunch_held_jobs, _hi);
+           if (NULL == _held) continue;
+           pmix_pointer_array_set_item(prte_prelaunch_held_jobs, _hi, NULL);
+           if (!success) {
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_NEVER_LAUNCHED);
+           } else if (prte_plm_base_job_needs_remap(_held)) {
+               prte_plm_base_reset_proc_map(_held);
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_MAP);
+           } else {
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_LAUNCH_APPS);
+           }
+           PMIX_RELEASE(_held);
+       }
+
+       /* campaigns are removed individually as their last ACK arrives;
+        * the list should be empty here, but do a safety sweep */
+       prte_shrink_campaign_t *_camp, *_next;
+       PMIX_LIST_FOREACH_SAFE(_camp, _next,
+                              &prte_shrink_campaigns, prte_shrink_campaign_t) {
+           pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
+           PMIX_RELEASE(_camp);
+       }
+   }
+
+**``prte_plm_base_job_needs_remap(jdata)``** iterates over ``jdata->procs``
+and returns ``true`` if any proc's assigned node has a daemon rank appearing
+in any active campaign:
+
+.. code-block:: c
+
+   bool prte_plm_base_job_needs_remap(prte_job_t *jdata)
+   {
+       prte_shrink_campaign_t *camp;
+       prte_proc_t *proc;
+       int p, t;
+
+       PMIX_LIST_FOREACH(camp, &prte_shrink_campaigns, prte_shrink_campaign_t) {
+           for (p = 0; p < jdata->procs->size; p++) {
+               proc = (prte_proc_t *)
+                   pmix_pointer_array_get_item(jdata->procs, p);
+               if (NULL == proc || NULL == proc->node ||
+                   NULL == proc->node->daemon) continue;
+               for (t = 0; t < camp->ntargets; t++) {
+                   if (camp->targets[t] == proc->node->daemon->name.rank) {
+                       return true;
+                   }
+               }
+           }
+       }
+       return false;
+   }
+
+**``prte_plm_base_reset_proc_map(jdata)``** un-claims all slot assignments
+made during the previous MAP pass so that the job can be remapped cleanly.
+Mirror the mapper's ``prte_rmaps_base_claim_slot()`` accounting, which does
+``node->num_procs++`` and ``++node->slots_inuse`` for each non-tool proc:
+
+.. code-block:: c
+
+   void prte_plm_base_reset_proc_map(prte_job_t *jdata)
+   {
+       int p, np;
+       prte_proc_t *proc;
+       prte_node_t *node;
+       prte_app_context_t *app;
+
+       for (p = 0; p < jdata->procs->size; p++) {
+           proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, p);
+           if (NULL == proc) continue;
+           node = proc->node;
+           if (NULL != node) {
+               /* remove from node's proc list */
+               for (np = 0; np < node->procs->size; np++) {
+                   if (pmix_pointer_array_get_item(node->procs, np) == proc) {
+                       pmix_pointer_array_set_item(node->procs, np, NULL);
+                       node->num_procs--;
+                       /* mirror claim_slot: tool procs do not count
+                        * against slots_inuse */
+                       app = (prte_app_context_t *)
+                           pmix_pointer_array_get_item(jdata->apps,
+                                                       proc->app_idx);
+                       if (NULL == app ||
+                           !PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
+                           node->slots_inuse--;
+                       }
+                       break;
+                   }
+               }
+           }
+           pmix_pointer_array_set_item(jdata->procs, p, NULL);
+           PMIX_RELEASE(proc);
+       }
+       jdata->num_procs = 0;
+       jdata->num_launched = 0;
+   }
+
+After remapping, the job re-enters ``prte_rmaps_base_map_job()`` which
+re-creates proc objects on the surviving nodes using the original
+``app->num_procs`` counts.
+
+Step 11 — Handle PRTE_PLM_SHRINK_ACK_CMD in plm_base_receive.c
+----------------------------------------------------------------
+
+In ``src/mca/plm/base/plm_base_receive.c``, add a case to the PLM receive
+switch (alongside ``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD``, etc.).  The ACK
+message carries the sending daemon's rank (packed by Step 8); unpack it to
+locate and update the correct campaign:
+
+.. code-block:: c
+
+   case PRTE_PLM_SHRINK_ACK_CMD: {
+       pmix_rank_t _drank;
+       size_t _n = 1;
+       prte_shrink_campaign_t *_camp;
+       int _t;
+
+       if (PMIX_SUCCESS !=
+               PMIx_Data_unpack(NULL, buffer, &_drank, &_n, PMIX_PROC_RANK)) {
+           PRTE_ERROR_LOG(PRTE_ERR_UNPACK_FAILURE);
+           break;
+       }
+       PMIX_LIST_FOREACH(_camp, &prte_shrink_campaigns,
+                         prte_shrink_campaign_t) {
+           for (_t = 0; _t < _camp->ntargets; _t++) {
+               if (_camp->targets[_t] != _drank) continue;
+               _camp->pending--;
+               prte_dvm_launch_fence--;
+               if (0 == _camp->pending) {
+                   pmix_list_remove_item(&prte_shrink_campaigns,
+                                        &_camp->super);
+                   PMIX_RELEASE(_camp);
+               }
+               if (0 == prte_dvm_launch_fence) {
+                   prte_plm_base_fence_release(true);
+               }
+               goto shrink_ack_done;
+           }
+       }
+       /* rank not found in any campaign — log and ignore */
+       PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                            "%s shrink ACK from unknown daemon %lu",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            (unsigned long) _drank));
+       shrink_ack_done:
+       break;
+   }
+
+Because the progress thread is single-threaded, the counter decrements and
+the list manipulation are atomic with respect to all other state machine
+callbacks.
+
+Step 12 — Errmgr fallback for crashed shrink daemons
+-----------------------------------------------------
+
+A daemon might crash before it can send ``PRTE_PLM_SHRINK_ACK_CMD``.
+Without a fallback, the fence would remain nonzero and held jobs would park
+indefinitely.
+
+In ``src/mca/errmgr/dvm/errmgr_dvm.c``, inside the ``PMIX_CHECK_NSPACE``
+daemon-proc block of ``proc_errors()`` (line 252), within the
+``PRTE_PROC_STATE_COMM_FAILED`` / heartbeat-failed handler, add after the
+"mark daemon as gone" logic:
+
+.. code-block:: c
+
+   /* check if this daemon was a pending shrink target */
+   {
+       prte_shrink_campaign_t *_camp, *_next;
+       int _t;
+       PMIX_LIST_FOREACH_SAFE(_camp, _next,
+                              &prte_shrink_campaigns, prte_shrink_campaign_t) {
+           for (_t = 0; _t < _camp->ntargets; _t++) {
+               if (_camp->targets[_t] != proc->rank) continue;
+               _camp->pending--;
+               prte_dvm_launch_fence--;
+               if (0 == _camp->pending) {
+                   pmix_list_remove_item(&prte_shrink_campaigns,
+                                        &_camp->super);
+                   PMIX_RELEASE(_camp);
+               }
+               if (0 == prte_dvm_launch_fence) {
+                   prte_plm_base_fence_release(true);
+               }
+               goto errmgr_shrink_done;
+           }
+       }
+       errmgr_shrink_done: ;
+   }
+
+This ensures that a daemon crash during a shrink does not permanently stall
+held jobs.  The node was being removed anyway; jobs that were mapped to it
+will be detected by ``prte_plm_base_job_needs_remap()`` and re-routed to
+surviving nodes.
+
+Summary of Files Changed (Shrink Fence)
+-----------------------------------------
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - File
+     - Change
+   * - ``src/mca/plm/plm_types.h``
+     - Add ``PRTE_PLM_SHRINK_ACK_CMD = 7``.
+   * - ``src/runtime/prte_globals.h``
+     - Declare ``prte_shrink_campaign_t`` (type + ``PMIX_CLASS_DECLARATION``)
+       and ``prte_shrink_campaigns`` (``pmix_list_t``).
+   * - ``src/runtime/prte_globals.c``
+     - Define ``PMIX_CLASS_INSTANCE`` for ``prte_shrink_campaign_t``
+       (destructor frees ``targets``).  Define ``prte_shrink_campaigns``.
+   * - ``src/runtime/prte_init.c``
+     - ``PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t)`` alongside
+       ``prte_held_jobs`` initialization.
+   * - ``src/runtime/prte_finalize.c``
+     - ``PMIX_LIST_DESTRUCT(&prte_shrink_campaigns)``.
+   * - ``src/mca/ras/base/ras_base_allocate.c``
+     - In ``PMIX_ALLOC_RELEASE`` branch of
+       ``prte_ras_base_complete_request()``: create a ``prte_shrink_campaign_t``,
+       copy the rank array into it, append to ``prte_shrink_campaigns``, and
+       increment ``prte_dvm_launch_fence`` by ``m`` — all before
+       ``free(ranks)``.  Add xcast-failure cleanup that removes the campaign
+       and decrements the fence.
+   * - ``src/prted/prted_comm.c``
+     - In ``PRTE_DAEMON_SHRINK_CMD`` handler: after the ``JOB_END``
+       notification wait, pack ``PRTE_PLM_SHRINK_ACK_CMD`` and
+       ``PRTE_PROC_MY_NAME->rank`` into a message and send to HNP on
+       ``PRTE_RML_TAG_PLM`` before activating
+       ``PRTE_JOB_STATE_DAEMONS_TERMINATED``.
+   * - ``src/mca/plm/base/plm_base_launch_support.c``
+     - Add ``prte_plm_base_fence_release()``,
+       ``prte_plm_base_job_needs_remap()``, and
+       ``prte_plm_base_reset_proc_map()``.
+       Add hold check in ``prte_plm_base_launch_apps()`` on
+       ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
+   * - ``src/mca/plm/base/plm_base_launch_support.h``
+     - Declare the three new functions.
+   * - ``src/mca/plm/base/plm_base_receive.c``
+     - Handle ``PRTE_PLM_SHRINK_ACK_CMD``: unpack sender rank, find the
+       owning campaign, decrement per-campaign ``pending`` and
+       ``prte_dvm_launch_fence``; remove campaign when ``pending`` hits zero;
+       call ``prte_plm_base_fence_release(true)`` when fence hits zero.
+   * - ``src/mca/state/dvm/state_dvm.c``
+     - Replace inline release loop in ``vm_ready`` and ``check_complete``
+       with calls to ``prte_plm_base_fence_release()``.
+   * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
+     - In ``proc_errors()``, daemon-comm-failure block: search
+       ``prte_shrink_campaigns`` for the dead daemon's rank; if found,
+       decrement campaign ``pending`` and fence; remove campaign when
+       ``pending`` hits zero; call ``prte_plm_base_fence_release(true)``
+       when fence hits zero.
+
+Summary of Files Changed (Grow Fence)
+--------------------------------------
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - File
+     - Change
+   * - ``src/mca/plm/plm_types.h``
+     - Add ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS = 17``.
+   * - ``src/util/error_strings.c``
+     - Add string for ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS``.
+   * - ``src/runtime/prte_globals.h``
+     - Declare ``prte_dvm_launch_fence``, ``prte_held_jobs``, and
+       ``prte_prelaunch_held_jobs``.
+   * - ``src/runtime/prte_globals.c``
+     - Define and initialize ``prte_dvm_launch_fence = 0``.
+   * - ``src/runtime/prte_init.c``
+     - Allocate and init ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
+   * - ``src/runtime/prte_finalize.c``
+     - Destruct ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
+   * - ``src/mca/plm/base/plm_base_launch_support.c``
+     - Increment ``prte_dvm_launch_fence`` in the
+       ``0 < map->num_new_daemons`` block at the end of
+       ``prte_plm_base_setup_virtual_machine()``.
+       Declare and define ``prte_plm_base_fence_release()`` (Step 10).
+   * - ``src/mca/state/dvm/state_dvm.c``
+     - In ``vm_ready``: (a) decrement fence and call
+       ``prte_plm_base_fence_release(true)`` at the bottom of the outer
+       ``PRTE_JOB_LAUNCHED_DAEMONS`` block; (b) call
+       ``prte_plm_base_fence_release(false)`` in all inner error-exit paths;
+       (c) add hold-check before ``preposition_files``.
+       In ``check_complete``: call ``prte_plm_base_fence_release(false)``
+       inside the ``PMIX_CHECK_NSPACE`` daemon block when a job with
+       ``PRTE_JOB_LAUNCHED_DAEMONS`` terminates abnormally.
+   * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
+     - In ``proc_errors()``, daemon-comm-failure block: if
+       ``prte_dvm_launch_fence > 0`` and ``PRTE_JOB_LAUNCHED_DAEMONS`` is
+       set on the daemon job, decrement fence and call
+       ``prte_plm_base_fence_release(false)`` if fence hits zero; then
+       remove ``PRTE_JOB_LAUNCHED_DAEMONS`` to prevent double-decrement.
+
+Design Invariants
+-----------------
+
+**Grow fence**
+
+* The fence counter and both held-job arrays are only accessed on the PRRTE
+  progress thread, so no locking is required anywhere.
+* The grow contribution to ``prte_dvm_launch_fence`` is incremented exactly
+  once per daemon launch campaign in ``setup_virtual_machine()``, which all
+  PLM backends call.  Symmetric decrement is at the bottom of the outer
+  ``PRTE_JOB_LAUNCHED_DAEMONS`` block in ``vm_ready`` (success or
+  ``DO_NOT_LAUNCH`` path), in each inner error-exit branch of ``vm_ready``
+  (failure), in the ``check_complete`` daemon block (late failure), and in
+  ``errmgr_dvm.c:proc_errors()`` (daemon crash during launch).
+* After ``prte_remove_attribute(...PRTE_JOB_LAUNCHED_DAEMONS...)`` is called
+  in the errmgr crash path, subsequent crashes in the same campaign do not
+  double-decrement the fence.
+* Jobs in ``prte_held_jobs`` hold a ``PMIX_RETAIN`` reference; the release
+  loop in ``prte_plm_base_fence_release()`` performs the matching
+  ``PMIX_RELEASE``.
+* Jobs already past ``MAP`` when a grow starts are unaffected: they were
+  mapped to existing nodes whose daemons are already running.
+
+**Shrink fence**
+
+* ``prte_shrink_campaigns`` is a ``pmix_list_t``; each entry covers exactly
+  one ``PMIX_ALLOC_RELEASE`` request.  Multiple concurrent shrink campaigns
+  are supported.
+* The fence is incremented by exactly ``m`` at campaign creation and
+  decremented by 1 for each ``PRTE_PLM_SHRINK_ACK_CMD`` received or for
+  each crash detected in the errmgr fallback.  A campaign is removed from
+  the list when its ``pending`` count reaches zero.
+* The ``LAUNCH_APPS`` hold uses ``!pmix_list_is_empty(&prte_shrink_campaigns)``,
+  not ``prte_dvm_launch_fence > 0``, so a concurrent grow does not stall
+  already-mapped jobs on surviving nodes.
+* ``prte_shrink_campaigns`` is stable throughout each campaign: the targets
+  array for a given campaign is valid from creation through removal, so
+  ``prte_plm_base_job_needs_remap()`` can safely iterate it during release.
+* Jobs in ``prte_prelaunch_held_jobs`` hold a ``PMIX_RETAIN`` reference;
+  ``prte_plm_base_fence_release()`` releases it after re-activating or
+  aborting the job.
+* ``prte_plm_base_fence_release()`` is called only when
+  ``prte_dvm_launch_fence`` reaches zero, which requires all grow campaigns
+  and all shrink campaigns to have completed.  The campaign list is therefore
+  empty (or nearly so — the safety sweep in ``fence_release`` handles the
+  degenerate case where an xcast failure left a partially-setup campaign).

--- a/docs/plans/elastic_dvm/dvm_launch_fence.rst
+++ b/docs/plans/elastic_dvm/dvm_launch_fence.rst
@@ -677,3 +677,64 @@ unaffected.  All access is on the progress thread, so no locking is required.
   and all shrink campaigns to have completed.  The campaign list is therefore
   empty (or nearly so — the safety sweep in ``fence_release`` handles the
   degenerate case where an xcast failure left a partially-setup campaign).
+
+Follow-up — collective shrink completion
+-----------------------------------------
+
+The shrink design above drains a campaign **one daemon at a time**: every
+targeted daemon exits on its own and the HNP discovers each departure
+independently through the errmgr comm-failure path (Step 11), decrementing the
+campaign's ``pending`` count and the fence once per death.  This is correct,
+but each individual departure drives a separate routing-tree repair —
+``prte_rml_repair_routing_tree()`` runs ``handle_promotion()`` and
+``update_descendants()`` for that single rank.  Shrinking ``m`` daemons that
+sit along one branch of the radix routing tree therefore triggers up to ``m``
+sequential promotions/descendant rewrites, which review of PR `#2472
+<https://github.com/openpmix/prrte/pull/2472>`_ flagged as potentially
+expensive for a large shrink (unprofiled).
+
+A **collective** completion scheme would repair the tree once per campaign
+instead of once per daemon:
+
+#. Broadcast the ``PRTE_DAEMON_SHRINK_CMD`` as today.
+#. Each targeted daemon records that it is leaving and does any local
+   processing, but **does not exit yet**.
+#. The HNP hooks the *broadcast's* completion.  The reliable xcast in
+   ``src/mca/grpcomm/direct/grpcomm_direct_xcast.c`` already tracks completion
+   via ACKs flowing up the tree (``finish_op`` on the master means every daemon
+   received the op); a per-op completion callback would be added, or the shrink
+   xcast special-cased, to fire a handler at that point.
+#. That handler reports **all** of the campaign's targets as failed in a single
+   batch via ``prte_rml_repair_routing_tree(failed_ranks, /*global=*/false)``,
+   which already accepts a rank array and performs one promotion/descendant
+   pass for the whole set (``src/rml/routed_radix.c``).
+#. Each doomed daemon exits once its lifeline disconnects — driven by the batch
+   failure report — rather than self-exiting.
+
+This is **not** the per-daemon acknowledgement that the
+*Design Decision — Complete on Death, Not on Acknowledgement* section above
+rejected.  That ACK announced a daemon's *intent* to leave and, acted upon,
+would have released held jobs while the HNP still believed the daemon present.
+Here the authoritative HNP-side teardown (route removal, ``num_daemons``, node
+state) still happens at the batch failure report, and held jobs are released
+only after it — so the invariant "act once teardown has occurred, not on
+intent" is preserved.  The doomed daemons exiting slightly later is harmless:
+they are already excluded from routing and mapping, so released jobs remap onto
+survivors correctly.  Completion would collapse to a single event per campaign,
+which also retires the per-rank ``PMIX_RANK_INVALID`` idempotency stamping and
+the double-count analysis that the per-death path requires.
+
+This is an **optimization, not a correctness fix**, so it is deliberately
+deferred out of the launch-fence work:
+
+* It needs a new xcast-completion callback hook (or a shrink special case).
+* It moves the daemon-side ``PRTE_DAEMON_SHRINK_CMD`` handler from self-exit to
+  record-and-wait-for-lifeline.
+* It moves the fence-completion trigger from the errmgr comm-failure path to the
+  batch-repair callback, and must verify that all daemon-loss bookkeeping that
+  currently rides on the comm-failure event still runs when the loss is
+  declared proactively.
+* The collective / whole-branch failure path is far less exercised than
+  individual daemon deaths and may surface bugs in the tree-repair and
+  fault-handling code, so it warrants validation against large multi-daemon and
+  single-branch shrinks.

--- a/docs/plans/elastic_dvm/dvm_launch_fence.rst
+++ b/docs/plans/elastic_dvm/dvm_launch_fence.rst
@@ -266,8 +266,60 @@ so that a concurrent grow does not unnecessarily hold jobs that have already
 been mapped to surviving nodes.
 
 Multiple concurrent shrink campaigns are supported: each campaign tracks its
-own pending-ACK count and is removed from the list when all its targets have
-confirmed exit.
+own count of still-living targets and is removed from the list when all of
+them have departed the DVM.
+
+Design Decision — Complete on Death, Not on Acknowledgement
+-----------------------------------------------------------
+
+An earlier revision of this plan had each targeted daemon send an explicit
+``PRTE_PLM_SHRINK_ACK_CMD`` to the HNP just before it exited, and the HNP
+decremented the campaign on *receipt of the ACK*.  The errmgr comm-failure
+path existed only as a *fallback* for a daemon that crashed before it could
+send its ACK.  That design was abandoned for the following reasons.
+
+**The ACK is the wrong signal.**  An ACK announces a daemon's *intent* to
+leave; it is sent while the daemon is still alive and still a participant in
+the DVM.  But the state the fence protects against — a job being mapped onto,
+or having launch data sent to, a departing daemon — is only safe once the
+daemon's routes, its ``num_daemons`` count, and its node state have actually
+been torn down.  That teardown happens on the comm-failure path
+(``errmgr_dvm.c``), *not* when the ACK is sent.  Releasing held jobs on ACK
+receipt could therefore unpark them into a DVM that still believed the
+departing daemon was present.
+
+**The reason for departure carries no information.**  The HNP only needs to
+know that a target is gone, not *why*.  A clean shrink exit and a crash have
+identical consequences for the campaign: the node is being removed either
+way, and the application processes beneath the daemon are killed (or die)
+when it terminates.  Distinguishing the two cases buys nothing, so the
+"clean ACK vs. crash fallback" split was pure complexity.
+
+**Two decrement paths caused double-counting.**  With both the ACK handler
+and the errmgr fallback live, each target could be counted twice — once when
+its ACK arrived (daemon still alive) and again when its subsequent death was
+detected — because nothing marked a target as already counted and the
+campaign was only removed once ``pending`` hit zero.  Worked through for a
+two-target campaign:
+
+.. code-block:: text
+
+   camp: ntargets=2, pending=2
+     daemon A acks   -> pending=1, fence-=1     (A still alive)
+     daemon A dies   -> errmgr matches A (still in targets, camp still listed)
+                     -> pending=0 -> camp removed+released, fence-=1
+     daemon B        -> never counted; campaign already "complete"
+
+The campaign completed and the fence released while daemon B was still
+present, re-opening exactly the race the fence was meant to close.
+
+**Resolution.**  The ACK was removed entirely (the daemon-side send, the
+``PRTE_PLM_SHRINK_ACK_CMD`` constant, and the HNP-side handler).  Campaign
+completion is driven solely by actual daemon departure on the comm-failure
+path, which is both the authoritative event and the point at which the
+relevant cleanup has occurred.  To make the single decrement idempotent
+against a daemon that emits more than one failure event, each matched target
+slot is stamped ``PMIX_RANK_INVALID`` once counted (Step 11).
 
 Step 7 — Shrink campaign type, list, and fence increment
 ---------------------------------------------------------
@@ -284,7 +336,7 @@ class instance in ``src/runtime/prte_globals.c``:
        pmix_list_item_t super;
        pmix_rank_t     *targets;   /* daemon ranks being terminated */
        int              ntargets;  /* initial count */
-       int              pending;   /* remaining ACKs expected */
+       int              pending;   /* targets not yet known to have departed */
    } prte_shrink_campaign_t;
    PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 
@@ -356,42 +408,24 @@ Because the campaign is appended before the xcast, any ``VM_READY`` event
 that fires on the progress thread after this point will see a nonzero fence
 and park the job.
 
-Step 8 — Daemon shrink acknowledgement
----------------------------------------
+Step 8 — Daemon exit (no acknowledgement)
+------------------------------------------
 
 A daemon that decides to exit in response to ``PRTE_DAEMON_SHRINK_CMD``
-must send an acknowledgement to the HNP **before** it activates
-``PRTE_JOB_STATE_DAEMONS_TERMINATED``, so the HNP can track completions.
+does **not** send any acknowledgement to the HNP.  After firing its
+``PMIX_EVENT_JOB_END`` notification it simply activates
+``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and exits.
 
-Add a new PLM command constant in ``src/mca/plm/plm_types.h``:
-
-.. code-block:: c
-
-   #define PRTE_PLM_SHRINK_ACK_CMD  7   /* daemon → HNP: I am exiting due to shrink */
-
-In ``src/prted/prted_comm.c``, in the ``PRTE_DAEMON_SHRINK_CMD`` handler
-(line 469), after ``PRTE_PMIX_WAIT_THREAD(&lk)`` completes the
-``PMIX_EVENT_JOB_END`` notification but *before*
-``PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED)``,
-insert:
-
-.. code-block:: c
-
-   {
-       pmix_data_buffer_t _ack;
-       prte_plm_cmd_flag_t _cmd = PRTE_PLM_SHRINK_ACK_CMD;
-       pmix_rank_t _myrank = PRTE_PROC_MY_NAME->rank;
-       PMIX_DATA_BUFFER_CONSTRUCT(&_ack);
-       PMIx_Data_pack(NULL, &_ack, &_cmd, 1, PMIX_UINT8);
-       PMIx_Data_pack(NULL, &_ack, &_myrank, 1, PMIX_PROC_RANK);
-       prte_rml.send_buffer_nb(PRTE_PROC_MY_HNP, &_ack,
-                               PRTE_RML_TAG_PLM,
-                               prte_rml_send_callback, NULL);
-   }
-
-The rank is packed so the HNP can match the ACK to the correct campaign
-entry.  The send is non-blocking; the daemon proceeds to shut down
-immediately after posting it.
+The HNP tracks campaign completion through the daemon's *actual departure*,
+not through a message announcing its intent to leave.  An acknowledgement
+sent before the daemon dies would be premature: the HNP cares only that the
+daemon is gone — the reason is irrelevant, and the application processes
+under it are killed when it terminates regardless.  More importantly, the
+acknowledgement would arrive *before* the daemon's routes, ``num_daemons``
+count, and node state have been torn down, so acting on it could release
+held jobs into a DVM that still believes the departing daemon is present.
+The comm-failure event (Step 12) is the only signal that coincides with that
+cleanup, so it is the sole completion trigger.
 
 Step 9 — Second hold point at LAUNCH_APPS
 ------------------------------------------
@@ -403,7 +437,7 @@ guard but before packing any data:
 .. code-block:: c
 
    /* if a shrink is in progress, hold this job until all targeted
-    * daemons have confirmed exit, to prevent sending launch data to
+    * daemons have departed the DVM, to prevent sending launch data to
     * a dying daemon */
    if (!pmix_list_is_empty(&prte_shrink_campaigns)) {
        jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
@@ -420,8 +454,9 @@ any shrink is in progress.
 Step 10 — Fence-release helper
 --------------------------------
 
-Both grow completion (``vm_ready``) and shrink ACK receipt decrement the
-fence and, when it hits zero, must release two classes of held jobs.
+Both grow completion (``vm_ready``) and shrink target departure (detected in
+the errmgr) decrement the fence and, when it hits zero, must release two
+classes of held jobs.
 Extract this logic into a single helper declared in
 ``src/mca/plm/base/plm_base_launch_support.h`` and defined in
 ``plm_base_launch_support.c``:
@@ -462,7 +497,7 @@ Extract this logic into a single helper declared in
            PMIX_RELEASE(_held);
        }
 
-       /* campaigns are removed individually as their last ACK arrives;
+       /* campaigns are removed individually as their last target dies;
         * the list should be empty here, but do a safety sweep */
        prte_shrink_campaign_t *_camp, *_next;
        PMIX_LIST_FOREACH_SAFE(_camp, _next,
@@ -548,63 +583,15 @@ After remapping, the job re-enters ``prte_rmaps_base_map_job()`` which
 re-creates proc objects on the surviving nodes using the original
 ``app->num_procs`` counts.
 
-Step 11 — Handle PRTE_PLM_SHRINK_ACK_CMD in plm_base_receive.c
-----------------------------------------------------------------
+Step 11 — Detect target departure in the errmgr
+-------------------------------------------------
 
-In ``src/mca/plm/base/plm_base_receive.c``, add a case to the PLM receive
-switch (alongside ``PRTE_PLM_LOCAL_LAUNCH_COMP_CMD``, etc.).  The ACK
-message carries the sending daemon's rank (packed by Step 8); unpack it to
-locate and update the correct campaign:
-
-.. code-block:: c
-
-   case PRTE_PLM_SHRINK_ACK_CMD: {
-       pmix_rank_t _drank;
-       size_t _n = 1;
-       prte_shrink_campaign_t *_camp;
-       int _t;
-
-       if (PMIX_SUCCESS !=
-               PMIx_Data_unpack(NULL, buffer, &_drank, &_n, PMIX_PROC_RANK)) {
-           PRTE_ERROR_LOG(PRTE_ERR_UNPACK_FAILURE);
-           break;
-       }
-       PMIX_LIST_FOREACH(_camp, &prte_shrink_campaigns,
-                         prte_shrink_campaign_t) {
-           for (_t = 0; _t < _camp->ntargets; _t++) {
-               if (_camp->targets[_t] != _drank) continue;
-               _camp->pending--;
-               prte_dvm_launch_fence--;
-               if (0 == _camp->pending) {
-                   pmix_list_remove_item(&prte_shrink_campaigns,
-                                        &_camp->super);
-                   PMIX_RELEASE(_camp);
-               }
-               if (0 == prte_dvm_launch_fence) {
-                   prte_plm_base_fence_release(true);
-               }
-               goto shrink_ack_done;
-           }
-       }
-       /* rank not found in any campaign — log and ignore */
-       PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                            "%s shrink ACK from unknown daemon %lu",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                            (unsigned long) _drank));
-       shrink_ack_done:
-       break;
-   }
-
-Because the progress thread is single-threaded, the counter decrements and
-the list manipulation are atomic with respect to all other state machine
-callbacks.
-
-Step 12 — Errmgr fallback for crashed shrink daemons
------------------------------------------------------
-
-A daemon might crash before it can send ``PRTE_PLM_SHRINK_ACK_CMD``.
-Without a fallback, the fence would remain nonzero and held jobs would park
-indefinitely.
+Campaign completion is driven entirely by the daemon-loss path: when a
+targeted daemon leaves the DVM, the HNP's comm-failure handler matches its
+rank against the active campaigns and drives the fence down.  This is the
+same event whether the daemon exited cleanly in response to the shrink
+command or crashed, so a single code path covers both — there is no separate
+"acknowledgement" message and no fallback to reconcile.
 
 In ``src/mca/errmgr/dvm/errmgr_dvm.c``, inside the ``PMIX_CHECK_NSPACE``
 daemon-proc block of ``proc_errors()`` (line 252), within the
@@ -621,6 +608,9 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
                               &prte_shrink_campaigns, prte_shrink_campaign_t) {
            for (_t = 0; _t < _camp->ntargets; _t++) {
                if (_camp->targets[_t] != proc->rank) continue;
+               /* stamp this slot so a repeated comm event for the same
+                * daemon cannot decrement the campaign twice */
+               _camp->targets[_t] = PMIX_RANK_INVALID;
                _camp->pending--;
                prte_dvm_launch_fence--;
                if (0 == _camp->pending) {
@@ -637,10 +627,14 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
        errmgr_shrink_done: ;
    }
 
-This ensures that a daemon crash during a shrink does not permanently stall
-held jobs.  The node was being removed anyway; jobs that were mapped to it
-will be detected by ``prte_plm_base_job_needs_remap()`` and re-routed to
-surviving nodes.
+Because the progress thread is single-threaded, the counter decrements and
+the list manipulation are atomic with respect to all other state machine
+callbacks.  Stamping the matched slot ``PMIX_RANK_INVALID`` makes the
+decrement idempotent: should the daemon generate more than one failure event,
+only the first is counted.  A daemon that crashes during a shrink is handled
+identically to one that exits cleanly — the node was being removed anyway,
+and jobs mapped to it are detected by ``prte_plm_base_job_needs_remap()`` and
+re-routed to surviving nodes.
 
 Summary of Files Changed (Shrink Fence)
 -----------------------------------------
@@ -651,8 +645,6 @@ Summary of Files Changed (Shrink Fence)
 
    * - File
      - Change
-   * - ``src/mca/plm/plm_types.h``
-     - Add ``PRTE_PLM_SHRINK_ACK_CMD = 7``.
    * - ``src/runtime/prte_globals.h``
      - Declare ``prte_shrink_campaign_t`` (type + ``PMIX_CLASS_DECLARATION``)
        and ``prte_shrink_campaigns`` (``pmix_list_t``).
@@ -673,10 +665,9 @@ Summary of Files Changed (Shrink Fence)
        and decrements the fence.
    * - ``src/prted/prted_comm.c``
      - In ``PRTE_DAEMON_SHRINK_CMD`` handler: after the ``JOB_END``
-       notification wait, pack ``PRTE_PLM_SHRINK_ACK_CMD`` and
-       ``PRTE_PROC_MY_NAME->rank`` into a message and send to HNP on
-       ``PRTE_RML_TAG_PLM`` before activating
-       ``PRTE_JOB_STATE_DAEMONS_TERMINATED``.
+       notification wait, activate ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and
+       exit.  No acknowledgement is sent; the HNP detects departure via the
+       comm-failure path.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
      - Add ``prte_plm_base_fence_release()``,
        ``prte_plm_base_job_needs_remap()``, and
@@ -685,20 +676,16 @@ Summary of Files Changed (Shrink Fence)
        ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
    * - ``src/mca/plm/base/plm_base_launch_support.h``
      - Declare the three new functions.
-   * - ``src/mca/plm/base/plm_base_receive.c``
-     - Handle ``PRTE_PLM_SHRINK_ACK_CMD``: unpack sender rank, find the
-       owning campaign, decrement per-campaign ``pending`` and
-       ``prte_dvm_launch_fence``; remove campaign when ``pending`` hits zero;
-       call ``prte_plm_base_fence_release(true)`` when fence hits zero.
    * - ``src/mca/state/dvm/state_dvm.c``
      - Replace inline release loop in ``vm_ready`` and ``check_complete``
        with calls to ``prte_plm_base_fence_release()``.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - In ``proc_errors()``, daemon-comm-failure block: search
-       ``prte_shrink_campaigns`` for the dead daemon's rank; if found,
-       decrement campaign ``pending`` and fence; remove campaign when
-       ``pending`` hits zero; call ``prte_plm_base_fence_release(true)``
-       when fence hits zero.
+       ``prte_shrink_campaigns`` for the dead daemon's rank; if found, stamp
+       the matched target slot ``PMIX_RANK_INVALID``, decrement campaign
+       ``pending`` and fence; remove campaign when ``pending`` hits zero;
+       call ``prte_plm_base_fence_release(true)`` when fence hits zero.  This
+       is the sole shrink-completion trigger.
 
 Summary of Files Changed (Grow Fence)
 --------------------------------------
@@ -772,9 +759,11 @@ Design Invariants
   one ``PMIX_ALLOC_RELEASE`` request.  Multiple concurrent shrink campaigns
   are supported.
 * The fence is incremented by exactly ``m`` at campaign creation and
-  decremented by 1 for each ``PRTE_PLM_SHRINK_ACK_CMD`` received or for
-  each crash detected in the errmgr fallback.  A campaign is removed from
-  the list when its ``pending`` count reaches zero.
+  decremented by 1 for each targeted daemon whose departure is detected on
+  the errmgr comm-failure path (clean exit and crash are indistinguishable
+  and handled identically).  Each target slot is stamped ``PMIX_RANK_INVALID``
+  once counted, so a repeated comm event cannot decrement twice.  A campaign
+  is removed from the list when its ``pending`` count reaches zero.
 * The ``LAUNCH_APPS`` hold uses ``!pmix_list_is_empty(&prte_shrink_campaigns)``,
   not ``prte_dvm_launch_fence > 0``, so a concurrent grow does not stall
   already-mapped jobs on surviving nodes.

--- a/docs/plans/elastic_dvm/dvm_launch_fence.rst
+++ b/docs/plans/elastic_dvm/dvm_launch_fence.rst
@@ -26,6 +26,16 @@ is required anywhere in this plan.
    ``LAUNCH_DAEMONS`` directly) where ``prte_dvm_ready`` is never cleared, and
    to ensure full correctness when both paths can interleave.
 
+.. note::
+   This document covers the **shared** fence mechanism (the counter, the
+   held-job arrays, and the two hold points) and the **shrink** path's fence
+   accounting.  The **grow** (daemon-launch) path's fence accounting was
+   originally described here as a single ``PRTE_JOB_LAUNCHED_DAEMONS`` boolean
+   plus a bare ``prte_dvm_launch_fence++``/``--``.  That design has since been
+   replaced by per-campaign, rank-tracked accounting; the authoritative
+   description now lives in :ref:`dvm-grow-campaign-label`.  The grow-specific
+   steps below have been reduced to pointers into that document.
+
 Step 1 — New state constant
 ---------------------------
 
@@ -70,76 +80,26 @@ Initialize both arrays in ``src/runtime/prte_init.c`` alongside the existing
 
 Destruct both in ``src/runtime/prte_finalize.c``.
 
-Step 3 — Increment the fence in setup_virtual_machine
+Steps 3 & 4 — Grow-path fence accounting (superseded)
 ------------------------------------------------------
 
-In ``src/mca/plm/base/plm_base_launch_support.c``, inside
-``prte_plm_base_setup_virtual_machine()``, the block at line 2380 already
-sets ``PRTE_JOB_LAUNCHED_DAEMONS`` when ``map->num_new_daemons > 0``:
+The grow (daemon-launch) path's fence increment and drain were originally
+described here — and in the now-removed Step 4 — as a bare
+``prte_dvm_launch_fence++`` in ``prte_plm_base_setup_virtual_machine()`` with
+a matching decrement in ``vm_ready``, keyed off the
+``PRTE_JOB_LAUNCHED_DAEMONS`` boolean.  **That design has been superseded.**
+The grow path now records each campaign explicitly — tracking the daemon
+ranks it is launching — and drains the whole campaign's fence contribution as
+a unit, so that an unrelated daemon death cannot consume the campaign's token
+and concurrent campaigns cannot wedge the fence.
 
-.. code-block:: c
-
-   /* existing code */
-   if (0 < map->num_new_daemons) {
-       rc = prte_set_attribute(&jdata->attributes,
-                               PRTE_JOB_LAUNCHED_DAEMONS, true, NULL, PMIX_BOOL);
-       if (PRTE_SUCCESS != rc) { ... }
-       /* ADD: increment the fence */
-       prte_dvm_launch_fence++;
-   }
-
-This location is reached by all four PLM backends (ssh, slurm, pals, lsf)
-through a single common code path, so a single insertion covers every
-extension scenario.
-
-Both expansion paths ultimately fire ``PRTE_JOB_STATE_LAUNCH_DAEMONS`` on
-the **daemon job** (app-triggered via ``prte_ras_base_complete_request()``;
-scheduler-push directly from the Slurm RAS module), so ``setup_virtual_machine()``
-always operates on the daemon job when an extension is in progress.  The
-``PRTE_JOB_EXTEND_DVM`` attribute is therefore set on the daemon job in both
-cases.
-
-Step 4 — Decrement the fence and release held jobs in vm_ready
---------------------------------------------------------------
-
-In ``src/mca/state/dvm/state_dvm.c``, ``vm_ready()`` has an outer block
-conditioned on ``PRTE_JOB_LAUNCHED_DAEMONS`` (line 275).  Inside that block,
-a nested ``if (!PRTE_JOB_DO_NOT_LAUNCH && 1 < prte_process_info.num_daemons)``
-block (lines 278–331) sends the nidmap xcast; the outer block closes at
-line 332.
-
-The fence decrement must be placed **just before the closing ``}`` of the
-outer** ``PRTE_JOB_LAUNCHED_DAEMONS`` **block** (between the inner block and
-line 332).  This position is reached by both the xcast path and the
-``DO_NOT_LAUNCH`` / single-daemon path:
-
-.. code-block:: c
-
-   if (prte_get_attribute(...PRTE_JOB_LAUNCHED_DAEMONS...)) {
-       if (!DO_NOT_LAUNCH && 1 < prte_process_info.num_daemons) {
-           /* existing xcast code (lines 283–330) */
-           /* error exits within this block each need:
-            *   prte_dvm_launch_fence--;
-            *   if (0 == prte_dvm_launch_fence)
-            *       prte_plm_base_fence_release(false);
-            * before PRTE_ACTIVATE_JOB_STATE / return          */
-           PMIX_DATA_BUFFER_DESTRUCT(&buf);   /* line 330 */
-       }
-       /* ADD: success path (and DO_NOT_LAUNCH / single-daemon path) */
-       prte_dvm_launch_fence--;
-       if (0 == prte_dvm_launch_fence) {
-           prte_plm_base_fence_release(true);
-       }
-   }   /* line 332 */
-
-Error exits inside the inner block (the ``PRTE_ACTIVATE_JOB_STATE(NULL,
-PRTE_JOB_STATE_FORCED_EXIT)`` branches at lines 288, 302, 310, 317, 327)
-return without reaching the decrement above, so each one must do its own
-decrement + ``prte_plm_base_fence_release(false)`` before returning.
-
-The held jobs re-enter ``vm_ready``; at that point ``PRTE_JOB_LAUNCHED_DAEMONS``
-is not set on them and the fence is zero, so they fall through to the
-``preposition_files → MAP`` path normally.
+See :ref:`dvm-grow-campaign-label` for the authoritative description of
+campaign creation in ``setup_virtual_machine()``, the success drain in
+``vm_ready`` (after the WIREUP xcast), the failure drain in the errmgr via
+``prte_plm_base_grow_target_failed()``, and the ``check_job_complete`` safety
+net.  The shared fence counter and held-job arrays (Step 2) and the
+``VM_READY → MAP`` hold point (Step 5) apply to both paths and are described
+in those steps.
 
 Step 5 — Park jobs at the VM_READY → MAP boundary
 --------------------------------------------------
@@ -166,75 +126,27 @@ Add the hold check here:
    }
    PMIX_RELEASE(caddy);
 
-Step 6 — Handle daemon launch failure
---------------------------------------
+Step 6 — Grow-path daemon launch failure (superseded)
+------------------------------------------------------
 
-If daemon launch fails, the normal ``vm_ready`` decrement path is never
-reached.  There are two distinct failure modes, each needing its own guard.
+Earlier revisions of this plan handled a daemon failure during a grow by
+decrementing ``prte_dvm_launch_fence`` directly in three places — the
+``vm_ready`` xcast error-exits, the ``errmgr_dvm.c`` comm-failure handler,
+and the ``check_complete`` safety net — each gated on the
+``PRTE_JOB_LAUNCHED_DAEMONS`` attribute.  **That approach has been
+superseded** by the per-campaign accounting in :ref:`dvm-grow-campaign-label`:
 
-**6a — xcast build/send errors inside** ``vm_ready``
+* The ``vm_ready`` xcast error-exits no longer touch the fence at all — the
+  whole DVM is being force-exited, and any held jobs are failed as part of
+  that teardown.
+* A daemon failure during a grow is routed to
+  ``prte_plm_base_grow_target_failed()`` in the errmgr, which acts only if the
+  dead rank belongs to an in-progress grow campaign (so an unrelated daemon
+  loss leaves the fence untouched).
+* The ``check_job_complete`` "received NULL job" branch drains any
+  still-pending grow campaigns with ``prte_plm_base_grow_drain(false)``.
 
-The error-exit paths inside the ``!DO_NOT_LAUNCH`` block (lines 288, 302,
-310, 317, 327) call ``PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT)``
-and return before reaching the common decrement at the bottom of the outer
-block.  Each of these branches must decrement and release explicitly, as
-described in Step 4.
-
-**6b — daemon crash after fence increment, before** ``vm_ready``
-
-A daemon might crash between ``setup_virtual_machine()`` (which increments
-the fence) and the ``DAEMONS_REPORTED → VM_READY`` transition.  In this case
-``vm_ready`` is never reached; the crash is routed to
-``errmgr_dvm.c:proc_errors()``.
-
-In ``src/mca/errmgr/dvm/errmgr_dvm.c``, inside the ``PMIX_CHECK_NSPACE``
-daemon block (line 252), within the ``PRTE_PROC_STATE_COMM_FAILED`` /
-``PRTE_PROC_STATE_HEARTBEAT_FAILED`` handler, add after the "mark daemon as
-gone" logic and before the early ``goto cleanup``:
-
-.. code-block:: c
-
-   /* if a grow campaign was in progress, fail the fence now so
-    * held jobs are not parked indefinitely */
-   if (0 < prte_dvm_launch_fence &&
-       prte_get_attribute(&jdata->attributes,
-                          PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL)) {
-       prte_dvm_launch_fence--;
-       if (0 == prte_dvm_launch_fence) {
-           prte_plm_base_fence_release(false);
-       }
-       /* remove the attribute so a second daemon crash in the same
-        * campaign does not decrement the fence again */
-       prte_remove_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS);
-   }
-
-**6c —** ``check_complete`` **safety net**
-
-If daemon launch fails through ``PRTE_JOB_STATE_TERMINATED`` on the daemon
-job (reached via the errmgr abort path), add a fence check **inside** the
-``if (NULL == jdata || PMIX_CHECK_NSPACE(...))`` block of ``check_complete``
-(line 539), before the early return at line 553:
-
-.. code-block:: c
-
-   if (NULL == jdata || PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
-       /* existing NULL / daemon-count checks ... */
-
-       /* ADD: if the daemon job held the grow fence, release it */
-       if (NULL != jdata &&
-           prte_get_attribute(&jdata->attributes,
-                              PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL) &&
-           0 < prte_dvm_launch_fence) {
-           prte_dvm_launch_fence--;
-           if (0 == prte_dvm_launch_fence) {
-               prte_plm_base_fence_release(false);
-           }
-       }
-       /* existing early return ... */
-
-Note: this block is the only path in ``check_complete`` that is reached by
-the daemon job.  The ``jdata->state > PRTE_JOB_STATE_UNTERMINATED`` check
-at line 566 is not reachable for the daemon job.
+See :ref:`dvm-grow-campaign-label` for the authoritative description.
 
 ----
 
@@ -424,7 +336,7 @@ under it are killed when it terminates regardless.  More importantly, the
 acknowledgement would arrive *before* the daemon's routes, ``num_daemons``
 count, and node state have been torn down, so acting on it could release
 held jobs into a DVM that still believes the departing daemon is present.
-The comm-failure event (Step 12) is the only signal that coincides with that
+The comm-failure event (Step 11) is the only signal that coincides with that
 cleanup, so it is the sole completion trigger.
 
 Step 9 — Second hold point at LAUNCH_APPS
@@ -687,8 +599,8 @@ Summary of Files Changed (Shrink Fence)
        call ``prte_plm_base_fence_release(true)`` when fence hits zero.  This
        is the sole shrink-completion trigger.
 
-Summary of Files Changed (Grow Fence)
---------------------------------------
+Summary of Files Changed (Shared Fence Infrastructure)
+-------------------------------------------------------
 
 .. list-table::
    :widths: 50 50
@@ -710,48 +622,29 @@ Summary of Files Changed (Grow Fence)
    * - ``src/runtime/prte_finalize.c``
      - Destruct ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
-     - Increment ``prte_dvm_launch_fence`` in the
-       ``0 < map->num_new_daemons`` block at the end of
-       ``prte_plm_base_setup_virtual_machine()``.
-       Declare and define ``prte_plm_base_fence_release()`` (Step 10).
+     - Declare and define ``prte_plm_base_fence_release()`` (Step 10).
    * - ``src/mca/state/dvm/state_dvm.c``
-     - In ``vm_ready``: (a) decrement fence and call
-       ``prte_plm_base_fence_release(true)`` at the bottom of the outer
-       ``PRTE_JOB_LAUNCHED_DAEMONS`` block; (b) call
-       ``prte_plm_base_fence_release(false)`` in all inner error-exit paths;
-       (c) add hold-check before ``preposition_files``.
-       In ``check_complete``: call ``prte_plm_base_fence_release(false)``
-       inside the ``PMIX_CHECK_NSPACE`` daemon block when a job with
-       ``PRTE_JOB_LAUNCHED_DAEMONS`` terminates abnormally.
-   * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
-     - In ``proc_errors()``, daemon-comm-failure block: if
-       ``prte_dvm_launch_fence > 0`` and ``PRTE_JOB_LAUNCHED_DAEMONS`` is
-       set on the daemon job, decrement fence and call
-       ``prte_plm_base_fence_release(false)`` if fence hits zero; then
-       remove ``PRTE_JOB_LAUNCHED_DAEMONS`` to prevent double-decrement.
+     - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
+       ``preposition_files`` (Step 5).
+
+For the **grow** path's file changes (campaign object, campaign creation in
+``setup_virtual_machine()``, the ``grow_drain`` / ``grow_target_failed``
+helpers, and the ``vm_ready`` / ``check_job_complete`` drains), see the
+"Touched files" table in :ref:`dvm-grow-campaign-label`.
 
 Design Invariants
 -----------------
 
 **Grow fence**
 
-* The fence counter and both held-job arrays are only accessed on the PRRTE
-  progress thread, so no locking is required anywhere.
-* The grow contribution to ``prte_dvm_launch_fence`` is incremented exactly
-  once per daemon launch campaign in ``setup_virtual_machine()``, which all
-  PLM backends call.  Symmetric decrement is at the bottom of the outer
-  ``PRTE_JOB_LAUNCHED_DAEMONS`` block in ``vm_ready`` (success or
-  ``DO_NOT_LAUNCH`` path), in each inner error-exit branch of ``vm_ready``
-  (failure), in the ``check_complete`` daemon block (late failure), and in
-  ``errmgr_dvm.c:proc_errors()`` (daemon crash during launch).
-* After ``prte_remove_attribute(...PRTE_JOB_LAUNCHED_DAEMONS...)`` is called
-  in the errmgr crash path, subsequent crashes in the same campaign do not
-  double-decrement the fence.
-* Jobs in ``prte_held_jobs`` hold a ``PMIX_RETAIN`` reference; the release
-  loop in ``prte_plm_base_fence_release()`` performs the matching
-  ``PMIX_RELEASE``.
-* Jobs already past ``MAP`` when a grow starts are unaffected: they were
-  mapped to existing nodes whose daemons are already running.
+The grow-path invariants now live with the per-campaign implementation; see
+the "Why this is correct" and "Design" sections of
+:ref:`dvm-grow-campaign-label`.  In brief: each live campaign contributes
+exactly its target count to ``prte_dvm_launch_fence`` until drained as a unit;
+the fence reaches zero (on success) only after the WIREUP xcast in
+``vm_ready``; an unrelated daemon death matches no campaign and leaves the
+fence untouched; and jobs already past ``MAP`` when a grow starts are
+unaffected.  All access is on the progress thread, so no locking is required.
 
 **Shrink fence**
 

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -128,18 +128,48 @@ The second hold point — at ``LAUNCH_APPS``, guarded by the shrink campaign lis
 rather than the fence counter — is shrink-specific and is described in
 :ref:`dvm-shrink-campaign-label`.
 
-Step 4 — Fence-release helper
------------------------------
+Step 4 — Held-job release helpers
+---------------------------------
 
-Both grow completion (``vm_ready``) and shrink target departure (detected in
-the errmgr) decrement the fence and, when it hits zero, must release two
-classes of held jobs.  Extract this logic into a single helper declared in
-``src/mca/plm/base/plm_base_launch_support.h`` and defined in
-``plm_base_launch_support.c``:
+There are two distinct ways a held job leaves its parked state, and they are
+**not** symmetric, so they are handled by two separate helpers rather than a
+single ``bool success`` flag:
+
+* **Global success.**  When the global fence reaches zero — every grow and
+  shrink campaign has completed *successfully* — both classes of held job are
+  admitted.  This is ``prte_plm_base_fence_release()``.
+
+* **Grow failure.**  When a grow campaign fails (see
+  :ref:`dvm-grow-campaign-label`, *Failure drain and rollback*), the spec
+  requires the whole **pre-map** held-job set to be aborted — the first-failure
+  semantics of a non-elastic launch.  But a grow failure must **not** touch the
+  **pre-launch** held jobs: those are parked solely on account of an in-progress
+  shrink (the ``LAUNCH_APPS`` hold is gated on the shrink list, not the fence),
+  so they do not wait on the grow, and the spec's conformance guarantee #4
+  states that a daemon failure may affect only the jobs waiting on the campaign
+  it belongs to.  This asymmetric abort is ``prte_plm_base_abort_premap_held()``.
+
+Folding both paths into one ``fence_release(bool success)`` was the original
+shape of this plan, but it could not honor the spec when a grow failed while a
+shrink was still in progress.  A single global ``success`` flag cannot express
+"abort the grow's waiters but leave the shrink's waiters parked," and gating the
+failure abort on the fence reaching zero would let a *later* shrink-success
+release **admit** a pre-map job whose grow dependency had already failed (the
+last campaign to drain — the shrink — would call the release with
+``success == true``).  Splitting the two release paths closes that gap: the
+grow-failure abort fires immediately on the pre-map array regardless of the
+fence value, and the success release is reached only when no campaign has
+failed.
+
+Both helpers are declared in ``src/mca/plm/base/plm_base_launch_support.h`` and
+defined in ``plm_base_launch_support.c``:
 
 .. code-block:: c
 
-   void prte_plm_base_fence_release(bool success)
+   /* SUCCESS release — invoked only when the global fence reaches zero, i.e.
+    * every grow and shrink campaign has completed successfully.  Admits both
+    * classes of held job and defensively sweeps any residual campaigns. */
+   void prte_plm_base_fence_release(void)
    {
        int _hi;
        prte_job_t *_held;
@@ -148,11 +178,11 @@ classes of held jobs.  Extract this logic into a single helper declared in
        for (_hi = 0; _hi < prte_held_jobs->size; _hi++) {
            _held = (prte_job_t *)
                pmix_pointer_array_get_item(prte_held_jobs, _hi);
-           if (NULL == _held) continue;
+           if (NULL == _held) {
+               continue;
+           }
            pmix_pointer_array_set_item(prte_held_jobs, _hi, NULL);
-           PRTE_ACTIVATE_JOB_STATE(_held,
-               success ? PRTE_JOB_STATE_VM_READY
-                       : PRTE_JOB_STATE_NEVER_LAUNCHED);
+           PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_VM_READY);
            PMIX_RELEASE(_held);
        }
 
@@ -160,11 +190,11 @@ classes of held jobs.  Extract this logic into a single helper declared in
        for (_hi = 0; _hi < prte_prelaunch_held_jobs->size; _hi++) {
            _held = (prte_job_t *)
                pmix_pointer_array_get_item(prte_prelaunch_held_jobs, _hi);
-           if (NULL == _held) continue;
+           if (NULL == _held) {
+               continue;
+           }
            pmix_pointer_array_set_item(prte_prelaunch_held_jobs, _hi, NULL);
-           if (!success) {
-               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_NEVER_LAUNCHED);
-           } else if (prte_plm_base_job_needs_remap(_held)) {
+           if (prte_plm_base_job_needs_remap(_held)) {
                prte_plm_base_reset_proc_map(_held);
                PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_MAP);
            } else {
@@ -173,21 +203,59 @@ classes of held jobs.  Extract this logic into a single helper declared in
            PMIX_RELEASE(_held);
        }
 
-       /* campaigns are removed individually as their last target dies;
-        * the list should be empty here, but do a safety sweep */
-       prte_shrink_campaign_t *_camp, *_next;
-       PMIX_LIST_FOREACH_SAFE(_camp, _next,
-                              &prte_shrink_campaigns, prte_shrink_campaign_t) {
-           pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
-           PMIX_RELEASE(_camp);
+       /* Campaigns are removed individually as their last target drains, so
+        * both lists should be empty here.  Sweep each defensively anyway — so
+        * a future change that can leave a residual campaign behind cannot wedge
+        * the fence — and sweep *both* kinds for symmetry, not just shrink. */
+       {
+           prte_shrink_campaign_t *_sc, *_sn;
+           PMIX_LIST_FOREACH_SAFE(_sc, _sn,
+                                  &prte_shrink_campaigns, prte_shrink_campaign_t) {
+               pmix_list_remove_item(&prte_shrink_campaigns, &_sc->super);
+               PMIX_RELEASE(_sc);
+           }
+       }
+       {
+           prte_grow_campaign_t *_gc, *_gn;
+           PMIX_LIST_FOREACH_SAFE(_gc, _gn,
+                                  &prte_grow_campaigns, prte_grow_campaign_t) {
+               pmix_list_remove_item(&prte_grow_campaigns, &_gc->super);
+               PMIX_RELEASE(_gc);
+           }
        }
    }
 
-This helper releases held jobs only; the pre-launch branch's two
-shrink-specific helpers — ``prte_plm_base_job_needs_remap()`` (does any held
-proc sit on a departing daemon?) and ``prte_plm_base_reset_proc_map()``
-(un-claim the previous mapping so the job can be remapped onto survivors) — are
-specified in :ref:`dvm-shrink-campaign-label`.
+   /* GROW-FAILURE abort — fails every job parked at the VM_READY -> MAP
+    * boundary to NEVER_LAUNCHED.  Called from the grow failure drain only, and
+    * independent of the fence value, so a grow failure aborts its pre-map
+    * waiters even while a concurrent shrink keeps the fence nonzero.  It
+    * deliberately leaves prte_prelaunch_held_jobs untouched: those jobs wait
+    * only on a shrink, never on the grow (conformance #4). */
+   void prte_plm_base_abort_premap_held(void)
+   {
+       int _hi;
+       prte_job_t *_held;
+
+       for (_hi = 0; _hi < prte_held_jobs->size; _hi++) {
+           _held = (prte_job_t *)
+               pmix_pointer_array_get_item(prte_held_jobs, _hi);
+           if (NULL == _held) {
+               continue;
+           }
+           pmix_pointer_array_set_item(prte_held_jobs, _hi, NULL);
+           PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_NEVER_LAUNCHED);
+           PMIX_RELEASE(_held);
+       }
+   }
+
+The pre-launch branch of ``fence_release()`` calls two shrink-specific
+helpers — ``prte_plm_base_job_needs_remap()`` (does any held proc sit on a
+departing daemon?) and ``prte_plm_base_reset_proc_map()`` (un-claim the previous
+mapping so the job can be remapped onto survivors) — specified in
+:ref:`dvm-shrink-campaign-label`.  Because shrink completion treats a clean exit
+and a crash identically (a targeted daemon's departure is always a success for
+its campaign), neither held-job array is ever failed on the shrink path; the
+only failure disposition of a held job is the grow-failure abort above.
 
 ``prte_plm_base_fence_release()`` acts when the **global** fence reaches zero,
 which requires *all* grow and shrink campaigns to have completed.  The
@@ -306,11 +374,15 @@ Summary of Files Changed (Shared Fence Infrastructure)
    * - ``src/runtime/prte_finalize.c``
      - Destruct ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
-     - Declare and define ``prte_plm_base_fence_release()`` (Step 4) and
+     - Define ``prte_plm_base_fence_release()`` and
+       ``prte_plm_base_abort_premap_held()`` (Step 4) and
        ``prte_plm_base_dvm_mod_notify()`` (Step 5).
    * - ``src/mca/plm/base/plm_base_launch_support.h``
-     - Declare ``prte_plm_base_fence_release()`` and
-       ``prte_plm_base_dvm_mod_notify()``.
+     - Declare ``prte_plm_base_fence_release()``,
+       ``prte_plm_base_abort_premap_held()``, and
+       ``prte_plm_base_dvm_mod_notify()`` (and, for the grow path,
+       ``prte_plm_base_grow_drain()`` / ``prte_plm_base_grow_target_failed()`` —
+       see :ref:`dvm-grow-campaign-label`).
    * - ``src/mca/state/dvm/state_dvm.c``
      - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
        ``preposition_files`` (Step 3).
@@ -335,11 +407,18 @@ Design Invariants
   (Step 3); the ``LAUNCH_APPS`` hold (shrink plan) is gated on the shrink
   campaign list, not the fence, so a concurrent grow does not stall an
   already-mapped job on surviving nodes.
-* ``prte_plm_base_fence_release()`` is called only when the fence reaches zero,
-  which requires *all* grow and shrink campaigns to have completed; the campaign
-  lists are therefore empty (or nearly so — ``fence_release`` does a safety
-  sweep for the degenerate case where an xcast failure left a partially-setup
-  campaign).
+* ``prte_plm_base_fence_release()`` is the **success-only** release; it is
+  called only when the fence reaches zero, which requires *all* grow and shrink
+  campaigns to have completed successfully.  The campaign lists are therefore
+  empty (or nearly so — ``fence_release`` does a defensive sweep of **both** the
+  grow and shrink lists for the degenerate case where some future change leaves
+  a partially-setup campaign behind).
+* A grow failure is the only path that fails a held job.  It calls
+  ``prte_plm_base_abort_premap_held()``, which aborts the pre-map held jobs
+  (``prte_held_jobs`` → ``NEVER_LAUNCHED``) immediately and independently of the
+  fence, and never touches ``prte_prelaunch_held_jobs``: those jobs wait only on
+  a shrink, so per conformance #4 a grow failure must leave them parked until the
+  shrink completes.
 * The per-campaign completion event (Step 5) is independent of the global fence:
   it fires when an individual request's campaign drains, even if other campaigns
   keep the fence nonzero.

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -161,8 +161,9 @@ grow-failure abort fires immediately on the pre-map array regardless of the
 fence value, and the success release is reached only when no campaign has
 failed.
 
-Both helpers are declared in ``src/mca/plm/base/plm_base_launch_support.h`` and
-defined in ``plm_base_launch_support.c``:
+Both helpers are declared in the public plm-base header
+``src/mca/plm/base/base.h`` (so the errmgr, ras, and state callers outside
+plm-base can see them) and defined in ``plm_base_launch_support.c``:
 
 .. code-block:: c
 
@@ -288,7 +289,7 @@ the allocation request that drove the operation.  A size change initiated with
 no PMIx requester (a scheduler push) leaves ``have_requester`` false and emits
 no event.
 
-A single shared helper, declared in ``plm_base_launch_support.h`` and defined in
+A single shared helper, declared in ``src/mca/plm/base/base.h`` and defined in
 ``plm_base_launch_support.c``, performs the emission.  Its prototype takes a
 ``bool success`` rather than an event code, so that **the two new status codes
 are named only inside the helper body** — call sites pass a bool and a cause and
@@ -377,12 +378,13 @@ Summary of Files Changed (Shared Fence Infrastructure)
      - Define ``prte_plm_base_fence_release()`` and
        ``prte_plm_base_abort_premap_held()`` (Step 4) and
        ``prte_plm_base_dvm_mod_notify()`` (Step 5).
-   * - ``src/mca/plm/base/plm_base_launch_support.h``
+   * - ``src/mca/plm/base/base.h``
      - Declare ``prte_plm_base_fence_release()``,
        ``prte_plm_base_abort_premap_held()``, and
        ``prte_plm_base_dvm_mod_notify()`` (and, for the grow path,
        ``prte_plm_base_grow_drain()`` / ``prte_plm_base_grow_target_failed()`` —
-       see :ref:`dvm-grow-campaign-label`).
+       see :ref:`dvm-grow-campaign-label`).  This is the public plm-base header,
+       so the errmgr/ras/state callers outside plm-base can include it.
    * - ``src/mca/state/dvm/state_dvm.c``
      - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
        ``preposition_files`` (Step 3).

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -37,6 +37,20 @@ fence; if it is nonzero the job parks itself in a held-job array
 The state machine is single-threaded on the progress thread, so no locking is
 required anywhere in this plan.
 
+**Gated on elastic mode.**  Every piece of this machinery is active only when
+the DVM is in elastic mode (the pre-existing ``prte_elastic_mode`` MCA
+parameter, off by default).  The gate is applied at the two points that *raise*
+the fence — grow-campaign creation in ``setup_virtual_machine()`` and
+shrink-campaign creation in the ``PMIX_ALLOC_RELEASE`` handler — so that outside
+elastic mode the fence is never raised, the campaign lists stay empty, and every
+downstream check (the ``VM_READY`` and ``LAUNCH_APPS`` holds, the errmgr
+campaign matching, the drains) is naturally inert.  The consumer sites also
+carry an explicit ``prte_elastic_mode`` guard so the non-elastic path is
+provably identical to the pre-feature behavior — in particular,
+``prte_plm_base_grow_target_failed()`` returns ``false`` immediately, so a
+daemon loss on a fixed-size DVM is handled by the ordinary errmgr abort path
+exactly as before.
+
 .. note::
    The app-triggered expansion path (``--add-host`` / ``--add-hostfile``)
    already sets ``prte_dvm_ready = false`` in ``add_hosts()`` before posting

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -1,0 +1,317 @@
+.. _elastic-dvm-plan-label:
+
+Elastic DVM Implementation Plan
+===============================
+
+This document describes the implementation of the **launch fence** — the
+shared mechanism that serialises application-job dispatch against in-progress
+DVM grow and shrink campaigns, closing the race between a DVM size change and
+concurrently-running application jobs.  For background on the race itself see
+:ref:`state-machine-label`, section *DVM Extension and the Daemon-Launch Race*.
+
+The externally observable contract this implementation delivers — the
+job-admission and placement guarantees, and the two-phase completion
+notification — is specified in :ref:`elastic-dvm-spec-label`, which is
+authoritative for observable behavior.  Where this plan and that specification
+disagree about observable behavior, the specification wins and this plan must
+be corrected.
+
+This plan is the **parent** of two campaign-specific plans:
+
+* :ref:`dvm-grow-campaign-label` — the grow (daemon-launch) path's per-campaign
+  fence accounting, failure rollback, and success/failure completion events.
+* :ref:`dvm-shrink-campaign-label` — the shrink (node-removal) path's campaign
+  tracking, the second (``LAUNCH_APPS``) hold point, completion detection, and
+  completion events.
+
+It covers the **shared** infrastructure both paths build on: the fence counter,
+the held-job arrays, the ``VM_READY → MAP`` hold point, the fence-release
+helper, and the completion-event emission common to both.
+
+The mechanism is a **global launch fence** — a counter
+(``prte_dvm_launch_fence``) that tracks the number of in-progress daemon launch
+campaigns.  An app job that reaches the ``VM_READY → MAP`` transition checks the
+fence; if it is nonzero the job parks itself in a held-job array
+(``prte_held_jobs``) and is released when the fence reaches zero.
+
+The state machine is single-threaded on the progress thread, so no locking is
+required anywhere in this plan.
+
+.. note::
+   The app-triggered expansion path (``--add-host`` / ``--add-hostfile``)
+   already sets ``prte_dvm_ready = false`` in ``add_hosts()`` before posting
+   the asynchronous RAS modify request, which causes newly-arriving jobs to be
+   stashed in ``prte_cache`` rather than dispatched immediately.  The launch
+   fence is still required for the scheduler-push path (e.g., Slurm firing
+   ``LAUNCH_DAEMONS`` directly) where ``prte_dvm_ready`` is never cleared, and
+   to ensure full correctness when both paths can interleave.
+
+Step 1 — New state constant
+---------------------------
+
+In ``src/mca/plm/plm_types.h``, add:
+
+.. code-block:: c
+
+   /* value 17 is currently unused in the running-state band */
+   #define PRTE_JOB_STATE_WAITING_FOR_DAEMONS  17
+
+Add a corresponding string to ``src/util/error_strings.c``.
+
+This state is used purely as a marker so that debugging tools and verbose
+output show clearly why a job is parked; no callback is registered for it.
+
+Step 2 — New global fence and held-job arrays
+---------------------------------------------
+
+In ``src/runtime/prte_globals.c`` and ``src/runtime/prte_globals.h``, add:
+
+.. code-block:: c
+
+   /* counts in-progress daemon launch campaigns */
+   int prte_dvm_launch_fence = 0;
+
+   /* jobs parked at the VM_READY → MAP boundary */
+   pmix_pointer_array_t *prte_held_jobs;
+
+   /* jobs parked at the LAUNCH_APPS boundary during a shrink */
+   pmix_pointer_array_t *prte_prelaunch_held_jobs;
+
+Initialize both arrays in ``src/runtime/prte_init.c`` alongside the existing
+``prte_cache`` initialization:
+
+.. code-block:: c
+
+   prte_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+   pmix_pointer_array_init(prte_held_jobs, 1, INT_MAX, 1);
+
+   prte_prelaunch_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+   pmix_pointer_array_init(prte_prelaunch_held_jobs, 1, INT_MAX, 1);
+
+Destruct both in ``src/runtime/prte_finalize.c``.
+
+The grow and shrink campaign lists (``prte_grow_campaigns`` and
+``prte_shrink_campaigns``) that drive the fence are declared, constructed, and
+destructed alongside these globals; their types and lifecycles are specified in
+the two child plans.
+
+Step 3 — Park jobs at the VM_READY → MAP boundary
+--------------------------------------------------
+
+This is the first of the two hold points and is shared by both paths: it stops
+*any* in-progress campaign (grow or shrink) from letting a freshly-arriving job
+map onto a node whose daemon is not ready.
+
+In ``vm_ready()``, the code at line 360 is reached only by app jobs (the
+daemon-job branch returns at line 357).  This is immediately before
+``prte_filem.preposition_files()`` which leads to ``files_ready → MAP``.
+Add the hold check here:
+
+.. code-block:: c
+
+   /* position any required files */
+   if (0 < prte_dvm_launch_fence) {
+       /* daemon launch in progress — park this job */
+       caddy->jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
+       PMIX_RETAIN(caddy->jdata);
+       pmix_pointer_array_add(prte_held_jobs, caddy->jdata);
+       PMIX_RELEASE(caddy);
+       return;
+   }
+   if (PRTE_SUCCESS !=
+           prte_filem.preposition_files(caddy->jdata, files_ready, caddy->jdata)) {
+       PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
+   }
+   PMIX_RELEASE(caddy);
+
+The second hold point — at ``LAUNCH_APPS``, guarded by the shrink campaign list
+rather than the fence counter — is shrink-specific and is described in
+:ref:`dvm-shrink-campaign-label`.
+
+Step 4 — Fence-release helper
+-----------------------------
+
+Both grow completion (``vm_ready``) and shrink target departure (detected in
+the errmgr) decrement the fence and, when it hits zero, must release two
+classes of held jobs.  Extract this logic into a single helper declared in
+``src/mca/plm/base/plm_base_launch_support.h`` and defined in
+``plm_base_launch_support.c``:
+
+.. code-block:: c
+
+   void prte_plm_base_fence_release(bool success)
+   {
+       int _hi;
+       prte_job_t *_held;
+
+       /* --- pre-map held jobs (parked at VM_READY) --- */
+       for (_hi = 0; _hi < prte_held_jobs->size; _hi++) {
+           _held = (prte_job_t *)
+               pmix_pointer_array_get_item(prte_held_jobs, _hi);
+           if (NULL == _held) continue;
+           pmix_pointer_array_set_item(prte_held_jobs, _hi, NULL);
+           PRTE_ACTIVATE_JOB_STATE(_held,
+               success ? PRTE_JOB_STATE_VM_READY
+                       : PRTE_JOB_STATE_NEVER_LAUNCHED);
+           PMIX_RELEASE(_held);
+       }
+
+       /* --- pre-launch held jobs (parked at LAUNCH_APPS) --- */
+       for (_hi = 0; _hi < prte_prelaunch_held_jobs->size; _hi++) {
+           _held = (prte_job_t *)
+               pmix_pointer_array_get_item(prte_prelaunch_held_jobs, _hi);
+           if (NULL == _held) continue;
+           pmix_pointer_array_set_item(prte_prelaunch_held_jobs, _hi, NULL);
+           if (!success) {
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_NEVER_LAUNCHED);
+           } else if (prte_plm_base_job_needs_remap(_held)) {
+               prte_plm_base_reset_proc_map(_held);
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_MAP);
+           } else {
+               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_LAUNCH_APPS);
+           }
+           PMIX_RELEASE(_held);
+       }
+
+       /* campaigns are removed individually as their last target dies;
+        * the list should be empty here, but do a safety sweep */
+       prte_shrink_campaign_t *_camp, *_next;
+       PMIX_LIST_FOREACH_SAFE(_camp, _next,
+                              &prte_shrink_campaigns, prte_shrink_campaign_t) {
+           pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
+           PMIX_RELEASE(_camp);
+       }
+   }
+
+This helper releases held jobs only; the pre-launch branch's two
+shrink-specific helpers — ``prte_plm_base_job_needs_remap()`` (does any held
+proc sit on a departing daemon?) and ``prte_plm_base_reset_proc_map()``
+(un-claim the previous mapping so the job can be remapped onto survivors) — are
+specified in :ref:`dvm-shrink-campaign-label`.
+
+``prte_plm_base_fence_release()`` acts when the **global** fence reaches zero,
+which requires *all* grow and shrink campaigns to have completed.  The
+per-campaign **completion event** (Step 5) is distinct: it fires for an
+individual request's campaign when that campaign drains, independent of whether
+other campaigns are still in flight.
+
+Step 5 — Completion-event emission (shared helper)
+--------------------------------------------------
+
+The spec's two-phase contract (see :ref:`elastic-dvm-spec-label`,
+*Asynchronous size-change completion*) requires that, when an accepted DVM
+operation finishes, the runtime deliver a directed event to the process that
+requested the size change: ``PMIX_DVM_IS_READY`` on success or
+``PMIX_ERR_DVM_MOD`` (carrying the underlying cause) on failure.
+
+Both campaign objects therefore record the requester so the event can be
+directed once the campaign drains:
+
+.. code-block:: c
+
+   pmix_proc_t  requester;       /* who requested the size change */
+   char        *alloc_id;        /* PMIX_ALLOC_ID of the affected allocation */
+   char        *req_id;          /* requester's PMIX_ALLOC_REQ_ID, or NULL */
+   bool         have_requester;  /* false for a scheduler push */
+
+These fields are populated where the campaign is created — for a shrink in the
+``PMIX_ALLOC_RELEASE`` handler, for a grow in ``setup_virtual_machine()`` — from
+the allocation request that drove the operation.  A size change initiated with
+no PMIx requester (a scheduler push) leaves ``have_requester`` false and emits
+no event.
+
+A single shared helper, declared in ``plm_base_launch_support.h`` and defined in
+``plm_base_launch_support.c``, performs the emission:
+
+.. code-block:: c
+
+   /* event_code is PMIX_DVM_IS_READY or PMIX_ERR_DVM_MOD; cause is the
+    * underlying pmix_status_t on failure (ignored on success) */
+   void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
+                                     const char *alloc_id,
+                                     const char *req_id,
+                                     pmix_status_t event_code,
+                                     pmix_status_t cause);
+
+It packs ``PMIX_ALLOC_ID`` (always), ``PMIX_ALLOC_REQ_ID`` (when ``req_id`` is
+non-NULL), and — for the failure event — the underlying ``cause`` status, then
+delivers the event **only** to ``requester`` (a directed, non-broadcast
+notification).
+
+The grow and shrink plans call this helper at their respective drain points: the
+grow path on the success drain in ``vm_ready`` and on the failure drain in
+``prte_plm_base_grow_target_failed()``; the shrink path when a campaign's last
+target departs (success) and on the xcast-failure cleanup at campaign creation
+(failure).
+
+Because ``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are defined by PMIx and
+may be absent in an older PMIx, both the helper body and every call site are
+guarded by a build-time capability check using the ``PRTE_CHECK_PMIX_CAP``
+idiom (``config/prte_setup_pmix.m4``); when the check fails the helper compiles
+to a no-op and no completion event is delivered, exactly as the spec's
+backward-compatibility clause requires.
+
+Summary of Files Changed (Shared Fence Infrastructure)
+-------------------------------------------------------
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - File
+     - Change
+   * - ``src/mca/plm/plm_types.h``
+     - Add ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS = 17``.
+   * - ``src/util/error_strings.c``
+     - Add string for ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS``.
+   * - ``src/runtime/prte_globals.h``
+     - Declare ``prte_dvm_launch_fence``, ``prte_held_jobs``, and
+       ``prte_prelaunch_held_jobs``.
+   * - ``src/runtime/prte_globals.c``
+     - Define and initialize ``prte_dvm_launch_fence = 0``.
+   * - ``src/runtime/prte_init.c``
+     - Allocate and init ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
+   * - ``src/runtime/prte_finalize.c``
+     - Destruct ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
+   * - ``src/mca/plm/base/plm_base_launch_support.c``
+     - Declare and define ``prte_plm_base_fence_release()`` (Step 4) and
+       ``prte_plm_base_dvm_mod_notify()`` (Step 5).
+   * - ``src/mca/plm/base/plm_base_launch_support.h``
+     - Declare ``prte_plm_base_fence_release()`` and
+       ``prte_plm_base_dvm_mod_notify()``.
+   * - ``src/mca/state/dvm/state_dvm.c``
+     - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
+       ``preposition_files`` (Step 3).
+   * - ``config/prte_setup_pmix.m4``
+     - Add the ``PRTE_CHECK_PMIX_CAP`` check that gates use of
+       ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` (Step 5).
+
+For the grow path's file changes see the "Touched files" table in
+:ref:`dvm-grow-campaign-label`; for the shrink path's, the "Touched files"
+table in :ref:`dvm-shrink-campaign-label`.
+
+Design Invariants
+-----------------
+
+**Shared fence**
+
+* The fence is a single ``int`` accessed only on the progress thread, so all
+  increments, decrements, and the zero test are race-free without locking.
+* A job is parked iff the fence is nonzero at the ``VM_READY → MAP`` boundary
+  (Step 3); the ``LAUNCH_APPS`` hold (shrink plan) is gated on the shrink
+  campaign list, not the fence, so a concurrent grow does not stall an
+  already-mapped job on surviving nodes.
+* ``prte_plm_base_fence_release()`` is called only when the fence reaches zero,
+  which requires *all* grow and shrink campaigns to have completed; the campaign
+  lists are therefore empty (or nearly so — ``fence_release`` does a safety
+  sweep for the degenerate case where an xcast failure left a partially-setup
+  campaign).
+* The per-campaign completion event (Step 5) is independent of the global fence:
+  it fires when an individual request's campaign drains, even if other campaigns
+  keep the fence nonzero.
+
+**Grow fence** — see the "Why this is correct" and "Design" sections of
+:ref:`dvm-grow-campaign-label`.
+
+**Shrink fence** — see the "Design Invariants" section of
+:ref:`dvm-shrink-campaign-label`.

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -244,12 +244,22 @@ grow path on the success drain in ``vm_ready`` and on the failure drain in
 target departs (success) and on the xcast-failure cleanup at campaign creation
 (failure).
 
-Because ``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are defined by PMIx and
-may be absent in an older PMIx, both the helper body and every call site are
-guarded by a build-time capability check using the ``PRTE_CHECK_PMIX_CAP``
-idiom (``config/prte_setup_pmix.m4``); when the check fails the helper compiles
-to a no-op and no completion event is delivered, exactly as the spec's
-backward-compatibility clause requires.
+``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are plain ``#define``\ d
+``pmix_status_t`` values (PMIx status codes are preprocessor macros, not enum
+constants), so their availability is decided entirely by whether the installed
+PMIx headers define the symbols — **no PMIx capability flag is involved**.  Both
+the helper body and every call site are therefore guarded by a simple
+preprocessor existence check, not by the ``PRTE_CHECK_PMIX_CAP`` machinery
+(which is for ``PMIX_CAP_*`` behavioral flags).  To preserve the project's
+``#if FOO`` discipline — so a mistyped guard is a compile error rather than a
+silent false — the recommended form is a one-line probe in
+``config/prte_setup_pmix.m4`` that defines ``PRTE_HAVE_DVM_MOD_EVENTS`` to ``0``
+or ``1`` from the presence of the two symbols, tested with
+``#if PRTE_HAVE_DVM_MOD_EVENTS``; a direct
+``#if defined(PMIX_DVM_IS_READY) && defined(PMIX_ERR_DVM_MOD)`` is equally
+correct.  When the guard is false the helper compiles to a no-op and no
+completion event is delivered, exactly as the spec's backward-compatibility
+clause requires.
 
 Summary of Files Changed (Shared Fence Infrastructure)
 -------------------------------------------------------
@@ -282,9 +292,11 @@ Summary of Files Changed (Shared Fence Infrastructure)
    * - ``src/mca/state/dvm/state_dvm.c``
      - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
        ``preposition_files`` (Step 3).
-   * - ``config/prte_setup_pmix.m4``
-     - Add the ``PRTE_CHECK_PMIX_CAP`` check that gates use of
-       ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` (Step 5).
+   * - ``config/prte_setup_pmix.m4`` (optional)
+     - If using the macro form, add a probe that defines
+       ``PRTE_HAVE_DVM_MOD_EVENTS`` from the presence of
+       ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` (Step 5); not needed if the
+       call sites use a direct ``#if defined(...)`` guard.
 
 For the grow path's file changes see the "Touched files" table in
 :ref:`dvm-grow-campaign-label`; for the shrink path's, the "Touched files"

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -161,9 +161,10 @@ grow-failure abort fires immediately on the pre-map array regardless of the
 fence value, and the success release is reached only when no campaign has
 failed.
 
-Both helpers are declared in the public plm-base header
-``src/mca/plm/base/base.h`` (so the errmgr, ras, and state callers outside
-plm-base can see them) and defined in ``plm_base_launch_support.c``:
+Both helpers are declared in ``src/mca/plm/base/plm_private.h`` (the header the
+errmgr, ras, and state callers already include for the existing
+``prte_plm_base_*`` launch helpers) and defined in
+``plm_base_launch_support.c``:
 
 .. code-block:: c
 
@@ -289,8 +290,9 @@ the allocation request that drove the operation.  A size change initiated with
 no PMIx requester (a scheduler push) leaves ``have_requester`` false and emits
 no event.
 
-A single shared helper, declared in ``src/mca/plm/base/base.h`` and defined in
-``plm_base_launch_support.c``, performs the emission.  Its prototype takes a
+A single shared helper, declared in ``src/mca/plm/base/plm_private.h`` and
+defined in ``plm_base_launch_support.c``, performs the emission.  Its prototype
+takes a
 ``bool success`` rather than an event code, so that **the two new status codes
 are named only inside the helper body** — call sites pass a bool and a cause and
 never reference ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` themselves:
@@ -378,13 +380,13 @@ Summary of Files Changed (Shared Fence Infrastructure)
      - Define ``prte_plm_base_fence_release()`` and
        ``prte_plm_base_abort_premap_held()`` (Step 4) and
        ``prte_plm_base_dvm_mod_notify()`` (Step 5).
-   * - ``src/mca/plm/base/base.h``
+   * - ``src/mca/plm/base/plm_private.h``
      - Declare ``prte_plm_base_fence_release()``,
        ``prte_plm_base_abort_premap_held()``, and
        ``prte_plm_base_dvm_mod_notify()`` (and, for the grow path,
        ``prte_plm_base_grow_drain()`` / ``prte_plm_base_grow_target_failed()`` —
-       see :ref:`dvm-grow-campaign-label`).  This is the public plm-base header,
-       so the errmgr/ras/state callers outside plm-base can include it.
+       see :ref:`dvm-grow-campaign-label`).  This is the header the errmgr, ras,
+       and state callers already include.
    * - ``src/mca/state/dvm/state_dvm.c``
      - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
        ``preposition_files`` (Step 3).

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -221,22 +221,24 @@ no PMIx requester (a scheduler push) leaves ``have_requester`` false and emits
 no event.
 
 A single shared helper, declared in ``plm_base_launch_support.h`` and defined in
-``plm_base_launch_support.c``, performs the emission:
+``plm_base_launch_support.c``, performs the emission.  Its prototype takes a
+``bool success`` rather than an event code, so that **the two new status codes
+are named only inside the helper body** — call sites pass a bool and a cause and
+never reference ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` themselves:
 
 .. code-block:: c
 
-   /* event_code is PMIX_DVM_IS_READY or PMIX_ERR_DVM_MOD; cause is the
-    * underlying pmix_status_t on failure (ignored on success) */
+   /* success => emit PMIX_DVM_IS_READY; otherwise emit PMIX_ERR_DVM_MOD
+    * carrying `cause` (the underlying failure pmix_status_t) */
    void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
                                      const char *alloc_id,
                                      const char *req_id,
-                                     pmix_status_t event_code,
+                                     bool success,
                                      pmix_status_t cause);
 
 It packs ``PMIX_ALLOC_ID`` (always), ``PMIX_ALLOC_REQ_ID`` (when ``req_id`` is
-non-NULL), and — for the failure event — the underlying ``cause`` status, then
-delivers the event **only** to ``requester`` (a directed, non-broadcast
-notification).
+non-NULL), and — on failure — the underlying ``cause`` status, then delivers the
+event **only** to ``requester`` (a directed, non-broadcast notification).
 
 The grow and shrink plans call this helper at their respective drain points: the
 grow path on the success drain in ``vm_ready`` and on the failure drain in
@@ -247,19 +249,39 @@ target departs (success) and on the xcast-failure cleanup at campaign creation
 ``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are plain ``#define``\ d
 ``pmix_status_t`` values (PMIx status codes are preprocessor macros, not enum
 constants), so their availability is decided entirely by whether the installed
-PMIx headers define the symbols — **no PMIx capability flag is involved**.  Both
-the helper body and every call site are therefore guarded by a simple
-preprocessor existence check, not by the ``PRTE_CHECK_PMIX_CAP`` machinery
-(which is for ``PMIX_CAP_*`` behavioral flags).  To preserve the project's
-``#if FOO`` discipline — so a mistyped guard is a compile error rather than a
-silent false — the recommended form is a one-line probe in
-``config/prte_setup_pmix.m4`` that defines ``PRTE_HAVE_DVM_MOD_EVENTS`` to ``0``
-or ``1`` from the presence of the two symbols, tested with
-``#if PRTE_HAVE_DVM_MOD_EVENTS``; a direct
-``#if defined(PMIX_DVM_IS_READY) && defined(PMIX_ERR_DVM_MOD)`` is equally
-correct.  When the guard is false the helper compiles to a no-op and no
-completion event is delivered, exactly as the spec's backward-compatibility
-clause requires.
+PMIx headers define the symbols — **no PMIx capability flag is involved** (the
+``PRTE_CHECK_PMIX_CAP`` machinery is for ``PMIX_CAP_*`` behavioral flags and
+does not apply here).
+
+To keep the project's ``#if FOO`` discipline — so a mistyped guard is a compile
+error rather than a silently-false ``#ifdef`` — a probe in
+``config/prte_setup_pmix.m4`` defines ``PRTE_HAVE_DVM_MOD_EVENTS`` to ``0`` or
+``1`` from the presence of the two symbols:
+
+.. code-block:: none
+
+   AC_MSG_CHECKING([for PMIx DVM modification event codes])
+   AC_PREPROC_IFELSE(
+       [AC_LANG_PROGRAM([[#include <pmix.h>
+   #if !defined(PMIX_DVM_IS_READY) || !defined(PMIX_ERR_DVM_MOD)
+   #error DVM modification event codes not present
+   #endif
+   ]], [[]])],
+       [AC_MSG_RESULT([yes])
+        AC_DEFINE([PRTE_HAVE_DVM_MOD_EVENTS], [1],
+                  [PMIx defines the DVM modification event codes])],
+       [AC_MSG_RESULT([no])
+        AC_DEFINE([PRTE_HAVE_DVM_MOD_EVENTS], [0],
+                  [PMIx defines the DVM modification event codes])])
+
+The macro is defined to ``0`` or ``1`` on both branches (never ``#undef``\ ed),
+so it can be tested with ``#if PRTE_HAVE_DVM_MOD_EVENTS``.  Because the helper's
+``bool``-based prototype keeps the two codes out of every call site, **only the
+helper body needs the guard**: when ``PRTE_HAVE_DVM_MOD_EVENTS`` is ``0`` the
+body compiles to a no-op (the ``bool``/``pmix_status_t`` prototype still
+compiles), the call sites are unchanged, and no completion event is delivered —
+exactly as the spec's backward-compatibility clause requires.  Because this
+touches ``*.m4``, ``./autogen.pl`` must be re-run before configuring.
 
 Summary of Files Changed (Shared Fence Infrastructure)
 -------------------------------------------------------
@@ -292,11 +314,11 @@ Summary of Files Changed (Shared Fence Infrastructure)
    * - ``src/mca/state/dvm/state_dvm.c``
      - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
        ``preposition_files`` (Step 3).
-   * - ``config/prte_setup_pmix.m4`` (optional)
-     - If using the macro form, add a probe that defines
-       ``PRTE_HAVE_DVM_MOD_EVENTS`` from the presence of
-       ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` (Step 5); not needed if the
-       call sites use a direct ``#if defined(...)`` guard.
+   * - ``config/prte_setup_pmix.m4``
+     - Add the ``AC_PREPROC_IFELSE`` probe that defines
+       ``PRTE_HAVE_DVM_MOD_EVENTS`` (``0``/``1``) from the presence of
+       ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` (Step 5).  Re-run
+       ``autogen.pl`` afterward.
 
 For the grow path's file changes see the "Touched files" table in
 :ref:`dvm-grow-campaign-label`; for the shrink path's, the "Touched files"

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -284,11 +284,23 @@ directed once the campaign drains:
    char        *req_id;          /* requester's PMIX_ALLOC_REQ_ID, or NULL */
    bool         have_requester;  /* false for a scheduler push */
 
-These fields are populated where the campaign is created — for a shrink in the
-``PMIX_ALLOC_RELEASE`` handler, for a grow in ``setup_virtual_machine()`` — from
-the allocation request that drove the operation.  A size change initiated with
-no PMIx requester (a scheduler push) leaves ``have_requester`` false and emits
-no event.
+These fields are populated where the campaign is created, from the allocation
+request that drove the operation:
+
+* **Shrink** — directly in the ``PMIX_ALLOC_RELEASE`` handler, from the request
+  object: ``requester`` is the request's ``tproc``, and ``alloc_id`` / ``req_id``
+  are read from its ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID`` info keys.
+* **Grow** — in ``setup_virtual_machine()``, *indirectly through the session*.
+  The RAS reservation machinery already records the driving request on the
+  session and back-points every reserved node at it
+  (``add_nodes_to_session()`` sets ``node->session``; the session carries
+  ``requestor``, ``alloc_refid``, and ``user_refid``).  The grow campaign reads
+  those from the first new daemon's ``node->session``, so the originating
+  request need not be threaded explicitly into the launch path.
+
+A size change initiated with no PMIx requester (a scheduler push, or the initial
+DVM bring-up, where the session is the default one or its ``requestor`` rank is
+``PMIX_RANK_INVALID``) leaves ``have_requester`` false and emits no event.
 
 A single shared helper, declared in ``src/mca/plm/base/plm_private.h`` and
 defined in ``plm_base_launch_support.c``, performs the emission.  Its prototype
@@ -308,14 +320,19 @@ never reference ``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` themselves:
                                      pmix_status_t cause);
 
 It packs ``PMIX_ALLOC_ID`` (always), ``PMIX_ALLOC_REQ_ID`` (when ``req_id`` is
-non-NULL), and — on failure — the underlying ``cause`` status, then delivers the
-event **only** to ``requester`` (a directed, non-broadcast notification).
+non-NULL), and — on failure — the underlying ``cause`` status (carried under
+``PMIX_JOB_TERM_STATUS``, the standard ``pmix_status_t``-typed info key; the PMIx
+contract for ``PMIX_ERR_DVM_MOD`` asks only for "any available information
+describing the cause"), then delivers the event **only** to ``requester`` as a
+directed, custom-range notification — the same ``PMIX_RANGE_CUSTOM`` mechanism
+used for ``PMIX_ALLOC_TIMEOUT_WARNING``.
 
 The grow and shrink plans call this helper at their respective drain points: the
-grow path on the success drain in ``vm_ready`` and on the failure drain in
-``prte_plm_base_grow_target_failed()``; the shrink path when a campaign's last
-target departs (success) and on the xcast-failure cleanup at campaign creation
-(failure).
+grow path inside ``prte_plm_base_grow_drain()`` (reached on success from
+``vm_ready`` after the WIREUP xcast, and on failure from
+``prte_plm_base_grow_target_failed()`` and the ``check_job_complete`` safety
+net); the shrink path when a campaign's last target departs (success, in the
+errmgr) and on the xcast-failure cleanup at campaign creation (failure).
 
 ``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are plain ``#define``\ d
 ``pmix_status_t`` values (PMIx status codes are preprocessor macros, not enum

--- a/docs/plans/elastic_dvm/elastic_dvm_plan.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_plan.rst
@@ -21,8 +21,10 @@ This plan is the **parent** of two campaign-specific plans:
 * :ref:`dvm-grow-campaign-label` — the grow (daemon-launch) path's per-campaign
   fence accounting, failure rollback, and success/failure completion events.
 * :ref:`dvm-shrink-campaign-label` — the shrink (node-removal) path's campaign
-  tracking, the second (``LAUNCH_APPS``) hold point, completion detection, and
-  completion events.
+  tracking, the second (``LAUNCH_APPS``) hold point, completion detection, the
+  RM-side resource release that runs at completion (a release may span multiple
+  allocations, so every active RAS module is offered the completed campaign),
+  and completion events.
 
 It covers the **shared** infrastructure both paths build on: the fence counter,
 the held-job arrays, the ``VM_READY → MAP`` hold point, the fence-release

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -1,0 +1,307 @@
+.. _elastic-dvm-spec-label:
+
+Elastic DVM Job Admission: Specification
+========================================
+
+Purpose
+-------
+
+This document specifies the externally observable behavior of job
+admission while the DVM changes size — that is, what an application,
+tool, or scheduler may rely on when a job is submitted during a DVM
+**grow** (a new-daemon launch campaign) or **shrink** (a node-removal
+campaign).  It defines *what* the runtime guarantees, not *how* it
+achieves it.  The companion design plans —
+:ref:`dvm-launch-fence-label` (the shared fence mechanism and the shrink
+path) and :ref:`dvm-grow-campaign-label` (the grow path's per-campaign
+accounting) — describe the internal data structures, code paths, and
+implementation order.  Where this specification and those plans disagree
+about observable behavior, **this specification is authoritative** and
+the plan must be corrected.
+
+The guarantees below are stated purely in terms of job lifecycle
+outcomes.  This feature introduces **no** new command-line options,
+environment variables, or PMIx attributes: the grow and shrink triggers
+that already exist (``--add-host`` / ``--add-hostfile``, a
+scheduler-driven daemon launch, and a ``PMIX_ALLOC_RELEASE`` that removes
+nodes) acquire correct concurrency semantics, and nothing else about a
+caller's interface changes.
+
+Scope
+-----
+
+In scope
+~~~~~~~~
+
+* The admission guarantee for an application job that reaches the
+  map-eligible boundary while a grow or shrink is in progress.
+* The placement guarantee for a job launched across a size change — onto
+  which set of nodes (pre- or post-change) it is permitted to map.
+* The disposition of a job that was already mapped onto a node that is
+  about to depart in a shrink.
+* The outcome of a daemon failure that occurs during a grow or a shrink,
+  and the distinction between a failure that belongs to the in-progress
+  campaign and an unrelated one.
+* The behavior when grow and shrink campaigns, or multiple campaigns of
+  the same kind, overlap in time.
+* The single observable artifact this feature adds: the
+  ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` job state reported for a parked
+  job in verbose and debugging output.
+
+Out of scope / non-goals
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The *policy* that decides when the DVM grows or shrinks.  That decision
+  is driven entirely by the existing triggers (a tool or application
+  expansion request, a scheduler action, or an allocation release); this
+  specification governs only how concurrent job submissions behave around
+  such a change, never whether the change happens.
+* Node selection — which physical nodes are added or removed — is the
+  responsibility of the resource manager and the existing allocation and
+  mapping machinery, and is unchanged.
+* The wire encoding of internal messages, the names and types of internal
+  counters and lists, and the precise timing of internal state
+  transitions are implementation details and are not specified here.
+* This document does not redefine the meaning of any DVM size-change
+  trigger; it specifies only the admission and placement guarantees that
+  now hold while one is in flight.
+
+Definitions
+-----------
+
+Grow campaign
+   A single in-progress launch of one or more new daemons that extends
+   the DVM onto additional nodes.  A grow campaign is *complete* when
+   every new daemon has reported in and the head node has distributed the
+   wireup (nidmap) information to the DVM.
+
+Shrink campaign
+   A single in-progress removal of one or more nodes from the DVM,
+   initiated by an allocation release.  A shrink campaign targets a fixed
+   set of daemon ranks and is *complete* when every targeted daemon has
+   actually departed the DVM.
+
+Size change
+   A grow campaign or a shrink campaign.  More than one may be in
+   progress at the same time.
+
+Map-eligible boundary
+   The point in a job's lifecycle at which it is ready to be assigned to
+   nodes (the ``VM_READY → MAP`` transition).  A job that has not yet
+   crossed this boundary has no node assignments.
+
+Launch boundary
+   The point at which a job's mapping is complete and the runtime is
+   ready to send launch data to the daemons that will host its processes
+   (the ``LAUNCH_APPS`` transition).  A job at this boundary already has
+   node assignments.
+
+Parked job
+   A job that has been held at the map-eligible boundary or the launch
+   boundary because a size change is in progress.  A parked job is
+   reported in the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state.  Parking
+   is invisible to the submitting tool beyond a delay in launch; the job
+   is neither failed nor restarted.
+
+Surviving node
+   A node that remains in the DVM after a shrink campaign completes.
+
+Departing node
+   A node whose daemon is a target of an in-progress shrink campaign.
+
+Admission contract
+-------------------
+
+The central guarantee is one of **non-destructive deferral**:
+
+   A job submitted while a size change is in progress is never failed
+   merely because the DVM is changing size.  It is held until the change
+   completes and then admitted onto the post-change set of nodes — except
+   that a job whose admission depends on a grow that *fails* is aborted
+   rather than launched onto an incomplete DVM.
+
+Two distinct placement hazards are closed by this contract, and a
+conforming implementation must close both:
+
+#. **A job must never be mapped onto a node whose daemon is not ready.**
+   During a grow this means a node whose daemon has started but has not
+   yet received its wireup information; during a shrink it means a node
+   whose daemon is a departure target.
+
+#. **A job must never have launch data sent to a daemon that is
+   departing.**  A job that completed mapping *before* a shrink began, and
+   was placed on a node now targeted for removal, must not transmit its
+   launch message to that daemon.
+
+Behavior during a grow
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+While a grow campaign is in progress:
+
+* A job that reaches the map-eligible boundary is parked.  It is admitted
+  only once **every** in-progress grow campaign has completed — that is,
+  only after the new daemons are not merely running but fully wired into
+  the DVM.  This guarantees hazard 1: the job cannot be mapped onto a
+  node whose daemon is up but not yet wired.
+
+* A job that had already crossed the map-eligible boundary before the
+  grow began is **unaffected**: it continues to launch on the nodes it
+  was assigned, and a grow never stalls it.
+
+* When the grow completes successfully, every job parked at the
+  map-eligible boundary is admitted and proceeds to mapping, now able to
+  consider the newly added nodes.
+
+* If a daemon belonging to the grow campaign **fails** before the
+  campaign completes, the grow is treated as failed as a whole, and every
+  job parked on account of the grow is aborted (it never launches) rather
+  than being admitted onto an incomplete DVM.  This matches the
+  first-failure semantics of a non-elastic launch.
+
+* A daemon failure that does **not** belong to any in-progress grow
+  campaign (for example, a pre-existing daemon dying for an unrelated
+  reason) does not release parked jobs early and does not abort them; the
+  grow proceeds unaffected.
+
+Behavior during a shrink
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+While a shrink campaign is in progress:
+
+* A job that reaches the map-eligible boundary is parked, exactly as for
+  a grow, and is admitted only once every in-progress size change has
+  completed.  This closes hazard 1 for the shrink case: a newly arriving
+  job cannot be mapped onto a node that is in the act of leaving.
+
+* A job that had already completed mapping and reaches the launch
+  boundary is parked **if and only if a shrink is in progress**, until
+  every targeted daemon has departed.  This closes hazard 2.  A grow in
+  progress does *not* park a job at the launch boundary, because a grow
+  removes no node and so cannot invalidate an existing mapping.
+
+* When the shrink completes, each parked job is admitted according to
+  whether the shrink invalidated its placement:
+
+  - A job parked at the launch boundary whose processes were **not**
+    assigned to any departing node proceeds directly to launch on its
+    existing mapping.
+  - A job parked at the launch boundary that had one or more processes
+    assigned to a departing node is **remapped** onto the surviving
+    nodes and then launched.  Its placement after the change reflects the
+    smaller DVM; the job is not failed.
+  - A job parked at the map-eligible boundary is admitted to mapping and
+    naturally considers only the surviving nodes.
+
+* Completion of a shrink is driven by the **actual departure** of each
+  targeted daemon, not by any advance announcement of intent to leave.  A
+  daemon that exits cleanly in response to the shrink and a daemon that
+  crashes during the shrink are indistinguishable to the contract: in
+  both cases the node is leaving, and any job mapped onto it is remapped
+  onto survivors as described above.  No job is admitted until the
+  departing daemons are genuinely gone and the DVM's view of its
+  membership has been updated to match.
+
+Concurrency
+-----------
+
+* Any number of grow campaigns, any number of shrink campaigns, or a
+  mixture, may be in progress simultaneously.  Parked jobs are admitted
+  only when **all** in-progress campaigns have completed; no campaign can
+  release another campaign's held jobs, and no campaign's completion is
+  consumed by an unrelated daemon event.
+
+* A grow campaign in progress concurrently with a shrink does not stall a
+  job at the launch boundary that has already been mapped onto surviving
+  nodes; only an in-progress shrink holds jobs there.
+
+* Each campaign is accounted for independently, so an overlapping or
+  partially-overlapping pair of campaigns cannot leave a job parked
+  indefinitely once the last campaign it is waiting on completes.
+
+Failure semantics
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - Event
+     - Observable outcome
+   * - A grow-target daemon fails before its grow completes
+     - The grow fails as a whole; all jobs parked on account of the grow
+       are aborted and never launch.
+   * - A daemon unrelated to any in-progress grow fails during a grow
+     - The grow is unaffected; parked jobs are neither released early nor
+       aborted.
+   * - A shrink-target daemon exits cleanly
+     - Counts as that target's departure; when the last target departs the
+       shrink completes and parked jobs are admitted (remapped if they
+       were on a departing node).
+   * - A shrink-target daemon crashes during the shrink
+     - Handled identically to a clean exit: the node is leaving regardless,
+       and jobs mapped onto it are remapped onto survivors.
+   * - The same departing daemon emits more than one failure event
+     - Counted once; a repeated event for an already-departed target has no
+       further effect on admission.
+   * - The controlling daemon job is torn down with grow campaigns still
+       pending
+     - The pending grows are drained as failures so that no job is left
+       parked across the teardown.
+
+In every case a parked job has no partial effect: until it is admitted it
+has launched no processes, and a job aborted because its grow failed
+leaves nothing running.
+
+Observability
+-------------
+
+The only externally visible artifact this feature introduces is a job
+state.  A parked job is reported as ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS``
+in verbose and debugging output (for example under
+``--prtemca state_base_verbose``), so an operator can see precisely why a
+job has not yet been mapped or launched.  The state is a passive marker:
+it triggers no callback and changes no other behavior.  Once the size
+change the job is waiting on completes, the job advances out of this state
+on its own.
+
+Backward compatibility and transparency
+----------------------------------------
+
+This feature is transparent to every caller:
+
+* No new command-line option, environment variable, or PMIx attribute is
+  defined or required.  A tool, application, or scheduler issues the same
+  requests it always has.
+* On a DVM that never grows or shrinks, no job is ever parked and behavior
+  is identical to a non-elastic DVM.
+* The only difference a caller can observe when a size change *is* in
+  progress is a launch delay for an affected job and, in debugging output,
+  the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state — never a spurious
+  failure and never a launch onto a node that is not ready or is leaving.
+
+Conformance summary
+-------------------
+
+A conforming implementation guarantees that:
+
+#. A job submitted while a size change is in progress is held, not failed,
+   solely on account of the change — and is then admitted onto the
+   post-change node set, with the sole exception of a job whose grow
+   dependency fails, which is aborted.
+#. A job is never mapped onto a node whose daemon is not yet wired into
+   the DVM (grow) or is a departure target (shrink).
+#. A job is never sent launch data destined for a departing daemon; a job
+   already mapped onto a departing node is remapped onto surviving nodes
+   before it launches.
+#. A daemon failure affects only the jobs waiting on the campaign that
+   failure belongs to; an unrelated daemon loss neither releases nor
+   aborts parked jobs.
+#. Shrink completion is driven by the actual departure of every targeted
+   daemon — clean exit and crash being indistinguishable — and is
+   idempotent against a daemon that reports its departure more than once.
+#. Concurrent campaigns of either kind never deadlock a parked job: it is
+   admitted once, and only once, every campaign it is waiting on has
+   completed.
+#. The feature adds no new caller-visible interface; its only observable
+   artifact is the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state shown for
+   a parked job in verbose and debugging output.

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -27,17 +27,26 @@ order.  Where this specification and those plans disagree about observable
 behavior, **this specification is authoritative** and the plan must be
 corrected.
 
-The job-admission guarantees are stated purely in terms of job lifecycle
-outcomes and introduce **no** new command-line options, environment
-variables, or PMIx attributes: the grow and shrink triggers that already
-exist (``--add-host`` / ``--add-hostfile``, a scheduler-driven daemon
-launch, and a ``PMIX_ALLOC_RELEASE`` that removes nodes) simply acquire
-correct concurrency semantics.  The completion contract does introduce two
-new PMIx event (status) codes — ``PMIX_DVM_IS_READY`` and
-``PMIX_ERR_DVM_MOD`` — used to notify the requester when the asynchronous
-DVM operation finishes; these are the only new caller-visible interface
-this feature adds, and both are optional (see `Backward compatibility and
-transparency`_).
+The whole of this behavior is gated on the DVM being in **elastic mode**,
+selected by the pre-existing ``prte_elastic_mode`` MCA parameter (off by
+default).  When it is not set the DVM is fixed-size: none of the
+job-admission deferral, parking, or completion-event machinery is active,
+and the runtime behaves exactly as it did before this feature — a daemon
+loss, for instance, is handled by the ordinary error path rather than
+absorbed as a campaign event.  Everything below describes the behavior
+**when elastic mode is enabled**.
+
+Within elastic mode, the job-admission guarantees are stated purely in
+terms of job lifecycle outcomes and introduce **no** new command-line
+options, environment variables, or PMIx attributes: the grow and shrink
+triggers that already exist (``--add-host`` / ``--add-hostfile``, a
+scheduler-driven daemon launch, and a ``PMIX_ALLOC_RELEASE`` that removes
+nodes) simply acquire correct concurrency semantics.  The completion
+contract does introduce two new PMIx event (status) codes —
+``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` — used to notify the
+requester when the asynchronous DVM operation finishes; these are the only
+new caller-visible interface this feature adds, and both are optional (see
+`Backward compatibility and transparency`_).
 
 Scope
 -----
@@ -446,9 +455,13 @@ Backward compatibility and transparency
 
 The **job-admission** contract is transparent to every caller:
 
+* It is inert unless the DVM is in elastic mode (``prte_elastic_mode``, off
+  by default).  A DVM started without that parameter is fixed-size and runs
+  exactly as it did before this feature — the launch fence is never raised,
+  no job is ever parked, and daemon losses follow the ordinary error path.
 * No new command-line option, environment variable, or PMIx attribute is
-  defined or required for it.  A tool, application, or scheduler issues the
-  same requests it always has.
+  defined or required for it (``prte_elastic_mode`` already existed).  A
+  tool, application, or scheduler issues the same requests it always has.
 * On a DVM that never grows or shrinks, no job is ever parked and behavior
   is identical to a non-elastic DVM.
 * The only difference a submitting caller can observe when a size change

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -18,12 +18,14 @@ node-removal campaign).  It covers two distinct audiences and contracts:
   succeeded or failed (see `Asynchronous size-change completion`_).
 
 It defines *what* the runtime guarantees, not *how* it achieves it.  The
-companion design plans — :ref:`dvm-launch-fence-label` (the shared fence
-mechanism and the shrink path) and :ref:`dvm-grow-campaign-label` (the
-grow path's per-campaign accounting) — describe the internal data
-structures, code paths, and implementation order.  Where this
-specification and those plans disagree about observable behavior, **this
-specification is authoritative** and the plan must be corrected.
+companion design plans — :ref:`elastic-dvm-plan-label` (the shared fence
+mechanism and completion-event helper), :ref:`dvm-grow-campaign-label`
+(the grow path's per-campaign accounting), and
+:ref:`dvm-shrink-campaign-label` (the shrink path's campaign tracking) —
+describe the internal data structures, code paths, and implementation
+order.  Where this specification and those plans disagree about observable
+behavior, **this specification is authoritative** and the plan must be
+corrected.
 
 The job-admission guarantees are stated purely in terms of job lifecycle
 outcomes and introduce **no** new command-line options, environment

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -307,13 +307,39 @@ validity with unrelated launch/teardown failures.  Decoupling lets the
 requester learn promptly that its request was accepted and then act only
 when the runtime actually reflects the new size.
 
+Resource release at shrink completion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The nodes a single shrink removes need not all come from the same
+underlying allocation.  A ``PMIX_ALLOC_RELEASE`` may name resources that
+the runtime originally obtained from more than one source — for example
+nodes acquired through different resource managers, or a mixture of
+scheduler-provided and statically-configured nodes — so the set of
+departing nodes can span several allocations, each managed by a different
+resource component.
+
+Accordingly, when a shrink completes — every targeted daemon has departed
+— the runtime offers the completed operation to **each** active resource
+component in turn *before* it emits the completion event, giving each the
+opportunity to release the share of the departing resources that belongs
+to it back to its resource manager.  What a component does with that
+opportunity is up to the component: it may return the nodes to a
+scheduler, defer, or do nothing if it has no stake in the operation.  The
+runtime guarantees only the *ordering* — that the release cycle is offered
+to every component, and runs to completion, before the completion event is
+delivered.  It does not guarantee that any particular resource was in fact
+handed back, since that is the component's decision, not the runtime's.
+
 Success event — ``PMIX_DVM_IS_READY``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the DVM operation completes successfully — for a grow, the new
 daemons are launched and wired into the DVM; for a shrink, every targeted
-daemon has departed and the routing tree is repaired — the runtime
-delivers a ``PMIX_DVM_IS_READY`` event to the requester.  After this event
+daemon has departed, the routing tree is repaired, and each resource
+component has been given the opportunity to release the freed resources
+back to its resource manager (see `Resource release at shrink
+completion`_) — the runtime delivers a ``PMIX_DVM_IS_READY`` event to the
+requester.  After this event
 the DVM reflects the requested size: a grow's new nodes are available to
 spawn onto, a shrink's removed nodes are gone.  The event payload carries:
 

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -378,10 +378,11 @@ its own (they belong to the PMIx standard and headers):
        ``PMIX_ALLOC_ID``, the underlying failure ``pmix_status_t``, and —
        when supplied — ``PMIX_ALLOC_REQ_ID``.
 
-Their use is gated at build time by a PMIx capability check (the
-``PRTE_CHECK_PMIX_CAP`` idiom): a PRRTE built against a PMIx that defines
-neither code simply omits the completion notification (see `Backward
-compatibility and transparency`_).
+Because PMIx status codes are plain preprocessor ``#define``\ s, their use is
+guarded at build time by a simple check for the codes' presence in the
+installed PMIx headers — no PMIx *capability* flag is required.  A PRRTE built
+against a PMIx that defines neither code simply omits the completion
+notification (see `Backward compatibility and transparency`_).
 
 Failure semantics
 -----------------
@@ -463,8 +464,9 @@ optional and degrade cleanly:
   requester that registers a handler for them; a requester that ignores
   them is unaffected beyond losing the completion signal.
 * When the underlying PMIx defines neither code, a PRRTE built against it
-  (gated by the ``PRTE_CHECK_PMIX_CAP`` capability check) omits the
-  asynchronous completion notification entirely.  The allocation response
+  (the call sites are guarded by a preprocessor check for the two
+  ``#define``\ d status codes) omits the asynchronous completion
+  notification entirely.  The allocation response
   (phase one) is unchanged, so a request is still accepted and the DVM
   still grows or shrinks; the requester simply receives no event-based
   signal that the operation finished or failed, exactly as before this

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -40,8 +40,9 @@ In scope
 * The disposition of a job that was already mapped onto a node that is
   about to depart in a shrink.
 * The outcome of a daemon failure that occurs during a grow or a shrink,
-  and the distinction between a failure that belongs to the in-progress
-  campaign and an unrelated one.
+  the distinction between a failure that belongs to the in-progress
+  campaign and an unrelated one, and the rollback of a failed grow to the
+  DVM's pre-grow membership.
 * The behavior when grow and shrink campaigns, or multiple campaigns of
   the same kind, overlap in time.
 * The single observable artifact this feature adds: the
@@ -153,10 +154,17 @@ While a grow campaign is in progress:
   consider the newly added nodes.
 
 * If a daemon belonging to the grow campaign **fails** before the
-  campaign completes, the grow is treated as failed as a whole, and every
-  job parked on account of the grow is aborted (it never launches) rather
-  than being admitted onto an incomplete DVM.  This matches the
-  first-failure semantics of a non-elastic launch.
+  campaign completes, the grow is treated as failed as a whole and is
+  **rolled back**: every daemon that the same campaign had already
+  started is terminated, and the nodes the campaign was adding leave the
+  DVM, so the DVM is restored to exactly the membership it had before that
+  campaign began.  A failed grow never leaves the DVM half-extended with a
+  partial, un-wired set of new daemons.  Every job parked on account of
+  the grow is then aborted (it never launches) rather than being admitted
+  onto an incomplete DVM.  This matches the first-failure semantics of a
+  non-elastic launch.  The rollback is scoped to the failed campaign: an
+  unrelated grow campaign running concurrently keeps its own daemons and
+  completes normally, and pre-existing daemons and nodes are untouched.
 
 * A daemon failure that does **not** belong to any in-progress grow
   campaign (for example, a pre-existing daemon dying for an unrelated
@@ -228,8 +236,10 @@ Failure semantics
    * - Event
      - Observable outcome
    * - A grow-target daemon fails before its grow completes
-     - The grow fails as a whole; all jobs parked on account of the grow
-       are aborted and never launch.
+     - The grow fails as a whole and is rolled back: every daemon the same
+       campaign had already started is terminated and its nodes leave the
+       DVM, restoring the pre-grow membership; all jobs parked on account
+       of the grow are aborted and never launch.
    * - A daemon unrelated to any in-progress grow fails during a grow
      - The grow is unaffected; parked jobs are neither released early nor
        aborted.
@@ -296,6 +306,11 @@ A conforming implementation guarantees that:
 #. A daemon failure affects only the jobs waiting on the campaign that
    failure belongs to; an unrelated daemon loss neither releases nor
    aborts parked jobs.
+#. A grow that fails is rolled back to the DVM's pre-grow membership: the
+   campaign's already-started daemons are terminated and its nodes leave
+   the DVM, so a failed grow never leaves the DVM half-extended.  The
+   rollback is scoped to the failed campaign and leaves concurrent
+   campaigns and pre-existing daemons untouched.
 #. Shrink completion is driven by the actual departure of every targeted
    daemon — clean exit and crash being indistinguishable — and is
    idempotent against a daemon that reports its departure more than once.

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -1,31 +1,41 @@
 .. _elastic-dvm-spec-label:
 
-Elastic DVM Job Admission: Specification
-========================================
+Elastic DVM: Specification
+==========================
 
 Purpose
 -------
 
-This document specifies the externally observable behavior of job
-admission while the DVM changes size — that is, what an application,
-tool, or scheduler may rely on when a job is submitted during a DVM
-**grow** (a new-daemon launch campaign) or **shrink** (a node-removal
-campaign).  It defines *what* the runtime guarantees, not *how* it
-achieves it.  The companion design plans —
-:ref:`dvm-launch-fence-label` (the shared fence mechanism and the shrink
-path) and :ref:`dvm-grow-campaign-label` (the grow path's per-campaign
-accounting) — describe the internal data structures, code paths, and
-implementation order.  Where this specification and those plans disagree
-about observable behavior, **this specification is authoritative** and
-the plan must be corrected.
+This document specifies the externally observable behavior of the DVM
+while it changes size — what an application, tool, or scheduler may rely
+on when the DVM **grows** (a new-daemon launch campaign) or **shrinks** (a
+node-removal campaign).  It covers two distinct audiences and contracts:
 
-The guarantees below are stated purely in terms of job lifecycle
-outcomes.  This feature introduces **no** new command-line options,
-environment variables, or PMIx attributes: the grow and shrink triggers
-that already exist (``--add-host`` / ``--add-hostfile``, a
-scheduler-driven daemon launch, and a ``PMIX_ALLOC_RELEASE`` that removes
-nodes) acquire correct concurrency semantics, and nothing else about a
-caller's interface changes.
+* **Job admission** — what happens to an application job that is submitted
+  *while* a grow or shrink is in progress (the bulk of this document).
+* **Size-change completion** — how the process that *requested* the size
+  change learns, asynchronously, whether the DVM operation eventually
+  succeeded or failed (see `Asynchronous size-change completion`_).
+
+It defines *what* the runtime guarantees, not *how* it achieves it.  The
+companion design plans — :ref:`dvm-launch-fence-label` (the shared fence
+mechanism and the shrink path) and :ref:`dvm-grow-campaign-label` (the
+grow path's per-campaign accounting) — describe the internal data
+structures, code paths, and implementation order.  Where this
+specification and those plans disagree about observable behavior, **this
+specification is authoritative** and the plan must be corrected.
+
+The job-admission guarantees are stated purely in terms of job lifecycle
+outcomes and introduce **no** new command-line options, environment
+variables, or PMIx attributes: the grow and shrink triggers that already
+exist (``--add-host`` / ``--add-hostfile``, a scheduler-driven daemon
+launch, and a ``PMIX_ALLOC_RELEASE`` that removes nodes) simply acquire
+correct concurrency semantics.  The completion contract does introduce two
+new PMIx event (status) codes — ``PMIX_DVM_IS_READY`` and
+``PMIX_ERR_DVM_MOD`` — used to notify the requester when the asynchronous
+DVM operation finishes; these are the only new caller-visible interface
+this feature adds, and both are optional (see `Backward compatibility and
+transparency`_).
 
 Scope
 -----
@@ -45,9 +55,15 @@ In scope
   DVM's pre-grow membership.
 * The behavior when grow and shrink campaigns, or multiple campaigns of
   the same kind, overlap in time.
-* The single observable artifact this feature adds: the
-  ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` job state reported for a parked
-  job in verbose and debugging output.
+* The two-phase model by which a dynamic allocation request that drives a
+  size change is answered: a synchronous response when the request is
+  *accepted*, and a later asynchronous event when the DVM operation
+  *completes* or *fails*.
+* The two new PMIx event codes — ``PMIX_DVM_IS_READY`` and
+  ``PMIX_ERR_DVM_MOD`` — that carry the asynchronous completion result to
+  the requester, and the allocation-identifying payload each delivers.
+* The ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` job state reported for a
+  parked job in verbose and debugging output.
 
 Out of scope / non-goals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,6 +125,26 @@ Surviving node
 
 Departing node
    A node whose daemon is a target of an in-progress shrink campaign.
+
+Size-change requester
+   The process whose request initiated a grow or shrink — for a dynamic
+   allocation this is the process that issued the ``PMIX_ALLOC_NEW`` /
+   ``PMIX_ALLOC_EXTEND`` (grow) or ``PMIX_ALLOC_RELEASE`` (shrink) request.
+   A size change initiated without a PMIx requester (for example a
+   scheduler pushing daemons directly) has no requester.
+
+Request acceptance
+   The point at which the runtime has finished *processing* a size-change
+   request — validated it and initiated the corresponding DVM operation —
+   and returns its synchronous response.  Acceptance is **phase one**; it
+   does not assert that the operation has finished.
+
+Operation completion
+   The point at which the initiated DVM operation actually finishes — the
+   grow's new daemons are launched and wired, or the shrink's targeted
+   daemons have departed and the routing tree is repaired — or
+   definitively fails.  Completion is **phase two** and is reported
+   asynchronously by event (see `Asynchronous size-change completion`_).
 
 Admission contract
 -------------------
@@ -226,6 +262,125 @@ Concurrency
   partially-overlapping pair of campaigns cannot leave a job parked
   indefinitely once the last campaign it is waiting on completes.
 
+Asynchronous size-change completion
+-----------------------------------
+
+A dynamic allocation request that grows or shrinks the DVM is answered in
+**two phases**, and the runtime separates the point at which the
+*allocation is complete* from the point at which the *runtime is ready*.
+
+Two-phase model
+~~~~~~~~~~~~~~~
+
+#. **Acceptance (synchronous).**  When the runtime has finished
+   *processing* the request — validated it, decided the resulting
+   session/reservation, and initiated the corresponding grow or shrink —
+   it returns the allocation response (status plus ``PMIX_ALLOC_ID``, as
+   specified in the companion allocation contract
+   ``node-reservation-spec.rst``).  This response confirms only that the
+   request was **accepted** and the DVM operation has **begun**.  It does
+   *not* assert that a grow's new daemons are up and wired, or that a
+   shrink's targeted daemons have departed.
+
+#. **Completion (asynchronous, by event).**  When the DVM operation later
+   finishes — or fails — the runtime delivers a directed PMIx event to the
+   **size-change requester**.  This is the signal that the *runtime is
+   ready* (or that the change will not happen), as distinct from the
+   acceptance in phase one.
+
+The two phases are decoupled because the DVM operation is inherently
+asynchronous and unbounded in time (daemon launch and wireup, or daemon
+termination and tree repair).  Blocking the allocation response until the
+operation finished would stall the requester and entangle the request's
+validity with unrelated launch/teardown failures.  Decoupling lets the
+requester learn promptly that its request was accepted and then act only
+when the runtime actually reflects the new size.
+
+Success event — ``PMIX_DVM_IS_READY``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the DVM operation completes successfully — for a grow, the new
+daemons are launched and wired into the DVM; for a shrink, every targeted
+daemon has departed and the routing tree is repaired — the runtime
+delivers a ``PMIX_DVM_IS_READY`` event to the requester.  After this event
+the DVM reflects the requested size: a grow's new nodes are available to
+spawn onto, a shrink's removed nodes are gone.  The event payload carries:
+
+* ``PMIX_ALLOC_ID`` (``char*``) — the allocation whose operation
+  completed; always present.
+* ``PMIX_ALLOC_REQ_ID`` (``char*``) — the requester's own request id,
+  included whenever one was supplied on the original request, so the
+  recipient can match the event by either identifier.
+
+Failure event — ``PMIX_ERR_DVM_MOD``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the accepted DVM modification fails — a grow cannot launch or wire its
+new daemons (and is rolled back per `Failure semantics`_), a shrink cannot
+be carried out, or any other condition leaves the requested change
+unrealized — the runtime delivers a ``PMIX_ERR_DVM_MOD`` event to the
+requester.  The event states that **no (further) DVM modification will be
+made** for this request and that the DVM has been returned to a stable
+state (for a failed grow, its pre-grow membership).  The payload carries:
+
+* ``PMIX_ALLOC_ID`` (``char*``) — always present.
+* ``PMIX_ALLOC_REQ_ID`` (``char*``) — when one was supplied.
+* The **underlying cause** — the specific ``pmix_status_t`` that prevented
+  the modification (for example a daemon-launch failure versus a resource
+  error), conveyed in the event's info array so the requester can
+  distinguish what went wrong rather than only that *something* did.
+
+Both events are **directed to the requesting process only** — they are not
+broadcast — mirroring the delivery of ``PMIX_ALLOC_TIMEOUT_WARNING``
+specified in ``node-reservation-spec.rst``.
+
+Delivery guarantees
+~~~~~~~~~~~~~~~~~~~
+
+* **Exactly one terminal event per operation.**  Each accepted request
+  that initiates a DVM grow or shrink yields exactly one of
+  ``PMIX_DVM_IS_READY`` or ``PMIX_ERR_DVM_MOD`` to its requester.
+* **No event for a phase-one rejection.**  A request rejected during
+  *processing* (the error cases in the companion
+  ``node-reservation-spec.rst``, e.g. a malformed or unauthorized request)
+  fails synchronously in the allocation response and produces **no**
+  completion event; the phase-two events report only the outcome of an
+  *accepted* request's DVM operation.
+* **No event when nothing changes.**  A request that is accepted but
+  initiates no actual DVM size change (for example an extend that adds no
+  new daemons) is fully complete at acceptance and emits no asynchronous
+  event.
+* **No requester, no directed event.**  A size change with no PMIx
+  requester (a scheduler-driven push) updates the runtime's own state but
+  has no specific process to direct a completion event to; none is sent.
+
+Proposed PMIx status codes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This contract requires two PMIx event codes that PRRTE cannot define on
+its own (they belong to the PMIx standard and headers):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Code
+     - Meaning
+   * - ``PMIX_DVM_IS_READY``
+     - Non-error event: an accepted DVM size change has completed and the
+       runtime now reflects the new size.  Carries ``PMIX_ALLOC_ID`` and,
+       when supplied, ``PMIX_ALLOC_REQ_ID``.
+   * - ``PMIX_ERR_DVM_MOD``
+     - Error event: an accepted DVM size change failed and will not be
+       made; the DVM has returned to a stable state.  Carries
+       ``PMIX_ALLOC_ID``, the underlying failure ``pmix_status_t``, and —
+       when supplied — ``PMIX_ALLOC_REQ_ID``.
+
+Their use is gated at build time by a PMIx capability check (the
+``PRTE_CHECK_PMIX_CAP`` idiom): a PRRTE built against a PMIx that defines
+neither code simply omits the completion notification (see `Backward
+compatibility and transparency`_).
+
 Failure semantics
 -----------------
 
@@ -265,29 +420,55 @@ leaves nothing running.
 Observability
 -------------
 
-The only externally visible artifact this feature introduces is a job
-state.  A parked job is reported as ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS``
-in verbose and debugging output (for example under
-``--prtemca state_base_verbose``), so an operator can see precisely why a
-job has not yet been mapped or launched.  The state is a passive marker:
-it triggers no callback and changes no other behavior.  Once the size
-change the job is waiting on completes, the job advances out of this state
-on its own.
+This feature introduces two externally visible artifacts.
+
+The first is a **job state**.  A parked job is reported as
+``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` in verbose and debugging output (for
+example under ``--prtemca state_base_verbose``), so an operator can see
+precisely why a job has not yet been mapped or launched.  The state is a
+passive marker: it triggers no callback and changes no other behavior.
+Once the size change the job is waiting on completes, the job advances out
+of this state on its own.
+
+The second is the pair of **completion events** described under
+`Asynchronous size-change completion`_: ``PMIX_DVM_IS_READY`` on success
+and ``PMIX_ERR_DVM_MOD`` on failure, each directed to the requester of the
+size change and carrying the allocation identifiers (and, on failure, the
+underlying cause).  Unlike the job state, these are an active interface a
+requester registers an event handler for; they are the requester's only
+signal that the asynchronous DVM operation has finished.
 
 Backward compatibility and transparency
 ----------------------------------------
 
-This feature is transparent to every caller:
+The **job-admission** contract is transparent to every caller:
 
 * No new command-line option, environment variable, or PMIx attribute is
-  defined or required.  A tool, application, or scheduler issues the same
-  requests it always has.
+  defined or required for it.  A tool, application, or scheduler issues the
+  same requests it always has.
 * On a DVM that never grows or shrinks, no job is ever parked and behavior
   is identical to a non-elastic DVM.
-* The only difference a caller can observe when a size change *is* in
-  progress is a launch delay for an affected job and, in debugging output,
-  the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state — never a spurious
-  failure and never a launch onto a node that is not ready or is leaving.
+* The only difference a submitting caller can observe when a size change
+  *is* in progress is a launch delay for an affected job and, in debugging
+  output, the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state — never a
+  spurious failure and never a launch onto a node that is not ready or is
+  leaving.
+
+The **completion** contract adds the two new PMIx event codes, which are
+optional and degrade cleanly:
+
+* ``PMIX_DVM_IS_READY`` and ``PMIX_ERR_DVM_MOD`` are delivered only to a
+  requester that registers a handler for them; a requester that ignores
+  them is unaffected beyond losing the completion signal.
+* When the underlying PMIx defines neither code, a PRRTE built against it
+  (gated by the ``PRTE_CHECK_PMIX_CAP`` capability check) omits the
+  asynchronous completion notification entirely.  The allocation response
+  (phase one) is unchanged, so a request is still accepted and the DVM
+  still grows or shrinks; the requester simply receives no event-based
+  signal that the operation finished or failed, exactly as before this
+  feature existed.  This is a functional gap, not merely a cosmetic one:
+  without the event a requester cannot reliably know when the runtime is
+  ready and must fall back to whatever coarse means it used previously.
 
 Conformance summary
 -------------------
@@ -317,6 +498,16 @@ A conforming implementation guarantees that:
 #. Concurrent campaigns of either kind never deadlock a parked job: it is
    admitted once, and only once, every campaign it is waiting on has
    completed.
-#. The feature adds no new caller-visible interface; its only observable
-   artifact is the ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` state shown for
-   a parked job in verbose and debugging output.
+#. A dynamic allocation that drives a size change is answered in two
+   phases: a synchronous response on acceptance (which does not assert the
+   operation has finished), and exactly one asynchronous terminal event —
+   ``PMIX_DVM_IS_READY`` on success or ``PMIX_ERR_DVM_MOD`` (carrying the
+   underlying cause) on failure — directed to the requester when the DVM
+   operation completes.  A phase-one rejection, a request that changes
+   nothing, and a requester-less scheduler push each produce no such event.
+#. The job-admission contract adds no caller-visible interface; the
+   completion contract adds only the two optional PMIx event codes above,
+   and when the underlying PMIx lacks them the runtime omits the
+   completion notification while leaving every other guarantee intact.
+   The job state ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS`` remains observable
+   for a parked job in verbose and debugging output.

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -1,0 +1,189 @@
+.. _dvm-grow-campaign-label:
+
+DVM Grow-Campaign Fence Tracking
+================================
+
+This document describes the implementation that makes the DVM **grow**
+(daemon-launch) path account for the launch fence on a per-daemon, rank-tracked
+basis, mirroring the design already used by the DVM **shrink** path.  For the
+fence mechanism itself and the race it closes, see
+:ref:`dvm-launch-fence-label` and :ref:`state-machine-label`, section
+*DVM Extension and the Daemon-Launch Race*.
+
+The state machine is single-threaded on the progress thread, so no locking is
+required anywhere in this plan.
+
+Motivation
+----------
+
+The launch fence (``prte_dvm_launch_fence``) holds application jobs at the
+``VM_READY → MAP`` boundary while a daemon-launch campaign is in progress, so
+that no job is mapped onto a node whose daemon is not yet up and wired.  The
+shrink path tracks the specific daemon ranks it is removing in a
+``prte_shrink_campaign_t`` and resolves the fence one rank at a time as each
+targeted daemon actually departs.
+
+The grow path, by contrast, originally encoded "a grow is in progress" as a
+single boolean — ``PRTE_JOB_LAUNCHED_DAEMONS`` — set on the one daemon job,
+together with a ``prte_dvm_launch_fence++`` performed once per campaign in
+``prte_plm_base_setup_virtual_machine()``.  The single decrement happened in
+``vm_ready`` on success, or in the ``errmgr/dvm`` comm-failure handler if a
+daemon died first.  Because that boolean carries no identity, two defects
+followed:
+
+#. **An unrelated daemon death consumed the campaign's token.**  The
+   comm-failure handler decremented the fence and cleared the boolean whenever
+   *any* daemon died while a grow was in progress — there is only one daemon
+   job, and it carried the token.  A pre-existing daemon dying mid-grow would
+   therefore release the held jobs early (reopening the very race the fence
+   exists to close) and clear the token, after which ``vm_ready`` skipped the
+   WIREUP xcast (it is gated on the same attribute), so the genuinely new
+   daemons could come up without ever receiving the nidmap/wireup buffer.
+
+#. **Concurrent campaigns could wedge the fence.**  Two overlapping grows would
+   raise the fence to two but share the single boolean token, which can only be
+   cleared once.  A daemon failure would clear it, leaving the fence stuck
+   above zero and the held jobs parked indefinitely.
+
+Both defects trace to the same root cause: the grow path tracked *that* a grow
+was happening, not *which* daemons it was launching.
+
+Design
+------
+
+Track each grow campaign explicitly, recording the ranks being launched, and
+hold the whole campaign's fence contribution until a single safe drain point.
+
+New campaign object
+~~~~~~~~~~~~~~~~~~~~
+
+In ``src/runtime/prte_globals.h`` / ``prte_globals.c``:
+
+.. code-block:: c
+
+   typedef struct {
+       pmix_list_item_t super;
+       pmix_rank_t     *targets;   /* daemon ranks being launched */
+       int              ntargets;  /* == this campaign's fence contribution */
+   } prte_grow_campaign_t;
+   PMIX_CLASS_DECLARATION(prte_grow_campaign_t);
+
+   PRTE_EXPORT extern pmix_list_t prte_grow_campaigns;
+
+The list is constructed in ``prte_init.c`` and destructed in
+``prte_finalize.c`` alongside ``prte_shrink_campaigns``.  A separate list (as
+opposed to unifying with the shrink list) is used deliberately: the
+``LAUNCH_APPS`` hold and the remap-on-release logic key off the *shrink* list's
+non-emptiness, and a grow must **not** stall jobs that are already mapped onto
+existing nodes.  Keeping the lists separate leaves the working shrink path
+untouched.
+
+Fence is campaign-granular, not per-rank
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unlike shrink, the grow fence contribution is **held in full until the
+campaign is drained as a unit**.  This is the key correctness point: the
+fence must not reach zero (for a successful grow) until *after* the WIREUP
+xcast in ``vm_ready``, otherwise an application job arriving in the window
+between "last daemon reported" and "wireup sent" would see a zero fence and
+map onto daemons that are up but not yet wired.  A naive per-rank decrement at
+daemon-report time would reopen exactly that window.  Holding the contribution
+until ``vm_ready`` drains it preserves the original ordering guarantee.
+
+The per-rank ``targets`` array therefore exists for one purpose: to decide
+whether a *failure* event belongs to this grow.
+
+Lifecycle
+~~~~~~~~~
+
+#. **Create** — in ``prte_plm_base_setup_virtual_machine()``, when
+   ``map->num_new_daemons > 0``: build a ``prte_grow_campaign_t`` recording the
+   ``num_new_daemons`` consecutive vpids starting at ``map->daemon_vpid_start``,
+   append it to ``prte_grow_campaigns``, and add ``num_new_daemons`` to the
+   fence.  ``PRTE_JOB_LAUNCHED_DAEMONS`` is still set on the daemon job for its
+   unrelated uses (the WIREUP gate in ``vm_ready`` and the odls path); it is no
+   longer consulted for fence accounting.
+
+#. **Success drain** — ``vm_ready`` fires only once every expected daemon has
+   reported (``num_reported == num_procs``), which means any in-progress grow
+   campaigns have fully succeeded.  After performing the WIREUP xcast, it calls
+   ``prte_plm_base_grow_drain(true)``, which removes every grow campaign,
+   subtracts each ``ntargets`` from the fence, and — if the fence has reached
+   zero — releases the held jobs with ``success == true``.
+
+#. **Failure drain** — in the ``errmgr/dvm`` comm-failure /
+   ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
+   ``prte_plm_base_grow_target_failed()``.  That function acts **only** if the
+   rank is a member of an in-progress grow campaign; an unrelated daemon loss
+   matches nothing and leaves the fence untouched (fixing defect 1).  If the
+   rank is a grow target, the grow is compromised, so it calls
+   ``prte_plm_base_grow_drain(false)`` — failing the held jobs.  Mirroring the
+   original single-token behavior, any grow failure fails the whole held-job
+   set.
+
+#. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
+   any still-pending grow campaigns with ``success == false`` so held jobs are
+   never parked across a daemon-job teardown.
+
+Because every live campaign contributes exactly its ``ntargets`` to the fence
+until drained as a unit, the fence's grow contribution is always the sum of the
+``ntargets`` of the campaigns on the list, and ``prte_plm_base_grow_drain()``
+zeroes that contribution in one pass — independent of how many concurrent
+campaigns exist (fixing defect 2).
+
+Why this is correct
+-------------------
+
+* **Unrelated daemon death during a grow.**  ``grow_target_failed()`` scans the
+  campaign target arrays; a non-target rank matches nothing, so the fence is
+  not touched, the held jobs are not released early, and the WIREUP xcast is
+  not skipped.
+
+* **Concurrent campaigns.**  Each campaign is an independent object with its own
+  contribution.  ``grow_drain()`` removes them all and the fence reaches zero
+  only when no grow contribution remains; there is no single token to exhaust.
+
+* **Wireup ordering.**  The fence stays at its full value throughout the grow
+  and is dropped only when ``vm_ready`` drains it after the WIREUP xcast (on
+  success) or when a target dies (on failure).  Jobs held at ``VM_READY → MAP``
+  are thus admitted only once the new daemons are wired up.
+
+* **Partial failure.**  A grow in which any target dies is failed as a whole:
+  the dying daemon triggers ``grow_drain(false)`` and the held jobs are
+  activated to ``NEVER_LAUNCHED``.  This matches the original first-failure
+  semantics.
+
+Touched files
+-------------
+
+.. list-table::
+   :widths: 45 55
+   :header-rows: 1
+
+   * - File
+     - Change
+   * - ``src/runtime/prte_globals.{h,c}``
+     - Add ``prte_grow_campaign_t``, ``prte_grow_campaigns`` list, and class.
+   * - ``src/runtime/prte_init.c`` / ``prte_finalize.c``
+     - Construct / destruct ``prte_grow_campaigns``.
+   * - ``src/mca/plm/base/plm_base_launch_support.c``
+     - Create the campaign in ``setup_virtual_machine``; add
+       ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
+   * - ``src/mca/plm/base/plm_private.h``
+     - Declare the two new helpers.
+   * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
+     - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
+       to ``prte_plm_base_grow_target_failed()``.
+   * - ``src/mca/state/dvm/state_dvm.c``
+     - Drain on success in ``vm_ready`` after WIREUP; drop the per-error fence
+       manipulation (the DVM is force-exiting); convert the
+       ``check_job_complete`` safety net to a drain.
+
+Follow-up
+---------
+
+The grow and shrink campaign objects are structurally similar and could be
+unified into a single ``prte_launch_campaign_t`` with a ``kind`` discriminator
+in a future cleanup.  That was intentionally deferred here to avoid disturbing
+the ``LAUNCH_APPS`` hold and remap-on-release logic, which must remain
+shrink-only.

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -113,10 +113,16 @@ Lifecycle
 #. **Create** — in ``prte_plm_base_setup_virtual_machine()``, when
    ``map->num_new_daemons > 0``: build a ``prte_grow_campaign_t`` recording the
    ``num_new_daemons`` consecutive vpids starting at ``map->daemon_vpid_start``,
-   record the requester / ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID`` (when the
-   grow was driven by an allocation request rather than a scheduler push),
-   append it to ``prte_grow_campaigns``, and add ``num_new_daemons`` to the
-   fence.  ``PRTE_JOB_LAUNCHED_DAEMONS`` is still set on the daemon job for its
+   record the requester / ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID`` for the
+   phase-two completion event, append it to ``prte_grow_campaigns``, and add
+   ``num_new_daemons`` to the fence.  The requester is taken from the first new
+   daemon's ``node->session`` — the RAS reservation machinery back-points each
+   reserved node at the session that records the driving request (``requestor``,
+   ``alloc_refid``, ``user_refid``).  When the grow was not driven by an
+   allocation request (the initial DVM bring-up, or a scheduler push — the
+   default session, or a session whose ``requestor`` rank is
+   ``PMIX_RANK_INVALID``), ``have_requester`` stays false and no event is
+   emitted.  ``PRTE_JOB_LAUNCHED_DAEMONS`` is still set on the daemon job for its
    unrelated uses (the WIREUP gate in ``vm_ready`` and the odls path); it is no
    longer consulted for fence accounting.
 
@@ -130,16 +136,13 @@ Lifecycle
    Step 5), and — if the fence has reached zero — admits the held jobs by
    calling ``prte_plm_base_fence_release()``.
 
-#. **Failure drain and rollback** — in the ``errmgr/dvm`` comm-failure /
+#. **Failure drain** — in the ``errmgr/dvm`` comm-failure /
    ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
    ``prte_plm_base_grow_target_failed()``.  That function acts **only** if the
    rank is a member of an in-progress grow campaign; an unrelated daemon loss
    matches nothing and leaves the fence untouched (fixing defect 1).  If the
-   rank is a grow target, the grow is compromised, so the campaign is rolled
-   back: its still-living daemons are terminated and all of its nodes are
-   removed from the DVM, returning the DVM to exactly the membership it had
-   before the campaign began (see `Rollback on failure`_).  The function then
-   calls ``prte_plm_base_grow_drain(false)``, which emits a ``PMIX_ERR_DVM_MOD``
+   rank is a grow target, the grow is compromised, so it calls
+   ``prte_plm_base_grow_drain(false)``, which emits a ``PMIX_ERR_DVM_MOD``
    completion event (carrying the underlying failure status) to each drained
    campaign's requester and then aborts the pre-map held jobs via
    ``prte_plm_base_abort_premap_held()`` (see :ref:`elastic-dvm-plan-label`,
@@ -149,8 +152,18 @@ Lifecycle
    job whose grow dependency has failed.  It deliberately does **not** disturb
    the pre-launch (``LAUNCH_APPS``) held jobs: those wait only on a shrink, not
    on the grow, so per the spec's conformance guarantee #4 a grow failure must
-   leave them parked.  The rollback ensures the DVM is never left half-extended
-   with a partial, un-wired set of new daemons.
+   leave them parked.
+
+   .. note::
+
+      The **rollback** described under `Rollback on failure`_ — terminating the
+      campaign's still-living daemons and removing its nodes so the DVM returns
+      to its exact pre-grow membership — is **not yet implemented**.  The
+      current ``grow_target_failed()`` drains the fence and aborts the held jobs
+      only; the partially-launched daemons are left running.  Until rollback
+      lands, a failed grow can leave the DVM half-extended, which does not yet
+      satisfy the spec's conformance guarantee #5.  This is the main open item
+      in the grow path.
 
 #. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
    any still-pending grow campaigns with ``success == false`` so pre-map held
@@ -165,11 +178,18 @@ campaigns exist (fixing defect 2).
 Rollback on failure
 ~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+   This section describes the **intended** rollback design; it is **not yet
+   implemented** (see the note under *Failure drain* above).  It is retained
+   here as the specification for the remaining grow-path work.
+
 The spec (:ref:`elastic-dvm-spec-label`) requires that a failed grow leave the
 DVM in its pre-grow state rather than half-extended.  Failing the held jobs is
 therefore necessary but not sufficient: the campaign's already-started daemons
-and the nodes it was adding must also be removed.  ``grow_target_failed()``
-performs this teardown for the matched campaign before draining its held jobs.
+and the nodes it was adding must also be removed.  ``grow_target_failed()`` is
+intended to perform this teardown for the matched campaign before draining its
+held jobs.
 
 The campaign's ``targets`` array enumerates every daemon rank the grow
 launched.  One of them is the rank whose loss triggered the failure; the
@@ -220,13 +240,14 @@ Why this is correct
   are thus admitted only once the new daemons are wired up.
 
 * **Partial failure.**  A grow in which any target dies is failed as a whole:
-  the dying daemon triggers ``grow_target_failed()``, which rolls the campaign
-  back — terminating its still-living daemons and removing its nodes from the
-  DVM — and then calls ``grow_drain(false)`` so the pre-map held jobs are
-  activated to ``NEVER_LAUNCHED`` (the pre-launch held jobs, which wait only on
-  a shrink, are left untouched).  This matches the original first-failure
-  semantics and, per the spec, leaves the DVM at its exact pre-grow membership
-  rather than half-extended.
+  the dying daemon triggers ``grow_target_failed()``, which calls
+  ``grow_drain(false)`` so the pre-map held jobs are activated to
+  ``NEVER_LAUNCHED`` (the pre-launch held jobs, which wait only on a shrink, are
+  left untouched).  This matches the original first-failure semantics for the
+  held jobs.  Leaving the DVM at its exact pre-grow membership additionally
+  requires the campaign rollback, which is **not yet implemented** (see the note
+  under *Failure drain*); until it lands, the partially-launched daemons remain
+  up.
 
 Touched files
 -------------
@@ -245,16 +266,18 @@ Touched files
      - Construct / destruct ``prte_grow_campaigns``.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
      - Create the campaign in ``setup_virtual_machine`` (recording the
-       requester / ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID``); add
+       requester from the first new daemon's ``node->session`` — its
+       ``requestor`` / ``alloc_refid`` / ``user_refid``); add
        ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
        ``grow_drain()`` emits the per-campaign completion event
        (``PMIX_DVM_IS_READY`` on success, ``PMIX_ERR_DVM_MOD`` on failure) via
        the shared ``prte_plm_base_dvm_mod_notify()`` helper, and disposes of the
        held jobs: on success via ``prte_plm_base_fence_release()`` when the
        fence reaches zero, on failure via ``prte_plm_base_abort_premap_held()``
-       (pre-map jobs only).  ``grow_target_failed()`` rolls the failed campaign
-       back — terminating its surviving daemons and removing its nodes from the
-       DVM via the shrink-path machinery — before draining.
+       (pre-map jobs only).  ``grow_target_failed()`` currently just calls
+       ``grow_drain(false)`` when the dead rank is a grow target; the campaign
+       rollback (terminating surviving daemons, removing nodes) is **not yet
+       implemented**.
    * - ``src/mca/plm/base/plm_private.h``
      - Declare ``prte_plm_base_grow_drain()`` and
        ``prte_plm_base_grow_target_failed()`` (alongside the shared
@@ -262,9 +285,10 @@ Touched files
        all the ``prte_plm_base_*`` launch-fence helpers live in the one header
        the errmgr already includes).
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
-     - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
-       to ``prte_plm_base_grow_target_failed()``, which both aborts the pre-map
-       held jobs and rolls the campaign's daemons/nodes back out of the DVM.
+     - In the daemon comm-failure block, pass the dead rank to
+       ``prte_plm_base_grow_target_failed()``, which aborts the pre-map held
+       jobs when the rank is a grow target.  (Rolling the campaign's
+       daemons/nodes back out of the DVM is the not-yet-implemented follow-up.)
    * - ``src/mca/state/dvm/state_dvm.c``
      - Drain on success in ``vm_ready`` after WIREUP; drop the per-error fence
        manipulation (the DVM is force-exiting); convert the
@@ -273,8 +297,16 @@ Touched files
 Follow-up
 ---------
 
-The grow and shrink campaign objects are structurally similar and could be
-unified into a single ``prte_launch_campaign_t`` with a ``kind`` discriminator
-in a future cleanup.  That was intentionally deferred here to avoid disturbing
-the ``LAUNCH_APPS`` hold and remap-on-release logic, which must remain
-shrink-only.
+* **Failure rollback (primary open item).**  ``grow_target_failed()`` does not
+  yet roll a failed campaign back out of the DVM — it only drains the fence and
+  aborts the pre-map held jobs.  The teardown specified under
+  `Rollback on failure`_ (terminating the campaign's surviving daemons and
+  removing its nodes so the DVM returns to its exact pre-grow membership) is
+  required to satisfy the spec's conformance guarantee #5 and remains to be
+  implemented.
+
+* **Campaign-object unification.**  The grow and shrink campaign objects are
+  structurally similar and could be unified into a single
+  ``prte_launch_campaign_t`` with a ``kind`` discriminator in a future cleanup.
+  That was intentionally deferred here to avoid disturbing the ``LAUNCH_APPS``
+  hold and remap-on-release logic, which must remain shrink-only.

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -95,8 +95,10 @@ map onto daemons that are up but not yet wired.  A naive per-rank decrement at
 daemon-report time would reopen exactly that window.  Holding the contribution
 until ``vm_ready`` drains it preserves the original ordering guarantee.
 
-The per-rank ``targets`` array therefore exists for one purpose: to decide
-whether a *failure* event belongs to this grow.
+The per-rank ``targets`` array serves two purposes: to decide whether a
+*failure* event belongs to this grow, and — when one does — to enumerate the
+daemons that must be torn down to roll the DVM back to its pre-grow membership
+(see `Rollback on failure`_).
 
 Lifecycle
 ~~~~~~~~~
@@ -116,15 +118,19 @@ Lifecycle
    subtracts each ``ntargets`` from the fence, and — if the fence has reached
    zero — releases the held jobs with ``success == true``.
 
-#. **Failure drain** — in the ``errmgr/dvm`` comm-failure /
+#. **Failure drain and rollback** — in the ``errmgr/dvm`` comm-failure /
    ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
    ``prte_plm_base_grow_target_failed()``.  That function acts **only** if the
    rank is a member of an in-progress grow campaign; an unrelated daemon loss
    matches nothing and leaves the fence untouched (fixing defect 1).  If the
-   rank is a grow target, the grow is compromised, so it calls
-   ``prte_plm_base_grow_drain(false)`` — failing the held jobs.  Mirroring the
-   original single-token behavior, any grow failure fails the whole held-job
-   set.
+   rank is a grow target, the grow is compromised, so the campaign is rolled
+   back: its still-living daemons are terminated and all of its nodes are
+   removed from the DVM, returning the DVM to exactly the membership it had
+   before the campaign began (see `Rollback on failure`_).  The function then
+   calls ``prte_plm_base_grow_drain(false)`` — failing the held jobs.
+   Mirroring the original single-token behavior, any grow failure fails the
+   whole held-job set, and the rollback ensures the DVM is never left
+   half-extended with a partial, un-wired set of new daemons.
 
 #. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
    any still-pending grow campaigns with ``success == false`` so held jobs are
@@ -135,6 +141,46 @@ until drained as a unit, the fence's grow contribution is always the sum of the
 ``ntargets`` of the campaigns on the list, and ``prte_plm_base_grow_drain()``
 zeroes that contribution in one pass — independent of how many concurrent
 campaigns exist (fixing defect 2).
+
+Rollback on failure
+~~~~~~~~~~~~~~~~~~~~
+
+The spec (:ref:`elastic-dvm-spec-label`) requires that a failed grow leave the
+DVM in its pre-grow state rather than half-extended.  Failing the held jobs is
+therefore necessary but not sufficient: the campaign's already-started daemons
+and the nodes it was adding must also be removed.  ``grow_target_failed()``
+performs this teardown for the matched campaign before draining its held jobs.
+
+The campaign's ``targets`` array enumerates every daemon rank the grow
+launched.  One of them is the rank whose loss triggered the failure; the
+remainder may be in any state from "not yet reported" through "reported and
+wired".  Rollback handles each target according to whether a daemon actually
+came up:
+
+* **A target that started** (it reported in, or at least established a route)
+  is terminated using the same daemon-termination machinery the DVM shrink path
+  uses — the campaign's surviving ranks are removed from the DVM exactly as a
+  shrink would remove them.
+
+* **A target that never started** (the ``FAILED_TO_START`` case — e.g. the
+  remote ``exec`` failed) has no daemon to terminate; only the node bookkeeping
+  added for it during ``setup_virtual_machine()`` is reverted.
+
+In both cases the campaign's node objects are removed from the DVM's node pool
+— reverting the additions made at campaign creation (clearing ``node->daemon``,
+dropping the node from the pool, and decrementing the DVM's daemon/node counts)
+— so that the moment the rollback runs, the mapper can no longer place any
+later job onto those nodes.  The actual daemon exits proceed asynchronously, as
+in any DVM contraction; because the nodes have already left the mapper's view
+and the held jobs were failed to ``NEVER_LAUNCHED``, no job is ever admitted
+onto a node that is being rolled back.
+
+The rollback is strictly campaign-scoped: it touches only the ranks in the
+failed campaign's ``targets`` array.  A concurrently-running grow campaign
+keeps its own daemons and completes normally, and no pre-existing daemon or
+node is disturbed — the same identity-based discrimination that keeps an
+unrelated daemon death from consuming the fence (defect 1) also keeps it out of
+the rollback set.
 
 Why this is correct
 -------------------
@@ -154,9 +200,12 @@ Why this is correct
   are thus admitted only once the new daemons are wired up.
 
 * **Partial failure.**  A grow in which any target dies is failed as a whole:
-  the dying daemon triggers ``grow_drain(false)`` and the held jobs are
-  activated to ``NEVER_LAUNCHED``.  This matches the original first-failure
-  semantics.
+  the dying daemon triggers ``grow_target_failed()``, which rolls the campaign
+  back — terminating its still-living daemons and removing its nodes from the
+  DVM — and then calls ``grow_drain(false)`` so the held jobs are activated to
+  ``NEVER_LAUNCHED``.  This matches the original first-failure semantics and,
+  per the spec, leaves the DVM at its exact pre-grow membership rather than
+  half-extended.
 
 Touched files
 -------------
@@ -174,11 +223,15 @@ Touched files
    * - ``src/mca/plm/base/plm_base_launch_support.c``
      - Create the campaign in ``setup_virtual_machine``; add
        ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
+       The latter rolls the failed campaign back — terminating its surviving
+       daemons and removing its nodes from the DVM via the shrink-path
+       machinery — before draining the held jobs.
    * - ``src/mca/plm/base/plm_private.h``
      - Declare the two new helpers.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
-       to ``prte_plm_base_grow_target_failed()``.
+       to ``prte_plm_base_grow_target_failed()``, which both fails the held jobs
+       and rolls the campaign's daemons/nodes back out of the DVM.
    * - ``src/mca/state/dvm/state_dvm.c``
      - Drain on success in ``vm_ready`` after WIREUP; drop the per-error fence
        manipulation (the DVM is force-exiting); convert the

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -136,84 +136,76 @@ Lifecycle
    Step 5), and — if the fence has reached zero — admits the held jobs by
    calling ``prte_plm_base_fence_release()``.
 
-#. **Failure drain** — in the ``errmgr/dvm`` comm-failure /
+#. **Failure drain and rollback** — in the ``errmgr/dvm`` comm-failure /
    ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
-   ``prte_plm_base_grow_target_failed()``.  That function acts **only** if the
-   rank is a member of an in-progress grow campaign; an unrelated daemon loss
-   matches nothing and leaves the fence untouched (fixing defect 1).  If the
-   rank is a grow target, the grow is compromised, so it calls
-   ``prte_plm_base_grow_drain(false)``, which emits a ``PMIX_ERR_DVM_MOD``
-   completion event (carrying the underlying failure status) to each drained
-   campaign's requester and then aborts the pre-map held jobs via
+   ``prte_plm_base_grow_target_failed()``, which returns ``true`` iff the rank
+   belonged to an in-progress grow campaign.  An unrelated daemon loss matches
+   nothing, returns ``false``, and is left to the errmgr's normal handling
+   (fixing defect 1).  When the rank *is* a grow target, the function handles
+   the loss completely — it removes **that** campaign from the list, drops its
+   ``ntargets`` from the fence, rolls it back out of the DVM (see
+   `Rollback on failure`_), emits a ``PMIX_ERR_DVM_MOD`` completion event to its
+   requester, and aborts the pre-map held jobs via
    ``prte_plm_base_abort_premap_held()`` (see :ref:`elastic-dvm-plan-label`,
-   Step 4).  Mirroring the original single-token behavior, any grow failure
-   fails the whole **pre-map** held-job set — and does so immediately,
-   regardless of the fence value, so a concurrent shrink cannot later admit a
-   job whose grow dependency has failed.  It deliberately does **not** disturb
-   the pre-launch (``LAUNCH_APPS``) held jobs: those wait only on a shrink, not
-   on the grow, so per the spec's conformance guarantee #4 a grow failure must
-   leave them parked.
+   Step 4) — and the errmgr, seeing the ``true`` return, ``goto``\ s its cleanup
+   so the general daemon-loss path (which would otherwise abort the whole DVM)
+   is skipped.  The failure is **campaign-scoped**: only the matched campaign is
+   torn down, so a concurrent grow keeps its daemons and completes normally.
+   Mirroring the original single-token behavior, any grow failure fails the
+   whole **pre-map** held-job set — immediately, regardless of the fence value,
+   so a concurrent shrink cannot later admit a job whose grow dependency has
+   failed.  It deliberately does **not** disturb the pre-launch
+   (``LAUNCH_APPS``) held jobs: those wait only on a shrink, not on the grow, so
+   per the spec's conformance guarantee #4 a grow failure must leave them
+   parked.
 
-   .. note::
+#. **Safety net** — ``check_job_complete``'s "received NULL job" branch calls
+   ``prte_plm_base_grow_drain(false)`` to drain any still-pending grow campaigns
+   as failures, so pre-map held jobs are never parked across a daemon-job
+   teardown.  (No rollback is needed there — the whole DVM is force-exiting.)
 
-      The **rollback** described under `Rollback on failure`_ — terminating the
-      campaign's still-living daemons and removing its nodes so the DVM returns
-      to its exact pre-grow membership — is **not yet implemented**.  The
-      current ``grow_target_failed()`` drains the fence and aborts the held jobs
-      only; the partially-launched daemons are left running.  Until rollback
-      lands, a failed grow can leave the DVM half-extended, which does not yet
-      satisfy the spec's conformance guarantee #5.  This is the main open item
-      in the grow path.
-
-#. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
-   any still-pending grow campaigns with ``success == false`` so pre-map held
-   jobs are never parked across a daemon-job teardown.
-
-Because every live campaign contributes exactly its ``ntargets`` to the fence
-until drained as a unit, the fence's grow contribution is always the sum of the
-``ntargets`` of the campaigns on the list, and ``prte_plm_base_grow_drain()``
-zeroes that contribution in one pass — independent of how many concurrent
-campaigns exist (fixing defect 2).
+The success drain (``grow_drain(true)`` from ``vm_ready``) still removes every
+grow campaign in one pass and zeroes the fence's entire grow contribution,
+independent of how many concurrent campaigns exist (fixing defect 2); the
+*failure* path, by contrast, is per-campaign so an unrelated concurrent grow is
+not dragged down with the failed one.
 
 Rollback on failure
 ~~~~~~~~~~~~~~~~~~~~
 
-.. note::
-
-   This section describes the **intended** rollback design; it is **not yet
-   implemented** (see the note under *Failure drain* above).  It is retained
-   here as the specification for the remaining grow-path work.
-
 The spec (:ref:`elastic-dvm-spec-label`) requires that a failed grow leave the
 DVM in its pre-grow state rather than half-extended.  Failing the held jobs is
 therefore necessary but not sufficient: the campaign's already-started daemons
-and the nodes it was adding must also be removed.  ``grow_target_failed()`` is
-intended to perform this teardown for the matched campaign before draining its
-held jobs.
+and the nodes it was adding must also be removed.  ``grow_target_failed()``
+performs this teardown (in the static helper ``grow_rollback()``) for the
+matched campaign before notifying the requester and aborting the held jobs.
 
 The campaign's ``targets`` array enumerates every daemon rank the grow
 launched.  One of them is the rank whose loss triggered the failure; the
 remainder may be in any state from "not yet reported" through "reported and
-wired".  Rollback handles each target according to whether a daemon actually
-came up:
+wired".  Routing for the triggering rank is repaired here with
+``prte_rml_route_lost()`` (the errmgr's own ``route_lost`` call is on the path
+that the ``true`` return skips).  Each *other* target is handled according to
+whether a daemon actually came up:
 
-* **A target that started** (it reported in, or at least established a route)
-  is terminated using the same daemon-termination machinery the DVM shrink path
-  uses — the campaign's surviving ranks are removed from the DVM exactly as a
-  shrink would remove them.
+* **A target that started** (``PRTE_PROC_FLAG_ALIVE`` — it reported in) is
+  terminated using the same ``PRTE_DAEMON_SHRINK_CMD`` xcast the DVM shrink path
+  uses.  It self-exits, and its departure is then reconciled on the normal
+  daemon-loss path (``route_lost`` succeeds, ``num_daemons`` is decremented) as
+  for any shrink — and because the campaign is already gone, that later event
+  returns ``false`` and is handled without a second rollback.
 
 * **A target that never started** (the ``FAILED_TO_START`` case — e.g. the
-  remote ``exec`` failed) has no daemon to terminate; only the node bookkeeping
-  added for it during ``setup_virtual_machine()`` is reverted.
+  remote ``exec`` failed) has no daemon to signal, so no comm-failure event will
+  arrive for it; its launch-time ``num_daemons`` bump is reverted directly in
+  ``grow_rollback()``.
 
-In both cases the campaign's node objects are removed from the DVM's node pool
-— reverting the additions made at campaign creation (clearing ``node->daemon``,
-dropping the node from the pool, and decrementing the DVM's daemon/node counts)
-— so that the moment the rollback runs, the mapper can no longer place any
-later job onto those nodes.  The actual daemon exits proceed asynchronously, as
-in any DVM contraction; because the nodes have already left the mapper's view
-and the held jobs were failed to ``NEVER_LAUNCHED``, no job is ever admitted
-onto a node that is being rolled back.
+In every case the node's daemon backpointer is cleared (``node->daemon = NULL``,
+releasing the retain taken at assignment, and detaching any reservation
+session), which removes the node from the mapper's usable set — the new nodes
+carry no application procs, since the jobs that would have used them were held
+at the fence and never launched, so clearing ``node->daemon`` is sufficient to
+keep any later job off them.
 
 The rollback is strictly campaign-scoped: it touches only the ranks in the
 failed campaign's ``targets`` array.  A concurrently-running grow campaign
@@ -221,6 +213,16 @@ keeps its own daemons and completes normally, and no pre-existing daemon or
 node is disturbed — the same identity-based discrimination that keeps an
 unrelated daemon death from consuming the fence (defect 1) also keeps it out of
 the rollback set.
+
+.. note::
+
+   Two edges remain, both within the rarely-exercised daemon-launch-failure
+   path and neither yet validated against a real multi-node allocation: a target
+   that is **slow to start** (neither ``ALIVE`` nor yet failed when the rollback
+   runs) is treated as never-started, so a later report-in or failure for it is
+   not specially handled; and node objects are detached via ``node->daemon``
+   rather than physically removed from ``prte_node_pool`` (matching how the
+   shrink path leaves the pool), so ``num_nodes`` is not decremented.
 
 Why this is correct
 -------------------
@@ -231,8 +233,9 @@ Why this is correct
   not skipped.
 
 * **Concurrent campaigns.**  Each campaign is an independent object with its own
-  contribution.  ``grow_drain()`` removes them all and the fence reaches zero
-  only when no grow contribution remains; there is no single token to exhaust.
+  contribution.  On success ``grow_drain()`` removes them all and the fence
+  reaches zero only when no grow contribution remains; on failure only the
+  matched campaign is removed.  Either way there is no single token to exhaust.
 
 * **Wireup ordering.**  The fence stays at its full value throughout the grow
   and is dropped only when ``vm_ready`` drains it after the WIREUP xcast (on
@@ -240,14 +243,14 @@ Why this is correct
   are thus admitted only once the new daemons are wired up.
 
 * **Partial failure.**  A grow in which any target dies is failed as a whole:
-  the dying daemon triggers ``grow_target_failed()``, which calls
-  ``grow_drain(false)`` so the pre-map held jobs are activated to
+  the dying daemon triggers ``grow_target_failed()``, which rolls the matched
+  campaign back out of the DVM — terminating its started daemons via the shrink
+  command and detaching its nodes — and aborts the pre-map held jobs to
   ``NEVER_LAUNCHED`` (the pre-launch held jobs, which wait only on a shrink, are
   left untouched).  This matches the original first-failure semantics for the
-  held jobs.  Leaving the DVM at its exact pre-grow membership additionally
-  requires the campaign rollback, which is **not yet implemented** (see the note
-  under *Failure drain*); until it lands, the partially-launched daemons remain
-  up.
+  held jobs and, per the spec, leaves the DVM at its pre-grow membership rather
+  than half-extended; the errmgr skips its DVM-wide abort because the loss was
+  reported as handled.
 
 Touched files
 -------------
@@ -268,27 +271,27 @@ Touched files
      - Create the campaign in ``setup_virtual_machine`` (recording the
        requester from the first new daemon's ``node->session`` — its
        ``requestor`` / ``alloc_refid`` / ``user_refid``); add
-       ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
-       ``grow_drain()`` emits the per-campaign completion event
-       (``PMIX_DVM_IS_READY`` on success, ``PMIX_ERR_DVM_MOD`` on failure) via
-       the shared ``prte_plm_base_dvm_mod_notify()`` helper, and disposes of the
-       held jobs: on success via ``prte_plm_base_fence_release()`` when the
-       fence reaches zero, on failure via ``prte_plm_base_abort_premap_held()``
-       (pre-map jobs only).  ``grow_target_failed()`` currently just calls
-       ``grow_drain(false)`` when the dead rank is a grow target; the campaign
-       rollback (terminating surviving daemons, removing nodes) is **not yet
-       implemented**.
+       ``prte_plm_base_grow_drain()``, the static ``grow_rollback()``, and
+       ``prte_plm_base_grow_target_failed()``.  ``grow_drain()`` (success drain /
+       teardown safety net) emits the per-campaign completion event via the
+       shared ``prte_plm_base_dvm_mod_notify()`` helper and, on success, admits
+       the held jobs via ``prte_plm_base_fence_release()`` when the fence reaches
+       zero.  ``grow_target_failed()`` returns ``bool`` and, for the matched
+       campaign, removes it, drops its fence contribution, calls
+       ``grow_rollback()`` (terminate started daemons via the shrink command,
+       revert never-started daemon counts, detach nodes), emits
+       ``PMIX_ERR_DVM_MOD``, and aborts the pre-map held jobs.
    * - ``src/mca/plm/base/plm_private.h``
-     - Declare ``prte_plm_base_grow_drain()`` and
+     - Declare ``prte_plm_base_grow_drain()`` and the now-``bool``-returning
        ``prte_plm_base_grow_target_failed()`` (alongside the shared
        ``fence_release`` / ``abort_premap_held`` / ``dvm_mod_notify`` helpers, so
        all the ``prte_plm_base_*`` launch-fence helpers live in the one header
        the errmgr already includes).
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
-     - In the daemon comm-failure block, pass the dead rank to
-       ``prte_plm_base_grow_target_failed()``, which aborts the pre-map held
-       jobs when the rank is a grow target.  (Rolling the campaign's
-       daemons/nodes back out of the DVM is the not-yet-implemented follow-up.)
+     - In the daemon comm-failure block, ``goto cleanup`` when
+       ``prte_plm_base_grow_target_failed()`` returns ``true``: the grow rollback
+       has fully absorbed the loss, so the general daemon-loss handling (which
+       would otherwise abort the whole DVM) must be skipped.
    * - ``src/mca/state/dvm/state_dvm.c``
      - Drain on success in ``vm_ready`` after WIREUP; drop the per-error fence
        manipulation (the DVM is force-exiting); convert the
@@ -296,14 +299,6 @@ Touched files
 
 Follow-up
 ---------
-
-* **Failure rollback (primary open item).**  ``grow_target_failed()`` does not
-  yet roll a failed campaign back out of the DVM — it only drains the fence and
-  aborts the pre-map held jobs.  The teardown specified under
-  `Rollback on failure`_ (terminating the campaign's surviving daemons and
-  removing its nodes so the DVM returns to its exact pre-grow membership) is
-  required to satisfy the spec's conformance guarantee #5 and remains to be
-  implemented.
 
 * **Campaign-object unification.**  The grow and shrink campaign objects are
   structurally similar and could be unified into a single

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -255,12 +255,12 @@ Touched files
        (pre-map jobs only).  ``grow_target_failed()`` rolls the failed campaign
        back — terminating its surviving daemons and removing its nodes from the
        DVM via the shrink-path machinery — before draining.
-   * - ``src/mca/plm/base/base.h``
+   * - ``src/mca/plm/base/plm_private.h``
      - Declare ``prte_plm_base_grow_drain()`` and
        ``prte_plm_base_grow_target_failed()`` (alongside the shared
        ``fence_release`` / ``abort_premap_held`` / ``dvm_mod_notify`` helpers, so
-       all the ``prte_plm_base_*`` launch-fence helpers live in the one public
-       plm-base header the errmgr also includes).
+       all the ``prte_plm_base_*`` launch-fence helpers live in the one header
+       the errmgr already includes).
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
        to ``prte_plm_base_grow_target_failed()``, which both aborts the pre-map

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -13,6 +13,11 @@ fence mechanism itself and the race it closes, see
 The state machine is single-threaded on the progress thread, so no locking is
 required anywhere in this plan.
 
+The observable job-admission and placement guarantees that the grow path
+upholds are specified in :ref:`elastic-dvm-spec-label`, which is
+authoritative for observable behavior; this document describes the
+implementation that delivers them.
+
 Motivation
 ----------
 

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -255,11 +255,12 @@ Touched files
        (pre-map jobs only).  ``grow_target_failed()`` rolls the failed campaign
        back — terminating its surviving daemons and removing its nodes from the
        DVM via the shrink-path machinery — before draining.
-   * - ``src/mca/plm/base/plm_base_launch_support.h``
+   * - ``src/mca/plm/base/base.h``
      - Declare ``prte_plm_base_grow_drain()`` and
        ``prte_plm_base_grow_target_failed()`` (alongside the shared
        ``fence_release`` / ``abort_premap_held`` / ``dvm_mod_notify`` helpers, so
-       all four ``prte_plm_base_*`` launch-fence helpers live in one header).
+       all the ``prte_plm_base_*`` launch-fence helpers live in the one public
+       plm-base header the errmgr also includes).
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
        to ``prte_plm_base_grow_target_failed()``, which both aborts the pre-map

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -127,8 +127,8 @@ Lifecycle
    subtracts each ``ntargets`` from the fence, emits a ``PMIX_DVM_IS_READY``
    completion event to each drained campaign's requester (via
    ``prte_plm_base_dvm_mod_notify()`` — see :ref:`elastic-dvm-plan-label`,
-   Step 5), and — if the fence has reached zero — releases the held jobs with
-   ``success == true``.
+   Step 5), and — if the fence has reached zero — admits the held jobs by
+   calling ``prte_plm_base_fence_release()``.
 
 #. **Failure drain and rollback** — in the ``errmgr/dvm`` comm-failure /
    ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
@@ -139,16 +139,22 @@ Lifecycle
    back: its still-living daemons are terminated and all of its nodes are
    removed from the DVM, returning the DVM to exactly the membership it had
    before the campaign began (see `Rollback on failure`_).  The function then
-   calls ``prte_plm_base_grow_drain(false)`` — emitting a ``PMIX_ERR_DVM_MOD``
+   calls ``prte_plm_base_grow_drain(false)``, which emits a ``PMIX_ERR_DVM_MOD``
    completion event (carrying the underlying failure status) to each drained
-   campaign's requester, and failing the held jobs.  Mirroring the original
-   single-token behavior, any grow failure fails the whole held-job set, and
-   the rollback ensures the DVM is never left half-extended with a partial,
-   un-wired set of new daemons.
+   campaign's requester and then aborts the pre-map held jobs via
+   ``prte_plm_base_abort_premap_held()`` (see :ref:`elastic-dvm-plan-label`,
+   Step 4).  Mirroring the original single-token behavior, any grow failure
+   fails the whole **pre-map** held-job set — and does so immediately,
+   regardless of the fence value, so a concurrent shrink cannot later admit a
+   job whose grow dependency has failed.  It deliberately does **not** disturb
+   the pre-launch (``LAUNCH_APPS``) held jobs: those wait only on a shrink, not
+   on the grow, so per the spec's conformance guarantee #4 a grow failure must
+   leave them parked.  The rollback ensures the DVM is never left half-extended
+   with a partial, un-wired set of new daemons.
 
 #. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
-   any still-pending grow campaigns with ``success == false`` so held jobs are
-   never parked across a daemon-job teardown.
+   any still-pending grow campaigns with ``success == false`` so pre-map held
+   jobs are never parked across a daemon-job teardown.
 
 Because every live campaign contributes exactly its ``ntargets`` to the fence
 until drained as a unit, the fence's grow contribution is always the sum of the
@@ -216,10 +222,11 @@ Why this is correct
 * **Partial failure.**  A grow in which any target dies is failed as a whole:
   the dying daemon triggers ``grow_target_failed()``, which rolls the campaign
   back — terminating its still-living daemons and removing its nodes from the
-  DVM — and then calls ``grow_drain(false)`` so the held jobs are activated to
-  ``NEVER_LAUNCHED``.  This matches the original first-failure semantics and,
-  per the spec, leaves the DVM at its exact pre-grow membership rather than
-  half-extended.
+  DVM — and then calls ``grow_drain(false)`` so the pre-map held jobs are
+  activated to ``NEVER_LAUNCHED`` (the pre-launch held jobs, which wait only on
+  a shrink, are left untouched).  This matches the original first-failure
+  semantics and, per the spec, leaves the DVM at its exact pre-grow membership
+  rather than half-extended.
 
 Touched files
 -------------
@@ -242,16 +249,21 @@ Touched files
        ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
        ``grow_drain()`` emits the per-campaign completion event
        (``PMIX_DVM_IS_READY`` on success, ``PMIX_ERR_DVM_MOD`` on failure) via
-       the shared ``prte_plm_base_dvm_mod_notify()`` helper.  ``grow_target_failed()``
-       rolls the failed campaign back — terminating its surviving daemons and
-       removing its nodes from the DVM via the shrink-path machinery — before
-       draining the held jobs.
-   * - ``src/mca/plm/base/plm_private.h``
-     - Declare the two new helpers.
+       the shared ``prte_plm_base_dvm_mod_notify()`` helper, and disposes of the
+       held jobs: on success via ``prte_plm_base_fence_release()`` when the
+       fence reaches zero, on failure via ``prte_plm_base_abort_premap_held()``
+       (pre-map jobs only).  ``grow_target_failed()`` rolls the failed campaign
+       back — terminating its surviving daemons and removing its nodes from the
+       DVM via the shrink-path machinery — before draining.
+   * - ``src/mca/plm/base/plm_base_launch_support.h``
+     - Declare ``prte_plm_base_grow_drain()`` and
+       ``prte_plm_base_grow_target_failed()`` (alongside the shared
+       ``fence_release`` / ``abort_premap_held`` / ``dvm_mod_notify`` helpers, so
+       all four ``prte_plm_base_*`` launch-fence helpers live in one header).
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - Replace the coarse ``PRTE_JOB_LAUNCHED_DAEMONS`` fence block with a call
-       to ``prte_plm_base_grow_target_failed()``, which both fails the held jobs
-       and rolls the campaign's daemons/nodes back out of the DVM.
+       to ``prte_plm_base_grow_target_failed()``, which both aborts the pre-map
+       held jobs and rolls the campaign's daemons/nodes back out of the DVM.
    * - ``src/mca/state/dvm/state_dvm.c``
      - Drain on success in ``vm_ready`` after WIREUP; drop the per-error fence
        manipulation (the DVM is force-exiting); convert the

--- a/docs/plans/elastic_dvm/grow_campaign.rst
+++ b/docs/plans/elastic_dvm/grow_campaign.rst
@@ -5,10 +5,10 @@ DVM Grow-Campaign Fence Tracking
 
 This document describes the implementation that makes the DVM **grow**
 (daemon-launch) path account for the launch fence on a per-daemon, rank-tracked
-basis, mirroring the design already used by the DVM **shrink** path.  For the
-fence mechanism itself and the race it closes, see
-:ref:`dvm-launch-fence-label` and :ref:`state-machine-label`, section
-*DVM Extension and the Daemon-Launch Race*.
+basis, mirroring the design already used by the DVM **shrink** path
+(:ref:`dvm-shrink-campaign-label`).  For the shared fence mechanism itself and
+the race it closes, see the parent plan :ref:`elastic-dvm-plan-label` and
+:ref:`state-machine-label`, section *DVM Extension and the Daemon-Launch Race*.
 
 The state machine is single-threaded on the progress thread, so no locking is
 required anywhere in this plan.
@@ -68,12 +68,19 @@ In ``src/runtime/prte_globals.h`` / ``prte_globals.c``:
 
    typedef struct {
        pmix_list_item_t super;
-       pmix_rank_t     *targets;   /* daemon ranks being launched */
-       int              ntargets;  /* == this campaign's fence contribution */
+       pmix_rank_t     *targets;        /* daemon ranks being launched */
+       int              ntargets;       /* == this campaign's fence contribution */
+       /* requester recorded for the spec's phase-two completion event */
+       pmix_proc_t      requester;      /* who requested the grow */
+       char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation */
+       char            *req_id;         /* PMIX_ALLOC_REQ_ID, or NULL */
+       bool             have_requester; /* false for a scheduler-driven push */
    } prte_grow_campaign_t;
    PMIX_CLASS_DECLARATION(prte_grow_campaign_t);
 
    PRTE_EXPORT extern pmix_list_t prte_grow_campaigns;
+
+The campaign's destructor frees ``targets``, ``alloc_id``, and ``req_id``.
 
 The list is constructed in ``prte_init.c`` and destructed in
 ``prte_finalize.c`` alongside ``prte_shrink_campaigns``.  A separate list (as
@@ -106,6 +113,8 @@ Lifecycle
 #. **Create** — in ``prte_plm_base_setup_virtual_machine()``, when
    ``map->num_new_daemons > 0``: build a ``prte_grow_campaign_t`` recording the
    ``num_new_daemons`` consecutive vpids starting at ``map->daemon_vpid_start``,
+   record the requester / ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID`` (when the
+   grow was driven by an allocation request rather than a scheduler push),
    append it to ``prte_grow_campaigns``, and add ``num_new_daemons`` to the
    fence.  ``PRTE_JOB_LAUNCHED_DAEMONS`` is still set on the daemon job for its
    unrelated uses (the WIREUP gate in ``vm_ready`` and the odls path); it is no
@@ -115,8 +124,11 @@ Lifecycle
    reported (``num_reported == num_procs``), which means any in-progress grow
    campaigns have fully succeeded.  After performing the WIREUP xcast, it calls
    ``prte_plm_base_grow_drain(true)``, which removes every grow campaign,
-   subtracts each ``ntargets`` from the fence, and — if the fence has reached
-   zero — releases the held jobs with ``success == true``.
+   subtracts each ``ntargets`` from the fence, emits a ``PMIX_DVM_IS_READY``
+   completion event to each drained campaign's requester (via
+   ``prte_plm_base_dvm_mod_notify()`` — see :ref:`elastic-dvm-plan-label`,
+   Step 5), and — if the fence has reached zero — releases the held jobs with
+   ``success == true``.
 
 #. **Failure drain and rollback** — in the ``errmgr/dvm`` comm-failure /
    ``FAILED_TO_START`` handler, the dead daemon's rank is passed to
@@ -127,10 +139,12 @@ Lifecycle
    back: its still-living daemons are terminated and all of its nodes are
    removed from the DVM, returning the DVM to exactly the membership it had
    before the campaign began (see `Rollback on failure`_).  The function then
-   calls ``prte_plm_base_grow_drain(false)`` — failing the held jobs.
-   Mirroring the original single-token behavior, any grow failure fails the
-   whole held-job set, and the rollback ensures the DVM is never left
-   half-extended with a partial, un-wired set of new daemons.
+   calls ``prte_plm_base_grow_drain(false)`` — emitting a ``PMIX_ERR_DVM_MOD``
+   completion event (carrying the underlying failure status) to each drained
+   campaign's requester, and failing the held jobs.  Mirroring the original
+   single-token behavior, any grow failure fails the whole held-job set, and
+   the rollback ensures the DVM is never left half-extended with a partial,
+   un-wired set of new daemons.
 
 #. **Safety net** — ``check_job_complete``'s "received NULL job" branch drains
    any still-pending grow campaigns with ``success == false`` so held jobs are
@@ -217,15 +231,21 @@ Touched files
    * - File
      - Change
    * - ``src/runtime/prte_globals.{h,c}``
-     - Add ``prte_grow_campaign_t``, ``prte_grow_campaigns`` list, and class.
+     - Add ``prte_grow_campaign_t`` (including the requester fields),
+       ``prte_grow_campaigns`` list, and class (destructor frees ``targets``,
+       ``alloc_id``, ``req_id``).
    * - ``src/runtime/prte_init.c`` / ``prte_finalize.c``
      - Construct / destruct ``prte_grow_campaigns``.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
-     - Create the campaign in ``setup_virtual_machine``; add
+     - Create the campaign in ``setup_virtual_machine`` (recording the
+       requester / ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID``); add
        ``prte_plm_base_grow_drain()`` and ``prte_plm_base_grow_target_failed()``.
-       The latter rolls the failed campaign back — terminating its surviving
-       daemons and removing its nodes from the DVM via the shrink-path
-       machinery — before draining the held jobs.
+       ``grow_drain()`` emits the per-campaign completion event
+       (``PMIX_DVM_IS_READY`` on success, ``PMIX_ERR_DVM_MOD`` on failure) via
+       the shared ``prte_plm_base_dvm_mod_notify()`` helper.  ``grow_target_failed()``
+       rolls the failed campaign back — terminating its surviving daemons and
+       removing its nodes from the DVM via the shrink-path machinery — before
+       draining the held jobs.
    * - ``src/mca/plm/base/plm_private.h``
      - Declare the two new helpers.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``

--- a/docs/plans/elastic_dvm/index.rst
+++ b/docs/plans/elastic_dvm/index.rst
@@ -1,0 +1,9 @@
+Elastic DVM Plans
+=================
+
+Implementation plans for dynamic DVM grow/shrink support.
+
+.. toctree::
+   :maxdepth: 2
+
+   dvm_launch_fence.rst

--- a/docs/plans/elastic_dvm/index.rst
+++ b/docs/plans/elastic_dvm/index.rst
@@ -6,5 +6,6 @@ Implementation plans for dynamic DVM grow/shrink support.
 .. toctree::
    :maxdepth: 2
 
+   elastic_dvm_spec.rst
    dvm_launch_fence.rst
    grow_campaign.rst

--- a/docs/plans/elastic_dvm/index.rst
+++ b/docs/plans/elastic_dvm/index.rst
@@ -7,3 +7,4 @@ Implementation plans for dynamic DVM grow/shrink support.
    :maxdepth: 2
 
    dvm_launch_fence.rst
+   grow_campaign.rst

--- a/docs/plans/elastic_dvm/index.rst
+++ b/docs/plans/elastic_dvm/index.rst
@@ -7,5 +7,6 @@ Implementation plans for dynamic DVM grow/shrink support.
    :maxdepth: 2
 
    elastic_dvm_spec.rst
-   dvm_launch_fence.rst
+   elastic_dvm_plan.rst
    grow_campaign.rst
+   shrink_campaign.rst

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -512,62 +512,7 @@ Design Invariants
 Follow-up — collective shrink completion
 -----------------------------------------
 
-The shrink design above drains a campaign **one daemon at a time**: every
-targeted daemon exits on its own and the HNP discovers each departure
-independently through the errmgr comm-failure path (Step 5), decrementing the
-campaign's ``pending`` count and the fence once per death.  This is correct,
-but each individual departure drives a separate routing-tree repair —
-``prte_rml_repair_routing_tree()`` runs ``handle_promotion()`` and
-``update_descendants()`` for that single rank.  Shrinking ``m`` daemons that
-sit along one branch of the radix routing tree therefore triggers up to ``m``
-sequential promotions/descendant rewrites, which review of PR `#2472
-<https://github.com/openpmix/prrte/pull/2472>`_ flagged as potentially
-expensive for a large shrink (unprofiled).
-
-A **collective** completion scheme would repair the tree once per campaign
-instead of once per daemon:
-
-#. Broadcast the ``PRTE_DAEMON_SHRINK_CMD`` as today.
-#. Each targeted daemon records that it is leaving and does any local
-   processing, but **does not exit yet**.
-#. The HNP hooks the *broadcast's* completion.  The reliable xcast in
-   ``src/mca/grpcomm/direct/grpcomm_direct_xcast.c`` already tracks completion
-   via ACKs flowing up the tree (``finish_op`` on the master means every daemon
-   received the op); a per-op completion callback would be added, or the shrink
-   xcast special-cased, to fire a handler at that point.
-#. That handler reports **all** of the campaign's targets as failed in a single
-   batch via ``prte_rml_repair_routing_tree(failed_ranks, /*global=*/false)``,
-   which already accepts a rank array and performs one promotion/descendant
-   pass for the whole set (``src/rml/routed_radix.c``).
-#. Each doomed daemon exits once its lifeline disconnects — driven by the batch
-   failure report — rather than self-exiting.
-
-This is **not** the per-daemon acknowledgement that the
-*Design Decision — Complete on Death, Not on Acknowledgement* section above
-rejected.  That ACK announced a daemon's *intent* to leave and, acted upon,
-would have released held jobs while the HNP still believed the daemon present.
-Here the authoritative HNP-side teardown (route removal, ``num_daemons``, node
-state) still happens at the batch failure report, and held jobs are released
-only after it — so the invariant "act once teardown has occurred, not on
-intent" is preserved.  The doomed daemons exiting slightly later is harmless:
-they are already excluded from routing and mapping, so released jobs remap onto
-survivors correctly.  Completion would collapse to a single event per campaign,
-which also retires the per-rank ``PMIX_RANK_INVALID`` idempotency stamping and
-the double-count analysis that the per-death path requires.  The completion
-event (``PMIX_DVM_IS_READY``) would then fire from that single batch point
-rather than from the last individual departure.
-
-This is an **optimization, not a correctness fix**, so it is deliberately
-deferred out of the launch-fence work:
-
-* It needs a new xcast-completion callback hook (or a shrink special case).
-* It moves the daemon-side ``PRTE_DAEMON_SHRINK_CMD`` handler from self-exit to
-  record-and-wait-for-lifeline.
-* It moves the fence-completion trigger from the errmgr comm-failure path to the
-  batch-repair callback, and must verify that all daemon-loss bookkeeping that
-  currently rides on the comm-failure event still runs when the loss is
-  declared proactively.
-* The collective / whole-branch failure path is far less exercised than
-  individual daemon deaths and may surface bugs in the tree-repair and
-  fault-handling code, so it warrants validation against large multi-daemon and
-  single-branch shrinks.
+A possible optimization — repairing the routing tree once per shrink campaign
+(a collective completion scheme) rather than once per departing daemon — has
+been deferred out of the launch-fence work and tracked separately as
+`openpmix/prrte#2492 <https://github.com/openpmix/prrte/issues/2492>`_.

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -381,8 +381,11 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
                _camp->pending--;
                prte_dvm_launch_fence--;
                if (0 == _camp->pending) {
-                   /* this request's shrink is complete — notify the
+                   /* this request's shrink is complete — first let the
+                    * active RAS modules release the freed resources back
+                    * to their resource manager(s), then notify the
                     * requester that the DVM now reflects the new size */
+                   prte_ras_base_shrink_complete(_camp);
                    if (_camp->have_requester) {
                        /* success == true => PMIX_DVM_IS_READY */
                        prte_plm_base_dvm_mod_notify(&_camp->requester,
@@ -411,6 +414,23 @@ only the first is counted.  A daemon that crashes during a shrink is handled
 identically to one that exits cleanly — the node was being removed anyway,
 and jobs mapped to it are detected by ``prte_plm_base_job_needs_remap()`` and
 re-routed to surviving nodes.
+
+Before the completion event is emitted, ``prte_ras_base_shrink_complete()``
+cycles across every active RAS module (``prte_ras_base.selected_modules``) and
+invokes the optional ``shrink_complete`` entry point on each, passing the
+completed ``prte_shrink_campaign_t``.  This is the component's opportunity to
+release the freed resources back to its resource manager; what it does with that
+opportunity is up to the component.  Unlike ``modify``, the cycle is not keyed
+to a single component: a single ``PMIX_ALLOC_RELEASE`` may remove nodes drawn
+from more than one allocation (see the "Resource release at shrink completion"
+section of :ref:`elastic-dvm-spec-label`), so every module is offered the
+campaign and each handles only the share that belongs to it.  A module with no
+``shrink_complete`` pointer, or with no stake in the operation, is a no-op.
+The runtime guarantees only the ordering: the release cycle runs ahead of
+``prte_plm_base_dvm_mod_notify()``, so by the time the requester sees
+``PMIX_DVM_IS_READY`` every component has been given its chance to act — not
+that any particular resource was in fact returned, which is the component's
+decision.
 
 The ``PMIX_DVM_IS_READY`` notification is **per campaign**: it fires when *this*
 request's last target departs, regardless of whether other (grow or shrink)
@@ -466,14 +486,28 @@ Summary of Files Changed (Shrink Fence)
        ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
    * - ``src/mca/plm/base/plm_private.h``
      - Declare the two remap helpers.
+   * - ``src/mca/ras/ras.h``
+     - Add the ``shrink_complete`` module entry point: a
+       ``prte_ras_base_module_shrink_complete_fn_t`` taking the completed
+       ``prte_shrink_campaign_t``, and a field for it in
+       ``prte_ras_base_module_t`` (after ``modify``).  Components that hand
+       resources back to a scheduler implement it; others leave it ``NULL``.
+   * - ``src/mca/ras/base/base.h``
+     - Declare ``prte_ras_base_shrink_complete(prte_shrink_campaign_t *)``.
+   * - ``src/mca/ras/base/ras_base_allocate.c``
+     - Define ``prte_ras_base_shrink_complete()``: cycle across
+       ``prte_ras_base.selected_modules`` and invoke each module's
+       ``shrink_complete`` (when non-NULL), passing the campaign.  Not keyed to
+       one component, since a release may span multiple allocations.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
-     - In ``proc_errors()``, daemon-comm-failure block: search
-       ``prte_shrink_campaigns`` for the dead daemon's rank; if found, stamp
-       the matched target slot ``PMIX_RANK_INVALID``, decrement campaign
-       ``pending`` and fence; when ``pending`` hits zero emit
-       ``PMIX_DVM_IS_READY`` to the requester and remove the campaign; call
-       ``prte_plm_base_fence_release()`` when the fence hits zero.  This is
-       the sole shrink-completion trigger.
+     - Add ``#include "src/mca/ras/base/base.h"``.  In ``proc_errors()``,
+       daemon-comm-failure block: search ``prte_shrink_campaigns`` for the dead
+       daemon's rank; if found, stamp the matched target slot
+       ``PMIX_RANK_INVALID``, decrement campaign ``pending`` and fence; when
+       ``pending`` hits zero call ``prte_ras_base_shrink_complete()`` to release
+       the resources RM-side, then emit ``PMIX_DVM_IS_READY`` to the requester
+       and remove the campaign; call ``prte_plm_base_fence_release()`` when the
+       fence hits zero.  This is the sole shrink-completion trigger.
 
 The shared infrastructure this path relies on — the fence counter, held-job
 arrays, ``VM_READY → MAP`` hold point, ``prte_plm_base_fence_release()``, and
@@ -508,6 +542,15 @@ Design Invariants
   ``PMIX_DVM_IS_READY`` (success) or, on an xcast failure at creation, exactly
   one ``PMIX_ERR_DVM_MOD`` — never both, and never for a scheduler-driven
   release with no requester.
+* The RM-side release cycle runs strictly *before* the completion event.  At
+  ``pending == 0`` the campaign-removal point calls
+  ``prte_ras_base_shrink_complete()``, which offers the campaign to every active
+  RAS module, and only then emits ``PMIX_DVM_IS_READY``.  Because the departing
+  nodes may span multiple allocations, all modules are cycled — each handling
+  only its own share.  The invariant is the *ordering* (every component is
+  offered the campaign before the event fires), not that any resource was
+  actually returned: that is the component's decision, outside the runtime's
+  control.
 
 Follow-up — collective shrink completion
 -----------------------------------------

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -160,12 +160,20 @@ branch of ``prte_ras_base_complete_request()`` builds the daemon rank array
 (``ranks``, count ``m``) and then calls ``free(ranks)`` at line 760 before
 the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
 (between lines 758 and 760), recording the requester (from the originating
-request) so the completion event can be directed at it:
+request) so the completion event can be directed at it.  Guard the whole setup
+on ``0 < m``: a release that removes no daemons creates no campaign, exactly as
+the grow path creates none when ``map->num_new_daemons == 0``:
 
 .. code-block:: c
 
-   /* record the campaign — must be before free(ranks) */
-   {
+   /* record the campaign — must be before free(ranks).  Skip entirely when the
+    * release removes no daemons (m == 0): an empty campaign would never drain
+    * (no target ever departs on the comm-failure path), so it would leave
+    * prte_shrink_campaigns non-empty forever — wedging every later job at the
+    * LAUNCH_APPS hold — and would emit no completion event.  Mirrors the grow
+    * path's `map->num_new_daemons > 0` guard and the spec's "no event when
+    * nothing changes" clause. */
+   if (0 < m) {
        prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
        _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
        memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
@@ -186,17 +194,20 @@ request) so the completion event can be directed at it:
 
    /* existing xcast */
    if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
-       /* clean up the campaign we just added, and tell the requester the
-        * DVM modification failed (spec phase-two failure event) */
-       prte_shrink_campaign_t *_camp =
-           (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
-       prte_dvm_launch_fence -= _camp->pending;
-       if (_camp->have_requester) {
-           /* success == false => PMIX_ERR_DVM_MOD carrying rc */
-           prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
-                                        _camp->req_id, false, rc);
+       /* clean up the campaign we just added (only if one was created), and
+        * tell the requester the DVM modification failed (spec phase-two
+        * failure event) */
+       if (0 < m) {
+           prte_shrink_campaign_t *_camp =
+               (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
+           prte_dvm_launch_fence -= _camp->pending;
+           if (_camp->have_requester) {
+               /* success == false => PMIX_ERR_DVM_MOD carrying rc */
+               prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
+                                            _camp->req_id, false, rc);
+           }
+           PMIX_RELEASE(_camp);
        }
-       PMIX_RELEASE(_camp);
        PRTE_ERROR_LOG(rc);
    }
 
@@ -377,7 +388,7 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
                    PMIX_RELEASE(_camp);
                }
                if (0 == prte_dvm_launch_fence) {
-                   prte_plm_base_fence_release(true);
+                   prte_plm_base_fence_release();
                }
                goto errmgr_shrink_done;
            }
@@ -451,7 +462,7 @@ Summary of Files Changed (Shrink Fence)
        the matched target slot ``PMIX_RANK_INVALID``, decrement campaign
        ``pending`` and fence; when ``pending`` hits zero emit
        ``PMIX_DVM_IS_READY`` to the requester and remove the campaign; call
-       ``prte_plm_base_fence_release(true)`` when the fence hits zero.  This is
+       ``prte_plm_base_fence_release()`` when the fence hits zero.  This is
        the sole shrink-completion trigger.
 
 The shared infrastructure this path relies on — the fence counter, held-job
@@ -478,8 +489,10 @@ Design Invariants
   array for a given campaign is valid from creation through removal, so
   ``prte_plm_base_job_needs_remap()`` can safely iterate it during release.
 * Jobs in ``prte_prelaunch_held_jobs`` hold a ``PMIX_RETAIN`` reference;
-  ``prte_plm_base_fence_release()`` releases it after re-activating or
-  aborting the job.
+  ``prte_plm_base_fence_release()`` releases it after re-activating the job.
+  These jobs wait only on a shrink and are never aborted by a concurrent
+  grow failure (the grow-failure abort touches only ``prte_held_jobs``); since
+  shrink completion is success-only, they are always re-activated, not failed.
 * The completion event is per campaign and fires from the campaign-removal
   point (``pending == 0``), so each accepted release yields exactly one
   ``PMIX_DVM_IS_READY`` (success) or, on an xcast failure at creation, exactly

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -157,12 +157,14 @@ Destruct in ``src/runtime/prte_finalize.c``:
 
 In ``src/mca/ras/base/ras_base_allocate.c``, the ``PMIX_ALLOC_RELEASE``
 branch of ``prte_ras_base_complete_request()`` builds the daemon rank array
-(``ranks``, count ``m``) and then calls ``free(ranks)`` at line 760 before
-the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
-(between lines 758 and 760), recording the requester (from the originating
-request) so the completion event can be directed at it.  Guard the whole setup
-on ``0 < m``: a release that removes no daemons creates no campaign, exactly as
-the grow path creates none when ``map->num_new_daemons == 0``:
+(``ranks``, count ``m``) and then calls ``free(ranks)`` before the xcast that
+carries ``PRTE_DAEMON_SHRINK_CMD`` to the daemons.  Insert the campaign setup
+**before** ``free(ranks)``, recording the requester directly from the request
+object (``req``) so the completion event can be directed at it.  Guard the whole
+setup on ``0 < m``: a release that removes no daemons creates no campaign,
+exactly as the grow path creates none when ``map->num_new_daemons == 0``.  The
+file must ``#include "src/mca/plm/base/plm_private.h"`` to see
+``prte_plm_base_dvm_mod_notify()``.
 
 .. code-block:: c
 
@@ -179,36 +181,41 @@ the grow path creates none when ``map->num_new_daemons == 0``:
        memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
        _camp->ntargets = m;
        _camp->pending  = m;
-       /* requester / ids captured from the PMIX_ALLOC_RELEASE request;
-        * have_requester stays false for a scheduler-driven release */
-       if (have_requester) {
-           PMIX_XFER_PROCID(&_camp->requester, &requester);
-           _camp->alloc_id = (NULL != alloc_id) ? strdup(alloc_id) : NULL;
-           _camp->req_id   = (NULL != req_id)   ? strdup(req_id)   : NULL;
-           _camp->have_requester = true;
+       /* this path always has a requesting process (req->tproc); a
+        * scheduler-driven release that has no requester does not pass through
+        * here.  Capture the requester and the allocation ids from the request. */
+       PMIX_XFER_PROCID(&_camp->requester, &req->tproc);
+       for (n = 0; n < req->ninfo; n++) {
+           if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+               _camp->alloc_id = strdup(req->info[n].value.data.string);
+           } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+               _camp->req_id = strdup(req->info[n].value.data.string);
+           }
        }
+       _camp->have_requester = true;
        pmix_list_append(&prte_shrink_campaigns, &_camp->super);
        prte_dvm_launch_fence += m;
    }
-   free(ranks);   /* existing line 760 */
+   free(ranks);
 
    /* existing xcast */
    if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+       PRTE_ERROR_LOG(rc);
        /* clean up the campaign we just added (only if one was created), and
         * tell the requester the DVM modification failed (spec phase-two
-        * failure event) */
+        * failure event).  rc is a PRTE code, so convert it to the
+        * pmix_status_t the event carries. */
        if (0 < m) {
            prte_shrink_campaign_t *_camp =
                (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
            prte_dvm_launch_fence -= _camp->pending;
            if (_camp->have_requester) {
-               /* success == false => PMIX_ERR_DVM_MOD carrying rc */
                prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
-                                            _camp->req_id, false, rc);
+                                            _camp->req_id, false,
+                                            prte_pmix_convert_rc(rc));
            }
            PMIX_RELEASE(_camp);
        }
-       PRTE_ERROR_LOG(rc);
    }
 
 Because the campaign is appended before the xcast, any ``VM_READY`` event
@@ -437,13 +444,16 @@ Summary of Files Changed (Shrink Fence)
    * - ``src/runtime/prte_finalize.c``
      - ``PMIX_LIST_DESTRUCT(&prte_shrink_campaigns)``.
    * - ``src/mca/ras/base/ras_base_allocate.c``
-     - In ``PMIX_ALLOC_RELEASE`` branch of
-       ``prte_ras_base_complete_request()``: create a ``prte_shrink_campaign_t``,
-       copy the rank array into it, record the requester / ``PMIX_ALLOC_ID`` /
-       ``PMIX_ALLOC_REQ_ID``, append to ``prte_shrink_campaigns``, and increment
+     - Add ``#include "src/mca/plm/base/plm_private.h"`` for
+       ``prte_plm_base_dvm_mod_notify()``.  In the ``PMIX_ALLOC_RELEASE`` branch
+       of ``prte_ras_base_complete_request()``, guarded on ``0 < m``: create a
+       ``prte_shrink_campaign_t``, copy the rank array into it, record the
+       requester from ``req->tproc`` and ``PMIX_ALLOC_ID`` / ``PMIX_ALLOC_REQ_ID``
+       from ``req->info``, append to ``prte_shrink_campaigns``, and increment
        ``prte_dvm_launch_fence`` by ``m`` — all before ``free(ranks)``.  Add
        xcast-failure cleanup that removes the campaign, decrements the fence,
-       and emits ``PMIX_ERR_DVM_MOD`` to the requester.
+       and emits ``PMIX_ERR_DVM_MOD`` (carrying ``prte_pmix_convert_rc(rc)``) to
+       the requester.
    * - ``src/prted/prted_comm.c``
      - In ``PRTE_DAEMON_SHRINK_CMD`` handler: after the ``JOB_END``
        notification wait, activate ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -265,7 +265,7 @@ Step 4 — Remap helpers
 
 The pre-launch branch of the shared ``prte_plm_base_fence_release()`` (parent
 plan, Step 4) calls two shrink-specific helpers, both defined in
-``plm_base_launch_support.c`` and declared in ``src/mca/plm/base/base.h``.
+``plm_base_launch_support.c`` and declared in ``src/mca/plm/base/plm_private.h``.
 
 **``prte_plm_base_job_needs_remap(jdata)``** iterates over ``jdata->procs``
 and returns ``true`` if any proc's assigned node has a daemon rank appearing
@@ -454,7 +454,7 @@ Summary of Files Changed (Shrink Fence)
        ``prte_plm_base_reset_proc_map()``.  Add hold check in
        ``prte_plm_base_launch_apps()`` on
        ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
-   * - ``src/mca/plm/base/base.h``
+   * - ``src/mca/plm/base/plm_private.h``
      - Declare the two remap helpers.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - In ``proc_errors()``, daemon-comm-failure block: search

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -1,163 +1,20 @@
-.. _dvm-launch-fence-label:
+.. _dvm-shrink-campaign-label:
 
-DVM Launch-Fence Implementation Plan
-=====================================
+DVM Shrink-Campaign Fence Tracking
+==================================
 
-This document describes the implementation plan for eliminating the race
-condition between a DVM extension (new-daemon launch campaign) and
-concurrently-running application jobs.  For background on the race itself see
-:ref:`state-machine-label`, section *DVM Extension and the Daemon-Launch Race*.
+This document describes the implementation of the DVM **shrink** (node-removal)
+path: how a ``PMIX_ALLOC_RELEASE`` that removes daemons is tracked against the
+launch fence, the second hold point that protects in-flight jobs, how campaign
+completion is detected, and the completion event delivered to the requester.
+For the shared fence mechanism it builds on — the counter, the held-job arrays,
+the ``VM_READY → MAP`` hold point, the fence-release helper, and the
+completion-event helper — see the parent plan :ref:`elastic-dvm-plan-label`.
+The externally observable contract is specified in :ref:`elastic-dvm-spec-label`,
+which is authoritative for observable behavior.
 
-The mechanism is a **global launch fence** — a counter
-(``prte_dvm_launch_fence``) that tracks the number of in-progress daemon
-launch campaigns.  An app job that reaches the ``VM_READY → MAP`` transition
-checks the fence; if it is nonzero the job parks itself in a held-job array
-(``prte_held_jobs``) and is released when the fence reaches zero.
-
-The state machine is single-threaded on the progress thread, so no locking
-is required anywhere in this plan.
-
-The externally observable contract that this mechanism implements — the
-job-admission and placement guarantees a caller may rely on while the DVM
-grows or shrinks — is specified in :ref:`elastic-dvm-spec-label`; that
-document is authoritative for observable behavior, and this one describes
-the implementation that delivers it.
-
-.. note::
-   The app-triggered expansion path (``--add-host`` / ``--add-hostfile``)
-   already sets ``prte_dvm_ready = false`` in ``add_hosts()`` before posting
-   the asynchronous RAS modify request, which causes newly-arriving jobs to be
-   stashed in ``prte_cache`` rather than dispatched immediately.  The launch
-   fence is still required for the scheduler-push path (e.g., Slurm firing
-   ``LAUNCH_DAEMONS`` directly) where ``prte_dvm_ready`` is never cleared, and
-   to ensure full correctness when both paths can interleave.
-
-.. note::
-   This document covers the **shared** fence mechanism (the counter, the
-   held-job arrays, and the two hold points) and the **shrink** path's fence
-   accounting.  The **grow** (daemon-launch) path's fence accounting was
-   originally described here as a single ``PRTE_JOB_LAUNCHED_DAEMONS`` boolean
-   plus a bare ``prte_dvm_launch_fence++``/``--``.  That design has since been
-   replaced by per-campaign, rank-tracked accounting; the authoritative
-   description now lives in :ref:`dvm-grow-campaign-label`.  The grow-specific
-   steps below have been reduced to pointers into that document.
-
-Step 1 — New state constant
----------------------------
-
-In ``src/mca/plm/plm_types.h``, add:
-
-.. code-block:: c
-
-   /* value 17 is currently unused in the running-state band */
-   #define PRTE_JOB_STATE_WAITING_FOR_DAEMONS  17
-
-Add a corresponding string to ``src/util/error_strings.c``.
-
-This state is used purely as a marker so that debugging tools and verbose
-output show clearly why a job is parked; no callback is registered for it.
-
-Step 2 — New global fence and held-job arrays
----------------------------------------------
-
-In ``src/runtime/prte_globals.c`` and ``src/runtime/prte_globals.h``, add:
-
-.. code-block:: c
-
-   /* counts in-progress daemon launch campaigns */
-   int prte_dvm_launch_fence = 0;
-
-   /* jobs parked at the VM_READY → MAP boundary */
-   pmix_pointer_array_t *prte_held_jobs;
-
-   /* jobs parked at the LAUNCH_APPS boundary during a shrink */
-   pmix_pointer_array_t *prte_prelaunch_held_jobs;
-
-Initialize both arrays in ``src/runtime/prte_init.c`` alongside the existing
-``prte_cache`` initialization:
-
-.. code-block:: c
-
-   prte_held_jobs = PMIX_NEW(pmix_pointer_array_t);
-   pmix_pointer_array_init(prte_held_jobs, 1, INT_MAX, 1);
-
-   prte_prelaunch_held_jobs = PMIX_NEW(pmix_pointer_array_t);
-   pmix_pointer_array_init(prte_prelaunch_held_jobs, 1, INT_MAX, 1);
-
-Destruct both in ``src/runtime/prte_finalize.c``.
-
-Steps 3 & 4 — Grow-path fence accounting (superseded)
-------------------------------------------------------
-
-The grow (daemon-launch) path's fence increment and drain were originally
-described here — and in the now-removed Step 4 — as a bare
-``prte_dvm_launch_fence++`` in ``prte_plm_base_setup_virtual_machine()`` with
-a matching decrement in ``vm_ready``, keyed off the
-``PRTE_JOB_LAUNCHED_DAEMONS`` boolean.  **That design has been superseded.**
-The grow path now records each campaign explicitly — tracking the daemon
-ranks it is launching — and drains the whole campaign's fence contribution as
-a unit, so that an unrelated daemon death cannot consume the campaign's token
-and concurrent campaigns cannot wedge the fence.
-
-See :ref:`dvm-grow-campaign-label` for the authoritative description of
-campaign creation in ``setup_virtual_machine()``, the success drain in
-``vm_ready`` (after the WIREUP xcast), the failure drain in the errmgr via
-``prte_plm_base_grow_target_failed()``, and the ``check_job_complete`` safety
-net.  The shared fence counter and held-job arrays (Step 2) and the
-``VM_READY → MAP`` hold point (Step 5) apply to both paths and are described
-in those steps.
-
-Step 5 — Park jobs at the VM_READY → MAP boundary
---------------------------------------------------
-
-In ``vm_ready()``, the code at line 360 is reached only by app jobs (the
-daemon-job branch returns at line 357).  This is immediately before
-``prte_filem.preposition_files()`` which leads to ``files_ready → MAP``.
-Add the hold check here:
-
-.. code-block:: c
-
-   /* position any required files */
-   if (0 < prte_dvm_launch_fence) {
-       /* daemon launch in progress — park this job */
-       caddy->jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
-       PMIX_RETAIN(caddy->jdata);
-       pmix_pointer_array_add(prte_held_jobs, caddy->jdata);
-       PMIX_RELEASE(caddy);
-       return;
-   }
-   if (PRTE_SUCCESS !=
-           prte_filem.preposition_files(caddy->jdata, files_ready, caddy->jdata)) {
-       PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
-   }
-   PMIX_RELEASE(caddy);
-
-Step 6 — Grow-path daemon launch failure (superseded)
-------------------------------------------------------
-
-Earlier revisions of this plan handled a daemon failure during a grow by
-decrementing ``prte_dvm_launch_fence`` directly in three places — the
-``vm_ready`` xcast error-exits, the ``errmgr_dvm.c`` comm-failure handler,
-and the ``check_complete`` safety net — each gated on the
-``PRTE_JOB_LAUNCHED_DAEMONS`` attribute.  **That approach has been
-superseded** by the per-campaign accounting in :ref:`dvm-grow-campaign-label`:
-
-* The ``vm_ready`` xcast error-exits no longer touch the fence at all — the
-  whole DVM is being force-exited, and any held jobs are failed as part of
-  that teardown.
-* A daemon failure during a grow is routed to
-  ``prte_plm_base_grow_target_failed()`` in the errmgr, which acts only if the
-  dead rank belongs to an in-progress grow campaign (so an unrelated daemon
-  loss leaves the fence untouched).
-* The ``check_job_complete`` "received NULL job" branch drains any
-  still-pending grow campaigns with ``prte_plm_base_grow_drain(false)``.
-
-See :ref:`dvm-grow-campaign-label` for the authoritative description.
-
-----
-
-DVM Shrink Fence
-================
+The state machine is single-threaded on the progress thread, so no locking is
+required anywhere in this plan.
 
 Background
 ----------
@@ -177,11 +34,10 @@ and send launch data to a daemon that dies between MAP and the send.  The
 existing VM_READY fence does not protect this window because the job already
 passed the fence before the shrink was initiated.
 
-Race 1 is covered by the existing grow-fence mechanism (the fence is also
-incremented for shrink — see Step 7).  Race 2 requires a second hold point
-guarded by checking the shrink campaign list (nonempty only during shrink)
-so that a concurrent grow does not unnecessarily hold jobs that have already
-been mapped to surviving nodes.
+Race 1 is covered by the shared fence (the fence is incremented for shrink — see
+Step 1).  Race 2 requires a second hold point guarded by checking the shrink
+campaign list (nonempty only during shrink) so that a concurrent grow does not
+unnecessarily hold jobs that have already been mapped to surviving nodes.
 
 Multiple concurrent shrink campaigns are supported: each campaign tracks its
 own count of still-living targets and is removed from the list when all of
@@ -237,12 +93,12 @@ completion is driven solely by actual daemon departure on the comm-failure
 path, which is both the authoritative event and the point at which the
 relevant cleanup has occurred.  To make the single decrement idempotent
 against a daemon that emits more than one failure event, each matched target
-slot is stamped ``PMIX_RANK_INVALID`` once counted (Step 11).
+slot is stamped ``PMIX_RANK_INVALID`` once counted (Step 5).
 
-Step 7 — Shrink campaign type, list, and fence increment
+Step 1 — Shrink campaign type, list, and fence increment
 ---------------------------------------------------------
 
-**7a — Campaign type**
+**1a — Campaign type**
 
 Add the following type to ``src/runtime/prte_globals.h`` and define the
 class instance in ``src/runtime/prte_globals.c``:
@@ -252,9 +108,14 @@ class instance in ``src/runtime/prte_globals.c``:
    /* one entry per in-progress shrink campaign */
    typedef struct {
        pmix_list_item_t super;
-       pmix_rank_t     *targets;   /* daemon ranks being terminated */
-       int              ntargets;  /* initial count */
-       int              pending;   /* targets not yet known to have departed */
+       pmix_rank_t     *targets;        /* daemon ranks being terminated */
+       int              ntargets;       /* initial count */
+       int              pending;        /* targets not yet known to have departed */
+       /* requester recorded for the spec's phase-two completion event */
+       pmix_proc_t      requester;      /* who issued the PMIX_ALLOC_RELEASE */
+       char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation */
+       char            *req_id;         /* PMIX_ALLOC_REQ_ID, or NULL */
+       bool             have_requester; /* false for a scheduler-driven release */
    } prte_shrink_campaign_t;
    PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 
@@ -265,11 +126,13 @@ In ``src/runtime/prte_globals.c``:
    static void campaign_destruct(prte_shrink_campaign_t *p)
    {
        free(p->targets);
+       free(p->alloc_id);
+       free(p->req_id);
    }
    PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
                        NULL, campaign_destruct);
 
-**7b — Global list**
+**1b — Global list**
 
 In ``src/runtime/prte_globals.h`` declare, and in ``src/runtime/prte_globals.c``
 define:
@@ -290,13 +153,14 @@ Destruct in ``src/runtime/prte_finalize.c``:
 
    PMIX_LIST_DESTRUCT(&prte_shrink_campaigns);
 
-**7c — Populate campaign and increment fence**
+**1c — Populate campaign and increment fence**
 
 In ``src/mca/ras/base/ras_base_allocate.c``, the ``PMIX_ALLOC_RELEASE``
 branch of ``prte_ras_base_complete_request()`` builds the daemon rank array
 (``ranks``, count ``m``) and then calls ``free(ranks)`` at line 760 before
 the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
-(between lines 758 and 760):
+(between lines 758 and 760), recording the requester (from the originating
+request) so the completion event can be directed at it:
 
 .. code-block:: c
 
@@ -307,6 +171,14 @@ the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
        memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
        _camp->ntargets = m;
        _camp->pending  = m;
+       /* requester / ids captured from the PMIX_ALLOC_RELEASE request;
+        * have_requester stays false for a scheduler-driven release */
+       if (have_requester) {
+           PMIX_XFER_PROCID(&_camp->requester, &requester);
+           _camp->alloc_id = (NULL != alloc_id) ? strdup(alloc_id) : NULL;
+           _camp->req_id   = (NULL != req_id)   ? strdup(req_id)   : NULL;
+           _camp->have_requester = true;
+       }
        pmix_list_append(&prte_shrink_campaigns, &_camp->super);
        prte_dvm_launch_fence += m;
    }
@@ -314,10 +186,15 @@ the xcast at line 763.  Insert the campaign setup **before** ``free(ranks)``
 
    /* existing xcast */
    if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
-       /* clean up the campaign we just added */
+       /* clean up the campaign we just added, and tell the requester the
+        * DVM modification failed (spec phase-two failure event) */
        prte_shrink_campaign_t *_camp =
            (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
        prte_dvm_launch_fence -= _camp->pending;
+       if (_camp->have_requester) {
+           prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
+                                        _camp->req_id, PMIX_ERR_DVM_MOD, rc);
+       }
        PMIX_RELEASE(_camp);
        PRTE_ERROR_LOG(rc);
    }
@@ -326,7 +203,7 @@ Because the campaign is appended before the xcast, any ``VM_READY`` event
 that fires on the progress thread after this point will see a nonzero fence
 and park the job.
 
-Step 8 — Daemon exit (no acknowledgement)
+Step 2 — Daemon exit (no acknowledgement)
 ------------------------------------------
 
 A daemon that decides to exit in response to ``PRTE_DAEMON_SHRINK_CMD``
@@ -342,10 +219,10 @@ under it are killed when it terminates regardless.  More importantly, the
 acknowledgement would arrive *before* the daemon's routes, ``num_daemons``
 count, and node state have been torn down, so acting on it could release
 held jobs into a DVM that still believes the departing daemon is present.
-The comm-failure event (Step 11) is the only signal that coincides with that
+The comm-failure event (Step 5) is the only signal that coincides with that
 cleanup, so it is the sole completion trigger.
 
-Step 9 — Second hold point at LAUNCH_APPS
+Step 3 — Second hold point at LAUNCH_APPS
 ------------------------------------------
 
 In ``src/mca/plm/base/plm_base_launch_support.c``,
@@ -367,63 +244,16 @@ guard but before packing any data:
 
 Using ``!pmix_list_is_empty(...)`` rather than a counter means the check
 automatically handles concurrent campaigns: the list is nonempty as long as
-any shrink is in progress.
+any shrink is in progress.  Keying on the **shrink** list specifically (not the
+shared fence counter) ensures a concurrent grow does not stall a job that has
+already been mapped onto surviving nodes.
 
-Step 10 — Fence-release helper
---------------------------------
+Step 4 — Remap helpers
+----------------------
 
-Both grow completion (``vm_ready``) and shrink target departure (detected in
-the errmgr) decrement the fence and, when it hits zero, must release two
-classes of held jobs.
-Extract this logic into a single helper declared in
-``src/mca/plm/base/plm_base_launch_support.h`` and defined in
-``plm_base_launch_support.c``:
-
-.. code-block:: c
-
-   void prte_plm_base_fence_release(bool success)
-   {
-       int _hi;
-       prte_job_t *_held;
-
-       /* --- pre-map held jobs (parked at VM_READY) --- */
-       for (_hi = 0; _hi < prte_held_jobs->size; _hi++) {
-           _held = (prte_job_t *)
-               pmix_pointer_array_get_item(prte_held_jobs, _hi);
-           if (NULL == _held) continue;
-           pmix_pointer_array_set_item(prte_held_jobs, _hi, NULL);
-           PRTE_ACTIVATE_JOB_STATE(_held,
-               success ? PRTE_JOB_STATE_VM_READY
-                       : PRTE_JOB_STATE_NEVER_LAUNCHED);
-           PMIX_RELEASE(_held);
-       }
-
-       /* --- pre-launch held jobs (parked at LAUNCH_APPS) --- */
-       for (_hi = 0; _hi < prte_prelaunch_held_jobs->size; _hi++) {
-           _held = (prte_job_t *)
-               pmix_pointer_array_get_item(prte_prelaunch_held_jobs, _hi);
-           if (NULL == _held) continue;
-           pmix_pointer_array_set_item(prte_prelaunch_held_jobs, _hi, NULL);
-           if (!success) {
-               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_NEVER_LAUNCHED);
-           } else if (prte_plm_base_job_needs_remap(_held)) {
-               prte_plm_base_reset_proc_map(_held);
-               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_MAP);
-           } else {
-               PRTE_ACTIVATE_JOB_STATE(_held, PRTE_JOB_STATE_LAUNCH_APPS);
-           }
-           PMIX_RELEASE(_held);
-       }
-
-       /* campaigns are removed individually as their last target dies;
-        * the list should be empty here, but do a safety sweep */
-       prte_shrink_campaign_t *_camp, *_next;
-       PMIX_LIST_FOREACH_SAFE(_camp, _next,
-                              &prte_shrink_campaigns, prte_shrink_campaign_t) {
-           pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
-           PMIX_RELEASE(_camp);
-       }
-   }
+The pre-launch branch of the shared ``prte_plm_base_fence_release()`` (parent
+plan, Step 4) calls two shrink-specific helpers, both defined in
+``plm_base_launch_support.c`` and declared in ``plm_base_launch_support.h``.
 
 **``prte_plm_base_job_needs_remap(jdata)``** iterates over ``jdata->procs``
 and returns ``true`` if any proc's assigned node has a daemon rank appearing
@@ -501,8 +331,8 @@ After remapping, the job re-enters ``prte_rmaps_base_map_job()`` which
 re-creates proc objects on the surviving nodes using the original
 ``app->num_procs`` counts.
 
-Step 11 — Detect target departure in the errmgr
--------------------------------------------------
+Step 5 — Detect target departure in the errmgr and notify completion
+--------------------------------------------------------------------
 
 Campaign completion is driven entirely by the daemon-loss path: when a
 targeted daemon leaves the DVM, the HNP's comm-failure handler matches its
@@ -532,6 +362,15 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
                _camp->pending--;
                prte_dvm_launch_fence--;
                if (0 == _camp->pending) {
+                   /* this request's shrink is complete — notify the
+                    * requester that the DVM now reflects the new size */
+                   if (_camp->have_requester) {
+                       prte_plm_base_dvm_mod_notify(&_camp->requester,
+                                                    _camp->alloc_id,
+                                                    _camp->req_id,
+                                                    PMIX_DVM_IS_READY,
+                                                    PMIX_SUCCESS);
+                   }
                    pmix_list_remove_item(&prte_shrink_campaigns,
                                         &_camp->super);
                    PMIX_RELEASE(_camp);
@@ -554,6 +393,15 @@ identically to one that exits cleanly — the node was being removed anyway,
 and jobs mapped to it are detected by ``prte_plm_base_job_needs_remap()`` and
 re-routed to surviving nodes.
 
+The ``PMIX_DVM_IS_READY`` notification is **per campaign**: it fires when *this*
+request's last target departs, regardless of whether other (grow or shrink)
+campaigns keep the shared fence nonzero.  The fence-release of held jobs, by
+contrast, waits for the global fence to reach zero.  The failure counterpart
+(``PMIX_ERR_DVM_MOD``) is emitted only on the xcast-failure cleanup in Step 1 —
+once the shrink command is on the wire, every targeted daemon's departure is a
+*success* for the campaign, since clean exit and crash are indistinguishable
+and both remove the node as requested.
+
 Summary of Files Changed (Shrink Fence)
 -----------------------------------------
 
@@ -564,11 +412,13 @@ Summary of Files Changed (Shrink Fence)
    * - File
      - Change
    * - ``src/runtime/prte_globals.h``
-     - Declare ``prte_shrink_campaign_t`` (type + ``PMIX_CLASS_DECLARATION``)
-       and ``prte_shrink_campaigns`` (``pmix_list_t``).
+     - Declare ``prte_shrink_campaign_t`` (type + ``PMIX_CLASS_DECLARATION``,
+       including the requester fields) and ``prte_shrink_campaigns``
+       (``pmix_list_t``).
    * - ``src/runtime/prte_globals.c``
      - Define ``PMIX_CLASS_INSTANCE`` for ``prte_shrink_campaign_t``
-       (destructor frees ``targets``).  Define ``prte_shrink_campaigns``.
+       (destructor frees ``targets``, ``alloc_id``, ``req_id``).  Define
+       ``prte_shrink_campaigns``.
    * - ``src/runtime/prte_init.c``
      - ``PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t)`` alongside
        ``prte_held_jobs`` initialization.
@@ -577,82 +427,39 @@ Summary of Files Changed (Shrink Fence)
    * - ``src/mca/ras/base/ras_base_allocate.c``
      - In ``PMIX_ALLOC_RELEASE`` branch of
        ``prte_ras_base_complete_request()``: create a ``prte_shrink_campaign_t``,
-       copy the rank array into it, append to ``prte_shrink_campaigns``, and
-       increment ``prte_dvm_launch_fence`` by ``m`` — all before
-       ``free(ranks)``.  Add xcast-failure cleanup that removes the campaign
-       and decrements the fence.
+       copy the rank array into it, record the requester / ``PMIX_ALLOC_ID`` /
+       ``PMIX_ALLOC_REQ_ID``, append to ``prte_shrink_campaigns``, and increment
+       ``prte_dvm_launch_fence`` by ``m`` — all before ``free(ranks)``.  Add
+       xcast-failure cleanup that removes the campaign, decrements the fence,
+       and emits ``PMIX_ERR_DVM_MOD`` to the requester.
    * - ``src/prted/prted_comm.c``
      - In ``PRTE_DAEMON_SHRINK_CMD`` handler: after the ``JOB_END``
        notification wait, activate ``PRTE_JOB_STATE_DAEMONS_TERMINATED`` and
        exit.  No acknowledgement is sent; the HNP detects departure via the
        comm-failure path.
    * - ``src/mca/plm/base/plm_base_launch_support.c``
-     - Add ``prte_plm_base_fence_release()``,
-       ``prte_plm_base_job_needs_remap()``, and
-       ``prte_plm_base_reset_proc_map()``.
-       Add hold check in ``prte_plm_base_launch_apps()`` on
+     - Add ``prte_plm_base_job_needs_remap()`` and
+       ``prte_plm_base_reset_proc_map()``.  Add hold check in
+       ``prte_plm_base_launch_apps()`` on
        ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
    * - ``src/mca/plm/base/plm_base_launch_support.h``
-     - Declare the three new functions.
-   * - ``src/mca/state/dvm/state_dvm.c``
-     - Replace inline release loop in ``vm_ready`` and ``check_complete``
-       with calls to ``prte_plm_base_fence_release()``.
+     - Declare the two remap helpers.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - In ``proc_errors()``, daemon-comm-failure block: search
        ``prte_shrink_campaigns`` for the dead daemon's rank; if found, stamp
        the matched target slot ``PMIX_RANK_INVALID``, decrement campaign
-       ``pending`` and fence; remove campaign when ``pending`` hits zero;
-       call ``prte_plm_base_fence_release(true)`` when fence hits zero.  This
-       is the sole shrink-completion trigger.
+       ``pending`` and fence; when ``pending`` hits zero emit
+       ``PMIX_DVM_IS_READY`` to the requester and remove the campaign; call
+       ``prte_plm_base_fence_release(true)`` when the fence hits zero.  This is
+       the sole shrink-completion trigger.
 
-Summary of Files Changed (Shared Fence Infrastructure)
--------------------------------------------------------
-
-.. list-table::
-   :widths: 50 50
-   :header-rows: 1
-
-   * - File
-     - Change
-   * - ``src/mca/plm/plm_types.h``
-     - Add ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS = 17``.
-   * - ``src/util/error_strings.c``
-     - Add string for ``PRTE_JOB_STATE_WAITING_FOR_DAEMONS``.
-   * - ``src/runtime/prte_globals.h``
-     - Declare ``prte_dvm_launch_fence``, ``prte_held_jobs``, and
-       ``prte_prelaunch_held_jobs``.
-   * - ``src/runtime/prte_globals.c``
-     - Define and initialize ``prte_dvm_launch_fence = 0``.
-   * - ``src/runtime/prte_init.c``
-     - Allocate and init ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
-   * - ``src/runtime/prte_finalize.c``
-     - Destruct ``prte_held_jobs`` and ``prte_prelaunch_held_jobs``.
-   * - ``src/mca/plm/base/plm_base_launch_support.c``
-     - Declare and define ``prte_plm_base_fence_release()`` (Step 10).
-   * - ``src/mca/state/dvm/state_dvm.c``
-     - In ``vm_ready``: add the ``VM_READY → MAP`` hold-check before
-       ``preposition_files`` (Step 5).
-
-For the **grow** path's file changes (campaign object, campaign creation in
-``setup_virtual_machine()``, the ``grow_drain`` / ``grow_target_failed``
-helpers, and the ``vm_ready`` / ``check_job_complete`` drains), see the
-"Touched files" table in :ref:`dvm-grow-campaign-label`.
+The shared infrastructure this path relies on — the fence counter, held-job
+arrays, ``VM_READY → MAP`` hold point, ``prte_plm_base_fence_release()``, and
+the ``prte_plm_base_dvm_mod_notify()`` completion-event helper — is listed in
+the "Shared Fence Infrastructure" table in :ref:`elastic-dvm-plan-label`.
 
 Design Invariants
 -----------------
-
-**Grow fence**
-
-The grow-path invariants now live with the per-campaign implementation; see
-the "Why this is correct" and "Design" sections of
-:ref:`dvm-grow-campaign-label`.  In brief: each live campaign contributes
-exactly its target count to ``prte_dvm_launch_fence`` until drained as a unit;
-the fence reaches zero (on success) only after the WIREUP xcast in
-``vm_ready``; an unrelated daemon death matches no campaign and leaves the
-fence untouched; and jobs already past ``MAP`` when a grow starts are
-unaffected.  All access is on the progress thread, so no locking is required.
-
-**Shrink fence**
 
 * ``prte_shrink_campaigns`` is a ``pmix_list_t``; each entry covers exactly
   one ``PMIX_ALLOC_RELEASE`` request.  Multiple concurrent shrink campaigns
@@ -672,18 +479,18 @@ unaffected.  All access is on the progress thread, so no locking is required.
 * Jobs in ``prte_prelaunch_held_jobs`` hold a ``PMIX_RETAIN`` reference;
   ``prte_plm_base_fence_release()`` releases it after re-activating or
   aborting the job.
-* ``prte_plm_base_fence_release()`` is called only when
-  ``prte_dvm_launch_fence`` reaches zero, which requires all grow campaigns
-  and all shrink campaigns to have completed.  The campaign list is therefore
-  empty (or nearly so — the safety sweep in ``fence_release`` handles the
-  degenerate case where an xcast failure left a partially-setup campaign).
+* The completion event is per campaign and fires from the campaign-removal
+  point (``pending == 0``), so each accepted release yields exactly one
+  ``PMIX_DVM_IS_READY`` (success) or, on an xcast failure at creation, exactly
+  one ``PMIX_ERR_DVM_MOD`` — never both, and never for a scheduler-driven
+  release with no requester.
 
 Follow-up — collective shrink completion
 -----------------------------------------
 
 The shrink design above drains a campaign **one daemon at a time**: every
 targeted daemon exits on its own and the HNP discovers each departure
-independently through the errmgr comm-failure path (Step 11), decrementing the
+independently through the errmgr comm-failure path (Step 5), decrementing the
 campaign's ``pending`` count and the fence once per death.  This is correct,
 but each individual departure drives a separate routing-tree repair —
 ``prte_rml_repair_routing_tree()`` runs ``handle_promotion()`` and
@@ -722,7 +529,9 @@ intent" is preserved.  The doomed daemons exiting slightly later is harmless:
 they are already excluded from routing and mapping, so released jobs remap onto
 survivors correctly.  Completion would collapse to a single event per campaign,
 which also retires the per-rank ``PMIX_RANK_INVALID`` idempotency stamping and
-the double-count analysis that the per-death path requires.
+the double-count analysis that the per-death path requires.  The completion
+event (``PMIX_DVM_IS_READY``) would then fire from that single batch point
+rather than from the last individual departure.
 
 This is an **optimization, not a correctness fix**, so it is deliberately
 deferred out of the launch-fence work:

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -192,8 +192,9 @@ request) so the completion event can be directed at it:
            (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
        prte_dvm_launch_fence -= _camp->pending;
        if (_camp->have_requester) {
+           /* success == false => PMIX_ERR_DVM_MOD carrying rc */
            prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
-                                        _camp->req_id, PMIX_ERR_DVM_MOD, rc);
+                                        _camp->req_id, false, rc);
        }
        PMIX_RELEASE(_camp);
        PRTE_ERROR_LOG(rc);
@@ -365,11 +366,11 @@ daemon-proc block of ``proc_errors()`` (line 252), within the
                    /* this request's shrink is complete — notify the
                     * requester that the DVM now reflects the new size */
                    if (_camp->have_requester) {
+                       /* success == true => PMIX_DVM_IS_READY */
                        prte_plm_base_dvm_mod_notify(&_camp->requester,
                                                     _camp->alloc_id,
                                                     _camp->req_id,
-                                                    PMIX_DVM_IS_READY,
-                                                    PMIX_SUCCESS);
+                                                    true, PMIX_SUCCESS);
                    }
                    pmix_list_remove_item(&prte_shrink_campaigns,
                                         &_camp->super);

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -265,7 +265,7 @@ Step 4 — Remap helpers
 
 The pre-launch branch of the shared ``prte_plm_base_fence_release()`` (parent
 plan, Step 4) calls two shrink-specific helpers, both defined in
-``plm_base_launch_support.c`` and declared in ``plm_base_launch_support.h``.
+``plm_base_launch_support.c`` and declared in ``src/mca/plm/base/base.h``.
 
 **``prte_plm_base_job_needs_remap(jdata)``** iterates over ``jdata->procs``
 and returns ``true`` if any proc's assigned node has a daemon rank appearing
@@ -454,7 +454,7 @@ Summary of Files Changed (Shrink Fence)
        ``prte_plm_base_reset_proc_map()``.  Add hold check in
        ``prte_plm_base_launch_apps()`` on
        ``!pmix_list_is_empty(&prte_shrink_campaigns)``.
-   * - ``src/mca/plm/base/plm_base_launch_support.h``
+   * - ``src/mca/plm/base/base.h``
      - Declare the two remap helpers.
    * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
      - In ``proc_errors()``, daemon-comm-failure block: search

--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -8,3 +8,4 @@ Detailed implementation plans for in-progress and upcoming features.
 
    per_app_mapping/index.rst
    node_reservation/index.rst
+   elastic_dvm/index.rst

--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -9,3 +9,4 @@ Detailed implementation plans for in-progress and upcoming features.
    per_app_mapping/index.rst
    node_reservation/index.rst
    elastic_dvm/index.rst
+   per_app_mapping/index.rst

--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -9,4 +9,3 @@ Detailed implementation plans for in-progress and upcoming features.
    per_app_mapping/index.rst
    node_reservation/index.rst
    elastic_dvm/index.rst
-   per_app_mapping/index.rst

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -291,6 +291,9 @@ static void proc_errors(int fd, short args, void *cbdata)
                                        &prte_shrink_campaigns, prte_shrink_campaign_t) {
                     for (_t = 0; _t < _camp->ntargets; _t++) {
                         if (_camp->targets[_t] != proc->rank) continue;
+                        /* stamp this slot so a repeated comm event for the
+                         * same daemon cannot decrement the campaign twice */
+                        _camp->targets[_t] = PMIX_RANK_INVALID;
                         _camp->pending--;
                         prte_dvm_launch_fence--;
                         if (0 == _camp->pending) {

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -290,11 +290,21 @@ static void proc_errors(int fd, short args, void *cbdata)
                         _camp->pending--;
                         prte_dvm_launch_fence--;
                         if (0 == _camp->pending) {
+                            /* this request's shrink is complete — notify the
+                             * requester that the DVM now reflects the new size
+                             * (clean exit and crash are both successes for the
+                             * campaign, so this drain is always success) */
+                            if (_camp->have_requester) {
+                                prte_plm_base_dvm_mod_notify(&_camp->requester,
+                                                             _camp->alloc_id,
+                                                             _camp->req_id,
+                                                             true, PMIX_SUCCESS);
+                            }
                             pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
                             PMIX_RELEASE(_camp);
                         }
                         if (0 == prte_dvm_launch_fence) {
-                            prte_plm_base_fence_release(true);
+                            prte_plm_base_fence_release();
                         }
                         goto errmgr_shrink_done;
                     }

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -271,18 +271,11 @@ static void proc_errors(int fd, short args, void *cbdata)
             pptr->state = state;
             /* adjust our num_procs */
             --prte_process_info.num_daemons;
-            /* check if a grow campaign was in progress: if so, fail the fence
-             * so that held jobs are not parked indefinitely */
-            if (0 < prte_dvm_launch_fence &&
-                prte_get_attribute(&jdata->attributes,
-                                   PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL)) {
-                prte_dvm_launch_fence--;
-                if (0 == prte_dvm_launch_fence) {
-                    prte_plm_base_fence_release(false);
-                }
-                /* clear attribute so a second crash does not double-decrement */
-                prte_remove_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS);
-            }
+            /* if this daemon was the target of an in-progress grow campaign,
+             * resolve its rank against the launch fence (failure).  Only the
+             * specific ranks being launched affect the fence, so an unrelated
+             * daemon loss during a grow no longer consumes the fence. */
+            prte_plm_base_grow_target_failed(proc->rank);
             /* check if this daemon was a pending shrink target */
             {
                 prte_shrink_campaign_t *_camp, *_next;

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -43,6 +43,7 @@
 #include "src/mca/iof/base/base.h"
 #include "src/mca/odls/base/base.h"
 #include "src/mca/plm/base/base.h"
+#include "src/mca/ras/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/rml/rml.h"
 #include "src/mca/state/base/base.h"
@@ -296,10 +297,13 @@ static void proc_errors(int fd, short args, void *cbdata)
                         _camp->pending--;
                         prte_dvm_launch_fence--;
                         if (0 == _camp->pending) {
-                            /* this request's shrink is complete — notify the
-                             * requester that the DVM now reflects the new size
-                             * (clean exit and crash are both successes for the
-                             * campaign, so this drain is always success) */
+                            /* this request's shrink is complete — first let the
+                             * active RAS modules release the freed resources
+                             * back to the scheduler, then notify the requester
+                             * that the DVM now reflects the new size (clean exit
+                             * and crash are both successes for the campaign, so
+                             * this drain is always success) */
+                            prte_ras_base_shrink_complete(_camp);
                             if (_camp->have_requester) {
                                 prte_plm_base_dvm_mod_notify(&_camp->requester,
                                                              _camp->alloc_id,

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -274,8 +274,14 @@ static void proc_errors(int fd, short args, void *cbdata)
             /* if this daemon was the target of an in-progress grow campaign,
              * resolve its rank against the launch fence (failure).  Only the
              * specific ranks being launched affect the fence, so an unrelated
-             * daemon loss during a grow no longer consumes the fence. */
-            prte_plm_base_grow_target_failed(proc->rank);
+             * daemon loss during a grow no longer consumes the fence.  When it
+             * was a grow target the campaign is rolled back out of the DVM and
+             * the loss is fully handled here, so skip the general daemon-loss
+             * handling below — that path would otherwise abort the whole DVM
+             * over a failure the grow rollback has already absorbed. */
+            if (prte_plm_base_grow_target_failed(proc->rank)) {
+                goto cleanup;
+            }
             /* check if this daemon was a pending shrink target */
             {
                 prte_shrink_campaign_t *_camp, *_next;

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -60,6 +60,7 @@
 #include "src/mca/errmgr/base/base.h"
 #include "src/mca/errmgr/base/errmgr_private.h"
 #include "src/mca/errmgr/errmgr.h"
+#include "src/mca/plm/base/plm_private.h"
 
 #include "errmgr_dvm.h"
 
@@ -270,6 +271,40 @@ static void proc_errors(int fd, short args, void *cbdata)
             pptr->state = state;
             /* adjust our num_procs */
             --prte_process_info.num_daemons;
+            /* check if a grow campaign was in progress: if so, fail the fence
+             * so that held jobs are not parked indefinitely */
+            if (0 < prte_dvm_launch_fence &&
+                prte_get_attribute(&jdata->attributes,
+                                   PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL)) {
+                prte_dvm_launch_fence--;
+                if (0 == prte_dvm_launch_fence) {
+                    prte_plm_base_fence_release(false);
+                }
+                /* clear attribute so a second crash does not double-decrement */
+                prte_remove_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS);
+            }
+            /* check if this daemon was a pending shrink target */
+            {
+                prte_shrink_campaign_t *_camp, *_next;
+                int _t;
+                PMIX_LIST_FOREACH_SAFE(_camp, _next,
+                                       &prte_shrink_campaigns, prte_shrink_campaign_t) {
+                    for (_t = 0; _t < _camp->ntargets; _t++) {
+                        if (_camp->targets[_t] != proc->rank) continue;
+                        _camp->pending--;
+                        prte_dvm_launch_fence--;
+                        if (0 == _camp->pending) {
+                            pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
+                            PMIX_RELEASE(_camp);
+                        }
+                        if (0 == prte_dvm_launch_fence) {
+                            prte_plm_base_fence_release(true);
+                        }
+                        goto errmgr_shrink_done;
+                    }
+                }
+              errmgr_shrink_done: ;
+            }
             /* if we have ordered prteds to terminate or abort
              * is in progress, record it */
             if (prte_prteds_term_ordered || prte_abnormal_term_ordered) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2414,6 +2414,13 @@ process:
         for (gk = 0, gr = map->daemon_vpid_start; gk < gcamp->ntargets; gk++, gr++) {
             gcamp->targets[gk] = gr;
         }
+        /* The phase-two completion event needs the requester that drove this
+         * grow, but the originating allocation request is not threaded through
+         * to setup_virtual_machine yet, so leave have_requester false for now
+         * (PMIX_NEW zero-inits it).  grow_drain() therefore emits no event for
+         * a grow until that plumbing lands; the fence accounting and rollback
+         * are unaffected.  A scheduler-driven push legitimately has no
+         * requester and stays false regardless. */
         pmix_list_append(&prte_grow_campaigns, &gcamp->super);
         prte_dvm_launch_fence += map->num_new_daemons;
     }
@@ -2421,28 +2428,94 @@ process:
     return PRTE_SUCCESS;
 }
 
-void prte_plm_base_fence_release(bool success)
+void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
+                                  const char *alloc_id,
+                                  const char *req_id,
+                                  bool success,
+                                  pmix_status_t cause)
+{
+#if PRTE_HAVE_DVM_MOD_EVENTS
+    pmix_status_t code = success ? PMIX_DVM_IS_READY : PMIX_ERR_DVM_MOD;
+    pmix_info_t *rinfo;
+    pmix_data_array_t parray;
+    pmix_proc_t ptarg;
+    size_t nrinfo, idx;
+    pmix_status_t rc;
+
+    /* Assemble a directed (custom-range) notification to the requester only,
+     * mirroring the PMIX_ALLOC_TIMEOUT_WARNING delivery: custom range plus the
+     * allocation id, the requester's own request id when one was supplied, and
+     * — on failure — the underlying cause so the requester can distinguish
+     * what went wrong rather than only that something did. */
+    nrinfo = 2;
+    if (NULL != req_id) {
+        nrinfo++;
+    }
+    if (!success) {
+        nrinfo++;
+    }
+    PMIX_INFO_CREATE(rinfo, nrinfo);
+    idx = 0;
+    PMIX_LOAD_PROCID(&ptarg, requester->nspace, requester->rank);
+    parray.type = PMIX_PROC;
+    parray.size = 1;
+    parray.array = &ptarg;
+    /* PMIX_INFO_LOAD deep-copies the data, so the stack copies are fine */
+    PMIX_INFO_LOAD(&rinfo[idx++], PMIX_EVENT_CUSTOM_RANGE, &parray, PMIX_DATA_ARRAY);
+    PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, (void *) alloc_id, PMIX_STRING);
+    if (NULL != req_id) {
+        PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_REQ_ID, (void *) req_id, PMIX_STRING);
+    }
+    if (!success) {
+        /* carry the underlying failure status; PMIX_JOB_TERM_STATUS is the
+         * standard pmix_status_t-typed info key (reconcile the carrier with
+         * PMIx PR openpmix#3917 should it define a dedicated DVM-mod cause
+         * key) */
+        PMIX_INFO_LOAD(&rinfo[idx++], PMIX_JOB_TERM_STATUS, &cause, PMIX_STATUS);
+    }
+    rc = PMIx_Notify_event(code, PRTE_PROC_MY_NAME, PMIX_RANGE_CUSTOM,
+                           rinfo, nrinfo, NULL, NULL);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    PMIX_INFO_FREE(rinfo, nrinfo);
+#else
+    /* The installed PMIx defines neither DVM modification event code, so the
+     * completion notification is compiled out per the spec's backward-
+     * compatibility clause.  The DVM still grows/shrinks; only the event is
+     * omitted. */
+    PRTE_HIDE_UNUSED_PARAMS(requester, alloc_id, req_id, success, cause);
+#endif
+}
+
+void prte_plm_base_fence_release(void)
 {
     int hi;
     prte_job_t *held;
-    prte_shrink_campaign_t *camp, *next;
+    prte_shrink_campaign_t *scamp, *snext;
+    prte_grow_campaign_t *gcamp, *gnext;
 
+    /* SUCCESS release — reached only when the global fence has dropped to
+     * zero, i.e. every grow and shrink campaign has completed successfully.
+     * Both classes of held job are admitted.  The only path that *fails* a
+     * held job is prte_plm_base_abort_premap_held() on a grow failure. */
     for (hi = 0; hi < prte_held_jobs->size; hi++) {
         held = (prte_job_t *) pmix_pointer_array_get_item(prte_held_jobs, hi);
-        if (NULL == held) continue;
+        if (NULL == held) {
+            continue;
+        }
         pmix_pointer_array_set_item(prte_held_jobs, hi, NULL);
-        PRTE_ACTIVATE_JOB_STATE(held,
-            success ? PRTE_JOB_STATE_VM_READY : PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_VM_READY);
         PMIX_RELEASE(held);
     }
 
     for (hi = 0; hi < prte_prelaunch_held_jobs->size; hi++) {
         held = (prte_job_t *) pmix_pointer_array_get_item(prte_prelaunch_held_jobs, hi);
-        if (NULL == held) continue;
+        if (NULL == held) {
+            continue;
+        }
         pmix_pointer_array_set_item(prte_prelaunch_held_jobs, hi, NULL);
-        if (!success) {
-            PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_NEVER_LAUNCHED);
-        } else if (prte_plm_base_job_needs_remap(held)) {
+        if (prte_plm_base_job_needs_remap(held)) {
             prte_plm_base_reset_proc_map(held);
             PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_MAP);
         } else {
@@ -2451,10 +2524,39 @@ void prte_plm_base_fence_release(bool success)
         PMIX_RELEASE(held);
     }
 
-    /* safety sweep — campaigns should already be empty at fence==0 */
-    PMIX_LIST_FOREACH_SAFE(camp, next, &prte_shrink_campaigns, prte_shrink_campaign_t) {
-        pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
-        PMIX_RELEASE(camp);
+    /* Campaigns are removed individually as they drain, so both lists should
+     * be empty here.  Sweep each defensively anyway — and sweep both kinds,
+     * not just shrink — so a future change that can leave a residual campaign
+     * behind cannot wedge the fence. */
+    PMIX_LIST_FOREACH_SAFE(scamp, snext, &prte_shrink_campaigns, prte_shrink_campaign_t) {
+        pmix_list_remove_item(&prte_shrink_campaigns, &scamp->super);
+        PMIX_RELEASE(scamp);
+    }
+    PMIX_LIST_FOREACH_SAFE(gcamp, gnext, &prte_grow_campaigns, prte_grow_campaign_t) {
+        pmix_list_remove_item(&prte_grow_campaigns, &gcamp->super);
+        PMIX_RELEASE(gcamp);
+    }
+}
+
+void prte_plm_base_abort_premap_held(void)
+{
+    int hi;
+    prte_job_t *held;
+
+    /* GROW-FAILURE abort — fail every job parked at the VM_READY -> MAP
+     * boundary, immediately and independent of the fence value, so a grow
+     * failure aborts its pre-map waiters even while a concurrent shrink keeps
+     * the fence nonzero.  The pre-launch held jobs are deliberately left
+     * untouched: they wait only on a shrink, never on the grow (spec
+     * conformance #4). */
+    for (hi = 0; hi < prte_held_jobs->size; hi++) {
+        held = (prte_job_t *) pmix_pointer_array_get_item(prte_held_jobs, hi);
+        if (NULL == held) {
+            continue;
+        }
+        pmix_pointer_array_set_item(prte_held_jobs, hi, NULL);
+        PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(held);
     }
 }
 
@@ -2467,15 +2569,33 @@ void prte_plm_base_grow_drain(bool success)
      * two safe points: from vm_ready on the all-success path (after the
      * WIREUP xcast, so held jobs are only admitted once the new daemons are
      * wired up), and from the failure path when one of the launched daemons
-     * dies.  Mirroring the original single-token behavior, any grow failure
-     * fails the whole set of held jobs. */
+     * dies.  Each drained campaign emits its phase-two completion event to its
+     * requester — PMIX_DVM_IS_READY on success, PMIX_ERR_DVM_MOD on failure. */
     while (NULL != (camp = (prte_grow_campaign_t *)
                                pmix_list_remove_first(&prte_grow_campaigns))) {
         prte_dvm_launch_fence -= camp->ntargets;
+        if (camp->have_requester) {
+            /* the specific daemon-failure status is not threaded down to this
+             * layer yet, so report a generic cause on failure (reconcile by
+             * passing the dying daemon's status as a follow-up) */
+            prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
+                                         camp->req_id, success,
+                                         success ? PMIX_SUCCESS : PMIX_ERROR);
+        }
         PMIX_RELEASE(camp);
     }
-    if (0 == prte_dvm_launch_fence) {
-        prte_plm_base_fence_release(success);
+    if (success) {
+        /* admit the held jobs only once the *global* fence is clear — a
+         * concurrent shrink may still hold it nonzero */
+        if (0 == prte_dvm_launch_fence) {
+            prte_plm_base_fence_release();
+        }
+    } else {
+        /* a grow failure fails the whole pre-map held-job set immediately,
+         * regardless of the fence value, so a concurrent shrink cannot later
+         * admit a job whose grow dependency has failed; the shrink-only
+         * pre-launch held jobs are left parked */
+        prte_plm_base_abort_premap_held();
     }
 }
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2414,13 +2414,26 @@ process:
         for (gk = 0, gr = map->daemon_vpid_start; gk < gcamp->ntargets; gk++, gr++) {
             gcamp->targets[gk] = gr;
         }
-        /* The phase-two completion event needs the requester that drove this
-         * grow, but the originating allocation request is not threaded through
-         * to setup_virtual_machine yet, so leave have_requester false for now
-         * (PMIX_NEW zero-inits it).  grow_drain() therefore emits no event for
-         * a grow until that plumbing lands; the fence accounting and rollback
-         * are unaffected.  A scheduler-driven push legitimately has no
-         * requester and stays false regardless. */
+        /* Record the requester for the spec's phase-two completion event.  The
+         * RAS reservation machinery sets each reserved node's ->session
+         * backpointer (add_nodes_to_session), and that session carries the
+         * requestor and the allocation ids; take them from the first new
+         * daemon's node.  The initial DVM bring-up and a scheduler-driven push
+         * have no such requestor (the default session, or an invalid requestor
+         * rank), so have_requester stays false and grow_drain() emits no event
+         * for them. */
+        {
+            prte_proc_t *dproc = (prte_proc_t *)
+                pmix_pointer_array_get_item(daemons->procs, map->daemon_vpid_start);
+            prte_session_t *sess =
+                (NULL != dproc && NULL != dproc->node) ? dproc->node->session : NULL;
+            if (NULL != sess && PMIX_RANK_INVALID != sess->requestor.rank) {
+                PMIX_XFER_PROCID(&gcamp->requester, &sess->requestor);
+                gcamp->alloc_id = (NULL != sess->alloc_refid) ? strdup(sess->alloc_refid) : NULL;
+                gcamp->req_id = (NULL != sess->user_refid) ? strdup(sess->user_refid) : NULL;
+                gcamp->have_requester = true;
+            }
+        }
         pmix_list_append(&prte_grow_campaigns, &gcamp->super);
         prte_dvm_launch_fence += map->num_new_daemons;
     }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -838,8 +838,10 @@ void prte_plm_base_launch_apps(int fd, short args, void *cbdata)
     caddy->jdata->state = caddy->job_state;
 
     /* if a shrink campaign is active, hold this job until all targeted
-     * daemons have departed the DVM to avoid sending launch data to a dying daemon */
-    if (!pmix_list_is_empty(&prte_shrink_campaigns)) {
+     * daemons have departed the DVM to avoid sending launch data to a dying
+     * daemon (shrink campaigns are only ever created in elastic mode, so the
+     * explicit guard keeps the non-elastic launch path identical) */
+    if (prte_elastic_mode && !pmix_list_is_empty(&prte_shrink_campaigns)) {
         jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
         PMIX_RETAIN(jdata);
         pmix_pointer_array_add(prte_prelaunch_held_jobs, jdata);
@@ -2390,16 +2392,23 @@ process:
     /* if new daemons are being launched, mark that this job
      * caused it to happen */
     if (0 < map->num_new_daemons) {
-        prte_grow_campaign_t *gcamp;
-        pmix_rank_t gr;
-        int gk;
-
         rc = prte_set_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS, true,
                                 NULL, PMIX_BOOL);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
+    }
+
+    /* The launch fence only operates when the DVM is permitted to grow/shrink.
+     * Outside elastic mode the DVM is fixed-size, so no campaign is recorded
+     * and the fence is never raised — leaving the normal launch path, and the
+     * normal daemon-failure handling, completely unchanged. */
+    if (prte_elastic_mode && 0 < map->num_new_daemons) {
+        prte_grow_campaign_t *gcamp;
+        pmix_rank_t gr;
+        int gk;
+
         /* Record this launch campaign so the launch fence can be resolved on
          * a per-daemon basis: each new daemon either reports home (success)
          * or its launch fails (comm-failure / failed-to-start), and only
@@ -2718,6 +2727,13 @@ bool prte_plm_base_grow_target_failed(pmix_rank_t rank)
 {
     prte_grow_campaign_t *camp;
     int t;
+
+    /* Outside elastic mode there are no grow campaigns and the daemon loss is
+     * the errmgr's to handle exactly as it always has — never report it as
+     * handled here, so the normal DVM-failure path is preserved. */
+    if (!prte_elastic_mode) {
+        return false;
+    }
 
     /* A daemon has died.  Only act if it was actually the target of an
      * in-progress grow campaign — an unrelated daemon loss must not consume

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -838,7 +838,7 @@ void prte_plm_base_launch_apps(int fd, short args, void *cbdata)
     caddy->jdata->state = caddy->job_state;
 
     /* if a shrink campaign is active, hold this job until all targeted
-     * daemons have confirmed exit to avoid sending launch data to a dying daemon */
+     * daemons have departed the DVM to avoid sending launch data to a dying daemon */
     if (!pmix_list_is_empty(&prte_shrink_campaigns)) {
         jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
         PMIX_RETAIN(jdata);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2390,13 +2390,32 @@ process:
     /* if new daemons are being launched, mark that this job
      * caused it to happen */
     if (0 < map->num_new_daemons) {
+        prte_grow_campaign_t *gcamp;
+        pmix_rank_t gr;
+        int gk;
+
         rc = prte_set_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS, true,
                                 NULL, PMIX_BOOL);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             return rc;
         }
-        prte_dvm_launch_fence++;
+        /* Record this launch campaign so the launch fence can be resolved on
+         * a per-daemon basis: each new daemon either reports home (success)
+         * or its launch fails (comm-failure / failed-to-start), and only
+         * those specific ranks affect this campaign.  This avoids an
+         * unrelated daemon loss consuming the fence, and lets concurrent
+         * campaigns be tracked independently.  The new daemons were assigned
+         * consecutive vpids starting at map->daemon_vpid_start (see the
+         * daemon-creation loop above). */
+        gcamp = PMIX_NEW(prte_grow_campaign_t);
+        gcamp->ntargets = map->num_new_daemons;
+        gcamp->targets = (pmix_rank_t *) malloc(gcamp->ntargets * sizeof(pmix_rank_t));
+        for (gk = 0, gr = map->daemon_vpid_start; gk < gcamp->ntargets; gk++, gr++) {
+            gcamp->targets[gk] = gr;
+        }
+        pmix_list_append(&prte_grow_campaigns, &gcamp->super);
+        prte_dvm_launch_fence += map->num_new_daemons;
     }
 
     return PRTE_SUCCESS;
@@ -2436,6 +2455,46 @@ void prte_plm_base_fence_release(bool success)
     PMIX_LIST_FOREACH_SAFE(camp, next, &prte_shrink_campaigns, prte_shrink_campaign_t) {
         pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
         PMIX_RELEASE(camp);
+    }
+}
+
+void prte_plm_base_grow_drain(bool success)
+{
+    prte_grow_campaign_t *camp;
+
+    /* Resolve all in-progress grow campaigns at once and drop their entire
+     * contribution from the launch fence.  This is called from exactly the
+     * two safe points: from vm_ready on the all-success path (after the
+     * WIREUP xcast, so held jobs are only admitted once the new daemons are
+     * wired up), and from the failure path when one of the launched daemons
+     * dies.  Mirroring the original single-token behavior, any grow failure
+     * fails the whole set of held jobs. */
+    while (NULL != (camp = (prte_grow_campaign_t *)
+                               pmix_list_remove_first(&prte_grow_campaigns))) {
+        prte_dvm_launch_fence -= camp->ntargets;
+        PMIX_RELEASE(camp);
+    }
+    if (0 == prte_dvm_launch_fence) {
+        prte_plm_base_fence_release(success);
+    }
+}
+
+void prte_plm_base_grow_target_failed(pmix_rank_t rank)
+{
+    prte_grow_campaign_t *camp;
+    int t;
+
+    /* A daemon has died.  Only act if it was actually the target of an
+     * in-progress grow campaign — an unrelated daemon loss must not consume
+     * the launch fence.  If it was a grow target, the grow is compromised,
+     * so drain the campaigns and fail any held jobs. */
+    PMIX_LIST_FOREACH(camp, &prte_grow_campaigns, prte_grow_campaign_t) {
+        for (t = 0; t < camp->ntargets; t++) {
+            if (camp->targets[t] == rank) {
+                prte_plm_base_grow_drain(false);
+                return;
+            }
+        }
     }
 }
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2612,23 +2612,142 @@ void prte_plm_base_grow_drain(bool success)
     }
 }
 
-void prte_plm_base_grow_target_failed(pmix_rank_t rank)
+/* Roll a failed grow campaign back out of the DVM so a failed grow leaves the
+ * DVM at its exact pre-grow membership rather than half-extended (spec
+ * conformance #5).  `trigger` is the rank whose death triggered the failure;
+ * the errmgr has already marked it not-alive and decremented num_daemons, and
+ * its routing is repaired here.  Every *other* target is handled by whether a
+ * daemon actually came up:
+ *
+ *   - a target that started (PRTE_PROC_FLAG_ALIVE) is terminated using the same
+ *     PRTE_DAEMON_SHRINK_CMD machinery the DVM shrink path uses; its departure
+ *     is then reconciled on the normal daemon-loss path as it exits;
+ *   - a target that never started has no daemon to signal, so its launch-time
+ *     daemon-count bump is reverted here (no comm-failure event will arrive for
+ *     it).
+ *
+ * In all cases the node's daemon backpointer is cleared so the mapper can no
+ * longer place a later job on it.  The new nodes carry no application procs —
+ * the jobs that would have used them were held at the fence, never launched —
+ * so clearing ``node->daemon`` is sufficient to remove the node from the DVM's
+ * usable set.  The teardown is strictly campaign-scoped: it touches only the
+ * ranks in this campaign's ``targets`` array. */
+static void grow_rollback(prte_grow_campaign_t *camp, pmix_rank_t trigger)
+{
+    prte_job_t *daemons;
+    prte_proc_t *dproc;
+    prte_node_t *node;
+    pmix_rank_t *kill;
+    int32_t nkill = 0;
+    int t;
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL == daemons) {
+        return;
+    }
+    kill = (pmix_rank_t *) malloc(camp->ntargets * sizeof(pmix_rank_t));
+    if (NULL == kill) {
+        return;
+    }
+
+    /* repair routing for the daemon whose loss triggered the failure — the
+     * errmgr's own route_lost call is skipped because grow_target_failed()
+     * reports the death as handled (so the errmgr does not abort the DVM) */
+    prte_rml_route_lost(trigger);
+
+    for (t = 0; t < camp->ntargets; t++) {
+        pmix_rank_t r = camp->targets[t];
+        if (PMIX_RANK_INVALID == r) {
+            continue;
+        }
+        dproc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, r);
+        if (NULL == dproc) {
+            continue;
+        }
+        node = dproc->node;
+        if (r != trigger) {
+            if (PRTE_FLAG_TEST(dproc, PRTE_PROC_FLAG_ALIVE)) {
+                /* a started daemon — terminate it via the shrink command */
+                kill[nkill++] = r;
+            } else {
+                /* never started: no comm-failure event will arrive, so revert
+                 * its launch-time daemon-count bump here */
+                if (0 < prte_process_info.num_daemons) {
+                    --prte_process_info.num_daemons;
+                }
+            }
+        }
+        /* detach the node from the DVM's usable set */
+        if (NULL != node) {
+            if (NULL != node->session && node->session != prte_default_session) {
+                node->session = NULL;
+            }
+            if (node->daemon == dproc) {
+                node->daemon = NULL;
+                PMIX_RELEASE(dproc);
+            }
+        }
+    }
+
+    if (0 < nkill) {
+        pmix_data_buffer_t msg;
+        prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+        pmix_status_t rc;
+
+        PMIX_DATA_BUFFER_CONSTRUCT(&msg);
+        rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_pack(NULL, &msg, &nkill, 1, PMIX_INT32);
+        }
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_pack(NULL, &msg, kill, nkill, PMIX_PROC_RANK);
+        }
+        if (PMIX_SUCCESS == rc) {
+            if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+                PRTE_ERROR_LOG(rc);
+            }
+        } else {
+            PMIX_ERROR_LOG(rc);
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&msg);
+    }
+    free(kill);
+}
+
+bool prte_plm_base_grow_target_failed(pmix_rank_t rank)
 {
     prte_grow_campaign_t *camp;
     int t;
 
     /* A daemon has died.  Only act if it was actually the target of an
      * in-progress grow campaign — an unrelated daemon loss must not consume
-     * the launch fence.  If it was a grow target, the grow is compromised,
-     * so drain the campaigns and fail any held jobs. */
+     * the launch fence (and must be left to the errmgr's normal handling).
+     * If it was a grow target, that campaign is compromised: roll it back out
+     * of the DVM, drop its fence contribution, notify its requester of the
+     * failure, and abort the pre-map held jobs.  The teardown is scoped to the
+     * matched campaign, so any concurrent grow keeps its own daemons and
+     * completes normally (spec conformance #5). */
     PMIX_LIST_FOREACH(camp, &prte_grow_campaigns, prte_grow_campaign_t) {
         for (t = 0; t < camp->ntargets; t++) {
-            if (camp->targets[t] == rank) {
-                prte_plm_base_grow_drain(false);
-                return;
+            if (camp->targets[t] != rank) {
+                continue;
             }
+            pmix_list_remove_item(&prte_grow_campaigns, &camp->super);
+            prte_dvm_launch_fence -= camp->ntargets;
+            grow_rollback(camp, rank);
+            if (camp->have_requester) {
+                /* the specific daemon-failure status is not threaded down to
+                 * this layer yet, so report a generic cause */
+                prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
+                                             camp->req_id, false, PMIX_ERROR);
+            }
+            PMIX_RELEASE(camp);
+            /* any grow failure fails the whole pre-map held-job set */
+            prte_plm_base_abort_premap_held();
+            return true;
         }
     }
+    return false;
 }
 
 bool prte_plm_base_job_needs_remap(prte_job_t *jdata)

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -837,6 +837,16 @@ void prte_plm_base_launch_apps(int fd, short args, void *cbdata)
     /* update job state */
     caddy->jdata->state = caddy->job_state;
 
+    /* if a shrink campaign is active, hold this job until all targeted
+     * daemons have confirmed exit to avoid sending launch data to a dying daemon */
+    if (!pmix_list_is_empty(&prte_shrink_campaigns)) {
+        jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
+        PMIX_RETAIN(jdata);
+        pmix_pointer_array_add(prte_prelaunch_held_jobs, jdata);
+        PMIX_RELEASE(caddy);
+        return;
+    }
+
     PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                          "%s plm:base:launch_apps for job %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          PRTE_JOBID_PRINT(jdata->nspace)));
@@ -2386,7 +2396,97 @@ process:
             PRTE_ERROR_LOG(rc);
             return rc;
         }
+        prte_dvm_launch_fence++;
     }
 
     return PRTE_SUCCESS;
+}
+
+void prte_plm_base_fence_release(bool success)
+{
+    int hi;
+    prte_job_t *held;
+    prte_shrink_campaign_t *camp, *next;
+
+    for (hi = 0; hi < prte_held_jobs->size; hi++) {
+        held = (prte_job_t *) pmix_pointer_array_get_item(prte_held_jobs, hi);
+        if (NULL == held) continue;
+        pmix_pointer_array_set_item(prte_held_jobs, hi, NULL);
+        PRTE_ACTIVATE_JOB_STATE(held,
+            success ? PRTE_JOB_STATE_VM_READY : PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(held);
+    }
+
+    for (hi = 0; hi < prte_prelaunch_held_jobs->size; hi++) {
+        held = (prte_job_t *) pmix_pointer_array_get_item(prte_prelaunch_held_jobs, hi);
+        if (NULL == held) continue;
+        pmix_pointer_array_set_item(prte_prelaunch_held_jobs, hi, NULL);
+        if (!success) {
+            PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        } else if (prte_plm_base_job_needs_remap(held)) {
+            prte_plm_base_reset_proc_map(held);
+            PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_MAP);
+        } else {
+            PRTE_ACTIVATE_JOB_STATE(held, PRTE_JOB_STATE_LAUNCH_APPS);
+        }
+        PMIX_RELEASE(held);
+    }
+
+    /* safety sweep — campaigns should already be empty at fence==0 */
+    PMIX_LIST_FOREACH_SAFE(camp, next, &prte_shrink_campaigns, prte_shrink_campaign_t) {
+        pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
+        PMIX_RELEASE(camp);
+    }
+}
+
+bool prte_plm_base_job_needs_remap(prte_job_t *jdata)
+{
+    prte_shrink_campaign_t *camp;
+    prte_proc_t *proc;
+    int p, t;
+
+    PMIX_LIST_FOREACH(camp, &prte_shrink_campaigns, prte_shrink_campaign_t) {
+        for (p = 0; p < jdata->procs->size; p++) {
+            proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, p);
+            if (NULL == proc || NULL == proc->node || NULL == proc->node->daemon) continue;
+            for (t = 0; t < camp->ntargets; t++) {
+                if (camp->targets[t] == proc->node->daemon->name.rank) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void prte_plm_base_reset_proc_map(prte_job_t *jdata)
+{
+    int p, np;
+    prte_proc_t *proc;
+    prte_node_t *node;
+    prte_app_context_t *app;
+
+    for (p = 0; p < jdata->procs->size; p++) {
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, p);
+        if (NULL == proc) continue;
+        node = proc->node;
+        if (NULL != node) {
+            for (np = 0; np < node->procs->size; np++) {
+                if (pmix_pointer_array_get_item(node->procs, np) == proc) {
+                    pmix_pointer_array_set_item(node->procs, np, NULL);
+                    node->num_procs--;
+                    app = (prte_app_context_t *)
+                        pmix_pointer_array_get_item(jdata->apps, proc->app_idx);
+                    if (NULL == app || !PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
+                        node->slots_inuse--;
+                    }
+                    break;
+                }
+            }
+        }
+        pmix_pointer_array_set_item(jdata->procs, p, NULL);
+        PMIX_RELEASE(proc);
+    }
+    jdata->num_procs = 0;
+    jdata->num_launched = 0;
 }

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -910,6 +910,44 @@ moveon:
         }
         break;
 
+    case PRTE_PLM_SHRINK_ACK_CMD: {
+        pmix_rank_t drank;
+        int32_t cnt = 1;
+        prte_shrink_campaign_t *camp;
+        int t;
+
+        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                             "%s plm:base:receive shrink ACK from %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(sender)));
+        rc = PMIx_Data_unpack(NULL, buffer, &drank, &cnt, PMIX_PROC_RANK);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto CLEANUP;
+        }
+        PMIX_LIST_FOREACH(camp, &prte_shrink_campaigns, prte_shrink_campaign_t) {
+            for (t = 0; t < camp->ntargets; t++) {
+                if (camp->targets[t] != drank) continue;
+                camp->pending--;
+                prte_dvm_launch_fence--;
+                if (0 == camp->pending) {
+                    pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
+                    PMIX_RELEASE(camp);
+                }
+                if (0 == prte_dvm_launch_fence) {
+                    prte_plm_base_fence_release(true);
+                }
+                goto shrink_ack_done;
+            }
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                             "%s plm:base:receive shrink ACK from unknown daemon %lu",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             (unsigned long) drank));
+      shrink_ack_done:
+        break;
+    }
+
     default:
         PRTE_ERROR_LOG(PRTE_ERR_VALUE_OUT_OF_BOUNDS);
         rc = PRTE_ERR_VALUE_OUT_OF_BOUNDS;

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -910,44 +910,6 @@ moveon:
         }
         break;
 
-    case PRTE_PLM_SHRINK_ACK_CMD: {
-        pmix_rank_t drank;
-        int32_t cnt = 1;
-        prte_shrink_campaign_t *camp;
-        int t;
-
-        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                             "%s plm:base:receive shrink ACK from %s",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                             PRTE_NAME_PRINT(sender)));
-        rc = PMIx_Data_unpack(NULL, buffer, &drank, &cnt, PMIX_PROC_RANK);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            goto CLEANUP;
-        }
-        PMIX_LIST_FOREACH(camp, &prte_shrink_campaigns, prte_shrink_campaign_t) {
-            for (t = 0; t < camp->ntargets; t++) {
-                if (camp->targets[t] != drank) continue;
-                camp->pending--;
-                prte_dvm_launch_fence--;
-                if (0 == camp->pending) {
-                    pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
-                    PMIX_RELEASE(camp);
-                }
-                if (0 == prte_dvm_launch_fence) {
-                    prte_plm_base_fence_release(true);
-                }
-                goto shrink_ack_done;
-            }
-        }
-        PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                             "%s plm:base:receive shrink ACK from unknown daemon %lu",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                             (unsigned long) drank));
-      shrink_ack_done:
-        break;
-    }
-
     default:
         PRTE_ERROR_LOG(PRTE_ERR_VALUE_OUT_OF_BOUNDS);
         rc = PRTE_ERR_VALUE_OUT_OF_BOUNDS;

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -97,7 +97,7 @@ PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_fence_release(void);
 PRTE_EXPORT void prte_plm_base_abort_premap_held(void);
 PRTE_EXPORT void prte_plm_base_grow_drain(bool success);
-PRTE_EXPORT void prte_plm_base_grow_target_failed(pmix_rank_t rank);
+PRTE_EXPORT bool prte_plm_base_grow_target_failed(pmix_rank_t rank);
 PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
 /* emit the spec's phase-two completion event to the size-change requester:

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -94,11 +94,20 @@ PRTE_EXPORT void prte_plm_base_reset_job(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_setup_prted_cmd(int *argc, char ***argv);
 PRTE_EXPORT void prte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
-PRTE_EXPORT void prte_plm_base_fence_release(bool success);
+PRTE_EXPORT void prte_plm_base_fence_release(void);
+PRTE_EXPORT void prte_plm_base_abort_premap_held(void);
 PRTE_EXPORT void prte_plm_base_grow_drain(bool success);
 PRTE_EXPORT void prte_plm_base_grow_target_failed(pmix_rank_t rank);
 PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
+/* emit the spec's phase-two completion event to the size-change requester:
+ * PMIX_DVM_IS_READY when success, else PMIX_ERR_DVM_MOD carrying `cause`.
+ * Compiles to a no-op when PMIx lacks the DVM modification event codes. */
+PRTE_EXPORT void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
+                                              const char *alloc_id,
+                                              const char *req_id,
+                                              bool success,
+                                              pmix_status_t cause);
 
 /**
  * Utilities for plm components that use proxy daemons

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -94,6 +94,9 @@ PRTE_EXPORT void prte_plm_base_reset_job(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_setup_prted_cmd(int *argc, char ***argv);
 PRTE_EXPORT void prte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
+PRTE_EXPORT void prte_plm_base_fence_release(bool success);
+PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
+PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
 
 /**
  * Utilities for plm components that use proxy daemons

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -95,6 +95,8 @@ PRTE_EXPORT int prte_plm_base_setup_prted_cmd(int *argc, char ***argv);
 PRTE_EXPORT void prte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_fence_release(bool success);
+PRTE_EXPORT void prte_plm_base_grow_drain(bool success);
+PRTE_EXPORT void prte_plm_base_grow_target_failed(pmix_rank_t rank);
 PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
 

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -229,7 +229,6 @@ typedef uint8_t prte_plm_cmd_flag_t;
 #define PRTE_PLM_TOOL_ATTACHED_CMD      4
 #define PRTE_PLM_READY_FOR_DEBUG_CMD    5
 #define PRTE_PLM_LOCAL_LAUNCH_COMP_CMD  6
-#define PRTE_PLM_SHRINK_ACK_CMD         7   /* daemon → HNP: exiting due to shrink */
 
 END_C_DECLS
 

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -130,6 +130,7 @@ typedef int32_t prte_job_state_t;
 #define PRTE_JOB_STATE_RUNNING               14 /* all procs have been fork'd */
 #define PRTE_JOB_STATE_SUSPENDED             15 /* job has been suspended */
 #define PRTE_JOB_STATE_REGISTERED            16 /* all procs registered for sync */
+#define PRTE_JOB_STATE_WAITING_FOR_DAEMONS   17 /* parked: daemon launch/shrink campaign in progress */
 #define PRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE 18 /* all local procs have attempted launch */
 #define PRTE_JOB_STATE_READY_FOR_DEBUG       19 /* all local procs report ready for debug */
 #define PRTE_JOB_STATE_STARTED               20 /* first process has been started */
@@ -228,6 +229,7 @@ typedef uint8_t prte_plm_cmd_flag_t;
 #define PRTE_PLM_TOOL_ATTACHED_CMD      4
 #define PRTE_PLM_READY_FOR_DEBUG_CMD    5
 #define PRTE_PLM_LOCAL_LAUNCH_COMP_CMD  6
+#define PRTE_PLM_SHRINK_ACK_CMD         7   /* daemon → HNP: exiting due to shrink */
 
 END_C_DECLS
 

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -88,6 +88,12 @@ PRTE_EXPORT void prte_ras_base_allocate(int fd, short args, void *cbdata);
 
 PRTE_EXPORT void prte_ras_base_modify(int fd, short args, void *cbdata);
 
+/* Notify the active RAS modules that a shrink campaign has completed so they
+ * can release the freed resources back to the scheduler. Cycles across every
+ * selected module, calling the shrink_complete entry point on each that
+ * provides one. */
+PRTE_EXPORT void prte_ras_base_shrink_complete(prte_shrink_campaign_t *campaign);
+
 PRTE_EXPORT void prte_ras_base_release_allocation(prte_session_t *session);
 
 /* Tear down a reservation: drop its hold on its nodes (clearing the

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -617,6 +617,21 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
     PMIX_RELEASE(req);
 }
 
+void prte_ras_base_shrink_complete(prte_shrink_campaign_t *campaign)
+{
+    prte_ras_base_selected_module_t *mod;
+
+    /* cycle across the active modules and give each that supports the
+     * entry point a chance to release the freed resources back to the
+     * scheduler. Unlike modify, a shrink completion is not keyed to a
+     * single component, so every module is offered the campaign. */
+    PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t) {
+        if (NULL != mod->module->shrink_complete) {
+            mod->module->shrink_complete(campaign);
+        }
+    }
+}
+
 /* monotonic counter used to mint unique session ids for reservations that
  * the host (rather than a scheduler) must identify on its own. */
 static uint32_t prte_ras_reservation_counter = 0;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1262,14 +1262,17 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
             req->pstatus = rc;
             return;
         }
-        /* Record the shrink campaign before freeing the ranks array.  Skip
-         * entirely when the release removes no daemons (m == 0): an empty
-         * campaign would never drain (no target ever departs on the comm-
-         * failure path), so prte_shrink_campaigns would stay non-empty forever
-         * and stall every later job at the LAUNCH_APPS hold, and no completion
-         * event would fire.  This mirrors the grow path's num_new_daemons > 0
-         * guard and the spec's "no event when nothing changes" clause. */
-        if (0 < m) {
+        /* Record the shrink campaign before freeing the ranks array.  Only in
+         * elastic mode: outside it the DVM is fixed-size, so the release still
+         * xcasts the shrink command below but no campaign is recorded and the
+         * fence is never raised — the legacy fire-and-forget behavior.  Also
+         * skip when the release removes no daemons (m == 0): an empty campaign
+         * would never drain (no target ever departs on the comm-failure path),
+         * so prte_shrink_campaigns would stay non-empty forever and stall every
+         * later job at the LAUNCH_APPS hold, and no completion event would fire.
+         * This mirrors the grow path's num_new_daemons > 0 guard and the spec's
+         * "no event when nothing changes" clause. */
+        if (prte_elastic_mode && 0 < m) {
             prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
             _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
             memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
@@ -1296,7 +1299,7 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
             PRTE_ERROR_LOG(rc);
             /* undo the campaign we just added (only if one was created), and
              * tell the requester the DVM modification failed */
-            if (0 < m) {
+            if (prte_elastic_mode && 0 < m) {
                 prte_shrink_campaign_t *_camp =
                     (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
                 prte_dvm_launch_fence -= _camp->pending;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1261,11 +1261,28 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
             req->pstatus = rc;
             return;
         }
+        /* record the shrink campaign before freeing the ranks array */
+        {
+            prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
+            _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
+            memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
+            _camp->ntargets = m;
+            _camp->pending  = m;
+            pmix_list_append(&prte_shrink_campaigns, &_camp->super);
+            prte_dvm_launch_fence += m;
+        }
         free(ranks);
 
         /* goes to all daemons */
         if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
             PRTE_ERROR_LOG(rc);
+            /* undo the campaign we just added */
+            {
+                prte_shrink_campaign_t *_camp =
+                    (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
+                prte_dvm_launch_fence -= _camp->pending;
+                PMIX_RELEASE(_camp);
+            }
         }
         PMIX_DATA_BUFFER_DESTRUCT(&msg);
     }

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -42,6 +42,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/iof/base/base.h"
 #include "src/mca/odls/odls_types.h"
+#include "src/mca/plm/base/plm_private.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
@@ -1261,13 +1262,30 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
             req->pstatus = rc;
             return;
         }
-        /* record the shrink campaign before freeing the ranks array */
-        {
+        /* Record the shrink campaign before freeing the ranks array.  Skip
+         * entirely when the release removes no daemons (m == 0): an empty
+         * campaign would never drain (no target ever departs on the comm-
+         * failure path), so prte_shrink_campaigns would stay non-empty forever
+         * and stall every later job at the LAUNCH_APPS hold, and no completion
+         * event would fire.  This mirrors the grow path's num_new_daemons > 0
+         * guard and the spec's "no event when nothing changes" clause. */
+        if (0 < m) {
             prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
             _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
             memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
             _camp->ntargets = m;
             _camp->pending  = m;
+            /* record the requester so the phase-two completion event can be
+             * directed at the process that issued this PMIX_ALLOC_RELEASE */
+            PMIX_XFER_PROCID(&_camp->requester, &req->tproc);
+            for (n = 0; n < req->ninfo; n++) {
+                if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+                    _camp->alloc_id = strdup(req->info[n].value.data.string);
+                } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+                    _camp->req_id = strdup(req->info[n].value.data.string);
+                }
+            }
+            _camp->have_requester = true;
             pmix_list_append(&prte_shrink_campaigns, &_camp->super);
             prte_dvm_launch_fence += m;
         }
@@ -1276,11 +1294,17 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
         /* goes to all daemons */
         if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
             PRTE_ERROR_LOG(rc);
-            /* undo the campaign we just added */
-            {
+            /* undo the campaign we just added (only if one was created), and
+             * tell the requester the DVM modification failed */
+            if (0 < m) {
                 prte_shrink_campaign_t *_camp =
                     (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
                 prte_dvm_launch_fence -= _camp->pending;
+                if (_camp->have_requester) {
+                    prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
+                                                 _camp->req_id, false,
+                                                 prte_pmix_convert_rc(rc));
+                }
                 PMIX_RELEASE(_camp);
             }
         }

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -676,20 +676,23 @@ static prte_session_t *create_reservation(const char *nspace, uint8_t inherit,
     return s;
 }
 
-/* Register the nodes named in ndlist with the destination reservation: set
- * each node's session backpointer and store a retained reference in the
- * reservation. The node objects themselves live in the global pool. */
-static void add_nodes_to_session(pmix_list_t *ndlist, prte_session_t *dest)
+/* Register the named nodes with the destination reservation: set each node's
+ * session backpointer and store a retained reference in the reservation. The
+ * node objects themselves live in the global pool, which is why this takes the
+ * node *names* and resolves them with prte_node_match: the caller's working
+ * list has already been drained into the pool by prte_ras_base_node_insert, so
+ * the names must be snapshotted before that insert and handed in here. */
+static void add_nodes_to_session(char **names, prte_session_t *dest)
 {
-    prte_node_t *nd, *gnode;
-    int k;
+    prte_node_t *gnode;
+    int k, i;
     bool present;
 
-    if (NULL == dest || dest == prte_default_session) {
+    if (NULL == dest || dest == prte_default_session || NULL == names) {
         return;
     }
-    PMIX_LIST_FOREACH(nd, ndlist, prte_node_t) {
-        gnode = prte_node_match(NULL, nd->name);
+    for (i = 0; NULL != names[i]; i++) {
+        gnode = prte_node_match(NULL, names[i]);
         if (NULL == gnode) {
             continue;
         }
@@ -946,6 +949,7 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
     prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
     size_t n;
     char **nodes, *ndstring;
+    char **rsv_names = NULL;
     int32_t cnt=0, m;
     int ret;
     prte_node_t *node;
@@ -1100,16 +1104,30 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
                     return;
                 }
                 free(ndstring);
+                /* prte_ras_base_node_insert() drains ndlist into the global
+                 * pool, so snapshot the node names first: add_nodes_to_session()
+                 * below needs them to re-find the pool objects and set their
+                 * session backpointer (which carries the requestor for the
+                 * phase-two completion event). */
+                {
+                    prte_node_t *snap;
+                    PMIX_LIST_FOREACH(snap, &ndlist, prte_node_t) {
+                        PMIx_Argv_append_nosize(&rsv_names, snap->name);
+                    }
+                }
                 ret = prte_ras_base_node_insert(&ndlist, NULL);
                 if (PRTE_SUCCESS != ret) {
                     PRTE_ERROR_LOG(ret);
                     PMIX_LIST_DESTRUCT(&ndlist);
+                    PMIx_Argv_free(rsv_names);
                     req->pstatus = prte_pmix_convert_rc(ret);
                     return;
                 }
                 /* when reserving, withhold these nodes from the default pool by
                  * registering them with the destination session */
-                add_nodes_to_session(&ndlist, dest);
+                add_nodes_to_session(rsv_names, dest);
+                PMIx_Argv_free(rsv_names);
+                rsv_names = NULL;
                 PMIX_LIST_DESTRUCT(&ndlist);
                 found = true;
             }

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -397,9 +397,8 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
      *     the named nodes and extend the DVM;
      *   - PMIX_ALLOC_RELEASE removes the named nodes (PMIX_ALLOC_NODE_LIST) or
      *     tears down a whole reservation (PMIX_ALLOC_ID).
-     * This is the schedulerless path that replaces the ras/pmix "simulate"
-     * shortcut, which discarded the request's node list and allocation ids and
-     * so could not target a specific reservation for release. */
+     * Keeping the original request info intact preserves the node list and the
+     * allocation ids, so a release can target a specific reservation. */
     switch (req->allocdir) {
     case PMIX_ALLOC_NEW:
     case PMIX_ALLOC_EXTEND:

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -343,6 +343,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     pmix_list_t nodes;
     size_t n, k;
     char **hostfiles;
+    bool handled = false;
 
     PMIX_CONSTRUCT(&nodes, pmix_list_t);
 
@@ -361,6 +362,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
                 }
             }
             PMIx_Argv_free(hostfiles);
+            handled = true;
         }
         if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOST)) {
             // comma-delimited list of hosts to add or delete
@@ -371,6 +373,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
                 req->pstatus = prte_pmix_convert_rc(rc);
                 return req->pstatus;
             }
+            handled = true;
         }
     }
 
@@ -384,5 +387,33 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
             return req->pstatus;
         }
     }
-    return PMIX_OPERATION_SUCCEEDED;
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* When no external scheduler is present, this component is the DVM's local
+     * resource authority for elastic operations.  Claim the size-change
+     * directives so the base prte_ras_base_complete_request() logic runs with
+     * the ORIGINAL request info intact:
+     *   - PMIX_ALLOC_NEW / PMIX_ALLOC_EXTEND carrying PMIX_ALLOC_NODE_LIST add
+     *     the named nodes and extend the DVM;
+     *   - PMIX_ALLOC_RELEASE removes the named nodes (PMIX_ALLOC_NODE_LIST) or
+     *     tears down a whole reservation (PMIX_ALLOC_ID).
+     * This is the schedulerless path that replaces the ras/pmix "simulate"
+     * shortcut, which discarded the request's node list and allocation ids and
+     * so could not target a specific reservation for release. */
+    switch (req->allocdir) {
+    case PMIX_ALLOC_NEW:
+    case PMIX_ALLOC_EXTEND:
+    case PMIX_ALLOC_RELEASE:
+        handled = true;
+        break;
+    default:
+        break;
+    }
+
+    /* If we satisfied something, let the base layer finish it; otherwise defer
+     * to the next module (this component is the lowest-priority RAS). */
+    if (handled) {
+        return PMIX_OPERATION_SUCCEEDED;
+    }
+    return PMIX_ERR_TAKE_NEXT_OPTION;
 }

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -129,7 +129,12 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     // attach if not
     rc = prte_pmix_set_scheduler();
     if (PMIX_SUCCESS != rc) {
-        return rc;
+        /* No scheduler is reachable, so we cannot forward this request.  Defer
+         * to the next RAS module rather than failing the whole request: in a
+         * schedulerless DVM the ras/hosts component handles node-list grow and
+         * shrink locally.  Returning a hard error here (e.g. PMIX_ERR_UNREACH)
+         * would instead abort the modify loop before hosts is consulted. */
+        return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 
     // we need to pass the request on to the scheduler

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -112,19 +112,6 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     pmix_info_t *xfer;
     size_t n;
 
-    if (prte_mca_ras_pmix_component.simulate) {
-        // pretend we are attached to a scheduler
-        xfer = PMIx_Info_create(1);
-        PMIX_INFO_LOAD(xfer, PMIX_ALLOC_NODE_LIST, prte_mca_ras_pmix_component.simulate_nodelist, PMIX_STRING);
-        req->pstatus = PMIX_SUCCESS;
-        req->info = xfer;
-        req->ninfo = 1;
-        prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
-        PMIX_POST_OBJECT(req);
-        prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
-        return PMIX_SUCCESS;
-    }
-
     // check if scheduler is attached and try to
     // attach if not
     rc = prte_pmix_set_scheduler();

--- a/src/mca/ras/pmix/ras_pmix.h
+++ b/src/mca/ras/pmix/ras_pmix.h
@@ -22,8 +22,6 @@ BEGIN_C_DECLS
 
 struct prte_ras_pmix_component_t {
     prte_ras_base_component_t super;
-    bool simulate;
-    char *simulate_nodelist;
     bool connect_to_system_scheduler;
     pmix_proc_t server;
     char *uri;

--- a/src/mca/ras/pmix/ras_pmix_component.c
+++ b/src/mca/ras/pmix/ras_pmix_component.c
@@ -67,18 +67,6 @@ static int ras_pmix_register(void)
 {
     pmix_mca_base_component_t *component = &prte_mca_ras_pmix_component.super;
 
-    prte_mca_ras_pmix_component.simulate = false;
-    (void) pmix_mca_base_component_var_register(component, "simulate",
-                                                "Simulate a scheduler interaction",
-                                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                                &prte_mca_ras_pmix_component.simulate);
-
-    prte_mca_ras_pmix_component.simulate_nodelist = NULL;
-    (void) pmix_mca_base_component_var_register(component, "simulate_nodelist",
-                                                "Comma-delimited list of nodes to use in simulation",
-                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                                &prte_mca_ras_pmix_component.simulate_nodelist);
-
     prte_mca_ras_pmix_component.uri = NULL;
     (void) pmix_mca_base_component_var_register(component, "uri",
                                                 "Specify the URI of the scheduler to which we are to connect, "

--- a/src/mca/ras/ras.h
+++ b/src/mca/ras/ras.h
@@ -90,6 +90,17 @@ typedef int (*prte_ras_base_module_allocate_fn_t)(prte_job_t *jdata, pmix_list_t
 typedef pmix_status_t (*prte_ras_base_module_modify_fn_t)(prte_pmix_server_req_t *req);
 
 /**
+ * Notify the resource manager that a shrink campaign has completed.
+ *
+ * Called once the campaign's targeted daemons have departed and before
+ * the final completion notification is emitted to the requester, so the
+ * module can release the freed resources back to the scheduler. The
+ * campaign object is passed so the module can identify which shrink
+ * completed.
+ */
+typedef void (*prte_ras_base_module_shrink_complete_fn_t)(prte_shrink_campaign_t *campaign);
+
+/**
  * Release an allocation associated with the given session.
  * Called when a prte_session_t is destructed. Returns PRTE_SUCCESS
  * if the module handled the release, PRTE_ERR_TAKE_NEXT_OPTION to
@@ -112,6 +123,8 @@ struct prte_ras_base_module_2_0_0_t {
     prte_ras_base_module_allocate_fn_t  allocate;
     // modify function pointer
     prte_ras_base_module_modify_fn_t    modify;
+    /** Notify the RM that a shrink campaign has completed */
+    prte_ras_base_module_shrink_complete_fn_t shrink_complete;
     /** Release an allocation when its session is destructed */
     prte_ras_base_module_release_fn_t   release_allocation;
     /** Finalization function pointer */

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -38,6 +38,7 @@
 #include "src/mca/iof/base/base.h"
 #include "src/mca/odls/odls_types.h"
 #include "src/mca/plm/base/base.h"
+#include "src/mca/plm/base/plm_private.h"
 #include "src/mca/ras/base/base.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/rml/rml.h"
@@ -285,6 +286,10 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                prte_dvm_launch_fence--;
+                if (0 == prte_dvm_launch_fence) {
+                    prte_plm_base_fence_release(false);
+                }
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
@@ -299,6 +304,10 @@ static void vm_ready(int fd, short args, void *cbdata)
                     NULL == val) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                    prte_dvm_launch_fence--;
+                    if (0 == prte_dvm_launch_fence) {
+                        prte_plm_base_fence_release(false);
+                    }
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -306,6 +315,10 @@ static void vm_ready(int fd, short args, void *cbdata)
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                    prte_dvm_launch_fence--;
+                    if (0 == prte_dvm_launch_fence) {
+                        prte_plm_base_fence_release(false);
+                    }
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -314,6 +327,10 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
                     PMIX_VALUE_RELEASE(val);
+                    prte_dvm_launch_fence--;
+                    if (0 == prte_dvm_launch_fence) {
+                        prte_plm_base_fence_release(false);
+                    }
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -324,10 +341,19 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_WIREUP, &buf))) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                prte_dvm_launch_fence--;
+                if (0 == prte_dvm_launch_fence) {
+                    prte_plm_base_fence_release(false);
+                }
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             PMIX_DATA_BUFFER_DESTRUCT(&buf);
+        }
+        /* success path (and DO_NOT_LAUNCH / single-daemon path) */
+        prte_dvm_launch_fence--;
+        if (0 == prte_dvm_launch_fence) {
+            prte_plm_base_fence_release(true);
         }
     }
     if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, caddy->jdata->nspace)) {
@@ -353,6 +379,15 @@ static void vm_ready(int fd, short args, void *cbdata)
         }
         /* progress the job */
         caddy->jdata->state = PRTE_JOB_STATE_VM_READY;
+        PMIX_RELEASE(caddy);
+        return;
+    }
+
+    /* if a daemon launch campaign is active, park this app job */
+    if (0 < prte_dvm_launch_fence) {
+        caddy->jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
+        PMIX_RETAIN(caddy->jdata);
+        pmix_pointer_array_add(prte_held_jobs, caddy->jdata);
         PMIX_RELEASE(caddy);
         return;
     }
@@ -542,6 +577,16 @@ static void check_complete(int fd, short args, void *cbdata)
             (2, prte_state_base_framework.framework_output,
              "%s state:dvm:check_job_complete - received NULL job, checking daemons",
              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        /* safety net: if the daemon job held the grow fence and reached
+         * terminated state, release held jobs now */
+        if (NULL != jdata &&
+            prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL) &&
+            0 < prte_dvm_launch_fence) {
+            prte_dvm_launch_fence--;
+            if (0 == prte_dvm_launch_fence) {
+                prte_plm_base_fence_release(false);
+            }
+        }
         if (0 == prte_rml_base.n_children) {
             /* orteds are done! */
             PMIX_OUTPUT_VERBOSE((2, prte_state_base_framework.framework_output,

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -351,8 +351,11 @@ static void vm_ready(int fd, short args, void *cbdata)
          * any in-progress grow campaigns have fully succeeded.  Drain them,
          * dropping their fence contribution, and release any held jobs.
          * Doing the release here — after the WIREUP xcast above — guarantees
-         * held jobs are only admitted once the new daemons are wired up. */
-        prte_plm_base_grow_drain(true);
+         * held jobs are only admitted once the new daemons are wired up.
+         * Nothing to drain outside elastic mode (no campaign was ever made). */
+        if (prte_elastic_mode) {
+            prte_plm_base_grow_drain(true);
+        }
     }
     if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, caddy->jdata->nspace)) {
         prte_dvm_ready = true;
@@ -381,8 +384,10 @@ static void vm_ready(int fd, short args, void *cbdata)
         return;
     }
 
-    /* if a daemon launch campaign is active, park this app job */
-    if (0 < prte_dvm_launch_fence) {
+    /* if a daemon launch campaign is active, park this app job (only possible
+     * in elastic mode, where the fence is raised; the explicit guard keeps the
+     * non-elastic path identical even if the fence were ever left nonzero) */
+    if (prte_elastic_mode && 0 < prte_dvm_launch_fence) {
         caddy->jdata->state = PRTE_JOB_STATE_WAITING_FOR_DAEMONS;
         PMIX_RETAIN(caddy->jdata);
         pmix_pointer_array_add(prte_held_jobs, caddy->jdata);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -286,10 +286,9 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_DESTRUCT(&buf);
-                prte_dvm_launch_fence--;
-                if (0 == prte_dvm_launch_fence) {
-                    prte_plm_base_fence_release(false);
-                }
+                /* the whole DVM is being torn down; held jobs will be
+                 * failed as part of that teardown, so leave the fence
+                 * untouched here */
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
@@ -304,10 +303,9 @@ static void vm_ready(int fd, short args, void *cbdata)
                     NULL == val) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
-                    prte_dvm_launch_fence--;
-                    if (0 == prte_dvm_launch_fence) {
-                        prte_plm_base_fence_release(false);
-                    }
+                    /* the whole DVM is being torn down; held jobs will be
+                     * failed as part of that teardown, so leave the fence
+                     * untouched here */
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -315,10 +313,9 @@ static void vm_ready(int fd, short args, void *cbdata)
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
-                    prte_dvm_launch_fence--;
-                    if (0 == prte_dvm_launch_fence) {
-                        prte_plm_base_fence_release(false);
-                    }
+                    /* the whole DVM is being torn down; held jobs will be
+                     * failed as part of that teardown, so leave the fence
+                     * untouched here */
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -327,10 +324,9 @@ static void vm_ready(int fd, short args, void *cbdata)
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&buf);
                     PMIX_VALUE_RELEASE(val);
-                    prte_dvm_launch_fence--;
-                    if (0 == prte_dvm_launch_fence) {
-                        prte_plm_base_fence_release(false);
-                    }
+                    /* the whole DVM is being torn down; held jobs will be
+                     * failed as part of that teardown, so leave the fence
+                     * untouched here */
                     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                     return;
                 }
@@ -341,20 +337,22 @@ static void vm_ready(int fd, short args, void *cbdata)
             if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_WIREUP, &buf))) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_DESTRUCT(&buf);
-                prte_dvm_launch_fence--;
-                if (0 == prte_dvm_launch_fence) {
-                    prte_plm_base_fence_release(false);
-                }
+                /* the whole DVM is being torn down; held jobs will be
+                 * failed as part of that teardown, so leave the fence
+                 * untouched here */
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 return;
             }
             PMIX_DATA_BUFFER_DESTRUCT(&buf);
         }
-        /* success path (and DO_NOT_LAUNCH / single-daemon path) */
-        prte_dvm_launch_fence--;
-        if (0 == prte_dvm_launch_fence) {
-            prte_plm_base_fence_release(true);
-        }
+        /* success path (and DO_NOT_LAUNCH / single-daemon path): the new
+         * daemons (if any) are now wired up.  This callback only fires once
+         * every expected daemon has reported (num_reported == num_procs), so
+         * any in-progress grow campaigns have fully succeeded.  Drain them,
+         * dropping their fence contribution, and release any held jobs.
+         * Doing the release here — after the WIREUP xcast above — guarantees
+         * held jobs are only admitted once the new daemons are wired up. */
+        prte_plm_base_grow_drain(true);
     }
     if (PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, caddy->jdata->nspace)) {
         prte_dvm_ready = true;
@@ -577,15 +575,11 @@ static void check_complete(int fd, short args, void *cbdata)
             (2, prte_state_base_framework.framework_output,
              "%s state:dvm:check_job_complete - received NULL job, checking daemons",
              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        /* safety net: if the daemon job held the grow fence and reached
-         * terminated state, release held jobs now */
-        if (NULL != jdata &&
-            prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCHED_DAEMONS, NULL, PMIX_BOOL) &&
-            0 < prte_dvm_launch_fence) {
-            prte_dvm_launch_fence--;
-            if (0 == prte_dvm_launch_fence) {
-                prte_plm_base_fence_release(false);
-            }
+        /* safety net: if grow campaigns were still pending when the daemon
+         * job reached this point, drain them so held jobs are not parked
+         * indefinitely */
+        if (!pmix_list_is_empty(&prte_grow_campaigns)) {
+            prte_plm_base_grow_drain(false);
         }
         if (0 == prte_rml_base.n_children) {
             /* orteds are done! */

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -506,19 +506,9 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 PRTE_PMIX_DESTRUCT_LOCK(&lk);
                 // mark abnormal exit status
                 PRTE_UPDATE_EXIT_STATUS(-1);
-                /* notify HNP that we are exiting due to shrink before
-                 * we activate DAEMONS_TERMINATED */
-                {
-                    pmix_data_buffer_t *_ack;
-                    prte_plm_cmd_flag_t _cmd = PRTE_PLM_SHRINK_ACK_CMD;
-                    pmix_rank_t _myrank = PRTE_PROC_MY_NAME->rank;
-                    PMIX_DATA_BUFFER_CREATE(_ack);
-                    PMIx_Data_pack(NULL, _ack, &_cmd, 1, PMIX_UINT8);
-                    PMIx_Data_pack(NULL, _ack, &_myrank, 1, PMIX_PROC_RANK);
-                    PRTE_RML_RELIABLE_SEND(ret, PRTE_PROC_MY_HNP->rank, _ack,
-                                           PRTE_RML_TAG_PLM);
-                }
-                // do a clean exit
+                /* do a clean exit; the HNP detects our departure via the
+                 * normal daemon-loss (comm-failure) path and completes the
+                 * shrink campaign there */
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
                 break;
             }

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -506,6 +506,18 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 PRTE_PMIX_DESTRUCT_LOCK(&lk);
                 // mark abnormal exit status
                 PRTE_UPDATE_EXIT_STATUS(-1);
+                /* notify HNP that we are exiting due to shrink before
+                 * we activate DAEMONS_TERMINATED */
+                {
+                    pmix_data_buffer_t *_ack;
+                    prte_plm_cmd_flag_t _cmd = PRTE_PLM_SHRINK_ACK_CMD;
+                    pmix_rank_t _myrank = PRTE_PROC_MY_NAME->rank;
+                    PMIX_DATA_BUFFER_CREATE(_ack);
+                    PMIx_Data_pack(NULL, _ack, &_cmd, 1, PMIX_UINT8);
+                    PMIx_Data_pack(NULL, _ack, &_myrank, 1, PMIX_PROC_RANK);
+                    PRTE_RML_RELIABLE_SEND(ret, PRTE_PROC_MY_HNP->rank, _ack,
+                                           PRTE_RML_TAG_PLM);
+                }
                 // do a clean exit
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
                 break;

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -92,6 +92,7 @@ int prte_finalize(void)
     PMIX_RELEASE(prte_held_jobs);
     PMIX_RELEASE(prte_prelaunch_held_jobs);
     PMIX_LIST_DESTRUCT(&prte_shrink_campaigns);
+    PMIX_LIST_DESTRUCT(&prte_grow_campaigns);
 
     /* call the finalize function for this environment */
     if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -89,6 +89,9 @@ int prte_finalize(void)
 #ifdef PRTE_PICKY_COMPILERS
     /* release the cache */
     PMIX_RELEASE(prte_cache);
+    PMIX_RELEASE(prte_held_jobs);
+    PMIX_RELEASE(prte_prelaunch_held_jobs);
+    PMIX_LIST_DESTRUCT(&prte_shrink_campaigns);
 
     /* call the finalize function for this environment */
     if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -79,6 +79,7 @@ int prte_dvm_launch_fence = 0;
 pmix_pointer_array_t *prte_held_jobs = NULL;
 pmix_pointer_array_t *prte_prelaunch_held_jobs = NULL;
 pmix_list_t prte_shrink_campaigns;
+pmix_list_t prte_grow_campaigns;
 
 static void campaign_destruct(prte_shrink_campaign_t *p)
 {
@@ -86,6 +87,13 @@ static void campaign_destruct(prte_shrink_campaign_t *p)
 }
 PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
                     NULL, campaign_destruct);
+
+static void grow_campaign_destruct(prte_grow_campaign_t *p)
+{
+    free(p->targets);
+}
+PMIX_CLASS_INSTANCE(prte_grow_campaign_t, pmix_list_item_t,
+                    NULL, grow_campaign_destruct);
 bool prte_persistent = true;
 bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -74,6 +74,18 @@ char *prte_tool_basename = NULL;
 char *prte_tool_actual = NULL;
 bool prte_dvm_ready = false;
 pmix_pointer_array_t *prte_cache = NULL;
+
+int prte_dvm_launch_fence = 0;
+pmix_pointer_array_t *prte_held_jobs = NULL;
+pmix_pointer_array_t *prte_prelaunch_held_jobs = NULL;
+pmix_list_t prte_shrink_campaigns;
+
+static void campaign_destruct(prte_shrink_campaign_t *p)
+{
+    free(p->targets);
+}
+PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
+                    NULL, campaign_destruct);
 bool prte_persistent = true;
 bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -81,6 +81,19 @@ pmix_pointer_array_t *prte_prelaunch_held_jobs = NULL;
 pmix_list_t prte_shrink_campaigns;
 pmix_list_t prte_grow_campaigns;
 
+static void campaign_construct(prte_shrink_campaign_t *p)
+{
+    /* zero the pointer/count fields: PMIX_NEW does not zero the object, and the
+     * creators set alloc_id/req_id only when the corresponding key is present,
+     * so without this the destructor would free() uninitialized garbage. */
+    p->targets = NULL;
+    p->ntargets = 0;
+    p->pending = 0;
+    PMIX_PROC_LOAD(&p->requester, NULL, PMIX_RANK_INVALID);
+    p->alloc_id = NULL;
+    p->req_id = NULL;
+    p->have_requester = false;
+}
 static void campaign_destruct(prte_shrink_campaign_t *p)
 {
     free(p->targets);
@@ -88,8 +101,17 @@ static void campaign_destruct(prte_shrink_campaign_t *p)
     free(p->req_id);
 }
 PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
-                    NULL, campaign_destruct);
+                    campaign_construct, campaign_destruct);
 
+static void grow_campaign_construct(prte_grow_campaign_t *p)
+{
+    p->targets = NULL;
+    p->ntargets = 0;
+    PMIX_PROC_LOAD(&p->requester, NULL, PMIX_RANK_INVALID);
+    p->alloc_id = NULL;
+    p->req_id = NULL;
+    p->have_requester = false;
+}
 static void grow_campaign_destruct(prte_grow_campaign_t *p)
 {
     free(p->targets);
@@ -97,7 +119,7 @@ static void grow_campaign_destruct(prte_grow_campaign_t *p)
     free(p->req_id);
 }
 PMIX_CLASS_INSTANCE(prte_grow_campaign_t, pmix_list_item_t,
-                    NULL, grow_campaign_destruct);
+                    grow_campaign_construct, grow_campaign_destruct);
 bool prte_persistent = true;
 bool prte_allow_run_as_root = false;
 bool prte_fwd_environment = false;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -84,6 +84,8 @@ pmix_list_t prte_grow_campaigns;
 static void campaign_destruct(prte_shrink_campaign_t *p)
 {
     free(p->targets);
+    free(p->alloc_id);
+    free(p->req_id);
 }
 PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
                     NULL, campaign_destruct);
@@ -91,6 +93,8 @@ PMIX_CLASS_INSTANCE(prte_shrink_campaign_t, pmix_list_item_t,
 static void grow_campaign_destruct(prte_grow_campaign_t *p)
 {
     free(p->targets);
+    free(p->alloc_id);
+    free(p->req_id);
 }
 PMIX_CLASS_INSTANCE(prte_grow_campaign_t, pmix_list_item_t,
                     NULL, grow_campaign_destruct);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -613,7 +613,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_rank_t     *targets;   /* daemon ranks being terminated */
     int              ntargets;  /* initial count */
-    int              pending;   /* remaining ACKs expected */
+    int              pending;   /* targets not yet known to have departed */
 } prte_shrink_campaign_t;
 PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -596,6 +596,29 @@ PRTE_EXPORT extern char *prte_data_server_uri;
 PRTE_EXPORT extern bool prte_dvm_ready;
 PRTE_EXPORT extern pmix_pointer_array_t *prte_cache;
 PRTE_EXPORT extern bool prte_persistent;
+
+/* --- DVM launch fence --- */
+
+/* tracks in-progress daemon launch campaigns (grow and shrink combined) */
+PRTE_EXPORT extern int prte_dvm_launch_fence;
+
+/* app jobs parked at VM_READY → MAP while a campaign is active */
+PRTE_EXPORT extern pmix_pointer_array_t *prte_held_jobs;
+
+/* app jobs parked at LAUNCH_APPS while a shrink campaign is active */
+PRTE_EXPORT extern pmix_pointer_array_t *prte_prelaunch_held_jobs;
+
+/* one entry per in-progress shrink campaign */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_rank_t     *targets;   /* daemon ranks being terminated */
+    int              ntargets;  /* initial count */
+    int              pending;   /* remaining ACKs expected */
+} prte_shrink_campaign_t;
+PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
+
+/* list of active shrink campaigns */
+PRTE_EXPORT extern pmix_list_t prte_shrink_campaigns;
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
 PRTE_EXPORT extern bool prte_xml_output;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -614,6 +614,13 @@ typedef struct {
     pmix_rank_t     *targets;   /* daemon ranks being terminated */
     int              ntargets;  /* initial count */
     int              pending;   /* targets not yet known to have departed */
+    /* requester recorded so the spec's phase-two completion event can be
+     * directed at the process that issued the PMIX_ALLOC_RELEASE; left unset
+     * (have_requester == false) for a scheduler-driven release */
+    pmix_proc_t      requester;
+    char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation, or NULL */
+    char            *req_id;         /* requester's PMIX_ALLOC_REQ_ID, or NULL */
+    bool             have_requester;
 } prte_shrink_campaign_t;
 PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 
@@ -633,6 +640,13 @@ typedef struct {
     pmix_list_item_t super;
     pmix_rank_t     *targets;   /* daemon ranks being launched */
     int              ntargets;  /* count, == this campaign's fence contribution */
+    /* requester recorded so the spec's phase-two completion event can be
+     * directed at the process that drove the grow; left unset
+     * (have_requester == false) for a scheduler-driven push */
+    pmix_proc_t      requester;
+    char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation, or NULL */
+    char            *req_id;         /* requester's PMIX_ALLOC_REQ_ID, or NULL */
+    bool             have_requester;
 } prte_grow_campaign_t;
 PMIX_CLASS_DECLARATION(prte_grow_campaign_t);
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -619,6 +619,26 @@ PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 
 /* list of active shrink campaigns */
 PRTE_EXPORT extern pmix_list_t prte_shrink_campaigns;
+
+/* one entry per in-progress grow (daemon-launch) campaign.  The campaign
+ * records the specific daemon ranks being launched so that the launch fence
+ * is only affected by those ranks: an unrelated daemon loss during a grow
+ * must not consume the fence, and concurrent campaigns must be tracked
+ * independently.  The fence contribution (ntargets) is held in full until
+ * the campaign is drained at a safe point — on success in vm_ready, after
+ * the WIREUP xcast, or on failure when one of the targets dies — so that
+ * jobs held at the VM_READY → MAP boundary are not admitted before the new
+ * daemons are wired up. */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_rank_t     *targets;   /* daemon ranks being launched */
+    int              ntargets;  /* count, == this campaign's fence contribution */
+} prte_grow_campaign_t;
+PMIX_CLASS_DECLARATION(prte_grow_campaign_t);
+
+/* list of active grow campaigns */
+PRTE_EXPORT extern pmix_list_t prte_grow_campaigns;
+
 PRTE_EXPORT extern bool prte_allow_run_as_root;
 PRTE_EXPORT extern bool prte_fwd_environment;
 PRTE_EXPORT extern bool prte_xml_output;

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -491,6 +491,13 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
     prte_cache = PMIX_NEW(pmix_pointer_array_t);
     pmix_pointer_array_init(prte_cache, 1, INT_MAX, 1);
 
+    /* initialize launch-fence held-job arrays */
+    prte_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_held_jobs, 1, INT_MAX, 1);
+    prte_prelaunch_held_jobs = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_prelaunch_held_jobs, 1, INT_MAX, 1);
+    PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t);
+
     /* All done */
     PMIX_ACQUIRE_THREAD(&prte_init_lock);
     prte_initialized = true;

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -497,6 +497,7 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
     prte_prelaunch_held_jobs = PMIX_NEW(pmix_pointer_array_t);
     pmix_pointer_array_init(prte_prelaunch_held_jobs, 1, INT_MAX, 1);
     PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_grow_campaigns, pmix_list_t);
 
     /* All done */
     PMIX_ACQUIRE_THREAD(&prte_init_lock);

--- a/src/util/error_strings.c
+++ b/src/util/error_strings.c
@@ -110,6 +110,8 @@ const char *prte_job_state_to_str(prte_job_state_t state)
         return "PROC CALLED ABORT";
     case PRTE_JOB_STATE_HEARTBEAT_FAILED:
         return "HEARTBEAT FAILED";
+    case PRTE_JOB_STATE_WAITING_FOR_DAEMONS:
+        return "WAITING FOR DAEMON CAMPAIGN";
     case PRTE_JOB_STATE_NEVER_LAUNCHED:
         return "NEVER LAUNCHED";
     case PRTE_JOB_STATE_ABORT_ORDERED:


### PR DESCRIPTION
## Summary

Introduce a global **launch fence** that serialises application-job dispatch
against in-progress daemon **grow** and **shrink** campaigns, so a job is never
mapped onto — or sent launch data destined for — a daemon that is not yet wired
into the DVM (grow) or is departing it (shrink).

## Races closed

**Race 1** – a new app job reaches `VM_READY → MAP` while daemons are still
launching (grow) or terminating (shrink). It could be mapped to a node whose
daemon does not yet exist or is dying.

**Race 2** – an app job completes MAP before a shrink is initiated and then
enters `prte_plm_base_launch_apps()` while a targeted daemon is dying between
MAP and the send.

## Mechanism (implemented)

- A single counter, `prte_dvm_launch_fence`, tracks in-progress launch
  campaigns. When it is nonzero, app jobs are parked in one of two held-job
  arrays — at `VM_READY → MAP` (both paths) and at `LAUNCH_APPS` (shrink only,
  gated on the shrink campaign list so a concurrent grow does not stall
  already-mapped jobs) — and released when the fence reaches zero. Parked jobs
  carry a new marker state, `PRTE_JOB_STATE_WAITING_FOR_DAEMONS`, visible in
  verbose output.

- **Per-campaign, rank-tracked accounting** for both paths, so a campaign's
  fence contribution can only be consumed by its own daemons:
  - `prte_grow_campaigns` / `prte_grow_campaign_t` record the daemon ranks a
    grow is launching; the whole campaign's contribution is drained as a unit
    only after the WIREUP xcast, so an unrelated daemon death cannot consume a
    campaign's token and concurrent campaigns cannot wedge the fence.
  - `prte_shrink_campaigns` / `prte_shrink_campaign_t` — one per
    `PMIX_ALLOC_RELEASE` — drive completion off the **actual departure** of each
    targeted daemon on the comm-failure path (no ACK), idempotent against a
    repeated failure event; a clean shrink exit and a crash are handled
    identically. Multiple concurrent shrink campaigns are supported.

- **Failed-grow rollback** — if a daemon in a grow campaign dies before the
  campaign completes, the campaign is rolled back: its already-started daemons
  are terminated and its nodes leave the DVM, restoring the exact pre-grow
  membership rather than leaving the DVM half-extended with an un-wired partial
  set. The rollback is scoped to the failed campaign; concurrent campaigns and
  pre-existing daemons are untouched.

- Held jobs are released through a single `prte_plm_base_fence_release()`; a job
  that had been mapped onto a departing node is remapped onto the survivors
  rather than failed.

## Documentation

A full plan/spec tree under `docs/plans/elastic_dvm/`, with the
race background in `docs/how-things-work/state_machine.rst`:

- `elastic_dvm_spec.rst` — the externally observable contract (authoritative
  over the plans): the job-admission/placement guarantees and the two-phase
  completion contract.
- `elastic_dvm_plan.rst` — the shared launch-fence implementation (parent).
- `grow_campaign.rst` / `shrink_campaign.rst` — the per-path designs, including
  the grow rollback and shrink completion-on-death.

## Specified here, not yet implemented

The spec defines a **two-phase completion contract**: a dynamic allocation that
grows or shrinks the DVM is answered synchronously when the request is
*accepted*, and a later **directed event** reports when the DVM operation
actually *completes* — `PMIX_DVM_IS_READY` on success, `PMIX_ERR_DVM_MOD`
(carrying the underlying cause) on failure — separating "the allocation is
complete" from "the runtime is ready". This is fully specified and threaded
through the plans (each campaign records the requester; a shared
`prte_plm_base_dvm_mod_notify()` helper guarded by `PRTE_HAVE_DVM_MOD_EVENTS`),
but the **event emission is not yet implemented in code** and depends on the two
new status codes being added upstream in PMIx. Because PMIx status codes are
plain `#define`d values, their use is gated by a simple preprocessor presence
check (an `AC_PREPROC_IFELSE` probe defining `PRTE_HAVE_DVM_MOD_EVENTS`), not a
`PMIX_CAP_*` capability flag.

## Follow-ups

- Add `PMIX_DVM_IS_READY` / `PMIX_ERR_DVM_MOD` upstream (openpmix), then
  implement the completion-event emission per the spec.
- **Collective shrink completion** (captured in `shrink_campaign.rst`): batch
  the routing-tree repair via xcast-completion rather than repairing once per
  departing daemon — an optimization for large/whole-branch shrinks, deferred to
  avoid pulling the less-tested batch tree-repair path into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
