### PR TITLE
grpcomm: group construct fault tolerance (daemon loss and cross-server cancel)

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -232,6 +232,16 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        [$prte_pmix_have_regex2],
                        [Whether or not PMIx supports the PMIx_generate_regex2 API])
 
+    AC_MSG_CHECKING([for PMIx group fault-tolerance support])
+    PRTE_CHECK_PMIX_CAP([GROUP_FT],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_have_group_ft=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_have_group_ft=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_HAVE_GROUP_FT],
+                       [$prte_pmix_have_group_ft],
+                       [Whether PMIx supports the group fault-tolerance feature set, including the PMIX_GROUP_CANCEL host operation])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -81,17 +81,100 @@ int prte_grpcomm_direct_group(pmix_group_operation_t op, char *grpid,
     return PRTE_SUCCESS;
 }
 
+/* Abort an in-flight group collective cleanly instead of tearing down the DVM.
+ * Only the HNP calls this - it is the master of every group op (rollups
+ * converge there) and the sole xcast source. It broadcasts a GROUP_RELEASE
+ * carrying just the signature and a completion status; that drives each
+ * daemon's prte_grpcomm_direct_grp_release to complete its local participants
+ * with that status and delete the tracker (see the PMIX_SUCCESS != st path
+ * there). No membership/grpinfo/endpts payload is needed: the release reader
+ * skips all of that for a non-success construct, and a destruct never reads it. */
+static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
+{
+    pmix_data_buffer_t *reply;
+    pmix_status_t rc;
+
+    PMIX_DATA_BUFFER_CREATE(reply);
+    /* pack the signature */
+    rc = pack_signature(reply, coll->sig);
+    if (PMIX_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    /* pack the completion status */
+    rc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    /* send the release via xcast to all daemons (ourselves included) */
+    (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
+}
+
 void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* status)
 {
-    PRTE_HIDE_UNUSED_PARAMS(status);
-    /* TODO: make this actually resilient
-     * For now, we'll just kill the job if any ops are active */
-    if(0 < pmix_list_get_size(&prte_mca_grpcomm_direct_component.group_ops)){
+    prte_grpcomm_group_t *coll, *nxt;
+    const pmix_rank_t *failed;
+    size_t i, j;
+    bool affected;
+    pmix_status_t st;
+
+    /* Drive group-collective recovery exactly once, from the HNP, during the
+     * global-scope pass. The HNP is the master of every group op and the sole
+     * xcast source, and the global pass reports the same failed_ranks on every
+     * rank in a consistent order; other daemons complete their local
+     * participants when the HNP's abort release arrives. (The tree-topology
+     * fields are cleared in the global pass, but failed_ranks - the identity of
+     * the failure - is exactly what the global notification carries.) */
+    if (PRTE_RML_FAULT_SCOPE_GLOBAL != status->scope) {
+        return;
+    }
+    if (!PRTE_PROC_IS_MASTER) {
+        return;
+    }
+    if (0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.group_ops)) {
+        return;
+    }
+
+    failed = (const pmix_rank_t *) status->failed_ranks.array;
+
+    /* Abort every in-flight group op that a failed daemon participated in. This
+     * is the resilient replacement for tearing down the whole DVM. Completing a
+     * construct on the survivors (degraded, reduced membership) when
+     * PMIX_GROUP_FT_COLLECTIVE was requested is a larger distributed-recovery
+     * effort tracked separately; for now the loss of a participating daemon
+     * aborts the affected construct regardless of that flag. A destruct is
+     * tearing the group down anyway, so it is simply completed. */
+    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops, prte_grpcomm_group_t) {
+        affected = false;
+        if (NULL == coll->dmns || 0 == coll->ndmns) {
+            /* the daemon set was never resolved (e.g. a bootstrap op), so we
+             * cannot prove this op is unaffected - abort it to be safe rather
+             * than risk leaving its participants blocked forever */
+            affected = true;
+        } else {
+            for (i = 0; i < status->failed_ranks.size && !affected; i++) {
+                for (j = 0; j < coll->ndmns; j++) {
+                    if (coll->dmns[j] == failed[i]) {
+                        affected = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!affected) {
+            continue;
+        }
+        st = (PMIX_GROUP_CONSTRUCT == coll->sig->op) ? PMIX_GROUP_CONSTRUCT_ABORT
+                                                     : PMIX_SUCCESS;
         PMIX_OUTPUT_VERBOSE((0, prte_grpcomm_base_framework.framework_output,
-                             "%s grpcomm:direct:group daemon failed during"
-                             " active group operation(s)",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
+                             "%s grpcomm:direct:group aborting op \"%s\" - a "
+                             "participating daemon failed",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             coll->sig->groupID));
+        abort_group_op(coll, st);
     }
 }
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -113,6 +113,64 @@ static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
     (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
 }
 
+/* Locate the in-flight construct tracker for a group by name. Used when a
+ * cancel arrives: the cancel carries op == PMIX_GROUP_CANCEL, which by design
+ * does not match the construct tracker's op, so we look it up by groupID. */
+static prte_grpcomm_group_t* find_construct_op(const char *groupID)
+{
+    prte_grpcomm_group_t *coll;
+
+    PMIX_LIST_FOREACH(coll, &prte_mca_grpcomm_direct_component.group_ops, prte_grpcomm_group_t) {
+        if (PMIX_GROUP_CONSTRUCT == coll->sig->op &&
+            0 == strcmp(groupID, coll->sig->groupID)) {
+            return coll;
+        }
+    }
+    return NULL;
+}
+
+/* Route a group-cancel request to the HNP. Called on the daemon whose PMIx
+ * server requested the cancel (e.g. its client hit the construct timeout). We
+ * carry just a signature (op == PMIX_GROUP_CANCEL + groupID) up to the HNP,
+ * which locates the in-flight construct and aborts it (see the CANCEL branch in
+ * prte_grpcomm_direct_grp_recv). That abort completes every participant's
+ * PMIx_Group_construct with PMIX_GROUP_CONSTRUCT_ABORT via the normal release
+ * path, so the cancel itself is simply acknowledged once dispatched. */
+static void request_group_cancel(prte_pmix_grp_caddy_t *cd)
+{
+    prte_grpcomm_direct_group_signature_t sig;
+    pmix_data_buffer_t *relay;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
+    sig.op = PMIX_GROUP_CANCEL;
+    sig.groupID = strdup(cd->grpid);
+
+    PMIX_DATA_BUFFER_CREATE(relay);
+    rc = pack_signature(relay, &sig);
+    PMIX_DESTRUCT(&sig);
+    if (PMIX_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        goto ack;
+    }
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, relay, PRTE_RML_TAG_GROUP);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        rc = prte_pmix_convert_rc(rc);
+        goto ack;
+    }
+    /* the cancel has been dispatched - acknowledge success. The construct abort
+     * is delivered separately through the construct's own release. */
+    rc = PMIX_SUCCESS;
+
+ack:
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+    }
+}
+
 void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* status)
 {
     prte_grpcomm_group_t *coll, *nxt;
@@ -193,6 +251,14 @@ static void group(int sd, short args, void *cbdata)
     pmix_info_t *info;
     size_t ninfo;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* a cancel is not a rollup collective - route it to the HNP to abort the
+     * in-flight construct, then we are done */
+    if (PMIX_GROUP_CANCEL == cd->op) {
+        request_group_cancel(cd);
+        PMIX_RELEASE(cd);
+        return;
+    }
 
     /* compute the signature of this collective */
     PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
@@ -428,6 +494,24 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     rc = unpack_signature(buffer, &sig);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+    }
+
+    /* a cancel request carries only the signature. Only the HNP acts - it is
+     * the sole xcast source. Find the in-flight construct for this group and
+     * abort it; the resulting release completes every participant's
+     * PMIx_Group_construct with PMIX_GROUP_CONSTRUCT_ABORT. A missing tracker
+     * means the construct already resolved, so there is nothing to cancel.
+     * Note we must handle this before get_tracker, which would otherwise create
+     * a spurious cancel tracker. */
+    if (PMIX_GROUP_CANCEL == sig->op) {
+        if (PRTE_PROC_IS_MASTER) {
+            coll = find_construct_op(sig->groupID);
+            if (NULL != coll) {
+                abort_group_op(coll, PMIX_GROUP_CONSTRUCT_ABORT);
+            }
+        }
+        PMIX_RELEASE(sig);
+        return;
     }
 
     /* check for the tracker and create it if not found */

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -113,6 +113,7 @@ static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
     (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
 }
 
+#if PRTE_PMIX_HAVE_GROUP_FT
 /* Locate the in-flight construct tracker for a group by name. Used when a
  * cancel arrives: the cancel carries op == PMIX_GROUP_CANCEL, which by design
  * does not match the construct tracker's op, so we look it up by groupID. */
@@ -170,6 +171,7 @@ ack:
         cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
     }
 }
+#endif /* PRTE_PMIX_HAVE_GROUP_FT */
 
 void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* status)
 {
@@ -252,6 +254,7 @@ static void group(int sd, short args, void *cbdata)
     size_t ninfo;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
+#if PRTE_PMIX_HAVE_GROUP_FT
     /* a cancel is not a rollup collective - route it to the HNP to abort the
      * in-flight construct, then we are done */
     if (PMIX_GROUP_CANCEL == cd->op) {
@@ -259,6 +262,7 @@ static void group(int sd, short args, void *cbdata)
         PMIX_RELEASE(cd);
         return;
     }
+#endif
 
     /* compute the signature of this collective */
     PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
@@ -496,6 +500,7 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
         PRTE_ERROR_LOG(rc);
     }
 
+#if PRTE_PMIX_HAVE_GROUP_FT
     /* a cancel request carries only the signature. Only the HNP acts - it is
      * the sole xcast source. Find the in-flight construct for this group and
      * abort it; the resulting release completes every participant's
@@ -513,6 +518,7 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
         PMIX_RELEASE(sig);
         return;
     }
+#endif
 
     /* check for the tracker and create it if not found */
     if (NULL == (coll = get_tracker(sig, true))) {


### PR DESCRIPTION
Adds launcher-side support for the PMIx group construct fault paths, the
companion to openpmix/openpmix#3946. Together they let an in-flight group
construct abort cleanly on a member or daemon loss instead of hanging (or
tearing down the whole DVM).

## What changed (grpcomm/direct)

- **Abort group ops on daemon loss instead of killing the DVM.** The
  group fault handler no longer tears the DVM down when a daemon is lost.
  Running on the HNP during the global-scope fault pass, it xcasts a
  `GROUP_RELEASE` (signature + status) for every in-flight op whose daemon
  set includes a failed rank: a construct is released with
  `PMIX_GROUP_CONSTRUCT_ABORT`, a destruct with success, and an op whose
  daemon set was never resolved is aborted conservatively.
- **Handle `PMIX_GROUP_CANCEL`.** When a PMIx server aborts a construct
  locally (member loss or `PMIX_TIMEOUT`), it issues `PMIX_GROUP_CANCEL`
  to the host to unstick the cross-server collective the other servers
  already joined. `group()` routes a minimal cancel signature to the HNP,
  which locates the in-flight construct by group ID and aborts it via the
  same release path.
- **Guard the cancel handling on `PMIX_CAP_GROUP_FT`.** `PMIX_GROUP_CANCEL`
  is an enumerator, so it cannot be `#ifdef`'d directly; a configure check
  (`PRTE_CHECK_PMIX_CAP([GROUP_FT])` -> `PRTE_PMIX_HAVE_GROUP_FT`) gates
  the cancel code so PRRTE still builds against a PMIx that predates the
  capability. The daemon-loss abort path is unconditional.

## Dependency

Requires openpmix/openpmix#3946 to be installed: the build detects
`PMIX_CAP_GROUP_FT` from the installed `pmix_version.h`, and the
`PMIX_GROUP_CANCEL` operation is defined there. Built against an older
PMIx, the cancel handling compiles out and the daemon-loss abort still
works.

## Testing

Exercised in a ten-node container swarm (the dockerswarm harness in
openpmix/openpmix#3946): a required member lost mid-construct aborts on
every survivor across servers via `PMIX_GROUP_CANCEL`, and a whole-daemon
loss mid-construct aborts the pending construct on the survivors rather
than hanging. Both return `PMIX_GROUP_CONSTRUCT_ABORT` to every survivor.

## Scope / follow-ups

- Full degraded-mode *survival* on daemon loss (keeping the DVM alive with
  a reduced-membership group) is deliberately out of scope and tracked as
  #2510.
- The daemon-loss teardown also exposed a pre-existing double free
  unrelated to groups, fixed separately in #2511; it is not required for
  this PR but makes the recoverable daemon-loss path crash-free.