### PR TITLE
Implement node reservation and session targeting

### DIFF
--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -68,6 +68,84 @@
 
 static bool recv_issued = false;
 
+/* Resolve the PRTE_JOB_SPAWN_TARGET list (a comma-delimited list of
+ * PMIX_ALLOC_ID strings, with an empty token denoting the default session)
+ * into the job's validated target_sessions set. The requester must own every
+ * named reservation. On success the spawned job becomes an owner of each
+ * targeted reservation and jdata->session is set to the primary (first)
+ * targeted session. Returns a PRTE error code on failure. */
+static int resolve_spawn_targets(prte_job_t *jdata, pmix_proc_t *requestor,
+                                 char *target_str)
+{
+    char *p, *start, saved;
+    prte_session_t *s, **tlist = NULL, *primary = NULL;
+    size_t ntl = 0;
+    bool done = false;
+
+    start = target_str;
+    for (p = target_str; !done; p++) {
+        if (',' != *p && '\0' != *p) {
+            continue;
+        }
+        saved = *p;
+        *p = '\0';
+        if ('\0' == saved) {
+            done = true;
+        }
+        /* an empty token denotes the default session */
+        if ('\0' == *start) {
+            s = prte_default_session;
+        } else {
+            s = prte_get_session_object_from_id(start);
+            if (NULL == s) {
+                free(tlist);
+                return PRTE_ERR_NOT_FOUND;
+            }
+        }
+        /* the requester may target only the default session and reservations
+         * its namespace owns (the scheduler excepted) */
+        if (!prte_session_is_owned_by(s, requestor->nspace)) {
+            free(tlist);
+            return PRTE_ERR_PERM;
+        }
+        /* add to the target set, de-duplicating */
+        {
+            size_t k;
+            bool present = false;
+            for (k = 0; k < ntl; k++) {
+                if (tlist[k] == s) {
+                    present = true;
+                    break;
+                }
+            }
+            if (!present) {
+                prte_session_t **t2 = (prte_session_t **)
+                    realloc(tlist, (ntl + 1) * sizeof(prte_session_t *));
+                if (NULL == t2) {
+                    free(tlist);
+                    return PRTE_ERR_OUT_OF_RESOURCE;
+                }
+                tlist = t2;
+                tlist[ntl++] = s;
+                if (NULL == primary) {
+                    primary = s;
+                }
+            }
+        }
+        /* the spawned job becomes an owner of the reservation it targets, so
+         * it may in turn spawn further jobs onto those nodes (no-op for the
+         * default session) */
+        prte_session_add_owner(s, jdata->nspace);
+        start = p + 1;
+    }
+
+    jdata->target_sessions = tlist;
+    jdata->num_target_sessions = ntl;
+    /* primary session: first targeted, or default if only invalid was named */
+    jdata->session = (NULL != primary) ? primary : prte_default_session;
+    return PRTE_SUCCESS;
+}
+
 int prte_plm_base_comm_start(void)
 {
     if (recv_issued) {
@@ -333,6 +411,21 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             goto ANSWER_LAUNCH;
         }
 
+        /* A spawn-target list takes precedence and may name multiple sessions
+         * (the union of allocations the job may map onto). Resolve it, validate
+         * ownership of each, cache the set on the job, and continue. */
+        tmp = NULL;
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_TARGET, (void **) &tmp, PMIX_STRING) &&
+            NULL != tmp) {
+            rc = resolve_spawn_targets(jdata, nptr, tmp);
+            free(tmp);
+            if (PRTE_SUCCESS != rc) {
+                goto ANSWER_LAUNCH;
+            }
+            session = jdata->session;
+            goto moveon;
+        }
+
         /* If an alloc id was given specifying the session within which
          * the job is to be spawned, then use it - otherwise default to parent session */
         session = NULL;
@@ -409,6 +502,19 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
 moveon:
         jdata->session = session;
         pmix_pointer_array_add(jdata->session->jobs, jdata);
+
+        /* a job reaching a reservation through the legacy single-session
+         * attributes (no spawn-target list) must still pass the ownership
+         * check and become an owner of that reservation */
+        if (NULL == jdata->target_sessions && NULL != session &&
+            session != prte_default_session &&
+            (PRTE_SESSION_FLAG_RESERVED & session->flags)) {
+            if (!prte_session_is_owned_by(session, nptr->nspace)) {
+                rc = PRTE_ERR_PERM;
+                goto ANSWER_LAUNCH;
+            }
+            prte_session_add_owner(session, jdata->nspace);
+        }
 
         /* get the parent's job object */
         if (NULL != (parent = prte_get_job_data_object(nptr->nspace)) &&

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -90,6 +90,22 @@ PRTE_EXPORT void prte_ras_base_modify(int fd, short args, void *cbdata);
 
 PRTE_EXPORT void prte_ras_base_release_allocation(prte_session_t *session);
 
+/* Tear down a reservation: drop its hold on its nodes (clearing the
+ * node->session backpointer so the nodes revert to the default pool) and
+ * deregister it so it can no longer be targeted. When return_to_scheduler is
+ * true, member nodes carrying a daemon are additionally shrunk out of the DVM
+ * and handed back to the scheduler; otherwise the nodes simply become
+ * unreserved within the session. */
+PRTE_EXPORT void prte_ras_base_teardown_reservation(prte_session_t *session,
+                                                    bool return_to_scheduler);
+
+/* Apply the namespace-termination inheritance disposition of every reservation
+ * when the namespace owning jdata terminates. NONE/DEFAULT fire when the owning
+ * namespace exits; CHILD/CHILD_DEFAULT fire when the last derived child of the
+ * owning namespace exits. The *_DEFAULT variants unreserve into the session
+ * rather than returning nodes to the scheduler. */
+PRTE_EXPORT void prte_ras_base_check_reservations_on_term(prte_job_t *jdata);
+
 PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
 
 PRTE_EXPORT char *prte_ras_base_flag_string(prte_node_t *node);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -616,6 +616,327 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
     PMIX_RELEASE(req);
 }
 
+/* monotonic counter used to mint unique session ids for reservations that
+ * the host (rather than a scheduler) must identify on its own. */
+static uint32_t prte_ras_reservation_counter = 0;
+
+/* Create a new reservation owned by the given namespace. Returns NULL on
+ * failure. alloc_id (scheduler-assigned PMIX_ALLOC_ID) and req_id
+ * (requester PMIX_ALLOC_REQ_ID) are optional. */
+static prte_session_t *create_reservation(const char *nspace, uint8_t inherit,
+                                          pmix_proc_t *requestor,
+                                          const char *alloc_id, const char *req_id)
+{
+    prte_session_t *s;
+    prte_job_t *ownerjob;
+    int rc;
+
+    s = PMIX_NEW(prte_session_t);
+    if (NULL == s) {
+        return NULL;
+    }
+    /* assign a fresh, unique session id (UINT32_MAX is reserved for the
+     * default session) */
+    do {
+        s->session_id = ++prte_ras_reservation_counter;
+    } while (UINT32_MAX == s->session_id ||
+             NULL != prte_get_session_object(s->session_id));
+    /* prefer a scheduler-assigned allocation id; otherwise mint one */
+    if (NULL != alloc_id) {
+        s->alloc_refid = strdup(alloc_id);
+    } else {
+        pmix_asprintf(&s->alloc_refid, "%s.%u", nspace, s->session_id);
+    }
+    if (NULL != req_id) {
+        s->user_refid = strdup(req_id);
+    }
+    s->flags |= PRTE_SESSION_FLAG_RESERVED | PRTE_SESSION_FLAG_DYNAMIC;
+    PMIX_LOAD_NSPACE(s->owner, nspace);
+    s->inheritance = inherit;
+    if (NULL != requestor) {
+        PMIX_XFER_PROCID(&s->requestor, requestor);
+    }
+    /* retain the owning namespace's job object so its children subtree stays
+     * walkable for CHILD-flavored drain; NULL for a tool with no job object */
+    ownerjob = prte_get_job_data_object(nspace);
+    if (NULL != ownerjob) {
+        PMIX_RETAIN(ownerjob);
+        s->owner_job = ownerjob;
+    }
+    /* seed the owner set with the owning namespace */
+    prte_session_add_owner(s, nspace);
+
+    rc = prte_set_session_object(s);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(s);
+        return NULL;
+    }
+    return s;
+}
+
+/* Register the nodes named in ndlist with the destination reservation: set
+ * each node's session backpointer and store a retained reference in the
+ * reservation. The node objects themselves live in the global pool. */
+static void add_nodes_to_session(pmix_list_t *ndlist, prte_session_t *dest)
+{
+    prte_node_t *nd, *gnode;
+    int k;
+    bool present;
+
+    if (NULL == dest || dest == prte_default_session) {
+        return;
+    }
+    PMIX_LIST_FOREACH(nd, ndlist, prte_node_t) {
+        gnode = prte_node_match(NULL, nd->name);
+        if (NULL == gnode) {
+            continue;
+        }
+        gnode->session = dest;
+        /* avoid a double reference on EXTEND */
+        present = false;
+        for (k = 0; k < dest->nodes->size; k++) {
+            if (gnode == (prte_node_t *) pmix_pointer_array_get_item(dest->nodes, k)) {
+                present = true;
+                break;
+            }
+        }
+        if (!present) {
+            PMIX_RETAIN(gnode);
+            pmix_pointer_array_add(dest->nodes, gnode);
+        }
+    }
+}
+
+void prte_ras_base_teardown_reservation(prte_session_t *session,
+                                        bool return_to_scheduler)
+{
+    prte_node_t *nd;
+    int k;
+    pmix_rank_t *ranks = NULL;
+    int32_t m = 0;
+    pmix_data_buffer_t msg;
+    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+    pmix_status_t rc;
+
+    if (NULL == session || session == prte_default_session) {
+        return;
+    }
+
+    /* if the nodes are being returned to the scheduler, collect the daemon
+     * ranks of the member nodes BEFORE detaching so the DVM can shrink them
+     * out. The shrink machinery terminates any jobs/daemons on those nodes. */
+    if (return_to_scheduler) {
+        ranks = (pmix_rank_t *) malloc(session->nodes->size * sizeof(pmix_rank_t));
+        if (NULL != ranks) {
+            for (k = 0; k < session->nodes->size; k++) {
+                nd = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, k);
+                if (NULL == nd || NULL == nd->daemon) {
+                    continue;
+                }
+                ranks[m++] = nd->daemon->name.rank;
+            }
+        }
+    }
+
+    /* clear the reservation's hold on its nodes BEFORE any shrink so the
+     * reservation bookkeeping does not race the shrink-campaign accounting.
+     * Each member node reverts to the default pool. */
+    for (k = 0; k < session->nodes->size; k++) {
+        nd = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, k);
+        if (NULL == nd) {
+            continue;
+        }
+        if (nd->session == session) {
+            nd->session = NULL;
+        }
+        pmix_pointer_array_set_item(session->nodes, k, NULL);
+        PMIX_RELEASE(nd);
+    }
+
+    /* the reservation no longer withholds nodes */
+    session->flags &= ~PRTE_SESSION_FLAG_RESERVED;
+    if (NULL != session->owners) {
+        PMIx_Argv_free(session->owners);
+        session->owners = NULL;
+    }
+    /* drop the retained owning-job reference taken in create_reservation */
+    if (NULL != session->owner_job) {
+        PMIX_RELEASE(session->owner_job);
+        session->owner_job = NULL;
+    }
+
+    /* deregister so the reservation can no longer be looked up / targeted.
+     * The session object itself is left for any still-running jobs that
+     * reference it (via session->jobs) and is reclaimed at DVM teardown. */
+    if (0 <= session->index) {
+        pmix_pointer_array_set_item(prte_sessions, session->index, NULL);
+        session->index = -1;
+    }
+
+    if (return_to_scheduler && NULL != ranks && 0 < m) {
+        PMIX_DATA_BUFFER_CONSTRUCT(&msg);
+        rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_pack(NULL, &msg, &m, 1, PMIX_INT32);
+        }
+        if (PMIX_SUCCESS == rc) {
+            rc = PMIx_Data_pack(NULL, &msg, ranks, m, PMIX_PROC_RANK);
+        }
+        if (PMIX_SUCCESS == rc) {
+            if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+                PRTE_ERROR_LOG(rc);
+            }
+        } else {
+            PMIX_ERROR_LOG(rc);
+        }
+        PMIX_DATA_BUFFER_DESTRUCT(&msg);
+    }
+    if (NULL != ranks) {
+        free(ranks);
+    }
+}
+
+/* True if nspace is the root job's namespace or any transitive spawn
+ * descendant of it (a recursive walk of prte_job_t::children). */
+static bool job_subtree_contains(prte_job_t *root, const pmix_nspace_t nspace)
+{
+    prte_job_t *child;
+
+    if (NULL == root) {
+        return false;
+    }
+    if (PMIX_CHECK_NSPACE(root->nspace, nspace)) {
+        return true;
+    }
+    PMIX_LIST_FOREACH(child, &root->children, prte_job_t) {
+        if (job_subtree_contains(child, nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* True if any job in the subtree rooted at root is still running (has not yet
+ * reached PRTE_JOB_STATE_TERMINATED). */
+static bool job_subtree_running(prte_job_t *root)
+{
+    prte_job_t *child;
+
+    if (NULL == root) {
+        return false;
+    }
+    if (root->state < PRTE_JOB_STATE_TERMINATED) {
+        return true;
+    }
+    PMIX_LIST_FOREACH(child, &root->children, prte_job_t) {
+        if (job_subtree_running(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* True if nspace is the reservation's owning namespace or one of its derived
+ * children (the transitive spawn subtree). Roots at the retained owner_job
+ * when present, else at the jobs spawned directly into the reservation (the
+ * tool-owner case). */
+static bool reservation_term_in_genealogy(prte_session_t *s,
+                                          const pmix_nspace_t nspace)
+{
+    int k;
+    prte_job_t *j;
+
+    if (PMIX_CHECK_NSPACE(s->owner, nspace)) {
+        return true;
+    }
+    if (NULL != s->owner_job) {
+        return job_subtree_contains(s->owner_job, nspace);
+    }
+    for (k = 0; k < s->jobs->size; k++) {
+        j = (prte_job_t *) pmix_pointer_array_get_item(s->jobs, k);
+        if (NULL != j && job_subtree_contains(j, nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* True if the owning namespace or any of its derived children is still
+ * running - i.e. the CHILD-flavored reservation has not yet drained. */
+static bool reservation_has_running_descendant(prte_session_t *s)
+{
+    int k;
+    prte_job_t *j;
+
+    if (NULL != s->owner_job) {
+        return job_subtree_running(s->owner_job);
+    }
+    for (k = 0; k < s->jobs->size; k++) {
+        j = (prte_job_t *) pmix_pointer_array_get_item(s->jobs, k);
+        if (NULL != j && job_subtree_running(j)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_ras_base_check_reservations_on_term(prte_job_t *jdata)
+{
+    int i;
+    prte_session_t *s;
+
+    if (NULL == prte_sessions || NULL == jdata) {
+        return;
+    }
+
+    for (i = 0; i < prte_sessions->size; i++) {
+        s = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i);
+        if (NULL == s || s == prte_default_session) {
+            continue;
+        }
+        if (!(s->flags & PRTE_SESSION_FLAG_RESERVED)) {
+            continue;
+        }
+
+        switch (s->inheritance) {
+#if defined(PMIX_ALLOC_INHERIT_NONE)
+        case PMIX_ALLOC_INHERIT_NONE:
+            /* release to scheduler when the owning namespace terminates */
+            if (PMIX_CHECK_NSPACE(s->owner, jdata->nspace)) {
+                prte_ras_base_teardown_reservation(s, true);
+            }
+            break;
+#endif
+#if defined(PMIX_ALLOC_INHERIT_CHILD)
+        case PMIX_ALLOC_INHERIT_CHILD:
+            /* release to scheduler once the last derived child terminates */
+            if (reservation_term_in_genealogy(s, jdata->nspace) &&
+                !reservation_has_running_descendant(s)) {
+                prte_ras_base_teardown_reservation(s, true);
+            }
+            break;
+#endif
+#if defined(PMIX_ALLOC_INHERIT_CHILD_DEFAULT)
+        case PMIX_ALLOC_INHERIT_CHILD_DEFAULT:
+            /* unreserve into the session once the last derived child terminates */
+            if (reservation_term_in_genealogy(s, jdata->nspace) &&
+                !reservation_has_running_descendant(s)) {
+                prte_ras_base_teardown_reservation(s, false);
+            }
+            break;
+#endif
+        default:
+            /* PMIX_ALLOC_INHERIT_DEFAULT (also the absent-attribute default):
+             * unreserve into the session when the owning namespace terminates */
+            if (PMIX_CHECK_NSPACE(s->owner, jdata->nspace)) {
+                prte_ras_base_teardown_reservation(s, false);
+            }
+            break;
+        }
+    }
+}
+
 void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
 {
     prte_job_t *daemons;
@@ -630,10 +951,111 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
     pmix_rank_t *ranks;
     pmix_list_t ndlist;
     bool found;
+    char *target = NULL;        /* PMIX_ALLOC_TARGET namespace, if any */
+    bool share = false;         /* default: reserve (do not share) */
+    bool have_share = false;
+    uint8_t inherit = PRTE_INHERIT_DEFAULT_VALUE;
+    bool have_inherit = false;
+    char *alloc_id = NULL;      /* PMIX_ALLOC_ID (scheduler-assigned) */
+    char *req_id = NULL;        /* PMIX_ALLOC_REQ_ID (user-provided) */
+    const char *owner_nspace;
+    prte_session_t *dest = NULL;
+    prte_job_t *reqjob;
+    bool is_tool;
 
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     if (PMIX_ALLOC_EXTEND == req->allocdir ||
         PMIX_ALLOC_NEW == req->allocdir) {
+        /* scan the request for the reservation-routing directives so we can
+         * resolve which session the new nodes will join before inserting
+         * them. The PMIX_ALLOC_NODE_LIST entries are handled in the loop
+         * below; PMIX_ALLOC_WARN_TIMEOUT is intentionally left in req->info
+         * to be forwarded verbatim to the scheduler. */
+        for (n=0; n < req->ninfo; n++) {
+#if defined(PMIX_ALLOC_TARGET)
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_TARGET)) {
+                target = req->info[n].value.data.string;
+                continue;
+            }
+#endif
+#if defined(PMIX_ALLOC_SHARE)
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_SHARE)) {
+                share = PMIX_INFO_TRUE(&req->info[n]);
+                have_share = true;
+                continue;
+            }
+#endif
+#if defined(PMIX_ALLOC_INHERITANCE)
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_INHERITANCE)) {
+                inherit = req->info[n].value.data.uint8;
+                have_inherit = true;
+                continue;
+            }
+#endif
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+                alloc_id = req->info[n].value.data.string;
+                continue;
+            }
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+                req_id = req->info[n].value.data.string;
+                continue;
+            }
+        }
+        (void) have_share;
+
+        /* an inheritance value this build cannot honor is rejected rather than
+         * silently dropped (it may have arrived over the wire from a newer
+         * peer) */
+#if !defined(PMIX_ALLOC_INHERITANCE)
+        if (have_inherit && PRTE_INHERIT_DEFAULT_VALUE != inherit) {
+            req->pstatus = PMIX_ERR_NOT_SUPPORTED;
+            return;
+        }
+#endif
+
+        reqjob = prte_get_job_data_object(req->tproc.nspace);
+        is_tool = (NULL == reqjob) || PRTE_FLAG_TEST(reqjob, PRTE_JOB_FLAG_TOOL);
+        /* the namespace the reservation is created for / must be owned by */
+        owner_nspace = (NULL != target) ? target : req->tproc.nspace;
+
+        if (have_share && share) {
+            dest = prte_default_session;            /* general use */
+        } else if (NULL != target && !is_tool) {
+            req->pstatus = PMIX_ERR_NO_PERMISSIONS; /* app may not retarget */
+            return;
+        } else if (PMIX_ALLOC_EXTEND == req->allocdir) {
+            /* extend an existing reservation named by either identifier */
+            if (NULL == alloc_id && NULL == req_id) {
+                req->pstatus = PMIX_ERR_BAD_PARAM;  /* nothing names the target */
+                return;
+            }
+            dest = (NULL != alloc_id) ? prte_get_session_object_from_id(alloc_id)
+                                      : NULL;
+            if (NULL == dest && NULL != req_id) {
+                dest = prte_get_session_object_from_refid(req_id);
+            }
+            if (NULL == dest ||
+                !prte_session_is_owned_by(dest, req->tproc.nspace)) {
+                req->pstatus = (NULL == dest) ? PMIX_ERR_NOT_FOUND
+                                              : PMIX_ERR_NO_PERMISSIONS;
+                return;
+            }
+            /* a new inheritance value on EXTEND updates the disposition */
+            if (have_inherit) {
+                dest->inheritance = inherit;
+            }
+            /* refresh the requestor so a timeout warning follows the most
+             * recent requester */
+            PMIX_XFER_PROCID(&dest->requestor, &req->tproc);
+        } else {                                    /* PMIX_ALLOC_NEW */
+            dest = create_reservation(owner_nspace, inherit, &req->tproc,
+                                      alloc_id, req_id);
+            if (NULL == dest) {
+                req->pstatus = PMIX_ERR_OUT_OF_RESOURCE;
+                return;
+            }
+        }
+
         found = false;
         for (n=0; n < req->ninfo; n++) {
             if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
@@ -684,6 +1106,9 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
                     req->pstatus = prte_pmix_convert_rc(ret);
                     return;
                 }
+                /* when reserving, withhold these nodes from the default pool by
+                 * registering them with the destination session */
+                add_nodes_to_session(&ndlist, dest);
                 PMIX_LIST_DESTRUCT(&ndlist);
                 found = true;
             }
@@ -696,7 +1121,53 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
             PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
         }
 
+        /* report the destination allocation id back to the requester so it can
+         * later target, extend, or release the reservation. The default
+         * (shared) session carries no allocation id, so nothing is reported. */
+        if (NULL != dest && dest != prte_default_session &&
+            NULL != dest->alloc_refid) {
+            pmix_info_t *rinfo;
+            size_t rn = (NULL != dest->user_refid) ? 2 : 1;
+
+            PMIX_INFO_CREATE(rinfo, rn);
+            PMIX_INFO_LOAD(&rinfo[0], PMIX_ALLOC_ID, dest->alloc_refid, PMIX_STRING);
+            if (2 == rn) {
+                PMIX_INFO_LOAD(&rinfo[1], PMIX_ALLOC_REQ_ID, dest->user_refid, PMIX_STRING);
+            }
+            /* the original req->info is borrowed from the PMIx caller; repoint
+             * to our response array and let the req destructor free it */
+            req->info = rinfo;
+            req->ninfo = rn;
+            req->copy = true;
+        }
+
     } else if (PMIX_ALLOC_RELEASE == req->allocdir) {
+
+        /* a release naming an allocation id tears down that whole reservation:
+         * any owner may release it, the scheduler may release any. The nodes
+         * are returned to the scheduler (the legacy disposition for an explicit
+         * release). */
+        char *rel_alloc_id = NULL;
+        for (n=0; n < req->ninfo; n++) {
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+                rel_alloc_id = req->info[n].value.data.string;
+                break;
+            }
+        }
+        if (NULL != rel_alloc_id) {
+            prte_session_t *rsession = prte_get_session_object_from_id(rel_alloc_id);
+            if (NULL == rsession || rsession == prte_default_session) {
+                req->pstatus = PMIX_ERR_NOT_FOUND;
+                return;
+            }
+            if (!prte_session_is_owned_by(rsession, req->tproc.nspace)) {
+                req->pstatus = PMIX_ERR_NO_PERMISSIONS;
+                return;
+            }
+            prte_ras_base_teardown_reservation(rsession, true);
+            req->pstatus = PMIX_SUCCESS;
+            return;
+        }
 
         // create the request
         PMIX_DATA_BUFFER_CONSTRUCT(&msg);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -855,24 +855,20 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
 
     PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
 
-        /* NOTE: the node-reservation/session-targeting design
-         * (docs/plans/node_reservation/node-reservation.rst) makes it a hard
-         * invariant that a session hold *references* to the global node
-         * objects, not copies. The mapper resolves a job's candidate nodes
-         * from the global pool filtered by node->session, and copies made here
-         * are daemon-less duplicates that the mapper and launch path cannot
-         * use. This path is therefore to be migrated (plan Implementation
-         * Order step 12) to insert these nodes into the global pool and store
-         * retained references (PMIX_RETAIN + node->session backpointer) rather
-         * than prte_node_copy(), once node->session lands (plan step 1). */
-        prte_node_t *node_cpy;
-        err = prte_node_copy(&node_cpy, node);
-
-        if (PRTE_SUCCESS != err) {
-            goto cleanup;
-        }
-
-        pmix_err = pmix_pointer_array_add(session->nodes, node_cpy);
+        /* Hold a retained *reference* to the very node object that will be
+         * inserted into the global pool by prte_ras_base_node_insert after
+         * this module's allocate() returns - never a prte_node_copy()
+         * duplicate, which would be daemon-less and unusable by the mapper and
+         * launch path. This is the hard reference-model invariant of the
+         * node-reservation design (docs/plans/node_reservation).
+         *
+         * These nodes form the DVM's startup (default) session, so
+         * node->session is intentionally left NULL: they remain in the general
+         * pool rather than being withheld from it. The session object here is
+         * a per-Slurm-jobid tracking handle used to identify and release the
+         * group later; it is not a reservation. */
+        PMIX_RETAIN(node);
+        pmix_err = pmix_pointer_array_add(session->nodes, node);
         if (0 > pmix_err) {
             err = prte_pmix_convert_status(pmix_err);
             PMIX_RELEASE(node);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -102,6 +102,28 @@ int prte_rmaps_base_filter_nodes(prte_app_context_t *app, pmix_list_t *nodes, bo
     return rc;
 }
 
+/* The session a node belongs to for targeting purposes. A node with no
+ * explicit session belongs to the default session (the unreserved pool). */
+static inline prte_session_t *node_owning_session(prte_node_t *nd)
+{
+    return (NULL == nd->session) ? prte_default_session : nd->session;
+}
+
+/* True if nd is usable by a job targeting the given set of sessions. */
+static bool node_in_targets(prte_node_t *nd,
+                            prte_session_t **targets, size_t ntargets)
+{
+    prte_session_t *owner = node_owning_session(nd);
+    size_t i;
+
+    for (i = 0; i < ntargets; i++) {
+        if (owner == targets[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /*
  * Query the registry for all nodes allocated to a specified app_context
  */
@@ -121,8 +143,24 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
     pmix_list_t nodes;
     char *hosts = NULL;
     bool needhosts = false;
+    prte_session_t **targets;
+    size_t ntargets;
+    prte_session_t *deftarget[1];
     /** set default answer */
     *total_num_slots = 0;
+
+    /* determine the set of sessions whose nodes this job may map onto. The HNP
+     * resolves PRTE_JOB_SPAWN_TARGET into jdata->target_sessions; absent that,
+     * the job maps onto its own (primary) session - preserving the historical
+     * single-session behavior. */
+    if (NULL != jdata->target_sessions && 0 < jdata->num_target_sessions) {
+        targets = jdata->target_sessions;
+        ntargets = jdata->num_target_sessions;
+    } else {
+        deftarget[0] = jdata->session;
+        targets = deftarget;
+        ntargets = 1;
+    }
 
     /* get the daemon job object */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
@@ -198,9 +236,13 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
          */
         PMIX_LIST_FOREACH_SAFE(nptr, next, &nodes, prte_node_t)
         {
-            for (i = 0; i < jdata->session->nodes->size; i++) {
-                node = (prte_node_t *) pmix_pointer_array_get_item(jdata->session->nodes, i);
+            for (i = 0; i < prte_node_pool->size; i++) {
+                node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
                 if (NULL == node) {
+                    continue;
+                }
+                /* ignore nodes that are not in the job's targeted session set */
+                if (!node_in_targets(node, targets, ntargets)) {
                     continue;
                 }
                 /* ignore nodes that are non-usable */
@@ -276,10 +318,13 @@ addknown:
     } else {
         nd = (prte_node_t *) pmix_list_get_last(allocated_nodes);
     }
-    for (i = 0; i < jdata->session->nodes->size; i++) {
-        if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(jdata->session->nodes, i))) {
+    for (i = 0; i < prte_node_pool->size; i++) {
+        if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i))) {
 
-
+            /* ignore nodes that are not in the job's targeted session set */
+            if (!node_in_targets(node, targets, ntargets)) {
+                continue;
+            }
             /* ignore nodes that are non-usable */
             if (PRTE_FLAG_TEST(node, PRTE_NODE_NON_USABLE)) {
                 continue;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -567,6 +567,10 @@ static void check_complete(int fd, short args, void *cbdata)
         jdata->state = PRTE_JOB_STATE_TERMINATED;
     }
 
+    /* apply any reservation inheritance dispositions triggered by the
+     * termination of this namespace */
+    prte_ras_base_check_reservations_on_term(jdata);
+
     /* see if there was any problem */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_ABORTED_PROC, NULL, PMIX_POINTER)) {
         rc = prte_pmix_convert_rc(jdata->exit_code);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -628,6 +628,80 @@ static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
     PRTE_PMIX_WAKEUP_THREAD(lock);
 }
 
+#if defined(PMIX_ALLOC_TIMEOUT_WARNING)
+/* Relay the scheduler's allocation-timeout warning to the process that
+ * requested the allocation. PRRTE is a pure relay here: it neither sets the
+ * timeout nor generates the warning, only re-emits it as a directed event to
+ * the recorded requestor. */
+static void alloc_timeout_warning_hdlr(size_t evhdlr_registration_id, pmix_status_t status,
+                                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t *results, size_t nresults,
+                                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n, idx, nrinfo;
+    char *alloc_id = NULL;
+    uint32_t time_remaining = 0;
+    bool have_time = false;
+    prte_session_t *session;
+    pmix_info_t *rinfo;
+    pmix_data_array_t parray;
+    pmix_proc_t ptarg;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIx_Check_key(info[n].key, PMIX_ALLOC_ID)) {
+            alloc_id = info[n].value.data.string;
+        } else if (PMIx_Check_key(info[n].key, PMIX_TIME_REMAINING)) {
+            time_remaining = info[n].value.data.uint32;
+            have_time = true;
+        }
+    }
+    if (NULL == alloc_id) {
+        goto done;
+    }
+    session = prte_get_session_object_from_id(alloc_id);
+    if (NULL == session || PMIX_RANK_INVALID == session->requestor.rank) {
+        goto done;
+    }
+
+    /* assemble a directed (custom-range) notification to the requestor only */
+    nrinfo = 2;  /* custom range + alloc id */
+    if (NULL != session->user_refid) {
+        nrinfo++;
+    }
+    if (have_time) {
+        nrinfo++;
+    }
+    PMIX_INFO_CREATE(rinfo, nrinfo);
+    idx = 0;
+    PMIX_LOAD_PROCID(&ptarg, session->requestor.nspace, session->requestor.rank);
+    parray.type = PMIX_PROC;
+    parray.size = 1;
+    parray.array = &ptarg;
+    /* PMIX_INFO_LOAD deep-copies the data array, so the stack copy is fine */
+    PMIX_INFO_LOAD(&rinfo[idx++], PMIX_EVENT_CUSTOM_RANGE, &parray, PMIX_DATA_ARRAY);
+    PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, session->alloc_refid, PMIX_STRING);
+    if (NULL != session->user_refid) {
+        PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_REQ_ID, session->user_refid, PMIX_STRING);
+    }
+    if (have_time) {
+        PMIX_INFO_LOAD(&rinfo[idx++], PMIX_TIME_REMAINING, &time_remaining, PMIX_UINT32);
+    }
+    rc = PMIx_Notify_event(PMIX_ALLOC_TIMEOUT_WARNING, PRTE_PROC_MY_NAME,
+                           PMIX_RANGE_CUSTOM, rinfo, nrinfo, NULL, NULL);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    PMIX_INFO_FREE(rinfo, nrinfo);
+
+done:
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+#endif
+
 /*
  * Initialize global variables used w/in the server.
  */
@@ -1002,6 +1076,21 @@ int pmix_server_init(void)
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(info, ninfo);
     rc = prte_pmix_convert_status(prc);
+
+#if defined(PMIX_ALLOC_TIMEOUT_WARNING)
+    /* register the allocation-timeout-warning relay handler */
+    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+    prc = PMIX_ALLOC_TIMEOUT_WARNING;
+    ninfo = 1;
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_HDLR_NAME, "ALLOC-TIMEOUT-WARNING", PMIX_STRING);
+    PMIx_Register_event_handler(&prc, 1, info, ninfo, alloc_timeout_warning_hdlr, regcbfunc, &lock);
+    PRTE_PMIX_WAIT_THREAD(&lock);
+    prc = lock.status;
+    PRTE_PMIX_DESTRUCT_LOCK(&lock);
+    PMIX_INFO_FREE(info, ninfo);
+    rc = prte_pmix_convert_status(prc);
+#endif
 
     return rc;
 }

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -254,6 +254,42 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_REF_ID,
                                PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
 
+#if defined(PMIX_SPAWN_TARGET)
+            /***   SPAWN TARGET ALLOCATION(S)   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TARGET)) {
+            /* the value is either a single PMIX_ALLOC_ID string or a
+             * pmix_data_array_t of PMIX_ALLOC_ID strings. Flatten it into a
+             * comma-delimited list (preserving empty tokens, which denote the
+             * default session) and stash it as PRTE_JOB_SPAWN_TARGET. Stored
+             * GLOBAL so the generic job-attribute pack loop forwards it to the
+             * HNP, where the multi-session resolution happens. */
+            char *tstr = NULL, *tmp2, *tok;
+            if (PMIX_STRING == info->value.type) {
+                tok = info->value.data.string;
+                tstr = strdup((NULL == tok) ? "" : tok);
+            } else if (PMIX_DATA_ARRAY == info->value.type &&
+                       NULL != info->value.data.darray &&
+                       PMIX_STRING == info->value.data.darray->type) {
+                char **strs = (char **) info->value.data.darray->array;
+                size_t k;
+                for (k = 0; k < info->value.data.darray->size; k++) {
+                    tok = (NULL == strs || NULL == strs[k]) ? "" : strs[k];
+                    if (NULL == tstr) {
+                        tstr = strdup(tok);
+                    } else {
+                        pmix_asprintf(&tmp2, "%s,%s", tstr, tok);
+                        free(tstr);
+                        tstr = tmp2;
+                    }
+                }
+            }
+            if (NULL != tstr) {
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_TARGET,
+                                   PRTE_ATTR_GLOBAL, tstr, PMIX_STRING);
+                free(tstr);
+            }
+#endif
+
             /***   DISPLAY MAP   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_MAP)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -655,6 +655,8 @@ static void prte_job_construct(prte_job_t *job)
     PMIX_DATA_BUFFER_CONSTRUCT(&job->launch_msg);
     PMIX_CONSTRUCT(&job->children, pmix_list_t);
     PMIX_LOAD_NSPACE(job->launcher, NULL);
+    job->target_sessions = NULL;
+    job->num_target_sessions = 0;
     job->ntraces = 0;
     job->traces = NULL;
     PMIX_CONSTRUCT(&job->cli, pmix_cli_result_t);
@@ -749,6 +751,12 @@ static void prte_job_destruct(prte_job_t *job)
     if (NULL != job->traces) {
         PMIx_Argv_free(job->traces);
     }
+    /* target_sessions holds borrowed session pointers - free only the array */
+    if (NULL != job->target_sessions) {
+        free(job->target_sessions);
+        job->target_sessions = NULL;
+    }
+    job->num_target_sessions = 0;
     PMIX_DESTRUCT(&job->cli);
 }
 
@@ -783,6 +791,7 @@ static void prte_node_construct(prte_node_t *node)
 
     node->flags = 0;
     PMIX_CONSTRUCT(&node->attributes, pmix_list_t);
+    node->session = NULL;
 }
 
 static void prte_node_destruct(prte_node_t *node)
@@ -830,6 +839,9 @@ static void prte_node_destruct(prte_node_t *node)
 
     /* release the attributes */
     PMIX_LIST_DESTRUCT(&node->attributes);
+
+    /* the session backpointer is borrowed, not retained - just clear it */
+    node->session = NULL;
 }
 
 PMIX_CLASS_INSTANCE(prte_node_t, pmix_list_item_t,
@@ -969,6 +981,11 @@ static void session_con(prte_session_t *s)
     pmix_pointer_array_init(s->children, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
                             PRTE_GLOBAL_ARRAY_MAX_SIZE,
                             PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+    s->owners = NULL;
+    PMIX_LOAD_NSPACE(s->owner, NULL);
+    s->owner_job = NULL;
+    PMIX_LOAD_PROCID(&s->requestor, NULL, PMIX_RANK_INVALID);
+    s->inheritance = PRTE_INHERIT_DEFAULT_VALUE;
 }
 static void session_des(prte_session_t *s)
 {
@@ -1016,6 +1033,16 @@ static void session_des(prte_session_t *s)
         }
     }
     PMIX_RELEASE(s->children);
+
+    if (NULL != s->owners) {
+        PMIx_Argv_free(s->owners);
+        s->owners = NULL;
+    }
+    /* balance the PMIX_RETAIN taken in create_reservation */
+    if (NULL != s->owner_job) {
+        PMIX_RELEASE(s->owner_job);
+        s->owner_job = NULL;
+    }
     // remove this from the global array
     if (0 <= s->index) {
         pmix_pointer_array_set_item(prte_sessions, s->index, NULL);
@@ -1024,6 +1051,50 @@ static void session_des(prte_session_t *s)
 PMIX_CLASS_INSTANCE(prte_session_t,
                     pmix_list_item_t,
                     session_con, session_des);
+
+bool prte_session_is_owned_by(prte_session_t *session,
+                              const pmix_nspace_t nspace)
+{
+    int n;
+
+    /* the default session is usable by everyone */
+    if (NULL == session || session == prte_default_session) {
+        return true;
+    }
+    /* the scheduler is an implicit owner of every session */
+    if (PMIX_CHECK_NSPACE(prte_pmix_server_globals.scheduler.nspace, nspace)) {
+        return true;
+    }
+    if (NULL == session->owners) {
+        return false;
+    }
+    for (n = 0; NULL != session->owners[n]; n++) {
+        if (PMIX_CHECK_NSPACE(session->owners[n], nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_session_add_owner(prte_session_t *session,
+                            const pmix_nspace_t nspace)
+{
+    int n;
+
+    /* the default session is owned by everyone - nothing to record */
+    if (NULL == session || session == prte_default_session) {
+        return;
+    }
+    if (NULL != session->owners) {
+        for (n = 0; NULL != session->owners[n]; n++) {
+            if (PMIX_CHECK_NSPACE(session->owners[n], nspace)) {
+                /* already present */
+                return;
+            }
+        }
+    }
+    PMIx_Argv_append_nosize(&session->owners, nspace);
+}
 
 #if PRTE_PICKY_COMPILERS
 void prte_hide_unused_params(int x, ...)

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -208,6 +208,17 @@ typedef struct {
 } prte_topology_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_topology_t);
 
+/* Default reservation inheritance disposition: a reservation becomes
+ * unreserved within the session when its owning namespace terminates. Defined
+ * as PMIX_ALLOC_INHERIT_DEFAULT when the installed PMIx provides the type, else
+ * the equivalent literal so the runtime builds against an inheritance-unaware
+ * PMIx (which performs this disposition unconditionally). */
+#if defined(PMIX_ALLOC_INHERIT_DEFAULT)
+#    define PRTE_INHERIT_DEFAULT_VALUE PMIX_ALLOC_INHERIT_DEFAULT
+#else
+#    define PRTE_INHERIT_DEFAULT_VALUE 3
+#endif
+
 /* Object for tracking allocations */
 typedef struct{
     pmix_object_t super;
@@ -221,6 +232,29 @@ typedef struct{
     pmix_pointer_array_t *nodes;
     pmix_pointer_array_t *jobs;
     pmix_pointer_array_t *children;
+    /* namespaces entitled to spawn onto this session's nodes. Seeded with the
+     * namespace the reservation was created for, then extended with each job
+     * spawned into the session. Empty for the default session (which everyone
+     * may use) and for scheduler-instantiated sessions not owned by a
+     * namespace. Stored as an argv-style array of nspace strings. */
+    char **owners;
+    /* The single namespace the reservation was created for (PMIX_ALLOC_TARGET,
+     * else the requester). Empty for the default session. owners[] additionally
+     * accumulates every namespace spawned into the reservation. */
+    pmix_nspace_t owner;
+    /* Retained reference to the owning namespace's job object, so its children
+     * subtree stays walkable for CHILD-flavored drain even after the owning
+     * namespace terminates. NULL for the default session. Released at teardown. */
+    struct prte_job_t *owner_job;
+    /* The process that requested this allocation (req->tproc). Target of the
+     * relayed PMIX_ALLOC_TIMEOUT_WARNING. Refreshed on EXTEND. */
+    pmix_proc_t requestor;
+    /* Disposition recorded at creation, governing teardown when the owning
+     * namespace (NONE/DEFAULT) or the last derived child (CHILD/CHILD_DEFAULT)
+     * terminates. Stored as the uint8_t underlying pmix_alloc_inheritance_t so
+     * the struct compiles against a PMIx that lacks the type; defaults to the
+     * value of PMIX_ALLOC_INHERIT_DEFAULT. */
+    uint8_t inheritance;
 } prte_session_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_session_t);
 
@@ -322,10 +356,14 @@ typedef struct {
     prte_node_flags_t flags;
     /* list of prte_attribute_t */
     pmix_list_t attributes;
+    /* session that owns this node; NULL means the node belongs to the
+     * default session (the general, unreserved pool). Not reference-counted
+     * to avoid an ownership cycle with prte_session_t->nodes. */
+    prte_session_t *session;
 } prte_node_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_node_t);
 
-typedef struct {
+typedef struct prte_job_t {
     /** Base object so this can be put on a list */
     pmix_list_item_t super;
     /* record the exit status for this job */
@@ -391,6 +429,14 @@ typedef struct {
     pmix_list_t children;
     /* track the launcher of these jobs */
     pmix_nspace_t launcher;
+    /* Sessions this job may map onto, resolved from PRTE_JOB_SPAWN_TARGET on the
+     * HNP after the ownership check. HNP-local; never packed (rebuilt from the
+     * attribute if ever needed). Defaults to { jdata->session } when no spawn
+     * target was given. target_sessions holds borrowed session pointers (owned
+     * via prte_set_session_object, not by the job), so the destructor frees only
+     * the array, not the sessions it points at. */
+    prte_session_t **target_sessions;
+    size_t num_target_sessions;
     /* track the number of stack traces recv'd */
     uint32_t ntraces;
     char **traces;
@@ -464,6 +510,17 @@ PRTE_EXPORT prte_session_t *prte_get_session_object_from_refid(const char *refid
 PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
 
 PRTE_EXPORT bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2);
+
+/* True if nspace is in session->owners, or session is the default session,
+ * or nspace is the scheduler. */
+PRTE_EXPORT bool prte_session_is_owned_by(prte_session_t *session,
+                                          const pmix_nspace_t nspace);
+
+/* Add nspace to session->owners if not already present (no-op for the
+ * default session). Called when a reservation is created and each time a
+ * job is spawned into the session. */
+PRTE_EXPORT void prte_session_add_owner(prte_session_t *session,
+                                        const pmix_nspace_t nspace);
 
 /**
  * Get a job data object

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -555,6 +555,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "ALLOCATION DISPLAYED";
         case PRTE_JOB_DO_NOT_SPAWN:
             return "DO_NOT_SPAWN";
+        case PRTE_JOB_SPAWN_TARGET:
+            return "SPAWN_TARGET";
 
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -262,6 +262,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_REPORT_PHYSICAL_CPUS       (PRTE_JOB_START_KEY + 121) // bool - report using physical (vs logical) cpu IDs
 #define PRTE_JOB_ALLOC_DISPLAYED            (PRTE_JOB_START_KEY + 122) // bool - allocation has been displayed
 #define PRTE_JOB_DO_NOT_SPAWN               (PRTE_JOB_START_KEY + 123) // bool - do not spawn app procs
+#define PRTE_JOB_SPAWN_TARGET               (PRTE_JOB_START_KEY + 124) // char* - comma-delimited list of PMIX_ALLOC_ID strings naming the
+                                                                       // allocations (sessions) this job may map onto; empty token = default session
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 
@@ -322,6 +324,7 @@ typedef uint16_t prte_proc_flags_t;
 /*** SESSION FLAGS ***/
 typedef uint16_t prte_session_flags_t;
 #define PRTE_SESSION_FLAG_DYNAMIC       0x0001 // session was dynamically allocated
+#define PRTE_SESSION_FLAG_RESERVED      0x0002 // nodes withheld from default pool
 
 
 /*** FLAG OPS ***/


### PR DESCRIPTION
## Problem

PRRTE already partitions an allocation through `prte_session_t`, but it lacked the machinery to place *dynamically* allocated nodes into a session other than the default, and to let a spawn request select which allocation(s) its processes may map onto. Every dynamically allocated node was therefore visible to every job, with no way to reserve nodes for a namespace or to direct a spawn onto a reservation.

## Solution

This realizes the contract specified in `docs/plans/node_reservation` (spec + design plan), implemented in the 12 steps laid out there:

- **Node→session backpointer** (`prte_node_t::session`); `NULL` means the default (unreserved) pool. The mapper (`get_target_nodes`) now draws candidates from the global pool filtered by the job's target-session set, so an untargeted job sees only unreserved nodes.
- **Session ownership** — `owners` set, `owner`/`owner_job`, `requestor`, `inheritance`, `PRTE_SESSION_FLAG_RESERVED`, and `prte_session_is_owned_by` / `prte_session_add_owner`.
- **Allocation routing** in `prte_ras_base_complete_request` honoring `PMIX_ALLOC_TARGET` / `PMIX_ALLOC_SHARE` / `PMIX_ALLOC_INHERITANCE` per the decision table, returning the destination `PMIX_ALLOC_ID` to the requester.
- **Spawn targeting** via `PMIX_SPAWN_TARGET` → `PRTE_JOB_SPAWN_TARGET`, resolved and ownership-checked on the HNP into a cached `target_sessions` set; a job spawned into a reservation becomes a co-owner.
- **Lifecycle** — explicit `PMIX_ALLOC_RELEASE`, plus inheritance dispositions fired at `PRTE_JOB_STATE_TERMINATED`. `NONE`/`DEFAULT` fire at owning-namespace exit; `CHILD`/`CHILD_DEFAULT` drain the owning namespace's spawn subtree (computed from the existing job genealogy, no new counter). `*_DEFAULT` unreserves into the session rather than returning nodes to the scheduler.
- **Timeout-warning relay** of the scheduler's `PMIX_ALLOC_TIMEOUT_WARNING` to the requesting process as a directed event.
- **SLURM RAS** migrated from `prte_node_copy` duplicates to retained references to the global pool's node objects.

All optional PMIx keys are referenced only inside `#if defined(<key>)` guards, so the runtime still builds warning-free and behaves sensibly against a PMIx that predates them.

## Notes

- The SLURM initial-allocation tracking session intentionally leaves `node->session` NULL: those nodes form the **default** session, and setting the backpointer would withhold them from the general pool. The backpointer is set only for true reservations created by `create_reservation`.
- Builds clean (zero warnings). The `donotlaunch` mapper smoke test produces unchanged baseline output.
- Not exercised at runtime here: the timeout-warning relay compiles out against the build's PMIx (no `PMIX_ALLOC_TIMEOUT_WARNING`; verified compilable by temporarily defining it), and the SLURM path and live multi-session spawn need a real scheduler to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)