### PR TITLE
Simplify and document the collapsed RML code tree

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -45,6 +45,7 @@ RST_SOURCE_FILES = \
         $(srcdir)/launching-apps/*.rst \
         $(srcdir)/how-things-work/*.rst \
         $(srcdir)/how-things-work/schedulers/*.rst \
+        $(srcdir)/how-things-work/rml/*.rst \
         $(srcdir)/developers/*.rst \
         $(srcdir)/man/*.rst \
         $(srcdir)/man/man1/*.rst \

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -13,3 +13,4 @@ find information on that subject here.
    per-app-mapping.rst
    schedulers/index.rst
    state_machine.rst
+   rml/index.rst

--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -11,7 +11,7 @@ this tag*, asynchronously and in order per connection.
 
 This page explains how the RML is put together and how a message flows through
 it.  The code lives entirely in ``src/rml/``; a shorter, editing-oriented map
-is in ``src/rml/README.md``.
+is in ``src/rml/AGENTS.md``.
 
 Historical note: one directory, once three frameworks
 -----------------------------------------------------
@@ -185,4 +185,4 @@ Where to look
 * Routing math: ``routed_radix.c`` and ``radix.h``.
 * Fault handling: ``routed_radix.c`` (``repair_routing_tree``),
   ``rml_fault_handler.c``, and ``relm/``.
-* Editing map and gotchas: ``src/rml/README.md``.
+* Editing map and gotchas: ``src/rml/AGENTS.md``.

--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -1,0 +1,188 @@
+.. _rml-label:
+
+The Runtime Messaging Layer (RML)
+=================================
+
+The Runtime Messaging Layer is how PRRTE daemons talk to one another.  Every
+control message that crosses the DVM — launch commands, I/O forwarding,
+collective operations, PMIx data exchanges, fault notices — travels over the
+RML.  It provides a single service: *deliver this buffer to that daemon, under
+this tag*, asynchronously and in order per connection.
+
+This page explains how the RML is put together and how a message flows through
+it.  The code lives entirely in ``src/rml/``; a shorter, editing-oriented map
+is in ``src/rml/README.md``.
+
+Historical note: one directory, once three frameworks
+-----------------------------------------------------
+
+``src/rml`` was originally **three** MCA frameworks:
+
+* **rml** — the messaging API,
+* **routed** — pluggable routing-tree algorithms, and
+* **oob** ("out of band") — pluggable transports, each with swappable modules.
+
+PRRTE only ever had one RML, one routing algorithm (a radix tree), and one
+transport (TCP), so the three frameworks were collapsed into the single
+``src/rml`` directory.  The collapse merged the files but, for a long time,
+left the multi-component *abstractions* in place — dead failover paths, a relay
+macro nobody called, a routed-module name in every wire header, and comments
+describing a world of many components, modules, and transports.  That
+scaffolding has since been removed.  When you read the code today there is one
+path: **RML API → radix routing → TCP transport**, plus a newer fault-tolerance
+layer layered on top.
+
+Architecture and key state
+--------------------------
+
+Two global structures hold essentially all RML state, and both are owned by the
+PRRTE progress thread:
+
+``prte_rml_base`` (``src/rml/rml.h``, defined in ``rml.c``)
+    The messaging and routing state.  It holds the two matching lists —
+    ``posted_recvs`` (receives the local code has posted) and
+    ``unmatched_msgs`` (messages that arrived before a matching receive was
+    posted) — plus the routing-tree state: the number of daemons ``n_dmns``,
+    the ``failed_dmns``/``global_failed_dmns`` bitmaps, this daemon's
+    ``ancestors`` and ``children`` in the tree, and its ``lifeline`` (immediate
+    parent).
+
+``prte_oob_base`` (``src/rml/oob/oob.h``, defined in ``oob_tcp.c``)
+    The transport state: the list of known ``peers`` (each with its addresses,
+    socket, and send queue), the local network interfaces, listener sockets,
+    and the many TCP tuning MCA parameters (buffer sizes, keepalives, retry
+    limits, ``max_msg_size``).
+
+The message objects (``src/rml/rml_types.h``) are reference-counted PMIx
+objects:
+
+* ``prte_rml_send_t`` — an outbound message (destination, origin, tag, data
+  buffer, retry count).
+* ``prte_rml_recv_t`` — an inbound message waiting to be matched/delivered.
+* ``prte_rml_posted_recv_t`` — a standing receive: a (peer, tag, persistent,
+  callback) tuple.
+
+Everything runs on one thread.  Work that originates elsewhere is moved onto
+the progress thread with a *caddy* — a small heap object carrying the request
+plus a ``pmix_event_t`` — posted via ``PRTE_PMIX_THREADSHIFT``.  ``PRTE_OOB_SEND``
+and ``prte_rml_recv_buffer_nb`` are the two entry points that do this.
+
+Sending a message
+-----------------
+
+The public entry point is the ``PRTE_RML_SEND(rc, dst, buffer, tag)`` macro,
+which calls ``prte_rml_send_buffer_nb`` (``src/rml/rml_send.c``).  The RML takes
+ownership of ``buffer``.
+
+#. **Validation and self-sends.**  Invalid tag/rank or a known-down destination
+   are rejected immediately.  A message addressed to *this* daemon never touches
+   the network: it is wrapped in a ``prte_rml_recv_t`` and re-posted locally with
+   ``PRTE_RML_ACTIVATE_MESSAGE``, so it enters the same delivery path as a
+   received message.
+
+#. **Hand to the transport.**  Otherwise the call builds a ``prte_rml_send_t``
+   (``dst``, ``origin`` = me, ``tag``, ``dbuf``) and invokes ``PRTE_OOB_SEND``,
+   which thread-shifts to ``prte_oob_base_send_nb`` (``oob_base_stubs.c``).
+
+#. **Route and connect.**  ``prte_oob_base_send_nb`` first drops the message if
+   the destination is down or the retry budget (``prte_rml_max_retries``) is
+   exhausted, reporting the failure back through the send callback.  Otherwise it
+   computes the **next hop** with ``prte_rml_get_route(dst)`` and looks up the
+   TCP peer for that hop.  If the peer is unknown, it obtains the peer's contact
+   URI (directly for the HNP, or from the PMIx store) and builds a peer object.
+
+#. **Queue.**  If the peer is already connected, the message is queued for
+   immediate transmission (``MCA_OOB_TCP_QUEUE_SEND``); otherwise it is queued as
+   pending (``MCA_OOB_TCP_QUEUE_PENDING``) and the connection state machine in
+   ``oob_tcp_connection.c`` is started.  Once the socket is up and the IDENT
+   handshake has completed, the send handler in ``oob_tcp_sendrecv.c`` writes the
+   header and then the payload.
+
+Receiving, matching, and relaying
+---------------------------------
+
+On the wire, every message carries a ``prte_oob_tcp_hdr_t``
+(``oob/oob_tcp_hdr.h``): the ``origin``, the final ``dst``, the ``tag``, a
+sequence number, the payload length, and a message ``type`` (``IDENT``/``PROBE``
+for the handshake, ``USER`` for a normal message).  The header is exchanged only
+between daemons of the same DVM — all running the same build — so its layout is
+not a stable ABI.
+
+When a peer's socket has delivered a complete message, the recv handler
+(``oob_tcp_sendrecv.c``) inspects ``hdr.dst``:
+
+* **For us.**  It calls ``PRTE_RML_POST_MESSAGE``, which thread-shifts to
+  ``prte_rml_base_process_msg`` (``rml_base_msg_handlers.c``).  That handler walks
+  ``posted_recvs`` looking for a receive whose (peer, tag) matches — using
+  ``PMIX_CHECK_PROCID`` so wildcard receives work — and fires its callback.  A
+  non-persistent receive is removed once it fires.  If nothing matches, the
+  message is parked on ``unmatched_msgs``.
+
+* **Not for us.**  This daemon is an intermediate hop.  The handler rebuilds a
+  ``prte_rml_send_t`` with the same ``origin``/``dst`` and re-enters
+  ``PRTE_OOB_SEND``, which routes the message on toward the next hop.  Relaying is
+  therefore just "send again from here."
+
+The dual of ``process_msg`` is ``prte_rml_base_post_recv``: when new code posts a
+receive, that handler also scans ``unmatched_msgs`` so that any message which
+arrived early is delivered right away.  ``prte_rml_purge`` clears both lists for a
+peer that has gone away.
+
+Routing: the radix tree
+-----------------------
+
+Daemons are numbered ``0 .. N-1`` (rank 0 is the HNP) and arranged in a radix
+tree.  The radix (fan-out) defaults to 64 and is set with
+``--prtemca prte_rml_radix``.  The tree keeps the number of hops between any two
+daemons small while bounding each daemon's connection count.
+
+``prte_rml_get_route(target)`` (``routed_radix.c``) returns the rank of the next
+hop:
+
+* ``target`` itself if it is this daemon;
+* this daemon's parent (its ``lifeline``) if ``target`` lies outside this
+  daemon's subtree — i.e., the message must go *up* the tree;
+* otherwise the child whose subtree contains ``target`` — the message goes
+  *down* toward it.
+
+All of the arithmetic — parent, child, sibling, "does this subtree contain rank
+r," "which child subtree holds r," moving up and down by depth, and "next living
+rank" traversals that skip failed daemons — lives as pure functions over rank
+numbers in ``radix.h``.  That header is deliberately self-contained and includes
+``radix_node_is_valid`` as an executable statement of the tree invariants; it is
+the first thing to read if you need to modify the routing math.
+
+Fault tolerance and reliable messaging
+--------------------------------------
+
+The routing tree is not static: daemons can fail, and (in elastic mode) the DVM
+can grow and shrink.  ``prte_rml_base`` therefore tracks which daemons have
+failed and repairs the tree in place.
+
+When a connection is lost (``prte_rml_route_lost``) or a fault notice arrives,
+``prte_rml_repair_routing_tree`` (``routed_radix.c``) recomputes this daemon's
+ancestors and children, works out whether this daemon has been *promoted* to
+fill a hole higher up, and packages the before/after difference into a
+``prte_rml_recovery_status_t``.  Faults are handled twice — once **locally** as
+they are discovered and once **globally** when the HNP broadcasts the confirmed
+set — so handlers can distinguish "recover now" from "everyone agrees this is
+final."  The recovery status is then delivered to the registered fault handlers:
+the RML's own (``rml_fault_handler.c``, which drives process states and
+death/adoption notices), followed by grpcomm, filem, and relm.
+
+``relm`` (the ``src/rml/relm/`` subtree) is the **reliable messaging** layer.
+``prte_rml_send_buffer_reliable_nb`` routes through it; it drives a small state
+machine that re-sends messages over the repaired tree so that a message in
+flight when a daemon dies is not simply lost.  It is newer than the collapsed
+core and is intentionally kept as its own module.
+
+Where to look
+-------------
+
+* Sending: ``rml_send.c`` → ``oob/oob_base_stubs.c`` → ``oob/oob_tcp_connection.c``
+  → ``oob/oob_tcp_sendrecv.c``.
+* Receiving/matching: ``oob/oob_tcp_sendrecv.c`` → ``rml_base_msg_handlers.c``.
+* Routing math: ``routed_radix.c`` and ``radix.h``.
+* Fault handling: ``routed_radix.c`` (``repair_routing_tree``),
+  ``rml_fault_handler.c``, and ``relm/``.
+* Editing map and gotchas: ``src/rml/README.md``.

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -5,7 +5,7 @@ This directory implements all daemon-to-daemon messaging in PRRTE: how a
 routed across the DVM, and how it is delivered to the code that posted a
 receive for it.
 
-This README is an orientation map for anyone (human or agent) about to modify
+This document is an orientation map for anyone (human or agent) about to modify
 the code. For a narrative walkthrough of *how it works*, see
 [`docs/how-things-work/rml/index.rst`](../../docs/how-things-work/rml/index.rst).
 

--- a/src/rml/CLAUDE.md
+++ b/src/rml/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/rml/README.md
+++ b/src/rml/README.md
@@ -1,0 +1,113 @@
+# `src/rml` — the Runtime Messaging Layer
+
+This directory implements all daemon-to-daemon messaging in PRRTE: how a
+`prte`/`prted` process sends a buffer to another daemon, how that buffer is
+routed across the DVM, and how it is delivered to the code that posted a
+receive for it.
+
+This README is an orientation map for anyone (human or agent) about to modify
+the code. For a narrative walkthrough of *how it works*, see
+[`docs/how-things-work/rml/index.rst`](../../docs/how-things-work/rml/index.rst).
+
+## History: three frameworks collapsed into one
+
+`src/rml` used to be **three** separate MCA frameworks:
+
+- **rml** — the messaging API (`send`/`recv`).
+- **routed** — pluggable routing-tree algorithms.
+- **oob** ("out of band") — pluggable transports, each with swappable modules.
+
+In practice PRRTE only ever shipped one RML, one routing algorithm (a radix
+tree), and one transport (TCP). The three frameworks were collapsed into this
+single directory. When reading the code, keep this in mind: language about
+"looping across components," "trying another module," or "some other
+transport" is **historical**. There is exactly one path: RML → radix routing →
+TCP. If you find such comments, they are cruft — fix them.
+
+## File map
+
+**Core RML (API, matching, dispatch):**
+
+| File | Responsibility |
+|------|----------------|
+| `rml.h`, `rml_types.h` | Public interface: `PRTE_RML_SEND`/`RECV` macros, RML tags, the `prte_rml_base` global, and the send/recv/posted-recv object types. |
+| `rml.c` | `prte_rml_open`/`close`/`register`; defines the `prte_rml_base` global and all RML class instances; `prte_rml_send_callback`; `prte_rml_is_node_up`. |
+| `rml_send.c` | `prte_rml_send_buffer_nb` (and the `_reliable_nb` variant). Short-circuits sends to self; otherwise hands the message to the OOB. |
+| `rml_recv.c` | `prte_rml_recv_buffer_nb` / `prte_rml_recv_cancel`. Thread-shifts the request onto the progress thread. |
+| `rml_base_msg_handlers.c` | The heart of matching: `prte_rml_base_post_recv` (add/cancel a posted recv), `prte_rml_base_process_msg` (deliver an arrived message to a posted recv, or hold it in `unmatched_msgs`). |
+| `rml_base_contact.c`, `rml_contact.h` | `prte_rml_parse_uris` — split a contact URI into name + address list. |
+| `rml_purge.c` | `prte_rml_purge` — drop posted recvs and held messages for a departed peer. |
+
+**Routing (the radix tree):**
+
+| File | Responsibility |
+|------|----------------|
+| `routed_radix.c` | `prte_rml_get_route` (next hop toward a target), subtree indexing, and the tree (re)computation used on startup and after faults: `compute_routing_tree`, `repair_routing_tree`, `update_ancestors`, promotion/descendant fixups, `route_lost`. |
+| `radix.h` | Header-only radix-tree math over daemon ranks: parent/child/sibling navigation, `subtree_contains`/`subtree_index`, depth motion, and "next living" traversal that skips failed ranks. Pure functions on rank numbers, no I/O. |
+
+**Fault tolerance / reliability (newer; not collapse cruft):**
+
+| File | Responsibility |
+|------|----------------|
+| `rml_fault_handler.c` | The RML's own reaction to a recomputed tree: sets process states and drives death/adoption notices. |
+| `relm/` | RELM — reliable messaging that survives daemon failures by re-driving messages over the repaired tree. Has its own small state machine (`relm/state_machine.c`, `relm/base/`). |
+
+**Transport (TCP — the `oob/` subdirectory):**
+
+| File | Responsibility |
+|------|----------------|
+| `oob/oob.h` | `prte_oob_base` global + the `PRTE_OOB_SEND` entry macro. |
+| `oob/oob_base_stubs.c` | `prte_oob_base_send_nb` — resolve the next hop, find/create its TCP peer, queue the message (connecting first if needed). Plus URI build (`get_addr`) and parse (`process_uri`/`set_addr`). |
+| `oob/oob_tcp.c` | OOB open/close/register: MCA params, interface discovery, listener startup; `recv_handler` (connection handshake); `simulate_node_failure` (test hook). |
+| `oob/oob_tcp_component.c` | Class instances; the `lost_connection` / `failed_to_connect` event handlers. |
+| `oob/oob_tcp_listener.c` | Listening sockets and the accept path. |
+| `oob/oob_tcp_connection.c` | Per-peer connection state machine: connect, IDENT ack/nack handshake, accept, close. |
+| `oob/oob_tcp_sendrecv.c`, `.h` | The socket send/recv event handlers and their queueing macros. The recv-completion path decides **deliver locally vs. relay onward**. |
+| `oob/oob_tcp_hdr.h` | The on-wire message header (`prte_oob_tcp_hdr_t`). |
+| `oob/oob_tcp_peer.h`, `oob/oob_tcp_common.[ch]` | Peer/address objects; socket options and state-name helpers. |
+
+## The two paths, in one paragraph each
+
+**Send.** `PRTE_RML_SEND(rc, dst, buf, tag)` calls `prte_rml_send_buffer_nb`
+(`rml_send.c`). A message to *self* is wrapped and re-posted locally without
+touching the network. Otherwise it becomes a `prte_rml_send_t` and goes to
+`PRTE_OOB_SEND`, which thread-shifts to `prte_oob_base_send_nb`
+(`oob_base_stubs.c`). That routine asks `prte_rml_get_route` for the next hop,
+looks up (or creates and connects) the TCP peer for that hop, and queues the
+message. The connection state machine (`oob_tcp_connection.c`) and send handler
+(`oob_tcp_sendrecv.c`) do the rest.
+
+**Receive / relay.** When a peer's socket has a complete message, the recv
+handler (`oob_tcp_sendrecv.c`) checks `hdr.dst`. If it is us, it calls
+`PRTE_RML_POST_MESSAGE`, which thread-shifts to `prte_rml_base_process_msg`
+(`rml_base_msg_handlers.c`): match the message against `posted_recvs` (peer +
+tag, wildcards allowed) and fire the callback, or hold it in `unmatched_msgs`
+until a matching recv is posted. If `hdr.dst` is *not* us, we are an
+intermediate hop: the handler re-enters `PRTE_OOB_SEND` so the message is
+routed on toward its destination.
+
+## Routing in one paragraph
+
+Daemons are ranks `0..N-1` (rank 0 is the HNP) arranged in a radix tree
+(default radix 64; `--prtemca prte_rml_radix`). `prte_rml_get_route(target)`
+returns: `target` if it is me; my parent (lifeline) if `target` is outside my
+subtree; otherwise the child whose subtree contains `target`. After a daemon
+fault, `prte_rml_repair_routing_tree` recomputes ancestors, children, and
+possible self-promotion, packages the delta into a
+`prte_rml_recovery_status_t`, and notifies the RML, grpcomm, filem, and relm
+fault handlers.
+
+## Gotchas before you edit
+
+- **Single progress thread.** All RML/OOB state is owned by the progress
+  thread. Cross-thread work uses a *caddy* + `PRTE_PMIX_THREADSHIFT` (see
+  `PRTE_OOB_SEND`, `prte_rml_recv_buffer_nb`). Never read or write shared RML
+  state off that thread, and never block on it.
+- **The wire header is not an ABI.** `prte_oob_tcp_hdr_t` is exchanged only
+  among daemons of the *same* DVM, which all run the same build. You may change
+  its layout, but every daemon must agree — there is no versioning.
+- **One transport, one router.** Do not reintroduce component/module
+  abstraction to "make it pluggable" unless there is a real second
+  implementation; that abstraction is exactly what was removed.
+- **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
+  tree warning-free.

--- a/src/rml/oob/oob.h
+++ b/src/rml/oob/oob.h
@@ -60,8 +60,6 @@ BEGIN_C_DECLS
  */
 typedef struct {
     int output;
-    uint32_t addr_count;             /**< total number of addresses */
-    int num_links;                   /**< number of logical links per physical device */
     int max_retries;                 /**< max number of retries before declaring peer gone */
     int max_uri_length;
     pmix_list_t events;              /**< events for monitoring connections */
@@ -129,18 +127,13 @@ typedef struct {
 } prte_oob_send_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_oob_send_t);
 
-/* All OOB sends are based on iovec's and are async as the RML
- * acts as the initial interface to prepare all communications.
- * The send_nb function will enter the message into the OOB
- * base, which will then check to see if a transport for the
- * intended target has already been assigned. If so, the message
- * is immediately placed into that module's event base for
- * transmission. If not, the function will loop across all available
- * components until one identifies that it has a module capable
- * of reaching the target.
+/* All OOB sends are async: the RML prepares the message and hands it to
+ * the OOB base via PRTE_OOB_SEND, which thread-shifts onto the event base
+ * and calls prte_oob_base_send_nb. That routine resolves the next hop
+ * toward the target (see prte_rml_get_route), looks up or creates the TCP
+ * peer for that hop, and queues the message on it - opening the connection
+ * first if one does not already exist.
  */
-typedef void (*mca_oob_send_callback_fn_t)(int status, struct iovec *iov, int count, void *cbdata);
-
 PRTE_EXPORT void prte_oob_base_send_nb(int fd, short args, void *cbdata);
 #define PRTE_OOB_SEND(m)                                                                          \
     do {                                                                                          \
@@ -152,21 +145,19 @@ PRTE_EXPORT void prte_oob_base_send_nb(int fd, short args, void *cbdata);
         PRTE_PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb);          \
     } while (0)
 
-/* During initial wireup, we can only transfer contact info on the daemon
- * command line. This limits what we can send to a string representation of
- * the actual contact info, which gets sent in a uri-like form. Not every
- * oob module can support this transaction, so this function will loop
- * across all oob components/modules, letting each add to the uri string if
- * it supports bootstrap operations. An error will be returned in the cbfunc
- * if NO component can successfully provide a contact.
+/* Build this process's contact URI: our name followed by the TCP
+ * address(es) we are listening on, in a semicolon-separated string. During
+ * initial wireup this can only be transferred on the daemon command line,
+ * so the result is a compact string representation of our listening
+ * endpoints.
  *
  * Note: since there is a limit to what an OS will allow on a cmd line, we
  * impose a limit on the length of the resulting uri via an MCA param. The
  * default value of -1 implies unlimited - however, users with large numbers
  * of interfaces on their nodes may wish to restrict the size.
  *
- * Since all components define their address info at component start,
- * it is unchanged and does not require acess via event
+ * Our address info is fixed once the listeners start, so this needs no
+ * event-base synchronization.
  */
 PRTE_EXPORT void prte_oob_base_get_addr(char **uri);
 

--- a/src/rml/oob/oob_base_stubs.c
+++ b/src/rml/oob/oob_base_stubs.c
@@ -159,12 +159,9 @@ send:
  * Obtain a uri for initial connection purposes
  *
  * During initial wireup, we can only transfer contact info on the daemon
- * command line. This limits what we can send to a string representation of
- * the actual contact info, which gets sent in a uri-like form. Not every
- * oob module can support this transaction, so this function will loop
- * across all oob components/modules, letting each add to the uri string if
- * it supports bootstrap operations. An error will be returned in the cbfunc
- * if NO component can successfully provide a contact.
+ * command line, so we render it as a compact, uri-like string: our process
+ * name followed by the TCP endpoints (IPv4 and, if enabled, IPv6) we are
+ * listening on. Returns *uri == NULL if we have no usable connection.
  *
  * Note: since there is a limit to what an OS will allow on a cmd line, we
  * impose a limit on the length of the resulting uri via an MCA param. The

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -76,8 +76,6 @@
 
 prte_oob_base_t prte_oob_base = {
     .output = -1,
-    .addr_count = 0,
-    .num_links = 0,
     .max_retries = 0,
     .max_uri_length = -1,
     .events = PMIX_LIST_STATIC_INIT,
@@ -137,7 +135,6 @@ int prte_oob_open(void)
         prte_oob_base.listen_thread_tv.tv_sec = 3600;
         prte_oob_base.listen_thread_tv.tv_usec = 0;
     }
-    prte_oob_base.addr_count = 0;
     prte_oob_base.ipv4conns = NULL;
     prte_oob_base.ipv4ports = NULL;
     prte_oob_base.ipv6conns = NULL;
@@ -548,7 +545,7 @@ int prte_oob_register(void)
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "max_msg_size",
                                         "Max size of an OOB message in Megabytes(default = 100)",
                                         PMIX_MCA_BASE_VAR_TYPE_INT,
-                                        &prte_oob_base.max_recon_attempts);
+                                        &prte_oob_base.max_msg_size);
 
     return PRTE_SUCCESS;
 }
@@ -605,52 +602,6 @@ void prte_oob_accept_connection(const int accepted_fd, const struct sockaddr *ad
      *  process ident message to complete this connection
      */
     PRTE_ACTIVATE_TCP_ACCEPT_STATE(accepted_fd, addr, recv_handler);
-}
-
-/* API functions */
-void prte_oob_ping(const pmix_proc_t *proc)
-{
-    prte_oob_tcp_peer_t *peer;
-
-    pmix_output_verbose(2, prte_oob_base.output,
-                        "%s:[%s:%d] processing ping to peer %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        __FILE__, __LINE__, PRTE_NAME_PRINT(proc));
-
-    /* do we know this peer? */
-    if (NULL == (peer = prte_oob_tcp_peer_lookup(proc))) {
-        /* push this back to the component so it can try
-         * another module within this transport. If no
-         * module can be found, the component can push back
-         * to the framework so another component can try
-         */
-        pmix_output_verbose(2, prte_oob_base.output,
-                            "%s:[%s:%d] hop %s unknown", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                            __FILE__, __LINE__, PRTE_NAME_PRINT(proc));
-        PRTE_ACTIVATE_TCP_MSG_ERROR(NULL, NULL, proc, prte_mca_oob_tcp_component_hop_unknown);
-        return;
-    }
-
-    /* if we are already connected, there is nothing to do */
-    if (MCA_OOB_TCP_CONNECTED == peer->state) {
-        pmix_output_verbose(2, prte_oob_base.output,
-                            "%s:[%s:%d] already connected to peer %s",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__, __LINE__,
-                            PRTE_NAME_PRINT(proc));
-        return;
-    }
-
-    /* if we are already connecting, there is nothing to do */
-    if (MCA_OOB_TCP_CONNECTING == peer->state || MCA_OOB_TCP_CONNECT_ACK == peer->state) {
-        pmix_output_verbose(2, prte_oob_base.output,
-                            "%s:[%s:%d] already connecting to peer %s",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), __FILE__, __LINE__,
-                            PRTE_NAME_PRINT(proc));
-        return;
-    }
-
-    /* attempt the connection */
-    peer->state = MCA_OOB_TCP_CONNECTING;
-    PRTE_ACTIVATE_TCP_CONN_STATE(peer, prte_oob_tcp_peer_try_connect);
 }
 
 /*

--- a/src/rml/oob/oob_tcp.h
+++ b/src/rml/oob/oob_tcp.h
@@ -70,9 +70,6 @@ PRTE_EXPORT void prte_oob_tcp_queue_msg(int sd, short args, void *cbdata);
 PRTE_EXPORT void prte_oob_accept_connection(const int accepted_fd, const struct sockaddr *addr);
 PRTE_EXPORT void prte_mca_oob_tcp_component_lost_connection(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_mca_oob_tcp_component_failed_to_connect(int fd, short args, void *cbdata);
-PRTE_EXPORT void prte_mca_oob_tcp_component_no_route(int fd, short args, void *cbdata);
-PRTE_EXPORT void prte_mca_oob_tcp_component_hop_unknown(int fd, short args, void *cbdata);
-PRTE_EXPORT void prte_oob_ping(const pmix_proc_t *proc);
 END_C_DECLS
 
 #endif /* MCA_OOB_TCP_H_ */

--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -115,52 +115,6 @@ void prte_mca_oob_tcp_component_lost_connection(int fd, short args, void *cbdata
     PMIX_RELEASE(pop);
 }
 
-void prte_mca_oob_tcp_component_no_route(int fd, short args, void *cbdata)
-{
-    prte_oob_tcp_msg_error_t *mop = (prte_oob_tcp_msg_error_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(fd, args);
-
-    PMIX_ACQUIRE_OBJECT(mop);
-
-    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
-                        "%s tcp:no route called for peer %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        PRTE_NAME_PRINT(&mop->hop));
-
-    if (prte_prteds_term_ordered || prte_finalizing || prte_abnormal_term_ordered) {
-        /* just ignore the problem */
-        PMIX_RELEASE(mop);
-        return;
-    }
-
-    /* report the error */
-    PRTE_ACTIVATE_PROC_STATE(&mop->hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
-
-    PMIX_RELEASE(mop);
-}
-
-void prte_mca_oob_tcp_component_hop_unknown(int fd, short args, void *cbdata)
-{
-    prte_oob_tcp_msg_error_t *mop = (prte_oob_tcp_msg_error_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(fd, args);
-
-    PMIX_ACQUIRE_OBJECT(mop);
-
-    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
-                        "%s tcp:unknown hop called for peer %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        PRTE_NAME_PRINT(&mop->hop));
-
-    if (prte_prteds_term_ordered || prte_finalizing || prte_abnormal_term_ordered) {
-        /* just ignore the problem */
-        PMIX_RELEASE(mop);
-        return;
-    }
-
-    /* post the error */
-    PRTE_ACTIVATE_PROC_STATE(&mop->hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
-
-    PMIX_RELEASE(mop);
-}
-
 void prte_mca_oob_tcp_component_failed_to_connect(int fd, short args, void *cbdata)
 {
     prte_oob_tcp_peer_op_t *pop = (prte_oob_tcp_peer_op_t *) cbdata;
@@ -253,8 +207,6 @@ static void pop_des(prte_oob_tcp_peer_op_t *pop)
     }
 }
 PMIX_CLASS_INSTANCE(prte_oob_tcp_peer_op_t, pmix_object_t, pop_cons, pop_des);
-
-PMIX_CLASS_INSTANCE(prte_oob_tcp_msg_op_t, pmix_object_t, NULL, NULL);
 
 PMIX_CLASS_INSTANCE(prte_oob_tcp_conn_op_t, pmix_object_t, NULL, NULL);
 

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -508,7 +508,6 @@ static int tcp_peer_send_connect_ack(prte_oob_tcp_peer_t *peer)
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
-    memset(hdr.routed, 0, PRTE_MAX_RTD_SIZE + 1);
 
     /* payload size */
     sdsize = sizeof(ack_flag) + strlen(prte_version_string) + 1;
@@ -563,7 +562,6 @@ static int tcp_peer_send_connect_nack(int sd, pmix_proc_t *name)
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
-    memset(hdr.routed, 0, PRTE_MAX_RTD_SIZE + 1);
 
     /* payload size */
     sdsize = sizeof(ack_flag);

--- a/src/rml/oob/oob_tcp_hdr.h
+++ b/src/rml/oob/oob_tcp_hdr.h
@@ -29,32 +29,24 @@
 
 #include "prte_config.h"
 
-/* define several internal-only message
- * types this component uses for its own
- * handshake operations, plus one indicating
- * the message came from an external (to
- * this component) source
+/* Message types carried in the TCP header. IDENT and PROBE are used
+ * during the connection handshake; USER marks a normal RML message,
+ * whether it is destined for us or is being relayed on to the next hop.
  */
 typedef uint8_t prte_oob_tcp_msg_type_t;
 
 #define MCA_OOB_TCP_IDENT 1
 #define MCA_OOB_TCP_PROBE 2
-#define MCA_OOB_TCP_PING  3
 #define MCA_OOB_TCP_USER  4
-
-#define PRTE_MAX_RTD_SIZE 31
 
 /* header for tcp msgs */
 typedef struct {
-    /* the originator of the message - if we are routing,
-     * it could be someone other than me
+    /* the originator of the message - when relaying, this is the
+     * process that first sent the message, not necessarily our peer
      */
     pmix_proc_t origin;
-    /* the intended final recipient - if we don't have
-     * a path directly to that process, then we will
-     * attempt to route. If we have no route to that
-     * process, then we should have rejected the message
-     * and let some other module try to send it
+    /* the intended final recipient. If it is not us, we relay the
+     * message onward toward that process using the routing tree
      */
     pmix_proc_t dst;
     /* the rml tag where this message is headed */
@@ -65,8 +57,6 @@ typedef struct {
     uint32_t nbytes;
     /* type of message */
     prte_oob_tcp_msg_type_t type;
-    /* routed module to be used */
-    char routed[PRTE_MAX_RTD_SIZE + 1];
 } prte_oob_tcp_hdr_t;
 /**
  * Convert the message header to host byte order

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -512,11 +512,13 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                                           peer->recv_msg->hdr.nbytes);
                     PMIX_RELEASE(peer->recv_msg);
                 } else {
-                    /* promote this to the OOB as some other transport might
-                     * be the next best hop */
+                    /* not for us - we are an intermediate hop. Re-enter the
+                     * OOB send path, which will route the message on toward
+                     * its final destination via the next hop in the tree.
+                     */
                     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
                                         prte_oob_base.output,
-                                        "%s TCP PROMOTING ROUTED MESSAGE FOR %s TO OOB",
+                                        "%s TCP RELAYING ROUTED MESSAGE FOR %s",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                         PRTE_NAME_PRINT(&peer->recv_msg->hdr.dst));
                     snd = PMIX_NEW(prte_rml_send_t);
@@ -592,10 +594,3 @@ static void rcv_cons(prte_oob_tcp_recv_t *ptr)
     ptr->rdbytes = 0;
 }
 PMIX_CLASS_INSTANCE(prte_oob_tcp_recv_t, pmix_list_item_t, rcv_cons, NULL);
-
-static void err_cons(prte_oob_tcp_msg_error_t *ptr)
-{
-    ptr->rmsg = NULL;
-    ptr->snd = NULL;
-}
-PMIX_CLASS_INSTANCE(prte_oob_tcp_msg_error_t, pmix_object_t, err_cons, NULL);

--- a/src/rml/oob/oob_tcp_sendrecv.h
+++ b/src/rml/oob/oob_tcp_sendrecv.h
@@ -89,11 +89,11 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         PRTE_PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg);    \
     } while (0)
 
-/* queue a message to be sent by one of our modules - must
+/* queue a message for transmission to a connected peer - must
  * provide the following params:
  *
  * m - the RML message to be sent
- * p - the final recipient
+ * p - the peer (next hop) to send it to
  */
 #define MCA_OOB_TCP_QUEUE_SEND(m, p)                                                           \
     do {                                                                                       \
@@ -121,11 +121,11 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         MCA_OOB_TCP_QUEUE_MSG((p), _s, true);                                                  \
     } while (0)
 
-/* queue a message to be sent by one of our modules upon completing
- * the connection process - must provide the following params:
+/* queue a message to be sent to a peer once its connection has finished
+ * being established - must provide the following params:
  *
  * m - the RML message to be sent
- * p - the final recipient
+ * p - the peer (next hop) to send it to
  */
 #define MCA_OOB_TCP_QUEUE_PENDING(m, p)                                                           \
     do {                                                                                          \
@@ -151,113 +151,6 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         _s->sdbytes = sizeof(prte_oob_tcp_hdr_t);                                                 \
         /* add to the msg queue for this peer */                                                  \
         MCA_OOB_TCP_QUEUE_MSG((p), _s, false);                                                    \
-    } while (0)
-
-/* queue a message for relay by one of our modules - must
- * provide the following params:
- *
- * m = the prte_oob_tcp_recv_t that was received
- * p - the next hop
- */
-#define MCA_OOB_TCP_QUEUE_RELAY(m, p)                                                           \
-    do {                                                                                        \
-        prte_oob_tcp_send_t *_s;                                                                \
-        pmix_output_verbose(5, prte_oob_base.output,                        \
-                            "%s:[%s:%d] queue relay to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
-                            __FILE__, __LINE__, PRTE_NAME_PRINT(&((p)->name)));                 \
-        _s = PMIX_NEW(prte_oob_tcp_send_t);                                                     \
-        /* setup the header */                                                                  \
-        PMIX_XFER_PROCID(&_s->hdr.origin, &(m)->hdr.origin);                                    \
-        PMIX_XFER_PROCID(&_s->hdr.dst, &(m)->hdr.dst);                                          \
-        _s->hdr.type = MCA_OOB_TCP_USER;                                                        \
-        _s->hdr.tag = (m)->hdr.tag;                                                             \
-        (void) pmix_string_copy(_s->hdr.routed, (m)->hdr.routed, PRTE_MAX_RTD_SIZE);            \
-        /* point to the actual message */                                                       \
-        _s->data = (m)->data;                                                                   \
-        /* set the total number of bytes to be sent */                                          \
-        _s->hdr.nbytes = (m)->hdr.nbytes;                                                       \
-        /* prep header for xmission */                                                          \
-        MCA_OOB_TCP_HDR_HTON(&_s->hdr);                                                         \
-        /* start the send with the header */                                                    \
-        _s->sdptr = (char *) &_s->hdr;                                                          \
-        _s->sdbytes = sizeof(prte_oob_tcp_hdr_t);                                               \
-        /* add to the msg queue for this peer */                                                \
-        MCA_OOB_TCP_QUEUE_MSG((p), _s, true);                                                   \
-    } while (0)
-
-/* State machine for processing message */
-typedef struct {
-    pmix_object_t super;
-    prte_event_t ev;
-    prte_rml_send_t *msg;
-} prte_oob_tcp_msg_op_t;
-PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_op_t);
-
-#define PRTE_ACTIVATE_TCP_POST_SEND(ms, cbfunc)                                               \
-    do {                                                                                      \
-        prte_oob_tcp_msg_op_t *mop;                                                           \
-        pmix_output_verbose(5, prte_oob_base.output,                      \
-                            "%s:[%s:%d] post send to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
-                            __FILE__, __LINE__, PRTE_NAME_PRINT(&((ms)->dst)));               \
-        mop = PMIX_NEW(prte_oob_tcp_msg_op_t);                                                \
-        mop->msg = (ms);                                                                      \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc));                                \
-    } while (0);
-
-typedef struct {
-    pmix_object_t super;
-    prte_event_t ev;
-    prte_rml_send_t *rmsg;
-    prte_oob_tcp_send_t *snd;
-    pmix_proc_t hop;
-} prte_oob_tcp_msg_error_t;
-PMIX_CLASS_DECLARATION(prte_oob_tcp_msg_error_t);
-
-#define PRTE_ACTIVATE_TCP_MSG_ERROR(s, r, h, cbfunc)                                               \
-    do {                                                                                           \
-        prte_oob_tcp_msg_error_t *mop;                                                             \
-        prte_oob_tcp_send_t *snd;                                                                  \
-        prte_oob_tcp_recv_t *proxy;                                                                \
-        pmix_output_verbose(5, prte_oob_base.output,                           \
-                            "%s:[%s:%d] post msg error to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
-                            __FILE__, __LINE__, PRTE_NAME_PRINT((h)));                             \
-        mop = PMIX_NEW(prte_oob_tcp_msg_error_t);                                                  \
-        if (NULL != (s)) {                                                                         \
-            mop->snd = (s);                                                                        \
-        } else if (NULL != (r)) {                                                                  \
-            /* use a proxy so we can pass NULL into the macro */                                   \
-            proxy = (r);                                                                           \
-            /* create a send object for this message */                                            \
-            snd = PMIX_NEW(prte_oob_tcp_send_t);                                                   \
-            mop->snd = snd;                                                                        \
-            /* transfer and prep the header */                                                     \
-            snd->hdr = proxy->hdr;                                                                 \
-            MCA_OOB_TCP_HDR_HTON(&snd->hdr);                                                       \
-            /* point to the data */                                                                \
-            snd->data = proxy->data;                                                               \
-            /* start the message with the header */                                                \
-            snd->sdptr = (char *) &snd->hdr;                                                       \
-            snd->sdbytes = sizeof(prte_oob_tcp_hdr_t);                                             \
-            /* protect the data */                                                                 \
-            proxy->data = NULL;                                                                    \
-        }                                                                                          \
-        PMIX_XFER_PROCID(&mop->hop, (h));                                                          \
-        /* this goes to the OOB framework, so use that event base */                               \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (cbfunc));                                     \
-    } while (0)
-
-#define PRTE_ACTIVATE_TCP_NO_ROUTE(r, h, c)                                                       \
-    do {                                                                                          \
-        prte_oob_tcp_msg_error_t *mop;                                                            \
-        pmix_output_verbose(5, prte_oob_base_.output,                          \
-                            "%s:[%s:%d] post no route to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
-                            __FILE__, __LINE__, PRTE_NAME_PRINT((h)));                            \
-        mop = PMIX_NEW(prte_oob_tcp_msg_error_t);                                                 \
-        mop->rmsg = (r);                                                                          \
-        PMIX_XFER_PROCID(&mop->hop, (h));                                                         \
-        /* this goes to the component, so use the framework                                       \
-         * event base */                                                                          \
-        PRTE_PMIX_THREADSHIFT(mop, prte_event_base, (c));                                         \
     } while (0)
 
 #endif /* _MCA_OOB_TCP_SENDRECV_H_ */

--- a/src/rml/radix.h
+++ b/src/rml/radix.h
@@ -35,15 +35,6 @@
         child = radix_right_sibling(&child) \
     )
 
-#define RADIX_NODE_STATIC_INIT         \
-    {                                  \
-        .rank = PMIX_RANK_INVALID,     \
-        .depth = 0,                    \
-        .width = 1,                    \
-        .count = 1,                    \
-        .base_rank = PMIX_RANK_INVALID \
-    }
-
 typedef prte_rml_routed_tree_node_t radix_node_t;
 
 /* Obtain a radix node configured for this rank */

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -162,7 +162,6 @@ PRTE_EXPORT void prte_rml_simulate_node_failure(void);
 typedef struct {
     int rml_output;
     int routed_output;
-    int oob_output;
     int max_retries;
     pmix_list_t posted_recvs;
     pmix_list_t unmatched_msgs;


### PR DESCRIPTION
## Problem

`src/rml` was originally three MCA frameworks — **rml** (the messaging API),
**routed** (pluggable routing-tree algorithms), and **oob** (pluggable
transports). PRRTE only ever had one RML, one routing algorithm (a radix
tree), and one transport (TCP), so the three were collapsed into a single
directory. The collapse merged the files but left the multi-component
*abstractions* in place. The leftover scaffolding is dead weight that makes
the tree harder to read and maintain:

- a "hand the failed message to another OOB component" failover chain
  (`prte_oob_ping` → `hop_unknown`/`no_route`/`msg_error`) that nothing
  drives;
- a relay macro (`MCA_OOB_TCP_QUEUE_RELAY`) and a `POST_SEND` macro that
  nothing calls, plus their now-orphaned caddy types;
- `PRTE_ACTIVATE_TCP_NO_ROUTE`, which references a misspelled global and so
  could never have compiled had anything used it;
- a routed-module name (`routed[]` / `PRTE_MAX_RTD_SIZE`) carried in every
  wire header;
- assorted dead constants/typedefs/fields and comments describing a world of
  many components, modules, and transports that no longer exists.

## What this changes

- **Removes the dead scaffolding** listed above (all verified unused by
  repo-wide grep; they form one self-consistent chain).
- **Shrinks the on-wire TCP header** by dropping the vestigial `routed[]`
  field. Safe because every daemon in a DVM runs the same build, so the
  header is never exchanged across versions.
- **Rewrites the stale multi-component comments** to describe the actual
  single path: RML → radix routing → TCP, with relay explained as
  re-entering the send path toward the next hop.
- **Fixes a latent bug found during the cleanup:** the `prte_max_msg_size`
  MCA parameter was registered against `max_recon_attempts`, so setting it
  silently corrupted the reconnect count while the real message-size limit
  stayed pinned at its default.
- **Adds documentation** so the tree is easier to modify going forward:
  `src/rml/README.md` (an editing-oriented map) and
  `docs/how-things-work/rml/` (a narrative of how the revised RML works).

No behavior change beyond the `max_msg_size` fix; this is a
simplification + documentation pass. Net **−280 / +337** across 15 files
(most of the additions are docs).

## Testing

Built clean and warning-free with `--enable-debug` (devel-check =
warnings-as-errors). Exercised end-to-end with the modified code live on all
nodes of the `contrib/dockerswarm/` 10-container DVM:

- `prterun` one-shot launch, local and multi-node (`--host node1..node4 -np
  8`): correct output, exit 0, no orphaned daemons.
- Persistent DVM + `prun`, and elastic **grow**/**shrink** (radix 64):
  daemons wire in via the IDENT handshake using the shortened header; shrink
  drives the comm-failure recovery path and the HNP survives.
- **radix-2 deep tree** grown across 8 nodes: the `DVM_IS_READY` completion
  fence spans a depth-3+ binary tree, so it must **relay through intermediate
  daemons** — it completed every time (a broken relay/header would hang to
  the 60s timeout), and shrink-at-depth kept the HNP and remaining daemons
  alive.

## Note for reviewers

The `max_msg_size` fix is bundled here because it lives in `oob_tcp.c`
alongside the dead-field removals and was found during the cleanup. Happy to
split it into its own PR if preferred.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
