### PR TITLE
fix: rmaps/lsf mapper broken when LSB_AFFINITY_HOSTFILE is set but empty

### DIFF
--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -142,6 +142,7 @@ static int lsf_map(prte_job_t *jdata,
         free(jdata->map->last_mapper);
     }
     jdata->map->last_mapper = strdup(c->pmix_mca_component_name);
+    options->map = PRTE_MAPPING_BYUSER;
 
     /* setup the node list */
     PMIX_CONSTRUCT(&node_list, pmix_list_t);
@@ -156,6 +157,7 @@ static int lsf_map(prte_job_t *jdata,
     /* start at the beginning... */
     vpid_start = 0;
     jdata->num_procs = 0;
+    num_ranks = 0;
     PMIX_CONSTRUCT(&rankmap, pmix_pointer_array_t);
     rc = pmix_pointer_array_init(&rankmap,
                                  PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
@@ -170,6 +172,13 @@ static int lsf_map(prte_job_t *jdata,
     if (PRTE_SUCCESS != (rc = file_parse(affinity_file))) {
         rc = PRTE_ERR_SILENT;
         goto error;
+    }
+    if (0 == num_ranks) {
+        /* empty affinity file means LSF set no pinning for this job -
+         * let the next mapper handle it normally */
+        PMIX_DESTRUCT(&rankmap);
+        PMIX_LIST_DESTRUCT(&node_list);
+        return PRTE_ERR_TAKE_NEXT_OPTION;
     }
 
     /* cycle through the app_contexts, mapping them sequentially */
@@ -315,7 +324,6 @@ static int lsf_map(prte_job_t *jdata,
             if (PRTE_SUCCESS != rc) {
                 goto error;
             }
-            options->map = PRTE_MAPPING_BYUSER;
             proc = prte_rmaps_base_setup_proc(jdata, app->idx, node, NULL, options);
             if (NULL == proc) {
                 PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
@@ -435,33 +443,27 @@ static int lsf_map(prte_job_t *jdata,
 
 error:
     PMIX_LIST_DESTRUCT(&node_list);
+    for (i = 0; i < rankmap.size; i++) {
+        if (NULL != (rfmap = pmix_pointer_array_get_item(&rankmap, i))) {
+            PMIX_RELEASE(rfmap);
+        }
+    }
+    PMIX_DESTRUCT(&rankmap);
+    num_ranks = 0;
 
     return rc;
 }
 
 static int file_parse(const char *affinity_file)
 {
-    int rc = PRTE_SUCCESS;
     int i, j;
     prte_rmaps_lsf_map_t *rfmap = NULL;
-    pmix_pointer_array_t *assigned_ranks_array;
     struct stat buf;
     FILE *fp;
     char *hstname, *membind_opt;
-    char *sep, *eptr, **cpus, *ptr;
+    char *sep = NULL, *eptr, **cpus, *ptr;
     prte_node_t *nptr, *node;
     hwloc_obj_t obj;
-
-    /* keep track of rank assignments */
-    assigned_ranks_array = PMIX_NEW(pmix_pointer_array_t);
-    rc = pmix_pointer_array_init(assigned_ranks_array,
-                                 PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
-                                 PRTE_GLOBAL_ARRAY_MAX_SIZE,
-                                 PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_RELEASE(assigned_ranks_array);
-        return PRTE_ERROR;
-    }
 
     /* check to see if the file is empty - if it is,
      * then affinity wasn't actually set for this job */


### PR DESCRIPTION
## Summary

Fixes #2449.

The `rmaps/lsf` component introduced in v3.0.13 fires whenever `LSB_AFFINITY_HOSTFILE` is set in the environment. LSF sets this variable for every job, even when the user has not requested process pinning — in that case the file exists but is empty. The mapper called `file_parse()`, which returned `PRTE_SUCCESS` immediately on an empty file leaving `num_ranks` at zero, then incorrectly triggered a fatal `bad-syntax` error instead of stepping aside. In v3.0.12 the equivalent code path in the rank_file mapper returned without setting `PRTE_MAPPING_BYUSER`, causing rank_file to pass through and let round_robin handle the job normally.

Five issues are fixed in this patch:

- **Empty affinity file → `PRTE_ERR_TAKE_NEXT_OPTION`**: when `file_parse()` returns with `num_ranks == 0`, the mapper now steps aside so normal mapping proceeds. This is the direct fix for issue #2449.

- **`num_ranks` not reset between jobs**: the static counter was never cleared between DVM jobs, so the second and subsequent jobs would store `rankmap` entries at wrong indices and read back NULLs, silently producing incorrect process placement.

- **`options->map` set too late**: `PRTE_MAPPING_BYUSER` was assigned inside the per-process inner loop, so `prte_rmaps_base_get_target_nodes()` was called with the wrong map type on the first app. Moved to just after `last_mapper` is set, matching the rank_file mapper.

- **Error path leaks `rankmap`**: the `error:` label only destructed `node_list`; `rankmap` entries were never released on failure.

- **Dead `assigned_ranks_array` removed**: allocated and initialized in `file_parse()` (copied from the rank_file parser) but never used or freed. Also initializes `sep = NULL` to prevent use of an indeterminate value on a malformed affinity-file line with no space separator.

## Test plan

- [ ] Run `bsub -Is -n 2 /bin/bash` on an LSF cluster without requesting CPU pinning; `prterun hostname` should complete normally using round_robin mapping
- [ ] Run `bsub -Is -n 2 -R "affinity[core(1)]" /bin/bash` on an LSF cluster with pinning; `prterun hostname` should use the lsf mapper and respect the affinity file
- [ ] Run two sequential `prun` jobs against the same DVM on an LSF cluster with affinity; both jobs should map correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)