### PR TITLE
contrib: add a Docker harness for elastic-DVM grow/shrink testing

### DIFF
--- a/contrib/dockerswarm/.gitignore
+++ b/contrib/dockerswarm/.gitignore
@@ -1,0 +1,2 @@
+# build.sh staging area (clean git-archive context + PMIx clone)
+_work/

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -1,0 +1,73 @@
+# Image for the PRRTE elastic-DVM test "swarm" (see README.md).
+#
+# Builds PMIx (cloned from git) and PRRTE (supplied in the build context by
+# build.sh as a clean git-archive of the local committed tree) into /usr/local,
+# plus the `elastic` test client and passwordless SSH between the container
+# "nodes".  Build this with ./build.sh, not a bare `docker build` -- build.sh
+# prepares the PRRTE source the COPY below expects.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential gcc g++ make \
+        autoconf automake libtool m4 flex \
+        perl python3 git \
+        libevent-dev libhwloc-dev zlib1g-dev \
+        openssh-server openssh-client \
+        iproute2 iputils-ping procps less vim ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- build PMIx ----
+# Cloned with its submodules so autogen.pl runs normally.  PMIx master is the
+# default because the DVM size-change event codes (PMIX_DVM_IS_READY /
+# PMIX_ERR_DVM_MOD) the elastic client registers for may not be in a release
+# yet; override with --build-arg if you need a specific PMIx.
+# Do NOT pass --with-libevent=/usr: it forces /usr/lib and misses the multiarch
+# dir (/usr/lib/<triplet>); let configure find the system libevent-dev/hwloc-dev.
+ARG PMIX_REPO=https://github.com/openpmix/openpmix.git
+ARG PMIX_REF=master
+RUN git clone --recursive --depth=1 -b "$PMIX_REF" "$PMIX_REPO" /src/pmix \
+    && cd /src/pmix \
+    && ./autogen.pl \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && ldconfig
+
+# ---- build PRRTE (this repo's committed tree, from the build context) ----
+# build.sh git-archives the local tree into ./prrte with config/oac populated
+# and .gitmodules removed, so autogen.pl skips its git-only submodule check and
+# runs from the VERSION file.  The archived tree has no .git, so configure does
+# NOT imply --enable-devel-check (warnings-as-errors); --enable-debug still
+# gives us debug symbols and assertions.
+COPY prrte /src/prrte
+RUN cd /src/prrte \
+    && ./autogen.pl \
+    && ./configure --prefix=/usr/local --with-pmix=/usr/local --enable-debug \
+    && make -j"$(nproc)" \
+    && make install \
+    && ldconfig
+
+# ---- elastic test client ----
+COPY elastic.c /src/elastic.c
+RUN gcc -O0 -g -o /usr/local/bin/elastic /src/elastic.c \
+        -I/usr/local/include -L/usr/local/lib -lpmix \
+    && ldconfig
+
+# ---- passwordless SSH between the container "nodes" ----
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519 \
+    && cp /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys \
+    && printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+         > /root/.ssh/config \
+    && chmod 600 /root/.ssh/* \
+    && sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && printf '\nAcceptEnv *\n' >> /etc/ssh/sshd_config
+
+# make the install discoverable for any login shell too
+RUN echo 'export PATH=/usr/local/bin:$PATH' > /etc/profile.d/prte.sh
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -1,0 +1,183 @@
+# PRRTE elastic-DVM test "swarm"
+
+A small, self-contained Docker harness for exercising PRRTE's **elastic DVM**
+(grow/shrink) behavior — without a real PMIx scheduler — across several
+container "nodes". It is the quickest way to bring up a multi-node DVM, drive a
+grow and a shrink, and watch the two-phase completion events.
+
+It is **not** a Docker Swarm in the orchestration sense — just four plain
+`ubuntu:24.04` containers on one bridge network, each acting as a DVM node.
+"Swarm" is only the nickname.
+
+> Orientation for an AI agent or new contributor: this directory contains
+> everything needed. Read this file top to bottom, then run the Quick start.
+> The one thing that will silently waste your time is forgetting
+> `--prtemca prte_elastic_mode 1` when starting the DVM — see §3.
+
+---
+
+## 1. What's here
+
+| File | Purpose |
+|------|---------|
+| `build.sh` | Builds the `prte-elastic:latest` image from **this repo's committed tree** plus a cloned PMIx. Start here. |
+| `Dockerfile` | Image recipe: builds PMIx + PRRTE + the `elastic` client into `/usr/local`, sets up passwordless SSH. Driven by `build.sh`. |
+| `docker-compose.yml` | Defines the four nodes `prte-node1`..`prte-node4` on bridge network `dvm`. |
+| `elastic.c` | The test client (`/usr/local/bin/elastic` in the image): issues a PMIx allocation request and waits for the phase-two completion event. |
+
+## 2. Prerequisites
+
+- Docker (with `docker compose`) and `git`.
+- **Network access during the build** — the Dockerfile clones PMIx and installs
+  apt packages.
+- Builds and runs as `aarch64` or `x86_64`; the image is arch-neutral.
+
+PMIx is cloned from **master** by default, because the DVM size-change event
+codes the client registers for (`PMIX_DVM_IS_READY` / `PMIX_ERR_DVM_MOD`) may
+not be in a tagged PMIx release yet. If you build against an older PMIx that
+lacks them, PRRTE compiles those completion events out (and `elastic.c` will not
+compile) — so stick with master unless you know your PMIx has the codes.
+
+## 3. Quick start
+
+```sh
+# from this directory (contrib/dockerswarm/)
+./build.sh                 # build prte-elastic:latest (PMIx master + this repo's HEAD)
+docker compose up -d       # start prte-node1 .. prte-node4
+
+# convenience: run everything on the head node as root, elastic mode ON
+RUN='docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 prte-node1 sh -c'
+
+# 1. start the DVM on node1 -- prte_elastic_mode is REQUIRED (see below)
+$RUN 'cd /root && nohup prte --daemonize --prtemca prte_elastic_mode 1 \
+        >/tmp/prte.out 2>&1 & sleep 6'
+
+# 2. baseline sanity (only node1 in the DVM so far)
+$RUN 'prun --np 1 hostname'
+
+# 3. grow onto node2 + node3, then shrink node3 back out
+$RUN 'elastic grow node2:2,node3:2'
+$RUN 'elastic shrink node3'
+
+# 4. tear the test DVM down (leaves the containers running)
+$RUN 'pterm'
+```
+
+Both `grow` and `shrink` should print
+`PHASE 2 (completion): received event PMIX_DVM_IS_READY` followed by `SUCCESS`.
+
+> **The flag that bites you.** PRRTE gates *all* of the grow/shrink launch-fence
+> and completion-event machinery behind the `prte_elastic_mode` MCA parameter
+> (default off). If you start the DVM **without** `--prtemca prte_elastic_mode 1`,
+> a grow returns phase-1 SUCCESS and even launches the daemons, but it **never
+> completes** — no `PMIX_DVM_IS_READY`, the client times out after 60s, and the
+> nodes never wire into the DVM. Always start with the flag.
+
+## 4. The `elastic` client
+
+```
+elastic grow   <node[:slots],...>   # PMIX_ALLOC_NEW, naming nodes to ADD
+elastic shrink <node,...>           # PMIX_ALLOC_RELEASE, naming nodes to REMOVE
+```
+
+(`extend` / `release` are accepted aliases.) It registers for both completion
+codes, prints the phase-1 allocation response, then waits up to 60s for the
+phase-2 event.
+
+A grow uses **`PMIX_ALLOC_NEW`** carrying `PMIX_ALLOC_NODE_LIST` (a new
+reservation naming the nodes to add) — **not** `PMIX_ALLOC_EXTEND`, which only
+enlarges an existing reservation. With no scheduler attached, PRRTE's `ras/hosts`
+component satisfies these requests locally using the real node names, and
+`plm/ssh` SSHes to the named nodes to launch their daemons (passwordless SSH is
+baked into the image).
+
+## 5. What "success" looks like
+
+**Grow** (`elastic grow node2:2,node3:2`): phase-1 `PMIX_SUCCESS` with a
+`pmix.alloc.id`, then phase-2 `PMIX_DVM_IS_READY`, and `prted` now running on
+node2 and node3.
+
+> The grown nodes join the **reservation** created by the request, so a plain
+> `prun -n 3 --map-by node hostname` still lands only on node1 — its default job
+> allocation is node1's base pool, not the reservation. That is the elastic
+> pooling model, not a failure. Confirm a grow by `prted` presence on the target
+> nodes and the `PMIX_DVM_IS_READY` event, not by plain-prun placement:
+>
+> ```sh
+> for n in 2 3; do docker exec prte-node$n pgrep -ax prted; done
+> ```
+
+**Shrink** (`elastic shrink node3`): phase-1 `PMIX_SUCCESS`, then phase-2
+`PMIX_DVM_IS_READY`, plus a **"PRRTE has lost communication with a remote
+daemon"** notice naming the shrunk node. **That notice is expected** — shrink
+completion is driven by the targeted daemon's actual *death* (the comm-failure
+path), not by an acknowledgement. The HNP must survive it. Afterward: HNP alive,
+node3's `prted` gone, node2's `prted` still alive, `prun -n 1 hostname` still
+works.
+
+## 6. Cleanup hygiene (prevents "multiple possible servers")
+
+Between DVM runs, clean stale state on **every** node:
+
+```sh
+for n in 1 2 3 4; do
+  docker exec prte-node$n sh -c 'pkill -9 -x prted; pkill -9 -x prte;
+    rm -rf /tmp/prte.* /tmp/prun.session.*; true'
+done
+```
+
+A detached `prted --daemonize` **survives an HNP kill** — if you only kill
+node1's `prte`, orphan `prted`s linger on the other nodes and the next DVM trips
+over stale rendezvous files reporting *"multiple possible servers"*. The `pkill`
+loop across all four nodes is mandatory, not optional. `pterm` is the clean way
+to bring a healthy DVM down; still run the loop afterward to be safe.
+
+## 7. Rebuilding after a code change
+
+`build.sh` always rebuilds from your **committed** tree (it uses `git archive`).
+After committing a change:
+
+```sh
+./build.sh && docker compose up -d --force-recreate
+```
+
+For a fast edit/test loop on **uncommitted** PRRTE changes without a full image
+rebuild, each running container already has the build tree at `/src/prrte`. Copy
+the changed files in and run an incremental build **on all four nodes** (every
+node runs a `prted` that loads the libraries, so an ABI/header change must be
+consistent across the DVM):
+
+```sh
+ROOT=$(git rev-parse --show-toplevel)
+FILES="src/mca/ras/ras.h src/mca/ras/base/base.h \
+       src/mca/ras/base/ras_base_allocate.c src/mca/errmgr/dvm/errmgr_dvm.c"
+for n in 1 2 3 4; do
+  for f in $FILES; do docker cp "$ROOT/$f" "prte-node$n:/src/prrte/$f"; done
+  docker exec prte-node$n sh -c \
+    'cd /src/prrte && make -j"$(nproc)" && make install && ldconfig'
+done
+```
+
+PMIx is untouched by PRRTE-only edits, so you never rebuild PMIx for a PRRTE
+change.
+
+## 8. Known issue
+
+Re-growing a node **immediately after** shrinking it can fail its TCP
+connect-back (`prted` exits 255) — the just-killed daemon/session may not have
+fully torn down — and the HNP does not always survive that cleanly. Tracked as
+[openpmix/prrte#2491](https://github.com/openpmix/prrte/issues/2491). Start a
+fresh DVM between grow/shrink cycles to avoid it. A single grow→shrink cycle on
+a fresh DVM is the reliable smoke test.
+
+## 9. Topology reference
+
+| Container | hostname | role |
+|-----------|----------|------|
+| `prte-node1` | node1 | head node (HNP) — start `prte` here, run all tools here |
+| `prte-node2` | node2 | DVM node (grow target) |
+| `prte-node3` | node3 | DVM node (grow/shrink target) |
+| `prte-node4` | node4 | spare DVM node |
+
+Network: bridge `dvm`. To add more nodes, copy a service block in
+`docker-compose.yml`.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Build the prte-elastic:latest image used by the DVM test swarm (README.md).
+#
+# It exports this repo's committed PRRTE tree (default: HEAD) into a clean build
+# context via `git archive` -- so the image contains exactly your committed code,
+# with no host build artifacts and no architecture mismatch -- then builds the
+# Dockerfile, which clones PMIx and compiles both into /usr/local.
+#
+# Test a different committed state with PRRTE_REF, or a specific PMIx with
+# PMIX_REF / PMIX_REPO.  Examples:
+#   ./build.sh
+#   PRRTE_REF=topic/lnch ./build.sh
+#   PMIX_REF=v6.1.0 ./build.sh
+#
+# Requires: docker, git, and network access during the build (for PMIx + apt).
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(git -C "$here" rev-parse --show-toplevel)"
+
+IMAGE="${IMAGE:-prte-elastic:latest}"
+PRRTE_REF="${PRRTE_REF:-HEAD}"
+PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
+PMIX_REF="${PMIX_REF:-master}"
+
+ctx="$here/_work/context"
+rm -rf "$ctx"
+mkdir -p "$ctx"
+
+echo ">>> exporting PRRTE source ($PRRTE_REF) from $root"
+git -C "$root" archive --prefix=prrte/ "$PRRTE_REF" | tar -x -C "$ctx"
+
+# git archive omits submodule contents, so add config/oac (needed by autogen's
+# m4) separately.  Make sure it is checked out on the host first.
+echo ">>> adding config/oac submodule contents"
+git -C "$root" submodule update --init -- config/oac >/dev/null 2>&1 || true
+git -C "$root/config/oac" archive --prefix=prrte/config/oac/ HEAD | tar -x -C "$ctx"
+
+# Drop .gitmodules so the in-container autogen.pl skips its submodule check,
+# which would otherwise run `git submodule status` and fail (no .git here).
+rm -f "$ctx/prrte/.gitmodules"
+
+cp "$here/Dockerfile" "$here/elastic.c" "$ctx/"
+
+echo ">>> docker build $IMAGE (PMIx $PMIX_REF)"
+docker build -t "$IMAGE" \
+    --build-arg PMIX_REPO="$PMIX_REPO" \
+    --build-arg PMIX_REF="$PMIX_REF" \
+    "$ctx"
+
+rm -rf "$here/_work"
+echo ">>> done: built $IMAGE"
+echo ">>> next: docker compose up -d   (then see README.md)"

--- a/contrib/dockerswarm/docker-compose.yml
+++ b/contrib/dockerswarm/docker-compose.yml
@@ -1,0 +1,33 @@
+# A 4-"node" PRRTE DVM on a private docker network for elastic grow/shrink
+# testing.  node1 is the head node (where you start `prte` and run the tests);
+# node2..node4 are spare nodes the DVM can grow onto and shrink back out of.
+# Each container just runs sshd; we `docker exec` into node1 to drive the DVM.
+services:
+  node1:
+    image: prte-elastic:latest
+    hostname: node1
+    container_name: prte-node1
+    networks: [dvm]
+    tty: true
+  node2:
+    image: prte-elastic:latest
+    hostname: node2
+    container_name: prte-node2
+    networks: [dvm]
+    tty: true
+  node3:
+    image: prte-elastic:latest
+    hostname: node3
+    container_name: prte-node3
+    networks: [dvm]
+    tty: true
+  node4:
+    image: prte-elastic:latest
+    hostname: node4
+    container_name: prte-node4
+    networks: [dvm]
+    tty: true
+
+networks:
+  dvm:
+    driver: bridge

--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -1,0 +1,198 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * Elastic-DVM test client.
+ *
+ * Connects to a running PRRTE DVM as a PMIx tool, registers handlers for the
+ * two DVM size-change completion events, and issues a grow or shrink request
+ * naming a node list.  It then waits for the directed PMIX_DVM_IS_READY
+ * (success) or PMIX_ERR_DVM_MOD (failure) event so the two-phase completion
+ * contract can be observed end to end.
+ *
+ *   elastic grow   <node[:slots],...>   # grow the DVM onto these nodes
+ *   elastic shrink <node,...>           # shrink the DVM by these nodes
+ *
+ * (extend/release are accepted as aliases for grow/shrink.)
+ *
+ * Build: gcc -o elastic elastic.c -lpmix
+ */
+
+#include <pmix.h>
+#include <pmix_tool.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <errno.h>
+#include <time.h>
+
+/* tiny lock so the main thread can block on async callbacks */
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+    volatile int active;
+    pmix_status_t status;
+} lock_t;
+
+static void lock_init(lock_t *l) {
+    pthread_mutex_init(&l->mtx, NULL);
+    pthread_cond_init(&l->cond, NULL);
+    l->active = 1;
+    l->status = PMIX_SUCCESS;
+}
+static void lock_wait(lock_t *l) {
+    pthread_mutex_lock(&l->mtx);
+    while (l->active) {
+        pthread_cond_wait(&l->cond, &l->mtx);
+    }
+    pthread_mutex_unlock(&l->mtx);
+}
+static void lock_wake(lock_t *l, pmix_status_t st) {
+    pthread_mutex_lock(&l->mtx);
+    l->status = st;
+    l->active = 0;
+    pthread_cond_signal(&l->cond);
+    pthread_mutex_unlock(&l->mtx);
+}
+
+static lock_t complete_lock;     /* fired by the DVM_IS_READY / ERR_DVM_MOD handler */
+static pmix_proc_t myproc;
+
+/* handler registration callback */
+static void reg_cb(pmix_status_t status, size_t evref, void *cbdata) {
+    lock_t *l = (lock_t *) cbdata;
+    (void) evref;
+    lock_wake(l, status);
+}
+
+/* allocation-request response (phase one: acceptance) */
+static void alloc_cb(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                     void *cbdata, pmix_release_cbfunc_t release_fn, void *release_cbdata) {
+    lock_t *l = (lock_t *) cbdata;
+    size_t n;
+    fprintf(stderr, ">>> PHASE 1 (acceptance): allocation request returned %s\n",
+            PMIx_Error_string(status));
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_STRING == info[n].value.type) {
+            fprintf(stderr, "      info[%zu] %s = %s\n", n, info[n].key,
+                    info[n].value.data.string);
+        } else {
+            fprintf(stderr, "      info[%zu] key=%s\n", n, info[n].key);
+        }
+    }
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    lock_wake(l, status);
+}
+
+/* phase two: the directed completion event */
+static void completion_evh(size_t evhdlr_id, pmix_status_t status,
+                           const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                           pmix_info_t results[], size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata) {
+    size_t n;
+    (void) evhdlr_id; (void) source; (void) results; (void) nresults;
+
+    fprintf(stderr, "\n>>> PHASE 2 (completion): received event %s (%d)\n",
+            PMIx_Error_string(status), status);
+    for (n = 0; n < ninfo; n++) {
+        fprintf(stderr, "      payload[%zu] key=%s\n", n, info[n].key);
+    }
+    if (PMIX_DVM_IS_READY == status) {
+        fprintf(stderr, ">>> SUCCESS: the DVM now reflects the requested size\n");
+    } else if (PMIX_ERR_DVM_MOD == status) {
+        fprintf(stderr, ">>> FAILURE: the DVM modification did not happen\n");
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    lock_wake(&complete_lock, status);
+}
+
+int main(int argc, char **argv) {
+    pmix_status_t rc;
+    pmix_info_t *info;
+    pmix_alloc_directive_t directive;
+    pmix_status_t codes[2];
+    lock_t reglock;
+    lock_t alloclock;
+    const char *op, *nodelist;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <grow|shrink> <node1,node2,...>\n", argv[0]);
+        return 1;
+    }
+    op = argv[1];
+    nodelist = argv[2];
+    /* A grow is a NEW reservation that names the nodes to add: PRRTE adds them
+     * to the pool and extends the DVM.  PMIX_ALLOC_EXTEND only adds to an
+     * already-existing reservation, so it is not the right trigger here. */
+    if (0 == strcmp(op, "grow") || 0 == strcmp(op, "extend")) {
+        directive = PMIX_ALLOC_NEW;
+    } else if (0 == strcmp(op, "shrink") || 0 == strcmp(op, "release")) {
+        directive = PMIX_ALLOC_RELEASE;
+    } else {
+        fprintf(stderr, "unknown op '%s' (want grow|shrink)\n", op);
+        return 1;
+    }
+
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
+        fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, "tool %s:%d connected to the DVM\n", myproc.nspace, myproc.rank);
+
+    /* register for BOTH completion codes in one handler */
+    lock_init(&complete_lock);
+    lock_init(&reglock);
+    codes[0] = PMIX_DVM_IS_READY;
+    codes[1] = PMIX_ERR_DVM_MOD;
+    PMIx_Register_event_handler(codes, 2, NULL, 0, completion_evh, reg_cb, &reglock);
+    lock_wait(&reglock);
+    fprintf(stderr, "registered for PMIX_DVM_IS_READY / PMIX_ERR_DVM_MOD\n");
+
+    /* issue the size-change request naming the node list */
+    lock_init(&alloclock);
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, nodelist, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, "elastic-test", PMIX_STRING);
+    fprintf(stderr, "requesting %s of nodes [%s] ...\n", op, nodelist);
+    rc = PMIx_Allocation_request_nb(directive, info, 2, alloc_cb, &alloclock);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+        fprintf(stderr, "PMIx_Allocation_request_nb failed immediately: %s\n",
+                PMIx_Error_string(rc));
+        goto done;
+    }
+    lock_wait(&alloclock);
+    PMIX_INFO_FREE(info, 2);
+
+    fprintf(stderr, "waiting for phase-two completion event (60s) ...\n");
+    /* crude bounded wait so the tool can't hang forever in a test */
+    {
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 60;
+        pthread_mutex_lock(&complete_lock.mtx);
+        while (complete_lock.active) {
+            if (ETIMEDOUT == pthread_cond_timedwait(&complete_lock.cond,
+                                                    &complete_lock.mtx, &ts)) {
+                fprintf(stderr, ">>> TIMEOUT: no completion event within 60s\n");
+                break;
+            }
+        }
+        pthread_mutex_unlock(&complete_lock.mtx);
+    }
+
+done:
+    PMIx_tool_finalize();
+    return 0;
+}


### PR DESCRIPTION
## Problem

Exercising PRRTE's elastic-DVM grow and shrink paths requires a multi-node
DVM, and the only way to drive those paths without a real PMIx scheduler has
been an ad-hoc set of containers rebuilt by hand each session. There is
nothing in the tree that lets a contributor stand up a working test DVM
quickly and reproducibly.

## What this adds

A self-contained Docker test harness under `contrib/dockerswarm/`:

- `build.sh` — exports this repo's committed tree via `git archive` (so the
  image contains exactly the code under test, with no host build artifacts and
  no architecture mismatch), clones PMIx, and builds the image.
- `Dockerfile` — builds PMIx and PRRTE into the image, plus the `elastic`
  PMIx tool client and passwordless SSH between the container "nodes".
- `docker-compose.yml` — four `ubuntu:24.04` nodes (`prte-node1`..`prte-node4`)
  on a private bridge network.
- `elastic.c` — a small PMIx tool that issues a grow/shrink allocation request
  and waits for the two-phase `PMIX_DVM_IS_READY` / `PMIX_ERR_DVM_MOD`
  completion event.
- `README.md` — the full workflow, success criteria, cleanup hygiene, and the
  pitfalls (most importantly that the DVM must be started with
  `--prtemca prte_elastic_mode 1`, or grow/shrink never complete).

Follows the existing `contrib/docker/` convention (git-tracked, not added to
`EXTRA_DIST`). No build-system or source changes — this is test tooling only.

## Verification

`./build.sh` builds end-to-end from a clean `git archive` to a working image;
`prte`, `prte_info`, and the `elastic` client all run. PMIx is cloned from
master so the DVM size-change event codes are present.

## Note

The harness is most useful alongside the elastic-DVM feature work; on master
it builds and runs, but the grow/shrink behaviors it drives land with that
feature.