### PR TITLE
Collective shrink completion: repair the routing tree once per campaign

### DIFF
--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -439,14 +439,49 @@ loop between runs.
 Re-grow of a just-shrunk node (#2491) is **partially** addressed here.  The
 ``prte_plm_base_reset_dvm_node()`` step above fixes the launcher-agnostic half —
 a shrunk node is no longer skipped ("daemon already exists") or duplicated on a
-later grow, verified on the testbed.  The remaining half is the daemon vpid
-space: a shrink leaves a dead vpid that the positional radix routing tree
-(``prte_rml_compute_routing_tree``) treats as a live daemon on the next grow, so
-the re-grown daemon fails wireup.  Reusing the vacated vpid would fix it for the
-ssh launcher but breaks the non-ssh launchers (slurm/pals/lsf), which launch
-daemons as a **sequential** vpid range; a launcher-agnostic fix therefore has to
-route the tree around the dead rank instead.  That routing-side fix is tracked
-separately and is not part of this change.
+later grow, verified on the testbed — and the prerequisite that landed in #2497
+also routes ``PRTE_PROC_STATE_FAILED_TO_CONNECT`` into the grow-failure rollback
+instead of the fatal "unsupported daemon error state" abort.  The remaining half
+is the daemon vpid space.  A shrink leaves a dead vpid in the daemon job array
+(the proc is marked terminated and ``prte_process_info.num_daemons`` is
+decremented, but it is *not* removed from ``daemons->procs`` and
+``daemons->num_procs`` is not decremented), and a later grow always **appends**
+(``proc->name.rank = daemons->num_procs``), so the hole becomes permanent.  The
+positional radix routing tree is pure vpid arithmetic over ``[0, num_daemons)``:
+the shrink's ``prte_rml_repair_routing_tree()`` correctly marks the dead rank as
+failed, but the next grow's ``prte_rml_compute_routing_tree()`` re-inits its
+failed-daemon bitmaps and **wipes those marks**, so it re-treats the dead rank
+as live and the re-grown daemon fails wireup.  Reusing the vacated vpid would
+fix it for the ssh launcher but breaks the non-ssh launchers (slurm/pals/lsf),
+which launch daemons as a **sequential** vpid range; the launcher-agnostic fix
+is therefore to route the tree *around* the dead rank rather than reuse the vpid.
+
+**This routing-side fix is now implemented.**  ``prte_rml_base`` carries a
+persistent ``dead_dmns`` bitmap that ``prte_rml_repair_routing_tree()`` sets
+whenever a rank departs and that ``prte_rml_compute_routing_tree()`` — unlike the
+per-event ``failed_dmns`` set — never re-initializes.  On every recompute the
+departed ranks are restored into ``failed_dmns`` and the freshly-built base tree
+is repaired around them (``prte_rml_update_ancestors`` / ``handle_promotion`` /
+``update_descendants``), so ``radix_is_living`` keeps the hole out of every
+survivor's ancestors, lifeline, and children.  One of the two supporting bugs is
+fixed alongside: the grow path into ``setup_vm`` now resets
+``map->num_new_daemons`` and ``map->daemon_vpid_start`` on entry rather than
+accumulating them across successive grows.  The other — the VM-ready gate
+(``num_reported == num_procs``) after a hole — is expected to be moot with
+append-only vpids plus the routing fix and is left tracked in #2491.
+
+A brand-new daemon starts with an empty ``dead_dmns`` set, so it could not learn
+the holes from the shrink events it never saw.  That gap is closed in the nidmap.
+``prte_util_nidmap_create`` now packs the true daemon vpid-space size
+(``prte_process_info.num_daemons``) in addition to the live daemon list, and
+``prte_util_decode_nidmap`` sets ``num_daemons`` from it and marks every vpid in
+``[0, num_daemons)`` that has no live daemon entry into ``dead_dmns`` before
+(re)computing the routing tree.  A shrunk-out rank is exactly such a gap, so
+every daemon — freshly grown or long-standing — converges on the same vpid span
+and the same dead set as the HNP, and the tree is routed around the hole even in
+a deep (multi-level) tree where a new daemon's own computed ancestor is a
+departed rank.  On an unshrunk DVM the packed span equals the live count, nothing
+is marked dead, and behavior is unchanged.
 
 Open questions
 --------------

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -1,0 +1,395 @@
+.. _dvm-collective-shrink-completion-label:
+
+Collective Shrink Completion — Repair the Routing Tree Once per Campaign
+=======================================================================
+
+This document plans the **optimization** tracked in
+`openpmix/prrte#2492 <https://github.com/openpmix/prrte/issues/2492>`_: draining
+a shrink campaign as a single collective event rather than one daemon at a time.
+It is a *revision* of the shrink path described in
+:ref:`dvm-shrink-campaign-label`; that document remains authoritative for the
+fence mechanism, the held-job arrays, the second hold point at ``LAUNCH_APPS``,
+and the campaign type.  Only the pieces this revision changes are restated here.
+
+This is an **optimization, not a correctness fix**.  The per-daemon completion
+path shipped in :ref:`dvm-shrink-campaign-label` is correct; it was deliberately
+kept simple and the collective scheme was deferred.  Nothing here changes the
+externally observable contract in :ref:`elastic-dvm-spec-label` — the same
+``PMIX_DVM_IS_READY`` / ``PMIX_ERR_DVM_MOD`` events fire for the same requests;
+only *when and how many times* the internal routing-tree repair runs changes.
+
+The state machine is single-threaded on the progress thread, so no locking is
+required anywhere in this plan.
+
+Background — the cost being removed
+-----------------------------------
+
+The shipped design drains a campaign **one daemon at a time**.  Every targeted
+daemon exits on its own in response to ``PRTE_DAEMON_SHRINK_CMD``
+(``src/prted/prted_comm.c``, the ``PRTE_DAEMON_SHRINK_CMD`` case), and the HNP
+discovers each departure independently through the errmgr comm-failure path
+(``src/mca/errmgr/dvm/errmgr_dvm.c``, ``proc_errors()``), decrementing the
+campaign's ``pending`` count and the shared fence once per death.
+
+Each of those independent departures drives a **separate** routing-tree repair.
+A daemon that exits triggers ``prte_rml_route_lost()``
+(``src/rml/routed_radix.c``), which calls
+``prte_rml_repair_routing_tree(&failed_ranks, /*global=*/false)`` with a
+**single** rank; that in turn runs ``handle_promotion()`` and
+``update_descendants()`` for that one rank.  Shrinking ``m`` daemons that sit
+along one branch of the radix routing tree therefore triggers up to ``m``
+sequential promotions/descendant rewrites.  Review of PR #2472 flagged this as
+potentially expensive for a large single-branch shrink (unprofiled).
+
+Crucially, ``prte_rml_repair_routing_tree()`` **already accepts a rank array**
+(``pmix_data_array_t *failed_ranks``) and performs a single promotion/descendant
+pass for the whole set.  The optimization is to feed it the whole campaign at
+once instead of one rank at a time.
+
+Design overview
+---------------
+
+Repair the tree **once per campaign**:
+
+#. The HNP broadcasts ``PRTE_DAEMON_SHRINK_CMD`` via the reliable xcast, exactly
+   as today.  The broadcast payload already carries the full target-rank list,
+   so **every** daemon learns the complete set of departing ranks from the
+   broadcast itself — no separate failure notice is needed to inform survivors.
+#. Each targeted daemon records that it is leaving and does its local
+   processing, but **does not exit yet** (today it self-exits).
+#. The HNP hooks the **broadcast's completion**.  The reliable xcast in
+   ``src/mca/grpcomm/direct/grpcomm_direct_xcast.c`` already tracks completion
+   via ACKs flowing up the tree: when ``finish_op()`` runs on the master, every
+   daemon in the DVM has received the op.  A per-op completion callback is added
+   (or the shrink op special-cased) to fire a handler at that point.
+#. That handler reports **all** of the campaign's targets as failed in a single
+   batch via ``prte_rml_repair_routing_tree(failed_ranks, /*global=*/false)`` —
+   one promotion/descendant pass for the whole set — and performs the HNP-side
+   teardown bookkeeping (``num_daemons``, node state, fence) for the batch.
+#. Each doomed daemon exits once its lifeline disconnects as a consequence of
+   the rewire, rather than self-exiting — but only because processing the shrink
+   command put it into a **new leaving mode** that converts lifeline loss into
+   termination (normally lifeline loss triggers *recovery*, not exit).  Because
+   that mode rides in the broadcast itself and reaches each doomed daemon through
+   its own lifeline, there is no race between learning "you are leaving" and the
+   lifeline failing (see Step 3's design decision).  The completion event
+   (``PMIX_DVM_IS_READY``) fires from this single batch point rather than from
+   the last individual departure.
+
+Why this is **not** the rejected per-daemon ACK
+-----------------------------------------------
+
+:ref:`dvm-shrink-campaign-label` rejected an earlier design in which each daemon
+sent a ``PRTE_PLM_SHRINK_ACK_CMD`` announcing its *intent* to leave, and the HNP
+decremented the campaign on receipt of that ACK.  That was wrong because the ACK
+arrived while the daemon was still a live participant — acting on it could
+release held jobs into a DVM that still believed the departing daemon present —
+and because two decrement paths (ACK plus errmgr fallback) double-counted.
+
+The collective scheme is **not** that design.  The authoritative HNP-side
+teardown — route removal, ``num_daemons``, node state, fence — still happens at
+the batch-repair callback, and held jobs are released only *after* it.  The
+signal is not a daemon announcing intent; it is the xcast-completion fact that
+every daemon has received the shrink order, at which point the HNP itself
+performs the teardown.  The invariant "act once teardown has occurred, not on
+intent" is preserved.  Because completion collapses to a single event per
+campaign, the per-rank ``PMIX_RANK_INVALID`` idempotency stamping and the
+double-count analysis that the per-death path required are retired: there is now
+exactly one teardown event per campaign, so there is nothing to make idempotent.
+
+Required revisions
+------------------
+
+Step 1 — Add an xcast completion callback (grpcomm/direct)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Today ``prte_grpcomm.xcast(tag, msg)`` is fire-and-forget
+(``src/mca/grpcomm/grpcomm.h``, ``prte_grpcomm_base_module_xcast_fn_t``).  The
+reliable xcast already *knows* when the whole DVM has received an op — on the
+master, ``finish_op()`` in ``grpcomm_direct_xcast.c`` runs when the last child
+ACK arrives, and ``op->sig.op_id`` is complete for the entire subtree, which for
+the master is the entire DVM.
+
+Add a mechanism to run a caller-supplied callback at that point.  Two options,
+in preference order:
+
+* **Per-op completion callback (preferred).**  Extend the xcast entry so the
+  caller may pass a completion function and an opaque ``cbdata``, cache them on
+  the ``op_t``, and invoke them from ``finish_op()`` **only on the master**
+  (``PRTE_PROC_IS_MASTER``) — the point at which whole-DVM receipt is known.
+  This is a general facility, useful beyond shrink.
+* **Special-case the shrink op.**  If a full callback API is deemed too broad
+  for this change, have ``finish_op()`` on the master recognize the shrink op
+  and call the shrink-completion handler directly.  Cheaper to write, less
+  reusable; a follow-up would still likely generalize it.
+
+Whichever is chosen, the callback fires on the progress thread inside
+``finish_op()``, so it may touch state-machine globals directly.
+
+.. note::
+
+   ``finish_op()`` also runs on non-master daemons (it ACKs to the parent).  The
+   completion callback must fire **only** where ``PRTE_PROC_IS_MASTER`` is true,
+   because only there does op completion mean *every* daemon received the op.  A
+   non-master's ``finish_op()`` means only its own subtree completed.
+
+Step 2 — HNP shrink-completion handler (new)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register the Step-1 callback when the shrink xcast is issued in
+``src/mca/ras/base/ras_base_allocate.c`` (the ``PMIX_ALLOC_RELEASE`` branch of
+``prte_ras_base_complete_request()`` and the reservation-teardown xcast in
+``prte_ras_base_teardown_reservation()`` — both send ``PRTE_DAEMON_SHRINK_CMD``).
+Carry the ``prte_shrink_campaign_t *`` as the callback ``cbdata`` so the handler
+has the target list and requester in hand.
+
+The handler, running once per campaign on the master, must do everything the
+per-death errmgr path currently does across ``m`` invocations — but for the
+whole batch, and exactly once:
+
+#. **Batch routing-tree repair.**  Build a ``pmix_data_array_t`` from
+   ``camp->targets`` and call
+   ``prte_rml_repair_routing_tree(&failed, /*global=*/false)`` **once**.  This is
+   the single promotion/descendant pass that replaces the per-daemon repairs.
+#. **Per-target HNP bookkeeping.**  For each target rank, apply the same
+   teardown the comm-failure block applies today (``errmgr_dvm.c`` lines
+   269-274): unset ``PRTE_PROC_FLAG_ALIVE``, set the proc state, and decrement
+   ``prte_process_info.num_daemons``.  This bookkeeping currently *rides on the
+   comm-failure event*; when the loss is declared proactively it must be done
+   here instead.  **This is the highest-risk part of the change** — see
+   *Validation* below.
+#. **Fence and completion.**  Decrement ``prte_dvm_launch_fence`` by
+   ``camp->pending`` (all at once), invoke
+   ``prte_ras_base_shrink_complete(camp)`` to give the RAS modules their release
+   hook, emit ``PMIX_DVM_IS_READY`` to the requester via
+   ``prte_plm_base_dvm_mod_notify()`` when ``camp->have_requester``, remove the
+   campaign from ``prte_shrink_campaigns``, and call
+   ``prte_plm_base_fence_release()`` when ``prte_dvm_launch_fence`` reaches zero.
+   These are the same calls the errmgr path makes; they simply move here and run
+   once for the batch.
+
+Step 3 — Daemon side: record-and-wait instead of self-exit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In ``src/prted/prted_comm.c``, the ``PRTE_DAEMON_SHRINK_CMD`` case currently, for
+a daemon that finds its own rank in the target list, fires the
+``PMIX_EVENT_JOB_END`` notification and immediately activates
+``PRTE_JOB_STATE_DAEMONS_TERMINATED`` (self-exit).  Revise so that:
+
+* **Every** daemon (target or survivor) uses the target list carried in the
+  broadcast to repair its *own* routing tree locally —
+  ``prte_rml_repair_routing_tree(targets, /*global=*/false)`` — so survivors
+  drop the departing ranks from their children/parent sets.  Because the list
+  travels in the broadcast, no global failure propagation is needed; this is why
+  Step 2 uses ``global=false``.
+* A daemon that finds **its own** rank among the targets records that it is
+  leaving by entering **leaving mode** — a flag set as it *processes the
+  ``PRTE_DAEMON_SHRINK_CMD`` itself*, not in response to any separate order (see
+  the design decision below) — fires its ``JOB_END`` notification, and then
+  **waits for its lifeline to disconnect** rather than self-exiting.  Entering
+  this mode is what changes the daemon's response to lifeline loss from
+  *recover* to *terminate*; see the warning below.
+
+.. warning::
+
+   **This code path does not exist today and must be created as part of this
+   effort.**  A daemon that loses its lifeline (its parent) normally attempts
+   **recovery** — it promotes and reconnects to an ancestor
+   (``prte_rml_route_lost()`` and the promotion path in ``routed_radix.c``); it
+   does **not** exit.  The collective scheme needs a doomed daemon to
+   *terminate* on lifeline loss instead, and that new behavior must be gated
+   strictly on the leaving mode set above: **termination on lifeline failure may
+   occur only when this daemon has processed the shrink command naming its own
+   rank.**  A daemon that loses its lifeline for any other reason (a genuine
+   fault) must still take the normal recover/promote path — never this exit.
+   The complementary half — actually *dropping* the doomed daemon's lifeline —
+   comes from the survivor-side rewire (driven off the same broadcast) closing
+   the connection to each departing child; for a single-branch shrink this
+   cascades from the top of the branch down.  Prove both halves on the testbed
+   before removing the daemon self-exit; a bounded self-exit fallback is the safe
+   interim so a daemon that never sees its lifeline drop still terminates.
+
+Design Decision — Leaving mode rides in the shrink command (race-free by construction)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+A tempting but wrong shape is to make "enter leaving mode" a *second*, separate
+order the HNP sends after the shrink command.  That opens a race: a doomed
+daemon's lifeline could fail (because a survivor already rewired and dropped it)
+**before** the separate leaving-mode order arrived, and the daemon — not yet in
+leaving mode — would take the recovery path and try to promote instead of
+exiting.  The fix is to **not** have a second order at all: leaving mode is set
+by the daemon as it processes ``PRTE_DAEMON_SHRINK_CMD``, so the "you are
+leaving" fact travels in the *same* broadcast that will ultimately tear the
+lifeline down.
+
+This is race-free by construction because the shrink broadcast propagates **down
+the routing tree, which is the very set of lifelines**:
+
+* A doomed daemon receives ``PRTE_DAEMON_SHRINK_CMD`` *through its own lifeline*
+  (its parent forwards the xcast to it over exactly the connection whose loss
+  will later trigger termination).
+* The reliable xcast **forwards to children before processing locally** for
+  ``PRTE_RML_TAG_DAEMON`` — the tag the shrink command uses.  In
+  ``grpcomm_direct_xcast.c`` (``prte_grpcomm_direct_xcast_recv()``), only
+  ``PRTE_RML_TAG_WIREUP`` and ``PRTE_RML_TAG_DAEMON_DIED`` are in the
+  ``process_first`` set; every other tag runs ``forward_op()`` then
+  ``process_msg()``.  So a parent hands the command to each child **before** it
+  runs its own handler and rewires/drops that child.
+* TCP in-order delivery on the lifeline then guarantees the doomed daemon reads
+  the command (and enters leaving mode) *before* it can observe that same
+  connection failing.  For a whole branch the cascade is inductive: each doomed
+  daemon forwards the command down to its own children before its later death
+  drops their lifelines, so every daemon on the branch is in leaving mode before
+  its lifeline dies.
+
+Two consequences for the implementation:
+
+#. The shrink command **must stay on** ``PRTE_RML_TAG_DAEMON`` (forward-first).
+   It must *not* be moved into the ``process_first`` set, or a parent could drop
+   a child before forwarding the command to it — reopening the race.
+#. The only remaining way a doomed daemon can see its lifeline fail before
+   entering leaving mode is a genuine, independent fault that races the
+   broadcast.  That is precisely the case the leaving-mode gate handles
+   correctly: not yet in leaving mode ⇒ recover/promote (correct — it really is
+   a fault), and the reliable xcast re-propagates the command through the
+   repaired tree, so the daemon still enters leaving mode and exits once the
+   command reaches it.
+
+Step 4 — Remove the per-death completion logic from the errmgr
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once completion is driven by Step 2, the shrink-campaign block in
+``proc_errors()`` (``errmgr_dvm.c`` lines 286-323 — the ``PMIX_LIST_FOREACH_SAFE``
+over ``prte_shrink_campaigns`` with the ``PMIX_RANK_INVALID`` stamping, the
+per-death ``pending``/fence decrement, ``prte_ras_base_shrink_complete()``, and
+``prte_plm_base_dvm_mod_notify()``) is removed.  The comm-failure event for a
+doomed daemon must then be **harmless**: because the daemon was already stamped
+gone and removed from routing in Step 2, a later comm-failure for the same rank
+should fall through the general daemon-loss handling without re-aborting the DVM.
+
+.. warning::
+
+   This reverses the current *ordering of cause and effect*.  Today the daemon
+   dies first, and the comm-failure event does the teardown.  In the collective
+   scheme the HNP does the teardown first, and the daemon dies afterward.  The
+   general daemon-loss handling below the removed block (``errmgr_dvm.c`` from
+   line 324 on) must tolerate a comm-failure for a rank the HNP has *already*
+   torn down — otherwise the doomed daemons' eventual deaths will trip DVM abort
+   logic.  Auditing that fall-through is mandatory, not optional.
+
+Interaction with the grow rollback path
+----------------------------------------
+
+The comm-failure block already special-cases grow targets via
+``prte_plm_base_grow_target_failed()`` (``errmgr_dvm.c`` line 283), which returns
+early.  That check must remain **ahead of** any shrink handling and is
+unaffected: a rank cannot be simultaneously a grow target and a shrink target,
+and the grow path still relies on the real comm-failure event.  Only the shrink
+branch moves to the collective callback.
+
+Design invariants preserved
+----------------------------
+
+* **Teardown before release.**  Held jobs are released only after the HNP-side
+  teardown (routes, ``num_daemons``, node state, fence) has run — now in the
+  Step-2 batch handler rather than the per-death path.
+* **Per-campaign completion event.**  ``PMIX_DVM_IS_READY`` still fires once per
+  request, when *this* campaign drains; other concurrent campaigns keeping the
+  shared fence nonzero do not delay it.  Held-job release still waits for the
+  global fence to reach zero.
+* **Clean exit and crash are indistinguishable.**  A daemon that crashes mid
+  shrink is still handled: its rank is in the batch, so it is torn down by
+  Step 2 regardless of whether it would have exited cleanly.
+* **Failure path unchanged.**  ``PMIX_ERR_DVM_MOD`` is still emitted only on the
+  xcast-failure cleanup in :ref:`dvm-shrink-campaign-label` Step 1; once the
+  shrink command is on the wire, every departure is a success for the campaign.
+
+Validation
+----------
+
+The collective / whole-branch failure path is far less exercised than
+individual daemon deaths and may surface bugs in the tree-repair and
+fault-handling code.  Validate on the in-repo Docker testbed
+(``contrib/dockerswarm/``), which is now sized to **ten** nodes precisely so a
+shrink can target several daemons on one branch of the radix tree at once:
+
+#. **Deep tree.**  Start the DVM in elastic mode and grow onto eight nodes in a
+   single request (``elastic grow node2:2,...,node9:2``); this builds a
+   nine-daemon radix tree with real depth.
+#. **Single-branch shrink.**  Shrink a contiguous set of daemons that sit on one
+   branch and confirm exactly **one** promotion/descendant pass runs (trace with
+   ``--prtemca ... routed/rml verbosity``), a single ``PMIX_DVM_IS_READY`` fires,
+   the HNP survives, and ``prun -n 1 hostname`` still works afterward.
+#. **Multi-daemon, multi-branch shrink.**  Shrink daemons drawn from more than
+   one branch in a single request; confirm the batch repair and the single
+   completion event still hold.
+#. **In-flight job.**  Drive a shrink while a job is held at the ``LAUNCH_APPS``
+   hold point and confirm it remaps onto survivors after completion.
+#. **Crash during shrink.**  Kill a doomed daemon (``docker exec ... pkill -9
+   prted``) after the broadcast but before its lifeline drops, and confirm the
+   campaign still drains exactly once.
+
+See ``contrib/dockerswarm/README.md`` for the elastic-mode flag, the cleanup
+loop between runs, and the known re-grow flake (#2491).
+
+Open questions
+--------------
+
+#. **Terminate-on-lifeline mode (design decided; code to build).**  Confirmed:
+   no terminate-on-lifeline-loss path exists today — a daemon that loses its
+   lifeline recovers/promotes, it does not exit — so this path must be *created*
+   as part of this effort.  The *race* concern (lifeline failing before the
+   daemon knows it is leaving) is resolved by construction — leaving mode rides
+   in the shrink command, which reaches each doomed daemon through its own
+   lifeline ahead of that lifeline's failure (see *Design Decision — Leaving mode
+   rides in the shrink command*).  The remaining build work is to (a) set and
+   honor the leaving-mode flag on the daemon side when it processes a shrink
+   command naming its own rank (Step 3) and (b) ensure the survivor-side rewire
+   actually closes the connection to each departing child so the lifeline drops.
+   Keep a bounded self-exit fallback until both halves are proven on the testbed.
+#. **General callback vs. shrink special case (Step 1).**  Is a general per-op
+   xcast completion callback wanted now, or a narrow shrink special case with a
+   later generalization?  Affects the ``grpcomm`` API surface.
+#. **Comm-failure fall-through (Step 4).**  Exactly which branches of the
+   post-shrink daemon-loss handling in ``errmgr_dvm.c`` must be taught to ignore
+   a rank the HNP already tore down, so the doomed daemons' eventual real deaths
+   are harmless?
+#. **Profiling.**  The original concern was unprofiled.  Worth measuring the
+   per-daemon vs. batch repair cost on a large single-branch shrink to confirm
+   the optimization earns its complexity before committing to it.
+
+Summary of files changed
+------------------------
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - File
+     - Change
+   * - ``src/mca/grpcomm/grpcomm.h``
+     - Extend the xcast module interface with an optional per-op completion
+       callback + ``cbdata`` (Step 1, preferred option).
+   * - ``src/mca/grpcomm/direct/grpcomm_direct_xcast.c``
+     - Cache the completion callback on ``op_t``; invoke it from ``finish_op()``
+       **only** when ``PRTE_PROC_IS_MASTER``.
+   * - ``src/mca/ras/base/ras_base_allocate.c``
+     - Register the completion callback (carrying the ``prte_shrink_campaign_t``)
+       on both ``PRTE_DAEMON_SHRINK_CMD`` xcasts.  Add the Step-2 handler:
+       batch ``prte_rml_repair_routing_tree()``, per-target HNP bookkeeping,
+       fence decrement, ``prte_ras_base_shrink_complete()``, ``dvm_mod_notify``,
+       campaign removal, ``prte_plm_base_fence_release()``.
+   * - ``src/prted/prted_comm.c``
+     - ``PRTE_DAEMON_SHRINK_CMD`` handler: every daemon repairs its own tree from
+       the broadcast target list; a targeted daemon records-and-waits for
+       lifeline loss instead of self-exiting (with a bounded fallback).
+   * - ``src/mca/errmgr/dvm/errmgr_dvm.c``
+     - Remove the per-death shrink-campaign block (lines 286-323) including the
+       ``PMIX_RANK_INVALID`` stamping.  Ensure the general daemon-loss handling
+       tolerates a comm-failure for a rank already torn down by Step 2.
+   * - ``src/rml/routed_radix.c``
+     - No change expected — ``prte_rml_repair_routing_tree()`` already accepts a
+       rank array and does one pass.  Listed for reference.
+   * - ``contrib/dockerswarm/``
+     - Testbed grown to ten nodes to exercise single-branch multi-daemon shrink
+       (already done alongside this plan).

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -315,6 +315,16 @@ collective completion handler), ``prted/prted_comm.c`` and ``rml/routed_radix.c`
 guard), and ``runtime/prte_globals.{h,c}``.  It builds warning-free under
 ``--enable-devel-check`` (``-Werror`` plus the full picky set).
 
+The entire machinery is gated behind ``prte_elastic_mode``.  The master only
+enqueues an ``xcast_nb`` completion (and pops it on the relay-to-self) when
+elastic mode is active; the daemon only enters leaving mode — the bounded
+departure timer and the lifeline-loss fast path — when ``prte_dvm_leaving`` is
+set, which happens exclusively on an elastic shrink; and the already-departed
+guard in ``errmgr/dvm`` is skipped entirely otherwise.  A default (non-elastic)
+``prterun`` and a persistent DVM plus ``prun`` were both re-validated after the
+gating went in: the launch and fault-handling paths are byte-for-byte the prior
+behavior when elastic mode is off.
+
 Two implementation choices settled the open questions the plan had flagged:
 
 * The completion hook is the **general** ``xcast_nb`` facility (open question #2's

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -304,30 +304,80 @@ Design invariants preserved
   xcast-failure cleanup in :ref:`dvm-shrink-campaign-label` Step 1; once the
   shrink command is on the wire, every departure is a success for the campaign.
 
-Validation
-----------
+Implementation status
+---------------------
 
-The collective / whole-branch failure path is far less exercised than
-individual daemon deaths and may surface bugs in the tree-repair and
-fault-handling code.  Validate on the in-repo Docker testbed
-(``contrib/dockerswarm/``), which is now sized to **ten** nodes precisely so a
-shrink can target several daemons on one branch of the radix tree at once:
+This plan has been implemented and validated on the ten-node Docker testbed.
+The change spans ``grpcomm/grpcomm.h``, ``grpcomm/direct/`` (the ``xcast_nb``
+entry point plus the completion FIFO), ``ras/base/ras_base_allocate.c`` (the
+collective completion handler), ``prted/prted_comm.c`` and ``rml/routed_radix.c``
+(the daemon leaving mode), ``errmgr/dvm/errmgr_dvm.c`` (the already-departed
+guard), and ``runtime/prte_globals.{h,c}``.  It builds warning-free under
+``--enable-devel-check`` (``-Werror`` plus the full picky set).
 
-#. **Deep tree.**  Start the DVM in elastic mode and grow onto eight nodes in a
-   single request (``elastic grow node2:2,...,node9:2``); this builds a
-   nine-daemon radix tree with real depth.
-#. **Single-branch shrink.**  Shrink a contiguous set of daemons that sit on one
-   branch and confirm exactly **one** promotion/descendant pass runs (trace with
-   ``--prtemca ... routed/rml verbosity``), a single ``PMIX_DVM_IS_READY`` fires,
-   the HNP survives, and ``prun -n 1 hostname`` still works afterward.
-#. **Multi-daemon, multi-branch shrink.**  Shrink daemons drawn from more than
-   one branch in a single request; confirm the batch repair and the single
-   completion event still hold.
-#. **In-flight job.**  Drive a shrink while a job is held at the ``LAUNCH_APPS``
-   hold point and confirm it remaps onto survivors after completion.
-#. **Crash during shrink.**  Kill a doomed daemon (``docker exec ... pkill -9
-   prted``) after the broadcast but before its lifeline drops, and confirm the
-   campaign still drains exactly once.
+Two implementation choices settled the open questions the plan had flagged:
+
+* The completion hook is the **general** ``xcast_nb`` facility (open question #2's
+  preferred option), not a shrink special case.
+* The daemon departs on a **bounded timer** with a lifeline-loss fast path (the
+  plan's endorsed fallback); the "survivor actively closes the connection" half
+  of open question #1 was *not* built — the timer covers it.
+
+One scope reduction is worth recording: **survivors are not batched.**  A survivor
+that loses several targets still repairs once per departure, exactly as before.
+Batching the survivors would require them to repair from the broadcast target
+list *mid-broadcast*, which races the reliable xcast's own ACK bookkeeping on the
+same tree — the interaction the plan flags as needing validation.  The HNP-side
+repair — the cost issue #2492 actually names — is collapsed to one pass; the
+survivor-side batching is left as a follow-up.
+
+Validation results
+------------------
+
+The collective / whole-branch failure path is far less exercised than individual
+daemon deaths, so it was exercised on the in-repo Docker testbed
+(``contrib/dockerswarm/``), sized to **ten** nodes and driven with
+``--prtemca rml_radix 2`` to force a real multi-level tree
+(``0 → 1,2   1 → 3,4   2 → 5,6   3 → 7,8``) rather than the default flat fan-out.
+
+#. **Single-branch multi-daemon shrink** (subtree ``{3,7,8}``): completed with a
+   single ``PMIX_DVM_IS_READY``; the HNP survived and ``prun`` still worked.  With
+   ``routed_base_verbose`` on the flat tree the collapse is visible directly — a
+   **single** repair pass takes children ``4,5,6 → INVALID`` in one shot, and
+   every one of the departing daemons' comm-failures is absorbed by the
+   already-departed guard (``errmgr_base_verbose`` shows the "ignoring it" line),
+   driving **zero** per-death repairs.
+#. **Multi-branch shrink** (ranks ``4`` and ``6``, one leaf under each of the
+   HNP's two children): one completion event, correct survivors, ``prun`` works.
+#. **Crash during shrink** (``pkill -9`` a target's ``prted`` inside the
+   departure window): the campaign still drained to a single completion event and
+   the HNP survived — confirming clean exit and crash are indistinguishable.
+#. **Fence under load** (forty rapid ``prun`` launches spanning a shrink): all
+   forty succeeded and the DVM stayed healthy, so the fence raised during a shrink
+   does not wedge concurrent traffic.
+
+The **in-flight-job remap-onto-survivors** path (a job held at the ``LAUNCH_APPS``
+hold point during a shrink, then remapped) could **not** be exercised in this
+harness: a plain ``prun`` maps only onto the head node's base pool, not the
+reservation the grown/shrunk nodes belong to, so a normal job is never held for a
+reservation-node shrink; and the ``elastic`` tool cannot connect while concurrent
+``prun`` sessions litter ``$TMPDIR`` with rendezvous files (it fails
+``PMIX_ERR_UNREACH`` — "multiple possible servers").  The hold/remap machinery is
+inherited unchanged from :ref:`dvm-shrink-campaign-label`; this plan only moves
+*when* the fence releases, which the tests above confirm fires correctly.  A
+reservation-targeted in-flight shrink remains to be validated.
+
+Two bugs surfaced and were fixed during validation, both worth noting because
+they are easy to reintroduce:
+
+* The completion callback was **lost across the master's relay-to-self**: the
+  op created in ``xcast_nb`` is discarded by ``begin_xcast`` and the master
+  rebuilds a fresh op on receipt, so the callback has to be carried in the FIFO
+  and re-attached when the master relays its own broadcast back.
+* The FIFO was first declared with ``PMIX_LIST_STATIC_INIT``, whose sentinel
+  ``next``/``prev`` are ``NULL``; appending to such a list corrupts memory and
+  silently wedged normal launches.  The list must be ``PMIX_CONSTRUCT``-ed — it
+  now lives in the xcast-ops object and is constructed in ``xcast_con``.
 
 See ``contrib/dockerswarm/README.md`` for the elastic-mode flag, the cleanup
 loop between runs, and the known re-grow flake (#2491).
@@ -335,28 +385,31 @@ loop between runs, and the known re-grow flake (#2491).
 Open questions
 --------------
 
-#. **Terminate-on-lifeline mode (design decided; code to build).**  Confirmed:
-   no terminate-on-lifeline-loss path exists today — a daemon that loses its
-   lifeline recovers/promotes, it does not exit — so this path must be *created*
-   as part of this effort.  The *race* concern (lifeline failing before the
-   daemon knows it is leaving) is resolved by construction — leaving mode rides
-   in the shrink command, which reaches each doomed daemon through its own
-   lifeline ahead of that lifeline's failure (see *Design Decision — Leaving mode
-   rides in the shrink command*).  The remaining build work is to (a) set and
-   honor the leaving-mode flag on the daemon side when it processes a shrink
-   command naming its own rank (Step 3) and (b) ensure the survivor-side rewire
-   actually closes the connection to each departing child so the lifeline drops.
-   Keep a bounded self-exit fallback until both halves are proven on the testbed.
-#. **General callback vs. shrink special case (Step 1).**  Is a general per-op
-   xcast completion callback wanted now, or a narrow shrink special case with a
-   later generalization?  Affects the ``grpcomm`` API surface.
-#. **Comm-failure fall-through (Step 4).**  Exactly which branches of the
-   post-shrink daemon-loss handling in ``errmgr_dvm.c`` must be taught to ignore
-   a rank the HNP already tore down, so the doomed daemons' eventual real deaths
-   are harmless?
+#. **Terminate-on-lifeline mode — resolved (with a fallback).**  Implemented: a
+   target sets ``prte_dvm_leaving`` as it processes the shrink command naming its
+   own rank, and departs on a bounded timer or, sooner, when its lifeline drops
+   (``prte_rml_route_lost`` exits early only while ``prte_dvm_leaving`` is set, so
+   a genuine unrelated fault still recovers).  The race is closed by construction
+   as the design decision argues.  The half that was **not** built is the
+   survivor *actively closing* the connection to each departing child; the timer
+   makes that unnecessary for correctness, at the cost of the doomed daemons
+   lingering a second or two after completion.  Building the active close would
+   let the fast path fire deterministically and retire the timer.
+#. **General callback vs. shrink special case — resolved.**  Implemented as the
+   general ``xcast_nb`` facility, usable beyond shrink.
+#. **Comm-failure fall-through — resolved.**  A daemon comm-failure is ignored
+   when the daemon is already not-alive **and** its recorded state is at or past
+   ``PRTE_PROC_STATE_TERMINATED`` (the state the completion handler stamps).  The
+   state test is what keeps the guard from swallowing a ``FAILED_TO_START`` daemon
+   (never alive, but its state is still below ``TERMINATED`` at that point).
+#. **Survivor-side batching — open follow-up.**  See *Implementation status*:
+   survivors still repair once per departure.  Batching them means repairing from
+   the broadcast list mid-broadcast, which must be reconciled with the reliable
+   xcast's ACK bookkeeping on the same tree.
 #. **Profiling.**  The original concern was unprofiled.  Worth measuring the
    per-daemon vs. batch repair cost on a large single-branch shrink to confirm
-   the optimization earns its complexity before committing to it.
+   the optimization earns its complexity — especially since only the HNP side is
+   batched so far.
 
 Summary of files changed
 ------------------------

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -158,6 +158,19 @@ whole batch, and exactly once:
    comm-failure event*; when the loss is declared proactively it must be done
    here instead.  **This is the highest-risk part of the change** — see
    *Validation* below.
+#. **Reset the node's launch state for re-grow.**  Detaching the daemon
+   (``node->daemon = NULL``, ``node->session = NULL``) is not enough to make the
+   node re-growable: the node object persists in the pool carrying the
+   ``PRTE_NODE_FLAG_DAEMON_LAUNCHED`` flag every plm launcher checks, and it
+   stays in the daemon-job map.  Left as-is, a later grow onto the same node is
+   skipped ("daemon already exists") and its prted never relaunches, and the
+   stale map entry lets ``setup_vm`` add the node a second time.  Call the shared
+   helper ``prte_plm_base_reset_dvm_node()`` for each detached node — it clears
+   ``PRTE_NODE_FLAG_DAEMON_LAUNCHED``/``PRTE_NODE_FLAG_LOC_VERIFIED`` and drops
+   the node from the daemon-job map.  This is launcher-agnostic and is a
+   prerequisite for re-growing a previously shrunk node (see #2491); it does not
+   by itself complete the re-grow, which additionally needs the daemon vpid space
+   left dense enough for the positional radix routing tree.
 #. **Fence and completion.**  Decrement ``prte_dvm_launch_fence`` by
    ``camp->pending`` (all at once), invoke
    ``prte_ras_base_shrink_complete(camp)`` to give the RAS modules their release
@@ -287,6 +300,18 @@ unaffected: a rank cannot be simultaneously a grow target and a shrink target,
 and the grow path still relies on the real comm-failure event.  Only the shrink
 branch moves to the collective callback.
 
+The grow-failure rollback (``prte_plm_base_grow_rollback``) tears nodes out of
+the DVM for the same reason a shrink does, so it shares the same
+``prte_plm_base_reset_dvm_node()`` step: a node whose grow was rolled back must
+also return to a pristine, never-launched state so a subsequent grow can reuse
+it.  Relatedly, the errmgr must treat ``PRTE_PROC_STATE_FAILED_TO_CONNECT`` like
+the other daemon comm-failures (``COMM_FAILED``, ``HEARTBEAT_FAILED``,
+``UNABLE_TO_SEND_MSG``, ``FAILED_TO_START``) so it flows into the
+``grow_target_failed`` rollback rather than the fatal
+"UNSUPPORTED DAEMON ERROR STATE" path — otherwise a daemon that comes up during
+a grow but cannot complete its connect-back takes the whole DVM down instead of
+failing just that grow.
+
 Design invariants preserved
 ----------------------------
 
@@ -314,6 +339,12 @@ collective completion handler), ``prted/prted_comm.c`` and ``rml/routed_radix.c`
 (the daemon leaving mode), ``errmgr/dvm/errmgr_dvm.c`` (the already-departed
 guard), and ``runtime/prte_globals.{h,c}``.  It builds warning-free under
 ``--enable-devel-check`` (``-Werror`` plus the full picky set).
+
+A follow-on commit adds the shared ``prte_plm_base_reset_dvm_node()`` helper
+(``plm/base/plm_base_launch_support.c``, declared in ``plm/base/plm_private.h``),
+called from the shrink-completion teardown and the grow-failure rollback, plus
+the ``PRTE_PROC_STATE_FAILED_TO_CONNECT`` routing in ``errmgr/dvm/errmgr_dvm.c``.
+Both are launcher-agnostic and build warning-free under the same picky set.
 
 The entire machinery is gated behind ``prte_elastic_mode``.  The master only
 enqueues an ``xcast_nb`` completion (and pops it on the relay-to-self) when
@@ -402,8 +433,20 @@ they are easy to reintroduce:
   silently wedged normal launches.  The list must be ``PMIX_CONSTRUCT``-ed — it
   now lives in the xcast-ops object and is constructed in ``xcast_con``.
 
-See ``contrib/dockerswarm/README.md`` for the elastic-mode flag, the cleanup
-loop between runs, and the known re-grow flake (#2491).
+See ``contrib/dockerswarm/README.md`` for the elastic-mode flag and the cleanup
+loop between runs.
+
+Re-grow of a just-shrunk node (#2491) is **partially** addressed here.  The
+``prte_plm_base_reset_dvm_node()`` step above fixes the launcher-agnostic half —
+a shrunk node is no longer skipped ("daemon already exists") or duplicated on a
+later grow, verified on the testbed.  The remaining half is the daemon vpid
+space: a shrink leaves a dead vpid that the positional radix routing tree
+(``prte_rml_compute_routing_tree``) treats as a live daemon on the next grow, so
+the re-grown daemon fails wireup.  Reusing the vacated vpid would fix it for the
+ssh launcher but breaks the non-ssh launchers (slurm/pals/lsf), which launch
+daemons as a **sequential** vpid range; a launcher-agnostic fix therefore has to
+route the tree around the dead rank instead.  That routing-side fix is tracked
+separately and is not part of this change.
 
 Open questions
 --------------

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -1,7 +1,7 @@
 .. _dvm-collective-shrink-completion-label:
 
 Collective Shrink Completion — Repair the Routing Tree Once per Campaign
-=======================================================================
+========================================================================
 
 This document plans the **optimization** tracked in
 `openpmix/prrte#2492 <https://github.com/openpmix/prrte/issues/2492>`_: draining

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -325,6 +325,19 @@ guard in ``errmgr/dvm`` is skipped entirely otherwise.  A default (non-elastic)
 gating went in: the launch and fault-handling paths are byte-for-byte the prior
 behavior when elastic mode is off.
 
+Threading the completion callback through ``xcast_nb`` takes one piece of care.
+The op the master initiates is discarded once it has been relayed; the op the
+master actually tracks and completes is a fresh one it builds when the broadcast
+loops back to itself.  The callback therefore rides a small FIFO of pending
+completions rather than the initiating op: one entry is queued per
+master-originated broadcast and popped, in order, as the master builds each
+tracked op on receipt.  The entry is enqueued in ``begin_xcast`` immediately
+before the reliable send that emits the broadcast, and unwound if that send
+fails, so the FIFO tracks exactly the broadcasts that reached the wire — a
+dropped send cannot shift the alignment onto the wrong op.  Both the enqueue and
+the receive-side op-id stamping run on the single progress thread with in-order
+delivery to self, so the ordering the FIFO relies on holds.
+
 Two implementation choices settled the open questions the plan had flagged:
 
 * The completion hook is the **general** ``xcast_nb`` facility (open question #2's

--- a/docs/plans/elastic_dvm/collective_shrink_completion.rst
+++ b/docs/plans/elastic_dvm/collective_shrink_completion.rst
@@ -192,9 +192,12 @@ a daemon that finds its own rank in the target list, fires the
 * **Every** daemon (target or survivor) uses the target list carried in the
   broadcast to repair its *own* routing tree locally —
   ``prte_rml_repair_routing_tree(targets, /*global=*/false)`` — so survivors
-  drop the departing ranks from their children/parent sets.  Because the list
-  travels in the broadcast, no global failure propagation is needed; this is why
-  Step 2 uses ``global=false``.
+  drop the departing ranks from their children/parent sets.  Here ``global``
+  describes the *source* of the failure information rather than the intended
+  response: ``false`` marks the departures as learned locally (from the
+  broadcast list), so each daemon repairs its own tree without re-raising a
+  redundant global failure notice for ranks the whole DVM already knows are
+  leaving.
 * A daemon that finds **its own** rank among the targets records that it is
   leaving by entering **leaving mode** — a flag set as it *processes the
   ``PRTE_DAEMON_SHRINK_CMD`` itself*, not in response to any separate order (see
@@ -377,13 +380,19 @@ Two implementation choices settled the open questions the plan had flagged:
   plan's endorsed fallback); the "survivor actively closes the connection" half
   of open question #1 was *not* built — the timer covers it.
 
-One scope reduction is worth recording: **survivors are not batched.**  A survivor
-that loses several targets still repairs once per departure, exactly as before.
-Batching the survivors would require them to repair from the broadcast target
-list *mid-broadcast*, which races the reliable xcast's own ACK bookkeeping on the
-same tree — the interaction the plan flags as needing validation.  The HNP-side
-repair — the cost issue #2492 actually names — is collapsed to one pass; the
-survivor-side batching is left as a follow-up.
+One point on scope is worth recording.  This PR explicitly collapses the
+**HNP-side** repair — the cost issue #2492 actually names — into a single pass.
+The survivors were *not* separately reworked, but per the reliable xcast's
+author the batching effectively falls out of the existing mechanism rather than
+needing new work: batching the repair at the root drives a batched repair on the
+rest as well.  The reliable xcast's ACK bookkeeping is designed to absorb repairs
+that happen *mid-broadcast*, so a survivor repairing from the broadcast target
+list does not race it.  The scheme stays two-phased — a lifeline first reports
+adoption status plus any failures within its new subtree, then the global
+broadcast conveys the full list to keep every daemon's view of the tree
+consistent — but the first phase already covers every failure that could require
+a repair, and the second is a follow-up that only informs about unrelated
+failures.
 
 Validation results
 ------------------
@@ -488,9 +497,14 @@ Open questions
 
 #. **Terminate-on-lifeline mode — resolved (with a fallback).**  Implemented: a
    target sets ``prte_dvm_leaving`` as it processes the shrink command naming its
-   own rank, and departs on a bounded timer or, sooner, when its lifeline drops
-   (``prte_rml_route_lost`` exits early only while ``prte_dvm_leaving`` is set, so
-   a genuine unrelated fault still recovers).  The race is closed by construction
+   own rank, and departs on a bounded timer or, sooner, on the **first** lost
+   connection (``prte_rml_route_lost`` exits early on any route loss while
+   ``prte_dvm_leaving`` is set, so a genuine unrelated fault still recovers).  It
+   exits on any lost route, not just the lifeline: a leaving daemon can see a
+   child connection drop before its lifeline, and treating that as a child
+   failure would emit an adoption notice that could be misread as a real fault
+   and propagated up the tree, so a leaving daemon never lets a disconnect be
+   mistaken for a fault.  The race is closed by construction
    as the design decision argues.  The half that was **not** built is the
    survivor *actively closing* the connection to each departing child; the timer
    makes that unnecessary for correctness, at the cost of the doomed daemons
@@ -503,10 +517,11 @@ Open questions
    ``PRTE_PROC_STATE_TERMINATED`` (the state the completion handler stamps).  The
    state test is what keeps the guard from swallowing a ``FAILED_TO_START`` daemon
    (never alive, but its state is still below ``TERMINATED`` at that point).
-#. **Survivor-side batching — open follow-up.**  See *Implementation status*:
-   survivors still repair once per departure.  Batching them means repairing from
-   the broadcast list mid-broadcast, which must be reconciled with the reliable
-   xcast's ACK bookkeeping on the same tree.
+#. **Survivor-side batching — resolved by the existing mechanism.**  Batching the
+   repair at the root drives a batched repair on the survivors as well, and the
+   reliable xcast's ACK bookkeeping is designed to absorb the mid-broadcast repair
+   rather than race it, so no separate survivor-side work is required.  See
+   *Implementation status* for the two-phase description.
 #. **Profiling.**  The original concern was unprofiled.  Worth measuring the
    per-daemon vs. batch repair cost on a large single-branch shrink to confirm
    the optimization earns its complexity — especially since only the HNP side is

--- a/docs/plans/elastic_dvm/index.rst
+++ b/docs/plans/elastic_dvm/index.rst
@@ -10,3 +10,4 @@ Implementation plans for dynamic DVM grow/shrink support.
    elastic_dvm_plan.rst
    grow_campaign.rst
    shrink_campaign.rst
+   collective_shrink_completion.rst

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -276,8 +276,11 @@ static void proc_errors(int fd, short args, void *cbdata)
              * arrives here already handled.  The state test keeps this from
              * swallowing a FAILED_TO_START daemon (never alive, but its recorded
              * state is still below TERMINATED at this point) so that genuine
-             * start failures are still handled below. */
-            if (!PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_ALIVE) &&
+             * start failures are still handled below.  Gated on elastic mode so
+             * the default fault-handling path is unchanged when no collective
+             * shrink can be in flight. */
+            if (prte_elastic_mode &&
+                !PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_ALIVE) &&
                 PRTE_PROC_STATE_TERMINATED <= pptr->state) {
                 PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
                                      "%s Comm failure for already-departed daemon %s - ignoring it",

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -266,6 +266,25 @@ static void proc_errors(int fd, short args, void *cbdata)
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
                 goto cleanup;
             }
+            /* If we have already torn this daemon out of the DVM, a later
+             * comm-failure for it is a harmless echo and must be ignored: acting
+             * on it again would double-decrement num_daemons and could re-drive
+             * the abort logic below.  This is the fall-through the collective
+             * DVM-shrink path relies on — its completion handler proactively
+             * marks each target not-alive and sets its state to TERMINATED (see
+             * ras_base_allocate.c), so the target's eventual real departure
+             * arrives here already handled.  The state test keeps this from
+             * swallowing a FAILED_TO_START daemon (never alive, but its recorded
+             * state is still below TERMINATED at this point) so that genuine
+             * start failures are still handled below. */
+            if (!PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_ALIVE) &&
+                PRTE_PROC_STATE_TERMINATED <= pptr->state) {
+                PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
+                                     "%s Comm failure for already-departed daemon %s - ignoring it",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                     PRTE_NAME_PRINT(proc)));
+                goto cleanup;
+            }
             /* mark the daemon as gone */
             PRTE_FLAG_UNSET(pptr, PRTE_PROC_FLAG_ALIVE);
             /* update the state */
@@ -283,44 +302,11 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (prte_plm_base_grow_target_failed(proc->rank)) {
                 goto cleanup;
             }
-            /* check if this daemon was a pending shrink target */
-            {
-                prte_shrink_campaign_t *_camp, *_next;
-                int _t;
-                PMIX_LIST_FOREACH_SAFE(_camp, _next,
-                                       &prte_shrink_campaigns, prte_shrink_campaign_t) {
-                    for (_t = 0; _t < _camp->ntargets; _t++) {
-                        if (_camp->targets[_t] != proc->rank) continue;
-                        /* stamp this slot so a repeated comm event for the
-                         * same daemon cannot decrement the campaign twice */
-                        _camp->targets[_t] = PMIX_RANK_INVALID;
-                        _camp->pending--;
-                        prte_dvm_launch_fence--;
-                        if (0 == _camp->pending) {
-                            /* this request's shrink is complete — first let the
-                             * active RAS modules release the freed resources
-                             * back to the scheduler, then notify the requester
-                             * that the DVM now reflects the new size (clean exit
-                             * and crash are both successes for the campaign, so
-                             * this drain is always success) */
-                            prte_ras_base_shrink_complete(_camp);
-                            if (_camp->have_requester) {
-                                prte_plm_base_dvm_mod_notify(&_camp->requester,
-                                                             _camp->alloc_id,
-                                                             _camp->req_id,
-                                                             true, PMIX_SUCCESS);
-                            }
-                            pmix_list_remove_item(&prte_shrink_campaigns, &_camp->super);
-                            PMIX_RELEASE(_camp);
-                        }
-                        if (0 == prte_dvm_launch_fence) {
-                            prte_plm_base_fence_release();
-                        }
-                        goto errmgr_shrink_done;
-                    }
-                }
-              errmgr_shrink_done: ;
-            }
+            /* NOTE: a daemon departing as part of a DVM *shrink* is not handled
+             * here.  The collective shrink-completion handler tears each target
+             * out of the DVM proactively when the shrink broadcast completes, so
+             * by the time the target's real comm-failure arrives it has already
+             * been marked not-alive and is caught by the guard above. */
             /* if we have ordered prteds to terminate or abort
              * is in progress, record it */
             if (prte_prteds_term_ordered || prte_abnormal_term_ordered) {

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -258,6 +258,7 @@ static void proc_errors(int fd, short args, void *cbdata)
         if (PRTE_PROC_STATE_COMM_FAILED == state ||
             PRTE_PROC_STATE_HEARTBEAT_FAILED == state ||
             PRTE_PROC_STATE_UNABLE_TO_SEND_MSG == state ||
+            PRTE_PROC_STATE_FAILED_TO_CONNECT == state ||
             PRTE_PROC_STATE_FAILED_TO_START == state) {
             /* if this is my own connection, ignore it */
             if (PRTE_PROC_MY_NAME->rank == proc->rank) {

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -49,6 +49,7 @@ prte_grpcomm_base_module_t prte_grpcomm_direct_module = {
     .finalize = finalize,
     .fault_handler = fault_handler,
     .xcast = prte_grpcomm_direct_xcast,
+    .xcast_nb = prte_grpcomm_direct_xcast_nb,
     .fence = prte_grpcomm_direct_fence,
     .group = prte_grpcomm_direct_group
 };

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -28,6 +28,9 @@ typedef struct {
     pmix_object_t super;
     // list of ongoing operations, defined in grpcomm_direct_xcast.c
     pmix_list_t ops;
+    // FIFO of completion callbacks for master-originated broadcasts awaiting
+    // relay back to the master (see grpcomm_direct_xcast.c)
+    pmix_list_t pending_completions;
     // ID of the last known completed (in our subtree) operation
     size_t op_id_completed;
     // op_id_completed when we were last promoted
@@ -181,6 +184,12 @@ PMIX_CLASS_DECLARATION(prte_pmix_fence_caddy_t);
 PRTE_MODULE_EXPORT extern
 int prte_grpcomm_direct_xcast(prte_rml_tag_t tag,
                               pmix_data_buffer_t *msg);
+
+PRTE_MODULE_EXPORT extern
+int prte_grpcomm_direct_xcast_nb(prte_rml_tag_t tag,
+                                 pmix_data_buffer_t *msg,
+                                 prte_grpcomm_xcast_complete_fn_t cbfunc,
+                                 void *cbdata);
 
 PRTE_MODULE_EXPORT extern
 void prte_grpcomm_direct_xcast_recv(int status, pmix_proc_t *sender,

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -143,8 +143,10 @@ int prte_grpcomm_direct_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
      * builds when this broadcast is relayed back to it.  Enqueue one entry for
      * every master-originated broadcast (even with a NULL callback) to keep the
      * FIFO aligned; non-master callers get no completion (a remote function
-     * pointer is meaningless to the master). */
-    if (PRTE_PROC_IS_MASTER) {
+     * pointer is meaningless to the master).  Gated on elastic mode: only the
+     * DVM-shrink path (elastic only) ever registers a completion, so outside
+     * elastic mode the FIFO stays untouched and xcast behaves exactly as before. */
+    if (PRTE_PROC_IS_MASTER && prte_elastic_mode) {
         pending_completion_t *pc = PMIX_NEW(pending_completion_t);
         pc->cbfunc = cbfunc;
         pc->cbdata = cbdata;
@@ -250,7 +252,7 @@ void prte_grpcomm_direct_xcast_recv(
         /* If we are the master and this is one of our own broadcasts, attach the
          * completion callback queued for it in xcast_nb (FIFO).  Remote-origin
          * broadcasts queue nothing, so they never consume an entry. */
-        if(PRTE_PROC_IS_MASTER && NULL != sender &&
+        if(PRTE_PROC_IS_MASTER && prte_elastic_mode && NULL != sender &&
            sender->rank == PRTE_PROC_MY_NAME->rank &&
            !pmix_list_is_empty(&XCAST.pending_completions)){
             pending_completion_t* pc =

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -249,7 +249,7 @@ void prte_grpcomm_direct_xcast_recv(
         /* If we are the master and this is one of our own broadcasts, attach the
          * completion callback queued for it in begin_xcast (FIFO).  Remote-origin
          * broadcasts queue nothing, so they never consume an entry. */
-        if(PRTE_PROC_IS_MASTER && prte_elastic_mode && NULL != sender &&
+        if(PRTE_PROC_IS_MASTER && NULL != sender &&
            sender->rank == PRTE_PROC_MY_NAME->rank &&
            !pmix_list_is_empty(&XCAST.pending_completions)){
             pending_completion_t* pc =
@@ -433,12 +433,12 @@ static void begin_xcast(int sd, short args, void* cbdata){
      * to it and it builds the op it tracks (see prte_grpcomm_direct_xcast_recv).
      * Enqueuing here — immediately before the send, and unwinding on failure —
      * rather than in xcast_nb keeps the FIFO aligned with exactly the broadcasts
-     * that were actually emitted, even if a send is abandoned.  Gated on elastic
-     * mode: only the DVM-shrink path (elastic only) ever registers a completion,
-     * so outside elastic mode the FIFO stays untouched and xcast behaves exactly
-     * as before. */
+     * that were actually emitted, even if a send is abandoned.  This is a general
+     * facility: any master-originated broadcast enqueues an entry (NULL callback
+     * included) so the FIFO stays aligned, and finish_op fires the callback only
+     * when one was actually registered. */
     pending_completion_t *pc = NULL;
-    if (PRTE_PROC_IS_MASTER && prte_elastic_mode) {
+    if (PRTE_PROC_IS_MASTER) {
         pc = PMIX_NEW(pending_completion_t);
         pc->cbfunc = op->cbfunc;
         pc->cbdata = op->cbdata;

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -40,6 +40,26 @@
 
 #define XCAST prte_mca_grpcomm_direct_component.xcast_ops
 
+/* The initiating op created in xcast_nb() is consumed by begin_xcast() (it is
+ * packed and relayed to the master, then discarded); the op the master actually
+ * tracks and completes is a fresh one built on receipt.  A completion callback
+ * therefore cannot simply ride on the initiating op.  Instead, because the
+ * master assigns op-ids for and relays every xcast — including its own — through
+ * itself, we queue one entry per master-originated broadcast here, in initiation
+ * order, and pop it (FIFO) when the master receives that broadcast back to build
+ * its tracked op.  One entry is enqueued for every master-originated xcast (NULL
+ * callback included) so the FIFO stays aligned with the stream of the master's
+ * own broadcasts.  cbfunc is a local function pointer, so it is only meaningful
+ * for broadcasts the master itself originates.  The queue lives in XCAST
+ * (XCAST.pending_completions), constructed with the xcast-ops object, so it is a
+ * properly initialized list rather than a static one that append would corrupt. */
+typedef struct {
+    pmix_list_item_t super;
+    prte_grpcomm_xcast_complete_fn_t cbfunc;
+    void *cbdata;
+} pending_completion_t;
+PMIX_CLASS_INSTANCE(pending_completion_t, pmix_list_item_t, NULL, NULL);
+
 /* internal signature used to uniquely track a particular xcast */
 typedef struct {
     size_t op_id;    // HNP's assigned collective ID, globally unique
@@ -68,6 +88,10 @@ typedef struct {
     bool msg_compressed;
     // tag for the underlying user message
     prte_rml_tag_t msg_tag;
+    // optional completion callback, fired on the master when the whole DVM has
+    // received this op (see prte_grpcomm_direct_xcast_nb).  NULL when unused.
+    prte_grpcomm_xcast_complete_fn_t cbfunc;
+    void *cbdata;
 } op_t;
 PMIX_CLASS_DECLARATION(op_t);
 
@@ -104,10 +128,28 @@ static int pack_bool    (pmix_data_buffer_t* buffer, bool* boolean);
 static int unpack_bool  (pmix_data_buffer_t* buffer, bool* boolean);
 
 int prte_grpcomm_direct_xcast(prte_rml_tag_t tag, pmix_data_buffer_t *msg){
+    return prte_grpcomm_direct_xcast_nb(tag, msg, NULL, NULL);
+}
+
+int prte_grpcomm_direct_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
+                                 prte_grpcomm_xcast_complete_fn_t cbfunc,
+                                 void *cbdata){
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct:xcast: with %d bytes",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (int) msg->bytes_used));
+
+    /* record the completion callback so the master can attach it to the op it
+     * builds when this broadcast is relayed back to it.  Enqueue one entry for
+     * every master-originated broadcast (even with a NULL callback) to keep the
+     * FIFO aligned; non-master callers get no completion (a remote function
+     * pointer is meaningless to the master). */
+    if (PRTE_PROC_IS_MASTER) {
+        pending_completion_t *pc = PMIX_NEW(pending_completion_t);
+        pc->cbfunc = cbfunc;
+        pc->cbdata = cbdata;
+        pmix_list_append(&XCAST.pending_completions, &pc->super);
+    }
 
     op_t* op = PMIX_NEW(op_t);
     op->msg_tag = tag;
@@ -204,6 +246,18 @@ void prte_grpcomm_direct_xcast_recv(
             pmix_list_remove_item(&XCAST.ops, &op->super);
             PMIX_RELEASE(op);
             return;
+        }
+        /* If we are the master and this is one of our own broadcasts, attach the
+         * completion callback queued for it in xcast_nb (FIFO).  Remote-origin
+         * broadcasts queue nothing, so they never consume an entry. */
+        if(PRTE_PROC_IS_MASTER && NULL != sender &&
+           sender->rank == PRTE_PROC_MY_NAME->rank &&
+           !pmix_list_is_empty(&XCAST.pending_completions)){
+            pending_completion_t* pc =
+                (pending_completion_t*) pmix_list_remove_first(&XCAST.pending_completions);
+            op->cbfunc = pc->cbfunc;
+            op->cbdata = pc->cbdata;
+            PMIX_RELEASE(pc);
         }
     }
 
@@ -427,6 +481,15 @@ static void finish_op(op_t* op) {
         }
     }
     process_msg(op); // If not already processed, process before releasing
+    /* on the master, a completed op means every daemon in the DVM has received
+     * this broadcast; fire the caller's completion callback if one was
+     * registered.  This is the hook the collective DVM-shrink path uses to run
+     * its single routing-tree repair and emit its completion event.  It fires
+     * only here (PRTE_PROC_IS_MASTER): a non-master's finish_op means only its
+     * own subtree completed, not the whole DVM. */
+    if (PRTE_PROC_IS_MASTER && NULL != op->cbfunc) {
+        op->cbfunc(op->cbdata);
+    }
     PMIX_RELEASE(op);
 }
 
@@ -678,6 +741,9 @@ static void op_con(op_t* p)
     PMIx_Byte_object_construct(&p->msg);
     p->msg_compressed = false;
     p->msg_tag = PRTE_RML_TAG_INVALID;
+
+    p->cbfunc = NULL;
+    p->cbdata = NULL;
 }
 static void op_des(op_t* p)
 {
@@ -689,6 +755,7 @@ PMIX_CLASS_INSTANCE(op_t, pmix_list_item_t, op_con, op_des);
 static void xcast_con(prte_grpcomm_xcast_t* p)
 {
     PMIX_CONSTRUCT(&p->ops, pmix_list_t);
+    PMIX_CONSTRUCT(&p->pending_completions, pmix_list_t);
     p->op_id_completed = 0;
     p->op_id_completed_at_promotion = 0;
     p->op_id_inited = 0;
@@ -696,6 +763,7 @@ static void xcast_con(prte_grpcomm_xcast_t* p)
 static void xcast_des(prte_grpcomm_xcast_t* p)
 {
     PMIX_LIST_DESTRUCT(&p->ops);
+    PMIX_LIST_DESTRUCT(&p->pending_completions);
 }
 PMIX_CLASS_INSTANCE(prte_grpcomm_xcast_t, pmix_object_t, xcast_con, xcast_des);
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -45,14 +45,19 @@
  * tracks and completes is a fresh one built on receipt.  A completion callback
  * therefore cannot simply ride on the initiating op.  Instead, because the
  * master assigns op-ids for and relays every xcast — including its own — through
- * itself, we queue one entry per master-originated broadcast here, in initiation
- * order, and pop it (FIFO) when the master receives that broadcast back to build
- * its tracked op.  One entry is enqueued for every master-originated xcast (NULL
- * callback included) so the FIFO stays aligned with the stream of the master's
- * own broadcasts.  cbfunc is a local function pointer, so it is only meaningful
- * for broadcasts the master itself originates.  The queue lives in XCAST
- * (XCAST.pending_completions), constructed with the xcast-ops object, so it is a
- * properly initialized list rather than a static one that append would corrupt. */
+ * itself, we queue one entry per master-originated broadcast and pop it (FIFO)
+ * when the master receives that broadcast back to build its tracked op.  The
+ * entry is enqueued in begin_xcast(), immediately before the broadcast is sent
+ * (and unwound if that send fails), so the queue tracks exactly the stream of
+ * broadcasts that were actually emitted, in emission order.  Enqueue and the
+ * op-id stamping done on receipt both run on the single progress thread and the
+ * send-to-self is delivered in order, so the FIFO stays aligned with the
+ * master's own broadcasts.  One entry is enqueued for every master-originated
+ * xcast (NULL callback included) to keep that alignment; cbfunc is a local
+ * function pointer, so it is only meaningful for broadcasts the master itself
+ * originates.  The queue lives in XCAST (XCAST.pending_completions), constructed
+ * with the xcast-ops object, so it is a properly initialized list rather than a
+ * static one that append would corrupt. */
 typedef struct {
     pmix_list_item_t super;
     prte_grpcomm_xcast_complete_fn_t cbfunc;
@@ -139,22 +144,14 @@ int prte_grpcomm_direct_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (int) msg->bytes_used));
 
-    /* record the completion callback so the master can attach it to the op it
-     * builds when this broadcast is relayed back to it.  Enqueue one entry for
-     * every master-originated broadcast (even with a NULL callback) to keep the
-     * FIFO aligned; non-master callers get no completion (a remote function
-     * pointer is meaningless to the master).  Gated on elastic mode: only the
-     * DVM-shrink path (elastic only) ever registers a completion, so outside
-     * elastic mode the FIFO stays untouched and xcast behaves exactly as before. */
-    if (PRTE_PROC_IS_MASTER && prte_elastic_mode) {
-        pending_completion_t *pc = PMIX_NEW(pending_completion_t);
-        pc->cbfunc = cbfunc;
-        pc->cbdata = cbdata;
-        pmix_list_append(&XCAST.pending_completions, &pc->super);
-    }
-
     op_t* op = PMIX_NEW(op_t);
     op->msg_tag = tag;
+    /* stash the completion callback on the initiating op.  It is not fired from
+     * this op (which is discarded after begin_xcast relays it); begin_xcast
+     * copies it into the pending-completion FIFO once the broadcast is actually
+     * sent, and finish_op fires it from the op the master builds on receipt. */
+    op->cbfunc = cbfunc;
+    op->cbdata = cbdata;
     /* Make a (possibly compressed) copy of this message in a new op - this is
      * non-destructive, so our caller is still responsible for releasing any
      * memory in the buffer they gave us
@@ -250,7 +247,7 @@ void prte_grpcomm_direct_xcast_recv(
             return;
         }
         /* If we are the master and this is one of our own broadcasts, attach the
-         * completion callback queued for it in xcast_nb (FIFO).  Remote-origin
+         * completion callback queued for it in begin_xcast (FIFO).  Remote-origin
          * broadcasts queue nothing, so they never consume an entry. */
         if(PRTE_PROC_IS_MASTER && prte_elastic_mode && NULL != sender &&
            sender->rank == PRTE_PROC_MY_NAME->rank &&
@@ -430,12 +427,34 @@ static void begin_xcast(int sd, short args, void* cbdata){
         return;
     }
 
+    /* Record the completion callback for this broadcast now that it is about to
+     * go out.  We enqueue one entry per master-originated broadcast, in send
+     * order, so the master can pop it (FIFO) when this broadcast is relayed back
+     * to it and it builds the op it tracks (see prte_grpcomm_direct_xcast_recv).
+     * Enqueuing here — immediately before the send, and unwinding on failure —
+     * rather than in xcast_nb keeps the FIFO aligned with exactly the broadcasts
+     * that were actually emitted, even if a send is abandoned.  Gated on elastic
+     * mode: only the DVM-shrink path (elastic only) ever registers a completion,
+     * so outside elastic mode the FIFO stays untouched and xcast behaves exactly
+     * as before. */
+    pending_completion_t *pc = NULL;
+    if (PRTE_PROC_IS_MASTER && prte_elastic_mode) {
+        pc = PMIX_NEW(pending_completion_t);
+        pc->cbfunc = op->cbfunc;
+        pc->cbdata = op->cbdata;
+        pmix_list_append(&XCAST.pending_completions, &pc->super);
+    }
+
     // send it to the HNP (could be myself) for relay
     PRTE_RML_RELIABLE_SEND(
         rc, PRTE_PROC_MY_HNP->rank, xcast_msg, PRTE_RML_TAG_XCAST
     );
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        if (NULL != pc) {
+            pmix_list_remove_item(&XCAST.pending_completions, &pc->super);
+            PMIX_RELEASE(pc);
+        }
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
         return;
     }

--- a/src/mca/grpcomm/grpcomm.h
+++ b/src/mca/grpcomm/grpcomm.h
@@ -93,6 +93,22 @@ typedef void (*prte_grpcomm_base_module_fault_handler_fn_t)(const prte_rml_recov
 typedef int (*prte_grpcomm_base_module_xcast_fn_t)(prte_rml_tag_t tag,
                                                    pmix_data_buffer_t *msg);
 
+/* Completion callback for xcast_nb: invoked on the DVM master once the reliable
+ * xcast has been confirmed received by every daemon in the DVM (i.e., when the
+ * broadcast's ACKs have all flowed back up the tree).  It fires on the progress
+ * thread; a handler that needs to do more than trivial work should thread-shift
+ * onto a fresh event rather than run inside the xcast call stack. */
+typedef void (*prte_grpcomm_xcast_complete_fn_t)(void *cbdata);
+
+/* Scalably send a message, requesting a completion callback.  Identical to
+ * xcast() except that, when cbfunc is non-NULL, it is invoked on the master when
+ * the whole DVM has received the broadcast.  cbfunc/cbdata are ignored on
+ * non-master daemons. */
+typedef int (*prte_grpcomm_base_module_xcast_nb_fn_t)(prte_rml_tag_t tag,
+                                                      pmix_data_buffer_t *msg,
+                                                      prte_grpcomm_xcast_complete_fn_t cbfunc,
+                                                      void *cbdata);
+
 
 /* fence - gather data from all specified procs. Barrier operations
  * will provide NULL data.
@@ -121,6 +137,7 @@ typedef struct {
     prte_grpcomm_base_module_fault_handler_fn_t fault_handler;
     /* collective operations */
     prte_grpcomm_base_module_xcast_fn_t         xcast;
+    prte_grpcomm_base_module_xcast_nb_fn_t      xcast_nb;
     prte_grpcomm_base_module_fence_fn_t         fence;
     prte_grpcomm_base_module_grp_fn_t           group;
 } prte_grpcomm_base_module_t;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2621,6 +2621,46 @@ void prte_plm_base_grow_drain(bool success)
     }
 }
 
+/* Return a node that has been torn out of the DVM (by a completed shrink or a
+ * rolled-back grow) to a pristine, never-launched state so a later grow can
+ * relaunch a daemon on it.  Clearing the daemon backpointer alone is not enough:
+ * the launch machinery keys off per-node flags and the persistent daemon-job
+ * map, and stale values there make a re-grow silently misbehave.  Specifically,
+ * PRTE_NODE_FLAG_DAEMON_LAUNCHED left set makes every plm launcher skip the node
+ * ("daemon already exists"), so the new prted is never spawned; and leaving the
+ * node in the daemon map lets setup_vm add it a second time, duplicating it in
+ * the VM.  Reset both here. */
+void prte_plm_base_reset_dvm_node(prte_node_t *node)
+{
+    prte_job_t *daemons;
+    prte_node_t *nptr;
+    int i;
+
+    if (NULL == node) {
+        return;
+    }
+
+    PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
+    PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_LOC_VERIFIED);
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL == daemons || NULL == daemons->map) {
+        return;
+    }
+    for (i = 0; i < daemons->map->nodes->size; i++) {
+        nptr = (prte_node_t *) pmix_pointer_array_get_item(daemons->map->nodes, i);
+        if (nptr != node) {
+            continue;
+        }
+        pmix_pointer_array_set_item(daemons->map->nodes, i, NULL);
+        if (0 < daemons->map->num_nodes) {
+            --daemons->map->num_nodes;
+        }
+        PMIX_RELEASE(node); /* the map held a retain */
+        break;
+    }
+}
+
 /* Roll a failed grow campaign back out of the DVM so a failed grow leaves the
  * DVM at its exact pre-grow membership rather than half-extended (spec
  * conformance #5).  `trigger` is the rank whose death triggered the failure;
@@ -2635,12 +2675,11 @@ void prte_plm_base_grow_drain(bool success)
  *     daemon-count bump is reverted here (no comm-failure event will arrive for
  *     it).
  *
- * In all cases the node's daemon backpointer is cleared so the mapper can no
- * longer place a later job on it.  The new nodes carry no application procs —
- * the jobs that would have used them were held at the fence, never launched —
- * so clearing ``node->daemon`` is sufficient to remove the node from the DVM's
- * usable set.  The teardown is strictly campaign-scoped: it touches only the
- * ranks in this campaign's ``targets`` array. */
+ * In all cases the node is reset out of the DVM's usable set (see
+ * prte_plm_base_reset_dvm_node).  The new nodes carry no application procs — the
+ * jobs that would have used them were held at the fence, never launched.  The
+ * teardown is strictly campaign-scoped: it touches only the ranks in this
+ * campaign's ``targets`` array. */
 static void grow_rollback(prte_grow_campaign_t *camp, pmix_rank_t trigger)
 {
     prte_job_t *daemons;
@@ -2695,6 +2734,10 @@ static void grow_rollback(prte_grow_campaign_t *camp, pmix_rank_t trigger)
                 node->daemon = NULL;
                 PMIX_RELEASE(dproc);
             }
+            /* return the node to a pristine, never-launched state so a later
+             * grow can relaunch a daemon on it (clears the launch flags and
+             * drops it from the daemon-job map) */
+            prte_plm_base_reset_dvm_node(node);
         }
     }
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1854,6 +1854,13 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM, NULL, PMIX_BOOL)) {
         // nodes have been added, so extend the DVM
         prte_remove_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM);
+        /* Reset the per-launch daemon accounting. The initial-VM path zeroes
+         * these further below, but the grow path jumps straight to construct:
+         * and would otherwise accumulate num_new_daemons across successive
+         * grows and reuse a stale daemon_vpid_start - corrupting the grow
+         * campaign's target list and suppressing its completion event (#2491). */
+        map->num_new_daemons = 0;
+        map->daemon_vpid_start = PMIX_RANK_INVALID;
         goto construct;
     }
 

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -98,6 +98,7 @@ PRTE_EXPORT void prte_plm_base_fence_release(void);
 PRTE_EXPORT void prte_plm_base_abort_premap_held(void);
 PRTE_EXPORT void prte_plm_base_grow_drain(bool success);
 PRTE_EXPORT bool prte_plm_base_grow_target_failed(pmix_rank_t rank);
+PRTE_EXPORT void prte_plm_base_reset_dvm_node(prte_node_t *node);
 PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
 /* emit the spec's phase-two completion event to the size-change requester:

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -45,6 +45,7 @@
 #include "src/mca/plm/base/plm_private.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/state/state.h"
+#include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_quit.h"
 #include "src/runtime/prte_wait.h"
@@ -630,6 +631,105 @@ void prte_ras_base_shrink_complete(prte_shrink_campaign_t *campaign)
             mod->module->shrink_complete(campaign);
         }
     }
+}
+
+/* Thread-shift target: collectively complete a DVM shrink campaign.  Runs once
+ * per campaign on the DVM master, on a fresh event (posted from the grpcomm
+ * xcast-completion callback below) so it never executes nested inside the xcast
+ * call stack.  By this point the reliable shrink broadcast has been received by
+ * every daemon, so the master tears the whole set of targets out of the DVM in
+ * a single batch — one routing-tree repair for all of them — rather than once
+ * per daemon as each departs.  Because every target is marked failed and its
+ * node detached here, the later real departures fall through the errmgr as
+ * harmless no-ops (see errmgr_dvm.c). */
+static void shrink_campaign_complete(int sd, short args, void *cbdata)
+{
+    prte_shrink_campaign_t *camp = (prte_shrink_campaign_t *) cbdata;
+    prte_job_t *daemons;
+    prte_proc_t *dproc;
+    prte_node_t *node;
+    pmix_data_array_t failed = PMIX_DATA_ARRAY_STATIC_INIT;
+    pmix_rank_t *fr;
+    int t;
+
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+
+    /* one batch routing-tree repair for the whole campaign: report every target
+     * as failed in a single promotion/descendant pass, replacing the up-to-m
+     * per-daemon repairs the individual departures would otherwise drive. */
+    failed.type = PMIX_PROC_RANK;
+    failed.size = camp->ntargets;
+    failed.array = malloc(camp->ntargets * sizeof(pmix_rank_t));
+    if (NULL != failed.array) {
+        fr = (pmix_rank_t *) failed.array;
+        for (t = 0; t < camp->ntargets; t++) {
+            fr[t] = camp->targets[t];
+        }
+        prte_rml_repair_routing_tree(&failed, false);
+        free(failed.array);
+        failed.array = NULL;
+    }
+
+    /* per-target HNP teardown: mark the daemon gone and detach its node from the
+     * DVM's usable set so a released job cannot remap onto it.  This mirrors the
+     * comm-failure bookkeeping (unset ALIVE, set state, decrement num_daemons)
+     * plus the node detach the grow-rollback path uses. */
+    if (NULL != daemons) {
+        for (t = 0; t < camp->ntargets; t++) {
+            dproc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs,
+                                                                camp->targets[t]);
+            if (NULL == dproc) {
+                continue;
+            }
+            node = dproc->node;
+            if (PRTE_FLAG_TEST(dproc, PRTE_PROC_FLAG_ALIVE)) {
+                PRTE_FLAG_UNSET(dproc, PRTE_PROC_FLAG_ALIVE);
+                dproc->state = PRTE_PROC_STATE_TERMINATED;
+                if (0 < prte_process_info.num_daemons) {
+                    --prte_process_info.num_daemons;
+                }
+            }
+            if (NULL != node) {
+                if (NULL != node->session && node->session != prte_default_session) {
+                    node->session = NULL;
+                }
+                if (node->daemon == dproc) {
+                    node->daemon = NULL;
+                    PMIX_RELEASE(dproc);
+                }
+            }
+        }
+    }
+
+    /* the campaign has drained: drop the fence it raised, give the RAS modules
+     * their release hook, tell the requester the DVM now reflects the new size,
+     * and release any jobs held behind the fence once it reaches zero. */
+    prte_dvm_launch_fence -= camp->pending;
+    prte_ras_base_shrink_complete(camp);
+    if (camp->have_requester) {
+        prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
+                                     camp->req_id, true, PMIX_SUCCESS);
+    }
+    pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
+    if (0 == prte_dvm_launch_fence) {
+        prte_plm_base_fence_release();
+    }
+    PMIX_RELEASE(camp);
+}
+
+/* grpcomm xcast-completion callback: fires on the master, inside the xcast call
+ * stack, once the whole DVM has received the shrink broadcast.  Keep it trivial
+ * — thread-shift the real teardown onto a fresh event, because that teardown
+ * drives routing-tree fault handlers that must not run nested inside grpcomm. */
+static void shrink_xcast_complete(void *cbdata)
+{
+    prte_shrink_campaign_t *camp = (prte_shrink_campaign_t *) cbdata;
+    prte_event_set(prte_event_base, &camp->ev, -1, PRTE_EV_WRITE,
+                   shrink_campaign_complete, camp);
+    PMIX_POST_OBJECT(camp);
+    prte_event_active(&camp->ev, PRTE_EV_WRITE, 1);
 }
 
 /* monotonic counter used to mint unique session ids for reservations that
@@ -1305,43 +1405,53 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
          * later job at the LAUNCH_APPS hold, and no completion event would fire.
          * This mirrors the grow path's num_new_daemons > 0 guard and the spec's
          * "no event when nothing changes" clause. */
+        prte_shrink_campaign_t *camp = NULL;
         if (prte_elastic_mode && 0 < m) {
-            prte_shrink_campaign_t *_camp = PMIX_NEW(prte_shrink_campaign_t);
-            _camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
-            memcpy(_camp->targets, ranks, m * sizeof(pmix_rank_t));
-            _camp->ntargets = m;
-            _camp->pending  = m;
+            camp = PMIX_NEW(prte_shrink_campaign_t);
+            camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
+            memcpy(camp->targets, ranks, m * sizeof(pmix_rank_t));
+            camp->ntargets = m;
+            camp->pending  = m;
             /* record the requester so the phase-two completion event can be
              * directed at the process that issued this PMIX_ALLOC_RELEASE */
-            PMIX_XFER_PROCID(&_camp->requester, &req->tproc);
+            PMIX_XFER_PROCID(&camp->requester, &req->tproc);
             for (n = 0; n < req->ninfo; n++) {
                 if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
-                    _camp->alloc_id = strdup(req->info[n].value.data.string);
+                    camp->alloc_id = strdup(req->info[n].value.data.string);
                 } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
-                    _camp->req_id = strdup(req->info[n].value.data.string);
+                    camp->req_id = strdup(req->info[n].value.data.string);
                 }
             }
-            _camp->have_requester = true;
-            pmix_list_append(&prte_shrink_campaigns, &_camp->super);
+            camp->have_requester = true;
+            pmix_list_append(&prte_shrink_campaigns, &camp->super);
             prte_dvm_launch_fence += m;
         }
         free(ranks);
 
-        /* goes to all daemons */
-        if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg))) {
+        /* goes to all daemons.  When a campaign was recorded, request a
+         * completion callback so the collective shrink-completion handler runs
+         * exactly once — when the whole DVM has received the command — driving a
+         * single routing-tree repair and one completion event, rather than
+         * discovering the departures one daemon at a time. */
+        if (NULL != camp) {
+            rc = prte_grpcomm.xcast_nb(PRTE_RML_TAG_DAEMON, &msg,
+                                       shrink_xcast_complete, camp);
+        } else {
+            rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg);
+        }
+        if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             /* undo the campaign we just added (only if one was created), and
              * tell the requester the DVM modification failed */
-            if (prte_elastic_mode && 0 < m) {
-                prte_shrink_campaign_t *_camp =
-                    (prte_shrink_campaign_t *) pmix_list_remove_last(&prte_shrink_campaigns);
-                prte_dvm_launch_fence -= _camp->pending;
-                if (_camp->have_requester) {
-                    prte_plm_base_dvm_mod_notify(&_camp->requester, _camp->alloc_id,
-                                                 _camp->req_id, false,
+            if (NULL != camp) {
+                pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
+                prte_dvm_launch_fence -= camp->pending;
+                if (camp->have_requester) {
+                    prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
+                                                 camp->req_id, false,
                                                  prte_pmix_convert_rc(rc));
                 }
-                PMIX_RELEASE(_camp);
+                PMIX_RELEASE(camp);
             }
         }
         PMIX_DATA_BUFFER_DESTRUCT(&msg);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -699,6 +699,10 @@ static void shrink_campaign_complete(int sd, short args, void *cbdata)
                     node->daemon = NULL;
                     PMIX_RELEASE(dproc);
                 }
+                /* return the node to a pristine, never-launched state so a later
+                 * grow can relaunch a daemon on it (clears the launch flags and
+                 * drops it from the daemon-job map) */
+                prte_plm_base_reset_dvm_node(node);
             }
         }
     }

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -512,15 +512,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         // see if we are one of them
         for (i=0; i < num_procs; i++) {
             if (ranks[i] == PRTE_PROC_MY_NAME->rank) {
-                /* We have been named as a shrink target.  Record that we are
-                 * leaving — this is what allows the lifeline-loss path to treat a
-                 * dropped connection as a cue to depart rather than recover — but
-                 * do NOT exit yet: exiting now, before our subtree's ACK of this
-                 * broadcast reaches the master, would prevent the master's
-                 * collective shrink-completion handler from ever firing.  Because
-                 * the shrink command reached us through our own lifeline, setting
-                 * this here can never race ahead of a genuine, unrelated fault. */
-                prte_dvm_leaving = true;
                 /* any tools attached to us will have done so via PMIx, so
                  * let's provide them with a friendly "job end" notification */
                 PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
@@ -534,14 +525,28 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 PRTE_PMIX_DESTRUCT_LOCK(&lk);
                 // mark abnormal exit status
                 PRTE_UPDATE_EXIT_STATUS(-1);
-                /* arm the bounded departure timer; we exit when it fires or, if
-                 * sooner, when our lifeline to the DVM drops (prte_rml_route_lost
-                 * departs early once prte_dvm_leaving is set).  The master
-                 * completes the campaign from the broadcast's completion, not
-                 * from our departure, so a slightly delayed exit is harmless. */
-                prte_event_evtimer_set(prte_event_base, &prte_shrink_depart_ev,
-                                       prte_shrink_depart, NULL);
-                prte_event_evtimer_add(&prte_shrink_depart_ev, &prte_shrink_depart_tv);
+                if (prte_elastic_mode) {
+                    /* Elastic shrink: the master completes the campaign from the
+                     * broadcast's completion, so we must NOT exit until our
+                     * subtree's ACK of this broadcast has reached it.  Record that
+                     * we are leaving — which also lets the lifeline-loss path treat
+                     * a dropped connection as a cue to depart rather than recover —
+                     * and arm a bounded departure timer; we exit when it fires or,
+                     * if sooner, when our lifeline drops (prte_rml_route_lost
+                     * departs early once prte_dvm_leaving is set).  Because the
+                     * shrink command reached us through our own lifeline, setting
+                     * this here can never race ahead of a genuine fault. */
+                    prte_dvm_leaving = true;
+                    prte_event_evtimer_set(prte_event_base, &prte_shrink_depart_ev,
+                                           prte_shrink_depart, NULL);
+                    prte_event_evtimer_add(&prte_shrink_depart_ev, &prte_shrink_depart_tv);
+                } else {
+                    /* legacy fire-and-forget shrink (no completion tracking): do a
+                     * clean immediate exit, exactly as before.  The HNP detects our
+                     * departure via the normal daemon-loss (comm-failure) path. */
+                    prte_abnormal_term_ordered = true;
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+                }
                 break;
             }
         }

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -93,6 +93,27 @@ static void _notify_release(pmix_status_t status, void *cbdata)
 
 static pmix_pointer_array_t *procs_prev_ordered_to_terminate = NULL;
 
+/* A daemon named as a target of a DVM shrink does not exit the instant it
+ * receives PRTE_DAEMON_SHRINK_CMD: it must stay alive long enough for its
+ * subtree's ACK of the shrink broadcast to reach the master, or the master's
+ * collective shrink-completion handler would never fire.  It therefore records
+ * that it is leaving and arms this bounded timer; the timer fires well after the
+ * broadcast has completed (broadcast ACKs propagate in milliseconds) and drives
+ * the actual departure.  A daemon leaves only once, so a file-static event
+ * suffices.  This is the "bounded self-exit fallback"; a lifeline-loss fast path
+ * (prte_rml_route_lost) departs sooner when the connection actually drops. */
+static prte_event_t prte_shrink_depart_ev;
+static struct timeval prte_shrink_depart_tv = {2, 0};
+
+static void prte_shrink_depart(int sd, short args, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(sd, args, cbdata);
+    /* communications to the rest of the DVM can no longer be relied upon, so
+     * force a local termination exactly as the comm-failure path would */
+    prte_abnormal_term_ordered = true;
+    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+}
+
 void prte_daemon_recv(int status, pmix_proc_t *sender,
                       pmix_data_buffer_t *buffer,
                       prte_rml_tag_t tag, void *cbdata)
@@ -491,8 +512,15 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         // see if we are one of them
         for (i=0; i < num_procs; i++) {
             if (ranks[i] == PRTE_PROC_MY_NAME->rank) {
-                /* this is an abnormal termination */
-                prte_abnormal_term_ordered = true;
+                /* We have been named as a shrink target.  Record that we are
+                 * leaving — this is what allows the lifeline-loss path to treat a
+                 * dropped connection as a cue to depart rather than recover — but
+                 * do NOT exit yet: exiting now, before our subtree's ACK of this
+                 * broadcast reaches the master, would prevent the master's
+                 * collective shrink-completion handler from ever firing.  Because
+                 * the shrink command reached us through our own lifeline, setting
+                 * this here can never race ahead of a genuine, unrelated fault. */
+                prte_dvm_leaving = true;
                 /* any tools attached to us will have done so via PMIx, so
                  * let's provide them with a friendly "job end" notification */
                 PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
@@ -506,10 +534,14 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 PRTE_PMIX_DESTRUCT_LOCK(&lk);
                 // mark abnormal exit status
                 PRTE_UPDATE_EXIT_STATUS(-1);
-                /* do a clean exit; the HNP detects our departure via the
-                 * normal daemon-loss (comm-failure) path and completes the
-                 * shrink campaign there */
-                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+                /* arm the bounded departure timer; we exit when it fires or, if
+                 * sooner, when our lifeline to the DVM drops (prte_rml_route_lost
+                 * departs early once prte_dvm_leaving is set).  The master
+                 * completes the campaign from the broadcast's completion, not
+                 * from our departure, so a slightly delayed exit is harmless. */
+                prte_event_evtimer_set(prte_event_base, &prte_shrink_depart_ev,
+                                       prte_shrink_depart, NULL);
+                prte_event_evtimer_add(&prte_shrink_depart_ev, &prte_shrink_depart_tv);
                 break;
             }
         }

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -53,6 +53,7 @@ prte_rml_base_t prte_rml_base = {
     .n_dmns = 0,
     .failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .global_failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
+    .dead_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
 };
 
 static int verbosity = 0;
@@ -117,6 +118,7 @@ void prte_rml_close(void)
     PMIX_LIST_DESTRUCT(&prte_rml_base.unmatched_msgs);
     PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
     PMIX_DESTRUCT(&prte_rml_base.global_failed_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
     PMIx_Data_array_destruct(&prte_rml_base.ancestors);
     PMIx_Data_array_destruct(&prte_rml_base.children);
     if (0 <= prte_rml_base.rml_output) {
@@ -137,6 +139,11 @@ int prte_rml_open(void)
     /* construct objects for holding failure information */
     PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
     PMIX_CONSTRUCT(&prte_rml_base.global_failed_dmns, pmix_bitmap_t);
+    /* the permanent departed-daemon set is initialized once here and never
+     * re-initialized: the bitmap auto-expands as ranks are marked, and it must
+     * persist across the recomputes that DVM grows trigger (#2491) */
+    PMIX_CONSTRUCT(&prte_rml_base.dead_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.dead_dmns, prte_process_info.num_daemons);
 
     /* set up failure notification receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_DIED, true,

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -175,6 +175,11 @@ typedef struct {
     pmix_bitmap_t failed_dmns;
     // All daemons globally confirmed to have failed
     pmix_bitmap_t global_failed_dmns;
+    // Ranks that have permanently departed the DVM (shrunk out, or lost to a
+    // fault). Unlike failed_dmns, this set is NOT re-initialized by
+    // prte_rml_compute_routing_tree, so it survives the recompute that a grow
+    // triggers and lets the rebuilt tree keep routing around the hole (#2491).
+    pmix_bitmap_t dead_dmns;
 
     // Track all ancestors up to HNP, to simplify fault handling
     pmix_data_array_t ancestors;

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -36,6 +36,7 @@
 
 #include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/filem/filem.h"
+#include "src/mca/state/state.h"
 #include "src/rml/relm/relm.h"
 
 
@@ -347,6 +348,17 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
 }
 
 int prte_rml_route_lost(pmix_rank_t route){
+    /* If we have been named as a shrink target and it is our lifeline to the
+     * DVM that has dropped, depart now rather than trying to recover: the DVM
+     * has removed us on purpose.  This fires only when prte_dvm_leaving is set,
+     * i.e., only after we processed a shrink command naming our own rank, so a
+     * genuine (unrelated) lifeline fault still takes the normal recovery path
+     * below.  It is a fast path only — a bounded timer (prted_comm.c) guarantees
+     * departure even if the connection never actually drops. */
+    if(prte_dvm_leaving && route == prte_rml_base.lifeline){
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+        return PRTE_SUCCESS;
+    }
     if(prte_finalizing || prte_prteds_term_ordered || prte_abnormal_term_ordered){
         /* see if it is one of our children - if so, remove it */
         pmix_rank_t* children = (pmix_rank_t*)prte_rml_base.children.array;

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -355,14 +355,20 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
 }
 
 int prte_rml_route_lost(pmix_rank_t route){
-    /* If we have been named as a shrink target and it is our lifeline to the
-     * DVM that has dropped, depart now rather than trying to recover: the DVM
-     * has removed us on purpose.  This fires only when prte_dvm_leaving is set,
-     * i.e., only after we processed a shrink command naming our own rank, so a
-     * genuine (unrelated) lifeline fault still takes the normal recovery path
-     * below.  It is a fast path only — a bounded timer (prted_comm.c) guarantees
-     * departure even if the connection never actually drops. */
-    if(prte_dvm_leaving && route == prte_rml_base.lifeline){
+    /* If we have been named as a shrink target, depart now on the first lost
+     * connection rather than trying to recover: the DVM has removed us on
+     * purpose.  This fires only when prte_dvm_leaving is set, i.e., only after
+     * we processed a shrink command naming our own rank, so a genuine
+     * (unrelated) route loss still takes the normal recovery path below.  We
+     * exit on *any* lost route, not just the lifeline: a child connection can
+     * be detected as dropping before the lifeline does, and if we treated that
+     * as a child failure we would emit an "adoption" notice for the promoted
+     * rank, which — arriving before news of our own departure — could be
+     * misread as a real failure and propagated up the tree.  Exiting
+     * unconditionally keeps a leaving daemon's disconnects from ever being
+     * mistaken for faults.  It is a fast path only — a bounded timer
+     * (prted_comm.c) guarantees departure even if no connection ever drops. */
+    if(prte_dvm_leaving){
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
         return PRTE_SUCCESS;
     }

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -249,6 +249,13 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
                 continue;
             }
             pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
+            // Record the departure permanently. compute_routing_tree re-inits
+            // failed_dmns on every DVM grow; dead_dmns is not re-initialized, so
+            // restoring it there keeps the rebuilt tree routing around this rank
+            // rather than treating the stale vpid hole as a live daemon (#2491).
+            // The DVM never reuses a daemon vpid, so a departed rank stays a
+            // permanent hole in [0, num_daemons).
+            pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
         }
         ((pmix_rank_t*)status.failed_ranks.array)[j++] = r;
     }
@@ -408,6 +415,21 @@ void prte_rml_compute_routing_tree(void){
     pmix_bitmap_init(&prte_rml_base.failed_dmns, prte_rml_base.n_dmns);
     pmix_bitmap_init(&prte_rml_base.global_failed_dmns, prte_rml_base.n_dmns);
 
+    // Restore any permanently-departed daemons into the freshly-initialized
+    // failed set. This routine runs again whenever the DVM grows, and the
+    // pmix_bitmap_init above wipes the failed marks; without restoring them the
+    // rebuilt tree would treat a shrunk-out (or previously failed) rank as a
+    // live daemon and route to that dead vpid, breaking wireup on the grow
+    // (#2491). dead_dmns is maintained in prte_rml_repair_routing_tree and is
+    // never re-initialized, so it carries the holes across the recompute.
+    bool have_dead = false;
+    for(pmix_rank_t r = 0; r < prte_rml_base.n_dmns; r++){
+        if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r)){
+            pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
+            have_dead = true;
+        }
+    }
+
     prte_rml_base.cur_node = radix_node(PRTE_PROC_MY_NAME->rank);
 
     // Build array of ancestors
@@ -431,6 +453,18 @@ void prte_rml_compute_routing_tree(void){
     }
     shrink_ranks(&prte_rml_base.children);
     prte_rml_base.n_children = prte_rml_base.children.size;
+
+    // If any daemon has permanently departed, route the freshly-built base
+    // tree around it - the same ancestry/child repair a fault would perform,
+    // minus the fault-handler notifications (this is a recompute, not a new
+    // fault). With the dead ranks restored into failed_dmns above, these
+    // helpers (which consult failed_dmns via radix_is_living) drop the holes
+    // from our ancestors, lifeline, and children.
+    if(have_dead){
+        prte_rml_update_ancestors(&prte_rml_base.ancestors);
+        handle_promotion();
+        update_descendants();
+    }
 
     // Print verbose output
     if (1 > pmix_output_get_verbosity(prte_rml_base.routed_output)) return;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -165,6 +165,7 @@ bool prte_routing_is_enabled = true;
 bool prte_dvm_abort_ordered = false;
 bool prte_prteds_term_ordered = false;
 bool prte_allowed_exit_without_sync = false;
+bool prte_dvm_leaving = false;
 
 int prte_timeout_usec_per_proc = -1;
 float prte_max_timeout = -1.0;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -621,6 +621,10 @@ typedef struct {
     char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation, or NULL */
     char            *req_id;         /* requester's PMIX_ALLOC_REQ_ID, or NULL */
     bool             have_requester;
+    /* used to thread-shift the shrink-broadcast completion callback off the
+     * grpcomm xcast call stack and onto a fresh event (see the collective
+     * shrink-completion handler in ras_base_allocate.c) */
+    prte_event_t     ev;
 } prte_shrink_campaign_t;
 PMIX_CLASS_DECLARATION(prte_shrink_campaign_t);
 
@@ -697,6 +701,12 @@ PRTE_EXPORT extern bool prte_routing_is_enabled;
 PRTE_EXPORT extern bool prte_dvm_abort_ordered;
 PRTE_EXPORT extern bool prte_prteds_term_ordered;
 PRTE_EXPORT extern bool prte_allowed_exit_without_sync;
+/* set on a daemon that has been named as a target of an in-progress DVM shrink:
+ * it converts the daemon's response to lifeline loss / broadcast completion from
+ * "recover" to "depart".  Set only while processing PRTE_DAEMON_SHRINK_CMD when
+ * the daemon finds its own rank among the targets, so it can never fire on a
+ * genuine, unrelated fault. */
+PRTE_EXPORT extern bool prte_dvm_leaving;
 
 PRTE_EXPORT extern int prte_timeout_usec_per_proc;
 PRTE_EXPORT extern float prte_max_timeout;

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -70,6 +70,19 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         return rc;
     }
 
+    /* pack the size of the daemon vpid space, [0, num_daemons). This can be
+     * larger than the number of live daemons packed below: a DVM shrink leaves
+     * a permanent hole in the vpid space (the DVM never reuses a daemon vpid),
+     * so the departed daemon has no entry in the name/vpid lists. Receivers
+     * need this exact span - not the live count - so their routing tree covers
+     * the same rank space the HNP uses, and so they can identify the holes as
+     * permanently-dead ranks to route around (#2491). */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &prte_process_info.num_daemons, 1, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
     /* daemon vpids start from 0 and increase linearly by one
      * up to the number of nodes in the system. The vpid is
      * a 32-bit value. We don't know how many of the nodes
@@ -221,6 +234,7 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
 {
     uint8_t u8;
     pmix_rank_t *vpid = NULL;
+    pmix_rank_t ndmns = 0;
     int cnt, n;
     bool compressed;
     size_t sz;
@@ -256,6 +270,15 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         prte_managed_allocation = true;
     } else {
         prte_managed_allocation = false;
+    }
+
+    /* unpack the size of the daemon vpid space (may exceed the live daemon
+     * count when the DVM carries shrunk-out vpid holes - see nidmap_create) */
+    cnt = 1;
+    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buf, &ndmns, &cnt, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
     }
 
     /* unpack compression flag for node names */
@@ -420,10 +443,27 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         nd->daemon = proc;
     }
 
-    /* update num procs */
-    if (prte_process_info.num_daemons != daemons->num_procs) {
-        prte_process_info.num_daemons = daemons->num_procs;
-        /* update the routing tree */
+    /* Record any vpid holes as permanently-dead ranks. The DVM spans [0, ndmns)
+     * daemon vpids, but a shrunk-out daemon leaves a hole with no entry above,
+     * so daemons->procs has a gap at that rank. Marking the gap in the
+     * persistent dead set makes this daemon's routing tree route around the
+     * hole exactly as the HNP and the surviving daemons do - closing the gap
+     * that a brand-new daemon (empty dead set) would otherwise have (#2491).
+     * On an unshrunk DVM ndmns equals the live count, so nothing is marked and
+     * behavior is unchanged. */
+    bool newdead = false;
+    for (pmix_rank_t r = 0; r < ndmns; r++) {
+        if (NULL == pmix_pointer_array_get_item(daemons->procs, r) &&
+            !pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r)) {
+            pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
+            newdead = true;
+        }
+    }
+
+    /* update num daemons and (re)build the routing tree if the vpid span grew
+     * or a new hole appeared */
+    if (prte_process_info.num_daemons != ndmns || newdead) {
+        prte_process_info.num_daemons = ndmns;
         prte_rml_compute_routing_tree();
     }
 


### PR DESCRIPTION
Collective shrink completion: repair the routing tree once per campaign

## Problem

Closes #2492.

When an elastic DVM shrinks, each targeted daemon's departure is observed
independently by the HNP and every survivor, and each observer repaired its
radix routing tree *per death*. A campaign that removes several daemons — and
especially several on one branch of the tree — therefore drove one
promotion/descendant pass per lost daemon, redundant work that scales with the
number of targets rather than the number of campaigns. Completion was also
driven implicitly by the comm-failure path, so the machinery leaned on daemon
deaths arriving as faults rather than on an ordered signal that the whole DVM
had seen the shrink.

## Approach

Drive shrink completion **collectively**, once per campaign:

- The HNP broadcasts the shrink order down the routing tree and waits for the
  reliable-xcast to complete (every daemon has received it) before tearing the
  targets out. This required a general, non-blocking `xcast_nb` completion
  facility in `grpcomm/direct` rather than a shrink special case.
- On completion the HNP performs a **single** `prte_rml_repair_routing_tree`
  pass over the whole target set, then does the per-target teardown. Survivors
  likewise pre-mark the targets so their subsequent per-death `route_lost`
  calls no-op.
- The targeted daemons enter a **leaving mode** carried in the shrink command
  itself (race-free by construction), departing on a bounded timer with a
  lifeline-loss fast path — so termination on lifeline failure happens only
  when the HNP has ordered it.
- `errmgr/dvm` gains an already-departed idempotency guard so the deaths that
  follow the collective teardown are absorbed rather than treated as failures.

The completion callback rides a small FIFO of pending completions (the op the
master initiates is discarded once relayed; the tracked op is rebuilt on the
loop-back). The FIFO entry is enqueued in `begin_xcast` immediately before the
send and unwound on failure, so a dropped broadcast cannot misalign a
completion onto the wrong op.

## Re-growable shrunk nodes — Closes #2491

This branch now also fixes re-grow of a just-shrunk node, end to end.

**Launcher-agnostic node reset (the prerequisite).** A shrink used to leave the
departed daemon's node object carrying its previous launch state — the
`PRTE_NODE_FLAG_DAEMON_LAUNCHED` flag every plm launcher checks, plus a stale
entry in the daemon-job map — so a later grow onto the same node was skipped
("daemon already exists") or duplicated. A shared helper
`prte_plm_base_reset_dvm_node()` returns such a node to a pristine,
never-launched state and is called from both the shrink-completion teardown and
the grow-failure rollback. `errmgr/dvm` also routes
`PRTE_PROC_STATE_FAILED_TO_CONNECT` through the comm-failure / grow-rollback
handling instead of the fatal "UNSUPPORTED DAEMON ERROR STATE" abort, so a
daemon that comes up but cannot complete its connect-back fails just that grow.

**Routing-side vpid-hole fix (the remaining half).** A shrink leaves a permanent
hole in the daemon vpid space — the DVM never reuses a daemon vpid, and the
non-ssh launchers (slurm/pals/lsf) require the new daemons' vpids to be a
*sequential* range, so vpid reuse is not an option. The positional radix routing
tree spans `[0, num_daemons)` and decides reachability purely from vpid
arithmetic, consulting `failed_dmns` to skip departed ranks — but
`prte_rml_compute_routing_tree()`, which a grow re-runs, re-initialized
`failed_dmns` and so forgot the hole, rebuilding a tree that routed to the dead
rank and broke wireup to the newly grown daemon. The fix keeps the vpid space
append-only and teaches the tree to route *around* the holes:

- A persistent `dead_dmns` bitmap on `prte_rml_base` records every departed
  rank and, unlike `failed_dmns`, is never re-initialized.
  `prte_rml_repair_routing_tree()` sets it; `prte_rml_compute_routing_tree()`
  restores it into the freshly-initialized failed set and repairs the base tree
  around the holes (the same ancestor/child pass a fault performs, minus the
  fault-handler notifications).
- The nidmap now carries the true `num_daemons` (the vpid-space size, holes
  included) in addition to the live-daemon list. On decode a daemon sets
  `num_daemons` from it and marks every vpid in `[0, num_daemons)` with no live
  entry into `dead_dmns` before computing its tree — so a brand-new daemon,
  which never witnessed the shrink events, still converges on the same span and
  dead set as the HNP, and deep (multi-level) trees route around the hole too.
- `setup_vm`'s grow path (`PRTE_JOB_EXTEND_DVM`) now resets
  `map->num_new_daemons` and `map->daemon_vpid_start` on entry instead of
  accumulating them across successive grow campaigns, which had corrupted the
  campaign target list and suppressed its completion event.

One follow-on remains tracked in #2491: the VM-ready gate
(`num_reported == num_procs`) after a hole, which is expected to be moot with
append-only vpids plus this routing fix and did not surface in testing.

## Gating

The collective-completion mechanism is gated behind `prte_elastic_mode`
(default off): the enqueue, daemon leaving mode, and errmgr guard are all
skipped, and the default launch/fault paths are unchanged. The re-grow fixes
are self-gating by construction — `reset_dvm_node` only runs on the elastic
shrink/grow-rollback paths, the `FAILED_TO_CONNECT` routing only changes a
previously-fatal case, and the routing/nidmap changes are no-ops on an unshrunk
DVM (with no holes the packed span equals the live count, nothing is marked
dead, and the tree is built exactly as before).

## Design doc

`docs/plans/elastic_dvm/collective_shrink_completion.rst` captures the design,
the settled open questions, the survivor-batching scope cut, the node
launch-state reset, and the routing-side re-grow fix with its results.

## Testing

Built warning-free under `--enable-devel-check` (`-Werror`).

- **Default (non-elastic):** persistent DVM + `prun` and a foreground
  `prterun` both `rc=0`; startup wireup, launch, and teardown unchanged.
- **Elastic shrink (ten-node Docker testbed):** grew to nine daemons, then
  shrank a three-daemon single branch — one `PMIX_DVM_IS_READY`, HNP survived,
  exactly the targeted daemons left, survivors intact, post-shrink `prun rc=0`.
  Multi-branch and pkill-mid-shrink scenarios also drain to a single
  completion.
- **Re-grow (#2491), full cycle on the ten-node testbed** (fresh image from
  this branch): `grow node2,node3` → `shrink node3` → **`grow node3` now
  completes** with `PMIX_DVM_IS_READY`. Repeated a second `shrink node3` →
  `grow node3`, plus a fresh `grow node4`. Every re-grow **appends** a new vpid
  (3, then 4, then 5) rather than reusing the shrunk rank, and each new daemon's
  `num_procs` tracks the full span (4 → 5 → 6) so the accumulating vpid holes
  are preserved and routed around. The HNP survived every cycle, no
  comm-failure / "UNSUPPORTED DAEMON" / abort appeared, and `prun rc=0`
  throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
