### PR TITLE
Fix node-state corruption and rank collisions in rmaps mapping

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -443,16 +443,6 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                     }
                 }
 
-                if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL) &&
-                    !prte_get_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, NULL, PMIX_BOOL)) {
-                    /* inherit the base defaults */
-                    if (prte_rmaps_base.hwthread_cpus) {
-                        prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                    } else {
-                        prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-                    }
-                }
-
                 if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING) &&
                     NULL != prte_rmaps_base.file) {
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_FILE, PRTE_ATTR_GLOBAL,
@@ -919,7 +909,6 @@ ranking:
             goto cleanup;
     }
     if (1 < options.cpus_per_rank ||
-        NULL != options.job_cpuset ||
         options.ordered) {
         /* REQUIRES binding to cpu */
         if (PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
@@ -997,7 +986,6 @@ ranking:
             goto cleanup;
         }
         rc = map_colocate(jdata, colocate_daemons, pernode, darray, procs_per_target, &options);
-        PMIX_DATA_ARRAY_FREE(darray);
         if (PRTE_SUCCESS != rc) {
             jdata->exit_code = PRTE_ERR_BAD_PARAM;
             PRTE_ERROR_LOG(jdata->exit_code);
@@ -1142,6 +1130,8 @@ ranking:
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_COMPLETE);
 
 cleanup:
+    /* release the colocation target array if one was provided/created */
+    PMIX_DATA_ARRAY_FREE(darray);
     /* reset any node map flags we used so the next job will start clean */
     for (int i = 0; i < jdata->map->nodes->size; i++) {
         if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(jdata->map->nodes, i))) {
@@ -1373,11 +1363,7 @@ static int map_colocate(prte_job_t *jdata,
         }
 
         /* calculate the ranks for this job */
-        { uint32_t _nv = 0; ret = prte_rmaps_base_compute_vpids(jdata, options, -1, &_nv); }
-        if (PRTE_SUCCESS != ret) {
-            return ret;
-        }
-        ret = PRTE_SUCCESS;
+        ret = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
         goto done;
     }
 
@@ -1459,11 +1445,7 @@ static int map_colocate(prte_job_t *jdata,
             }
         }
     }
-    { uint32_t _nv = 0; ret = prte_rmaps_base_compute_vpids(jdata, options, -1, &_nv); }
-    if (PRTE_SUCCESS != ret) {
-        return ret;
-    }
-    ret = PRTE_SUCCESS;
+    ret = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
 
 done:
     // ensure all the nodes are marked as not mapped

--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -437,8 +437,12 @@ static int lsf_map(prte_job_t *jdata,
         }
     }
     PMIX_DESTRUCT(&rankmap);
-    /* compute local/app ranks */
-    rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    /* compute local/app ranks - in per-app dispatch mode (app_idx >= 0)
+     * the base computes the ranks with the correct cross-app numbering,
+     * so skip it here */
+    if (options->app_idx < 0) {
+        rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    }
     return rc;
 
 error:

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -395,8 +395,12 @@ static int ppr_mapper(prte_job_t *jdata,
         PMIX_LIST_DESTRUCT(&node_list);
     }
     free(jobppr);
-    /* calculate the ranks for this app */
-    rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    /* calculate the ranks for this job - in per-app dispatch mode
+     * (app_idx >= 0) the base computes the vpids with the correct
+     * cross-app numbering, so skip it here to avoid colliding ranks */
+    if (options->app_idx < 0) {
+        rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    }
     return rc;
 
 error:

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -453,8 +453,12 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
     if (NULL != rankfile) {
         free(rankfile);
     }
-    /* compute local/app ranks */
-    rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    /* compute local/app ranks - in per-app dispatch mode (app_idx >= 0)
+     * the base computes the ranks with the correct cross-app numbering,
+     * so skip it here */
+    if (options->app_idx < 0) {
+        rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    }
     return rc;
 
 error:

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -165,8 +165,12 @@ static int prte_rmaps_rr_map(prte_job_t *jdata,
          */
         PMIX_LIST_DESTRUCT(&node_list);
     }
-    /* calculate the ranks for this job */
-    rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    /* calculate the ranks for this job - in per-app dispatch mode
+     * (app_idx >= 0) the base computes the vpids with the correct
+     * cross-app numbering, so skip it here to avoid colliding ranks */
+    if (options->app_idx < 0) {
+        rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    }
 
     return rc;
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -410,7 +410,7 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
     }
 
     nprocs_mapped = 0;
-    savecpuset = strdup(options->cpuset);
+    savecpuset = (NULL != options->cpuset) ? strdup(options->cpuset) : NULL;
 
 pass:
     PMIX_LIST_FOREACH_SAFE(node, nd, node_list, prte_node_t)
@@ -509,7 +509,7 @@ pass:
                 hwloc_bitmap_free(options->job_cpuset);
                 options->job_cpuset = NULL;
             }
-            options->cpuset = strdup(savecpuset);
+            options->cpuset = (NULL != savecpuset) ? strdup(savecpuset) : NULL;
             if (NULL != savecpuset) {
                 free(savecpuset);
             }
@@ -526,7 +526,7 @@ pass:
         if (NULL != options->cpuset) {
             free(options->cpuset);
         }
-        options->cpuset = strdup(savecpuset);
+        options->cpuset = (NULL != savecpuset) ? strdup(savecpuset) : NULL;
     } // next node
 
     /* second pass: if we haven't mapped everyone yet, it is
@@ -553,7 +553,7 @@ pass:
         if (NULL != options->cpuset) {
             free(options->cpuset);
         }
-        options->cpuset = strdup(savecpuset);
+        options->cpuset = (NULL != savecpuset) ? strdup(savecpuset) : NULL;
         // Rescan the nodes
         second_pass = true;
         goto pass;

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -393,8 +393,12 @@ process:
             save = sq;
         }
     }
-    /* compute local/app ranks */
-    rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    /* compute local/app ranks - in per-app dispatch mode (app_idx >= 0)
+     * the base computes the ranks with the correct cross-app numbering,
+     * so skip it here */
+    if (options->app_idx < 0) {
+        rc = prte_rmaps_base_compute_vpids(jdata, options, -1, NULL);
+    }
     return rc;
 
 error:


### PR DESCRIPTION
The colocation mapper computed vpids and, on failure, returned directly instead of jumping to its cleanup label. That early return skipped both the destruction of the target node list and the clearing of the PRTE_NODE_FLAG_MAPPED flag on the affected nodes. Because that flag is global node state, leaving it set misled the mapping pass of the next job. Route both compute_vpids failures through the cleanup label so the list is released and the flags are reset on every exit.

In per-app dispatch mode the base assigns vpids per app while threading a running counter across apps. Each mapper, however, also ranked the whole job from zero on every invocation. Since compute_vpids skips already-ranked procs without advancing its counter, the second app's first proc was handed the same rank as the first app's, producing duplicate ranks. Have the mappers compute vpids only when not in per-app mode and let the base perform the cross-app numbering.

While here, drop a duplicated CPU-designation inheritance block whose guard was always false after the preceding identical block, free the colocation target array on all error exits rather than only on success, guard the bycpu mapper's strdup calls against a NULL cpuset, and remove a dead job_cpuset test that is always NULL at that point.