### PR TITLE
Multiple commits

### DIFF
--- a/examples/debugger/daemon.c
+++ b/examples/debugger/daemon.c
@@ -26,11 +26,14 @@
  */
 
 #define _GNU_SOURCE
+#include <errno.h>
 #include <libgen.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -216,10 +219,12 @@ int main(int argc, char **argv)
     int i;
     pmix_data_array_t darray;
     int cospawned_namespace = 0;
+    bool stop_on_exec;
     char hostname[256];
 
     pid = getpid();
     gethostname(hostname, sizeof hostname);
+    stop_on_exec = (NULL != getenv("PRTE_DBG_STOP_ON_EXEC"));
 
     /* Initialize this daemon - since we were launched by the RM, our
      * connection info * will have been provided at startup. */
@@ -414,34 +419,55 @@ int main(int argc, char **argv)
      */
     (void) strncpy(proc.nspace, target_namespace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    // Since we are using the 'wildcard' only one daemon should send
-    // the release message.
-    // If we are 'cospawned' then the daemons are not ranked separately
-    // from the application (this is a bug) so just have everyone
-    // send the release.
-    if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        PMIX_INFO_LIST_START(dirs);
-        /* Send release notification to application namespace */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
-        /* Don't send notification to default event handlers */
-        PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
-        PMIX_INFO_LIST_RELEASE(dirs);
-        info = darray.array;
-        ninfo = darray.size;
+    if (stop_on_exec) {
+        /* Processes were stopped at exec with SIGSTOP before connecting to PMIx.
+         * Each daemon releases only its own local processes via SIGCONT; no
+         * rank-0 gating needed since every daemon operates on its own proctable. */
+        for (i = 0; i < (int) myquery_data.info[0].value.data.darray->size; i++) {
+            printf("[%s:%u:%lu] Sending SIGCONT to pid %lu (rank %u)\n",
+                   myproc.nspace, myproc.rank, (unsigned long) pid,
+                   (unsigned long) proctable[i].pid, proctable[i].proc.rank);
+            if (-1 == kill(proctable[i].pid, SIGCONT)) {
+                fprintf(stderr, "[%s:%u:%lu] kill(%lu, SIGCONT) failed: %s\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        (unsigned long) proctable[i].pid, strerror(errno));
+            }
+        }
+    } else {
+        /* Processes are stopped inside PMIx_Init / MPI_Init and have a PMIx
+         * event handler registered.  Send a single wildcard release; only one
+         * daemon needs to send it to avoid duplicate deliveries. */
+        // Since we are using the 'wildcard' only one daemon should send
+        // the release message.
+        // If we are 'cospawned' then the daemons are not ranked separately
+        // from the application (this is a bug) so just have everyone
+        // send the release.
+        if (0 == myproc.rank || 1 == cospawned_namespace) {
 
-        // Todo: Move this to the main tool
-        // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
-        sleep(1);
-        printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
-        rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo, NULL,
-                               NULL);
-        PMIX_DATA_ARRAY_DESTRUCT(&darray);
-        if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n", myproc.nspace,
-                    myproc.rank, (unsigned long) pid, PMIx_Error_string(rc), rc);
-            goto done;
+            PMIX_INFO_LIST_START(dirs);
+            /* Send release notification to application namespace */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);
+            /* Don't send notification to default event handlers */
+            PMIX_INFO_LIST_ADD(rc, dirs, PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+            PMIX_INFO_LIST_CONVERT(rc, dirs, &darray);
+            PMIX_INFO_LIST_RELEASE(dirs);
+            info = darray.array;
+            ninfo = darray.size;
+
+            // Todo: Move this to the main tool
+            // https://github.com/openpmix/prrte/pull/857#discussion_r600849033
+            sleep(1);
+            printf("[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long) pid);
+            rc = PMIx_Notify_event(PMIX_DEBUGGER_RELEASE, NULL, PMIX_RANGE_CUSTOM, info, ninfo,
+                                   NULL, NULL);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                        myproc.nspace, myproc.rank, (unsigned long) pid,
+                        PMIx_Error_string(rc), rc);
+                goto done;
+            }
         }
     }
 

--- a/examples/debugger/indirect.c
+++ b/examples/debugger/indirect.c
@@ -115,6 +115,15 @@ static void spawn_cbfunc(size_t evhdlr_registration_id, pmix_status_t status,
 {
     size_t n;
 
+    /* PMIX_READY_FOR_DEBUG fires once per job (all nodes coalesced), but guard
+     * against any future change that could deliver it more than once. */
+    if (NULL != appnspace) {
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_NSPACE)) {
             appnspace = strdup(info[n].value.data.string);
@@ -139,7 +148,7 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     size_t ninfo, napps;
     char *requested_launcher;
-    int timeout;
+    int timeout, c;
     size_t n;
     char cwd[1024];
     pmix_status_t code = PMIX_EVENT_JOB_END;
@@ -147,7 +156,7 @@ int main(int argc, char **argv)
     pid_t pid;
     char *launchers[] = {"prun", "mpirun", "mpiexec", "prterun", NULL};
     pmix_proc_t proc, target_proc;
-    bool found;
+    bool found, stop_on_exec = false;
     pmix_data_array_t darray, darray2;
     pmix_nspace_t clientspace, dbnspace;
     pmix_value_t *val;
@@ -156,16 +165,32 @@ int main(int argc, char **argv)
     myquery_data_t *mydata = NULL;
     pmix_rank_t rank;
 
-    /* need to provide args */
-    if (2 > argc) {
-        fprintf(stderr, "Usage: %s [launcher] [app]\n", argv[0]);
+    /* parse options */
+    {
+        static struct option long_opts[] = {
+            { "stop-on-exec", no_argument, NULL, 'e' },
+            { NULL, 0, NULL, 0 }
+        };
+        while (-1 != (c = getopt_long(argc, argv, "+e", long_opts, NULL))) {
+            switch (c) {
+            case 'e':
+                stop_on_exec = true;
+                break;
+            default:
+                fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
+                exit(1);
+            }
+        }
+    }
+    if (optind >= argc) {
+        fprintf(stderr, "Usage: %s [-e|--stop-on-exec] [launcher] [app]\n", argv[0]);
         exit(0);
     }
 
     /* check to see if we are using an intermediate launcher - we only
      * support those we recognize */
     found = false;
-    requested_launcher = basename(argv[1]);
+    requested_launcher = basename(argv[optind]);
     for (n = 0; NULL != launchers[n]; n++) {
         if (0 == strcmp(requested_launcher, launchers[n])) {
             found = true;
@@ -247,11 +272,11 @@ int main(int argc, char **argv)
     napps = 1;
     PMIX_APP_CREATE(app, napps);
     /* setup the executable */
-    app[0].cmd = strdup(argv[1]);
-    PMIX_ARGV_APPEND(rc, app[0].argv, argv[1]);
+    app[0].cmd = strdup(argv[optind]);
+    PMIX_ARGV_APPEND(rc, app[0].argv, argv[optind]);
     /* pass it the rest of the cmd line as we don't know
      * how to parse it */
-    for (n = 2; n < argc; n++) {
+    for (n = (size_t) optind + 1; n < (size_t) argc; n++) {
         PMIX_ARGV_APPEND(rc, app[0].argv, argv[n]);
     }
     if (NULL == getcwd(cwd, 1024)) { // point us to our current directory
@@ -278,8 +303,10 @@ int main(int argc, char **argv)
      * to do with the app it is going to spawn for us */
     PMIX_INFO_LIST_START(linfo);
     rank = PMIX_RANK_WILDCARD;
-    if (NULL != strstr(argv[1], "mpi")) {
-        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL); // stop all procs in MPI_Init
+    if (NULL != strstr(argv[optind], "mpi")) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL);   // stop all procs in MPI_Init
+    } else if (stop_on_exec) {
+        PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_ON_EXEC, NULL, PMIX_BOOL);  // stop all procs at first exec
     } else {
         PMIX_INFO_LIST_ADD(rc, linfo, PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // stop all procs in PMIx_Init
     }
@@ -421,6 +448,10 @@ int main(int argc, char **argv)
     }
     mydata->apps[0].cwd = strdup(cwd);
     mydata->apps[0].maxprocs = 1;
+    if (stop_on_exec) {
+        /* tell the daemon which release mechanism to use */
+        PMIX_SETENV(rc, "PRTE_DBG_STOP_ON_EXEC", "1", &mydata->apps[0].env);
+    }
     PMIX_LOAD_PROCID(&target_proc, (void *) appnspace, PMIX_RANK_WILDCARD);
     /* provide directives so the daemons go where we want, and
      * let the RM know these are debugger daemons */

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -45,6 +45,9 @@
 #include <pmix_server.h>
 #include <signal.h>
 #include <time.h>
+#ifdef HAVE_SYS_PTRACE_H
+#    include <sys/ptrace.h>
+#endif
 
 #include "prte_stdint.h"
 #include "src/hwloc/hwloc-internal.h"
@@ -1742,6 +1745,46 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
         goto MOVEON;
     }
+
+#if PRTE_HAVE_STOP_ON_EXEC
+    /* If the child stopped due to the ptrace TRACEME+exec SIGTRAP, this is the
+     * stop-on-exec debug-attach point.  The wait_signal_callback consumed the
+     * ptrace-stop notification before do_parent could see it; handle it here
+     * instead.  Detach with SIGSTOP injected so the child stays stopped for
+     * the debugger, re-register for its eventual exit, and fire READY_FOR_DEBUG.
+     * Do NOT fall through to the exit-handling logic below. */
+    if (WIFSTOPPED(proc->exit_code) && WSTOPSIG(proc->exit_code) == SIGTRAP) {
+        if (NULL != jobdat &&
+            prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+            PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                 "%s odls:waitpid_fired ptrace-stop for %s, detaching with SIGSTOP",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(&proc->name)));
+            errno = 0;
+#    if PRTE_HAVE_LINUX_PTRACE
+            ptrace(PRTE_DETACH, proc->pid, 0, (void *) SIGSTOP);
+#    else
+            ptrace(PRTE_DETACH, proc->pid, 0, SIGSTOP);
+#    endif
+            if (0 != errno) {
+                PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                                     "%s odls:waitpid_fired ptrace detach failed for %s: %s",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                     PRTE_NAME_PRINT(&proc->name), strerror(errno)));
+                state = PRTE_PROC_STATE_FAILED_TO_START;
+                PRTE_FLAG_UNSET(proc, PRTE_PROC_FLAG_ALIVE);
+                goto MOVEON;
+            }
+            proc->state = PRTE_PROC_STATE_RUNNING;
+            PRTE_FLAG_SET(proc, PRTE_PROC_FLAG_ALIVE);
+            /* re-register to catch the child's eventual exit after the debugger releases it */
+            prte_wait_cb(proc, prte_odls_base_default_wait_local_proc, NULL);
+            PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
+            PMIX_RELEASE(t2);
+            return;
+        }
+    }
+#endif
 
     /* determine the state of this process */
     if (WIFEXITED(proc->exit_code)) {

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1544,12 +1544,28 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                  PRTE_NAME_PRINT(&child->name)));
 
-            /* determine the thread that will handle this child */
-            ++prte_odls_globals.next_base;
-            if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-                prte_odls_globals.next_base = 0;
+            /* determine the thread that will handle this child.
+             *
+             * STOP_ON_EXEC requires that the SAME thread which calls fork()
+             * (and thereby becomes the ptrace(2) tracer of the child) also
+             * performs the later ptrace(PTRACE_DETACH) call - ptrace control
+             * operations are only permitted from the exact tracer thread,
+             * even though waitpid() for the same status is visible to any
+             * thread in the process.  Our STOP_ON_EXEC detach happens in
+             * wait_local_proc(), which always runs on prte_event_base, so
+             * force the fork onto that same base instead of handing it to
+             * one of the odls worker threads - otherwise the PTRACE_DETACH
+             * call fails (ESRCH) once the local proc count reaches the
+             * worker-thread-pool cutoff. */
+            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+                evb = prte_event_base;
+            } else {
+                ++prte_odls_globals.next_base;
+                if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
+                    prte_odls_globals.next_base = 0;
+                }
+                evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
             }
-            evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
 
             /* set the waitpid callback here for thread protection and
              * to ensure we can capture the callback on shortlived apps */
@@ -2244,11 +2260,17 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
             goto CLEANUP;
         }
     }
-    ++prte_odls_globals.next_base;
-    if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-        prte_odls_globals.next_base = 0;
+    /* see comment in launch_local_procs() regarding STOP_ON_EXEC + ptrace
+     * tracer-thread affinity */
+    if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
+        evb = prte_event_base;
+    } else {
+        ++prte_odls_globals.next_base;
+        if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
+            prte_odls_globals.next_base = 0;
+        }
+        evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
     }
-    evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
     prte_wait_cb(child, prte_odls_base_default_wait_local_proc, NULL);
 
     PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output, "%s restarting app %s",

--- a/src/mca/odls/default/odls_default_module.c
+++ b/src/mca/odls/default/odls_default_module.c
@@ -371,7 +371,6 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     set_handler_default(SIGHUP);
     set_handler_default(SIGPIPE);
     set_handler_default(SIGCHLD);
-    set_handler_default(SIGTRAP);
 
     /* Unblock all signals, for many of the same reasons that we
        set the default handlers, above.  This is noticable on
@@ -424,7 +423,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
 
 static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
 {
-    int rc, status;
+    int rc;
     prte_odls_pipe_err_msg_t msg;
     char file[PRTE_ODLS_MAX_FILE_LEN + 1], topic[PRTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
@@ -433,51 +432,6 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
     }
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
-
-#if PRTE_HAVE_STOP_ON_EXEC
-    if (NULL != cd->child) {
-        if (prte_get_attribute(&cd->jdata->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
-            rc = waitpid(cd->child->pid, &status, WUNTRACED);
-            if (-1 == rc) {
-                /* doomed */
-                cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                close(read_fd);
-                return PRTE_ERR_FAILED_TO_START;
-            }
-            /* tell the child to stop */
-            if (WIFSTOPPED(status)) {
-                rc = kill(cd->child->pid, SIGSTOP);
-                if (-1 == rc) {
-                    /* doomed */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                errno = 0;
-#    if PRTE_HAVE_LINUX_PTRACE
-                ptrace(PRTE_DETACH, cd->child->pid, 0, (void *) SIGSTOP);
-#    else
-                ptrace(PRTE_DETACH, cd->child->pid, 0, SIGSTOP);
-#    endif
-                if (0 != errno) {
-                    /* couldn't detach */
-                    cd->child->state = PRTE_PROC_STATE_FAILED_TO_START;
-                    PRTE_FLAG_UNSET(cd->child, PRTE_PROC_FLAG_ALIVE);
-                    close(read_fd);
-                    return PRTE_ERR_FAILED_TO_START;
-                }
-                /* record that this proc is ready for debug */
-                PRTE_ACTIVATE_PROC_STATE(&cd->child->name, PRTE_PROC_STATE_READY_FOR_DEBUG);
-            }
-            cd->child->state = PRTE_PROC_STATE_RUNNING;
-            PRTE_FLAG_SET(cd->child, PRTE_PROC_FLAG_ALIVE);
-            close(read_fd);
-            return PRTE_SUCCESS;
-        }
-    }
-#endif
 
     /* Block reading a message from the pipe */
     while (1) {


### PR DESCRIPTION
[odls: fix STOP_ON_EXEC race between do_parent and wait_signal_callback](https://github.com/openpmix/prrte/commit/5200d72265795a3f5537068b9eebdf0ab125b084)

Background
----------
When PRTE_JOB_STOP_ON_EXEC is set the daemon forks each child, the child
calls ptrace(PTRACE_TRACEME) immediately before execve(), and the kernel
delivers SIGTRAP to the new process before any user code runs, placing it
in a ptrace-stop.  The parent is then expected to observe the stop, detach
with SIGSTOP injected (so the process stays stopped for a debugger to
attach), and fire PRTE_PROC_STATE_READY_FOR_DEBUG.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/2c82be0cbf2305f0f12b83af6a24656ec64cfa94)

[examples/debugger: add STOP_ON_EXEC support to indirect + daemon](https://github.com/openpmix/prrte/commit/446a4cc2a1e8655a837960506c4e384e496f0541)

indirect.c
----------
Add a -e / --stop-on-exec flag (getopt_long).  When given, the launch
directive sent to the intermediate launcher is PMIX_DEBUG_STOP_ON_EXEC
instead of PMIX_DEBUG_STOP_IN_INIT.  Application processes will be
stopped with SIGSTOP by the PRRTE daemon immediately after exec, before
any user code runs, and the PMIX_READY_FOR_DEBUG event will fire once
all processes across all nodes have stopped (two-level coalescing in the
state machine confirmed: per-node in state_prted, global in
plm_base_receive + state_dvm).

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/929946d2fca69863d1e42aa6a153d07a3d333595)

[odls: pin STOP_ON_EXEC children to prte_event_base (ptrace tracer-thread affinity)](https://github.com/openpmix/prrte/commit/70fe8de94d4494ef882ab9346591ac58457eb5cf)

Problem
-------
After the previous race fix (commit https://github.com/openpmix/prrte/commit/57c247a9f617ef1e609341f4572e5a94c1c428f3), STOP_ON_EXEC still
fails - but only once the local proc count crosses the odls worker
thread pool cutoff (MCA param odls_base_cutoff, default 32).  4 local
procs work; 48 do not, with explicit FAILED_TO_START errors for the
affected processes rather than a silent hang or runaway.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/5c34b862ec48c6fc1713d575b084cf6dc2f20a3b)
