### PR TITLE
ras: centralize FQDN/short-name normalization in the RAS base

### DIFF
--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -40,6 +40,32 @@
 
 #include "src/mca/ras/base/base.h"
 
+/* Normalize a node name to the short form, storing the FQDN as rawname
+ * and as an alias so both forms resolve via prte_quickmatch / prte_nptr_match.
+ * No-op when keep_fqdn_hostnames is set or the name is an IP address. */
+static void normalize_node(prte_node_t *node)
+{
+    char *ptr, *fqdn;
+
+    if (prte_keep_fqdn_hostnames || pmix_net_isaddr(node->name)) {
+        return;
+    }
+    ptr = strchr(node->name, '.');
+    if (NULL == ptr) {
+        return;
+    }
+    /* copy the full FQDN, then truncate node->name in place to the short name */
+    fqdn = strdup(node->name);
+    *ptr = '\0';
+    if (NULL == node->rawname) {
+        node->rawname = fqdn;
+    } else {
+        PMIx_Argv_append_unique_nosize(&node->aliases, fqdn);
+        free(fqdn);
+    }
+    PMIx_Argv_append_unique_nosize(&node->aliases, node->rawname);
+}
+
 /*
  * Add the specified node definitions to the global data store
  * NOTE: this removes all items from the list!
@@ -214,6 +240,11 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                      */
                     PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
                 }
+                /* detect FQDN before normalizing, then normalize to short name */
+                if (!pmix_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
+                    prte_have_fqdn_allocation = true;
+                }
+                normalize_node(node);
                 /* insert it into the array */
                 node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
                 if (PRTE_SUCCESS > (rc = node->index)) {
@@ -238,10 +269,6 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
             }
             /* update the total slots in the job */
             prte_ras_base.total_slots_alloc += node->slots;
-            /* check if we have fqdn names in the allocation */
-            if (!pmix_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
-                prte_have_fqdn_allocation = true;
-            }
             /* duplicate the node if requested */
             for (i = 1; i < prte_ras_base.multiplier; i++) {
                 rc = prte_node_copy(&nptr, node);

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -93,8 +93,6 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
     int slots = 0;
     bool slots_given;
     char *cptr;
-    char *shortname;
-    char *rawname;
     bool add_slots = false;
 
     PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
@@ -250,34 +248,15 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             }
         }
 
-        /* check for local name and compute non-fqdn name */
-        shortname = NULL;
-        rawname = NULL;
-
+        /* check for local name */
         if (prte_check_host_is_local(mini_map[i])) {
             ndname = prte_process_info.nodename;
         } else {
             ndname = mini_map[i];
         }
 
-        if (!prte_keep_fqdn_hostnames) {
-            // Strip off the FQDN if present, ignore IP addresses
-            if (!pmix_net_isaddr(mini_map[i])) {
-                 cptr = strchr(ndname, '.');
-                if (NULL != cptr) {
-                    rawname = strdup(ndname);
-                    *cptr = '\0';
-                    shortname = strdup(ndname);
-                    *cptr = '.';
-                }
-            }
-        }
-
         /* see if a node of this name is already on the list */
         node = prte_node_match(&adds, ndname);
-        if (NULL == node && NULL != shortname) {
-            node = prte_node_match(&adds, shortname);
-        }
         if (NULL != node) {
             if (slots_given) {
                 node->slots += slots;
@@ -296,36 +275,14 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                                  "%s dashhost: node %s already on list - slots %d",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name, node->slots));
-            if (NULL != shortname) {
-                free(shortname);
-                shortname = NULL;
-            }
-            if (NULL != rawname) {
-                node->rawname = rawname;
-                rawname = NULL;
-            }
         } else {
             /* if we didn't find it, add it to the list */
             node = PMIX_NEW(prte_node_t);
             if (NULL == node) {
                 PMIx_Argv_free(mapped_nodes);
-                if (NULL != shortname) {
-                    free(shortname);
-                }
-                if (NULL != rawname) {
-                    free(rawname);
-                }
                 return PRTE_ERR_OUT_OF_RESOURCE;
             }
-            if (prte_keep_fqdn_hostnames || NULL == shortname) {
-                node->name = strdup(ndname);
-            } else {
-                node->name = strdup(shortname);
-            }
-            if (NULL != rawname) {
-                node->rawname = rawname;
-                rawname = NULL;
-            }
+            node->name = strdup(ndname);
             PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                                  "%s dashhost: added node %s to list - slots %d",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name, slots));
@@ -349,18 +306,8 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
             pmix_list_append(&adds, &node->super);
         }
         if (0 != strcmp(node->name, mini_map[i])) {
-            // add the mini_map name to the list of aliases
+            // add the mini_map entry as an alias if it differs from the resolved name
             PMIx_Argv_append_unique_nosize(&node->aliases, mini_map[i]);
-        }
-        // ensure the non-fqdn version is saved
-        if (NULL != shortname && 0 != strcmp(shortname, node->name)) {
-            PMIx_Argv_append_unique_nosize(&node->aliases, shortname);
-        }
-        if (NULL != shortname) {
-            free(shortname);
-        }
-        if (NULL != rawname) {
-            free(rawname);
         }
     }
     PMIx_Argv_free(mini_map);

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -115,7 +115,6 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
     int cnt;
     int number_of_slots = 0;
     char buff[64];
-    char *alias = NULL;
 
     if (PRTE_HOSTFILE_STRING == token || PRTE_HOSTFILE_HOSTNAME == token ||
         PRTE_HOSTFILE_INT == token || PRTE_HOSTFILE_IPV4 == token ||
@@ -141,17 +140,6 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             return PRTE_ERROR;
         }
         PMIx_Argv_free(argv);
-
-        if (!prte_keep_fqdn_hostnames) {
-            // Strip off the FQDN if present, ignore IP addresses
-            if (!pmix_net_isaddr(node_name)) {
-                char *ptr;
-                alias = strdup(node_name);
-                if (NULL != (ptr = strchr(node_name, '.'))) {
-                    *ptr = '\0';
-                }
-            }
-        }
 
         /* if the first letter of the name is '^', then this is a node
          * to be excluded. Remove the ^ character so the nodename is
@@ -181,19 +169,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             node = prte_node_match(exclude, node_name);
             if (NULL == node) {
                 node = PMIX_NEW(prte_node_t);
-                if (prte_keep_fqdn_hostnames || NULL == alias) {
-                    node->name = strdup(node_name);
-                } else {
-                    node->name = strdup(alias);
-                    node->rawname = strdup(node_name);
-                }
+                node->name = strdup(node_name);
                 if (NULL != username) {
                     prte_set_attribute(&node->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_LOCAL,
                                        username, PMIX_STRING);
-                }
-                if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                    // new node object, so alias must be unique
-                    PMIx_Argv_append_nosize(&node->aliases, alias);
                 }
                 pmix_list_append(exclude, &node->super);
             } else {
@@ -203,13 +182,6 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                     PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
                 }
                 free(node_name);
-                if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                    PMIx_Argv_append_unique_nosize(&node->aliases, alias);
-                }
-            }
-            if (NULL != alias) {
-                free(alias);
-                alias = NULL;
             }
             if (NULL != username) {
                 free(username);
@@ -237,21 +209,12 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         /* Do we need to make a new node object? */
         if (keep_all || NULL == (node = prte_node_match(updates, node_name))) {
             node = PMIX_NEW(prte_node_t);
-            if (prte_keep_fqdn_hostnames || NULL == alias) {
-                node->name = strdup(node_name);
-            } else {
-                node->name = strdup(node_name);
-                node->rawname = strdup(alias);
-            }
+            node->name = strdup(node_name);
             free(node_name);
             node->slots = 1;
             if (NULL != username) {
                 prte_set_attribute(&node->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_LOCAL, username,
                                    PMIX_STRING);
-            }
-            if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                // new node object, so alias must be unique
-                PMIx_Argv_append_nosize(&node->aliases, alias);
             }
             pmix_list_append(updates, &node->super);
         } else {
@@ -264,44 +227,13 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                 PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
             }
             free(node_name);
-            if (NULL != alias && 0 != strcmp(alias, node->name)) {
-                PMIx_Argv_append_unique_nosize(&node->aliases, alias);
-            }
-        }
-        if (NULL != alias) {
-            free(alias);
-            alias = NULL;
         }
 
     } else if (PRTE_HOSTFILE_RELATIVE == token) {
         /* store this for later processing */
         node = PMIX_NEW(prte_node_t);
-        // Strip off the FQDN if present, ignore IP addresses
-        if (!pmix_net_isaddr(prte_util_hostfile_value.sval)) {
-            char *ptr;
-            alias = strdup(prte_util_hostfile_value.sval);
-            if (NULL != (ptr = strchr(alias, '.'))) {
-                *ptr = '\0';
-            } else {
-                free(alias);
-                alias = NULL;
-            }
-        }
-        if (prte_keep_fqdn_hostnames || NULL == alias) {
-            node->name = strdup(prte_util_hostfile_value.sval);
-        } else {
-            node->name = strdup(alias);
-            node->rawname = strdup(prte_util_hostfile_value.sval);
-        }
-        if (NULL != alias && 0 != strcmp(alias, node->name)) {
-            // new node object, so alias must be unique
-            PMIx_Argv_append_nosize(&node->aliases, alias);
-        }
+        node->name = strdup(prte_util_hostfile_value.sval);
         pmix_list_append(updates, &node->super);
-        if (NULL != alias) {
-            free(alias);
-            alias = NULL;
-        }
 
     } else if (PRTE_HOSTFILE_RANK == token) {
         /* we can ignore the rank, but we need to extract the node name. we
@@ -339,15 +271,6 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         }
         PMIx_Argv_free(argv);
 
-        // Strip off the FQDN if present, ignore IP addresses
-        if (!prte_keep_fqdn_hostnames && !pmix_net_isaddr(node_name)) {
-            char *ptr;
-            alias = strdup(node_name);
-            if (NULL != (ptr = strchr(alias, '.'))) {
-                *ptr = '\0';
-            }
-        }
-
         /* Do we need to make a new node object? */
         if (NULL == (node = prte_node_match(updates, node_name))) {
             node = PMIX_NEW(prte_node_t);
@@ -366,12 +289,6 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             if (0 != strcmp(node_name, node->name)) {
                 PMIx_Argv_append_unique_nosize(&node->aliases, node_name);
             }
-        }
-        if (NULL != alias) {
-            PMIx_Argv_append_unique_nosize(&node->aliases, alias);
-            free(alias);
-            node->rawname = strdup(node_name);
-            alias = NULL;
         }
         PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                              "%s hostfile: node %s slots %d nodes-given %s",

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -194,10 +194,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
          */
 
         PMIX_OUTPUT_VERBOSE((3, prte_ras_base_framework.framework_output,
-                             "%s hostfile: node %s is being included - keep all is %s alias %s",
+                             "%s hostfile: node %s is being included - keep all is %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node_name,
-                             keep_all ? "TRUE" : "FALSE",
-                             (NULL == alias) ? "NULL" : alias));
+                             keep_all ? "TRUE" : "FALSE"));
 
         /* see if this is another name for us */
         if (prte_check_host_is_local(node_name)) {


### PR DESCRIPTION
## Summary

- All RAS components (`lsf`, `slurm`, `pbs`, `flux`, `gridengine`, `hosts`) were inserting nodes into `prte_node_pool` with no FQDN/short-name normalization, meaning nodes sourced directly from a scheduler API (e.g. `lsb_getalloc()`) carried no short-name alias. This caused `prte_quickmatch` and `prte_nptr_match` to fail when an affinity file or `-host` list used a different form of the same hostname.
- Add `normalize_node()` in `ras_base_node.c`: when `keep_fqdn_hostnames` is not set and a node name contains a dot, truncate `node->name` to the short form, store the FQDN in `node->rawname`, and append it to `node->aliases`. Called for every new node just before insertion into `prte_node_pool`.
- Remove the equivalent per-site normalization from `hostfile.c` (STRING, RELATIVE, and RANK token branches) and `dash_host.c`. Both utilities now pass raw names through; the RAS base handles normalization uniformly for all sources.

## Test plan

- [ ] Build with LSF support and verify `ras/lsf` nodes are normalized (short name in pool, FQDN as alias)
- [ ] Verify `--host server1.domain.com` resolves correctly against a pool built from short names
- [ ] Verify `--hostfile` with FQDNs maps correctly against the pool
- [ ] Verify `prte_keep_fqdn_hostnames=1` leaves names untouched
- [ ] Smoke test: `prte --daemonize && prun -n 4 hostname && pterm`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)