### PR TITLE
Reservation logic

### DIFF
--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -7,3 +7,4 @@ Detailed implementation plans for in-progress and upcoming features.
    :maxdepth: 2
 
    per_app_mapping/index.rst
+   node_reservation/index.rst

--- a/docs/plans/node_reservation/index.rst
+++ b/docs/plans/node_reservation/index.rst
@@ -1,0 +1,10 @@
+Node Reservation and Session Targeting Plans
+============================================
+
+Implementation plans for associating nodes with sessions and reserving
+sessions for use by specific namespaces and jobs.
+
+.. toctree::
+   :maxdepth: 2
+
+   node-reservation.rst

--- a/docs/plans/node_reservation/index.rst
+++ b/docs/plans/node_reservation/index.rst
@@ -7,4 +7,5 @@ sessions for use by specific namespaces and jobs.
 .. toctree::
    :maxdepth: 2
 
+   node-reservation-spec.rst
    node-reservation.rst

--- a/docs/plans/node_reservation/node-reservation-spec.rst
+++ b/docs/plans/node_reservation/node-reservation-spec.rst
@@ -216,8 +216,10 @@ A request carrying the ``PMIX_ALLOC_NEW`` directive always mints a fresh
 reservation, even for a namespace that already owns one; the namespace
 may thus hold several reservations, each distinguished by its allocation
 id.  A request carrying ``PMIX_ALLOC_EXTEND`` adds nodes to the existing
-reservation named by the request's ``PMIX_ALLOC_ID``, and succeeds only
-when the requester's namespace owns that reservation.
+reservation named by the request's ``PMIX_ALLOC_ID`` (the
+scheduler-assigned id) or ``PMIX_ALLOC_REQ_ID`` (the requester's own
+request id); it must carry at least one, and succeeds only when the
+requester's namespace owns the named reservation.
 
 Reporting the result
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -300,6 +302,9 @@ Error semantics
      - ``PMIX_ERR_NO_PERMISSIONS``
    * - ``PMIX_ALLOC_EXTEND`` names an allocation that does not exist
      - ``PMIX_ERR_NOT_FOUND``
+   * - ``PMIX_ALLOC_EXTEND`` carries neither ``PMIX_ALLOC_ID`` nor
+       ``PMIX_ALLOC_REQ_ID`` to name its target
+     - ``PMIX_ERR_BAD_PARAM``
    * - ``PMIX_SPAWN_TARGET`` names an allocation that resolves to no session
      - ``PMIX_ERR_NOT_FOUND``
    * - ``PMIX_SPAWN_TARGET`` names a session the requester does not own

--- a/docs/plans/node_reservation/node-reservation-spec.rst
+++ b/docs/plans/node_reservation/node-reservation-spec.rst
@@ -1,0 +1,533 @@
+Node Reservation and Session Targeting: Specification
+=====================================================
+
+Purpose
+-------
+
+This document specifies the externally observable behavior of node
+reservation and session targeting in PRRTE: the contract a tool,
+scheduler, or application may rely on when it asks the DVM to set aside
+nodes for later use and to direct spawned jobs onto those nodes.  It
+defines *what* the runtime does, not *how* it does it.  The companion
+design plan, ``node-reservation.rst``, describes the internal data
+structures, code paths, and implementation order; where this
+specification and that plan disagree about observable behavior, this
+specification is authoritative and the plan must be corrected.
+
+The contract is expressed entirely in terms of PMIx attributes supplied
+on allocation and spawn requests and the PMIx status codes returned in
+response.  No new command-line options, environment variables, or tool
+behaviors are introduced.
+
+Scope
+-----
+
+In scope
+~~~~~~~~
+
+* The meaning of the ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``,
+  ``PMIX_ALLOC_INHERITANCE``, ``PMIX_ALLOC_WARN_TIMEOUT``, and
+  ``PMIX_SPAWN_TARGET`` attributes as interpreted by PRRTE.
+* The rules that decide which pool of nodes a dynamically allocated set
+  of nodes joins.
+* The rules that decide which nodes a spawned job may be mapped onto.
+* The ownership model that governs who may target a reservation.
+* The events that end a reservation — including the per-reservation
+  inheritance disposition — and the observable effect of each.
+* The relay of the scheduler's ``PMIX_ALLOC_TIMEOUT_WARNING`` event to the
+  requester ahead of an allocation's expiration.
+* The behavior guaranteed when the underlying PMIx does not define one or
+  more of the attributes above.
+
+Out of scope / non-goals
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* PRRTE invents no reservation *policy* of its own.  It does not decide
+  on its own to reserve, share, time-out, or reclaim nodes; every such
+  decision is driven by an attribute the requester supplied or by the
+  scheduler returning nodes.  The sole defaults are those stated below.
+* No guarantee is made about the *physical* nodes chosen to satisfy a
+  dynamic allocation — node selection remains the scheduler's
+  responsibility.  This specification governs only which *session* the
+  resulting nodes are placed into.
+* Quotas, fair-share, priority, and accounting across reservations are
+  not addressed.
+* The wire encoding of attributes and the timing of internal state
+  transitions are implementation details and are not specified here.
+
+Definitions
+-----------
+
+Allocation
+   A set of nodes returned by a single resource request, identified by
+   its ``PMIX_ALLOC_ID`` string.
+
+Default session
+   The general, unreserved pool of nodes.  Every node discovered when the
+   DVM starts belongs to the default session, and any job that does not
+   target a reservation may map onto it.  The default session is referred
+   to in a request by the **invalid namespace** sentinel (an empty
+   allocation id / ``PMIX_NSPACE_INVALID``).
+
+Reservation
+   A non-default session whose nodes are withheld from the default pool
+   and made available only to the namespaces that own it or to jobs that
+   explicitly target it by allocation id.
+
+Owner set
+   The set of namespaces entitled to spawn jobs onto a reservation's
+   nodes.  Reservations have a *set* of owners, not a single owner (see
+   `Ownership model`_).  The scheduler is an implicit owner of every
+   session.
+
+Namespace / job
+   Every job is its own namespace and every namespace maps to exactly one
+   job; the two terms are interchangeable in this specification.  "A
+   namespace owns a reservation" therefore means "this one job, and any
+   process within it, may spawn onto that reservation."
+
+Attribute contract
+-------------------
+
+``PMIX_ALLOC_TARGET``
+   Supplied on an allocation request to name the namespace a new
+   reservation is created for (or whose existing reservation is
+   extended).  Honored only when the requester is a **tool**; an
+   application that supplies it is rejected (see `Error semantics`_).
+   When absent, the reservation is created for the requester's own
+   namespace.
+
+``PMIX_ALLOC_SHARE``
+   A boolean that governs the allocation's **initial** reservation state
+   — its disposition *while the owning namespace lives*.  When absent or
+   ``false`` (the default), the nodes are **reserved** for the owning
+   namespace.  When ``true``, the nodes are **unreserved** from the
+   outset: they join the **default session** and are usable by any member
+   of the session.  ``PMIX_ALLOC_SHARE`` is orthogonal to
+   ``PMIX_ALLOC_INHERITANCE``: the former describes the allocation while
+   its owning namespace lives, the latter what happens when that
+   namespace dies.  (This attribute replaces the former
+   ``PMIX_ALLOC_RESERVED`` with inverted sense.)
+
+``PMIX_ALLOC_INHERITANCE``
+   Supplied on an allocation request to select what becomes of the
+   allocation when its **owning namespace** terminates.  Its value is a
+   ``pmix_alloc_inheritance_t`` taking one of four dispositions —
+   ``PMIX_ALLOC_INHERIT_NONE``, ``PMIX_ALLOC_INHERIT_CHILD``,
+   ``PMIX_ALLOC_INHERIT_DEFAULT``, or ``PMIX_ALLOC_INHERIT_CHILD_DEFAULT``
+   — whose meanings are defined under `Lifecycle`_.  It is honored on
+   ``PMIX_ALLOC_NEW`` and ``PMIX_ALLOC_EXTEND`` requests and ignored on
+   ``PMIX_ALLOC_RELEASE``, ``PMIX_ALLOC_REAQUIRE``, and
+   ``PMIX_ALLOC_REQ_CANCEL``.  Because the disposition governs behavior at
+   the owning namespace's death rather than the reservation's live state,
+   it is meaningful even for a shared (unreserved) allocation — there it
+   still decides whether the nodes return to the scheduler
+   (``NONE``/``CHILD``) or remain in the session.  When absent, the host
+   behaves as if ``PMIX_ALLOC_INHERIT_DEFAULT`` had been specified (see
+   `Lifecycle`_); the legacy "release to the scheduler on termination"
+   behavior must be requested explicitly with ``PMIX_ALLOC_INHERIT_NONE``.
+   A non-default value that the host does not support is rejected (see
+   `Error semantics`_) rather than silently ignored, so the requester is
+   never misled about its allocation's lifetime.
+
+``PMIX_ALLOC_WARN_TIMEOUT``
+   A ``uint32_t`` supplied on a ``PMIX_ALLOC_NEW`` or ``PMIX_ALLOC_EXTEND``
+   request, giving the number of seconds before the allocation's
+   expiration at which the requester wishes to be warned.  It is advisory:
+   a scheduler that does not implement it simply ignores it and no warning
+   is delivered.  When honored, the scheduler delivers a
+   ``PMIX_ALLOC_TIMEOUT_WARNING`` event to the requester as the deadline
+   nears; see `Allocation timeout warning`_.
+
+``PMIX_SPAWN_TARGET``
+   Supplied on a spawn request to select the allocation(s) whose nodes
+   the job may map onto.  Its value is either a single allocation-id
+   string or an array of allocation-id strings.  Each entry names a
+   reservation by its ``PMIX_ALLOC_ID``; an entry equal to the invalid
+   namespace denotes the default session.  When absent, the job uses the
+   default session (or its parent's session, exactly as today).
+
+All five attributes are optional.  A request that supplies none of them
+behaves exactly as a pre-reservation PRRTE would (see `Backward
+compatibility`_).
+
+Allocation behavior
+-------------------
+
+When the scheduler returns nodes for a dynamic allocation request,
+the nodes are always added to the DVM so daemons can be launched on them.
+*Which session they become available to* is decided as follows, by
+requester class and the attributes present.
+
+There are three requester/allocation cases:
+
+#. **Startup allocation.**  The nodes discovered when the DVM starts form
+   the default session.  No request drives this; it is the baseline.
+#. **Tool-requested dynamic allocation.**  A tool (a PMIx client with no
+   job of its own — e.g. a scheduler or a ``prun``-class process) issues
+   the request.
+#. **Application-requested dynamic allocation.**  A process belonging to a
+   running job issues the request.
+
+The routing rule is summarized in the decision table below.  "Session
+owned by ``<nspace>``" means a reservation whose owner set is seeded with
+``<nspace>``.  ``PMIX_ALLOC_SHARE`` governs only the *destination*
+(reserved versus shared); ``PMIX_ALLOC_TARGET`` independently designates
+the **owning namespace** for inheritance and accounting, which still
+applies even when the nodes are shared.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 24 18 40
+
+   * - Requester
+     - ``PMIX_ALLOC_TARGET``
+     - ``PMIX_ALLOC_SHARE``
+     - Destination
+   * - Tool
+     - ``<nspace>``
+     - absent / ``false``
+     - reservation owned by ``<nspace>``
+   * - Tool
+     - absent
+     - absent / ``false``
+     - reservation owned by the tool's own namespace
+   * - Tool
+     - absent
+     - ``true``
+     - default session (shared)
+   * - Application
+     - absent
+     - absent / ``false``
+     - reservation owned by the application's namespace
+   * - Application
+     - absent
+     - ``true``
+     - default session (shared)
+   * - Application
+     - present
+     - any
+     - rejected — ``PMIX_ERR_NO_PERMISSIONS``
+
+New versus extend
+~~~~~~~~~~~~~~~~~~
+
+A request carrying the ``PMIX_ALLOC_NEW`` directive always mints a fresh
+reservation, even for a namespace that already owns one; the namespace
+may thus hold several reservations, each distinguished by its allocation
+id.  A request carrying ``PMIX_ALLOC_EXTEND`` adds nodes to the existing
+reservation named by the request's ``PMIX_ALLOC_ID``, and succeeds only
+when the requester's namespace owns that reservation.
+
+Reporting the result
+~~~~~~~~~~~~~~~~~~~~~~
+
+A successful allocation response returns the destination's
+``PMIX_ALLOC_ID`` so the requester can later target the reservation when
+spawning or extend or release it.  When the request supplied a
+``PMIX_ALLOC_REQ_ID``, that id is echoed back in the response.
+
+Spawn targeting behavior
+------------------------
+
+A spawn request selects its candidate nodes through ``PMIX_SPAWN_TARGET``:
+
+* **Absent, or naming only the invalid namespace** — the job maps onto
+  the default session.  This is the unchanged, pre-reservation behavior.
+* **One or more valid allocation ids** — the job may map onto the
+  **union** of those reservations' nodes.
+* **Valid ids plus the invalid namespace** — the union additionally
+  includes the default pool.  This is the supported way to request
+  "my reservation, and the general pool too."
+
+Every targeted allocation is subject to the ownership check below.  A
+job's candidate node pool is exactly the union of the sessions it is
+permitted to target; it can see no other nodes.
+
+A consequence for existing jobs: once any node is reserved, a job that
+targets the default session no longer sees reserved nodes.  This
+isolation is intended.  A job that targets no reservation behaves
+identically to today on an allocation where nothing has been reserved.
+
+Ownership model
+---------------
+
+A reservation is owned by a **set** of namespaces:
+
+* The set is seeded with the **owning namespace** — the namespace the
+  reservation was created for (the ``PMIX_ALLOC_TARGET`` namespace for a
+  tool request, otherwise the requester's own namespace).  A reservation
+  has exactly one owning namespace for its lifetime; it is the namespace
+  whose termination drives inheritance (see `Lifecycle`_).
+* Each time a job is successfully spawned *into* a reservation, that
+  job's namespace is added to the owner set as a **child namespace**, and
+  may then spawn further jobs onto the same nodes.  This owner set is the
+  *authorization* layer — who may map onto and target the reservation.
+* Distinct from authorization, a **derived child** is, for lifetime
+  purposes, any namespace reachable by following the spawn relationship
+  from the owning namespace to arbitrary depth — a descendant at any
+  level, not just an immediate child.  Children launched into the
+  reservation via ``PMIX_SPAWN_TARGET`` count as derived children.  The
+  set of derived children is what the ``CHILD``-flavored inheritance
+  rules track (see `Lifecycle`_); it is distinct from the single owning
+  namespace that seeded the reservation.
+* Ownership is **not** inherited transitively.  A child owns only the
+  reservation it was spawned into — never the other reservations its
+  parent happens to own.
+* The scheduler is an implicit owner of every session and may target or
+  release any of them.
+
+A spawn may target a session only if, for **every** entry in
+``PMIX_SPAWN_TARGET``, at least one of the following holds: the entry is
+the default session; the requester's namespace is in the session's owner
+set; or the requester is the scheduler.  If any entry fails this check
+the entire spawn is rejected (see `Error semantics`_) — the request is
+never silently narrowed to the permitted subset, so the caller always
+learns its request was not honored in full.
+
+Error semantics
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 55 45
+
+   * - Condition
+     - Returned status
+   * - Application request carries ``PMIX_ALLOC_TARGET``
+     - ``PMIX_ERR_NO_PERMISSIONS``
+   * - ``PMIX_ALLOC_EXTEND`` names an allocation the requester does not own
+     - ``PMIX_ERR_NO_PERMISSIONS``
+   * - ``PMIX_ALLOC_EXTEND`` names an allocation that does not exist
+     - ``PMIX_ERR_NOT_FOUND``
+   * - ``PMIX_SPAWN_TARGET`` names an allocation that resolves to no session
+     - ``PMIX_ERR_NOT_FOUND``
+   * - ``PMIX_SPAWN_TARGET`` names a session the requester does not own
+     - ``PMIX_ERR_NO_PERMISSIONS``
+   * - ``PMIX_ALLOC_INHERITANCE`` carries a non-default value the host
+       does not support
+     - ``PMIX_ERR_NOT_SUPPORTED``
+
+In every rejection case no partial effect is observable: a rejected
+allocation reserves nothing, and a rejected spawn launches no processes.
+A non-default ``PMIX_ALLOC_INHERITANCE`` value is rejected rather than
+silently ignored so the requester is never misled about its allocation's
+lifetime.
+
+Lifecycle
+---------
+
+A reservation's lifetime is governed by two independent mechanisms:
+**unconditional triggers** that end it regardless of any other state, and
+a **namespace-termination disposition** selected at creation by
+``PMIX_ALLOC_INHERITANCE`` that decides what its termination does to the
+reservation.
+
+Unconditional triggers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Independently of the inheritance disposition, a reservation ends when any
+of these occurs:
+
+#. **An owner releases it** by issuing ``PMIX_ALLOC_RELEASE`` for the
+   reservation's allocation id.  Any namespace in the owner set may
+   release it; the scheduler may release any reservation.
+#. **The DVM tears down.**  All sessions, default and reserved alike, end
+   with the DVM.
+#. **The scheduler terminates the allocation** — for example on a timeout
+   or an administrative reclaim — which arrives as a scheduler-driven
+   release for the allocation id.
+
+Namespace-termination disposition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PMIX_ALLOC_INHERITANCE`` selects, at allocation time, what becomes of
+the reservation as its **owning namespace** and **derived children**
+(see `Ownership model`_) terminate.  It answers two coupled, orthogonal
+questions — *when* the disposition fires (**lifetime**: at the owning
+namespace's termination, or only after the last derived child has also
+terminated) and *what* it then does (**disposition**: return the nodes to
+the scheduler, or merely make them **unreserved** within the session):
+
+``PMIX_ALLOC_INHERIT_NONE``
+   When the **owning namespace** terminates, the reservation is released
+   and its nodes are returned to the scheduler, even if derived children
+   are still running on them.  This is the legacy behavior.
+``PMIX_ALLOC_INHERIT_CHILD``
+   The reservation outlives its owning namespace and is released — nodes
+   returned to the scheduler — only when **all** derived children have
+   terminated.
+``PMIX_ALLOC_INHERIT_DEFAULT``
+   When the **owning namespace** terminates, the nodes are **not**
+   returned to the scheduler; they become **unreserved** and remain in
+   the session.
+``PMIX_ALLOC_INHERIT_CHILD_DEFAULT``
+   The nodes become **unreserved** within the session when the **last
+   derived child** terminates, rather than being returned to the
+   scheduler.
+
+The two axes combine as:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 33 33
+
+   * -
+     - **Returned to scheduler**
+     - **Unreserved in session**
+   * - **At owning-namespace termination**
+     - ``PMIX_ALLOC_INHERIT_NONE``
+     - ``PMIX_ALLOC_INHERIT_DEFAULT``
+   * - **At last-derived-child termination**
+     - ``PMIX_ALLOC_INHERIT_CHILD``
+     - ``PMIX_ALLOC_INHERIT_CHILD_DEFAULT``
+
+**Returned to the scheduler** runs the same path as an explicit
+``PMIX_ALLOC_RELEASE``: the nodes leave the reservation and go back to the
+scheduler's general pool (the DVM shrinks for nodes the scheduler owns;
+nodes that were carved from the DVM's own startup pool revert to the
+default session).  **Unreserved in session** never returns nodes to the
+scheduler on this trigger; the named allocation goes away but every node
+stays in the DVM, clears its reservation, and joins the default session
+for general use.  Such nodes return to the scheduler only when the
+session (DVM) itself ends or they are explicitly released — inheritance
+alone never hands them back.
+
+Default disposition
+~~~~~~~~~~~~~~~~~~~~~
+
+When ``PMIX_ALLOC_INHERITANCE`` is absent, the host behaves as if
+``PMIX_ALLOC_INHERIT_DEFAULT`` had been specified: on termination of the
+owning namespace the reservation's nodes become unreserved and remain in
+the session rather than being returned to the scheduler.  The legacy
+"release to the scheduler on termination" behavior is **not** the
+default; a requester that wants it must pass ``PMIX_ALLOC_INHERIT_NONE``
+explicitly.
+
+Ending a reservation while jobs are still mapped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any trigger — an unconditional one or a namespace-termination
+disposition — may fire while jobs are still mapped onto the
+reservation's nodes (for example, ``PMIX_ALLOC_INHERIT_NONE`` releasing
+the reservation while child jobs run on it).  The observable outcome
+depends only on whether the nodes leave the DVM:
+
+* **Nodes stay in the DVM** (an owner release whose nodes are not
+  returned to the scheduler, or a ``*_DEFAULT`` disposition becoming
+  unreserved).  No process is killed.  The nodes revert to the default
+  pool, already-running jobs continue undisturbed, and only the mapping of
+  *new* jobs stops seeing the reservation.
+* **Nodes leave the DVM** (a scheduler reclaim or timeout, a ``NONE`` or
+  ``CHILD`` disposition returning nodes to the scheduler, or any release
+  of scheduler-owned nodes).  This is the existing DVM-shrink behavior:
+  jobs and daemons on the departing nodes are terminated before the nodes
+  leave.
+
+Reservation teardown never itself kills a job; process termination occurs
+only when nodes physically depart, under the pre-existing shrink
+behavior.
+
+Allocation timeout warning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Scheduler reclaim (unconditional trigger 3) is frequently driven by a
+bounded allocation lifetime: when the granted period expires the
+scheduler reclaims the nodes, terminating any jobs still running on them.
+To let an owner checkpoint, drain work, or request an extension before
+that happens, a requester may ask for advance notice when it creates or
+extends the allocation.  PRRTE acts purely as the **relay** between the
+requester and the scheduler here — it neither sets the timeout nor
+generates the warning:
+
+* On a ``PMIX_ALLOC_NEW`` or ``PMIX_ALLOC_EXTEND`` request the requester
+  includes ``PMIX_ALLOC_WARN_TIMEOUT`` (``uint32_t`` seconds before
+  expiration).  PRRTE forwards it to the scheduler.  Being advisory, a
+  scheduler that does not implement it ignores it and no warning follows.
+
+* When the threshold is reached the scheduler issues a
+  ``PMIX_ALLOC_TIMEOUT_WARNING`` event.  PRRTE delivers it **only to the
+  process that requested the allocation** — it is a directed event, not a
+  broadcast — carrying:
+
+  - ``PMIX_ALLOC_ID`` (``char*``) — the affected allocation; always
+    present.
+  - ``PMIX_ALLOC_REQ_ID`` (``char*``) — the requester's own request id,
+    included whenever one was supplied on the original request, so the
+    recipient can match the warning by either identifier.
+  - ``PMIX_TIME_REMAINING`` (``uint32_t``) — seconds left before
+    expiration, in the same units as ``PMIX_ALLOC_WARN_TIMEOUT``.
+
+* The recipient reacts within its event handler — typically by issuing a
+  ``PMIX_ALLOC_EXTEND`` (optionally renewing ``PMIX_ALLOC_WARN_TIMEOUT``)
+  to lengthen the allocation, or by beginning an orderly drain or
+  shutdown — and returns the appropriate event status.  If the allocation
+  is not extended, it expires and the scheduler reclaims its nodes through
+  the existing shrink path described above, terminating the jobs still
+  mapped onto them.
+
+The warning is strictly advance notice; it changes nothing about the
+reservation by itself.  Only the subsequent expiration (or an explicit
+extend/release) alters the allocation, and that flows through the
+unconditional triggers and dispositions already specified.
+
+Backward compatibility
+----------------------
+
+Every attribute in this specification is optional, and PRRTE must build
+and run against a PMIx that defines none, some, or all of them.
+
+* When ``PMIX_ALLOC_TARGET`` is unavailable, a dynamic allocation is
+  always reserved to the requester's own namespace.
+* When ``PMIX_ALLOC_SHARE`` is unavailable, the "reserve" default applies
+  and nodes are never routed to the default pool by a dynamic request.
+* When ``PMIX_ALLOC_INHERITANCE`` is unavailable, every reservation takes
+  the default disposition (``PMIX_ALLOC_INHERIT_DEFAULT``): on termination
+  of its owning namespace the nodes become unreserved within the session.
+  The non-default dispositions — in particular the legacy
+  ``PMIX_ALLOC_INHERIT_NONE`` (release to the scheduler) — cannot be
+  requested, and a request carrying a non-default value is rejected (see
+  `Error semantics`_).
+* When ``PMIX_ALLOC_WARN_TIMEOUT`` is unavailable, no advance timeout
+  warning is requested; an allocation still expires and is reclaimed by
+  the scheduler as before, only without the advisory
+  ``PMIX_ALLOC_TIMEOUT_WARNING`` event beforehand.
+* When ``PMIX_SPAWN_TARGET`` is unavailable, spawns use the default or
+  parent session exactly as they do today.
+
+A DVM whose PMIx lacks all five attributes still partitions resources
+sensibly — dynamic allocations reserve to the requesting namespace,
+reservations become unreserved within the session when their owning
+namespace exits, allocations expire and are reclaimed without an advance
+warning, and spawns use the default/parent session — and exhibits no
+behavior change for any request beyond that prescribed default
+disposition.
+
+Conformance summary
+-------------------
+
+A conforming implementation guarantees that:
+
+#. A job's candidate nodes are exactly the union of the sessions it is
+   permitted to target, and never include a reserved node it does not
+   own.
+#. A reservation is created, extended, shared, targeted, or released only
+   in response to a requester-supplied attribute or a scheduler action —
+   never by PRRTE's own initiative.
+#. Every rejection listed in `Error semantics`_ leaves no observable
+   partial effect.
+#. A reservation ends on an unconditional trigger (owner release, DVM
+   teardown, or scheduler termination) or on the namespace-termination
+   disposition recorded at its creation — defaulting to
+   ``PMIX_ALLOC_INHERIT_DEFAULT`` (unreserve in session) when none was
+   supplied — and on no other event.
+#. Nodes are returned to the scheduler only under a ``NONE``/``CHILD``
+   disposition, an explicit release, or session (DVM) teardown; a
+   ``*_DEFAULT`` disposition only ever unreserves nodes within the
+   session.
+#. A ``PMIX_ALLOC_TIMEOUT_WARNING`` event, when the scheduler honors a
+   ``PMIX_ALLOC_WARN_TIMEOUT`` request, is relayed only to the process
+   that requested the allocation, and is advisory — it alters nothing
+   about the reservation by itself.
+#. The defaults and rejections above hold unchanged when the underlying
+   PMIx lacks any of the five attributes.

--- a/docs/plans/node_reservation/node-reservation.rst
+++ b/docs/plans/node_reservation/node-reservation.rst
@@ -26,7 +26,7 @@ This document specifies the changes required to:
 
 1. Treat the original startup allocation as the default session (no change to
    observable behavior — documented here for completeness).
-2. Honor ``PMIX_ALLOC_TARGET`` and ``PMIX_ALLOC_RESERVED`` on dynamic
+2. Honor ``PMIX_ALLOC_TARGET`` and ``PMIX_ALLOC_SHARE`` on dynamic
    allocation requests to decide which session receives the new nodes.
 3. Honor a new ``PMIX_SPAWN_TARGET`` attribute on spawn requests to select the
    union of allocations a job may map onto.
@@ -45,7 +45,7 @@ Goals
 3. Reservation decisions are driven entirely by PMIx attributes supplied by
    the requester (tool or application); PRRTE invents no policy of its own
    beyond the defaults specified below.
-4. Code that references ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_RESERVED``, or
+4. Code that references ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``, or
    ``PMIX_SPAWN_TARGET`` is guarded so a PMIx that lacks any of these keys
    still builds warning-free and behaves as it does today.
 
@@ -106,8 +106,8 @@ routed as follows:
 * ``PMIX_ALLOC_TARGET`` absent: the new nodes are reserved to the *tool's own*
   namespace, so that processes the tool subsequently launches via
   ``PMIx_Spawn`` land on them by default.
-* ``PMIX_ALLOC_TARGET`` absent **and** ``PMIX_ALLOC_RESERVED`` present and set
-  to ``false``: the new nodes go into the default session and are available to
+* ``PMIX_ALLOC_TARGET`` absent **and** ``PMIX_ALLOC_SHARE`` present and set
+  to ``true``: the new nodes go into the default session and are available to
   all namespaces.
 
 Case 3 — Dynamic allocation requested by an application
@@ -118,7 +118,7 @@ request:
 
 * Default: the new nodes are reserved to the requesting process's namespace.
   Any process in that namespace may spawn jobs against them.
-* ``PMIX_ALLOC_RESERVED`` present and set to ``false``: the new nodes go into
+* ``PMIX_ALLOC_SHARE`` present and set to ``true``: the new nodes go into
   the default session for general use.
 
 Note that ``PMIX_ALLOC_TARGET`` is honored only for tool requesters (Case 2);
@@ -135,7 +135,7 @@ Decision summary
 
    * - Requester
      - ``PMIX_ALLOC_TARGET``
-     - ``PMIX_ALLOC_RESERVED``
+     - ``PMIX_ALLOC_SHARE``
      - Destination session
    * - Tool
      - ``<nspace>``
@@ -143,19 +143,19 @@ Decision summary
      - session owned by ``<nspace>``
    * - Tool
      - absent
-     - absent or ``true``
+     - absent or ``false``
      - session owned by the tool's namespace
    * - Tool
      - absent
-     - ``false``
+     - ``true``
      - default session
    * - Application
      - absent
-     - absent or ``true``
+     - absent or ``false``
      - session owned by the app's namespace
    * - Application
      - absent
-     - ``false``
+     - ``true``
      - default session
    * - Application
      - present
@@ -251,6 +251,29 @@ after ``PRTE_JOB_DO_NOT_SPAWN = PRTE_JOB_START_KEY + 123`` is used:
 
 ``PRTE_JOB_MAX_KEY`` already allows headroom (``+200``); no bump is required.
 
+Two registration steps are easy to overlook and both cause *silent* failures
+rather than build errors, so they are called out explicitly:
+
+* **Add a case to** ``prte_attr_key_to_str`` (``src/util/attr.c``).  That
+  switch has no ``default`` that names the key; an unregistered key prints as
+  ``UNKNOWN``, which is harmless at runtime but masks the attribute in every
+  map/state debug dump and makes the feature far harder to diagnose.
+* **Set the attribute with the global flag.**  The generic job-attribute pack
+  loop in ``prte_dt_packing_fns.c`` forwards only attributes whose ``local``
+  field is ``PRTE_ATTR_GLOBAL`` (which is ``false``).  The spawn target must
+  therefore be stored with::
+
+     prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_TARGET,
+                        PRTE_ATTR_GLOBAL, target_str, PMIX_STRING);
+
+  If it is set ``PRTE_ATTR_LOCAL`` instead, the attribute lives only on the
+  process that parsed ``PMIX_SPAWN_TARGET`` and never reaches the HNP, so the
+  multi-session resolution in ``plm_base_receive.c`` silently falls back to the
+  default/parent session.  Storing it global is what lets the plan claim the
+  target "is packed/unpacked with the rest of the job attributes" — no bespoke
+  pack/unpack code is needed because the generic loop handles any global
+  ``char*`` attribute.
+
 Allocation-Time Handling
 ------------------------
 
@@ -278,8 +301,8 @@ returns a non-tool job; otherwise it is a **tool**.  The directive scan in
 .. code-block:: c
 
    char *target = NULL;        /* PMIX_ALLOC_TARGET namespace, if any */
-   bool reserved = true;       /* default: reserve */
-   bool have_reserved = false;
+   bool share = false;         /* default: reserve (do not share) */
+   bool have_share = false;
 
    for (n = 0; n < req->ninfo; n++) {
    #if defined(PMIX_ALLOC_TARGET)
@@ -288,10 +311,10 @@ returns a non-tool job; otherwise it is a **tool**.  The directive scan in
            continue;
        }
    #endif
-   #if defined(PMIX_ALLOC_RESERVED)
-       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_RESERVED)) {
-           reserved = PMIX_INFO_TRUE(&req->info[n]);
-           have_reserved = true;
+   #if defined(PMIX_ALLOC_SHARE)
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_SHARE)) {
+           share = PMIX_INFO_TRUE(&req->info[n]);
+           have_share = true;
            continue;
        }
    #endif
@@ -310,7 +333,7 @@ Destination resolution then follows the decision table, with the allocation
    /* the namespace the reservation is created for / must be owned by */
    const char *owner_nspace = (NULL != target) ? target : req->tproc.nspace;
 
-   if (have_reserved && !reserved) {
+   if (have_share && share) {
        dest = prte_default_session;            /* general use */
    } else if (NULL != target && !is_tool) {
        req->pstatus = PMIX_ERR_NO_PERMISSIONS; /* app may not retarget */
@@ -339,7 +362,7 @@ allocation id.
 When the installed PMIx lacks ``PMIX_ALLOC_TARGET``, the ``target`` guard keeps
 it ``NULL`` so ``owner_nspace`` is always the requester's namespace — the
 behavior required when the key is unavailable.  Likewise, without
-``PMIX_ALLOC_RESERVED`` the ``reserved`` default of ``true`` means a bare
+``PMIX_ALLOC_SHARE`` the ``share`` default of ``false`` means a bare
 ``PMIX_ALLOC_NEW`` reserves to the requester's namespace.
 
 Placing the nodes
@@ -524,7 +547,7 @@ pool when requested).
 Backward Compatibility
 -----------------------
 
-* ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_RESERVED``, and ``PMIX_SPAWN_TARGET`` are
+* ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``, and ``PMIX_SPAWN_TARGET`` are
   referenced only inside ``#if defined(<key>)`` blocks.  These keys are plain
   string ``#define``\ s supplied by PMIx; their mere presence in
   ``pmix_common.h`` is the availability signal, so ``#if defined`` (not the
@@ -533,7 +556,7 @@ Backward Compatibility
   the ``PRTE_CHECK_PMIX_CAP`` mechanism in ``config/prte_setup_pmix.m4`` and a
   configure-defined ``PRTE_HAVE_*`` macro.
 * With an older PMIx that lacks all three keys, ``target`` is always ``NULL``,
-  ``reserved`` is never observed, and ``PRTE_JOB_SPAWN_TARGET`` is never set.
+  ``share`` is never observed, and ``PRTE_JOB_SPAWN_TARGET`` is never set.
   Dynamic allocations then fall to the "reserve to the requester's namespace"
   default — which, combined with the mapping change, still partitions
   resources sensibly — while spawns continue to use the default/parent session
@@ -566,6 +589,31 @@ references in ``session->nodes``, and only then proceed with any DVM shrink for
 nodes that are being returned to the scheduler.  The clear-before-shrink
 ordering keeps the reservation bookkeeping from racing the shrink-campaign
 accounting (``prte_dvm_launch_fence`` / ``prte_shrink_campaigns``).
+
+Releasing while jobs are still mapped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because a reservation outlives the jobs that run in it, a release request may
+arrive while one or more jobs are still mapped onto the reservation's nodes —
+an owner releasing prematurely, or a scheduler timeout/reclaim firing under a
+running job.  The two sub-cases differ:
+
+* **Owner-initiated release** of a reservation whose nodes are *not* being
+  returned to the scheduler (the nodes stay in the DVM): no process is killed.
+  The nodes simply revert to the default pool when ``node->session`` is
+  cleared, and the already-running jobs continue on them; their
+  ``jdata->session`` still points at the now-detached session object, which is
+  kept alive by the normal ``session->jobs`` references until those jobs
+  terminate.  Mapping for *new* jobs no longer sees the reservation.
+* **Release that returns nodes to the scheduler** (scheduler reclaim, timeout,
+  or an owner release of scheduler-owned nodes): this is the existing DVM
+  shrink path, which already terminates the affected jobs and daemons before
+  the nodes leave.  The reservation cleanup adds nothing new here beyond the
+  clear-before-shrink ordering above; it reuses the established shrink-campaign
+  teardown.
+
+Either way the reservation cleanup never *itself* kills a job — termination is
+driven only by the pre-existing shrink machinery when nodes physically depart.
 
 Implementation Order
 --------------------
@@ -604,10 +652,10 @@ Open Questions
 Resolved decisions
 ~~~~~~~~~~~~~~~~~~~
 
-* **Default ``PMIX_ALLOC_RESERVED`` means "reserve."**  An
-  ``ALLOC_RESERVED``-absent dynamic request reserves the nodes to the
+* **Default (``PMIX_ALLOC_SHARE`` absent) means "reserve."**  An
+  ``ALLOC_SHARE``-absent dynamic request reserves the nodes to the
   requester's (or target's) namespace; only an explicit
-  ``PMIX_ALLOC_RESERVED == false`` routes nodes to the default pool.
+  ``PMIX_ALLOC_SHARE == true`` routes nodes to the default pool.
 * **``PMIX_SPAWN_TARGET`` is limited by an ownership check.**  A requester may
   target only the default session and reservations its namespace owns (the
   scheduler excepted).  See *Ownership check* above.

--- a/docs/plans/node_reservation/node-reservation.rst
+++ b/docs/plans/node_reservation/node-reservation.rst
@@ -28,11 +28,19 @@ This document specifies the changes required to:
    observable behavior — documented here for completeness).
 2. Honor ``PMIX_ALLOC_TARGET`` and ``PMIX_ALLOC_SHARE`` on dynamic
    allocation requests to decide which session receives the new nodes.
-3. Honor a new ``PMIX_SPAWN_TARGET`` attribute on spawn requests to select the
+3. Honor ``PMIX_ALLOC_INHERITANCE`` to decide what becomes of a reservation
+   when its owning namespace terminates.
+4. Relay the scheduler's allocation-timeout warning
+   (``PMIX_ALLOC_WARN_TIMEOUT`` request, ``PMIX_ALLOC_TIMEOUT_WARNING`` event)
+   to the requester.
+5. Honor a new ``PMIX_SPAWN_TARGET`` attribute on spawn requests to select the
    union of allocations a job may map onto.
 
-All three PMIx keys are optional and **must** be compiled out cleanly when the
-installed PMIx headers predate them, preserving backward compatibility.
+The observable contract for all of the above is specified in
+``node-reservation-spec.rst``; this document describes the implementation that
+realizes it.  All of these PMIx keys are optional and **must** be compiled out
+cleanly when the installed PMIx headers predate them, preserving backward
+compatibility.
 
 Goals
 -----
@@ -45,7 +53,8 @@ Goals
 3. Reservation decisions are driven entirely by PMIx attributes supplied by
    the requester (tool or application); PRRTE invents no policy of its own
    beyond the defaults specified below.
-4. Code that references ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``, or
+4. Code that references ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``,
+   ``PMIX_ALLOC_INHERITANCE``, ``PMIX_ALLOC_WARN_TIMEOUT``, or
    ``PMIX_SPAWN_TARGET`` is guarded so a PMIx that lacks any of these keys
    still builds warning-free and behaves as it does today.
 
@@ -235,6 +244,93 @@ located by their allocation id with the existing
 ``prte_get_session_object_from_id`` (which matches ``session->alloc_refid``),
 and ownership is then checked with ``prte_session_is_owned_by``.
 
+Owning namespace and inheritance disposition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``owners`` list is the *authorization* set (who may map onto and target
+the reservation).  The inheritance rules in ``node-reservation-spec.rst`` also
+require a distinguished **owning namespace** — the single namespace the
+reservation was created for, whose termination drives the ``NONE`` and
+``DEFAULT`` dispositions — and the recorded disposition itself.
+``prte_session_t`` gains:
+
+.. code-block:: c
+
+   /* The single namespace the reservation was created for (PMIX_ALLOC_TARGET,
+    * else the requester). Empty for the default session. owners[] additionally
+    * accumulates every namespace spawned into the reservation. */
+   pmix_nspace_t owner;
+
+   /* Retained reference to the owning namespace's job object, so its children
+    * subtree stays walkable for CHILD-flavored drain even after the owning
+    * namespace terminates. NULL for the default session. Released at teardown. */
+   prte_job_t *owner_job;
+
+   /* Disposition recorded at creation, governing teardown when the owning
+    * namespace (NONE/DEFAULT) or the last derived child (CHILD/CHILD_DEFAULT)
+    * terminates. Stored as the uint8_t underlying pmix_alloc_inheritance_t so
+    * the struct compiles against a PMIx that lacks the type; defaults to the
+    * value of PMIX_ALLOC_INHERIT_DEFAULT. */
+   uint8_t inheritance;
+
+The ``inheritance`` field is typed ``uint8_t`` rather than
+``pmix_alloc_inheritance_t`` so the struct compiles even when the installed
+PMIx predates the type; the four disposition constants are only referenced
+inside ``#if defined`` guards.  The constructor sets ``owner`` empty,
+``owner_job`` to ``NULL``, and ``inheritance`` to the default-disposition value
+(``PMIX_ALLOC_INHERIT_DEFAULT`` when defined, else the equivalent "unreserve on
+owning-namespace termination" behavior, which is what an inheritance-unaware
+build performs unconditionally).  The destructor releases ``owner_job`` if still
+set, so DVM teardown (which runs the session destructor directly) also balances
+the reference.
+
+For the ``CHILD``-flavored dispositions, teardown is deferred until the owning
+namespace and **all of its derived children** — the full transitive spawn
+subtree rooted at the owning namespace, per the spec — have terminated.  The
+owner set is *not* sufficient for this: a descendant may run in some other
+session (not spawned into this reservation) yet still counts as a derived child
+that holds the reservation open.  The drain condition must therefore be
+computed from the job genealogy, not from ``owners``.
+
+PRRTE already records that genealogy on ``prte_job_t``:
+
+* ``prte_job_t::children`` — a list of the job's **immediate** child jobs,
+  populated in ``plm_base_receive.c`` when a spawn's parent is resolved.
+* ``prte_job_t::launcher`` — the nspace of the **root** launcher of the tree.
+  All descendants of an original spawn inherit the same ``launcher`` value (the
+  spawn code copies the parent's ``launcher``, or sets it to the parent when the
+  parent is itself an original spawn).
+
+The transitive subtree under an owning namespace *O* is obtained by recursively
+walking ``children`` from *O*'s job object.  PRRTE already does exactly this
+kind of genealogy traversal on the termination path: ``prte_dump_aborted_procs``
+(``src/runtime/prte_quit.c``) resolves a job's ``launcher`` and walks the
+launcher's ``children`` to report a failed descendant.  Because that tree-walk
+cost is already paid when jobs terminate, the drain condition reuses the
+**existing parentage tracking** rather than introducing parallel bookkeeping: at
+each ``PRTE_JOB_STATE_TERMINATED``, traverse the owning namespace's ``children``
+subtree and ask whether any job in it is still running.  A per-reservation
+descendant *counter* was considered and rejected — it would duplicate state the
+genealogy already holds, and add spawn-time bookkeeping for no traversal saving
+the termination path does not already incur.
+
+The walk must root at *O*'s own job object (``launcher`` names only the *root*
+of a tree, so it cannot root the subtree of an owning namespace that sits
+mid-genealogy).  Since a ``CHILD``-flavored reservation outlives *O*, that job
+object must stay queryable after *O* terminates: ``create_reservation`` takes a
+reference on it (``PMIX_RETAIN``) and stores it as ``session->owner_job``,
+released during teardown.  Each job retains its own ``children``, so retaining
+the subtree root keeps the whole subtree reachable.  This mirrors how
+``session->jobs`` already retains job objects for the session's lifetime and
+introduces no new tracking machinery.
+
+When the owning namespace is a **tool** (no ``prte_job_t``), ``owner_job`` is
+``NULL`` and there is no single root job.  The tool's derived children are the
+jobs it spawned directly into the reservation — present in ``session->jobs`` —
+so the drain walk roots at those and descends through their ``children``.  This
+covers descendants the tool's children later spawn into other sessions, since
+those are reached through the child jobs' own ``children`` links.
+
 New job attribute for spawn targeting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -296,13 +392,15 @@ Resolving the destination session
 The requester is ``req->tproc`` (recorded in ``pmix_server_alloc_fn``).  A
 requester is an **application** iff ``prte_get_job_data_object(req->tproc.nspace)``
 returns a non-tool job; otherwise it is a **tool**.  The directive scan in
-``prte_ras_base_complete_request`` is extended to read the two new keys:
+``prte_ras_base_complete_request`` is extended to read the new keys:
 
 .. code-block:: c
 
    char *target = NULL;        /* PMIX_ALLOC_TARGET namespace, if any */
    bool share = false;         /* default: reserve (do not share) */
    bool have_share = false;
+   uint8_t inherit = PRTE_INHERIT_DEFAULT_VALUE;  /* see below */
+   bool have_inherit = false;
 
    for (n = 0; n < req->ninfo; n++) {
    #if defined(PMIX_ALLOC_TARGET)
@@ -318,8 +416,27 @@ returns a non-tool job; otherwise it is a **tool**.  The directive scan in
            continue;
        }
    #endif
+   #if defined(PMIX_ALLOC_INHERITANCE)
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_INHERITANCE)) {
+           inherit = req->info[n].value.data.inheritance;
+           have_inherit = true;
+           continue;
+       }
+   #endif
+       /* PMIX_ALLOC_WARN_TIMEOUT is not consumed here: it is left in
+        * req->info to be forwarded verbatim to the scheduler; see
+        * "Allocation timeout warning" below. */
        /* ... existing PMIX_ALLOC_NODE_LIST handling ... */
    }
+
+``PRTE_INHERIT_DEFAULT_VALUE`` is a small internal macro defined as
+``PMIX_ALLOC_INHERIT_DEFAULT`` when that constant is available and as the
+equivalent literal otherwise, so the default disposition is the same whether
+or not the running PMIx defines the type.  A non-default ``inherit`` value that
+this build cannot honor (for example, because ``PMIX_ALLOC_INHERITANCE`` is
+undefined and the value arrived over the wire from a newer peer) is rejected
+with ``PMIX_ERR_NOT_SUPPORTED`` rather than silently dropped, matching the
+spec's error contract.
 
 Destination resolution then follows the decision table, with the allocation
 *directive* deciding whether a reservation is created or extended:
@@ -351,19 +468,30 @@ Destination resolution then follows the decision table, with the allocation
        dest = create_reservation(owner_nspace);
    }
 
-``create_reservation(nspace)`` allocates a new ``prte_session_t``, assigns a
-fresh ``session_id`` and ``alloc_refid``, sets ``flags |=
-PRTE_SESSION_FLAG_RESERVED | PRTE_SESSION_FLAG_DYNAMIC``, seeds the owners list
-with ``prte_session_add_owner(dest, nspace)``, and registers it with
+``create_reservation(nspace, inherit)`` allocates a new ``prte_session_t``,
+assigns a fresh ``session_id`` and ``alloc_refid``, sets ``flags |=
+PRTE_SESSION_FLAG_RESERVED | PRTE_SESSION_FLAG_DYNAMIC``, records the owning
+namespace (``PMIX_LOAD_NSPACE(dest->owner, nspace)``) and the disposition
+(``dest->inheritance = inherit``), takes and stores a retained reference to the
+owning namespace's job object when one exists (``dest->owner_job`` via
+``PMIX_RETAIN``; it is ``NULL`` for a tool requester that has no job), seeds the
+owners list with ``prte_session_add_owner(dest, nspace)``, and registers it with
 ``prte_set_session_object``.  A ``PMIX_ALLOC_NEW`` request always mints a new
 reservation; the same namespace may thus own several, each distinguished by its
-allocation id.
+allocation id.  On a ``PMIX_ALLOC_EXTEND`` that carried an inheritance value,
+``dest->inheritance`` is updated to the new value (the spec permits inheritance
+on ``EXTEND``); when the request omits it, the existing disposition is left
+untouched.
 
 When the installed PMIx lacks ``PMIX_ALLOC_TARGET``, the ``target`` guard keeps
 it ``NULL`` so ``owner_nspace`` is always the requester's namespace — the
 behavior required when the key is unavailable.  Likewise, without
 ``PMIX_ALLOC_SHARE`` the ``share`` default of ``false`` means a bare
-``PMIX_ALLOC_NEW`` reserves to the requester's namespace.
+``PMIX_ALLOC_NEW`` reserves to the requester's namespace.  Without
+``PMIX_ALLOC_INHERITANCE`` the ``inherit`` default keeps every reservation at
+``PMIX_ALLOC_INHERIT_DEFAULT`` semantics — unreserve into the session when the
+owning namespace terminates — which is exactly the disposition the spec
+prescribes for an absent attribute.
 
 Placing the nodes
 ~~~~~~~~~~~~~~~~~~
@@ -407,6 +535,36 @@ returned through ``req->infocbfunc`` includes the destination's
 ``alloc_refid`` as ``PMIX_ALLOC_ID`` (and, when newly minted, ``PMIX_ALLOC_REQ_ID``
 echoing any user-supplied ``PMIX_ALLOC_REQ_ID``).  This reuses the existing
 response array assembly in ``pmix_server_alloc_request_resp``.
+
+Allocation timeout warning
+--------------------------
+
+The spec requires PRRTE to act as the relay for the scheduler's
+allocation-timeout warning; PRRTE neither sets the timeout nor generates the
+warning.  Two directions are involved:
+
+* **Request (outbound).**  ``PMIX_ALLOC_WARN_TIMEOUT`` (``uint32_t`` seconds)
+  arriving on a ``PMIX_ALLOC_NEW`` or ``PMIX_ALLOC_EXTEND`` is not consumed by
+  the routing logic above; it is left in the info array that the RAS forwards
+  to the host/scheduler so the scheduler can honor it.  In a DVM with no
+  backing scheduler, there is no timeout source and the attribute is simply
+  never acted upon — the advisory contract permits this.
+
+* **Event (inbound).**  When the scheduler fires ``PMIX_ALLOC_TIMEOUT_WARNING``,
+  it is delivered to the HNP through the existing PMIx event channel.  PRRTE
+  relays it **only to the process that requested the allocation** — a directed
+  notification, not a DVM-wide broadcast — by setting the event range to that
+  process (the requester recorded as the reservation's creator, ``tproc`` on
+  the originating request).  The relayed payload carries the same
+  ``PMIX_ALLOC_ID``, the user's ``PMIX_ALLOC_REQ_ID`` when one was supplied, and
+  ``PMIX_TIME_REMAINING`` (``uint32_t`` seconds) unchanged from the scheduler.
+
+The whole path is guarded by ``#if defined(PMIX_ALLOC_TIMEOUT_WARNING)`` (and
+the companion key/event guards); a PMIx that predates the event registers no
+handler and relays nothing, while allocation expiry still flows through the
+ordinary scheduler-reclaim/shrink path (see *Session Lifecycle*).  The warning
+changes no reservation state by itself: only a subsequent ``PMIX_ALLOC_EXTEND``
+or the actual expiry alters the allocation.
 
 Spawn-Time Handling
 -------------------
@@ -547,70 +705,126 @@ pool when requested).
 Backward Compatibility
 -----------------------
 
-* ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``, and ``PMIX_SPAWN_TARGET`` are
-  referenced only inside ``#if defined(<key>)`` blocks.  These keys are plain
-  string ``#define``\ s supplied by PMIx; their mere presence in
-  ``pmix_common.h`` is the availability signal, so ``#if defined`` (not the
-  logical-macro ``#if FOO`` idiom) is the correct guard here.  Where a future
-  PMIx exposes a capability flag for any of these, the guard can be migrated to
-  the ``PRTE_CHECK_PMIX_CAP`` mechanism in ``config/prte_setup_pmix.m4`` and a
-  configure-defined ``PRTE_HAVE_*`` macro.
-* With an older PMIx that lacks all three keys, ``target`` is always ``NULL``,
-  ``share`` is never observed, and ``PRTE_JOB_SPAWN_TARGET`` is never set.
-  Dynamic allocations then fall to the "reserve to the requester's namespace"
-  default — which, combined with the mapping change, still partitions
-  resources sensibly — while spawns continue to use the default/parent session
-  exactly as today.  No new warnings are introduced under
-  ``--enable-devel-check``.
+* ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_SHARE``, ``PMIX_ALLOC_INHERITANCE``,
+  ``PMIX_ALLOC_WARN_TIMEOUT``, ``PMIX_ALLOC_TIMEOUT_WARNING``, and
+  ``PMIX_SPAWN_TARGET`` are referenced only inside ``#if defined(<key>)``
+  blocks.  These keys are plain string ``#define``\ s supplied by PMIx (and the
+  inheritance type ``pmix_alloc_inheritance_t`` likewise); their mere presence
+  in ``pmix_common.h`` is the availability signal, so ``#if defined`` (not the
+  logical-macro ``#if FOO`` idiom) is the correct guard here.  The
+  ``session->inheritance`` field is typed ``uint8_t`` precisely so the struct
+  needs no guard.  Where a future PMIx exposes a capability flag for any of
+  these, the guard can be migrated to the ``PRTE_CHECK_PMIX_CAP`` mechanism in
+  ``config/prte_setup_pmix.m4`` and a configure-defined ``PRTE_HAVE_*`` macro.
+* With an older PMIx that lacks these keys, ``target`` is always ``NULL``,
+  ``share`` is never observed, ``inherit`` stays at the default-disposition
+  value, no timeout warning is relayed, and ``PRTE_JOB_SPAWN_TARGET`` is never
+  set.  Dynamic allocations then fall to the "reserve to the requester's
+  namespace" default, every reservation behaves as ``PMIX_ALLOC_INHERIT_DEFAULT``
+  (unreserve into the session when the owning namespace exits), and — combined
+  with the mapping change — resources are still partitioned sensibly, while
+  spawns continue to use the default/parent session exactly as today.  No new
+  warnings are introduced under ``--enable-devel-check``.
 
 Session Lifecycle
 -----------------
 
-A reservation is **not** tied to the lifetime of any single job.  Because every
-job is its own namespace, the jobs that run in a reservation come and go while
-the reservation persists; a job terminating (even the one that created the
-reservation) does not release it.  A reservation lives until one of exactly
-three events occurs:
+A reservation's lifetime is governed by two mechanisms, matching the spec:
+**unconditional triggers** that end it regardless of any other state, and the
+**namespace-termination disposition** recorded in ``session->inheritance`` at
+creation.
+
+Unconditional triggers
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Independently of the disposition, a reservation ends when:
 
 1. **An owner issues** ``PMIX_ALLOC_RELEASE`` for the reservation's allocation
    id.  Any namespace in ``session->owners`` may release it; the scheduler may
    release any reservation.
 2. **The DVM tears down.**  All sessions, default and reserved alike, are
    destroyed with the DVM.
-3. **The scheduler terminates the allocation** — for example on a timeout
-   (``session->timeout``) or an administrative reclaim.  This arrives as a
-   scheduler-driven release for the allocation id.
+3. **The scheduler terminates the allocation** — for example on a timeout or an
+   administrative reclaim.  This arrives as a scheduler-driven release for the
+   allocation id (and may be preceded by the timeout warning relayed above).
 
-In all three cases the release runs through the existing
-``prte_ras_base_release_allocation`` path.  Releasing a reservation must, in
-order: clear ``node->session`` on each member node (so any node that survives
-in the DVM falls back to the default pool), drop the reservation's retained
-references in ``session->nodes``, and only then proceed with any DVM shrink for
-nodes that are being returned to the scheduler.  The clear-before-shrink
-ordering keeps the reservation bookkeeping from racing the shrink-campaign
-accounting (``prte_dvm_launch_fence`` / ``prte_shrink_campaigns``).
+Namespace-termination disposition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Releasing while jobs are still mapped
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The other end of a reservation's life is driven by namespace termination per
+``session->inheritance``.  PRRTE already observes job (namespace) termination
+in the state machine / errmgr at ``PRTE_JOB_STATE_TERMINATED``.  That site is
+extended: when namespace *N* terminates, walk the registered reservations and,
+for each one whose disposition fires, run the corresponding teardown.
 
-Because a reservation outlives the jobs that run in it, a release request may
-arrive while one or more jobs are still mapped onto the reservation's nodes —
-an owner releasing prematurely, or a scheduler timeout/reclaim firing under a
-running job.  The two sub-cases differ:
+* ``PMIX_ALLOC_INHERIT_NONE`` — when ``N`` equals ``session->owner``: **release**
+  (return nodes to the scheduler), even if entries of ``session->owners`` are
+  still running.
+* ``PMIX_ALLOC_INHERIT_DEFAULT`` (also the default when no value was recorded) —
+  when ``N`` equals ``session->owner``: **unreserve** (clear ``node->session``
+  and drop the reservation's references, leaving the nodes in the DVM default
+  pool; do not shrink, do not return them to the scheduler).
+* ``PMIX_ALLOC_INHERIT_CHILD`` — when ``N`` is the owning namespace or any
+  derived child of it, and after ``N`` exits no job in the owning namespace's
+  transitive spawn subtree remains running: **release**.
+* ``PMIX_ALLOC_INHERIT_CHILD_DEFAULT`` — same drain condition as ``CHILD`` but
+  the teardown is **unreserve** rather than release.
 
-* **Owner-initiated release** of a reservation whose nodes are *not* being
-  returned to the scheduler (the nodes stay in the DVM): no process is killed.
-  The nodes simply revert to the default pool when ``node->session`` is
-  cleared, and the already-running jobs continue on them; their
-  ``jdata->session`` still points at the now-detached session object, which is
-  kept alive by the normal ``session->jobs`` references until those jobs
-  terminate.  Mapping for *new* jobs no longer sees the reservation.
-* **Release that returns nodes to the scheduler** (scheduler reclaim, timeout,
-  or an owner release of scheduler-owned nodes): this is the existing DVM
-  shrink path, which already terminates the affected jobs and daemons before
-  the nodes leave.  The reservation cleanup adds nothing new here beyond the
-  clear-before-shrink ordering above; it reuses the established shrink-campaign
-  teardown.
+The ``CHILD`` drain condition is evaluated against the **job genealogy**, not
+the owner set: a derived child is any transitive spawn descendant of the owning
+namespace, even one running in another session.  As described under *Owning
+namespace and inheritance disposition*, this is computed by traversing the
+owning namespace's ``prte_job_t::children`` subtree — the same parentage walk
+``prte_dump_aborted_procs`` already performs on the termination path — so no
+counter or parallel bookkeeping is added.  The subtree root stays reachable
+after the owning namespace exits because the reservation holds a retained
+reference to it in ``session->owner_job``.  The owner set continues to serve
+only *authorization* (who may map onto and target the reservation); it is
+deliberately **not** reused for the lifetime computation.
+
+Release versus unreserve
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both teardowns share a prefix and differ only in the tail:
+
+* **Release** runs the existing ``prte_ras_base_release_allocation`` path.  In
+  order: clear ``node->session`` on each member node (so any node that survives
+  in the DVM falls back to the default pool), drop the reservation's retained
+  references in ``session->nodes``, and only then proceed with any DVM shrink
+  for nodes being returned to the scheduler.  The clear-before-shrink ordering
+  keeps the reservation bookkeeping from racing the shrink-campaign accounting
+  (``prte_dvm_launch_fence`` / ``prte_shrink_campaigns``).
+* **Unreserve** performs the same clear-and-drop prefix but **stops there**: it
+  never shrinks and never returns nodes to the scheduler.  The nodes remain in
+  the DVM as part of the default pool, available to any job, until the DVM (the
+  PMIx "session") itself ends.  The reservation object is deregistered with
+  ``prte_set_session_object`` once its nodes and owners are cleared.
+
+Both tails also drop the reservation's retained owning-job reference
+(``PMIX_RELEASE(session->owner_job)``) as the session object is torn down,
+balancing the ``PMIX_RETAIN`` taken in ``create_reservation``.
+
+Teardown while jobs are still mapped
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A trigger or disposition may fire while jobs are still mapped onto the
+reservation's nodes — an owner releasing prematurely, a scheduler
+timeout/reclaim under a running job, or ``PMIX_ALLOC_INHERIT_NONE`` firing while
+spawned children still run.  The outcome depends only on whether the nodes
+leave the DVM:
+
+* **Nodes stay in the DVM** (an owner release or a ``*_DEFAULT`` unreserve whose
+  nodes are not returned to the scheduler): no process is killed.  The nodes
+  revert to the default pool when ``node->session`` is cleared, and
+  already-running jobs continue on them; their ``jdata->session`` still points
+  at the now-detached session object, kept alive by the normal ``session->jobs``
+  references until those jobs terminate.  Mapping for *new* jobs no longer sees
+  the reservation.
+* **Nodes leave the DVM** (scheduler reclaim or timeout, or a ``NONE``/``CHILD``
+  release of scheduler-owned nodes): this is the existing DVM shrink path, which
+  already terminates the affected jobs and daemons before the nodes leave.  The
+  reservation cleanup adds nothing beyond the clear-before-shrink ordering
+  above; it reuses the established shrink-campaign teardown.
 
 Either way the reservation cleanup never *itself* kills a job — termination is
 driven only by the pre-existing shrink machinery when nodes physically depart.
@@ -626,17 +840,38 @@ Implementation Order
    the default target set ``{ prte_default_session }`` so existing behavior is
    preserved (reserved-node exclusion becomes active but no node is reserved
    yet).
-4. Implement allocation-time routing in ``prte_ras_base_complete_request``
-   (Cases 2 and 3), guarded by ``#if defined`` on the two alloc keys.
-5. Add ``PRTE_JOB_SPAWN_TARGET`` and the ``PMIX_SPAWN_TARGET`` parsing in the
+4. Add ``prte_session_t::owner`` and ``::inheritance``, with the constructor
+   defaulting ``inheritance`` to the ``PMIX_ALLOC_INHERIT_DEFAULT`` value; still
+   no behavior change.
+5. Implement allocation-time routing in ``prte_ras_base_complete_request``
+   (Cases 2 and 3), guarded by ``#if defined`` on the alloc keys, recording
+   ``owner``, ``owner_job`` (retained), and ``inheritance`` on each new
+   reservation.
+6. Add ``PRTE_JOB_SPAWN_TARGET`` and the ``PMIX_SPAWN_TARGET`` parsing in the
    spawn path, plus the multi-session resolution in ``plm_base_receive.c``.
-6. Return the allocation id to the requester from the alloc response.
-7. Wire reservation release/cleanup into the ``PMIX_ALLOC_RELEASE`` path
+7. Return the allocation id to the requester from the alloc response.
+8. Wire reservation release/cleanup into the ``PMIX_ALLOC_RELEASE`` path
    (owner-initiated, scheduler-initiated, and DVM teardown), clearing
    ``node->session`` before any shrink — see *Session Lifecycle*.
+9. Implement the strict ``CHILD`` drain as a recursive walk of the owning
+   namespace's ``prte_job_t::children`` subtree, rooted at ``session->owner_job``
+   (or, for a tool owner, at the reservation's ``session->jobs``), reusing the
+   parentage tracking ``prte_dump_aborted_procs`` already traverses.  The
+   retained ``owner_job`` from step 5 keeps that subtree reachable after the
+   owning namespace exits.  No counter is introduced.
+10. Drive the namespace-termination disposition from
+    ``PRTE_JOB_STATE_TERMINATED``: on each namespace exit, apply
+    ``NONE``/``DEFAULT`` (owner-keyed) and ``CHILD``/``CHILD_DEFAULT``
+    (transitive-descendant drain, via a recursive ``prte_job_t::children`` walk
+    rooted at the owning namespace) teardowns, distinguishing release from
+    unreserve.  ``DEFAULT`` is in force for every reservation by default, so
+    this step also makes the absent-attribute behavior correct.
+11. Relay the allocation-timeout warning: forward ``PMIX_ALLOC_WARN_TIMEOUT`` to
+    the scheduler and relay ``PMIX_ALLOC_TIMEOUT_WARNING`` back to the
+    requesting process, guarded by ``#if defined``.
 
-Each step builds and is testable on its own; steps 1–3 are behavior-preserving
-groundwork, and the observable feature lands with steps 4–6.
+Each step builds and is testable on its own; steps 1–4 are behavior-preserving
+groundwork, and the observable feature lands with steps 5–11.
 
 Open Questions
 --------------
@@ -663,7 +898,41 @@ Resolved decisions
   job is its own namespace.  A reservation's owners are the namespace it was
   created for plus every job spawned into it; a child job owns only the
   reservation it was spawned into, not the parent's other reservations.
-* **Reservation teardown has three triggers.**  An owner's
-  ``PMIX_ALLOC_RELEASE``, DVM teardown, or scheduler termination of the
-  allocation (e.g. timeout).  A job terminating never releases a reservation.
-  See *Session Lifecycle*.
+* **Reservation teardown has unconditional triggers plus an inheritance
+  disposition.**  The unconditional triggers are an owner's
+  ``PMIX_ALLOC_RELEASE``, DVM teardown, and scheduler termination of the
+  allocation (e.g. timeout).  In addition, namespace termination drives teardown
+  per ``session->inheritance``: ``NONE``/``DEFAULT`` fire when the owning
+  namespace exits, ``CHILD``/``CHILD_DEFAULT`` when the last derived child
+  exits; the ``*_DEFAULT`` variants unreserve into the session rather than
+  returning nodes to the scheduler.  See *Session Lifecycle*.
+* **``CHILD`` tracking is strict transitive-descendant tracking, via the
+  existing parentage system.**  A derived child is *any* transitive spawn
+  descendant of the owning namespace, per the spec and the PMIx inheritance
+  overview — including descendants that run in another session.  The drain
+  condition is computed from the job genealogy (a recursive walk of
+  ``prte_job_t::children``), not from the reservation's owner set.  This reuses
+  the parentage tracking that ``prte_dump_aborted_procs`` already traverses on
+  the termination path, so the tree-walk cost is already borne; a per-reservation
+  descendant counter was considered and rejected.
+* **The owning namespace's job object is retained on the reservation.**  Because
+  a ``CHILD``/``CHILD_DEFAULT`` reservation outlives its owning namespace *O*
+  while descendants run, ``create_reservation`` takes a reference on *O*'s
+  ``prte_job_t`` (``PMIX_RETAIN``) and stores it on the session; the teardown
+  (release or unreserve) drops it.  This keeps *O*'s ``children`` subtree — each
+  job retains its own children — walkable after *O* terminates, so the drain
+  test always has a root.  It mirrors how ``session->jobs`` already retains and
+  releases job objects for the session's lifetime, and adds no new tracking
+  machinery.  ``prte_session_t`` therefore also carries a
+  ``prte_job_t *owner_job`` alongside the ``owner`` nspace.
+* **The default disposition is ``PMIX_ALLOC_INHERIT_DEFAULT``.**  When
+  ``PMIX_ALLOC_INHERITANCE`` is absent, a reservation becomes unreserved within
+  the session when its owning namespace terminates; the legacy "release to the
+  scheduler on termination" behavior requires an explicit
+  ``PMIX_ALLOC_INHERIT_NONE``.  This matches the PMIx inheritance overview, and
+  supersedes the earlier "a job terminating never releases a reservation"
+  decision.
+* **The allocation-timeout warning is relayed, not invented.**  PRRTE forwards
+  ``PMIX_ALLOC_WARN_TIMEOUT`` to the scheduler and relays the scheduler's
+  ``PMIX_ALLOC_TIMEOUT_WARNING`` event only to the requesting process.  See
+  *Allocation timeout warning*.

--- a/docs/plans/node_reservation/node-reservation.rst
+++ b/docs/plans/node_reservation/node-reservation.rst
@@ -1,0 +1,621 @@
+Node Reservation and Session Targeting
+======================================
+
+Overview
+--------
+
+PRRTE already owns the data structures needed to partition an allocation
+into independently mappable pools.  Each ``prte_job_t`` carries a
+``prte_session_t *session`` (``src/runtime/prte_globals.h``), and the mapper
+draws a job's candidate nodes exclusively from ``jdata->session->nodes`` (see
+``prte_rmaps_base_get_target_nodes`` in
+``src/mca/rmaps/base/rmaps_base_support_fns.c``).  The "default" session
+created at startup points its ``nodes`` array directly at the global
+``prte_node_pool`` (``src/runtime/prte_init.c``), so jobs assigned to the
+default session can map onto every node in the allocation.
+
+What is missing is the machinery to (a) place *dynamically* allocated nodes
+into a session other than the default, and (b) let a spawn request select
+which session(s) — i.e. which allocation(s) — its processes may use.  Today
+``prte_ras_base_complete_request`` (``src/mca/ras/base/ras_base_allocate.c``)
+unconditionally inserts every newly allocated node into the global pool via
+``prte_ras_base_node_insert(&ndlist, NULL)``, making all dynamic resources
+visible to every job.
+
+This document specifies the changes required to:
+
+1. Treat the original startup allocation as the default session (no change to
+   observable behavior — documented here for completeness).
+2. Honor ``PMIX_ALLOC_TARGET`` and ``PMIX_ALLOC_RESERVED`` on dynamic
+   allocation requests to decide which session receives the new nodes.
+3. Honor a new ``PMIX_SPAWN_TARGET`` attribute on spawn requests to select the
+   union of allocations a job may map onto.
+
+All three PMIx keys are optional and **must** be compiled out cleanly when the
+installed PMIx headers predate them, preserving backward compatibility.
+
+Goals
+-----
+
+1. Nodes belong to exactly one session.  Unreserved nodes belong to the
+   default session; reserved nodes belong to the session of the namespace (or
+   allocation) that reserved them.
+2. A job maps only onto nodes owned by the session(s) it targets.  With no
+   target specified, behavior is unchanged: the job uses the default session.
+3. Reservation decisions are driven entirely by PMIx attributes supplied by
+   the requester (tool or application); PRRTE invents no policy of its own
+   beyond the defaults specified below.
+4. Code that references ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_RESERVED``, or
+   ``PMIX_SPAWN_TARGET`` is guarded so a PMIx that lacks any of these keys
+   still builds warning-free and behaves as it does today.
+
+Terminology
+-----------
+
+Throughout this document an **allocation** is identified by its
+``PMIX_ALLOC_ID`` string, which PRRTE stores as ``session->alloc_refid``.  A
+**reservation** is a non-default ``prte_session_t`` whose nodes are withheld
+from the default pool and made available only to the owning namespace or to
+jobs that explicitly target the allocation.  The **invalid namespace** is the
+sentinel (``PMIX_NSPACE_INVALID`` / an empty allocation id) that, when used as
+a spawn target, denotes the default session.
+
+A word on jobs and namespaces, since the two are sometimes conflated.  **Every
+job is its own namespace**, and a namespace maps to exactly one job: there is
+no way to run job A and later run job B under the same namespace.  All app
+contexts within a single job share that one namespace.  Two distinct jobs are
+always two distinct namespaces, even when they run in the same session.
+Consequently, "the namespace's reservation" always means "this one job's
+reservation," and any process within a job (i.e. within that namespace) may
+spawn new jobs onto resources reserved for its namespace.
+
+A reservation therefore has a **set of owning namespaces**, not a single owner.
+The set is seeded with the namespace the reservation is created for, and it
+grows by one each time a job is spawned *into* the reservation: a child job
+spawned into a reservation becomes an owner of that reservation (so it, in
+turn, may spawn further jobs onto those nodes).  Ownership is **not inherited**
+transitively — a child owns only the reservation it was spawned into, not any
+*other* reservations its parent happens to own.  The scheduler is treated as an
+implicit owner of every session.
+
+The Three Allocation Cases
+--------------------------
+
+Case 1 — Original allocation detected at DVM startup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The nodes discovered by the RAS at startup form the default session.  This is
+already implemented: ``prte_init.c`` constructs ``prte_default_session`` with
+``session_id == UINT32_MAX`` and aliases its ``nodes`` array to
+``prte_node_pool``.  Every job that does not target a reservation is assigned
+this session and may use any node in it.  **No code change is required**; the
+behavior is restated here because it anchors the semantics of the other cases.
+
+Case 2 — Dynamic allocation requested by a tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A tool (a PMIx process with no session of its own — e.g. the scheduler or a
+``prun``-class client) issues ``PMIx_Allocation_request``.  The new nodes are
+routed as follows:
+
+* ``PMIX_ALLOC_TARGET`` given (a target namespace): the new nodes are reserved
+  to that namespace.  A ``PMIX_ALLOC_NEW`` directive mints a fresh reservation
+  owned by the target namespace; a ``PMIX_ALLOC_EXTEND`` directive adds the
+  nodes to the existing reservation named by the request's ``PMIX_ALLOC_ID``,
+  provided the target namespace owns it.
+* ``PMIX_ALLOC_TARGET`` absent: the new nodes are reserved to the *tool's own*
+  namespace, so that processes the tool subsequently launches via
+  ``PMIx_Spawn`` land on them by default.
+* ``PMIX_ALLOC_TARGET`` absent **and** ``PMIX_ALLOC_RESERVED`` present and set
+  to ``false``: the new nodes go into the default session and are available to
+  all namespaces.
+
+Case 3 — Dynamic allocation requested by an application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An application process (one whose namespace owns a ``prte_job_t``) issues the
+request:
+
+* Default: the new nodes are reserved to the requesting process's namespace.
+  Any process in that namespace may spawn jobs against them.
+* ``PMIX_ALLOC_RESERVED`` present and set to ``false``: the new nodes go into
+  the default session for general use.
+
+Note that ``PMIX_ALLOC_TARGET`` is honored only for tool requesters (Case 2);
+an application cannot redirect a reservation to a *different* namespace.  An
+application request carrying ``PMIX_ALLOC_TARGET`` is rejected with
+``PMIX_ERR_NO_PERMISSIONS``.
+
+Decision summary
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 20 35
+
+   * - Requester
+     - ``PMIX_ALLOC_TARGET``
+     - ``PMIX_ALLOC_RESERVED``
+     - Destination session
+   * - Tool
+     - ``<nspace>``
+     - any/absent
+     - session owned by ``<nspace>``
+   * - Tool
+     - absent
+     - absent or ``true``
+     - session owned by the tool's namespace
+   * - Tool
+     - absent
+     - ``false``
+     - default session
+   * - Application
+     - absent
+     - absent or ``true``
+     - session owned by the app's namespace
+   * - Application
+     - absent
+     - ``false``
+     - default session
+   * - Application
+     - present
+     - any
+     - rejected (``PMIX_ERR_NO_PERMISSIONS``)
+
+Data Structure Changes
+----------------------
+
+Node-to-session backpointer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``prte_node_t`` (``src/runtime/prte_globals.h``) gains a back-reference to its
+owning session:
+
+.. code-block:: c
+
+   /* session that owns this node; NULL means the node belongs to the
+    * default session (the general, unreserved pool). Not reference-counted
+    * to avoid an ownership cycle with prte_session_t->nodes. */
+   prte_session_t *session;
+
+The pointer is **not** retained: the session already holds the authoritative
+references to its nodes through ``session->nodes``, and a node never outlives
+its session.  The constructor in ``src/runtime/prte_globals.c`` initializes the
+field to ``NULL``; the destructor clears it without releasing.
+
+This backpointer is what lets the *default* session — whose ``nodes`` array is
+the entire global pool — exclude nodes that have been reserved elsewhere.  A
+node is considered part of the default session iff ``node->session == NULL``.
+
+Session ownership and lookup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because a reservation has a *set* of owning namespaces (see Terminology),
+``prte_session_t`` gains an owners list and a reserved flag:
+
+.. code-block:: c
+
+   /* namespaces entitled to spawn onto this session's nodes. Seeded with the
+    * namespace the reservation was created for, then extended with each job
+    * spawned into the session. Empty for the default session (which everyone
+    * may use) and for scheduler-instantiated sessions not owned by a
+    * namespace. Stored as an argv-style array of nspace strings. */
+   char **owners;
+
+An argv-style array of namespace strings is used rather than an array of
+``pmix_nspace_t`` so the ``PMIx_Argv_*`` helpers can manage membership.  The
+constructor initializes it to ``NULL``; the destructor frees it with
+``PMIx_Argv_free``.
+
+A new session flag is added in ``src/util/attr.h`` alongside
+``PRTE_SESSION_FLAG_DYNAMIC``:
+
+.. code-block:: c
+
+   #define PRTE_SESSION_FLAG_RESERVED   0x0002 // nodes withheld from default pool
+
+Two helpers are added in ``src/runtime/prte_globals.{h,c}``:
+
+.. code-block:: c
+
+   /* True if nspace is in session->owners, or session is the default session,
+    * or nspace is the scheduler. */
+   PRTE_EXPORT bool prte_session_is_owned_by(prte_session_t *session,
+                                             const pmix_nspace_t nspace);
+
+   /* Add nspace to session->owners if not already present (no-op for the
+    * default session). Called when a reservation is created and each time a
+    * job is spawned into the session. */
+   PRTE_EXPORT void prte_session_add_owner(prte_session_t *session,
+                                           const pmix_nspace_t nspace);
+
+No new "lookup by owner" helper is introduced: because a namespace may own
+several reservations, owner is not a unique key.  Existing reservations are
+located by their allocation id with the existing
+``prte_get_session_object_from_id`` (which matches ``session->alloc_refid``),
+and ownership is then checked with ``prte_session_is_owned_by``.
+
+New job attribute for spawn targeting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new ``PRTE_JOB_*`` key carries the resolved spawn target list on the
+``prte_job_t`` so it survives the pack/unpack to the HNP.  The next free key
+after ``PRTE_JOB_DO_NOT_SPAWN = PRTE_JOB_START_KEY + 123`` is used:
+
+.. code-block:: c
+
+   /* Comma-delimited list of PMIX_ALLOC_ID strings naming the allocations
+    * (sessions) whose nodes this job may map onto. An empty token denotes the
+    * default session. Populated from PMIX_SPAWN_TARGET. */
+   #define PRTE_JOB_SPAWN_TARGET   (PRTE_JOB_START_KEY + 124) // char*
+
+``PRTE_JOB_MAX_KEY`` already allows headroom (``+200``); no bump is required.
+
+Allocation-Time Handling
+------------------------
+
+All reservation routing happens in ``prte_ras_base_complete_request``
+(``src/mca/ras/base/ras_base_allocate.c``), which already runs on the progress
+thread and already parses ``PMIX_ALLOC_NODE_LIST`` for the ``PMIX_ALLOC_EXTEND``
+and ``PMIX_ALLOC_NEW`` directives.  The node-insertion call there is currently:
+
+.. code-block:: c
+
+   ret = prte_ras_base_node_insert(&ndlist, NULL);
+
+The change is to first resolve the destination session, then place the new
+nodes into both the global pool (so daemons launch and the nidmap is complete)
+and, when reserving, into the destination session with the backpointer set.
+
+Resolving the destination session
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The requester is ``req->tproc`` (recorded in ``pmix_server_alloc_fn``).  A
+requester is an **application** iff ``prte_get_job_data_object(req->tproc.nspace)``
+returns a non-tool job; otherwise it is a **tool**.  The directive scan in
+``prte_ras_base_complete_request`` is extended to read the two new keys:
+
+.. code-block:: c
+
+   char *target = NULL;        /* PMIX_ALLOC_TARGET namespace, if any */
+   bool reserved = true;       /* default: reserve */
+   bool have_reserved = false;
+
+   for (n = 0; n < req->ninfo; n++) {
+   #if defined(PMIX_ALLOC_TARGET)
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_TARGET)) {
+           target = req->info[n].value.data.string;
+           continue;
+       }
+   #endif
+   #if defined(PMIX_ALLOC_RESERVED)
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_RESERVED)) {
+           reserved = PMIX_INFO_TRUE(&req->info[n]);
+           have_reserved = true;
+           continue;
+       }
+   #endif
+       /* ... existing PMIX_ALLOC_NODE_LIST handling ... */
+   }
+
+Destination resolution then follows the decision table, with the allocation
+*directive* deciding whether a reservation is created or extended:
+
+.. code-block:: c
+
+   prte_session_t *dest;
+   prte_job_t *reqjob = prte_get_job_data_object(req->tproc.nspace);
+   bool is_tool = (NULL == reqjob) || PRTE_FLAG_TEST(reqjob, PRTE_JOB_FLAG_TOOL);
+
+   /* the namespace the reservation is created for / must be owned by */
+   const char *owner_nspace = (NULL != target) ? target : req->tproc.nspace;
+
+   if (have_reserved && !reserved) {
+       dest = prte_default_session;            /* general use */
+   } else if (NULL != target && !is_tool) {
+       req->pstatus = PMIX_ERR_NO_PERMISSIONS; /* app may not retarget */
+       return;
+   } else if (PMIX_ALLOC_EXTEND == req->allocdir) {
+       /* extend an existing reservation named by its alloc id */
+       dest = prte_get_session_object_from_id(/* PMIX_ALLOC_ID from req->info */);
+       if (NULL == dest ||
+           !prte_session_is_owned_by(dest, req->tproc.nspace)) {
+           req->pstatus = (NULL == dest) ? PMIX_ERR_NOT_FOUND
+                                         : PMIX_ERR_NO_PERMISSIONS;
+           return;
+       }
+   } else {                                    /* PMIX_ALLOC_NEW */
+       dest = create_reservation(owner_nspace);
+   }
+
+``create_reservation(nspace)`` allocates a new ``prte_session_t``, assigns a
+fresh ``session_id`` and ``alloc_refid``, sets ``flags |=
+PRTE_SESSION_FLAG_RESERVED | PRTE_SESSION_FLAG_DYNAMIC``, seeds the owners list
+with ``prte_session_add_owner(dest, nspace)``, and registers it with
+``prte_set_session_object``.  A ``PMIX_ALLOC_NEW`` request always mints a new
+reservation; the same namespace may thus own several, each distinguished by its
+allocation id.
+
+When the installed PMIx lacks ``PMIX_ALLOC_TARGET``, the ``target`` guard keeps
+it ``NULL`` so ``owner_nspace`` is always the requester's namespace — the
+behavior required when the key is unavailable.  Likewise, without
+``PMIX_ALLOC_RESERVED`` the ``reserved`` default of ``true`` means a bare
+``PMIX_ALLOC_NEW`` reserves to the requester's namespace.
+
+Placing the nodes
+~~~~~~~~~~~~~~~~~~
+
+The new nodes are always inserted into the global pool so the DVM can launch
+daemons on them and the nidmap stays complete (this is unchanged and is what
+drives ``PRTE_JOB_EXTEND_DVM`` / ``PRTE_JOB_STATE_LAUNCH_DAEMONS``).  When
+``dest`` is not the default session, the same node objects are additionally
+registered with the reservation:
+
+.. code-block:: c
+
+   ret = prte_ras_base_node_insert(&ndlist, NULL);   /* into global pool */
+   /* ... existing error handling ... */
+
+   if (dest != prte_default_session) {
+       for (each newly inserted node nd) {
+           nd->session = dest;                 /* withhold from default pool */
+           PMIX_RETAIN(nd);
+           pmix_pointer_array_add(dest->nodes, nd);
+       }
+   }
+
+The reservation holds **references** to the global node objects, not copies.
+This keeps live state — ``node->daemon``, ``slots_inuse``, ``topology`` — in a
+single place, which the mapper and the launch path both rely on.  (The SLURM
+RAS dynamic path in ``ras_slurm_module.c`` currently stores ``prte_node_copy``
+results in ``session->nodes``; reconciling that path to references is tracked
+as a follow-up below.)
+
+Because reserved nodes carry ``node->session != NULL``, they are automatically
+excluded from the default session even though they remain in the global pool
+that ``prte_default_session->nodes`` aliases.  The mapper changes below
+implement that exclusion.
+
+Reporting the allocation id back to the requester
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+So a tool or application can later target the reservation, the response info
+returned through ``req->infocbfunc`` includes the destination's
+``alloc_refid`` as ``PMIX_ALLOC_ID`` (and, when newly minted, ``PMIX_ALLOC_REQ_ID``
+echoing any user-supplied ``PMIX_ALLOC_REQ_ID``).  This reuses the existing
+response array assembly in ``pmix_server_alloc_request_resp``.
+
+Spawn-Time Handling
+-------------------
+
+Selecting the target session(s)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A spawn request may carry ``PMIX_SPAWN_TARGET`` whose value is either:
+
+* a single ``PMIX_ALLOC_ID`` string (``PMIX_STRING``), or
+* an array of ``PMIX_ALLOC_ID`` strings (``pmix_data_array_t*`` of
+  ``PMIX_STRING``).
+
+Each entry names an allocation (session via ``alloc_refid``).  An entry whose
+value is the invalid namespace / empty allocation id denotes the default
+session.  Resolution rules:
+
+* ``PMIX_SPAWN_TARGET`` absent, or present but naming only the invalid
+  namespace: the job uses the **default** session — unchanged behavior.
+* One or more valid allocation ids given: the job may map onto the **union** of
+  those sessions' nodes.  Including an invalid-namespace entry alongside valid
+  ids adds the default pool to the union (the documented way to request
+  "reserved plus default").
+* A named allocation id that resolves to no session is a fatal error for the
+  spawn (``PMIX_ERR_NOT_FOUND``), consistent with the existing handling of an
+  unknown ``PRTE_JOB_SESSION_ID``.
+* A named allocation id that resolves to a session the requester does not own
+  is rejected with ``PMIX_ERR_NO_PERMISSIONS``.  A requester may target only
+  the default session (via the invalid namespace) and reservations owned by
+  its own namespace; see *Ownership check* below.
+
+Ownership check
+~~~~~~~~~~~~~~~~
+
+A spawn may only target allocations the requester is entitled to use.  The
+requester is the spawning process recorded as the job's launch proxy
+(``PRTE_JOB_LAUNCH_PROXY`` / ``nptr`` in ``plm_base_receive.c``).  A targeted
+session ``S`` passes the ownership check iff any of:
+
+* ``S`` is the default session (named by the invalid namespace), which is
+  always permitted; or
+* the requester's namespace is in ``S->owners`` — i.e. it created the
+  reservation or was previously spawned into it; or
+* the requester *is* the scheduler, which may target any session.
+
+All three are folded into ``prte_session_is_owned_by(S, requester_nspace)``.
+
+Each entry in the resolved target set is validated against this check on the
+HNP, where the authoritative session objects and the requester identity are
+both known.  A failing entry rejects the entire spawn with
+``PMIX_ERR_NO_PERMISSIONS`` rather than silently dropping the target, so the
+caller learns its request was not honored.  This mirrors the allocation-time
+rule that an application may not retarget a reservation to a foreign
+namespace.
+
+This is handled where the spawn request is unpacked and ``PMIX_SPAWN_TARGET``
+is available, in the PMIx server spawn path
+(``src/prted/pmix/pmix_server_dyn.c``), under:
+
+.. code-block:: c
+
+   #if defined(PMIX_SPAWN_TARGET)
+       /* flatten the single string or string array into a comma-delimited
+        * list and stash it as PRTE_JOB_SPAWN_TARGET on the jdata */
+   #endif
+
+When the key is unavailable, ``PRTE_JOB_SPAWN_TARGET`` is never set and every
+path below falls through to the existing default/parent-session logic.
+
+Carrying the target to the HNP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The resolved target list rides on the job as ``PRTE_JOB_SPAWN_TARGET`` and is
+packed/unpacked with the rest of the job attributes.  On the HNP,
+``plm_base_receive.c`` already resolves a single session from
+``PRTE_JOB_SESSION_ID`` / ``PRTE_JOB_ALLOC_ID`` / ``PRTE_JOB_REF_ID`` before
+falling back to the parent session.  That block is extended so that, when
+``PRTE_JOB_SPAWN_TARGET`` is present, it resolves the (possibly multiple)
+sessions named there.  The existing single-session attributes continue to work
+and are treated as a one-element target set.
+
+Each resolved session is validated against the ownership check described above
+before it is admitted to the target set.  Once admitted, the spawned job's
+namespace is added as an owner of that reservation with
+``prte_session_add_owner(S, jdata->nspace)`` — this is what makes the child a
+co-owner of the reservation it was spawned into, so it may in turn spawn
+further jobs onto those nodes.  The default session is never modified by this
+step (``prte_session_add_owner`` is a no-op for it), and the child gains
+ownership of *only* the reservations it was spawned into, never the other
+reservations its parent may own — ownership does not propagate transitively.
+
+``jdata->session`` retains its present meaning as the job's *primary* session
+(used for accounting, refids, and the ``session->jobs`` linkage).  It is set to
+the first valid targeted session, or to the default session when only the
+invalid namespace is targeted.  The full target set drives mapping.
+
+Mapping Changes
+---------------
+
+``prte_rmaps_base_get_target_nodes``
+(``src/mca/rmaps/base/rmaps_base_support_fns.c``) is generalized from "iterate
+``jdata->session->nodes``" to "iterate the candidate pool defined by the job's
+target session set."  Define the membership predicate:
+
+.. code-block:: c
+
+   /* The session a node belongs to for targeting purposes. */
+   static inline prte_session_t *node_owning_session(prte_node_t *nd)
+   {
+       return (NULL == nd->session) ? prte_default_session : nd->session;
+   }
+
+   /* True if nd is usable by a job targeting the given set of sessions. */
+   static bool node_in_targets(prte_node_t *nd,
+                               prte_session_t **targets, size_t ntargets);
+
+Both node-collection branches in ``get_target_nodes`` change:
+
+* The dash-host / hostfile branch (which matches user-named nodes against the
+  session) matches against the global pool but **accepts a match only if the
+  node passes** ``node_in_targets``.
+* The ``addknown`` branch, which currently walks ``jdata->session->nodes``,
+  walks the global ``prte_node_pool`` and includes a node iff it passes
+  ``node_in_targets``.
+
+For a job with no spawn target (the overwhelmingly common case) the target set
+is ``{ prte_default_session }``, so ``node_in_targets`` accepts exactly the
+nodes with ``node->session == NULL`` — i.e. the unreserved pool — and rejects
+reserved nodes.  This is the only behavioral change for existing jobs: they no
+longer see nodes that some other namespace has reserved, which is the intended
+isolation.
+
+For a reserved-session job the target set is ``{ that session }`` (optionally
+unioned with the default session when the invalid namespace is also targeted),
+and ``node_in_targets`` accepts exactly the reserved nodes (plus the default
+pool when requested).
+
+Backward Compatibility
+-----------------------
+
+* ``PMIX_ALLOC_TARGET``, ``PMIX_ALLOC_RESERVED``, and ``PMIX_SPAWN_TARGET`` are
+  referenced only inside ``#if defined(<key>)`` blocks.  These keys are plain
+  string ``#define``\ s supplied by PMIx; their mere presence in
+  ``pmix_common.h`` is the availability signal, so ``#if defined`` (not the
+  logical-macro ``#if FOO`` idiom) is the correct guard here.  Where a future
+  PMIx exposes a capability flag for any of these, the guard can be migrated to
+  the ``PRTE_CHECK_PMIX_CAP`` mechanism in ``config/prte_setup_pmix.m4`` and a
+  configure-defined ``PRTE_HAVE_*`` macro.
+* With an older PMIx that lacks all three keys, ``target`` is always ``NULL``,
+  ``reserved`` is never observed, and ``PRTE_JOB_SPAWN_TARGET`` is never set.
+  Dynamic allocations then fall to the "reserve to the requester's namespace"
+  default — which, combined with the mapping change, still partitions
+  resources sensibly — while spawns continue to use the default/parent session
+  exactly as today.  No new warnings are introduced under
+  ``--enable-devel-check``.
+
+Session Lifecycle
+-----------------
+
+A reservation is **not** tied to the lifetime of any single job.  Because every
+job is its own namespace, the jobs that run in a reservation come and go while
+the reservation persists; a job terminating (even the one that created the
+reservation) does not release it.  A reservation lives until one of exactly
+three events occurs:
+
+1. **An owner issues** ``PMIX_ALLOC_RELEASE`` for the reservation's allocation
+   id.  Any namespace in ``session->owners`` may release it; the scheduler may
+   release any reservation.
+2. **The DVM tears down.**  All sessions, default and reserved alike, are
+   destroyed with the DVM.
+3. **The scheduler terminates the allocation** — for example on a timeout
+   (``session->timeout``) or an administrative reclaim.  This arrives as a
+   scheduler-driven release for the allocation id.
+
+In all three cases the release runs through the existing
+``prte_ras_base_release_allocation`` path.  Releasing a reservation must, in
+order: clear ``node->session`` on each member node (so any node that survives
+in the DVM falls back to the default pool), drop the reservation's retained
+references in ``session->nodes``, and only then proceed with any DVM shrink for
+nodes that are being returned to the scheduler.  The clear-before-shrink
+ordering keeps the reservation bookkeeping from racing the shrink-campaign
+accounting (``prte_dvm_launch_fence`` / ``prte_shrink_campaigns``).
+
+Implementation Order
+--------------------
+
+1. Add ``prte_node_t::session`` backpointer plus constructor/destructor
+   handling; no behavior change yet.
+2. Add ``prte_session_t::owners``, ``PRTE_SESSION_FLAG_RESERVED``, and the
+   ``prte_session_is_owned_by`` / ``prte_session_add_owner`` helpers.
+3. Generalize ``get_target_nodes`` to the target-session-set predicate, with
+   the default target set ``{ prte_default_session }`` so existing behavior is
+   preserved (reserved-node exclusion becomes active but no node is reserved
+   yet).
+4. Implement allocation-time routing in ``prte_ras_base_complete_request``
+   (Cases 2 and 3), guarded by ``#if defined`` on the two alloc keys.
+5. Add ``PRTE_JOB_SPAWN_TARGET`` and the ``PMIX_SPAWN_TARGET`` parsing in the
+   spawn path, plus the multi-session resolution in ``plm_base_receive.c``.
+6. Return the allocation id to the requester from the alloc response.
+7. Wire reservation release/cleanup into the ``PMIX_ALLOC_RELEASE`` path
+   (owner-initiated, scheduler-initiated, and DVM teardown), clearing
+   ``node->session`` before any shrink — see *Session Lifecycle*.
+
+Each step builds and is testable on its own; steps 1–3 are behavior-preserving
+groundwork, and the observable feature lands with steps 4–6.
+
+Open Questions
+--------------
+
+1. **SLURM RAS reconciliation.**  ``ras_slurm_module.c`` stores
+   ``prte_node_copy`` results in ``session->nodes`` rather than references to
+   the global node objects.  The reference-based model here is incompatible
+   with copies (the mapper would see daemon-less duplicates).  Recommendation:
+   migrate the SLURM dynamic-session path to references for a single,
+   consistent model.  A source-code note has been added at the copy site to
+   flag the required change.
+
+Resolved decisions
+~~~~~~~~~~~~~~~~~~~
+
+* **Default ``PMIX_ALLOC_RESERVED`` means "reserve."**  An
+  ``ALLOC_RESERVED``-absent dynamic request reserves the nodes to the
+  requester's (or target's) namespace; only an explicit
+  ``PMIX_ALLOC_RESERVED == false`` routes nodes to the default pool.
+* **``PMIX_SPAWN_TARGET`` is limited by an ownership check.**  A requester may
+  target only the default session and reservations its namespace owns (the
+  scheduler excepted).  See *Ownership check* above.
+* **Ownership is a set, conferred by spawning-into, and not inherited.**  Every
+  job is its own namespace.  A reservation's owners are the namespace it was
+  created for plus every job spawned into it; a child job owns only the
+  reservation it was spawned into, not the parent's other reservations.
+* **Reservation teardown has three triggers.**  An owner's
+  ``PMIX_ALLOC_RELEASE``, DVM teardown, or scheduler termination of the
+  allocation (e.g. timeout).  A job terminating never releases a reservation.
+  See *Session Lifecycle*.

--- a/docs/plans/node_reservation/node-reservation.rst
+++ b/docs/plans/node_reservation/node-reservation.rst
@@ -78,14 +78,22 @@ Consequently, "the namespace's reservation" always means "this one job's
 reservation," and any process within a job (i.e. within that namespace) may
 spawn new jobs onto resources reserved for its namespace.
 
-A reservation therefore has a **set of owning namespaces**, not a single owner.
-The set is seeded with the namespace the reservation is created for, and it
-grows by one each time a job is spawned *into* the reservation: a child job
-spawned into a reservation becomes an owner of that reservation (so it, in
-turn, may spawn further jobs onto those nodes).  Ownership is **not inherited**
-transitively — a child owns only the reservation it was spawned into, not any
-*other* reservations its parent happens to own.  The scheduler is treated as an
-implicit owner of every session.
+A reservation distinguishes two related but distinct notions.  Its **owning
+namespace** is the single namespace it was created for (the
+``PMIX_ALLOC_TARGET`` namespace, else the requester) — recorded as
+``session->owner`` — and it is the namespace whose termination drives the
+inheritance disposition.  Separately, the reservation carries a **set of
+owners** (``session->owners``): the *authorization* set of namespaces entitled
+to map onto and target the reservation.  That set is seeded with the owning
+namespace and grows by one each time a job is spawned *into* the reservation: a
+child job becomes an owner (so it, in turn, may spawn further jobs onto those
+nodes).  Authorization is **not inherited** transitively — a child owns only
+the reservation it was spawned into, not any *other* reservations its parent
+happens to own.  The scheduler is treated as an implicit owner of every session.
+(For the ``CHILD``-flavored inheritance rules, the namespaces whose drain ends a
+reservation are the owning namespace's transitive spawn *descendants*, a
+genealogy-derived set distinct from this authorization set — see *Session
+Lifecycle*.)
 
 The Three Allocation Cases
 --------------------------
@@ -199,8 +207,9 @@ node is considered part of the default session iff ``node->session == NULL``.
 Session ownership and lookup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because a reservation has a *set* of owning namespaces (see Terminology),
-``prte_session_t`` gains an owners list and a reserved flag:
+Because a reservation has a *set* of owner namespaces for authorization (see
+Terminology), distinct from its single owning namespace, ``prte_session_t``
+gains an owners list and a reserved flag:
 
 .. code-block:: c
 
@@ -517,10 +526,13 @@ registered with the reservation:
 
 The reservation holds **references** to the global node objects, not copies.
 This keeps live state — ``node->daemon``, ``slots_inuse``, ``topology`` — in a
-single place, which the mapper and the launch path both rely on.  (The SLURM
-RAS dynamic path in ``ras_slurm_module.c`` currently stores ``prte_node_copy``
-results in ``session->nodes``; reconciling that path to references is tracked
-as a follow-up below.)
+single place, which the mapper and the launch path both rely on.  This is a
+hard invariant: a session's ``nodes`` array must never contain
+``prte_node_copy`` duplicates, only retained references to the global pool's
+node objects.  The SLURM RAS dynamic path
+(``prte_ras_slurm_assign_new_session`` in ``ras_slurm_module.c``) is the one
+place that violates it today; it is migrated to references as part of this work
+(see *Resolved decisions* and *Implementation Order*).
 
 Because reserved nodes carry ``node->session != NULL``, they are automatically
 excluded from the default session even though they remain in the global pool
@@ -869,23 +881,39 @@ Implementation Order
 11. Relay the allocation-timeout warning: forward ``PMIX_ALLOC_WARN_TIMEOUT`` to
     the scheduler and relay ``PMIX_ALLOC_TIMEOUT_WARNING`` back to the
     requesting process, guarded by ``#if defined``.
+12. Migrate ``prte_ras_slurm_assign_new_session`` (``ras_slurm_module.c``) from
+    ``prte_node_copy`` into ``session->nodes`` to inserting its nodes into the
+    global pool and storing retained references with ``node->session`` set —
+    the same reference model the base path uses.  Depends only on step 1
+    (``node->session``); it can land any time after it and is testable in a
+    SLURM allocation independent of the rest.
 
-Each step builds and is testable on its own; steps 1–4 are behavior-preserving
-groundwork, and the observable feature lands with steps 5–11.
+Each step builds and is testable on its own; steps 1–4 (and 12) are
+behavior-preserving groundwork, and the observable feature lands with steps
+5–11.
 
 Open Questions
 --------------
 
-1. **SLURM RAS reconciliation.**  ``ras_slurm_module.c`` stores
-   ``prte_node_copy`` results in ``session->nodes`` rather than references to
-   the global node objects.  The reference-based model here is incompatible
-   with copies (the mapper would see daemon-less duplicates).  Recommendation:
-   migrate the SLURM dynamic-session path to references for a single,
-   consistent model.  A source-code note has been added at the copy site to
-   flag the required change.
+No open *design* questions remain; the decisions that shape observable
+behavior are settled below.  What is left for the implementer is purely to
+locate a few exact code sites (the inbound timeout-warning handler, the
+``PMIX_ALLOC_ID`` extraction in the ``EXTEND`` lookup, and the carrier that
+threads the resolved target set into the mapper); none of these changes the
+design.
 
 Resolved decisions
 ~~~~~~~~~~~~~~~~~~~
+
+* **The SLURM RAS holds references, never copies.**  A session's ``nodes``
+  array must contain only retained references to the global pool's node
+  objects, with ``node->session`` set — never ``prte_node_copy`` duplicates,
+  which would be daemon-less and unusable by the mapper and launch path.
+  ``prte_ras_slurm_assign_new_session`` (``ras_slurm_module.c``) is the one
+  site that copies today; it is migrated to insert its nodes into the global
+  pool and store references in ``session->nodes`` exactly as the base
+  allocation path does.  This is a hard invariant of the reference-based model,
+  not an optional cleanup.
 
 * **Default (``PMIX_ALLOC_SHARE`` absent) means "reserve."**  An
   ``ALLOC_SHARE``-absent dynamic request reserves the nodes to the

--- a/docs/plans/node_reservation/node-reservation.rst
+++ b/docs/plans/node_reservation/node-reservation.rst
@@ -275,6 +275,10 @@ reservation was created for, whose termination drives the ``NONE`` and
     * namespace terminates. NULL for the default session. Released at teardown. */
    prte_job_t *owner_job;
 
+   /* The process that requested this allocation (req->tproc). Target of the
+    * relayed PMIX_ALLOC_TIMEOUT_WARNING. Refreshed on EXTEND. */
+   pmix_proc_t requestor;
+
    /* Disposition recorded at creation, governing teardown when the owning
     * namespace (NONE/DEFAULT) or the last derived child (CHILD/CHILD_DEFAULT)
     * terminates. Stored as the uint8_t underlying pmix_alloc_inheritance_t so
@@ -286,12 +290,12 @@ The ``inheritance`` field is typed ``uint8_t`` rather than
 ``pmix_alloc_inheritance_t`` so the struct compiles even when the installed
 PMIx predates the type; the four disposition constants are only referenced
 inside ``#if defined`` guards.  The constructor sets ``owner`` empty,
-``owner_job`` to ``NULL``, and ``inheritance`` to the default-disposition value
-(``PMIX_ALLOC_INHERIT_DEFAULT`` when defined, else the equivalent "unreserve on
-owning-namespace termination" behavior, which is what an inheritance-unaware
-build performs unconditionally).  The destructor releases ``owner_job`` if still
-set, so DVM teardown (which runs the session destructor directly) also balances
-the reference.
+``owner_job`` to ``NULL``, ``requestor`` to an invalid proc, and ``inheritance``
+to the default-disposition value (``PMIX_ALLOC_INHERIT_DEFAULT`` when defined,
+else the equivalent "unreserve on owning-namespace termination" behavior, which
+is what an inheritance-unaware build performs unconditionally).  The destructor
+releases ``owner_job`` if still set, so DVM teardown (which runs the session
+destructor directly) also balances the reference.
 
 For the ``CHILD``-flavored dispositions, teardown is deferred until the owning
 namespace and **all of its derived children** — the full transitive spawn
@@ -410,6 +414,8 @@ returns a non-tool job; otherwise it is a **tool**.  The directive scan in
    bool have_share = false;
    uint8_t inherit = PRTE_INHERIT_DEFAULT_VALUE;  /* see below */
    bool have_inherit = false;
+   char *alloc_id = NULL;      /* PMIX_ALLOC_ID (scheduler-assigned) */
+   char *req_id = NULL;        /* PMIX_ALLOC_REQ_ID (user-provided) */
 
    for (n = 0; n < req->ninfo; n++) {
    #if defined(PMIX_ALLOC_TARGET)
@@ -432,6 +438,14 @@ returns a non-tool job; otherwise it is a **tool**.  The directive scan in
            continue;
        }
    #endif
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+           alloc_id = req->info[n].value.data.string;
+           continue;
+       }
+       if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+           req_id = req->info[n].value.data.string;
+           continue;
+       }
        /* PMIX_ALLOC_WARN_TIMEOUT is not consumed here: it is left in
         * req->info to be forwarded verbatim to the scheduler; see
         * "Allocation timeout warning" below. */
@@ -465,8 +479,18 @@ Destination resolution then follows the decision table, with the allocation
        req->pstatus = PMIX_ERR_NO_PERMISSIONS; /* app may not retarget */
        return;
    } else if (PMIX_ALLOC_EXTEND == req->allocdir) {
-       /* extend an existing reservation named by its alloc id */
-       dest = prte_get_session_object_from_id(/* PMIX_ALLOC_ID from req->info */);
+       /* extend an existing reservation named by either identifier:
+        * PMIX_ALLOC_ID matches session->alloc_refid, PMIX_ALLOC_REQ_ID
+        * matches session->user_refid. ALLOC_ID is tried first. */
+       dest = (NULL != alloc_id) ? prte_get_session_object_from_id(alloc_id)
+                                 : NULL;
+       if (NULL == dest && NULL != req_id) {
+           dest = prte_get_session_object_from_refid(req_id);
+       }
+       if (NULL == alloc_id && NULL == req_id) {
+           req->pstatus = PMIX_ERR_BAD_PARAM;  /* nothing names the target */
+           return;
+       }
        if (NULL == dest ||
            !prte_session_is_owned_by(dest, req->tproc.nspace)) {
            req->pstatus = (NULL == dest) ? PMIX_ERR_NOT_FOUND
@@ -477,14 +501,22 @@ Destination resolution then follows the decision table, with the allocation
        dest = create_reservation(owner_nspace);
    }
 
+Both ``prte_get_session_object_from_id`` (``alloc_refid`` / ``PMIX_ALLOC_ID``)
+and ``prte_get_session_object_from_refid`` (``user_refid`` / ``PMIX_ALLOC_REQ_ID``)
+already exist, so an ``EXTEND`` may be named by the scheduler-assigned id or the
+requester's own request id; an ``EXTEND`` carrying neither is rejected with
+``PMIX_ERR_BAD_PARAM``.
+
 ``create_reservation(nspace, inherit)`` allocates a new ``prte_session_t``,
 assigns a fresh ``session_id`` and ``alloc_refid``, sets ``flags |=
 PRTE_SESSION_FLAG_RESERVED | PRTE_SESSION_FLAG_DYNAMIC``, records the owning
 namespace (``PMIX_LOAD_NSPACE(dest->owner, nspace)``) and the disposition
-(``dest->inheritance = inherit``), takes and stores a retained reference to the
-owning namespace's job object when one exists (``dest->owner_job`` via
-``PMIX_RETAIN``; it is ``NULL`` for a tool requester that has no job), seeds the
-owners list with ``prte_session_add_owner(dest, nspace)``, and registers it with
+(``dest->inheritance = inherit``), records the requesting process
+(``PMIX_XFER_PROCID(&dest->requestor, &req->tproc)`` for the timeout-warning
+relay), takes and stores a retained reference to the owning namespace's job
+object when one exists (``dest->owner_job`` via ``PMIX_RETAIN``; it is ``NULL``
+for a tool requester that has no job), seeds the owners list with
+``prte_session_add_owner(dest, nspace)``, and registers it with
 ``prte_set_session_object``.  A ``PMIX_ALLOC_NEW`` request always mints a new
 reservation; the same namespace may thus own several, each distinguished by its
 allocation id.  On a ``PMIX_ALLOC_EXTEND`` that carried an inheritance value,
@@ -562,14 +594,36 @@ warning.  Two directions are involved:
   backing scheduler, there is no timeout source and the attribute is simply
   never acted upon — the advisory contract permits this.
 
-* **Event (inbound).**  When the scheduler fires ``PMIX_ALLOC_TIMEOUT_WARNING``,
-  it is delivered to the HNP through the existing PMIx event channel.  PRRTE
-  relays it **only to the process that requested the allocation** — a directed
-  notification, not a DVM-wide broadcast — by setting the event range to that
-  process (the requester recorded as the reservation's creator, ``tproc`` on
-  the originating request).  The relayed payload carries the same
-  ``PMIX_ALLOC_ID``, the user's ``PMIX_ALLOC_REQ_ID`` when one was supplied, and
-  ``PMIX_TIME_REMAINING`` (``uint32_t`` seconds) unchanged from the scheduler.
+* **Event (inbound).**  PRRTE registers a **dedicated PMIx event handler** for
+  ``PMIX_ALLOC_TIMEOUT_WARNING`` at PMIx-server init, alongside the existing
+  registrations (``parent_died_fn`` in ``prte.c``, ``lost_connection_hdlr`` in
+  ``pmix_server.c``).  The handler keys off the event's ``PMIX_ALLOC_ID`` to
+  find the reservation (``prte_get_session_object_from_id``), recovers the proc
+  that requested the allocation from ``session->requestor`` (recorded at
+  creation — see below), and re-emits the event **only to that process** — a
+  directed notification, not a DVM-wide broadcast — by restricting the
+  notification range to it through the existing relay machinery
+  (``pmix_server_notify_event`` / ``PMIx_Notify_event`` with a proc-scoped
+  custom range, the same path PRRTE already uses for directed events).  The
+  relayed payload carries the same ``PMIX_ALLOC_ID``, the user's
+  ``PMIX_ALLOC_REQ_ID`` when one was supplied, and ``PMIX_TIME_REMAINING``
+  (``uint32_t`` seconds) unchanged from the scheduler.
+
+  To deliver to a specific process, the reservation must remember who requested
+  it; ``prte_session_t`` therefore also carries a ``pmix_proc_t requestor``,
+  set from ``req->tproc`` in ``create_reservation`` (and refreshed on an
+  ``EXTEND`` so the warning follows the most recent requester).
+
+.. note::
+
+   This assumes the scheduler delivers the warning as a **PMIx event** that
+   surfaces through PRRTE's registered handlers.  Some host/scheduler
+   integrations instead deliver allocation-control traffic as an RML
+   *controller command* on PRRTE's scheduler channel (see the scheduler-request
+   recv path in ``pmix_server.c``).  Confirm the delivery mechanism against the
+   target scheduler; if it is the controller-command path, the relay is wired
+   there instead, but the requester-directed forwarding and payload above are
+   unchanged.
 
 The whole path is guarded by ``#if defined(PMIX_ALLOC_TIMEOUT_WARNING)`` (and
 the companion key/event guards); a PMIx that predates the event registers no
@@ -671,7 +725,29 @@ reservations its parent may own — ownership does not propagate transitively.
 ``jdata->session`` retains its present meaning as the job's *primary* session
 (used for accounting, refids, and the ``session->jobs`` linkage).  It is set to
 the first valid targeted session, or to the default session when only the
-invalid namespace is targeted.  The full target set drives mapping.
+invalid namespace is targeted.
+
+The full target set is **resolved once here, on the HNP**, where ownership is
+already validated, and cached on the job for the mapper to consume — rather than
+re-parsed per app context inside the mapper (``get_target_nodes`` runs once per
+app).  ``prte_job_t`` gains an HNP-local, non-packed pair:
+
+.. code-block:: c
+
+   /* Sessions this job may map onto, resolved from PRTE_JOB_SPAWN_TARGET on the
+    * HNP after the ownership check. HNP-local; never packed (rebuilt from the
+    * attribute if ever needed). Defaults to { jdata->session } when no spawn
+    * target was given. */
+   prte_session_t **target_sessions;
+   size_t           num_target_sessions;
+
+These are populated in ``plm_base_receive.c`` immediately after the ownership
+check and the ``prte_session_add_owner`` step above.  When
+``PRTE_JOB_SPAWN_TARGET`` is absent, the array is the single element
+``{ jdata->session }``, so existing jobs are unchanged.  ``target_sessions``
+holds **borrowed** session pointers (the sessions are owned via
+``prte_set_session_object``, not by the job), so the job destructor frees only
+the array, not the sessions it points at.
 
 Mapping Changes
 ---------------
@@ -679,7 +755,11 @@ Mapping Changes
 ``prte_rmaps_base_get_target_nodes``
 (``src/mca/rmaps/base/rmaps_base_support_fns.c``) is generalized from "iterate
 ``jdata->session->nodes``" to "iterate the candidate pool defined by the job's
-target session set."  Define the membership predicate:
+target session set."  No signature change is needed: the function already
+receives ``jdata``, so it reads the pre-resolved
+``jdata->target_sessions`` / ``num_target_sessions`` cached on the HNP (see
+*Carrying the target to the HNP*) rather than re-resolving the attribute itself.
+Define the membership predicate:
 
 .. code-block:: c
 
@@ -692,6 +772,9 @@ target session set."  Define the membership predicate:
    /* True if nd is usable by a job targeting the given set of sessions. */
    static bool node_in_targets(prte_node_t *nd,
                                prte_session_t **targets, size_t ntargets);
+
+The two branches pass ``jdata->target_sessions`` / ``num_target_sessions`` as
+``targets`` / ``ntargets``.
 
 Both node-collection branches in ``get_target_nodes`` change:
 
@@ -857,10 +940,13 @@ Implementation Order
    no behavior change.
 5. Implement allocation-time routing in ``prte_ras_base_complete_request``
    (Cases 2 and 3), guarded by ``#if defined`` on the alloc keys, recording
-   ``owner``, ``owner_job`` (retained), and ``inheritance`` on each new
-   reservation.
+   ``owner``, ``owner_job`` (retained), ``requestor``, and ``inheritance`` on
+   each new reservation, and resolving an ``EXTEND`` target by either
+   ``PMIX_ALLOC_ID`` or ``PMIX_ALLOC_REQ_ID``.
 6. Add ``PRTE_JOB_SPAWN_TARGET`` and the ``PMIX_SPAWN_TARGET`` parsing in the
-   spawn path, plus the multi-session resolution in ``plm_base_receive.c``.
+   spawn path, plus the multi-session resolution in ``plm_base_receive.c`` that
+   caches the validated ``target_sessions`` on the job; ``get_target_nodes``
+   consumes that cache with no signature change.
 7. Return the allocation id to the requester from the alloc response.
 8. Wire reservation release/cleanup into the ``PMIX_ALLOC_RELEASE`` path
    (owner-initiated, scheduler-initiated, and DVM teardown), clearing
@@ -896,11 +982,16 @@ Open Questions
 --------------
 
 No open *design* questions remain; the decisions that shape observable
-behavior are settled below.  What is left for the implementer is purely to
-locate a few exact code sites (the inbound timeout-warning handler, the
-``PMIX_ALLOC_ID`` extraction in the ``EXTEND`` lookup, and the carrier that
-threads the resolved target set into the mapper); none of these changes the
-design.
+behavior are settled below, and the previously under-specified code sites (the
+``EXTEND`` identifier extraction, the inbound timeout-warning handler, and the
+carrier threading the target set into the mapper) are now pinned in their
+respective sections.
+
+One item is worth confirming against a real system before coding, though it
+does not change the design: whether the target scheduler delivers
+``PMIX_ALLOC_TIMEOUT_WARNING`` as a PMIx event or as an RML controller command.
+The relay logic is identical either way; only the registration site differs.
+See *Allocation timeout warning*.
 
 Resolved decisions
 ~~~~~~~~~~~~~~~~~~~

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -855,6 +855,15 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
 
     PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
 
+        /* NOTE: the node-reservation/session-targeting design
+         * (docs/plans/node_reservation/node-reservation.rst) requires that a
+         * session hold *references* to the global node objects, not copies.
+         * The mapper resolves a job's candidate nodes from the global pool
+         * filtered by node->session, and copies made here are daemon-less
+         * duplicates that the mapper and launch path cannot use. This path
+         * must be migrated to retain and add the global node objects
+         * (PMIX_RETAIN + node->session backpointer) rather than
+         * prte_node_copy() once that work lands. */
         prte_node_t *node_cpy;
         err = prte_node_copy(&node_cpy, node);
 

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -856,14 +856,15 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
     PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
 
         /* NOTE: the node-reservation/session-targeting design
-         * (docs/plans/node_reservation/node-reservation.rst) requires that a
-         * session hold *references* to the global node objects, not copies.
-         * The mapper resolves a job's candidate nodes from the global pool
-         * filtered by node->session, and copies made here are daemon-less
-         * duplicates that the mapper and launch path cannot use. This path
-         * must be migrated to retain and add the global node objects
-         * (PMIX_RETAIN + node->session backpointer) rather than
-         * prte_node_copy() once that work lands. */
+         * (docs/plans/node_reservation/node-reservation.rst) makes it a hard
+         * invariant that a session hold *references* to the global node
+         * objects, not copies. The mapper resolves a job's candidate nodes
+         * from the global pool filtered by node->session, and copies made here
+         * are daemon-less duplicates that the mapper and launch path cannot
+         * use. This path is therefore to be migrated (plan Implementation
+         * Order step 12) to insert these nodes into the global pool and store
+         * retained references (PMIX_RETAIN + node->session backpointer) rather
+         * than prte_node_copy(), once node->session lands (plan step 1). */
         prte_node_t *node_cpy;
         err = prte_node_copy(&node_cpy, node);
 


### PR DESCRIPTION
This PR is a design spec and implementation plan for review. It is documentation-only (`docs/plans/node_reservation/`); no code behavior changes.

## Problem

PRRTE can already partition an allocation into independently mappable pools — each job carries a `prte_session_t` and the mapper draws candidate nodes from that session — but it lacks the machinery to place dynamically allocated nodes into a non-default session and to let a spawn select which allocations its processes may map onto. There was also no statement of the externally observable contract such a feature must satisfy, and recent upstream PMIx work (allocation inheritance, scheduler/timeout integration) was not yet reflected in PRRTE's design.

## What this adds

- **`node-reservation-spec.rst`** (new) — the externally observable contract: the allocation-routing decision table (`PMIX_ALLOC_TARGET` / `PMIX_ALLOC_SHARE`), `PMIX_SPAWN_TARGET` targeting and the ownership model, the reservation lifecycle, error semantics, and backward compatibility. The "what", with implementation left to the plan.
- **`node-reservation.rst`** (plan) — the implementing design: a `node->session` backpointer; `prte_session_t` gaining `owner`, `owner_job`, `requestor`, `owners`, and an `inheritance` disposition; allocation-time routing in `prte_ras_base_complete_request`; spawn-time multi-session resolution; and the mapper change to filter the global pool by target-session membership.

### Conformance with upstream PMIx how-things-work docs

- **Allocation inheritance** — `PMIX_ALLOC_INHERITANCE` selects what becomes of a reservation when its owning namespace terminates. The absent-attribute default is `PMIX_ALLOC_INHERIT_DEFAULT` (unreserve into the session), not the legacy release-to-scheduler; the four NONE/CHILD/DEFAULT/CHILD_DEFAULT dispositions are specified on the orthogonal release-vs-unreserve and owner-vs-last-child axes. `CHILD`-flavored teardown uses strict transitive-descendant tracking computed from the existing job genealogy (recursive `prte_job_t::children` walk, as `prte_dump_aborted_procs` already performs), with the owning job retained on the session so its subtree stays reachable.
- **Scheduler / allocation-timeout warning** — `PMIX_ALLOC_WARN_TIMEOUT` is forwarded to the scheduler and `PMIX_ALLOC_TIMEOUT_WARNING` is relayed to the requesting process alone.

### Design decisions resolved

- The SLURM RAS shall hold only references to global node objects, never `prte_node_copy` duplicates (a hard invariant of the reference-based model); `prte_ras_slurm_assign_new_session` is migrated accordingly.
- The `EXTEND` target may be named by either `PMIX_ALLOC_ID` or `PMIX_ALLOC_REQ_ID`.
- The resolved spawn target set is computed once on the HNP and cached on the job; `get_target_nodes` consumes it with no signature change.

The plan carries an ordered, independently testable implementation sequence and one residual to confirm against a real system (whether the timeout warning arrives as a PMIx event or an RML controller command — relay logic is identical either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

