### PR TITLE
Document the RML transport and reliable-messaging subsystems

### DIFF
--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -11,7 +11,18 @@ this tag*, asynchronously and in order per connection.
 
 This page explains how the RML is put together and how a message flows through
 it.  The code lives entirely in ``src/rml/``; a shorter, editing-oriented map
-is in ``src/rml/AGENTS.md``.
+is in ``src/rml/AGENTS.md``.  Two subsystems are large enough to have their own
+pages:
+
+.. toctree::
+   :maxdepth: 1
+
+   oob
+   relm
+
+This page covers the RML core (the send/receive API, message matching, and the
+radix routing tree).  :ref:`rml-oob-label` covers the TCP transport in detail,
+and :ref:`rml-relm-label` covers reliable messaging.
 
 Historical note: one directory, once three frameworks
 -----------------------------------------------------
@@ -174,7 +185,39 @@ death/adoption notices), followed by grpcomm, filem, and relm.
 ``prte_rml_send_buffer_reliable_nb`` routes through it; it drives a small state
 machine that re-sends messages over the repaired tree so that a message in
 flight when a daemon dies is not simply lost.  It is newer than the collapsed
-core and is intentionally kept as its own module.
+core and is intentionally kept as its own module.  Its protocol — message
+states, acknowledgements, replay, and the link-update recovery dance — is
+described on its own page: :ref:`rml-relm-label`.
+
+Elastic growth and launcher-less bootstrap
+------------------------------------------
+
+The tree is not fixed for the life of the DVM.  In *elastic* mode it can grow
+and shrink, and in a *bootstrapped* DVM the daemons come up independently rather
+than being fanned out by a launcher.  Both add behavior to the routing and
+transport layers:
+
+* **A permanent departure set.**  ``prte_rml_base`` carries a third failure
+  bitmap, ``dead_dmns``, alongside ``failed_dmns`` and ``global_failed_dmns``.
+  The first two are re-initialized on every ``prte_rml_compute_routing_tree``;
+  ``dead_dmns`` is constructed once and never reset, so a daemon that shrank out
+  (or failed) stays a permanent hole across the recompute a subsequent grow
+  triggers.  ``compute_routing_tree`` restores the dead marks into the
+  freshly-wiped ``failed_dmns`` before rebuilding the tree, so the rebuilt tree
+  routes around the hole instead of addressing a reused-looking but dead vpid.
+  (The DVM never reuses a daemon vpid.)
+
+* **A leaving daemon departs on the first lost route.**  When
+  ``prte_dvm_leaving`` is set — this daemon was named as a shrink target —
+  ``prte_rml_route_lost`` terminates immediately on *any* dropped connection
+  rather than trying to recover, so a departing daemon's normal disconnects are
+  never mistaken for faults.
+
+* **Bootstrap synthesizes contact information on demand.**  With no nidmap to
+  distribute URIs, the OOB derives a peer's contact URI from configuration when
+  it first needs to reach it, tolerates a synthesized URI that lacks an
+  interface mask, and treats a parent that is not yet up as a heal-to-ancestor
+  event rather than a fatal failure.  The details live in :ref:`rml-oob-label`.
 
 Where to look
 -------------

--- a/docs/how-things-work/rml/oob.rst
+++ b/docs/how-things-work/rml/oob.rst
@@ -1,0 +1,159 @@
+.. _rml-oob-label:
+
+The OOB TCP Transport
+=====================
+
+The OOB ("out of band") transport is the layer beneath the RML API that moves a
+message's bytes across a socket to the next daemon in the routing tree.  Where
+the RML core (:ref:`rml-label`) decides *what* to send, *to whom*, and *which
+way through the tree*, the OOB owns the sockets, the connection handshake, the
+on-wire framing, and the retry logic.  The code lives in ``src/rml/oob/``; the
+editing-oriented map is in ``src/rml/oob/AGENTS.md``.
+
+One transport, not a framework
+------------------------------
+
+The OOB was once an MCA framework with pluggable transport *components*, each
+with swappable *modules* — TCP was one, with notional room for others.  PRRTE
+only ever shipped TCP, so the framework was collapsed into the single
+``src/rml/oob`` directory.  Any language in the code about "trying the next
+component," "another transport module," or a selection loop is historical
+cruft.  There is exactly one transport: TCP.
+
+Key state
+---------
+
+All transport state hangs off one global, ``prte_oob_base``
+(``src/rml/oob/oob.h``, defined in ``oob_tcp.c``), and is owned by the progress
+thread:
+
+* the list of known **peers** (``prte_oob_tcp_peer_t``), each with its
+  addresses, socket, connection state, and send queue;
+* the local network **interfaces** the daemon may bind and connect from;
+* the **listener** sockets;
+* the many TCP tuning MCA parameters — buffer sizes, keepalives, retry limits,
+  ``max_msg_size``, and the connection-retry knobs described below.
+
+Each peer is a ``prte_oob_tcp_peer_t`` (``oob_tcp_peer.h``): the peer's name, a
+list of candidate addresses, the active address, the socket, a state enum, the
+send queue, and retry bookkeeping (``num_retries`` and ``first_attempt``).
+
+The wire header
+---------------
+
+Every message on the wire is preceded by a ``prte_oob_tcp_hdr_t``
+(``oob_tcp_hdr.h``): the ``origin``, the final ``dst``, the ``tag``, a sequence
+number, the payload length, and a message ``type``:
+
+* ``IDENT`` / ``PROBE`` — the connection handshake, and
+* ``USER`` — a normal message.
+
+The header is exchanged **only** among daemons of the same DVM, all running the
+same build, so it is **not** a stable ABI.  Its layout may change freely, but
+every daemon in a build must agree; there is no versioning.
+
+Sending
+-------
+
+``PRTE_OOB_SEND(msg)`` (a macro in ``oob.h``) thread-shifts the send onto the
+progress thread, where ``prte_oob_base_send_nb`` (``oob_base_stubs.c``) runs:
+
+#. **Give-up checks.**  If the destination is known down, or the message's retry
+   budget (``prte_rml_max_retries``) is exhausted, the message is dropped and
+   the failure is reported back through its send callback.
+
+#. **Route.**  ``prte_rml_get_route(dst)`` returns the rank of the next hop.
+
+#. **Find or build the peer.**  If a ``prte_oob_tcp_peer_t`` for that hop already
+   exists, use it.  Otherwise obtain the hop's contact URI — directly for the
+   HNP, from the PMIx store otherwise, or (in a bootstrapped DVM) synthesized
+   from configuration — and build the peer with ``process_uri`` / ``set_addr``.
+
+#. **Queue.**  If the peer is connected, the message is queued for immediate
+   transmission (``MCA_OOB_TCP_QUEUE_SEND``).  Otherwise it is queued as pending
+   (``MCA_OOB_TCP_QUEUE_PENDING``) and the connection state machine is started.
+
+Once the socket is up and the IDENT handshake has completed, the send handler in
+``oob_tcp_sendrecv.c`` writes the header and then the payload.
+
+The connection state machine
+----------------------------
+
+``oob_tcp_connection.c`` drives a peer from unconnected to usable.  The daemon
+that initiates a connection sends an ``IDENT`` naming itself; the acceptor
+(``recv_handler`` in ``oob_tcp.c``, plus ``oob_tcp_listener.c`` for the accept
+socket) checks the identity and either acks or nacks.  Because two daemons can
+try to connect to each other simultaneously, the handshake resolves which socket
+survives so a pair of peers does not end up with two half-open connections.
+
+Retry and backoff.  When a connect attempt finds no listener yet — a common race
+during startup — ``prte_oob_tcp_peer_try_connect`` schedules a retry.  The base
+behavior is a fixed ``retry_delay``-second wait, bounded by
+``max_recon_attempts``.  Two MCA parameters modify this, both defaulting to the
+original behavior:
+
+* ``prte_retry_max_delay`` — when larger than ``retry_delay``, the delay backs
+  off exponentially (``retry_delay``, 2×, 4×, …) capped at ``retry_max_delay``,
+  so a daemon waiting on an absent peer polls quickly at first and then settles
+  onto a steady rate rather than busy-spinning.  The exponent is clamped before
+  the shift so an unbounded retry count cannot overflow.
+
+* ``prte_connect_max_time`` — caps how long a **non-lifeline** peer is chased
+  (measured from the peer's ``first_attempt`` timestamp) before giving up so the
+  routing tree can heal to an ancestor.  ``0`` means retry forever.  The HNP is
+  never subject to this cap; it is always retried forever.
+
+Receiving and relaying
+----------------------
+
+When a peer's socket has delivered a complete message, the recv handler in
+``oob_tcp_sendrecv.c`` inspects ``hdr.dst``:
+
+* **For us.**  It calls ``PRTE_RML_POST_MESSAGE`` to hand the message up to the
+  RML matching layer (:ref:`rml-label`).
+
+* **Not for us.**  This daemon is an intermediate hop.  The handler rebuilds a
+  ``prte_rml_send_t`` with the same ``origin`` / ``dst`` and re-enters
+  ``PRTE_OOB_SEND``, so relaying is simply "send again from here," routed on
+  toward the destination.
+
+Connection loss.  When a socket drops, ``oob_tcp_component.c`` fires its
+``lost_connection`` / ``failed_to_connect`` handlers, which turn a transport
+event into a routing event: the RML is told to treat the peer as lost so the
+tree can be repaired (see :ref:`rml-label`).
+
+Bootstrap specifics
+-------------------
+
+In a launcher-less (bootstrapped) DVM the daemons boot independently, so the
+transport cannot rely on a launcher having pre-distributed everyone's contact
+information:
+
+* **URIs are synthesized on demand.**  With ``prte_bootstrap_setup`` set and no
+  peer object present, ``prte_oob_base_send_nb`` derives the next hop's URI from
+  configuration via ``prte_ess_base_bootstrap_peer_uri`` — the same synthesis a
+  prted uses for its original parent — rather than reading a nidmap that was
+  never distributed.  This also covers a healed lifeline whose new parent (a
+  former grandparent) was never pre-synthesized.
+
+* **A missing interface mask is tolerated.**  A synthesized URI cannot know the
+  peer's interface mask, so ``set_addr`` treats a missing or empty mask as
+  ``/0`` (universally reachable) instead of rejecting the address.
+
+* **A not-yet-present parent is not fatal.**  Because a parent may simply not be
+  up when a child times out on it,
+  ``prte_mca_oob_tcp_component_failed_to_connect`` (in bootstrap mode) heals the
+  tree the way a lost *live* parent would: ``prte_rml_route_lost`` promotes the
+  daemon to the next ancestor and returns a ``COMM_FAILED`` recovery, instead of
+  raising a fatal ``FAILED_TO_CONNECT``.  The HNP is the exception — it is
+  retried forever and never allowed to time out.
+
+Where to look
+-------------
+
+* Send entry and routing: ``oob_base_stubs.c``.
+* Connection handshake, retry, backoff: ``oob_tcp_connection.c``,
+  ``oob_tcp_listener.c``, and ``recv_handler`` in ``oob_tcp.c``.
+* Socket I/O and the deliver-vs-relay decision: ``oob_tcp_sendrecv.c``.
+* Transport-to-routing fault events: ``oob_tcp_component.c``.
+* The wire header: ``oob_tcp_hdr.h``.

--- a/docs/how-things-work/rml/relm.rst
+++ b/docs/how-things-work/rml/relm.rst
@@ -1,0 +1,204 @@
+.. _rml-relm-label:
+
+Reliable Messaging (RELM)
+=========================
+
+A normal RML send is fire-and-forget.  It rides the radix routing tree
+(:ref:`rml-label`), and if a daemon on the path dies while a message is in
+flight, that message is simply lost — the tree repairs itself, but the bytes are
+gone.  For most runtime traffic that is acceptable, because the higher-level
+protocol will retry or the information is reconstructible.  Some traffic is not
+so forgiving.  **RELM** ("reliable messaging") is the layer that guarantees a
+message is delivered exactly once to its destination even if daemons on the path
+fail and the tree is rebuilt underneath it.
+
+RELM lives in ``src/rml/relm/``; its editing map is ``src/rml/relm/AGENTS.md``
+and the concrete implementation's map is ``src/rml/relm/base/AGENTS.md``.
+
+How RELM is invoked
+-------------------
+
+Application code sends reliably with ``prte_rml_send_buffer_reliable_nb``
+(wrapped by the ``PRTE_RML_RELIABLE_SEND`` macro).  That call routes through the
+``prte_relm`` module to ``prte_relm_start_msg``.  Everything else in the
+subsystem runs in reaction to two things: RELM control messages received from
+neighbors, and fault notices from the routing layer.
+
+RELM is shaped like a small framework — the ``prte_relm_module_t`` interface and
+a state machine (``prte_relm_state_machine_t``) full of function pointers — so a
+different reliability strategy could be substituted.  Today there is exactly one
+implementation, the *base* module, which ``relm.c`` installs at open time by
+copying ``prte_relm_base_module`` into the global ``prte_relm`` and wiring every
+state-machine callback to a ``prte_relm_base_*`` function.
+
+Identifying a message
+--------------------
+
+Every reliable message has a stable, globally-unique identity that all daemons
+on its path agree on:
+
+* the **origin** ``src`` (the rank that called ``reliable_send``) and a
+  per-source **UID** together form a globally-unique id;
+* adding the destination ``dst`` yields the message **signature**
+  (``prte_relm_signature_t``);
+* the pair ``<src, uid>`` is hashed into a 64-bit **GUID**
+  (``prte_relm_guid_t``) used as the hash-table key.
+
+The UID (``prte_relm_uid_t``) is a 32-bit counter that is allowed to wrap; the
+design assumes a message is globally complete and unreferenced long before its
+UID could be reused.  The top of the range is reserved for sentinels
+(``UNKNOWN`` / ``NONE`` / ``INVALID``), so valid UIDs run up to
+``PRTE_RELM_UID_MAX``.
+
+State is kept per destination.  ``prte_relm_state_machine_t`` holds a hash table
+of ``prte_relm_rank_t`` objects keyed by destination rank; each of those holds a
+hash table of ``prte_relm_msg_t`` objects keyed by GUID.  A ``prte_relm_msg_t``
+records the message's ``src`` / ``uid`` / ``dst``, its current state, the
+message data (while it may still be needed), and ``prev_uid`` / ``next_uid``
+links that chain together the messages this origin has sent to this destination.
+
+Ordering
+--------
+
+Messages from one origin to one destination are delivered **in order**.  The
+``prev_uid`` / ``next_uid`` chain enforces this: a message may only be posted to
+the application once its predecessor has been posted, and an acknowledgement of a
+message implicitly acknowledges everything before it in the chain.  A message
+whose predecessor has not yet arrived is parked in the ``PENDING`` state and
+released to ``SENDING`` when the predecessor is posted.
+
+The message lifecycle
+--------------------
+
+Each ``prte_relm_msg_t`` moves through a small set of *lasting* states
+(``types.h``).  Because the same message object exists on every daemon along the
+path, "the state" means *this daemon's* view of the message:
+
+``SENDING``
+    The message (with its data) is queued to go one hop further downstream,
+    toward ``dst``.
+``SENT``
+    This daemon has handed the message to the next hop.  An intermediate daemon
+    caches the data at this point in case a replay is needed.
+``REQUESTED``
+    A replay has been requested — the data was lost from somewhere downstream
+    and must be re-sent.
+``PENDING``
+    The message is held for ordering, waiting on its predecessor.
+``ACKED``
+    The destination has posted the message; an acknowledgement is travelling
+    back upstream toward ``src``.
+``ACKACKED``
+    The origin has seen the ACK and is releasing state; the ACK-of-ACK travels
+    back downstream so every daemon can drop the message.
+
+A handful of *ephemeral* states (``NEW``, ``ACKACKED`` when used to trigger,
+``CACHED``, ``EVICTED``) drive transitions but are **never stored** as a
+message's ``state``; the engine enforces this.
+
+Steady-state flow.  When ``reliable_send`` starts a message, the origin
+constructs it in ``NEW``, records the data, links it after the previous message
+to that destination, and moves it to ``SENDING``.  The data is forwarded one hop
+at a time; each hop transitions ``SENDING`` → ``SENT`` and (if it is neither
+source nor destination) caches the data.  When the data reaches ``dst``, the
+destination posts it to the application — respecting the ``prev_uid`` ordering,
+holding it ``PENDING`` if its predecessor has not yet posted — and moves it to
+``ACKED``.  The ACK walks back upstream hop by hop; at the origin it becomes an
+ACK-of-ACK, which walks back downstream so every daemon on the path releases its
+copy.
+
+State updates on the wire
+------------------------
+
+State changes propagate as small RELM control messages carrying the message's
+signature, its ``prev_uid``, its state, and (for ``SENDING``) the data.  They
+are sent with the ordinary RML over a single ``prte_rml_get_route`` hop, tagged
+``PRTE_RML_TAG_RELM_STATE``.  ``state_machine.c`` provides the two emitters —
+``prte_relm_send_state_downstream`` (toward ``dst``) and
+``prte_relm_send_state_upstream`` (toward ``src``) — and a receiver,
+``prte_relm_message_handler``, that unpacks an update, finds or creates the local
+message object, and feeds it to the state machine.
+
+The interesting logic is ``prte_relm_base_update_state`` (``state_updates.c``),
+which routes an incoming update by **who sent it**:
+
+* ``local_update`` — a change requested by this daemon itself;
+* ``downstream_update`` — a change reported by the neighbor toward ``dst``
+  (typically an ACK coming back);
+* ``upstream_update`` — a change reported by the neighbor toward ``src``
+  (typically data coming forward, or a replay request).
+
+Each of those is a switch over the incoming state that decides what to do given
+the message's current state: forward the data, post to the application, cache
+the data, request or replay a lost message, emit an ACK, or tear the message
+down.  Updates that arrive from a rank that is no longer this message's upstream
+or downstream neighbor are simply ignored — a natural consequence of the tree
+having changed.
+
+Caching and replay
+-----------------
+
+An intermediate daemon holds a message's data after forwarding it (state
+``SENT``) so it can replay the data if a downstream daemon lost it during a
+fault.  Cached data is bounded two ways, both configurable:
+
+* by **time** — ``relm_base_cache_ms`` (default 500 ms), after which an eviction
+  timer fires and drops the data; and
+* by **count** — ``relm_base_cache_max_count`` (default 30), beyond which the
+  oldest cached message is evicted.
+
+When data is needed but no longer cached anywhere reachable, a daemon issues a
+``REQUESTED`` update upstream; the first daemon that still holds the data (or the
+origin, which always can) replays it as a fresh ``SENDING``.
+
+Surviving a fault: link updates
+------------------------------
+
+The steady-state protocol assumes the path is stable.  When a daemon fails, the
+routing layer repairs the tree and notifies the registered fault handlers (RML,
+grpcomm, filem, then relm — see :ref:`rml-label`).  RELM's handler
+(``link_updates.c``) is where in-flight messages are stitched back onto the new
+tree.
+
+The handler acts only on the **local**-scope recovery notice.  (Faults are
+reported twice: once locally as they are discovered and once globally when the
+HNP confirms them.  By the time the global notice arrives, RML recovery has
+already run and the tree shows no delta, so a component must save whatever it
+needs between the two calls.)  On the local notice, the handler:
+
+#. **Purges** dead paths — messages to or from a failed rank, and messages this
+   daemon is, after the repair, no longer on the direct path of.
+
+#. **Exchanges link updates** with each neighbor whose identity changed.  A link
+   update (tagged ``PRTE_RML_TAG_RELM_LINK``) carries the full state of every
+   in-flight message that routes through that link, so a new neighbor learns
+   exactly what is outstanding and can resume it.
+
+Two mechanisms keep this correct under cascading or concurrent promotions:
+
+* **Depth stamping.**  Each link update carries the sender's tree depth.  A
+  receiver ignores an update whose depth does not match the expected
+  parent/child depth, so lingering updates from *before* a promotion are
+  discarded rather than misapplied.
+
+* **Update gating.**  The ``upstream_links_updated`` and
+  ``downstream_links_updated`` bitmaps track which neighbors this daemon has
+  exchanged state with since its last promotion.  A daemon will not forward
+  updates onward until it has gathered enough neighbor state to do so correctly;
+  ``try_send_pending_link_updates`` releases pending updates as the missing
+  pieces arrive.
+
+Because a promoted daemon may have inherited children that briefly believed they
+had a different parent, the recovery code treats all of a promoted daemon's
+children as new — see the commentary on ``prte_rml_recovery_status_t`` in
+``rml_types.h``.
+
+Where to look
+-------------
+
+* Entry point and message identity: ``state_machine.c`` (``start_msg``,
+  ``find``/``get``, GUID math in ``types.h``).
+* Steady-state transitions: ``base/state_updates.c``.
+* Fault recovery and link updates: ``base/link_updates.c``.
+* Pack/unpack and helper macros: ``util.c`` / ``util.h``.
+* Module wiring and MCA parameters: ``base/base.c``.

--- a/docs/how-things-work/rml/relm.rst
+++ b/docs/how-things-work/rml/relm.rst
@@ -32,7 +32,7 @@ copying ``prte_relm_base_module`` into the global ``prte_relm`` and wiring every
 state-machine callback to a ``prte_relm_base_*`` function.
 
 Identifying a message
---------------------
+---------------------
 
 Every reliable message has a stable, globally-unique identity that all daemons
 on its path agree on:
@@ -68,7 +68,7 @@ whose predecessor has not yet arrived is parked in the ``PENDING`` state and
 released to ``SENDING`` when the predecessor is posted.
 
 The message lifecycle
---------------------
+---------------------
 
 Each ``prte_relm_msg_t`` moves through a small set of *lasting* states
 (``types.h``).  Because the same message object exists on every daemon along the
@@ -108,7 +108,7 @@ ACK-of-ACK, which walks back downstream so every daemon on the path releases its
 copy.
 
 State updates on the wire
-------------------------
+-------------------------
 
 State changes propagate as small RELM control messages carrying the message's
 signature, its ``prev_uid``, its state, and (for ``SENDING``) the data.  They
@@ -136,7 +136,7 @@ or downstream neighbor are simply ignored — a natural consequence of the tree
 having changed.
 
 Caching and replay
------------------
+------------------
 
 An intermediate daemon holds a message's data after forwarding it (state
 ``SENT``) so it can replay the data if a downstream daemon lost it during a
@@ -152,7 +152,7 @@ When data is needed but no longer cached anywhere reachable, a daemon issues a
 origin, which always can) replays it as a fresh ``SENDING``.
 
 Surviving a fault: link updates
-------------------------------
+-------------------------------
 
 The steady-state protocol assumes the path is stable.  When a daemon fails, the
 routing layer repairs the tree and notifies the registered fault handlers (RML,

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -42,7 +42,7 @@ TCP. If you find such comments, they are cruft — fix them.
 
 | File | Responsibility |
 |------|----------------|
-| `routed_radix.c` | `prte_rml_get_route` (next hop toward a target), subtree indexing, and the tree (re)computation used on startup and after faults: `compute_routing_tree`, `repair_routing_tree`, `update_ancestors`, promotion/descendant fixups, `route_lost`. |
+| `routed_radix.c` | `prte_rml_get_route` (next hop toward a target), subtree indexing, and the tree (re)computation used on startup and after faults: `compute_routing_tree`, `repair_routing_tree`, `update_ancestors`, promotion/descendant fixups, `route_lost`. Also maintains `prte_rml_base.dead_dmns` — the *permanent* departed-daemon set that survives the recomputes an elastic grow triggers. |
 | `radix.h` | Header-only radix-tree math over daemon ranks: parent/child/sibling navigation, `subtree_contains`/`subtree_index`, depth motion, and "next living" traversal that skips failed ranks. Pure functions on rank numbers, no I/O. |
 
 **Fault tolerance / reliability (newer; not collapse cruft):**
@@ -50,7 +50,9 @@ TCP. If you find such comments, they are cruft — fix them.
 | File | Responsibility |
 |------|----------------|
 | `rml_fault_handler.c` | The RML's own reaction to a recomputed tree: sets process states and drives death/adoption notices. |
-| `relm/` | RELM — reliable messaging that survives daemon failures by re-driving messages over the repaired tree. Has its own small state machine (`relm/state_machine.c`, `relm/base/`). |
+| `relm/` | RELM — reliable messaging that survives daemon failures by re-driving messages over the repaired tree. Has its own small state machine (`relm/state_machine.c`, `relm/base/`). See [`relm/AGENTS.md`](relm/AGENTS.md). |
+
+The transport lives in [`oob/`](oob/AGENTS.md), which has its own editing map.
 
 **Transport (TCP — the `oob/` subdirectory):**
 
@@ -97,6 +99,62 @@ possible self-promotion, packages the delta into a
 `prte_rml_recovery_status_t`, and notifies the RML, grpcomm, filem, and relm
 fault handlers.
 
+## Elastic DVM and launcher-less bootstrap
+
+The tree is no longer fixed for the life of the DVM. In elastic mode it can
+**grow** and **shrink**, and in a **bootstrapped** DVM the daemons come up
+independently rather than being fanned out by a launcher. Both push new
+behavior into the RML/OOB; keep these in mind when touching routing or the
+connection path.
+
+- **`dead_dmns` — a departure set that outlives a recompute.** `prte_rml_base`
+  now carries three failure bitmaps, not two: `failed_dmns` and
+  `global_failed_dmns` (both re-initialized on every `compute_routing_tree`)
+  plus `dead_dmns`, which is constructed **once** in `prte_rml_open` and never
+  re-initialized. `repair_routing_tree` records every departed rank in it, and
+  `compute_routing_tree` restores those marks into the freshly-wiped
+  `failed_dmns` before rebuilding ancestors/children. Without it, a grow would
+  wipe the failure marks and route to the dead vpid of a shrunk-out daemon
+  (#2491). The DVM never reuses a daemon vpid, so a hole in `[0, num_daemons)`
+  is permanent.
+
+- **A leaving daemon exits on the first lost route.** `prte_rml_route_lost`
+  checks `prte_dvm_leaving` first: if this daemon has been named as a shrink
+  target, it activates `PRTE_JOB_STATE_DAEMONS_TERMINATED` on *any* dropped
+  connection rather than trying to recover. This prevents a departing daemon's
+  normal disconnects from being misread as faults and propagated as adoption
+  notices. It is only a fast path — a bounded timer in `prted_comm.c`
+  guarantees departure even if no connection ever drops.
+
+- **Bootstrap synthesizes peer URIs on demand.** Normally a peer's contact URI
+  comes from the nidmap or the PMIx store. In a bootstrapped DVM no nidmap
+  distributed URIs during formation, and a healed lifeline's new parent (a
+  former grandparent) was never pre-synthesized. When `prte_bootstrap_setup` is
+  set and no peer object exists, `prte_oob_base_send_nb` derives the next hop's
+  URI from configuration via `prte_ess_base_bootstrap_peer_uri` and connects to
+  it. A synthesized URI cannot know the peer's interface mask, so `set_addr`
+  treats a missing/empty mask as `/0` (universally reachable) rather than
+  rejecting the address.
+
+- **Bootstrap tolerates a not-yet-present parent.** Because daemons boot
+  independently, a parent may simply not be up when a child times out on it.
+  In bootstrap mode, `prte_mca_oob_tcp_component_failed_to_connect` heals the
+  tree the same way a lost live parent would — `prte_rml_route_lost` promotes
+  to the next ancestor (a `COMM_FAILED` recovery) — instead of raising a fatal
+  `FAILED_TO_CONNECT`. The HNP is the exception: it is retried forever and
+  never allowed to time out.
+
+- **Two new connection-retry knobs.** `prte_oob_base` gained `retry_max_delay`
+  and `connect_max_time` (MCA params `prte_retry_max_delay`,
+  `prte_connect_max_time`), and each peer gained a `first_attempt` timestamp.
+  When `retry_max_delay > retry_delay`, the retry delay backs off exponentially
+  (retry_delay, 2×, 4×, …) capped at `retry_max_delay`, so a daemon waiting on
+  an absent peer polls fast at first and then settles onto a steady rate.
+  `connect_max_time` bounds how long a **non-lifeline** peer is chased before
+  giving up so the tree can heal to an ancestor; `0` (the default) means retry
+  forever, preserving the original behavior. The HNP is never subject to
+  `connect_max_time`.
+
 ## Gotchas before you edit
 
 - **Single progress thread.** All RML/OOB state is owned by the progress
@@ -109,5 +167,9 @@ fault handlers.
 - **One transport, one router.** Do not reintroduce component/module
   abstraction to "make it pluggable" unless there is a real second
   implementation; that abstraction is exactly what was removed.
+- **Do not re-initialize `dead_dmns`.** It is deliberately the one failure
+  bitmap that is *not* reset by `compute_routing_tree`; resetting it reopens the
+  #2491 grow bug. `pmix_bitmap` auto-expands as ranks are set, so it needs no
+  resizing when the DVM grows.
 - **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
   tree warning-free.

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -1,0 +1,112 @@
+# `src/rml/oob` — the TCP transport
+
+This directory is the OOB ("out of band") transport: the code that actually
+moves an RML message's bytes across a socket to the next daemon in the routing
+tree. It is one layer below the RML API and routing logic in the parent
+directory; read [`../AGENTS.md`](../AGENTS.md) first for the whole picture, and
+[`docs/how-things-work/rml/oob.rst`](../../../docs/how-things-work/rml/oob.rst)
+for the narrative walkthrough.
+
+## History: one transport, not a framework
+
+OOB was once an MCA framework with pluggable transport *components* (each with
+swappable *modules*) — TCP, and room for others. PRRTE only ever shipped TCP.
+The framework was collapsed into this single directory. Comments or names that
+speak of "trying the next component," "another transport module," or a
+component-selection loop are **historical cruft** — there is exactly one
+transport, TCP. If you find such language, fix it. Do **not** reintroduce the
+component/module abstraction to "make it pluggable" unless a real second
+transport actually exists; that abstraction is precisely what was removed.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `oob.h` | The `prte_oob_base` global (peers list, interfaces, listeners, TCP tuning params) and the `PRTE_OOB_SEND` entry macro that thread-shifts a send onto the progress thread. |
+| `oob_base_stubs.c` | `prte_oob_base_send_nb` — resolve the next hop via `prte_rml_get_route`, find or create its TCP peer, and queue the message (connecting first if needed). Also URI build (`get_addr`) and parse (`process_uri` / `set_addr`), including the bootstrap fallbacks. |
+| `oob_tcp.c` | OOB `open`/`close`/`register`: MCA parameter registration, local interface discovery, listener startup, the connection-handshake `recv_handler`, and `simulate_node_failure` (test hook). |
+| `oob_tcp_component.c` | Class instances for peers/addresses/messages, plus the `lost_connection` and `failed_to_connect` event handlers. |
+| `oob_tcp_connection.c` | The per-peer connection state machine: connect with retry/backoff, the IDENT ack/nack handshake, accept, and close. |
+| `oob_tcp_listener.c` | Listening sockets and the accept path. |
+| `oob_tcp_sendrecv.c`, `.h` | The socket send/recv event handlers and their queueing macros. The recv-completion path decides **deliver locally vs. relay onward**. |
+| `oob_tcp_hdr.h` | The on-wire message header, `prte_oob_tcp_hdr_t`. |
+| `oob_tcp_peer.h` | The peer object (`prte_oob_tcp_peer_t`): name, addresses, socket, state, send queue, retry bookkeeping. |
+| `oob_tcp_common.[ch]` | Socket-option helpers and state-name strings. |
+| `help-oob-tcp.txt` | `pmix_show_help` text for TCP errors. |
+
+## The send path in one paragraph
+
+`PRTE_OOB_SEND(msg)` thread-shifts to `prte_oob_base_send_nb`
+(`oob_base_stubs.c`). It drops the message if the destination is down or the
+retry budget (`prte_rml_max_retries`) is exhausted, reporting failure through
+the send callback. Otherwise it computes the next hop with
+`prte_rml_get_route(dst)` and looks up that hop's `prte_oob_tcp_peer_t`. If no
+peer exists it obtains the contact URI (directly for the HNP, from the PMIx
+store otherwise, or — in a bootstrapped DVM — synthesized via
+`prte_ess_base_bootstrap_peer_uri`) and builds one with `process_uri`. If the
+peer is connected the message is queued for immediate send
+(`MCA_OOB_TCP_QUEUE_SEND`); otherwise it is queued pending
+(`MCA_OOB_TCP_QUEUE_PENDING`) and the connection state machine in
+`oob_tcp_connection.c` is started. Once the socket is up and the IDENT
+handshake has completed, the send handler in `oob_tcp_sendrecv.c` writes the
+header then the payload.
+
+## The recv path in one paragraph
+
+When a peer's socket has delivered a complete message, the recv handler in
+`oob_tcp_sendrecv.c` inspects `hdr.dst`. If it is us, it calls
+`PRTE_RML_POST_MESSAGE` to hand the message up to the RML matching layer. If it
+is not us, this daemon is an intermediate hop: the handler rebuilds a
+`prte_rml_send_t` with the same `origin`/`dst` and re-enters `PRTE_OOB_SEND`, so
+relaying is just "send again from here."
+
+## The wire header
+
+Every message carries a `prte_oob_tcp_hdr_t` (`oob_tcp_hdr.h`): `origin`, final
+`dst`, `tag`, a sequence number, payload length, and a message `type`
+(`IDENT`/`PROBE` for the handshake, `USER` for a normal message). It is
+exchanged **only** among daemons of the same DVM, which all run the same build,
+so it is **not** a stable ABI — you may change its layout, but every daemon must
+agree; there is no versioning.
+
+## Connection retry and backoff
+
+`prte_oob_tcp_peer_try_connect` (`oob_tcp_connection.c`) drives retries. The
+base case is a fixed `retry_delay`-second wait, bounded by `max_recon_attempts`.
+Two knobs modify this (both default to preserving the original behavior):
+
+- **`prte_retry_max_delay`** (`prte_oob_base.retry_max_delay`): when larger than
+  `retry_delay`, the delay backs off exponentially — `retry_delay`, 2×, 4×, …,
+  capped at `retry_max_delay`. The exponent is clamped before the shift so an
+  unbounded `num_retries` cannot overflow.
+- **`prte_connect_max_time`** (`prte_oob_base.connect_max_time`): caps how long
+  a **non-lifeline** peer is chased (measured from the peer's `first_attempt`
+  timestamp) before giving up so the routing tree can heal to an ancestor. `0`
+  means retry forever. The HNP is never subject to this — it is retried forever.
+
+## Bootstrap specifics
+
+In a launcher-less (bootstrapped) DVM daemons boot independently, so:
+
+- **Peer URIs are synthesized on demand.** With `prte_bootstrap_setup` set and
+  no peer object present, `prte_oob_base_send_nb` derives the next hop's URI
+  from configuration rather than the (absent) nidmap. See
+  `prte_ess_base_bootstrap_peer_uri`.
+- **Missing interface masks are tolerated.** A synthesized URI cannot know the
+  peer's interface mask, so `set_addr` treats a missing/empty mask as `/0`
+  (universally reachable) instead of rejecting the address.
+- **A not-yet-present parent is not fatal.** In bootstrap mode,
+  `prte_mca_oob_tcp_component_failed_to_connect` heals the tree via
+  `prte_rml_route_lost` (promoting to the next ancestor, a `COMM_FAILED`
+  recovery) rather than raising `FAILED_TO_CONNECT`.
+
+## Gotchas before you edit
+
+- **Single progress thread.** All OOB state — peers, sockets, send queues — is
+  owned by the progress thread. Cross-thread entry goes through `PRTE_OOB_SEND`
+  (a caddy + `PRTE_PMIX_THREADSHIFT`). Never touch peer/socket state off that
+  thread, and never block on it.
+- **The header is not an ABI.** See above; do not add versioning, but do keep
+  every daemon in a build in sync.
+- **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
+  tree warning-free.

--- a/src/rml/oob/CLAUDE.md
+++ b/src/rml/oob/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -1,0 +1,78 @@
+# `src/rml/relm` — RELM, the reliable-messaging layer
+
+RELM ("reliable messaging") sits *on top of* the RML. A normal RML send is
+fire-and-forget: if a daemon on the path dies while a message is in flight, the
+message is simply lost. RELM guarantees delivery across daemon failures by
+tracking each message's state hop-by-hop and re-driving it over the routing tree
+after the tree has been repaired. It is newer than the collapsed RML core and is
+intentionally kept as its own module.
+
+Read [`../AGENTS.md`](../AGENTS.md) for how RELM plugs into the RML, and
+[`docs/how-things-work/rml/relm.rst`](../../../docs/how-things-work/rml/relm.rst)
+for the full protocol walkthrough. The base implementation lives in
+[`base/`](base/AGENTS.md).
+
+## How it is reached
+
+`prte_rml_send_buffer_reliable_nb` (`../rml_send.c`, wrapped by the
+`PRTE_RML_RELIABLE_SEND` macro) calls `prte_relm.reliable_send`, which is
+`prte_relm_start_msg`. That is the only entry point application code uses;
+everything else in this directory runs in response to received RELM control
+messages or to fault notices from the routing layer.
+
+## The module indirection
+
+RELM is structured like a mini-framework so alternative reliability strategies
+could be dropped in, but today there is exactly **one** implementation — the
+base module. `relm.c` copies `prte_relm_base_module` into the global
+`prte_relm` at open time. The state machine
+(`prte_relm_state_machine_t`, `state_machine.h`) holds function pointers for
+every customization point (`new_rank`, `pack_state_update`, `update_state`,
+`upstream_rank`, `downstream_rank`, `fault_handler`, …); `base/` fills them all
+in. Do not add a second module speculatively.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `relm.h`, `relm.c` | The `prte_relm_module_t` interface and the global `prte_relm`; `register`/`open`/`close`. `open` installs the base module. |
+| `types.h`, `types.c` | The core objects: `prte_relm_msg_t` (per-message state + optional data), `prte_relm_rank_t` (per-destination message table), `prte_relm_signature_t`/GUID identity, the `prte_relm_state_t` enum, and UID sentinels. |
+| `state_machine.h`, `state_machine.c` | The `prte_relm_state_machine_t` object and the generic engine: message lookup/creation (`find`/`get`), message ordering via prev/next UID links, `start_msg`, `release_msg`, the send-upstream/send-downstream state emitters, and the received-message and link-update handlers. |
+| `util.h`, `util.c` | Pack/unpack helpers for signatures, states, UIDs, and data; the local post helper (`prte_relm_post`); state-name strings; and the `PRTE_RELM_*` output/error macros. |
+| `base/` | The one concrete implementation of the state machine's callbacks. See [`base/AGENTS.md`](base/AGENTS.md). |
+
+## The model in one paragraph
+
+Every reliable message has a globally-unique identity — the pair `<src, uid>`,
+extended with `dst` to a signature, hashed to a `prte_relm_guid_t`. Each daemon
+on the path keeps a `prte_relm_msg_t` recording where that message is in its
+lifecycle (`SENDING` → `SENT` → `ACKED` → `ACKACKED`, with `REQUESTED` for
+replay and `PENDING` for ordering), plus the message data while it may still be
+needed. Messages to the same destination are chained by `prev_uid`/`next_uid` so
+ordering is preserved and an ACK implicitly acks everything before it. State
+changes propagate as small RELM control messages (`PRTE_RML_TAG_RELM_STATE`)
+sent one hop upstream (toward `src`) or downstream (toward `dst`) using ordinary
+`prte_rml_get_route` hops. When the routing tree changes, the fault handler
+purges dead paths and exchanges **link updates** (`PRTE_RML_TAG_RELM_LINK`) with
+new neighbors so in-flight messages resume over the repaired tree.
+
+## Gotchas before you edit
+
+- **Single progress thread.** Like the rest of the RML, all RELM state is owned
+  by the progress thread. `prte_relm_start_msg` packs on the caller's thread but
+  hands off with `PRTE_PMIX_THREADSHIFT`; everything else already runs on the
+  progress thread.
+- **Ephemeral vs. lasting states.** States at or after
+  `PRTE_RELM_EPHEMERAL_STATES_START` (`NEW`, `ACKACKED`, `CACHED`, `EVICTED`)
+  drive transitions but must **never** be stored as a message's `state`. The
+  engine asserts this; don't defeat it.
+- **UIDs wrap.** `prte_relm_uid_t` is a `uint32_t` that is allowed to wrap; the
+  design assumes a message is globally complete (and dereferenced) long before
+  its UID is reused. Reserved sentinels (`UNKNOWN`/`NONE`/`INVALID`) sit at the
+  top of the range — respect `PRTE_RELM_UID_MAX`.
+- **Data lifetime.** A message's `data` is unloaded/emptied when it is posted or
+  evicted; cached data is dropped by timer (`relm_base_cache_ms`) or when the
+  cache exceeds `relm_base_cache_max_count`. Don't assume `msg->data.bytes` is
+  non-NULL.
+- **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
+  tree warning-free.

--- a/src/rml/relm/CLAUDE.md
+++ b/src/rml/relm/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/rml/relm/base/AGENTS.md
+++ b/src/rml/relm/base/AGENTS.md
@@ -1,0 +1,56 @@
+# `src/rml/relm/base` — the RELM base implementation
+
+This is the one concrete implementation of the RELM state machine. The parent
+directory ([`../AGENTS.md`](../AGENTS.md)) defines the generic engine and the
+`prte_relm_state_machine_t` bundle of callbacks; the files here supply those
+callbacks and register the module. There is no second implementation — the
+"module" indirection exists only so one could be added, so don't build the
+abstraction out further without a real second strategy.
+
+For the protocol itself see
+[`docs/how-things-work/rml/relm.rst`](../../../../docs/how-things-work/rml/relm.rst).
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `base.h`, `base.c` | `prte_relm_base_module` (the module the global `prte_relm` is copied from) and `prte_relm_base` (config: verbosity, cache TTL `cache_ms`, cache cap `cache_max_count`). `init` builds the state machine, wires every callback to a `prte_relm_base_*` function, and posts the two persistent RELM receives (`PRTE_RML_TAG_RELM_STATE`, `PRTE_RML_TAG_RELM_LINK`). `register` registers the MCA params. |
+| `state_updates.c` | The heart of the protocol: `prte_relm_base_update_state` dispatches a state change by who originated it — `local_update`, `downstream_update` (from the neighbor toward `dst`), or `upstream_update` (from the neighbor toward `src`) — plus `pack_state_update` and the cache-eviction timer callback. |
+| `link_updates.c` | Post-fault recovery: `pack_link_update`/`update_link` exchange in-flight message state with new neighbors after a promotion, `fault_handler` reacts to a `PRTE_RML_FAULT_SCOPE_LOCAL` recovery (purge dead paths, then re-exchange), and the upstream/downstream "links updated" bitmaps gate when updates may be sent. |
+| `state_machine.h` | Static inline defaults for the simple callbacks: `new_rank`/`new_msg` (just `PMIX_NEW`), and `upstream_rank`/`downstream_rank` (just `prte_rml_get_route` toward `src`/`dst`). Declares the non-trivial ones implemented in the `.c` files. |
+
+## Two message flows to understand
+
+- **Steady state (`state_updates.c`).** A message walks `SENDING` → `SENT` at
+  each hop as its data is forwarded downstream, then an ACK walks back upstream
+  (`ACKED`) and an ACK-of-ACK (`ACKACKED`) walks down again to release state.
+  `local_update` is the interesting switch: it decides whether to forward,
+  post-to-the-application (at `dst`), cache, request a replay, or tear down.
+  Ordering is enforced through the `prev_uid`/`next_uid` chain — a `PENDING`
+  message waits for its predecessor to be posted, and an ACK implicitly acks all
+  earlier messages.
+
+- **Recovery (`link_updates.c`).** When the routing tree is repaired,
+  `fault_handler` runs on the **local**-scope notice (it ignores global scope —
+  by then RML recovery has already happened and the tree shows no delta). It
+  purges messages to/from failed ranks and messages this daemon is no longer on
+  the path for, then, for every changed link, sends a link update carrying all
+  in-flight message states routed through that link. A depth stamp on each
+  update lets a receiver discard lingering updates from before a promotion. The
+  `upstream_links_updated` / `downstream_links_updated` bitmaps ensure a daemon
+  has gathered enough neighbor state before it forwards updates onward.
+
+## Gotchas before you edit
+
+- **Scope matters.** The fault handler acts only on
+  `PRTE_RML_FAULT_SCOPE_LOCAL`. Global-scope notices arrive after RML recovery
+  and report no tree change; a component must therefore save whatever it needs
+  between the local and global calls. Don't move recovery work to global scope.
+- **Depth-stamped link updates.** A link update is ignored unless the sender's
+  reported depth matches the expected parent/child depth. If you change how
+  promotions renumber depth, keep `pack_link_update`/`update_link` in sync or
+  recovery messages will be silently dropped.
+- **Never persist ephemeral states.** `CACHED`/`EVICTED`/`NEW`/`ACKACKED` are
+  transitions, not stored states (see `../AGENTS.md`).
+- **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
+  tree warning-free.

--- a/src/rml/relm/base/CLAUDE.md
+++ b/src/rml/relm/base/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Problem

The `src/rml` editing map had drifted behind the code. The elastic-DVM and launcher-less bootstrap work added a permanent departed-daemon set (`dead_dmns`), a leaving-daemon fast exit in `route_lost`, on-demand peer-URI synthesis, missing-mask tolerance, bootstrap heal-to-ancestor on connect timeout, and new connection-retry knobs (`prte_retry_max_delay`, `prte_connect_max_time`) — none of which were captured in the orientation docs.

Meanwhile the `oob/` and `relm/` subtrees had no orientation map of their own, and the how-things-work narrative stopped at a single overview page that only gestured at the TCP transport and said almost nothing about reliable messaging.

## Change

Documentation only — no code changes.

- Update `src/rml/AGENTS.md` for the bootstrap and elastic revisions.
- Add an `AGENTS.md` (with the `CLAUDE.md` symlink) to each of `oob/`, `relm/`, and `relm/base/` so an agent or contributor editing those directories has a local map.
- Expand `docs/how-things-work/rml/` with dedicated pages that walk through the TCP transport (`oob.rst`) and the RELM reliable-messaging protocol (`relm.rst`) in detail, and wire them into the section toctree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)