### PR TITLE
docs: add community Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# PRRTE Community Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the PRRTE project or its community. Examples of representing the project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of the project may be further defined and clarified by PRRTE maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at maintainers@pmix.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,9 @@ docs/_build
 docs/_static
 docs/_static/css/custom.css
 docs/_templates
+
+# Generated RST files
+docs/code-of-conduct.rst
 src/docs/_build
 src/docs/mca/mca.rst
 src/docs/mca/help*rst

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    pre_build:
+      - python3 docs/generate-code-of-conduct-rst.py --input .github/CODE_OF_CONDUCT.md --output docs/code-of-conduct.rst
 
 python:
   install:

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -31,6 +31,9 @@ OUTDIR             = _build
 SPHINX_CONFIG      = conf.py
 SPHINX_OPTS       ?= -W --keep-going -j auto
 
+MARKDOWN_SOURCE_FILES = \
+        $(top_srcdir)/.github/CODE_OF_CONDUCT.md
+
 # Note: it is significantly more convenient to list all the source
 # files here using wildcards (vs. listing every single .rst file).
 # However, it is necessary to list $(srcdir) when using wildcards.
@@ -50,8 +53,10 @@ RST_SOURCE_FILES = \
 
 EXTRA_DIST = \
         requirements.txt \
+        generate-code-of-conduct-rst.py \
         _templates/configurator.html \
         $(SPHINX_CONFIG) \
+        $(MARKDOWN_SOURCE_FILES) \
         $(RST_SOURCE_FILES)
 
 ###########################################################################
@@ -93,6 +98,10 @@ if PRTE_BUILD_DOCS
 
 include $(top_srcdir)/Makefile.prte-rules
 
+# Generate this file from CODE_OF_CONDUCT.md as part of the Sphinx
+# docs build.
+CODE_OF_CONDUCT_RST = $(srcdir)/code-of-conduct.rst
+
 # Have to not list these targets in EXTRA_DIST outside of the
 # PRTE_BUILD_DOCS conditional because "make dist" will fail due to
 # these missing targets (and therefore not run the "dist-hook" target
@@ -109,6 +118,12 @@ ALL_MAN_BUILT = \
         $(PRTE_MAN1_BUILT) $(PRTE_MAN5_BUILT)
 $(ALL_MAN_BUILT): $(RST_SOURCE_FILES) $(IMAGE_SOURCE_FILES)
 $(ALL_MAN_BUILT): $(TEXT_SOURCE_FILES) $(SPHINX_CONFIG)
+$(ALL_MAN_BUILT): $(CODE_OF_CONDUCT_RST)
+
+$(CODE_OF_CONDUCT_RST): $(top_srcdir)/.github/CODE_OF_CONDUCT.md
+$(CODE_OF_CONDUCT_RST): generate-code-of-conduct-rst.py
+	$(PRTE_V_GEN) python3 $(srcdir)/generate-code-of-conduct-rst.py \
+		--input $(top_srcdir)/.github/CODE_OF_CONDUCT.md --output $@
 
 # List both commands (HTML and man) in a single rule because they
 # really need to be run in serial.  Specifically, if they were two
@@ -130,12 +145,13 @@ linkcheck:
 
 maintainer-clean-local:
 	$(SPHINX_BUILD) -M clean "$(srcdir)" "$(OUTDIR)" $(SPHINX_OPTS)
+	rm -f $(CODE_OF_CONDUCT_RST)
 
 # List all the built man pages here in the Automake BUILT_SOURCES
 # macro.  This hooks into the normal Automake build mechanisms, and
 # will ultimately cause the invocation of the above rule that runs
 # Sphinx to build the HTML and man pages.
-BUILT_SOURCES = $(ALL_MAN_BUILT)
+BUILT_SOURCES = $(CODE_OF_CONDUCT_RST) $(ALL_MAN_BUILT)
 
 endif PRTE_BUILD_DOCS
 

--- a/docs/generate-code-of-conduct-rst.py
+++ b/docs/generate-code-of-conduct-rst.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+"""Convert PRRTE's Markdown CODE_OF_CONDUCT.md to reStructuredText."""
+
+import argparse
+import re
+from pathlib import Path
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+REF_DEF_RE = re.compile(r"^\[([^\]]+)\]:\s*(\S+)\s*$")
+REF_LINK_RE = re.compile(r"\[([^\]]+)\]\[([^\]]+)\]")
+INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+BULLET_RE = re.compile(r"^\s*[*+-]\s+")
+UNDERLINES = ["=", "-", "~", "^", '"', "'"]
+
+
+def _rst_link(text, url):
+    return "`{} <{}>`_".format(text, url)
+
+
+def _convert_links(line, refs):
+    def repl_ref(match):
+        text = match.group(1)
+        ref = match.group(2)
+        return _rst_link(text, refs.get(ref, ref))
+
+    def repl_inline(match):
+        return _rst_link(match.group(1), match.group(2))
+
+    line = REF_LINK_RE.sub(repl_ref, line)
+    line = INLINE_LINK_RE.sub(repl_inline, line)
+    return line
+
+
+def convert(lines):
+    refs = {}
+    for line in lines:
+        match = REF_DEF_RE.match(line.strip())
+        if match:
+            refs[match.group(1)] = match.group(2)
+
+    out = [
+        "..",
+        "   This file was generated from .github/CODE_OF_CONDUCT.md by docs/Makefile.am.",
+        "   Do not edit directly.",
+        "",
+    ]
+
+    skip_next_blank = False
+    prev_bullet = False
+    for line in lines:
+        if REF_DEF_RE.match(line.strip()):
+            continue
+        if skip_next_blank and not line.strip():
+            skip_next_blank = False
+            continue
+        skip_next_blank = False
+
+        match = HEADING_RE.match(line)
+        if match:
+            if out and out[-1] != "":
+                out.append("")
+            title = _convert_links(match.group(2), refs)
+            level = min(len(match.group(1)) - 1, len(UNDERLINES) - 1)
+            out.extend([title, UNDERLINES[level] * len(title), ""])
+            skip_next_blank = True
+            prev_bullet = False
+        else:
+            is_bullet = bool(BULLET_RE.match(line))
+            if is_bullet and out and out[-1] != "" and not prev_bullet:
+                out.append("")
+            out.append(_convert_links(line, refs))
+            prev_bullet = is_bullet
+
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        convert(input_path.read_text(encoding="utf-8").splitlines()),
+        encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Table of contents
    session-directory
    developers/index
    contributing
+   code-of-conduct
    license
    man/index
    versions


### PR DESCRIPTION
## Summary

- Add `.github/CODE_OF_CONDUCT.md` (Contributor Covenant v1.4, PRRTE-branded) as the authoritative source
- Add `docs/generate-code-of-conduct-rst.py` to convert the Markdown to RST at build time, following the same pattern used by OpenPMIx
- Wire the generation rule into `docs/Makefile.am` so `code-of-conduct.rst` is produced automatically during the Sphinx docs build
- Add `code-of-conduct` to the `docs/index.rst` toctree between Contributing and License

The generated `docs/code-of-conduct.rst` is not committed; it is produced by `make` and cleaned by `maintainer-clean-local`.

## Test plan

- [ ] Confirm `python3 docs/generate-code-of-conduct-rst.py --input .github/CODE_OF_CONDUCT.md --output docs/code-of-conduct.rst` produces valid RST
- [ ] Confirm `make` inside `docs/` regenerates `code-of-conduct.rst` and Sphinx builds without errors
- [ ] Confirm the Code of Conduct page appears correctly in the HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)