### PR TITLE
Make proc resource recovery idempotent to avoid a double free

### DIFF
--- a/.github/workflows/prte_mpi4py.yaml
+++ b/.github/workflows/prte_mpi4py.yaml
@@ -111,6 +111,9 @@ jobs:
         mca_params="$HOME/.prte/mca-params.conf"
         mkdir -p "$(dirname "$mca_params")"
         echo rmaps_default_mapping_policy = :oversubscribe >> "$mca_params"
+        mca_params="$HOME/.pmix/mca-params.conf"
+        mkdir -p "$(dirname "$mca_params")"
+        echo mca_base_suppress_deprecated_warning = true >> "$mca_params"
 
     - name: Show MPI
       run:  ompi_info

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -974,6 +974,30 @@ void prte_state_base_recover_resources(prte_job_t *jdata, prte_proc_t *pptr)
     node = pptr->node;
     map = jdata->map;
 
+    /* Find this proc in the node's proc array.  This routine can be entered
+     * more than once for the same proc - e.g. a daemon loss marks the proc
+     * PRTE_PROC_STATE_TERM_WO_SYNC and a subsequent job abort delivers a
+     * second terminal state - so it must be idempotent.  If the proc is no
+     * longer in the node array, its resources were already recovered on an
+     * earlier pass; recovering again would double-decrement the node counters
+     * and, worse, release the proc a second time (see the release below),
+     * freeing an object still held in jdata->procs and corrupting the eventual
+     * job teardown.  So treat an already-recovered proc as a no-op. */
+    proc_idx = INT_MAX;
+    for (n=0; n < node->procs->size; n++) {
+        p = (prte_proc_t*)pmix_pointer_array_get_item(node->procs, n);
+        if (NULL == p) {
+            continue;
+        }
+        if (p == pptr) {
+            proc_idx = n;
+            break;
+        }
+    }
+    if (INT_MAX == proc_idx) {
+        return;
+    }
+
     // recover node resources
     node->slots_inuse--;
     node->num_procs--;
@@ -988,18 +1012,6 @@ void prte_state_base_recover_resources(prte_job_t *jdata, prte_proc_t *pptr)
         }
         if (nptr == node) {
             node_idx = n;
-        }
-    }
-
-    // find the proc in the node array
-    proc_idx = INT_MAX;
-    for (n=0; n < node->procs->size; n++) {
-        p = (prte_proc_t*)pmix_pointer_array_get_item(node->procs, n);
-        if (NULL == p) {
-            continue;
-        }
-        if (p == pptr) {
-            proc_idx = n;
         }
     }
 


### PR DESCRIPTION
`prte_state_base_recover_resources()` can be invoked more than once for
the same proc, and it was not idempotent — leading to a double free that
crashes the launcher on teardown.

## The bug

When a daemon is lost, the HNP marks each proc on the departed node
`PRTE_PROC_STATE_TERM_WO_SYNC`. A subsequent job abort (for example, a
`--timeout` expiry) then delivers a *second* terminal state for that same
proc. Each terminal state on a recoverable job drives another call into
`recover_resources()`.

The routine unconditionally decremented the node resource counters and,
at its tail, unconditionally released the proc "once for the map entry"
— even when the proc had already been removed from the node's proc array
on an earlier pass. The node holds a retained reference for its map entry
(added in `rmaps_base_support_fns.c`, released by the node destructor),
so the first pass correctly drops that reference; the second pass then
drops the job's reference, freeing a proc object still held in
`jdata->procs`. When the job is later torn down, `prte_job_destruct()`
walks `jdata->procs` and releases that already-freed proc, tripping:

```
prte_job_destruct: Assertion `PMIX_OBJ_MAGIC_ID == _obj->obj_magic_id' failed.
```

and aborting the launcher.

## Reproducer

```
prterun --rtos recoverable --host n1:1,n2:1,n3:1,n4:1 -np 4 \
        --map-by node sleep 300
```

then kill the fourth node's `prted`: the surviving procs recover, the
job hits its timeout, and the launcher crashes during teardown. No PMIx
group operation is involved — this is purely the recoverable daemon-loss
path.

I confirmed the reference accounting under gdb: `recover_resources()`
fires twice for the lost node's rank, the proc's reference count goes
2 → 1 → 0, and the freed object then reappears in `prte_job_destruct`
with a corrupted magic id.

## The fix

Locate the proc in the node's array first and return immediately if it
is not present — its resources were already recovered — before touching
any counters or releasing anything. A single recovery per proc is thus
guaranteed, so the map-entry reference is dropped exactly once and the
job's reference survives for `prte_job_destruct()`.

With the fix, the reproducer above tears down cleanly with no assertion.