### PR TITLE
Fix prterun exit status for failed maps and a bare ppr crash

### DIFF
--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -379,6 +379,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     pmix_list_t nodes;
     int slots, len;
     bool flag, *fptr;
+    bool map_succeeded = false;
 
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -1371,9 +1372,21 @@ ranking:
     }
 
     /* set the job state to the next position */
+    map_succeeded = true;
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_COMPLETE);
 
 cleanup:
+    /* Every failure path above reaches this label via "goto cleanup" after
+     * activating PRTE_JOB_STATE_MAP_FAILED, but only some of them set an exit
+     * code first. Because the job state is activated asynchronously, we cannot
+     * read jdata->state here to tell success from failure - so we rely on the
+     * map_succeeded flag, which is only set on the success fall-through. Ensure
+     * a failed map always leaves a non-zero exit_code so the eventual
+     * PRTE_UPDATE_EXIT_STATUS() reflects the failure rather than defaulting
+     * to 0 (success). Do not overwrite a more specific code already set. */
+    if (!map_succeeded && 0 == jdata->exit_code) {
+        jdata->exit_code = -PRTE_JOB_STATE_MAP_FAILED;
+    }
     /* release the colocation target array if one was provided/created */
     PMIX_DATA_ARRAY_FREE(darray);
     /* reset any node map flags we used so the next job will start clean */

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -947,9 +947,15 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 // see if they specified "socket" as the resource
                 p1 = strdup(opt->values[0]);
                 p2 = strrchr(p1, ':');
-                ++p2;
-                if (0 == strncasecmp(p2, "socket", strlen("socket")) ||
-                    0 == strncasecmp(p2, "skt", strlen("skt"))) {
+                /* a bare "ppr" with no ":resource" qualifier has nothing to
+                 * inspect - strrchr returns NULL, so guard against advancing
+                 * past it (which would dereference address 0x1 and crash) */
+                if (NULL != p2) {
+                    ++p2;
+                }
+                if (NULL != p2 &&
+                    (0 == strncasecmp(p2, "socket", strlen("socket")) ||
+                     0 == strncasecmp(p2, "skt", strlen("skt")))) {
                     *p2 = '\0';
                     pmix_asprintf(&p2, "%spackage", p1);
                     if (warn) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1031,6 +1031,22 @@ complete:
         PMIX_LOAD_NSPACE(nspace, NULL);
         prc = prte_pmix_convert_rc(rc);
         cd->spcbfunc(prc, nspace, cd->cbdata);
+        /* record the failure on the job itself for any consumer of its state */
+        if (0 == jdata->exit_code) {
+            jdata->exit_code = rc;
+        }
+        /* A spawn-setup failure (e.g. an unrecognized map-by directive) must
+         * be reflected in our process exit status. The spawn-completion
+         * notification above carries the error to the requestor, but when we
+         * are the requestor (prterun) that notification races the DVM teardown
+         * triggered by NEVER_LAUNCHED below - if teardown wins, the status is
+         * lost and we would exit 0. So, exactly as check_complete() does on
+         * normal termination, record it directly here for a one-shot launch.
+         * A persistent DVM survives the failed spawn, so its status is left
+         * untouched (the requestor still learns of the error via the cbfunc). */
+        if (!prte_persistent) {
+            PRTE_UPDATE_EXIT_STATUS(rc);
+        }
         /* this isn't going to launch, so indicate that */
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
     }


### PR DESCRIPTION
## Problem

`prterun` could report success (exit 0) for a job that failed to map, and the value it did return varied from run to run. Investigating that further surfaced a hard crash on a bare `--map-by ppr`.

These are three related defects in the map/launch failure-reporting path:

1. **Inconsistent map-failure exit code.** The exit status of a mapped-but-not-launched job is drawn from `jdata->exit_code`, but several `MAP_FAILED` sites in the mapper jumped to cleanup without setting it, leaving it at zero — so a failed map could be reported as success.

2. **Bare `--map-by ppr` segfault.** The deprecated-CLI converter advanced past a `:` qualifier located with `strrchr` without checking for `NULL`, dereferencing address `0x1` when no qualifier was present.

3. **Lost spawn-setup error.** A spawn that fails during setup (e.g. an unrecognized map-by directive caught only at policy-parse time) reported the error via the spawn callback while simultaneously tearing the DVM down. For `prterun` — its own requestor — those two actions race; when teardown won, the error was dropped and `prterun` exited 0 non-deterministically.

## Fix

- Record a non-zero `exit_code` once at the mapper's cleanup label whenever the map did not complete, preserving any more specific code.
- Guard the `ppr` qualifier rewrite on a non-`NULL` `strrchr` result.
- Record the failure directly in the process exit status at the point of a failed spawn setup, mirroring `check_complete()`, confined to the non-persistent (one-shot `prterun`) case so a persistent DVM is unaffected.

## Testing

Verified with `prterun --rtos donotlaunch --display map` against a simulated topology (`test/topologies/test-topo.xml`):

- valid maps (`--map-by node`, `ppr:2:package`, `core` + `--rank-by fill`) exit **0**;
- map failures (oversubscription, object-based `--rank-by`) exit non-zero;
- schizo/policy parse errors (`ppr`, `boguspolicy`, `bogusranker`) exit non-zero;
- bare `--map-by ppr` no longer crashes and exits **213 deterministically** (15/15 runs, previously a 0/255 mix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)