### PR TITLE
Unheal a bootstrapped DVM when a departed daemon returns

### DIFF
--- a/docs/plans/bootstrap/index.rst
+++ b/docs/plans/bootstrap/index.rst
@@ -9,3 +9,4 @@ instantiating a persistent DVM.
 
    bootstrap_spec.rst
    bootstrap_plan.rst
+   unheal_plan.rst

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -378,12 +378,28 @@ the returned daemon now decodes the full span, its routing stays consistent, and
 a job launched after the unheal runs across the returned daemon and its child
 with every daemon surviving; the elastic suite (16/16) is unaffected.
 
-**Stage 6 — Incarnation guard.**  Add the boot-epoch field to the wire header
-(``prte_oob_tcp_hdr_t``), stamp outgoing messages with the sender's epoch,
-carry the returned daemon's epoch through the ``DAEMON_RETURNED`` /
-``DAEMON_REVIVED`` exchange, and drop inbound traffic stamped with a stale
-epoch for a rank.  This closes the stale-message window that the return of a
-same-rank/new-process daemon opens.
+**Stage 6 — Incarnation guard (done).**  Each process captures a boot epoch -- a
+millisecond wall-clock timestamp taken once at RML startup -- and stamps it into
+the OOB wire header (``prte_oob_tcp_hdr_t``) as the origin's epoch: a message
+built locally carries this process's epoch, and a relayed message preserves the
+original sender's epoch from the received header.  Every daemon records the
+highest epoch it has learned per rank; in a bootstrapped DVM it drops
+daemon-namespace traffic stamped with a strictly *older* epoch for a rank (the
+check runs after the whole message is read, so the byte stream stays framed, and
+only for the daemon namespace, since tool namespaces reuse rank numbers).  A
+newer epoch passes but does not advance the table -- the arbitrated revival does
+that.  The returning daemon announces its epoch in ``DAEMON_RETURNED``; the HNP
+accepts the return only if that epoch is strictly greater than the one last
+recorded for the rank (rejecting a stale or degenerate same-timestamp reboot and
+forcing a retry), then carries it in the ``DAEMON_REVIVED`` broadcast so every
+daemon records the new incarnation and drops any lingering traffic from the old
+one.  The wire header is exchanged only among daemons of one DVM, all on the same
+build, so the added field is no ABI concern.  The drop path is bootstrap-gated,
+so launched and elastic DVMs are unaffected; harness-verified -- the elastic
+suite (16/16) and the bootstrap unheal end-to-end (revival, ``get_route``
+stability, a post-unheal job across the returned daemon) both pass with the guard
+in place, and no legitimate traffic is dropped.  This closes the stale-message
+window that the return of a same-rank/new-process daemon opens.
 
 Testing
 -------

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -356,15 +356,27 @@ The harness confirms the ``OUT_OF_ORDER`` exit is gone, and the elastic suite
 (16/16) confirms the normal xcast path is unaffected.  This also removes a
 latent grow hazard.
 
-*The nidmap/job-data half remains.*  With ordering fixed, the returned daemon
-now reaches the launch itself and fails one layer deeper: lacking the current
-nidmap and job data, it recomputes an inconsistent tree mid-launch (its child
-leaves its subtree) and then sends to a node it wrongly believes is down,
-force-exiting (``rml_send.c`` "Node has gone down").  Wiring the returned daemon
-through the grow-style state handoff -- current nidmap (with holes) and active
-job/proc data, reconciled with the ``nidmap.c`` hole scan so the returning rank
-is not re-marked dead -- is the remaining Stage 5 work, and this is its concrete
-failure signature to build against.
+*The nidmap/job-data half is now done and verified.*  The "Node has gone down"
+force-exit turned out not to be missing job data but a nidmap **span** bug in
+the handoff itself.  When the returned daemon's connection warms up, the HNP
+builds the handoff nidmap (``prte_util_nidmap_create``) while
+``prte_process_info.num_daemons`` still holds the *departed* count -- the error
+manager decremented it on the death and the daemon's formal relaunch report,
+which restores it, has not run yet.  The departed node's ``node->daemon`` entry
+persists, though, so every vpid is still packed.  Encoding ``num_daemons`` as
+the span therefore declared a span one short of the highest packed vpid.  The
+returned daemon decoded the short span, reset its own ``num_daemons`` to it, and
+recomputed a routing tree over a rank space that excluded the top daemon --
+so its live child dropped out of its subtree and traffic bound for that child
+was misrouted to the parent.  (The short span also under-sized the encode-side
+vpid buffer by one entry.)  The fix derives the span from the pool instead:
+``max(num_daemons, highest_packed_vpid + 1)``, which covers every packed daemon
+while still preserving a legitimate top-of-range shrink hole, and sizes the
+buffer to match.  The decode-side hole scan additionally records a bootstrap
+hole as *absent* (clearable) rather than permanently *dead*.  Harness-verified:
+the returned daemon now decodes the full span, its routing stays consistent, and
+a job launched after the unheal runs across the returned daemon and its child
+with every daemon surviving; the elastic suite (16/16) is unaffected.
 
 **Stage 6 — Incarnation guard.**  Add the boot-epoch field to the wire header
 (``prte_oob_tcp_hdr_t``), stamp outgoing messages with the sender's epoch,

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -346,10 +346,25 @@ the returned daemon was asked to participate in a reliable xcast, it died with
 ``PRTE_ERR_OUT_OF_ORDER_MSG`` (``grpcomm_direct_xcast.c``, the
 ``op_id != op_id_completed + 1`` check): it rejoined with a fresh xcast op-id
 counter while the DVM's broadcast stream was already at a higher op-id, so the
-first op forwarded to it was out of order and it force-exited.  Bringing the
-returned daemon up to the **current xcast op-id** is therefore part of this
-stage, alongside the nidmap and job data -- it is the concrete form the
-"already holds current state" precondition of Stages 3-4 takes.
+first op forwarded to it was out of order and it force-exited.
+
+*The op-id half is now done and verified.*  ``xcast_recv`` recognizes a late
+joiner (a daemon with ``op_id_inited == 0`` handed an op above one -- grown,
+returned, or simply booted after the first broadcast) and adopts the
+intervening ops as complete, so ordering holds for that op and every one after.
+The harness confirms the ``OUT_OF_ORDER`` exit is gone, and the elastic suite
+(16/16) confirms the normal xcast path is unaffected.  This also removes a
+latent grow hazard.
+
+*The nidmap/job-data half remains.*  With ordering fixed, the returned daemon
+now reaches the launch itself and fails one layer deeper: lacking the current
+nidmap and job data, it recomputes an inconsistent tree mid-launch (its child
+leaves its subtree) and then sends to a node it wrongly believes is down,
+force-exiting (``rml_send.c`` "Node has gone down").  Wiring the returned daemon
+through the grow-style state handoff -- current nidmap (with holes) and active
+job/proc data, reconciled with the ``nidmap.c`` hole scan so the returning rank
+is not re-marked dead -- is the remaining Stage 5 work, and this is its concrete
+failure signature to build against.
 
 **Stage 6 — Incarnation guard.**  Add the boot-epoch field to the wire header
 (``prte_oob_tcp_hdr_t``), stamp outgoing messages with the sender's epoch,

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -1,0 +1,371 @@
+Rewiring a Returned Daemon: the "Unheal" Path
+=============================================
+
+Status: **design draft**.  This document proposes a mechanism, not yet
+implemented, for restoring a daemon to the routing tree after it has
+disappeared and later returned.  It builds directly on the heal path
+described in :doc:`bootstrap_plan` (Step 7b) and reuses the fault
+machinery in ``src/rml``.
+
+Problem statement
+-----------------
+
+In a bootstrapped DVM the compute nodes come up independently and are not
+fanned out by a launcher.  A node can therefore *leave* the DVM without the
+DVM being torn down — the node is powered off, loses power, or is rebooted —
+and then *return* when it comes back up.  Its daemon boots again with the
+**same rank** (rank is derived from the node's fixed position in the
+``DVMNodes`` ordering, not assigned at launch).
+
+Today the RML handles only half of this life cycle:
+
+* **Heal (works).**  When the daemon disappears, ``lost_connection`` /
+  ``failed_to_connect`` drive ``prte_rml_route_lost`` →
+  ``prte_rml_repair_routing_tree``, which promotes the orphaned children to
+  their grandparent and drives adoption/failure notices.  The tree closes
+  over the hole.
+
+* **Unheal (missing).**  When the daemon returns, nothing re-inserts it.  The
+  departure was recorded as **permanent**: ``prte_rml_repair_routing_tree``
+  sets the rank in both ``failed_dmns`` *and* ``dead_dmns``
+  (``routed_radix.c``), and ``dead_dmns`` is never cleared and is restored
+  into ``failed_dmns`` on every ``prte_rml_compute_routing_tree``.  From then
+  on ``radix_is_living`` reports the rank dead forever, so ``get_route``, the
+  children array, and the ancestor list never point back at it.  The returned
+  daemon becomes a zombie the tree ignores; its former children stay attached
+  to the grandparent.
+
+The goal of this design is to make the return a first-class event: the
+returned daemon rejoins its old slot in the tree, its children drop the
+grandparent lifeline and re-home to it, and the DVM converges on the same
+tree it would have computed had the daemon never left.
+
+Scope and non-goals
+-------------------
+
+* **Bootstrap mode only.**  Unheal is gated on ``prte_bootstrap_setup``.  In a
+  launcher-driven or elastic-shrink DVM a departed vpid is genuinely
+  permanent (a shrink retires the vpid on purpose; #2491 depends on it), and
+  those modes keep their current behavior unchanged.
+* **Same rank, same identity.**  We handle a node that returns as *itself*
+  (same nspace + rank).  We do **not** reuse a vpid for a different node; that
+  invariant is preserved.
+* **No change to the heal path's externally observed behavior.**  A daemon
+  that leaves and never returns must behave exactly as it does today.
+
+Design principle: revival is the inverse of repair, not a special case of it
+----------------------------------------------------------------------------
+
+The tree is a deterministic function of ``(radix, num_daemons, failed_set)``.
+Death removes a rank from the live set and everyone recomputes; revival adds
+it back and everyone recomputes.  The two are symmetric at the level of the
+routing math, but **not** at the level of the notification code:
+
+* ``prte_rml_repair_routing_tree`` and the adoption-inference logic in
+  ``rml_fault_handler.c`` assume **depth only ever decreases** — a promotion.
+  ``prte_rml_recv_adoption_notice`` explicitly treats an ancestor list that
+  *grew* as an unrecoverable invariant violation
+  (``rml_fault_handler.c``, the ``report.size > ancestors.size`` branch that
+  raises ``PRTE_ERR_UNRECOVERABLE``).
+
+* Revival is exactly the case that grows a daemon's ancestor list: a rank is
+  re-inserted **above** the daemons in its former subtree, demoting them one
+  level.  Feeding that through the death path would trip the invariant check.
+
+Therefore revival needs its **own** recompute-and-notify entry point,
+``prte_rml_revive_routing_tree``, parallel to ``prte_rml_repair_routing_tree``,
+plus its own notice tags.  It must not be bolted onto the repair path.
+
+Separating "absent" from "dead"
+-------------------------------
+
+The root cause of the missing behavior is that one bitmap
+(``dead_dmns``) is asked to mean two different things.  Split them:
+
+===================  ============  ==================================  ==================
+Set                  Persistent?   Set by                              Cleared by
+===================  ============  ==================================  ==================
+``failed_dmns``      no (per       repair / revive / compute restore   compute re-init;
+                     recompute)                                        revive
+``global_failed``    no            global death xcast                  revive
+``dead_dmns``        yes           shrink holes (``nidmap.c``);         **never**
+                                   non-bootstrap faults
+``absent_dmns``      yes           **bootstrap** faults (new)          revive (new)
+(new)
+===================  ============  ==================================  ==================
+
+* ``absent_dmns`` is a new persistent bitmap constructed once in
+  ``prte_rml_open`` alongside ``dead_dmns`` and, like it, **not** re-initialized
+  by ``prte_rml_compute_routing_tree``.
+* ``prte_rml_repair_routing_tree`` chooses the target set by mode: in a
+  bootstrapped DVM a fault records the rank in ``absent_dmns``; otherwise it
+  records it in ``dead_dmns`` exactly as today.  Both are restored into the
+  freshly-initialized ``failed_dmns`` at the top of
+  ``prte_rml_compute_routing_tree`` (so a grow still routes around an
+  absent-but-not-yet-returned daemon).
+* Revival clears the rank from ``failed_dmns``, ``global_failed_dmns``, and
+  ``absent_dmns``.  ``dead_dmns`` is still never touched — a shrunk-out rank
+  can never be revived, which is correct.
+
+This keeps the #2491 fix and all launcher/elastic behavior byte-for-byte
+identical (nothing outside bootstrap ever populates ``absent_dmns``), while
+giving bootstrap a departure set that *can* be reversed.
+
+The trigger: a returned daemon announces itself to the HNP
+----------------------------------------------------------
+
+When the node reboots, its daemon runs the normal bootstrap startup
+(:doc:`bootstrap_plan`, Steps 4–7).  It computes a **healthy** tree — its own
+``absent_dmns`` is empty, so it sees the full DVM — and connects up its
+lifeline.  It has no way to know, on its own, that the rest of the DVM wrote
+it off while it was gone.
+
+Rather than infer the return from a stray inbound socket (routing policy does
+not belong in the OOB accept path), make it explicit and route it through the
+arbiter of global tree state, the **HNP**, mirroring how death is globally
+xcast:
+
+#. **Rejoin request (up).**  On bootstrap startup, when
+   ``prte_bootstrap_setup`` is set, the daemon sends
+   ``PRTE_RML_TAG_DAEMON_RETURNED{rank=self}`` toward the HNP along its
+   computed lifeline.  Intermediate hops relay it by destination as usual; a
+   relaying hop does not need the source to be "live" in its own tree, so the
+   message reaches the HNP even though the sender is still marked absent
+   upstream.  (First-boot daemons send this too; the HNP simply finds the rank
+   not marked absent and does nothing — see idempotence below.)
+
+#. **HNP validates and broadcasts (global).**  The HNP checks the rank against
+   ``absent_dmns``.  If absent, it clears the rank locally and xcasts
+   ``PRTE_RML_TAG_DAEMON_REVIVED{rank}`` to the whole DVM, exactly as
+   ``send_failures_notice`` xcasts ``PRTE_RML_TAG_DAEMON_DIED`` from the master
+   (``rml_fault_handler.c``).  If the rank is not absent (a genuine first boot,
+   or a duplicate), the HNP drops the request — the operation is idempotent.
+
+#. **Everyone converges (global).**  Each daemon's
+   ``prte_rml_recv_revival_notice`` clears the rank from its failure sets and
+   calls ``prte_rml_revive_routing_tree(rank)``.  Because the failed set is now
+   globally consistent again, every daemon deterministically recomputes the
+   same tree.
+
+Centralizing at the HNP avoids the split-brain that per-subtree local revival
+would invite, and reuses the existing global-xcast plumbing.
+
+``prte_rml_revive_routing_tree`` — the recompute and its deltas
+-----------------------------------------------------------------
+
+Symmetric to ``prte_rml_repair_routing_tree``:
+
+#. Clear ``rank`` from ``failed_dmns`` / ``global_failed_dmns`` /
+   ``absent_dmns`` (the recv handler does this before calling in, matching how
+   ``repair`` sets the bit before recomputing).
+#. Snapshot ``prev_ancestors`` / ``prev_parent`` / ``prev_children`` into a
+   ``prte_rml_recovery_status_t``.
+#. Re-derive ancestors, promotion/**demotion**, and children.  Most of this is
+   the existing helpers run against the updated (smaller) failed set:
+
+   * ``prte_rml_update_ancestors`` already walks to the next *living* ancestor;
+     with ``rank`` now living again it will re-appear in the lists of the
+     daemons below it, **growing** their ancestor arrays.  This is the case the
+     current code deliberately rejects, so ``update_ancestors`` needs an
+     audited pass to confirm it produces the right list when depth increases
+     (it may need a companion to the promotion path — a "demotion" fixup —
+     analogous to ``handle_promotion``).
+   * The daemon that had adopted ``rank``'s orphans (``rank``'s parent) loses
+     them from its child list; ``rank`` regains them.  ``update_descendants``
+     recomputes children from the live set, so the child arrays fall out
+     correctly once the failed bit is cleared; the work is producing the
+     *delta* for the notices.
+
+#. Fill in ``parent_changed`` / ``children_changed`` / a new ``demoted`` flag
+   (mirroring ``promoted``) and notify the components:
+   ``prte_rml_fault_handler``, ``prte_grpcomm.fault_handler``,
+   ``prte_filem.fault_handler``, ``prte_relm.fault_handler``.
+
+Recovery-status and component impact
+------------------------------------
+
+The existing ``prte_rml_recovery_status_t`` is close but assumes promotion.
+Two additions:
+
+* Add a ``bool demoted`` flag (a daemon gained an ancestor / its subtree
+  shrank), the mirror of ``promoted``.  Handlers that "treat all children as
+  new when promoted" need the analogous rule: **treat the re-homing children
+  as new when a neighbor is revived**, because a child that briefly had the
+  grandparent as parent must discard that lineage.
+* The RML's own reaction (``rml_fault_handler.c``) needs revival analogues of
+  its two notices:
+
+  - **Re-home notice (down)** — the inverse of the adoption notice.  ``rank``'s
+    parent tells the affected promoted children "your ancestor list has
+    changed; ``rank`` is back above you," so they drop the grandparent lifeline
+    and re-open their lifeline to ``rank`` (or the closest revived ancestor in
+    their path).  The receive handler is the inverse of
+    ``prte_rml_recv_adoption_notice`` and must accept a *grown* ancestor list
+    rather than rejecting it.
+  - **Rejoin/rollup (up)** — RELM re-drives any messages that were in flight
+    across the re-homing so nothing is lost, exactly as it re-drives across a
+    heal.
+
+``prte_grpcomm`` and ``prte_filem`` already receive the recovery status on
+every tree change; they must tolerate a change whose net effect is a daemon
+*appearing*.  The audit here is: does any collective/xcast accounting assume
+membership only shrinks?  ``prte_rml_get_num_contributors`` counts live
+children, so a revived child correctly re-enters the count once the failed bit
+clears — but in-progress collectives that already excluded ``rank`` need the
+same "save state between local and global scope" discipline the death path
+uses (``rml_types.h`` documents this contract on the status struct).
+
+Bringing the returned daemon up to date
+----------------------------------------
+
+The routing tree is only half the problem.  While it was gone the returned
+daemon missed everything: jobs launched, other faults, nidmap growth from
+elastic grows.  It boots with a stale world view.  Re-inserting it into the
+tree without resynchronizing its state would let it route correctly but act on
+stale data.
+
+This is the same problem the **elastic grow** path already solves — "admit a
+daemon into a running DVM and hand it the current state" — with one twist: the
+vpid is the returned daemon's own, not a newly minted one.  Reuse that
+machinery:
+
+* The HNP, on processing the rejoin, drives the returned daemon through the
+  grow-style wireup so it receives the current nidmap (with any holes) and the
+  active job/proc data, rather than the boot-time snapshot.
+* Because the returned rank is an existing hole rather than an extension of the
+  vpid span, ``num_daemons`` does **not** change; only the returned rank's
+  ``dead``/``absent`` state and the tree change.  The nidmap-hole bookkeeping
+  in ``nidmap.c`` must not re-mark the returning rank as dead when it repopulates
+  ``daemons->procs`` — clearing ``absent_dmns`` for the rank must precede, or be
+  reconciled with, that scan.
+
+Concurrency and correctness concerns
+------------------------------------
+
+* **Incarnation / stale-message hazard.**  The returned daemon is a *new
+  process* wearing the *old rank*.  Messages queued to the old incarnation, or
+  late death/adoption notices still in flight, could be mis-delivered to the
+  new one.  **Decided:** tag each daemon with a **boot epoch** — a
+  monotonically increasing incarnation counter — and carry it in the wire
+  header (``prte_oob_tcp_hdr.h``) so a hop can drop a message addressed to a
+  stale incarnation of a rank.  This is safe to add: the header is not an ABI
+  (see the RML ``AGENTS.md`` — it is exchanged only among daemons of one DVM,
+  which all run the same PRRTE build), so there is no cross-version concern,
+  only the requirement that every daemon agree, which a single build
+  guarantees.  The epoch is the daemon's **boot timestamp**, captured once at
+  startup (a wall-clock time at ``prte_init``); no persisted on-disk counter is
+  needed.  A reboot yields a later timestamp, so the returned incarnation
+  always outranks the one the DVM wrote off.  (The one degenerate case — a
+  reboot fast enough, or with a reset clock, to reproduce the prior timestamp —
+  is bounded by timestamp resolution; use at least millisecond granularity, and
+  the HNP can reject a ``DAEMON_RETURNED`` whose epoch is not strictly greater
+  than the recorded one, forcing a retry.)  The epoch is announced in the
+  ``DAEMON_RETURNED`` request so the HNP propagates it in the
+  ``DAEMON_REVIVED`` xcast; peers record the current epoch per rank and reject
+  header-stamped traffic from an older one.  See Stage 6.
+* **Revive/again-die races.**  A node that flaps (returns, dies again before
+  the revival xcast completes) must converge.  Because both death and revival
+  are HNP-arbitrated global xcasts over the same rank, ordering them at the HNP
+  (serialize per-rank; the last event wins) keeps every daemon consistent.  The
+  recv handlers must be idempotent (clearing an already-clear bit, or setting an
+  already-set one, is a no-op that produces an empty delta and no notices — the
+  ``status.failed_ranks.size == 0`` early return in ``repair`` already models
+  this).
+* **Stale OOB peer object.**  The peer object for ``rank`` on its neighbors is
+  in a closed/failed state from the original loss.  Revival must reset it (or
+  drop it so the next send re-synthesizes the URI via
+  ``prte_ess_base_bootstrap_peer_uri`` and reconnects, as the heal path already
+  does for adopted parents).
+
+Staged implementation plan
+--------------------------
+
+The stages are independently reviewable and ordered so the tree keeps building
+and behaving at each step.
+
+**Stage 1 — Split the departure sets.**  Add ``absent_dmns`` to
+``prte_rml_base`` (construct in ``prte_rml_open``, restore into ``failed_dmns``
+in ``prte_rml_compute_routing_tree``).  Route bootstrap faults to it instead of
+``dead_dmns``.  No behavior change yet (an absent daemon still never returns);
+this only reclassifies where the mark lives.  Verify launched/elastic behavior
+is untouched (nothing populates ``absent_dmns`` outside bootstrap).
+
+**Stage 2 — Revival recompute.**  Implement
+``prte_rml_revive_routing_tree(rank)`` and the ``demoted`` status flag; audit
+``update_ancestors`` for growing ancestor lists and add a demotion fixup if
+needed.  Unit-exercise it by directly clearing a bit and calling it on a small
+synthetic tree.
+
+**Stage 3 — Global protocol.**  Add ``PRTE_RML_TAG_DAEMON_RETURNED`` and
+``PRTE_RML_TAG_DAEMON_REVIVED``, the HNP validate-and-xcast, and
+``prte_rml_recv_revival_notice``.  At this point a returned daemon that already
+holds current state rejoins the tree and children re-home.
+
+**Stage 4 — Re-home and RELM.**  Add the re-home (inverse-adoption) notice and
+its receiver that accepts a grown ancestor list, and extend the RELM fault
+handler to re-drive across a revival.
+
+**Stage 5 — State resync.**  Wire the returned daemon through the grow-style
+state handoff so it comes back with the current nidmap and job data; reconcile
+with the ``nidmap.c`` hole scan.
+
+**Stage 6 — Incarnation guard.**  Add the boot-epoch field to the wire header
+(``prte_oob_tcp_hdr_t``), stamp outgoing messages with the sender's epoch,
+carry the returned daemon's epoch through the ``DAEMON_RETURNED`` /
+``DAEMON_REVIVED`` exchange, and drop inbound traffic stamped with a stale
+epoch for a rank.  This closes the stale-message window that the return of a
+same-rank/new-process daemon opens.
+
+Testing
+-------
+
+The Docker multi-node bootstrap harness (``contrib/dockerswarm/``) already
+drives launcher-less formation.  Extend it:
+
+#. Form a bootstrapped DVM of enough nodes to have a non-trivial interior
+   (radix small enough that some daemon has both a parent and children).
+#. Kill an interior node's daemon (or ``docker stop`` the node); confirm the
+   heal — children promote to the grandparent — via ``rml_base_verbose``.
+#. Restart the node; confirm the unheal — the ``DAEMON_RETURNED`` /
+   ``DAEMON_REVIVED`` exchange, the children re-homing to the returned rank,
+   and the tree matching a never-failed run.
+#. Launch a job across the DVM *after* the unheal to confirm the returned
+   daemon carries current state and participates in collectives.
+#. Flap test: kill and restart in quick succession to exercise the
+   race/idempotence handling.
+
+Resolved decisions
+------------------
+
+#. **Incarnation identity — boot-epoch in the wire header.**  Adopt a boot-epoch
+   incarnation counter carried in ``prte_oob_tcp_hdr_t`` (Stage 6) rather than
+   trying to close the stale-message window with xcast ordering and peer reset
+   alone.  There is no ABI cost: every daemon of a DVM runs the same PRRTE
+   build, so the header can change freely as long as all daemons agree.  The
+   epoch value is the daemon's **boot timestamp** (captured at ``prte_init``),
+   not a persisted counter — a reboot always produces a later value, so no
+   on-disk state is required.
+#. **Bootstrap-only — no launched/elastic re-launch.**  Unheal stays gated on
+   ``prte_bootstrap_setup``.  Extending it to a launched or elastic DVM would
+   require re-launching the returned daemon into its **original** vpid (an
+   existing hole), and the bulk launchers cannot do that: SLURM, PALS, and
+   similar RMs assign vpids sequentially over the node set they are handed and
+   offer no way to force a *particular* vpid one-at-a-time, so there is no
+   portable re-launch-into-hole primitive to build on.  Only bootstrap, where a
+   returned node re-derives its own rank from static configuration and re-runs
+   its own daemon, provides the returned-with-original-rank precondition the
+   mechanism needs.  The RML core (the ``absent_dmns`` split,
+   ``prte_rml_revive_routing_tree``, the revival protocol, re-home notices, the
+   boot-epoch guard) is not itself launcher-specific, so this could be revisited
+   if a launcher ever gains per-vpid placement — but it is out of scope now.
+
+Open questions
+--------------
+
+#. **Trigger source.**  Route the rejoin through the HNP (this proposal) or let
+   the returned daemon's *parent* arbitrate locally and forward up?  HNP-central
+   is simpler and race-safe but adds one hop of latency to the rejoin.
+#. **Partial returns.**  If several daemons in one subtree are absent and only
+   some return, the recompute must handle a partially-repopulated path; confirm
+   ``update_ancestors`` walks correctly when the returned rank is itself below
+   another still-absent ancestor.

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -125,14 +125,19 @@ not belong in the OOB accept path), make it explicit and route it through the
 arbiter of global tree state, the **HNP**, mirroring how death is globally
 xcast:
 
-#. **Rejoin request (up).**  On bootstrap startup, when
+#. **Rejoin request (one hop up, then filtered).**  On bootstrap startup, when
    ``prte_bootstrap_setup`` is set, the daemon sends
-   ``PRTE_RML_TAG_DAEMON_RETURNED{rank=self}`` toward the HNP along its
-   computed lifeline.  Intermediate hops relay it by destination as usual; a
-   relaying hop does not need the source to be "live" in its own tree, so the
-   message reaches the HNP even though the sender is still marked absent
-   upstream.  (First-boot daemons send this too; the HNP simply finds the rank
-   not marked absent and does nothing — see idempotence below.)
+   ``PRTE_RML_TAG_DAEMON_RETURNED{rank=self}`` **to its parent** (one hop up its
+   lifeline), not to the HNP.  The parent is exactly the daemon that knows
+   whether the rank was absent -- the global death broadcast marked it
+   everywhere -- so the parent filters: if the rank is not in *its*
+   ``absent_dmns`` (a first boot, a duplicate) it drops the notice, and only if
+   the rank really was absent does it escalate one relayed message to the HNP.
+   This deliberately avoids an N-to-root pattern: on the common first-boot path
+   the root is never involved (it sees announcements only from its own few
+   direct children, all dropped), and the notice rides the existing lifeline
+   link so no daemon opens a socket to the root.  A real return costs one
+   escalated message to the root, ``O(1)``.
 
 #. **HNP validates and broadcasts (global).**  The HNP checks the rank against
    ``absent_dmns``.  If absent, it clears the rank locally and xcasts
@@ -358,13 +363,20 @@ Resolved decisions
    ``prte_rml_revive_routing_tree``, the revival protocol, re-home notices, the
    boot-epoch guard) is not itself launcher-specific, so this could be revisited
    if a launcher ever gains per-vpid placement — but it is out of scope now.
+#. **Trigger source — announce to the parent, escalate to the HNP.**  A
+   returning daemon announces one hop up to its *parent*, which filters on its
+   own ``absent_dmns`` and escalates only a genuine return to the HNP; the HNP
+   remains the sole arbiter that broadcasts the revival.  This is chosen over
+   the daemon announcing straight to the HNP specifically to avoid an N-to-root
+   pattern: funnelling every daemon's boot-time announcement onto the root makes
+   the root aggregate ``N`` messages and, at the transport, sustain the fan-in
+   that burdens the OS and hurts responsiveness at scale.  Parent-filtered
+   escalation keeps the root out of the common (first-boot) path entirely while
+   preserving single-arbiter global consistency.
 
 Open questions
 --------------
 
-#. **Trigger source.**  Route the rejoin through the HNP (this proposal) or let
-   the returned daemon's *parent* arbitrate locally and forward up?  HNP-central
-   is simpler and race-safe but adds one hop of latency to the rejoin.
 #. **Partial returns.**  If several daemons in one subtree are absent and only
    some return, the recompute must handle a partially-repopulated path; confirm
    ``update_ancestors`` walks correctly when the returned rank is itself below

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -338,7 +338,18 @@ the DVM and check nothing was lost).
 
 **Stage 5 — State resync.**  Wire the returned daemon through the grow-style
 state handoff so it comes back with the current nidmap and job data; reconcile
-with the ``nidmap.c`` hole scan.
+with the ``nidmap.c`` hole scan.  **Harness evidence (2026-07-04):** the topology
+unheal was verified end-to-end on the Docker swarm (a radix-2 bootstrap DVM;
+killing the interior daemon healed its child up to the grandparent, restarting
+it drove the return/revival broadcast and the child re-homed back).  But once
+the returned daemon was asked to participate in a reliable xcast, it died with
+``PRTE_ERR_OUT_OF_ORDER_MSG`` (``grpcomm_direct_xcast.c``, the
+``op_id != op_id_completed + 1`` check): it rejoined with a fresh xcast op-id
+counter while the DVM's broadcast stream was already at a higher op-id, so the
+first op forwarded to it was out of order and it force-exited.  Bringing the
+returned daemon up to the **current xcast op-id** is therefore part of this
+stage, alongside the nidmap and job data -- it is the concrete form the
+"already holds current state" precondition of Stages 3-4 takes.
 
 **Stage 6 — Incarnation guard.**  Add the boot-epoch field to the wire header
 (``prte_oob_tcp_hdr_t``), stamp outgoing messages with the sender's epoch,

--- a/docs/plans/bootstrap/unheal_plan.rst
+++ b/docs/plans/bootstrap/unheal_plan.rst
@@ -306,9 +306,35 @@ synthetic tree.
 ``prte_rml_recv_revival_notice``.  At this point a returned daemon that already
 holds current state rejoins the tree and children re-home.
 
-**Stage 4 — Re-home and RELM.**  Add the re-home (inverse-adoption) notice and
-its receiver that accepts a grown ancestor list, and extend the RELM fault
-handler to re-drive across a revival.
+**Stage 4 — Component re-drive (done).**  ``prte_rml_revive_routing_tree`` now
+notifies ``grpcomm``, ``filem``, and ``relm`` of the reshape (but *not* the
+death-only ``prte_rml_fault_handler``).  Two simplifications fell out of the
+xcast-driven design and are worth recording:
+
+* **No separate re-home notice is needed.**  The inverse-adoption notice was
+  meant to tell promoted children that a rank returned above them.  But a
+  revival is driven entirely by the single ``DAEMON_REVIVED`` xcast, so every
+  daemon recomputes from the same signal and re-homes locally; there is no
+  local-detection-versus-broadcast race for an adoption-style notice to close,
+  unlike a fault.
+
+* **No revival-specific handler branch is needed.**  A revival is pure
+  *shrinkage* from every reshaping daemon's view (the returned rank's former
+  parent swaps orphans for the rank; the orphans re-home; deeper daemons only
+  gain an ancestor).  That trips only the existing ``parent_changed`` /
+  ``children_changed`` paths in the ``grpcomm`` and ``relm`` handlers; the
+  ``promoted``-only paths (replay-pending, op-id-at-promotion) are for the
+  growth direction and correctly stay dormant.  So the tested handlers are
+  reused rather than forked.
+
+One **watch item** remains for harness validation: RELM link updates are depth
+stamped and ``update_link`` drops a mismatched one, while revival changes
+depths and rides the xcast forward-first.  Static analysis argues it is safe --
+each daemon recomputes synchronously right after forwarding, so both ends have
+settled on their new depths before any link update (a later, separate message)
+is processed -- but the multi-hop update gating is subtle enough to confirm on
+the Docker harness (kill an interior node, restart it, then launch a job across
+the DVM and check nothing was lost).
 
 **Stage 5 — State resync.**  Wire the returned daemon through the grow-style
 state handoff so it comes back with the current nidmap and job data; reconcile
@@ -373,11 +399,19 @@ Resolved decisions
    that burdens the OS and hurts responsiveness at scale.  Parent-filtered
    escalation keeps the root out of the common (first-boot) path entirely while
    preserving single-arbiter global consistency.
+#. **Partial returns — handled by the base-rebuild reduction.**  If several
+   daemons in one subtree are absent and only some return, or a returned rank is
+   itself below a still-absent ancestor, no special handling is needed.  After
+   ``prte_rml_revive_routing_tree`` clears the returned rank's bit, the failed
+   set is exactly what ``compute_routing_tree`` would hold for the same
+   still-absent ranks, and both routines derive the tree through the same
+   ``build_tree_from_base`` helper -- which starts from the full-depth base
+   ancestor list and drops whatever is still failed.  A revival therefore
+   produces the identical tree a fresh compute would for that failed set, so
+   ``update_ancestors`` walks partial-return cases correctly by construction.
 
 Open questions
 --------------
 
-#. **Partial returns.**  If several daemons in one subtree are absent and only
-   some return, the recompute must handle a partially-repopulated path; confirm
-   ``update_ancestors`` walks correctly when the returned rank is itself below
-   another still-absent ancestor.
+*(none currently open — remaining work is the Stage 4 RELM watch item and
+Stages 5–6, all tracked in the staged plan above.)*

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -202,6 +202,21 @@ void prte_grpcomm_direct_xcast_recv(
     signature_t sig;
     if(PMIX_SUCCESS != unpack_sig(buffer, &sig)) return;
 
+    // A daemon that has never seen any xcast (op_id_inited == 0) yet is being
+    // handed an op is a *late joiner*: a daemon grown into a running DVM, or one
+    // whose node rebooted and returned (the bootstrap unheal path), or simply a
+    // bootstrap daemon that booted after the first broadcast. It cannot have the
+    // ops that preceded this one, so it must adopt them as already complete
+    // rather than enforce ordering it can never satisfy -- finish_op would
+    // otherwise raise PRTE_ERR_OUT_OF_ORDER_MSG on the first op above 1 and the
+    // daemon would force-exit. Setting op_id_completed_at_promotion below the
+    // completed mark makes those prior ops assume-complete exactly as a
+    // promotion does. The master assigns op-ids and is never a late joiner, so
+    // it is excluded. This is safe because a daemon that has *ever* participated
+    // has op_id_inited > 0, so a genuine ordering violation mid-stream is still
+    // caught.
+    bool late_joiner = !PRTE_PROC_IS_MASTER && (0 == XCAST.op_id_inited);
+
     if(PRTE_PROC_IS_MASTER){
         if(sig.op_id){
             // If I'm HNP, I expect sender has not assigned a global ID
@@ -216,6 +231,12 @@ void prte_grpcomm_direct_xcast_recv(
     }
     if(sig.op_id > XCAST.op_id_inited){
         XCAST.op_id_inited = sig.op_id;
+    }
+    if(late_joiner && sig.op_id > 1){
+        // Catch up to just below this op: ops 1..op_id-1 are taken as complete,
+        // and this op is processed in order as our first.
+        XCAST.op_id_completed = sig.op_id - 1;
+        XCAST.op_id_completed_at_promotion = sig.op_id - 1;
     }
 
     // If we marked our subtree as completed, but then were promoted, our

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -281,7 +281,14 @@ void prte_grpcomm_direct_xcast_recv(
     // We need to process (invoke the user msg's callback, generally) and
     // forward to our children.
     // For most xcasts, it's best to forward first to maintain message ordering,
-    // but xcasts that modify how we send messages should be processed first
+    // but xcasts that modify how we send messages should be processed first.
+    // DAEMON_DIED is processed first because a death *grows* our child set
+    // (orphans promote to us), and we must repair before forwarding so the
+    // promoted grandchildren receive it. DAEMON_REVIVED is the opposite: a
+    // return *shrinks* our child set (the returned rank reclaims its orphans),
+    // so it must stay on the forward-first path -- forwarding to our current
+    // children before the reshape is what delivers the notice to the very
+    // children that are about to re-home. Do not move it into this set.
     bool process_first = PRTE_RML_TAG_WIREUP == op->msg_tag ||
                          PRTE_RML_TAG_DAEMON_DIED == op->msg_tag;
     if(process_first){

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1322,6 +1322,20 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             prted_failed_launch = true;
             goto CLEANUP;
         }
+        /* A returning daemon (the bootstrap unheal path): its node rebooted and
+         * it is reporting in again after we recorded it COMM_FAILED and
+         * decremented num_daemons on its death. Restore the count so the nidmap
+         * span [0, num_daemons) and every daemon-count-derived computation are
+         * correct again -- otherwise the launch nidmap encodes a shorter span
+         * than the live daemon set and re-poisons the returned daemon (it decodes
+         * its own rank, or a peer beyond the truncated span, as a dead hole).
+         * Only a daemon that had actually failed reaches this: a first launch or
+         * a grow target is not COMM_FAILED here, so formation and grow are
+         * unaffected, and once set RUNNING below a duplicate report cannot
+         * double-count. Gated on bootstrap, the only mode a daemon can return in. */
+        if (prte_bootstrap_setup && PRTE_PROC_STATE_COMM_FAILED == daemon->state) {
+            ++prte_process_info.num_daemons;
+        }
         daemon->state = PRTE_PROC_STATE_RUNNING;
         /* record that this daemon is alive */
         PRTE_FLAG_SET(daemon, PRTE_PROC_FLAG_ALIVE);

--- a/src/rml/oob/oob_tcp_hdr.h
+++ b/src/rml/oob/oob_tcp_hdr.h
@@ -29,6 +29,8 @@
 
 #include "prte_config.h"
 
+#include "types.h"
+
 /* Message types carried in the TCP header. IDENT and PROBE are used
  * during the connection handshake; USER marks a normal RML message,
  * whether it is destined for us or is being relayed on to the next hop.
@@ -55,6 +57,10 @@ typedef struct {
     uint32_t seq_num;
     /* number of bytes in message */
     uint32_t nbytes;
+    /* boot epoch (incarnation) of the origin. A daemon that departs and reboots
+     * into the same rank comes back with a strictly-greater epoch, so a hop can
+     * drop late traffic stamped with the stale incarnation's epoch. */
+    uint64_t epoch;
     /* type of message */
     prte_oob_tcp_msg_type_t type;
 } prte_oob_tcp_hdr_t;
@@ -65,7 +71,8 @@ typedef struct {
     (h)->origin.rank = ntohl((h)->origin.rank); \
     (h)->dst.rank = ntohl((h)->dst.rank);       \
     (h)->tag = PRTE_RML_TAG_NTOH((h)->tag);     \
-    (h)->nbytes = ntohl((h)->nbytes);
+    (h)->nbytes = ntohl((h)->nbytes);           \
+    (h)->epoch = prte_ntoh64((h)->epoch);
 
 /**
  * Convert the message header to network byte order
@@ -74,6 +81,7 @@ typedef struct {
     (h)->origin.rank = htonl((h)->origin.rank); \
     (h)->dst.rank = htonl((h)->dst.rank);       \
     (h)->tag = PRTE_RML_TAG_HTON((h)->tag);     \
-    (h)->nbytes = htonl((h)->nbytes);
+    (h)->nbytes = htonl((h)->nbytes);           \
+    (h)->epoch = prte_hton64((h)->epoch);
 
 #endif /* _MCA_OOB_TCP_HDR_H_ */

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -499,6 +499,29 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     PRTE_NAME_PRINT(&peer->recv_msg->hdr.origin), (int) peer->recv_msg->hdr.nbytes,
                     PRTE_NAME_PRINT(&peer->recv_msg->hdr.dst), peer->recv_msg->hdr.tag);
 
+                /* Incarnation guard (bootstrap only): a departed daemon can
+                 * reboot into the same rank and return with a strictly-greater
+                 * boot epoch. Drop traffic stamped with a stale (older) epoch
+                 * for a daemon rank so the old incarnation's late messages are
+                 * not confused with the new one. Only daemon-namespace traffic
+                 * is checked -- tool namespaces reuse rank numbers. The full
+                 * message has already been read off the socket, so dropping
+                 * here leaves the byte stream correctly framed. */
+                if (prte_bootstrap_setup &&
+                    PMIX_CHECK_NSPACE(peer->recv_msg->hdr.origin.nspace,
+                                      PRTE_PROC_MY_NAME->nspace) &&
+                    !prte_rml_epoch_ok(peer->recv_msg->hdr.origin.rank,
+                                       peer->recv_msg->hdr.epoch)) {
+                    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
+                                        "%s DROPPING STALE-INCARNATION MSG FROM %s epoch %lu",
+                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                        PRTE_NAME_PRINT(&peer->recv_msg->hdr.origin),
+                                        (unsigned long) peer->recv_msg->hdr.epoch);
+                    PMIX_RELEASE(peer->recv_msg);
+                    peer->recv_msg = NULL;
+                    return;
+                }
+
                 /* am I the intended recipient (header was already converted back to host order)? */
                 if (PMIX_CHECK_PROCID(&peer->recv_msg->hdr.dst, PRTE_PROC_MY_NAME)) {
                     /* yes - post it to the RML for delivery */
@@ -524,6 +547,9 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     snd = PMIX_NEW(prte_rml_send_t);
                     snd->dst = peer->recv_msg->hdr.dst;
                     PMIX_XFER_PROCID(&snd->origin, &peer->recv_msg->hdr.origin);
+                    /* preserve the origin's epoch across the relay (the
+                     * constructor defaulted it to our own epoch) */
+                    snd->epoch = peer->recv_msg->hdr.epoch;
                     snd->tag = peer->recv_msg->hdr.tag;
                     bo.bytes = peer->recv_msg->data;
                     bo.size = peer->recv_msg->hdr.nbytes;

--- a/src/rml/oob/oob_tcp_sendrecv.h
+++ b/src/rml/oob/oob_tcp_sendrecv.h
@@ -108,6 +108,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         _s->hdr.type = MCA_OOB_TCP_USER;                                                       \
         _s->hdr.tag = (m)->tag;                                                                \
         _s->hdr.seq_num = (m)->seq_num;                                                        \
+        _s->hdr.epoch = (m)->epoch;                                                            \
         /* point to the actual message */                                                      \
         _s->msg = (m);                                                                         \
         /* set the total number of bytes to be sent */                                         \
@@ -140,6 +141,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         _s->hdr.type = MCA_OOB_TCP_USER;                                                          \
         _s->hdr.tag = (m)->tag;                                                                   \
         _s->hdr.seq_num = (m)->seq_num;                                                           \
+        _s->hdr.epoch = (m)->epoch;                                                               \
         /* point to the actual message */                                                         \
         _s->msg = (m);                                                                            \
         /* set the total number of bytes to be sent */                                            \

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -54,6 +54,7 @@ prte_rml_base_t prte_rml_base = {
     .failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .global_failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .dead_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
+    .absent_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
 };
 
 static int verbosity = 0;
@@ -119,6 +120,7 @@ void prte_rml_close(void)
     PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
     PMIX_DESTRUCT(&prte_rml_base.global_failed_dmns);
     PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.absent_dmns);
     PMIx_Data_array_destruct(&prte_rml_base.ancestors);
     PMIx_Data_array_destruct(&prte_rml_base.children);
     if (0 <= prte_rml_base.rml_output) {
@@ -144,6 +146,11 @@ int prte_rml_open(void)
      * persist across the recomputes that DVM grows trigger (#2491) */
     PMIX_CONSTRUCT(&prte_rml_base.dead_dmns, pmix_bitmap_t);
     pmix_bitmap_init(&prte_rml_base.dead_dmns, prte_process_info.num_daemons);
+    /* absent_dmns holds bootstrap daemons that are gone but may return; like
+     * dead_dmns it persists across recomputes, but it is cleared when a daemon
+     * comes back (the unheal path). Initialized once here for the same reason. */
+    PMIX_CONSTRUCT(&prte_rml_base.absent_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.absent_dmns, prte_process_info.num_daemons);
 
     /* set up failure notification receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_DIED, true,

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -322,6 +322,7 @@ static void rscon(prte_rml_recovery_status_t* p){
     p->scope = PRTE_RML_FAULT_SCOPE_LOCAL;
     p->failed_ranks = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
     p->promoted = false;
+    p->demoted = false;
 
     p->ancestors_changed = false;
     p->prev_ancestors = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <signal.h>
+#include <sys/time.h>
 #include <pmix.h>
 
 #include "src/mca/base/pmix_mca_base_component_repository.h"
@@ -55,9 +56,78 @@ prte_rml_base_t prte_rml_base = {
     .global_failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .dead_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .absent_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
+    .peer_epochs = NULL,
+    .peer_epochs_size = 0,
 };
 
+uint64_t prte_rml_boot_epoch = 0;
+
 static int verbosity = 0;
+
+/* Grow the per-rank epoch table so index rank is valid, zero-filling new slots
+ * (0 = unknown). Ranks are dense and small, so a flat array indexed by rank is
+ * ample. Runs only on the progress thread, like all RML state. */
+static void ensure_epoch_slot(pmix_rank_t rank)
+{
+    if ((size_t) rank < prte_rml_base.peer_epochs_size) {
+        return;
+    }
+    size_t newsize = (size_t) rank + 8;
+    uint64_t *tmp = (uint64_t *) realloc(prte_rml_base.peer_epochs,
+                                         newsize * sizeof(uint64_t));
+    if (NULL == tmp) {
+        return;
+    }
+    for (size_t i = prte_rml_base.peer_epochs_size; i < newsize; i++) {
+        tmp[i] = 0;
+    }
+    prte_rml_base.peer_epochs = tmp;
+    prte_rml_base.peer_epochs_size = newsize;
+}
+
+bool prte_rml_epoch_ok(pmix_rank_t rank, uint64_t epoch)
+{
+    /* an unstamped message (epoch 0) carries no incarnation claim - accept */
+    if (0 == epoch) {
+        return true;
+    }
+    ensure_epoch_slot(rank);
+    if ((size_t) rank >= prte_rml_base.peer_epochs_size) {
+        /* allocation failed - fail open rather than drop live traffic */
+        return true;
+    }
+    uint64_t known = prte_rml_base.peer_epochs[rank];
+    if (0 == known) {
+        /* first time we have seen this rank - learn its epoch */
+        prte_rml_base.peer_epochs[rank] = epoch;
+        return true;
+    }
+    if (epoch < known) {
+        /* stale incarnation - drop. A newer epoch passes but does not advance
+         * the table here; the arbitrated revival advances it authoritatively. */
+        return false;
+    }
+    return true;
+}
+
+void prte_rml_record_epoch(pmix_rank_t rank, uint64_t epoch)
+{
+    if (0 == epoch) {
+        return;
+    }
+    ensure_epoch_slot(rank);
+    if ((size_t) rank < prte_rml_base.peer_epochs_size) {
+        prte_rml_base.peer_epochs[rank] = epoch;
+    }
+}
+
+uint64_t prte_rml_get_epoch(pmix_rank_t rank)
+{
+    if ((size_t) rank < prte_rml_base.peer_epochs_size) {
+        return prte_rml_base.peer_epochs[rank];
+    }
+    return 0;
+}
 
 void prte_rml_register(void)
 {
@@ -121,6 +191,11 @@ void prte_rml_close(void)
     PMIX_DESTRUCT(&prte_rml_base.global_failed_dmns);
     PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
     PMIX_DESTRUCT(&prte_rml_base.absent_dmns);
+    if (NULL != prte_rml_base.peer_epochs) {
+        free(prte_rml_base.peer_epochs);
+        prte_rml_base.peer_epochs = NULL;
+        prte_rml_base.peer_epochs_size = 0;
+    }
     PMIx_Data_array_destruct(&prte_rml_base.ancestors);
     PMIx_Data_array_destruct(&prte_rml_base.children);
     if (0 <= prte_rml_base.rml_output) {
@@ -151,6 +226,16 @@ int prte_rml_open(void)
      * comes back (the unheal path). Initialized once here for the same reason. */
     PMIX_CONSTRUCT(&prte_rml_base.absent_dmns, pmix_bitmap_t);
     pmix_bitmap_init(&prte_rml_base.absent_dmns, prte_process_info.num_daemons);
+
+    /* Capture this process's boot epoch (incarnation): a millisecond wall-clock
+     * timestamp taken once here. A departed daemon that reboots into the same
+     * rank returns with a strictly-greater epoch, letting peers drop late
+     * traffic from the stale incarnation. Millisecond granularity keeps the
+     * degenerate same-timestamp reboot vanishingly unlikely; the HNP's return
+     * validation (strictly-greater epoch) catches it if it ever happens. */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    prte_rml_boot_epoch = (uint64_t) tv.tv_sec * 1000 + (uint64_t) tv.tv_usec / 1000;
 
     /* set up failure notification receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_DIED, true,
@@ -264,6 +349,10 @@ static void send_cons(prte_rml_send_t *ptr)
     ptr->cbdata = NULL;
     ptr->dbuf = NULL;
     ptr->seq_num = 0xFFFFFFFF;
+    /* Default to this process's own epoch: a message built here originates
+     * here. The relay path overrides this with the origin's epoch carried in
+     * the received wire header so a relayed message keeps its original stamp. */
+    ptr->epoch = prte_rml_boot_epoch;
 }
 static void send_des(prte_rml_send_t *ptr)
 {

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -158,6 +158,12 @@ int prte_rml_open(void)
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_ADOPTED, true,
                   prte_rml_recv_adoption_notice, NULL);
 
+    /* set up return/revival receives for the bootstrap unheal path */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_RETURNED, true,
+                  prte_rml_recv_return_request, NULL);
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_REVIVED, true,
+                  prte_rml_recv_revival_notice, NULL);
+
     /* compute the routing tree - only thing we need to know is the
      * number of daemons in the DVM */
     prte_rml_compute_routing_tree();

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -175,10 +175,19 @@ typedef struct {
     // All daemons globally confirmed to have failed
     pmix_bitmap_t global_failed_dmns;
     // Ranks that have permanently departed the DVM (shrunk out, or lost to a
-    // fault). Unlike failed_dmns, this set is NOT re-initialized by
-    // prte_rml_compute_routing_tree, so it survives the recompute that a grow
-    // triggers and lets the rebuilt tree keep routing around the hole (#2491).
+    // fault in a launched/elastic DVM). Unlike failed_dmns, this set is NOT
+    // re-initialized by prte_rml_compute_routing_tree, so it survives the
+    // recompute that a grow triggers and lets the rebuilt tree keep routing
+    // around the hole (#2491).
     pmix_bitmap_t dead_dmns;
+    // Ranks currently absent from a bootstrapped DVM because their node was
+    // lost (e.g. powered off) but which may return with the same rank when the
+    // node reboots. Like dead_dmns this persists across compute_routing_tree
+    // recomputes and is restored into failed_dmns, so the tree routes around
+    // the hole while the daemon is gone; unlike dead_dmns it is cleared when
+    // the daemon returns (the "unheal" path). Only bootstrap faults populate
+    // it -- a launched/elastic departure remains permanent in dead_dmns.
+    pmix_bitmap_t absent_dmns;
 
     // Track all ancestors up to HNP, to simplify fault handling
     pmix_data_array_t ancestors;

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -189,6 +189,14 @@ typedef struct {
     // it -- a launched/elastic departure remains permanent in dead_dmns.
     pmix_bitmap_t absent_dmns;
 
+    // Highest boot epoch (incarnation) known for each daemon rank, indexed by
+    // rank; 0 means "not yet learned". A rebooted bootstrap daemon returns with
+    // a strictly-greater epoch, so traffic stamped with an older epoch for a
+    // rank is a stale incarnation and is dropped. Grown on demand as ranks
+    // appear; see prte_rml_epoch_ok / prte_rml_record_epoch.
+    uint64_t *peer_epochs;
+    size_t peer_epochs_size;
+
     // Track all ancestors up to HNP, to simplify fault handling
     pmix_data_array_t ancestors;
     // My immediate ancestor
@@ -205,6 +213,23 @@ typedef struct {
 } prte_rml_base_t;
 
 PRTE_EXPORT extern prte_rml_base_t prte_rml_base;
+
+/* This process's boot epoch (incarnation) - a millisecond wall-clock timestamp
+ * captured once at startup. A daemon that departs and reboots into the same
+ * rank comes back with a strictly-greater epoch. Stamped into every outgoing
+ * message's wire header as the origin's epoch. */
+PRTE_EXPORT extern uint64_t prte_rml_boot_epoch;
+
+/* Incarnation guard. prte_rml_epoch_ok records rank's epoch on first sight and
+ * returns false only for traffic stamped with an epoch strictly older than the
+ * one already known for that rank (a stale incarnation to be dropped); a newer
+ * epoch passes but does not advance the table (the arbitrated revival does
+ * that). prte_rml_record_epoch force-sets the authoritative epoch for a rank
+ * (used by the revival path and the HNP's return validation);
+ * prte_rml_get_epoch reads it (0 if unknown). */
+PRTE_EXPORT bool prte_rml_epoch_ok(pmix_rank_t rank, uint64_t epoch);
+PRTE_EXPORT void prte_rml_record_epoch(pmix_rank_t rank, uint64_t epoch);
+PRTE_EXPORT uint64_t prte_rml_get_epoch(pmix_rank_t rank);
 
 PRTE_EXPORT void prte_rml_register(void);
 PRTE_EXPORT void prte_rml_close(void);

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -230,6 +230,17 @@ PRTE_EXPORT void prte_rml_recv_adoption_notice(int status, pmix_proc_t *sender,
                                                pmix_data_buffer_t* buf,
                                                prte_rml_tag_t tag,
                                                void *cbdata);
+/* A bootstrap daemon announces its (re)appearance to the HNP; the HNP
+ * validates the rank is currently absent and broadcasts a revival. */
+PRTE_EXPORT void prte_rml_send_return_notice(void);
+PRTE_EXPORT void prte_rml_recv_return_request(int status, pmix_proc_t *sender,
+                                              pmix_data_buffer_t* buf,
+                                              prte_rml_tag_t tag,
+                                              void *cbdata);
+PRTE_EXPORT void prte_rml_recv_revival_notice(int status, pmix_proc_t *sender,
+                                              pmix_data_buffer_t* buf,
+                                              prte_rml_tag_t tag,
+                                              void *cbdata);
 PRTE_EXPORT int prte_rml_route_lost(pmix_rank_t route);
 PRTE_EXPORT pmix_rank_t prte_rml_get_route(pmix_rank_t target);
 PRTE_EXPORT int prte_rml_get_subtree_index(pmix_rank_t target);

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -219,6 +219,7 @@ PRTE_EXPORT void prte_rml_compute_routing_tree(void);
 PRTE_EXPORT void prte_rml_update_ancestors(pmix_data_array_t* ancestors);
 PRTE_EXPORT void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks,
                                               bool global);
+PRTE_EXPORT void prte_rml_revive_routing_tree(pmix_rank_t rank);
 PRTE_EXPORT void prte_rml_fault_handler(const prte_rml_recovery_status_t* s);
 PRTE_EXPORT int prte_rml_get_num_contributors(pmix_rank_t *dmns, size_t ndmns);
 PRTE_EXPORT void prte_rml_recv_failures_notice(int status, pmix_proc_t *sender,

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -353,3 +353,95 @@ void prte_rml_fault_handler(const prte_rml_recovery_status_t* status){
     send_adoption_notices(status);
     send_failures_notice(status);
 }
+
+/* Bootstrap trigger: a daemon that has just come up announces itself to the
+ * HNP. If this is a genuine return (the HNP still has our rank marked absent)
+ * the HNP will broadcast a revival; if it is a first boot the HNP finds the
+ * rank live and ignores it, so the send is always safe to make. */
+void prte_rml_send_return_notice(void){
+    pmix_data_buffer_t* msg = PMIx_Data_buffer_create();
+    pmix_rank_t rank = PRTE_PROC_MY_NAME->rank;
+    int ret = PMIx_Data_pack(NULL, msg, &rank, 1, PMIX_PROC_RANK);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+    PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, msg, PRTE_RML_TAG_DAEMON_RETURNED);
+    if(PRTE_SUCCESS != ret){
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+    }
+}
+
+/* HNP side: validate a daemon's return and, if it really was absent, broadcast
+ * the revival so every daemon re-inserts the rank into its routing tree. */
+void prte_rml_recv_return_request(
+    int status, pmix_proc_t* sender, pmix_data_buffer_t* buf,
+    prte_rml_tag_t tag, void* cbdata
+) {
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    /* Only the DVM master arbitrates returns. */
+    if(!PRTE_PROC_IS_MASTER){
+        return;
+    }
+
+    int cnt = 1;
+    pmix_rank_t rank;
+    int ret = PMIx_Data_unpack(NULL, buf, &rank, &cnt, PMIX_PROC_RANK);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        return;
+    }
+
+    /* Idempotent: a rank that is not currently absent (a first boot, a
+     * duplicate notice, or one we already revived) needs no action. */
+    if(!pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, rank)){
+        return;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_rml_base.routed_output,
+                         "%s routed:radix: daemon %s returned; broadcasting"
+                         " revival", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         PRTE_VPID_PRINT(rank)));
+
+    /* Broadcast the revival. We do NOT revive our own tree here: the master
+     * relays its own xcast back through the normal receive path, so we converge
+     * via prte_rml_recv_revival_notice like everyone else -- and, crucially, on
+     * the xcast's forward-first path. If we are the returned rank's parent we
+     * are currently holding its orphaned children; reviving early would drop
+     * them from our tree before the xcast forwards to them, stranding them.
+     * Forward-first delivery reshapes our tree only after those children have
+     * been handed the notice. The xcast travels the current tree, which routes
+     * around the absent rank, so it need not (and will not) reach the returned
+     * daemon itself -- that daemon already computed a healthy tree. */
+    pmix_data_buffer_t* msg = PMIx_Data_buffer_create();
+    ret = PMIx_Data_pack(NULL, msg, &rank, 1, PMIX_PROC_RANK);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+    prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON_REVIVED, msg);
+    PMIX_DATA_BUFFER_RELEASE(msg);
+}
+
+/* All daemons: converge on a broadcast revival by re-inserting the returned
+ * rank into the local routing tree. Idempotent via prte_rml_revive_routing_tree
+ * (a no-op if the rank is not marked absent here). */
+void prte_rml_recv_revival_notice(
+    int status, pmix_proc_t* sender, pmix_data_buffer_t* buf,
+    prte_rml_tag_t tag, void* cbdata
+) {
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    int cnt = 1;
+    pmix_rank_t rank;
+    int ret = PMIx_Data_unpack(NULL, buf, &rank, &cnt, PMIX_PROC_RANK);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        return;
+    }
+    prte_rml_revive_routing_tree(rank);
+}

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -372,6 +372,14 @@ void prte_rml_send_return_notice(void){
         PMIX_DATA_BUFFER_RELEASE(msg);
         return;
     }
+    /* announce our boot epoch so the HNP can confirm this is a strictly-newer
+     * incarnation and propagate it in the revival for the stale-message guard */
+    ret = PMIx_Data_pack(NULL, msg, &prte_rml_boot_epoch, 1, PMIX_UINT64);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
     PRTE_RML_SEND(ret, PRTE_PROC_MY_PARENT->rank, msg,
                   PRTE_RML_TAG_DAEMON_RETURNED);
     if(PRTE_SUCCESS != ret){
@@ -399,6 +407,13 @@ void prte_rml_recv_return_request(
         PMIX_ERROR_LOG(ret);
         return;
     }
+    cnt = 1;
+    uint64_t epoch = 0;
+    ret = PMIx_Data_unpack(NULL, buf, &epoch, &cnt, PMIX_UINT64);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        return;
+    }
 
     /* Idempotent filter: if this rank is not absent in our view, there is
      * nothing to revive -- drop it here rather than burden anyone upstream. */
@@ -417,6 +432,12 @@ void prte_rml_recv_return_request(
             PMIX_DATA_BUFFER_RELEASE(up);
             return;
         }
+        ret = PMIx_Data_pack(NULL, up, &epoch, 1, PMIX_UINT64);
+        if(PMIX_SUCCESS != ret){
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(up);
+            return;
+        }
         PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, up,
                       PRTE_RML_TAG_DAEMON_RETURNED);
         if(PRTE_SUCCESS != ret){
@@ -425,6 +446,16 @@ void prte_rml_recv_return_request(
         }
         return;
     }
+
+    /* Arbiter: accept the return only if it announces a strictly-newer
+     * incarnation than the one we last recorded for this rank. A stale or
+     * duplicate epoch (including the degenerate same-timestamp reboot) is
+     * dropped, forcing the daemon to retry with a later epoch. Record the new
+     * epoch as authoritative before broadcasting so the guard is armed. */
+    if(0 != epoch && epoch <= prte_rml_get_epoch(rank)){
+        return;
+    }
+    prte_rml_record_epoch(rank, epoch);
 
     PMIX_OUTPUT_VERBOSE((1, prte_rml_base.routed_output,
                          "%s routed:radix: daemon %s returned; broadcasting"
@@ -443,6 +474,12 @@ void prte_rml_recv_return_request(
      * daemon itself -- that daemon already computed a healthy tree. */
     pmix_data_buffer_t* msg = PMIx_Data_buffer_create();
     ret = PMIx_Data_pack(NULL, msg, &rank, 1, PMIX_PROC_RANK);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+    ret = PMIx_Data_pack(NULL, msg, &epoch, 1, PMIX_UINT64);
     if(PMIX_SUCCESS != ret){
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(msg);
@@ -468,5 +505,15 @@ void prte_rml_recv_revival_notice(
         PMIX_ERROR_LOG(ret);
         return;
     }
+    cnt = 1;
+    uint64_t epoch = 0;
+    ret = PMIx_Data_unpack(NULL, buf, &epoch, &cnt, PMIX_UINT64);
+    if(PMIX_SUCCESS != ret){
+        PMIX_ERROR_LOG(ret);
+        return;
+    }
+    /* Record the returned incarnation's epoch as authoritative before rewiring,
+     * so any late traffic from the old incarnation is dropped from here on. */
+    prte_rml_record_epoch(rank, epoch);
     prte_rml_revive_routing_tree(rank);
 }

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -354,10 +354,15 @@ void prte_rml_fault_handler(const prte_rml_recovery_status_t* status){
     send_failures_notice(status);
 }
 
-/* Bootstrap trigger: a daemon that has just come up announces itself to the
- * HNP. If this is a genuine return (the HNP still has our rank marked absent)
- * the HNP will broadcast a revival; if it is a first boot the HNP finds the
- * rank live and ignores it, so the send is always safe to make. */
+/* Bootstrap trigger: a daemon that has just come up announces itself to its
+ * parent (one hop up its lifeline), NOT to the HNP. Its parent is precisely the
+ * daemon that knows whether this rank was absent -- the global death broadcast
+ * marked it everywhere -- so the parent can tell a genuine return from a first
+ * boot and only escalate the former. Announcing to the parent instead of the
+ * root keeps a returning daemon off the root's back: on a first boot every
+ * parent simply drops the notice, so the root sees nothing (beyond its own few
+ * direct children) and no daemon opens a socket to the root. The notice rides
+ * the existing lifeline link, so it costs no new connection. */
 void prte_rml_send_return_notice(void){
     pmix_data_buffer_t* msg = PMIx_Data_buffer_create();
     pmix_rank_t rank = PRTE_PROC_MY_NAME->rank;
@@ -367,25 +372,25 @@ void prte_rml_send_return_notice(void){
         PMIX_DATA_BUFFER_RELEASE(msg);
         return;
     }
-    PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, msg, PRTE_RML_TAG_DAEMON_RETURNED);
+    PRTE_RML_SEND(ret, PRTE_PROC_MY_PARENT->rank, msg,
+                  PRTE_RML_TAG_DAEMON_RETURNED);
     if(PRTE_SUCCESS != ret){
         PRTE_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(msg);
     }
 }
 
-/* HNP side: validate a daemon's return and, if it really was absent, broadcast
- * the revival so every daemon re-inserts the rank into its routing tree. */
+/* Handle a return announcement. A daemon sends this one hop to its parent; the
+ * parent that finds the rank absent escalates one relayed message to the HNP,
+ * and the HNP -- the single arbiter -- broadcasts the revival. A daemon that
+ * does not have the rank marked absent (a first boot, a duplicate, or one it
+ * already revived) drops the notice, so the whole exchange is idempotent and,
+ * on the common first-boot path, never reaches the root at all. */
 void prte_rml_recv_return_request(
     int status, pmix_proc_t* sender, pmix_data_buffer_t* buf,
     prte_rml_tag_t tag, void* cbdata
 ) {
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
-
-    /* Only the DVM master arbitrates returns. */
-    if(!PRTE_PROC_IS_MASTER){
-        return;
-    }
 
     int cnt = 1;
     pmix_rank_t rank;
@@ -395,9 +400,29 @@ void prte_rml_recv_return_request(
         return;
     }
 
-    /* Idempotent: a rank that is not currently absent (a first boot, a
-     * duplicate notice, or one we already revived) needs no action. */
+    /* Idempotent filter: if this rank is not absent in our view, there is
+     * nothing to revive -- drop it here rather than burden anyone upstream. */
     if(!pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, rank)){
+        return;
+    }
+
+    /* Not the arbiter: pass the notice one step toward the HNP. The message is
+     * addressed to the HNP, so intermediate hops relay it without processing;
+     * only the master's handler runs. This is O(1) per real return. */
+    if(!PRTE_PROC_IS_MASTER){
+        pmix_data_buffer_t* up = PMIx_Data_buffer_create();
+        ret = PMIx_Data_pack(NULL, up, &rank, 1, PMIX_PROC_RANK);
+        if(PMIX_SUCCESS != ret){
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(up);
+            return;
+        }
+        PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, up,
+                      PRTE_RML_TAG_DAEMON_RETURNED);
+        if(PRTE_SUCCESS != ret){
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(up);
+        }
         return;
     }
 

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -181,6 +181,12 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 #define PRTE_RML_TAG_RELM_STATE           78
 #define PRTE_RML_TAG_RELM_LINK            79
 
+/* daemon return / revival (the bootstrap "unheal" path): a rebooted daemon
+ * announces itself to the HNP with DAEMON_RETURNED; the HNP broadcasts
+ * DAEMON_REVIVED so every daemon re-inserts the returned rank into its tree */
+#define PRTE_RML_TAG_DAEMON_RETURNED      80
+#define PRTE_RML_TAG_DAEMON_REVIVED       81
+
 #define PRTE_RML_TAG_MAX                 100
 
 #define PRTE_RML_TAG_NTOH(t) ntohl(t)

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -315,6 +315,13 @@ typedef struct {
     // Similar reasoning applies to our parent.
     bool promoted;
 
+    // The mirror of promoted, set by the unheal path: a daemon that had
+    // departed returned, re-inserting itself above us, so our ancestor list
+    // grew and our subtree shrank. As with promotion, handlers should treat
+    // the re-homing children as new, because a child that briefly routed
+    // through the grandparent must discard that lineage.
+    bool demoted;
+
     bool ancestors_changed;
     pmix_data_array_t prev_ancestors; // pmix_rank_t
 

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -231,6 +231,11 @@ typedef struct {
     pmix_data_buffer_t *dbuf;
     /* msg seq number */
     uint32_t seq_num;
+    /* boot epoch (incarnation) of the origin. Defaults to this process's own
+     * epoch when a message originates here; a relayed message carries the
+     * original sender's epoch, copied from the received wire header. Lets a
+     * hop drop traffic from a stale incarnation of a rebooted bootstrap rank. */
+    uint64_t epoch;
 } prte_rml_send_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_rml_send_t);
 

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -393,6 +393,17 @@ void prte_rml_revive_routing_tree(pmix_rank_t rank){
     // re-takes its slot above us if it was our ancestor (demoting us), or
     // re-takes its subtree if it was our descendant (shrinking our children).
     // The repair helpers inside route around any daemons still failed.
+    //
+    // Partial returns are handled here for free. After the bit clear above, the
+    // failed set is exactly what compute_routing_tree would hold for the same
+    // set of still-absent ranks, and build_tree_from_base is the very helper
+    // both routines share -- so a revival produces the identical tree a fresh
+    // compute would, for any failed set. If the returned rank is itself below
+    // another still-absent ancestor, or if several daemons in one subtree are
+    // absent and only some return, update_ancestors simply starts from the
+    // full-depth base list and drops whatever is still failed: the returned
+    // rank reappears at its slot while the still-absent ones stay skipped. No
+    // partial-return case needs special handling.
     build_tree_from_base();
 
     // Compute the delta. A revival can only *lengthen* our ancestor list -- the
@@ -449,13 +460,40 @@ void prte_rml_revive_routing_tree(pmix_rank_t rank){
                              prte_rml_base.ancestors.size));
     }
 
-    // TODO(unheal Stage 3/4): notify the components of the revival. The fault
-    // handlers cannot be reused as-is -- they read the status as a *fault* and
-    // would purge the returned rank and emit death/adoption notices. The
-    // parallel revival path (re-home notice down, rejoin/rollup up) and the
-    // RELM re-drive are added in the following stages; for now the local
-    // recompute stands on its own and is behavior-safe because nothing calls
-    // this routine yet.
+    // Notify the components so their in-flight state re-drives over the
+    // reshaped tree. We do NOT call prte_rml_fault_handler here: that is the
+    // death path (it purges the "failed" ranks and emits adoption/failure
+    // notices), all wrong for a return. The remaining handlers, however, key on
+    // the structural delta -- parent_changed, children_changed -- and a revival
+    // is pure shrinkage from every reshaping daemon's view: the returned rank's
+    // former parent swaps orphans for the rank in its child list, the orphans
+    // point their lifeline back at the rank, and daemons deeper down only gain
+    // an ancestor. None of that trips the promotion-only paths (replay-pending,
+    // op-id-at-promotion), which exist for the growth direction, so the existing
+    // handlers do the right thing without a revival-specific branch.
+    //
+    // The topological re-home needs no separate RML notice: unlike a fault,
+    // which is detected locally and raced against the global broadcast, a
+    // revival is driven entirely by the one DAEMON_REVIVED xcast, so every
+    // daemon recomputes from the same signal and the adoption-style ancestry
+    // reconciliation is unnecessary.
+    //
+    // WATCH ITEM (needs Docker-harness validation, see unheal_plan.rst): RELM
+    // link updates carry a depth stamp and update_link drops any whose depth is
+    // not exactly parent/child +/- 1, and revival changes depths. Static
+    // analysis says this is safe: each daemon recomputes synchronously in
+    // process_msg right after forwarding the xcast to its children, and a
+    // neighbor's link update is a separate message that only arrives a later
+    // event-loop turn, by which point both ends have settled on their new
+    // depths -- the sender because fault_handler runs after the rebuild here,
+    // the receiver because it recomputed the moment it forwarded. The multi-hop
+    // gating (the upstream/downstream "links updated" bitmaps) is subtle enough
+    // that this ordering argument must still be confirmed on the harness, but no
+    // change is expected.
+    const prte_rml_recovery_status_t* s = &status;
+    prte_grpcomm.fault_handler(s);
+    prte_filem  .fault_handler(s);
+    prte_relm   .fault_handler(s);
 
     PMIX_DESTRUCT(&status);
 }

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -249,13 +249,23 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
                 continue;
             }
             pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
-            // Record the departure permanently. compute_routing_tree re-inits
-            // failed_dmns on every DVM grow; dead_dmns is not re-initialized, so
-            // restoring it there keeps the rebuilt tree routing around this rank
-            // rather than treating the stale vpid hole as a live daemon (#2491).
-            // The DVM never reuses a daemon vpid, so a departed rank stays a
-            // permanent hole in [0, num_daemons).
-            pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
+            // Record the departure so it survives the recompute a DVM grow
+            // triggers (compute_routing_tree re-inits failed_dmns; the
+            // persistent set is restored there so the rebuilt tree keeps routing
+            // around this rank rather than treating the stale vpid hole as a
+            // live daemon -- #2491).
+            //
+            // In a bootstrapped DVM the departure may be temporary: the node can
+            // reboot and its daemon return with the same rank. Record it as
+            // absent (clearable by the unheal path) rather than dead. In a
+            // launched/elastic DVM a departed vpid is permanent -- no launcher
+            // can re-place a daemon at a specific existing vpid -- so it goes to
+            // dead_dmns exactly as before.
+            if(prte_bootstrap_setup){
+                pmix_bitmap_set_bit(&prte_rml_base.absent_dmns, r);
+            } else {
+                pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
+            }
         }
         ((pmix_rank_t*)status.failed_ranks.array)[j++] = r;
     }
@@ -428,9 +438,14 @@ void prte_rml_compute_routing_tree(void){
     // live daemon and route to that dead vpid, breaking wireup on the grow
     // (#2491). dead_dmns is maintained in prte_rml_repair_routing_tree and is
     // never re-initialized, so it carries the holes across the recompute.
+    // absent_dmns (bootstrap daemons whose node is gone but may return) is
+    // restored the same way: while the daemon is absent the tree must route
+    // around its hole, so it counts as failed for this recompute. It differs
+    // from dead_dmns only in that the unheal path can later clear it.
     bool have_dead = false;
     for(pmix_rank_t r = 0; r < prte_rml_base.n_dmns; r++){
-        if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r)){
+        if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r) ||
+           pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, r)){
             pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
             have_dead = true;
         }

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -224,6 +224,9 @@ static void update_descendants(void){
     return;
 }
 
+// Defined below, shared with prte_rml_compute_routing_tree.
+static void build_tree_from_base(void);
+
 void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
     if(global){
         // Make sure these are given local notice first, but mark as globally
@@ -364,6 +367,99 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
     PMIX_DESTRUCT(&status);
 }
 
+void prte_rml_revive_routing_tree(pmix_rank_t rank){
+    // Only a bootstrap-absent rank can return. A rank that never failed, or one
+    // that is permanently dead (a launched/elastic departure, which is never
+    // recorded as absent), has nothing to revive -- treat it as a no-op so the
+    // operation is idempotent under duplicate/late return notices.
+    if(!pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, rank)){
+        return;
+    }
+
+    // Snapshot the current (healed) tree before we change it: the recovery
+    // status the fault handlers consume is a prev-vs-current delta, and the
+    // constructor captures prev from prte_rml_base as it stands now.
+    prte_rml_recovery_status_t status;
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+
+    // The returned rank is live again. Clear every failure mark for it.
+    // dead_dmns is deliberately left alone -- a revivable rank is never in it,
+    // and the guard above already guaranteed that.
+    pmix_bitmap_clear_bit(&prte_rml_base.failed_dmns, rank);
+    pmix_bitmap_clear_bit(&prte_rml_base.global_failed_dmns, rank);
+    pmix_bitmap_clear_bit(&prte_rml_base.absent_dmns, rank);
+
+    // Rebuild from the base positions with the returned rank now living: it
+    // re-takes its slot above us if it was our ancestor (demoting us), or
+    // re-takes its subtree if it was our descendant (shrinking our children).
+    // The repair helpers inside route around any daemons still failed.
+    build_tree_from_base();
+
+    // Compute the delta. A revival can only *lengthen* our ancestor list -- the
+    // returned rank re-inserts above us -- so a size change means we were
+    // demoted, the mirror of the promotion a fault produces.
+    if(status.prev_ancestors.size != prte_rml_base.ancestors.size){
+        status.ancestors_changed = true;
+        status.demoted = true;
+    } else {
+        for(size_t i = 0; i < status.prev_ancestors.size; i++){
+            pmix_rank_t prev = ((pmix_rank_t*)status.prev_ancestors.array)[i];
+            pmix_rank_t cur = ((pmix_rank_t*)prte_rml_base.ancestors.array)[i];
+            if(prev != cur){
+                status.ancestors_changed = true;
+                break;
+            }
+        }
+    }
+
+    status.parent_changed = status.prev_parent != prte_rml_base.lifeline;
+
+    if(status.prev_children.size != prte_rml_base.children.size){
+        status.children_changed = true;
+        // A convenience for fault handlers, so they can always safely iterate
+        // up to the larger of the two child arrays.
+        if(status.prev_children.size < prte_rml_base.children.size){
+            resize_ranks(&status.prev_children, prte_rml_base.children.size);
+        }
+    } else {
+        for(size_t i = 0; i < status.prev_children.size; i++){
+            pmix_rank_t prev = ((pmix_rank_t*)status.prev_children.array)[i];
+            pmix_rank_t cur = ((pmix_rank_t*)prte_rml_base.children.array)[i];
+            if(prev != cur){
+                status.children_changed = true;
+                break;
+            }
+        }
+    }
+
+    if(status.parent_changed){
+        PMIX_OUTPUT_VERBOSE((1, prte_rml_base.routed_output,
+                             "%s routed:radix: reviving %s with parent update"
+                             " %s->%s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_VPID_PRINT(rank),
+                             PRTE_VPID_PRINT(status.prev_parent),
+                             PRTE_VPID_PRINT(prte_rml_base.lifeline)));
+    }
+    if(status.demoted){
+        PMIX_OUTPUT_VERBOSE((1, prte_rml_base.routed_output,
+                             "%s routed:radix: reviving %s with new depth"
+                             " %lu->%lu", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_VPID_PRINT(rank),
+                             status.prev_ancestors.size,
+                             prte_rml_base.ancestors.size));
+    }
+
+    // TODO(unheal Stage 3/4): notify the components of the revival. The fault
+    // handlers cannot be reused as-is -- they read the status as a *fault* and
+    // would purge the returned rank and emit death/adoption notices. The
+    // parallel revival path (re-home notice down, rejoin/rollup up) and the
+    // RELM re-drive are added in the following stages; for now the local
+    // recompute stands on its own and is behavior-safe because nothing calls
+    // this routine yet.
+
+    PMIX_DESTRUCT(&status);
+}
+
 int prte_rml_route_lost(pmix_rank_t route){
     /* If we have been named as a shrink target, depart now on the first lost
      * connection rather than trying to recover: the DVM has removed us on
@@ -423,34 +519,15 @@ int prte_rml_route_lost(pmix_rank_t route){
     return PRTE_SUCCESS;
 }
 
-void prte_rml_compute_routing_tree(void){
-    // Save our state prior to any daemon failures
-    prte_rml_base.n_dmns = prte_process_info.num_daemons;
-
-    // TODO: Should we save this info when DVM is resized?
-    pmix_bitmap_init(&prte_rml_base.failed_dmns, prte_rml_base.n_dmns);
-    pmix_bitmap_init(&prte_rml_base.global_failed_dmns, prte_rml_base.n_dmns);
-
-    // Restore any permanently-departed daemons into the freshly-initialized
-    // failed set. This routine runs again whenever the DVM grows, and the
-    // pmix_bitmap_init above wipes the failed marks; without restoring them the
-    // rebuilt tree would treat a shrunk-out (or previously failed) rank as a
-    // live daemon and route to that dead vpid, breaking wireup on the grow
-    // (#2491). dead_dmns is maintained in prte_rml_repair_routing_tree and is
-    // never re-initialized, so it carries the holes across the recompute.
-    // absent_dmns (bootstrap daemons whose node is gone but may return) is
-    // restored the same way: while the daemon is absent the tree must route
-    // around its hole, so it counts as failed for this recompute. It differs
-    // from dead_dmns only in that the unheal path can later clear it.
-    bool have_dead = false;
-    for(pmix_rank_t r = 0; r < prte_rml_base.n_dmns; r++){
-        if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r) ||
-           pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, r)){
-            pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
-            have_dead = true;
-        }
-    }
-
+// Derive our placement in the routing tree from the fault-free radix positions,
+// then route around whatever is currently marked failed. Shared by the initial
+// compute and by revival: both must rebuild from the base positions rather than
+// mutate the current (already-healed) arrays. Rebuilding from base is what lets
+// revival re-insert a returned ancestor -- update_ancestors only ever walks a
+// dead ancestor forward to its next living inheritor, so it can shorten a list
+// but never grow one; starting from the full-depth base list and dropping the
+// still-failed ranks yields the correct list in either direction.
+static void build_tree_from_base(void){
     prte_rml_base.cur_node = radix_node(PRTE_PROC_MY_NAME->rank);
 
     // Build array of ancestors
@@ -475,17 +552,44 @@ void prte_rml_compute_routing_tree(void){
     shrink_ranks(&prte_rml_base.children);
     prte_rml_base.n_children = prte_rml_base.children.size;
 
-    // If any daemon has permanently departed, route the freshly-built base
-    // tree around it - the same ancestry/child repair a fault would perform,
-    // minus the fault-handler notifications (this is a recompute, not a new
-    // fault). With the dead ranks restored into failed_dmns above, these
-    // helpers (which consult failed_dmns via radix_is_living) drop the holes
-    // from our ancestors, lifeline, and children.
-    if(have_dead){
-        prte_rml_update_ancestors(&prte_rml_base.ancestors);
-        handle_promotion();
-        update_descendants();
+    // Route the freshly-built base tree around any failed rank - the same
+    // ancestry/child repair a fault would perform. These helpers consult
+    // failed_dmns via radix_is_living and are no-ops when nothing is failed,
+    // so it is safe to run them unconditionally.
+    prte_rml_update_ancestors(&prte_rml_base.ancestors);
+    handle_promotion();
+    update_descendants();
+}
+
+void prte_rml_compute_routing_tree(void){
+    // Save our state prior to any daemon failures
+    prte_rml_base.n_dmns = prte_process_info.num_daemons;
+
+    // TODO: Should we save this info when DVM is resized?
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, prte_rml_base.n_dmns);
+    pmix_bitmap_init(&prte_rml_base.global_failed_dmns, prte_rml_base.n_dmns);
+
+    // Restore any permanently-departed daemons into the freshly-initialized
+    // failed set. This routine runs again whenever the DVM grows, and the
+    // pmix_bitmap_init above wipes the failed marks; without restoring them the
+    // rebuilt tree would treat a shrunk-out (or previously failed) rank as a
+    // live daemon and route to that dead vpid, breaking wireup on the grow
+    // (#2491). dead_dmns is maintained in prte_rml_repair_routing_tree and is
+    // never re-initialized, so it carries the holes across the recompute.
+    // absent_dmns (bootstrap daemons whose node is gone but may return) is
+    // restored the same way: while the daemon is absent the tree must route
+    // around its hole, so it counts as failed for this recompute. It differs
+    // from dead_dmns only in that the unheal path can later clear it.
+    for(pmix_rank_t r = 0; r < prte_rml_base.n_dmns; r++){
+        if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r) ||
+           pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, r)){
+            pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
+        }
     }
+
+    // Derive ancestors, lifeline, and children from the base radix positions
+    // and route around whatever is currently failed (the restored holes above).
+    build_tree_from_base();
 
     // Print verbose output
     if (1 > pmix_output_get_verbosity(prte_rml_base.routed_output)) return;

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -542,6 +542,17 @@ int main(int argc, char *argv[])
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_PRTED_CALLBACK,
                   PRTE_RML_PERSISTENT, rollup, NULL);
 
+    /* In a bootstrapped DVM, announce our appearance to the HNP. On a first
+     * boot the HNP finds our rank live and ignores this; if our node had left
+     * and rebooted, the HNP still has us marked absent and will broadcast a
+     * revival so the DVM re-inserts us into the routing tree (the unheal path).
+     * Only bootstrap daemons do this -- launched daemons cannot return with
+     * their original vpid, so nothing revives them. The controller took the
+     * bootstrap_wait branch above and never reaches here. */
+    if (prte_bootstrap_setup) {
+        prte_rml_send_return_notice();
+    }
+
     if (prte_static_ports || NULL != prte_parent_uri) {
         /* since we will be waiting for any children to send us
          * their rollup info before sending to our parent, save

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -542,9 +542,10 @@ int main(int argc, char *argv[])
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_PRTED_CALLBACK,
                   PRTE_RML_PERSISTENT, rollup, NULL);
 
-    /* In a bootstrapped DVM, announce our appearance to the HNP. On a first
-     * boot the HNP finds our rank live and ignores this; if our node had left
-     * and rebooted, the HNP still has us marked absent and will broadcast a
+    /* In a bootstrapped DVM, announce our appearance one hop up to our parent.
+     * On a first boot the parent finds our rank live and drops the notice, so
+     * the root is never involved; if our node had left and rebooted, the parent
+     * (which had us marked absent) escalates to the HNP, which broadcasts a
      * revival so the DVM re-inserts us into the routing tree (the unheal path).
      * Only bootstrap daemons do this -- launched daemons cannot return with
      * their original vpid, so nothing revives them. The controller took the

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -38,6 +38,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     pmix_rank_t *vpids = NULL;
     uint8_t u8;
     int n, m, ndaemons, nbytes;
+    pmix_rank_t span;
     bool compressed;
     char **names = NULL;
     char **aliases = NULL, **als;
@@ -70,14 +71,34 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         return rc;
     }
 
-    /* pack the size of the daemon vpid space, [0, num_daemons). This can be
-     * larger than the number of live daemons packed below: a DVM shrink leaves
-     * a permanent hole in the vpid space (the DVM never reuses a daemon vpid),
+    /* Pack the size of the daemon vpid space, [0, span). This can be larger
+     * than the number of live daemons packed below: a DVM shrink leaves a
+     * permanent hole in the vpid space (the DVM never reuses a daemon vpid),
      * so the departed daemon has no entry in the name/vpid lists. Receivers
      * need this exact span - not the live count - so their routing tree covers
      * the same rank space the HNP uses, and so they can identify the holes as
-     * permanently-dead ranks to route around (#2491). */
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &prte_process_info.num_daemons, 1, PMIX_PROC_RANK);
+     * permanently-dead ranks to route around (#2491).
+     *
+     * The span must cover every vpid we actually pack below. num_daemons is
+     * normally that span, but it can transiently lag the pool: a bootstrap
+     * daemon that departed and rebooted still has its node->daemon entry (so it
+     * is packed), yet num_daemons is not restored until the daemon formally
+     * reports its (re)launch. Encoding num_daemons as the span in that window
+     * would exclude the top vpid, corrupting the receiver's routing tree. So
+     * pre-scan the pool for the highest daemon vpid and use span =
+     * max(num_daemons, highest_vpid + 1) - large enough to cover every packed
+     * daemon while still preserving a top-of-range shrink hole. */
+    span = prte_process_info.num_daemons;
+    for (n = 0; n < pool->size; n++) {
+        nptr = (prte_node_t *) pmix_pointer_array_get_item(pool, n);
+        if (NULL == nptr || NULL == nptr->daemon) {
+            continue;
+        }
+        if (nptr->daemon->name.rank + 1 > span) {
+            span = nptr->daemon->name.rank + 1;
+        }
+    }
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &span, 1, PMIX_PROC_RANK);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -90,8 +111,9 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
      * all just yet. However, even the largest systems won't
      * have more than a million nodes for quite some time,
      * so for now we'll just allocate enough space to hold
-     * them all. Someone can optimize this further later */
-    nbytes = prte_process_info.num_daemons * sizeof(pmix_rank_t);
+     * them all. Someone can optimize this further later. Size
+     * the buffer to the span so it holds every packed vpid. */
+    nbytes = span * sizeof(pmix_rank_t);
     vpids = (pmix_rank_t *) malloc(nbytes);
 
     ndaemons = 0;
@@ -443,18 +465,30 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         nd->daemon = proc;
     }
 
-    /* Record any vpid holes as permanently-dead ranks. The DVM spans [0, ndmns)
-     * daemon vpids, but a shrunk-out daemon leaves a hole with no entry above,
-     * so daemons->procs has a gap at that rank. Marking the gap in the
-     * persistent dead set makes this daemon's routing tree route around the
-     * hole exactly as the HNP and the surviving daemons do - closing the gap
-     * that a brand-new daemon (empty dead set) would otherwise have (#2491).
-     * On an unshrunk DVM ndmns equals the live count, so nothing is marked and
-     * behavior is unchanged. */
+    /* Record any vpid holes as departed ranks. The DVM spans [0, ndmns) daemon
+     * vpids, but a shrunk-out (or not-yet-present bootstrap) daemon leaves a
+     * hole with no entry above, so daemons->procs has a gap at that rank.
+     * Marking the gap makes this daemon's routing tree route around the hole
+     * exactly as the HNP and the surviving daemons do - closing the gap that a
+     * brand-new daemon (empty failure set) would otherwise have (#2491). On an
+     * unshrunk, fully-present DVM ndmns equals the live count, so nothing is
+     * marked and behavior is unchanged. */
     bool newdead = false;
     for (pmix_rank_t r = 0; r < ndmns; r++) {
-        if (NULL == pmix_pointer_array_get_item(daemons->procs, r) &&
-            !pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r)) {
+        if (NULL != pmix_pointer_array_get_item(daemons->procs, r)) {
+            continue;
+        }
+        // In a bootstrapped DVM a vpid hole is not necessarily permanent: the
+        // node can reboot and its daemon return with the same rank. Record it
+        // as absent (clearable by the unheal path) rather than dead. In a
+        // launched/elastic DVM the hole is permanent (#2491) and goes to
+        // dead_dmns exactly as before.
+        if (prte_bootstrap_setup) {
+            if (!pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, r)) {
+                pmix_bitmap_set_bit(&prte_rml_base.absent_dmns, r);
+                newdead = true;
+            }
+        } else if (!pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r)) {
             pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
             newdead = true;
         }


### PR DESCRIPTION
## Problem

In a launcher-less (bootstrapped) DVM, a compute node can drop out of the
routing tree without the DVM being torn down — its node is powered off,
loses power, or is rebooted — and then *return* when it comes back up, its
daemon booting again into the **same rank**. The RML already **heals** around
the loss (a child promotes to its grandparent). It did not **unheal**: when
the node returned, nothing re-inserted it. `repair_routing_tree` recorded the
departure in the permanent `dead_dmns` set, so `radix_is_living` reported the
rank dead forever and the returned daemon was never re-adopted. The design was
architecturally opposed to reconnection.

This PR implements unheal for a bootstrapped DVM: a returned daemon is
re-inserted into the routing tree, its former children re-home to it, and the
DVM continues to launch jobs across it.

## Approach

Unheal is gated on `prte_bootstrap_setup`; launched/elastic DVMs are untouched
(a bulk launcher cannot re-place a daemon into a specific existing vpid, so the
returned-with-original-rank precondition only exists in bootstrap).

The tree is a deterministic function of `(radix, num_daemons, failed_set)`.
Death removes a rank and recomputes; revival adds it back and recomputes —
symmetric in the routing math, but **not** in the notification code (the repair
path assumes depth only ever decreases). So revival gets its own recompute
built from the base radix positions, which sidesteps the "growing ancestor
list" problem and handles partial returns by reduction.

Staged, each stage independently reviewable:

1. **Split the departure sets** — a new clearable `absent_dmns` (bootstrap
   faults) beside the permanent `dead_dmns` (shrink/#2491, unchanged).
2. **Revival recompute** — `prte_rml_revive_routing_tree`, sharing a
   `build_tree_from_base` helper with `compute_routing_tree`.
3. **Return/revival protocol** — a returned daemon announces itself one hop up;
   the parent filters on its own `absent_dmns` and escalates a genuine return to
   the HNP, which is the sole arbiter and broadcasts `DAEMON_REVIVED`. This
   avoids an N-to-root fan-in (the root never opens a socket per returning
   daemon).
4. **Component re-drive** — the revival recompute notifies grpcomm/filem/relm;
   a revival is pure shrinkage from every reshaping daemon's view, so it reuses
   the existing tested handler paths rather than forking new ones.
5. **State resync** — a late-joining/returned daemon is caught up to the current
   xcast op-id, and the returned-daemon handoff nidmap is corrected (see below).
6. **Incarnation guard** — a boot-epoch wire stamp so late traffic from the old
   incarnation of a rebooted rank is dropped.

## Two correctness fixes surfaced along the way

- **xcast op-id catch-up.** A daemon that joins after the first reliable
  broadcast (grown, returned, or simply late) started its op-id counter at 0
  while the DVM stream was ahead, tripping the strict ordering check and
  force-exiting. It now adopts the intervening ops as complete. This also fixes
  a latent elastic-grow hazard.

- **nidmap vpid span.** The handoff nidmap sent to a returning daemon was
  encoded with `num_daemons` as the vpid span while the departed count was still
  in effect, even though the departed node's `node->daemon` entry (and thus its
  vpid) was still packed. The span came out one short of the highest packed
  vpid, so the returned daemon recomputed a tree that excluded a live daemon and
  misrouted to it. The span is now `max(num_daemons, highest_packed_vpid + 1)`,
  which also fixes a one-entry heap over-write on the encode side and preserves
  the elastic top-of-range shrink hole.

## Testing

Validated on the in-repo Docker multi-node bootstrap/elastic harness
(`contrib/dockerswarm/`):

- **Elastic regression 16/16 PASS** — single/multi-node launch, grow/shrink at
  radix 64 and a radix-2 deep tree with multi-hop relay — confirming the routing
  refactor and the new failure/epoch machinery do not regress the paths every DVM
  uses.
- **Bootstrap unheal end-to-end PASS** — a radix-2 bootstrap DVM; killing the
  interior daemon heals its child up to the grandparent, restarting the daemon
  drives the return/revival broadcast, the child re-homes back, `get_route`
  stays consistent, and a job launched after the unheal runs across the returned
  daemon with every daemon surviving.

Documentation: `docs/plans/bootstrap/unheal_plan.rst` describes the design,
the resolved decisions, and the harness evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
