### PR TITLE
Make the odls fork/exec child path async-signal-safe

### DIFF
--- a/config/prte_check_setaffinity.m4
+++ b/config/prte_check_setaffinity.m4
@@ -1,0 +1,51 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2026      Nanook Consulting  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# See if we have sched_setaffinity(2) and the cpu_set_t API (a glibc/Linux
+# bundle).  When available, the odls child can bind itself just before
+# execve() by issuing a bare sched_setaffinity() syscall - which is
+# async-signal-safe - instead of calling hwloc, which allocates.  On
+# platforms without it (e.g., macOS) the child falls back to hwloc.
+
+AC_DEFUN([PRTE_CHECK_SETAFFINITY],[
+
+    PRTE_VAR_SCOPE_PUSH([prte_have_sched_setaffinity])
+
+    prte_have_sched_setaffinity=0
+
+    AC_CHECK_HEADERS([sched.h])
+
+    AC_CHECK_FUNC([sched_setaffinity],
+                  [AC_MSG_CHECKING([for usable cpu_set_t and CPU_ALLOC API])
+                   AC_COMPILE_IFELSE(
+                       [AC_LANG_PROGRAM(
+                           [[#ifndef _GNU_SOURCE
+                             #define _GNU_SOURCE
+                             #endif
+                             #include <sched.h>]],
+                           [[cpu_set_t *set = CPU_ALLOC(128);
+                             size_t setsize = CPU_ALLOC_SIZE(128);
+                             CPU_ZERO_S(setsize, set);
+                             CPU_SET_S(1, setsize, set);
+                             (void) sched_setaffinity(0, setsize, set);
+                             CPU_FREE(set);]])
+                       ],
+                       [AC_MSG_RESULT([yes])
+                        prte_have_sched_setaffinity=1],
+                       [AC_MSG_RESULT([no])
+                        prte_have_sched_setaffinity=0])
+                  ],
+                  [prte_have_sched_setaffinity=0])
+
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_SCHED_SETAFFINITY], [$prte_have_sched_setaffinity],
+        [Whether we have sched_setaffinity() and the cpu_set_t API for async-signal-safe CPU binding])
+
+    PRTE_VAR_SCOPE_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -867,6 +867,12 @@ prte_show_title "Ptrace stop-on-exec support"
 
 PRTE_CHECK_PTRACE
 
+# Check for async-signal-safe CPU affinity support (sched_setaffinity)
+
+prte_show_title "CPU affinity (sched_setaffinity) support"
+
+PRTE_CHECK_SETAFFINITY
+
 ############################################################################
 # Final top-level PRTE configuration
 ############################################################################

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -277,27 +277,44 @@ component's raw fork:
 - On success stores the pid (on the master) and activates
   `PRTE_PROC_STATE_RUNNING`; on failure activates a failure state.
 
-### 6. Applying binding in the child — `prte_odls_base_set()` (`odls_base_bind.c`)
+### 6. Applying binding — `prte_odls_base_prepare_binding()` + `prte_odls_base_set()` (`odls_base_bind.c`)
 
-Called from *inside the forked child* (by the component's `do_child`)
-before `execve`. It reads the proc's computed `child->cpuset` (the hwloc
-bitmap string the mapper produced) and calls `hwloc_set_cpubind` /
-`prte_hwloc_base_set_process_membind_policy`. Because the child is not a
-real PRTE process — and, more importantly, runs in the async-signal-safe
-window between `fork()` and `execve()` — **it cannot use normal error
-reporting or even render a `show_help` message** (that allocates, reads
-the help file, and scans directories, any of which can deadlock in a
-forked child). Instead it reports a fixed-size code-plus-errno record up
-the pipe via `prte_odls_base_child_fail` (fatal, `_exit`s) /
-`prte_odls_base_child_warn` (non-fatal, returns) — the
-`prte_odls_pipe_err_msg_t` / `prte_odls_child_err_t` types in
-`odls_types.h` — and the *parent* renders the human-readable diagnostic.
-Whether a binding failure is fatal or a warning depends on
-`PRTE_BINDING_REQUIRED` and
-`PRTE_BINDING_POLICY_IS_SET` (a *required, explicitly-requested* binding
-that fails kills the child; a defaulted one degrades to a warning). If the
-proc has no cpuset but the daemon itself is bound, the child is "freed" to
-all allowed cpus.
+Binding is split across the fork so the child stays async-signal-safe:
+
+- **`prte_odls_base_prepare_binding(cd)`** runs in the **parent**, in
+  `spawn_proc` just before `fork_local`. It does everything that
+  allocates, parses, or prints: it parses the proc's computed
+  `child->cpuset` (the hwloc bitmap string the mapper produced) into a
+  stored `hwloc_cpuset_t`, classifies the binding, precomputes the
+  memory-binding policy, emits `--report-bindings` output and the
+  "incorrectly bound" warning, and — where the platform has
+  `sched_setaffinity` (`PRTE_HAVE_SCHED_SETAFFINITY`) — precomputes a raw
+  `cpu_set_t` affinity mask. All of this is stashed on the caddy.
+- **`prte_odls_base_set(cd, write_fd)`** runs in the forked **child**, in
+  the async-signal-safe window before `execve`. It only *issues the bind
+  syscalls*: a bare `sched_setaffinity` with the precomputed mask on Linux,
+  or `hwloc_set_cpubind` as the `#else` fallback (macOS and other platforms
+  without `sched_setaffinity`), plus `hwloc_set_membind`. It allocates
+  nothing and renders nothing.
+
+Because the child is not a real PRTE process — and runs in that
+async-signal-safe window — **it cannot use normal error reporting or
+render a `show_help` message** (that allocates, reads the help file, and
+scans directories, any of which can deadlock in a forked child). It
+reports a fixed-size code-plus-errno record up the pipe via
+`prte_odls_base_child_fail` (fatal, `_exit`s) / `prte_odls_base_child_warn`
+(non-fatal, returns) — the `prte_odls_pipe_err_msg_t` /
+`prte_odls_child_err_t` types in `odls_types.h` — and the *parent* renders
+the human-readable diagnostic. Whether a binding failure is fatal or a
+warning depends on `PRTE_BINDING_REQUIRED` and `PRTE_BINDING_POLICY_IS_SET`
+(a *required, explicitly-requested* binding that fails kills the child; a
+defaulted one degrades to a warning). If the proc has no cpuset but the
+daemon itself is bound, the proc is "freed" to all allowed cpus.
+
+The one remaining hwloc call in the child is `hwloc_set_membind` (memory
+binding), which still allocates internally; converting it to a bare
+`set_mempolicy`/`mbind` syscall would mean reproducing hwloc's NUMA
+nodeset handling and is left for later.
 
 ### 7. Reaping children — `prte_odls_base_default_wait_local_proc()`
 

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -283,11 +283,17 @@ Called from *inside the forked child* (by the component's `do_child`)
 before `execve`. It reads the proc's computed `child->cpuset` (the hwloc
 bitmap string the mapper produced) and calls `hwloc_set_cpubind` /
 `prte_hwloc_base_set_process_membind_policy`. Because the child is not a
-real PRTE process, **it cannot use normal error reporting** — instead it
-writes rendered `show_help` messages back up the pipe to the parent
-(`send_warn_show_help` / `send_error_show_help`, using the
-`prte_odls_pipe_err_msg_t` struct from `odls_types.h`). Whether a binding
-failure is fatal or a warning depends on `PRTE_BINDING_REQUIRED` and
+real PRTE process — and, more importantly, runs in the async-signal-safe
+window between `fork()` and `execve()` — **it cannot use normal error
+reporting or even render a `show_help` message** (that allocates, reads
+the help file, and scans directories, any of which can deadlock in a
+forked child). Instead it reports a fixed-size code-plus-errno record up
+the pipe via `prte_odls_base_child_fail` (fatal, `_exit`s) /
+`prte_odls_base_child_warn` (non-fatal, returns) — the
+`prte_odls_pipe_err_msg_t` / `prte_odls_child_err_t` types in
+`odls_types.h` — and the *parent* renders the human-readable diagnostic.
+Whether a binding failure is fatal or a warning depends on
+`PRTE_BINDING_REQUIRED` and
 `PRTE_BINDING_POLICY_IS_SET` (a *required, explicitly-requested* binding
 that fails kills the child; a defaulted one degrades to a warning). If the
 proc has no cpuset but the daemon itself is bound, the child is "freed" to
@@ -344,7 +350,7 @@ computed proc state.
 | `prte_local_children` | `src/runtime/prte_globals` (a `pmix_pointer_array_t`) | The daemon's authoritative list of the procs it launched — every base fn iterates it. Allocated at framework open, released at close. |
 | `prte_odls_spawn_caddy_t` | `base.h` | Per-child fork caddy: `cmd`, `wdir`, `argv`, `env`, `jdata`, `app`, `child`, IOF `opts`, and the `fork_local` fn ptr. Carries `ev` for thread-shifting. Heap-allocated, released after spawn. |
 | `prte_odls_launch_local_t` | `base.h` | Per-node "start launching job J" caddy carried by `PRTE_ACTIVATE_LOCAL_LAUNCH`; holds `job`, `fork_local`, and a `retries` counter for the sys-limit backoff. |
-| `prte_odls_pipe_err_msg_t` | `odls_types.h` | Fixed struct written up the child→parent pipe to proxy a `show_help` error (fatal flag + exit status + three string lengths). |
+| `prte_odls_pipe_err_msg_t` / `prte_odls_child_err_t` | `odls_types.h` | Fixed-size record written up the child→parent pipe (fatal flag + exit status + failure code + errno). Carries no strings and needs no allocation, so it is safe to emit from the async-signal-safe window before `execve`; the parent renders the `show_help` diagnostic from the code and errno. |
 | `PRTE_DAEMON_*` command flags | `odls_types.h` | The daemon command byte that leads every RML control message to a prted (ADD_LOCAL_PROCS, KILL, SIGNAL, EXIT, …). |
 
 ---
@@ -388,9 +394,13 @@ computed proc state.
   `PRTE_ACTIVATE_PROC_STATE(FAILED_TO_LAUNCH/FAILED_TO_START)` or
   `PRTE_ACTIVATE_JOB_STATE(NEVER_LAUNCHED)` so the HNP can react — don't
   just bubble an `rc` up into the event loop.
-- **The child cannot log normally.** Between `fork` and `execve`, error
-  reporting goes up the pipe as a rendered `show_help` string; never call
-  ordinary PRRTE logging there.
+- **The child cannot log normally — or render `show_help`.** Between
+  `fork` and `execve` only async-signal-safe calls are permitted, so the
+  child must not allocate, use stdio, scan `/proc/self/fd`, or call
+  `show_help` (all of which can deadlock in a forked child). It reports a
+  fixed-size code-plus-errno record up the pipe
+  (`prte_odls_base_child_fail` / `prte_odls_base_child_warn`) and the
+  parent renders the message; never call ordinary PRRTE logging there.
 - **STOP_ON_EXEC pins the tracer thread.** Both the fork (in
   `launch_local`/`restart_proc`) and the ptrace detach (in
   `wait_local_proc`) must happen on `prte_event_base`; do not "optimize"

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -30,6 +30,14 @@
  */
 #include "prte_config.h"
 
+#if PRTE_HAVE_SCHED_SETAFFINITY
+#    ifndef _GNU_SOURCE
+#        define _GNU_SOURCE
+#    endif
+#    include <sched.h>
+#endif
+
+#include "src/hwloc/hwloc-internal.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_framework.h"
 #include "src/mca/iof/base/iof_base_setup.h"
@@ -100,6 +108,19 @@ typedef struct {
     bool index_argv;
     prte_iof_base_io_conf_t opts;
     prte_odls_base_fork_local_proc_fn_t fork_local;
+    /* CPU/memory binding computed by the parent
+       (prte_odls_base_prepare_binding) for the child to apply in the
+       async-signal-safe window before execve(), so the child does no
+       allocation or parsing of its own. */
+    hwloc_cpuset_t bind_cpuset;         /* target cpu set, NULL if no binding */
+    bool bind_fatal;                    /* preparation hit a required-binding error */
+    bool do_membind;                    /* also apply the memory binding policy */
+    hwloc_membind_policy_t membind_policy;
+    int membind_flags;
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    cpu_set_t *bind_mask;               /* CPU_ALLOC'd mask for sched_setaffinity */
+    size_t bind_masksize;               /* CPU_ALLOC_SIZE of bind_mask */
+#endif
 } prte_odls_spawn_caddy_t;
 PMIX_CLASS_DECLARATION(prte_odls_spawn_caddy_t);
 
@@ -156,7 +177,16 @@ PRTE_EXPORT void prte_odls_base_start_threads(prte_job_t *jdata);
 
 PRTE_EXPORT void prte_odls_base_harvest_threads(void);
 
-/* Binding support */
+/* Binding support.
+ *
+ * prte_odls_base_prepare_binding runs in the parent before the fork: it
+ * parses the mapper's cpuset, classifies the binding, precomputes the
+ * memory-binding policy and (where available) the raw sched_setaffinity
+ * mask, and emits any --report-bindings / warning output. It stashes the
+ * result on the caddy.  prte_odls_base_set then runs in the forked child,
+ * in the async-signal-safe window before execve(), and only issues the
+ * bind syscalls, reporting failures up the pipe. */
+PRTE_EXPORT void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd);
 PRTE_EXPORT void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd);
 
 /*

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -159,6 +159,22 @@ PRTE_EXPORT void prte_odls_base_harvest_threads(void);
 /* Binding support */
 PRTE_EXPORT void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd);
 
+/*
+ * Async-signal-safe child->parent error reporting. These are called from
+ * inside the forked child, in the window between fork() and execve(),
+ * where only async-signal-safe operations are permitted. They write a
+ * fixed-size record (no strings, no allocation, no show_help) up the pipe
+ * to the waiting parent, which renders the human-readable diagnostic from
+ * the code and errno. child_fail is fatal - it reports the failure and
+ * terminates the child with _exit(); child_warn reports a non-fatal
+ * condition and returns so the child can continue toward execve().
+ */
+PRTE_EXPORT void prte_odls_base_child_fail(int write_fd, int exit_status,
+                                           prte_odls_child_err_t which,
+                                           int errnum) __prte_attribute_noreturn__;
+PRTE_EXPORT void prte_odls_base_child_warn(int write_fd, prte_odls_child_err_t which,
+                                           int errnum);
+
 
 #define PRTE_ODLS_SET_ERROR(ns, s, j)                                                   \
 do {                                                                                    \

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -85,94 +85,55 @@ static void report_binding(prte_job_t *jobdat, int rank)
     hwloc_bitmap_free(mycpus);
 }
 
-static int write_help_msg(int fd, prte_odls_pipe_err_msg_t *msg, const char *file,
-                          const char *topic, va_list ap)
+/* Report a fatal failure from inside the forked child and terminate it.
+ *
+ * This runs in the async-signal-safe window between fork() and execve(),
+ * so it must not allocate, use stdio, or render a show_help message -
+ * fork() leaves any lock another thread held frozen in the child, and
+ * touching malloc/stdio/opendir can deadlock. We therefore write only a
+ * fixed-size record carrying the failure code and errno; the parent
+ * renders the human-readable diagnostic. We _exit() rather than exit() so
+ * no atexit handlers run and no stdio buffers are flushed in the child. */
+void prte_odls_base_child_fail(int write_fd, int exit_status, prte_odls_child_err_t which,
+                               int errnum)
 {
-    int ret;
-    char *str;
-
-    if (NULL == file || NULL == topic) {
-        return PRTE_ERR_BAD_PARAM;
-    }
-
-    str = pmix_show_help_vstring(file, topic, true, ap);
-
-    msg->file_str_len = (int) strlen(file);
-    if (msg->file_str_len > PRTE_ODLS_MAX_FILE_LEN) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-    msg->topic_str_len = (int) strlen(topic);
-    if (msg->topic_str_len > PRTE_ODLS_MAX_TOPIC_LEN) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-    msg->msg_str_len = (int) strlen(str);
-
-    /* Only keep writing if each write() succeeds */
-    if (PRTE_SUCCESS != (ret = pmix_fd_write(fd, sizeof(*msg), msg))) {
-        goto out;
-    }
-    if (msg->file_str_len > 0
-        && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->file_str_len, file))) {
-        goto out;
-    }
-    if (msg->topic_str_len > 0
-        && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->topic_str_len, topic))) {
-        goto out;
-    }
-    if (msg->msg_str_len > 0 && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->msg_str_len, str))) {
-        goto out;
-    }
-
-out:
-    free(str);
-    return ret;
-}
-
-static int send_warn_show_help(int fd, const char *file, const char *topic, ...)
-{
-    int ret;
-    va_list ap;
-    prte_odls_pipe_err_msg_t msg;
-
-    msg.fatal = false;
-    msg.exit_status = 0; /* ignored */
-
-    /* Send it */
-    va_start(ap, topic);
-    ret = write_help_msg(fd, &msg, file, topic, ap);
-    va_end(ap);
-
-    return ret;
-}
-
-static void send_error_show_help(int fd, int exit_status, const char *file,
-                                 const char *topic, ...)
-{
-    va_list ap;
     prte_odls_pipe_err_msg_t msg;
 
     msg.fatal = true;
     msg.exit_status = exit_status;
+    msg.which = (int) which;
+    msg.errnum = errnum;
 
-    /* Send it */
-    va_start(ap, topic);
-    write_help_msg(fd, &msg, file, topic, ap);
-    va_end(ap);
+    /* best effort - if the write fails there is nothing safe we can do
+     * here, and the parent will still see the pipe close */
+    (void) pmix_fd_write(write_fd, sizeof(msg), &msg);
 
-    exit(exit_status);
+    _exit(exit_status);
+}
+
+/* Report a non-fatal condition from inside the forked child and return so
+ * the child can continue on toward execve(). Same async-signal-safety
+ * constraints as prte_odls_base_child_fail. */
+void prte_odls_base_child_warn(int write_fd, prte_odls_child_err_t which, int errnum)
+{
+    prte_odls_pipe_err_msg_t msg;
+
+    msg.fatal = false;
+    msg.exit_status = 0; /* ignored */
+    msg.which = (int) which;
+    msg.errnum = errnum;
+
+    /* best effort */
+    (void) pmix_fd_write(write_fd, sizeof(msg), &msg);
 }
 
 void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
 {
     prte_job_t *jobdat = cd->jdata;
     prte_proc_t *child = cd->child;
-    prte_app_context_t *context = cd->app;
     hwloc_cpuset_t cpuset;
     hwloc_obj_t root;
     int rc = PRTE_ERROR;
-    char *msg;
 
     pmix_output_verbose(2, prte_odls_base_framework.framework_output,
                         "%s hwloc:set on child %s cpuset %s",
@@ -196,37 +157,21 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
         if (NULL != prte_daemon_cores) {
             root = hwloc_get_root_obj(prte_hwloc_topology);
             if (NULL == root->userdata) {
-                send_warn_show_help(write_fd, "help-prte-odls-default.txt",
-                                    "incorrectly bound", prte_process_info.nodename,
-                                    context->app, __FILE__, __LINE__);
+                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_INCORRECT, 0);
             }
             /* bind this proc to all available processors */
             cpuset = (hwloc_cpuset_t)hwloc_topology_get_allowed_cpuset(prte_hwloc_topology);
             rc = hwloc_set_cpubind(prte_hwloc_topology, cpuset, 0);
-            /* if we got an error and this wasn't a default binding policy, then report it */
+            /* if we got an error and this wasn't a default binding policy, then report it.
+             * We are between fork() and execve() here, so we cannot render the message -
+             * we send the errno up the pipe and let the parent do the rendering. */
             if (rc < 0 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-                if (errno == ENOSYS) {
-                    msg = "hwloc indicates cpu binding not supported";
-                } else if (errno == EXDEV) {
-                    msg = "hwloc indicates cpu binding cannot be enforced";
-                } else {
-                    char *tmp;
-                    (void) hwloc_bitmap_list_asprintf(&tmp, cpuset);
-                    pmix_asprintf(&msg, "hwloc_set_cpubind returned \"%s\" for bitmap \"%s\"",
-                                  prte_strerror(rc), tmp);
-                    free(tmp);
-                }
                 if (PRTE_BINDING_REQUIRED(jobdat->map->binding)) {
                     /* If binding is required, send an error up the pipe (which exits
                        -- it doesn't return). */
-                    send_error_show_help(write_fd, 1, "help-prte-odls-default.txt",
-                                         "binding generic error",
-                                         prte_process_info.nodename, context->app,
-                                         msg, __FILE__, __LINE__);
+                    prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, errno);
                 } else {
-                    send_warn_show_help(write_fd, "help-prte-odls-default.txt",
-                                        "not bound", prte_process_info.nodename,
-                                        context->app, msg, __FILE__, __LINE__);
+                    prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, errno);
                     return;
                 }
             }
@@ -249,26 +194,17 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
         /* convert the list to a cpuset */
         cpuset = hwloc_bitmap_alloc();
         if (0 != (rc = hwloc_bitmap_list_sscanf(cpuset, child->cpuset))) {
-            /* See comment above about "This may be a small memory leak" */
-            pmix_asprintf(&msg, "hwloc_bitmap_sscanf returned \"%s\" for the string \"%s\"",
-                          prte_strerror(rc), child->cpuset);
-            if (NULL == msg) {
-                msg = "failed to convert bitmap list to hwloc bitmap";
-            }
             if (PRTE_BINDING_REQUIRED(jobdat->map->binding) &&
                 PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
                 /* If binding is required and a binding directive was explicitly
                  * given (i.e., we are not binding due to a default policy),
                  * send an error up the pipe (which exits -- it doesn't return).
-                 */
-                send_error_show_help(write_fd, 1, "help-prte-odls-default.txt",
-                                     "binding generic error",
-                                     prte_process_info.nodename, context->app, msg,
-                                     __FILE__, __LINE__);
+                 * This is a parse failure, not a syscall failure, so there is
+                 * no meaningful errno to report. */
+                hwloc_bitmap_free(cpuset);
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, 0);
             } else {
-                send_warn_show_help(write_fd, "help-prte-odls-default.txt",
-                                    "not bound", prte_process_info.nodename,
-                                    context->app, msg, __FILE__, __LINE__);
+                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, 0);
                 hwloc_bitmap_free(cpuset);
                 return;
             }
@@ -278,27 +214,12 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
         hwloc_bitmap_free(cpuset);
         /* if we got an error and this wasn't a default binding policy, then report it */
         if (rc < 0 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-            if (errno == ENOSYS) {
-                msg = strdup("hwloc indicates cpu binding not supported");
-            } else if (errno == EXDEV) {
-                msg = strdup("hwloc indicates cpu binding cannot be enforced");
-            } else {
-                pmix_asprintf(&msg, "hwloc_set_cpubind returned \"%s\" for bitmap \"%s\"",
-                              prte_strerror(rc), child->cpuset);
-            }
             if (PRTE_BINDING_REQUIRED(jobdat->map->binding)) {
                 /* If binding is required, send an error up the pipe (which exits
                    -- it doesn't return). */
-                send_error_show_help(write_fd, 1, "help-prte-odls-default.txt",
-                                     "binding generic error",
-                                     prte_process_info.nodename, context->app, msg,
-                                     __FILE__, __LINE__);
-                free(msg);  // silence static analyzer warning
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, errno);
             } else {
-                send_warn_show_help(write_fd, "help-prte-odls-default.txt",
-                                    "not bound", prte_process_info.nodename,
-                                    context->app, msg, __FILE__, __LINE__);
-                free(msg);
+                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, errno);
                 return;
             }
         }
@@ -313,24 +234,12 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
          */
         rc = prte_hwloc_base_set_process_membind_policy();
         if (PRTE_SUCCESS != rc && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-            if (errno == ENOSYS) {
-                msg = "hwloc indicates memory binding not supported";
-            } else if (errno == EXDEV) {
-                msg = "hwloc indicates memory binding cannot be enforced";
-            } else {
-                msg = "failed to bind memory";
-            }
             if (PRTE_HWLOC_BASE_MBFA_ERROR == prte_hwloc_base_mbfa) {
                 /* If binding is required, send an error up the pipe (which exits
                    -- it doesn't return). */
-                send_error_show_help(write_fd, 1, "help-prte-odls-default.txt",
-                                     "memory binding error",
-                                     prte_process_info.nodename, context->app, msg,
-                                     __FILE__, __LINE__);
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND_MEM, errno);
             } else {
-                send_warn_show_help(write_fd, "help-prte-odls-default.txt",
-                                    "memory not bound", prte_process_info.nodename,
-                                    context->app, msg, __FILE__, __LINE__);
+                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, errno);
                 return;
             }
         }

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -59,30 +59,31 @@
 
 #include "src/mca/odls/base/base.h"
 
-static void report_binding(prte_job_t *jobdat, int rank)
+/* Runs in the parent. Renders, for --report-bindings, the binding we are
+   about to apply to the child (the cpuset requested by the mapper).  It
+   cannot read the child's actual applied binding - the child does not
+   exist yet - but for a successful bind the two are identical, and this
+   keeps the (allocating) rendering out of the async-signal-safe child. */
+static void report_binding(prte_job_t *jobdat, int rank, hwloc_cpuset_t cpuset)
 {
     char *tmp1;
-    hwloc_cpuset_t mycpus;
     bool use_hwthread_cpus;
     bool physical;
 
+    if (NULL == cpuset || hwloc_bitmap_iszero(cpuset)) {
+        pmix_output(0, "Rank %d is not bound (or bound to all available processors)", rank);
+        return;
+    }
     /* check for type of cpu being used */
     if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL)) {
         use_hwthread_cpus = true;
     } else {
         use_hwthread_cpus = false;
     }
-    /* get the cpus we are bound to */
-    mycpus = hwloc_bitmap_alloc();
-    if (hwloc_get_cpubind(prte_hwloc_topology, mycpus, HWLOC_CPUBIND_PROCESS) < 0) {
-        pmix_output(0, "Rank %d is not bound", rank);
-    } else {
-        physical = prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_PHYSICAL_CPUS, NULL, PMIX_BOOL);
-        tmp1 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, physical, prte_hwloc_topology);
-        pmix_output(0, "Rank %d bound to %s", rank, tmp1);
-        free(tmp1);
-    }
-    hwloc_bitmap_free(mycpus);
+    physical = prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_PHYSICAL_CPUS, NULL, PMIX_BOOL);
+    tmp1 = prte_hwloc_base_cset2str(cpuset, use_hwthread_cpus, physical, prte_hwloc_topology);
+    pmix_output(0, "Rank %d bound to %s", rank, tmp1);
+    free(tmp1);
 }
 
 /* Report a fatal failure from inside the forked child and terminate it.
@@ -127,121 +128,190 @@ void prte_odls_base_child_warn(int write_fd, prte_odls_child_err_t which, int er
     (void) pmix_fd_write(write_fd, sizeof(msg), &msg);
 }
 
-void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
+/* Runs in the PARENT, before the fork. Does everything that requires
+   allocation, parsing, or output - parsing the mapper's cpuset,
+   classifying the binding, computing the memory-binding policy, precomputing
+   the raw sched_setaffinity mask, and emitting --report-bindings and the
+   "incorrectly bound" warning - and stashes the ready-to-apply result on
+   the caddy. The forked child (prte_odls_base_set) then only issues the
+   bind syscalls. */
+void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd)
 {
     prte_job_t *jobdat = cd->jdata;
     prte_proc_t *child = cd->child;
+    prte_app_context_t *context = cd->app;
     hwloc_cpuset_t cpuset;
     hwloc_obj_t root;
-    int rc = PRTE_ERROR;
+    bool report;
+
+    cd->bind_cpuset = NULL;
+    cd->bind_fatal = false;
+    cd->do_membind = false;
 
     pmix_output_verbose(2, prte_odls_base_framework.framework_output,
-                        "%s hwloc:set on child %s cpuset %s",
+                        "%s hwloc:prepare on child %s cpuset %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         (NULL == child) ? "NULL" : PRTE_NAME_PRINT(&child->name),
-                        (NULL == child->cpuset) ? "NULL" : child->cpuset);
+                        (NULL == child || NULL == child->cpuset) ? "NULL" : child->cpuset);
 
     if (NULL == jobdat || NULL == child) {
         /* nothing for us to do */
-        pmix_output_verbose(2, prte_odls_base_framework.framework_output,
-                            "%s hwloc:set jobdat %s child %s - nothing to do",
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                            (NULL == jobdat) ? "NULL" : PRTE_JOBID_PRINT(jobdat->nspace),
-                            (NULL == child) ? "NULL" : PRTE_NAME_PRINT(&child->name));
         return;
     }
 
-    /* Set process affinity, if given */
+    report = prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL);
+
+    /* Compute process affinity, if given */
     if (NULL == child->cpuset || 0 == strlen(child->cpuset)) {
-        /* if the daemon is bound, then we need to "free" this proc */
+        /* no explicit binding was computed for this proc */
         if (NULL != prte_daemon_cores) {
+            /* the daemon is bound, so we must "free" this proc to all
+               available processors */
             root = hwloc_get_root_obj(prte_hwloc_topology);
             if (NULL == root->userdata) {
-                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_INCORRECT, 0);
+                pmix_show_help("help-prte-odls-default.txt", "incorrectly bound", true,
+                               prte_process_info.nodename, context->app);
             }
-            /* bind this proc to all available processors */
-            cpuset = (hwloc_cpuset_t)hwloc_topology_get_allowed_cpuset(prte_hwloc_topology);
-            rc = hwloc_set_cpubind(prte_hwloc_topology, cpuset, 0);
-            /* if we got an error and this wasn't a default binding policy, then report it.
-             * We are between fork() and execve() here, so we cannot render the message -
-             * we send the errno up the pipe and let the parent do the rendering. */
-            if (rc < 0 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-                if (PRTE_BINDING_REQUIRED(jobdat->map->binding)) {
-                    /* If binding is required, send an error up the pipe (which exits
-                       -- it doesn't return). */
-                    prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, errno);
-                } else {
-                    prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, errno);
-                    return;
-                }
+            cd->bind_cpuset = hwloc_bitmap_dup(
+                hwloc_topology_get_allowed_cpuset(prte_hwloc_topology));
+            if (report) {
+                report_binding(jobdat, child->name.rank, cd->bind_cpuset);
             }
-            if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL,
-                                   PMIX_BOOL)) {
-                if (0 == rc) {
-                    report_binding(jobdat, child->name.rank);
-                } else {
-                    pmix_output(0,
-                                "Rank %d is not bound (or bound to all available processors)",
-                                child->name.rank);
-                }
-            }
-        } else if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL,
-                                      PMIX_BOOL)) {
+        } else if (report) {
             pmix_output(0, "Rank %d is not bound (or bound to all available processors)",
                         child->name.rank);
         }
+        /* NB: no memory binding is applied on this path, matching the
+           historical behavior */
     } else {
-        /* convert the list to a cpuset */
+        /* an explicit cpuset was produced by the mapper - convert the list */
         cpuset = hwloc_bitmap_alloc();
-        if (0 != (rc = hwloc_bitmap_list_sscanf(cpuset, child->cpuset))) {
-            if (PRTE_BINDING_REQUIRED(jobdat->map->binding) &&
-                PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-                /* If binding is required and a binding directive was explicitly
-                 * given (i.e., we are not binding due to a default policy),
-                 * send an error up the pipe (which exits -- it doesn't return).
-                 * This is a parse failure, not a syscall failure, so there is
-                 * no meaningful errno to report. */
+        if (NULL == cpuset || 0 != hwloc_bitmap_list_sscanf(cpuset, child->cpuset)) {
+            /* out-of-memory or a malformed string (the latter should never
+               happen - the mapper produced it). If binding was explicitly
+               required, flag it fatal so the child reports it up the pipe;
+               otherwise warn now (safe here in the parent) and continue
+               unbound. */
+            if (NULL != cpuset) {
                 hwloc_bitmap_free(cpuset);
-                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, 0);
-            } else {
-                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, 0);
-                hwloc_bitmap_free(cpuset);
+            }
+            if (PRTE_BINDING_REQUIRED(jobdat->map->binding)
+                && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+                cd->bind_fatal = true;
+            } else if (PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+                pmix_show_help("help-prte-odls-default.txt", "not bound", true,
+                               prte_process_info.nodename, context->app,
+                               "unable to apply the requested binding");
+            }
+            return;
+        }
+        cd->bind_cpuset = cpuset;
+        if (report) {
+            report_binding(jobdat, child->name.rank, cd->bind_cpuset);
+        }
+        /* precompute the memory-binding policy (mirrors
+           prte_hwloc_base_set_process_membind_policy) so the child need not
+           read any MCA state */
+        cd->do_membind = true;
+        switch (prte_hwloc_base_map) {
+        case PRTE_HWLOC_BASE_MAP_LOCAL_ONLY:
+            cd->membind_policy = HWLOC_MEMBIND_BIND;
+            cd->membind_flags = HWLOC_MEMBIND_STRICT;
+            break;
+        case PRTE_HWLOC_BASE_MAP_NONE:
+        default:
+            cd->membind_policy = HWLOC_MEMBIND_DEFAULT;
+            cd->membind_flags = 0;
+            break;
+        }
+    }
+
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    /* precompute the raw affinity mask so the child can bind with a bare
+       sched_setaffinity() syscall instead of calling into hwloc (which
+       allocates) in the async-signal-safe window before execve() */
+    if (NULL != cd->bind_cpuset) {
+        int last = hwloc_bitmap_last(cd->bind_cpuset);
+        unsigned ncpus = (0 > last) ? 1 : (unsigned) (last + 1);
+        cd->bind_mask = CPU_ALLOC(ncpus);
+        if (NULL != cd->bind_mask) {
+            unsigned id;
+            cd->bind_masksize = CPU_ALLOC_SIZE(ncpus);
+            CPU_ZERO_S(cd->bind_masksize, cd->bind_mask);
+            hwloc_bitmap_foreach_begin(id, cd->bind_cpuset) {
+                CPU_SET_S(id, cd->bind_masksize, cd->bind_mask);
+            }
+            hwloc_bitmap_foreach_end();
+        }
+    }
+#endif
+}
+
+/* Runs in the forked CHILD, in the async-signal-safe window before
+   execve(). It only issues the bind syscalls prepared by the parent and
+   reports any failure up the pipe (prte_odls_base_child_fail/_warn); it
+   performs no allocation, parsing, or rendering. */
+void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
+{
+    prte_job_t *jobdat = cd->jdata;
+    int rc;
+
+    /* A required binding could not even be prepared (out-of-memory or a
+       malformed cpuset in the parent) - report it now and exit. */
+    if (cd->bind_fatal) {
+        prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, 0);
+        /* does not return */
+    }
+
+    /* nothing to bind */
+    if (NULL == cd->bind_cpuset) {
+        return;
+    }
+
+    /* Apply CPU affinity. On systems with sched_setaffinity() we issue a
+       bare syscall using the mask the parent precomputed - that is
+       async-signal-safe. Elsewhere (e.g., macOS) we fall back to hwloc,
+       which is not strictly async-signal-safe but is the best available. */
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    if (NULL == cd->bind_mask) {
+        errno = ENOMEM;
+        rc = -1;
+    } else {
+        rc = sched_setaffinity(0, cd->bind_masksize, cd->bind_mask);
+    }
+#else
+    rc = hwloc_set_cpubind(prte_hwloc_topology, cd->bind_cpuset, 0);
+#endif
+    /* if we got an error and this wasn't a default binding policy, report it.
+       We send only the errno up the pipe; the parent renders the message. */
+    if (0 != rc && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+        if (PRTE_BINDING_REQUIRED(jobdat->map->binding)) {
+            /* required binding failed: fatal (child_fail exits) */
+            prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, errno);
+            /* does not return */
+        }
+        prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, errno);
+        return;
+    }
+
+    /* Apply the memory-binding policy, if one was requested. hwloc is used
+       on all platforms here; converting this to a bare syscall would mean
+       reproducing hwloc's NUMA nodeset handling and is left for later. */
+    if (cd->do_membind) {
+        rc = hwloc_set_membind(prte_hwloc_topology, cd->bind_cpuset, cd->membind_policy,
+                               cd->membind_flags);
+        if (0 != rc && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+            /* hwloc failing with ENOSYS when no explicit policy was set is
+               not really an error (mirrors the historical membind path) */
+            if (ENOSYS == errno && PRTE_HWLOC_BASE_MAP_NONE == prte_hwloc_base_map) {
                 return;
             }
-        }
-        /* bind as specified */
-        rc = hwloc_set_cpubind(prte_hwloc_topology, cpuset, 0);
-        hwloc_bitmap_free(cpuset);
-        /* if we got an error and this wasn't a default binding policy, then report it */
-        if (rc < 0 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-            if (PRTE_BINDING_REQUIRED(jobdat->map->binding)) {
-                /* If binding is required, send an error up the pipe (which exits
-                   -- it doesn't return). */
-                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND, errno);
-            } else {
-                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_NOT_BOUND, errno);
-                return;
-            }
-        }
-
-        if (0 == rc
-            && prte_get_attribute(&jobdat->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL)) {
-            report_binding(jobdat, child->name.rank);
-        }
-
-        /* set memory affinity policy - if we get an error, don't report
-         * anything unless the user actually specified the binding policy
-         */
-        rc = prte_hwloc_base_set_process_membind_policy();
-        if (PRTE_SUCCESS != rc && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
             if (PRTE_HWLOC_BASE_MBFA_ERROR == prte_hwloc_base_mbfa) {
-                /* If binding is required, send an error up the pipe (which exits
-                   -- it doesn't return). */
                 prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND_MEM, errno);
-            } else {
-                prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, errno);
-                return;
+                /* does not return */
             }
+            prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, errno);
+            return;
         }
     }
 }

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1085,6 +1085,10 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         free(output);
     }
 
+    /* compute this child's binding in the parent, before the fork, so the
+       async-signal-safe child only has to issue the bind syscalls */
+    prte_odls_base_prepare_binding(cd);
+
     if (PRTE_SUCCESS != (rc = cd->fork_local(cd))) {
         /* error message already output */
         state = PRTE_PROC_STATE_FAILED_TO_START;

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -337,6 +337,13 @@ static void sccon(prte_odls_spawn_caddy_t *p)
     p->wdir = NULL;
     p->argv = NULL;
     p->env = NULL;
+    p->bind_cpuset = NULL;
+    p->bind_fatal = false;
+    p->do_membind = false;
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    p->bind_mask = NULL;
+    p->bind_masksize = 0;
+#endif
 }
 static void scdes(prte_odls_spawn_caddy_t *p)
 {
@@ -352,6 +359,14 @@ static void scdes(prte_odls_spawn_caddy_t *p)
     if (NULL != p->env) {
         PMIx_Argv_free(p->env);
     }
+    if (NULL != p->bind_cpuset) {
+        hwloc_bitmap_free(p->bind_cpuset);
+    }
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    if (NULL != p->bind_mask) {
+        CPU_FREE(p->bind_mask);
+    }
+#endif
 }
 PMIX_CLASS_INSTANCE(prte_odls_spawn_caddy_t,
                     pmix_object_t,

--- a/src/mca/odls/odls_types.h
+++ b/src/mca/odls/odls_types.h
@@ -91,7 +91,36 @@ typedef uint8_t prte_daemon_cmd_flag_t;
 #define PRTE_DAEMON_SHRINK_CMD (prte_daemon_cmd_flag_t) 35
 
 /*
- * Struct written up the pipe from the child to the parent.
+ * Identifies which point in the child's setup/exec sequence failed. The
+ * child code that runs between fork() and execve() must be
+ * async-signal-safe, so it cannot format a message or call show_help
+ * (which allocates, reads the help file, and scans directories); instead
+ * it reports one of these codes plus errno up the pipe, and the parent
+ * renders the human-readable diagnostic. The WARN_* codes describe a
+ * non-fatal condition (e.g., a degraded binding) after which the child
+ * continues on toward execve().
+ */
+typedef enum {
+    PRTE_ODLS_CHILD_ERR_NONE = 0,
+    /* fatal errors - the child exits after reporting */
+    PRTE_ODLS_CHILD_ERR_IOF_SETUP,      /* stdio/IOF child setup failed */
+    PRTE_ODLS_CHILD_ERR_NEG_FD,         /* open("/dev/null") returned < 0 */
+    PRTE_ODLS_CHILD_ERR_BIND,           /* required cpu binding failed */
+    PRTE_ODLS_CHILD_ERR_BIND_MEM,       /* required memory binding failed */
+    PRTE_ODLS_CHILD_ERR_WDIR,           /* chdir to the working dir failed */
+    PRTE_ODLS_CHILD_ERR_STOP_ON_EXEC,   /* ptrace(TRACEME) failed */
+    PRTE_ODLS_CHILD_ERR_EXEC,           /* execve failed */
+    /* non-fatal warnings - the child continues on toward execve */
+    PRTE_ODLS_CHILD_WARN_NOT_BOUND,     /* could not apply cpu binding */
+    PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, /* could not apply memory binding */
+    PRTE_ODLS_CHILD_WARN_INCORRECT      /* daemon bound but proc left unbound */
+} prte_odls_child_err_t;
+
+/*
+ * Fixed-size record written up the pipe from the child to the parent. It
+ * carries no strings and needs no allocation, so it is safe to emit from
+ * the async-signal-safe window between fork() and execve(). The parent
+ * renders the message from "which" and "errnum".
  */
 typedef struct {
     /* True if the child has died; false if this is just a warning to
@@ -99,19 +128,11 @@ typedef struct {
     bool fatal;
     /* Relevant only if fatal==true */
     int exit_status;
-
-    /* Length of the strings that are written up the pipe after this
-       struct */
-    int file_str_len;
-    int topic_str_len;
-    int msg_str_len;
+    /* which failure occurred (prte_odls_child_err_t) */
+    int which;
+    /* errno captured at the point of failure (0 if not applicable) */
+    int errnum;
 } prte_odls_pipe_err_msg_t;
-
-/*
- * Max length of strings from the prte_odls_pipe_err_msg_t
- */
-#define PRTE_ODLS_MAX_FILE_LEN  511
-#define PRTE_ODLS_MAX_TOPIC_LEN PRTE_ODLS_MAX_FILE_LEN
 
 END_C_DECLS
 

--- a/src/mca/odls/pdefault/AGENTS.md
+++ b/src/mca/odls/pdefault/AGENTS.md
@@ -102,9 +102,11 @@ Runs in the forked child; `__prte_attribute_noreturn__`. In order:
 2. Make the pipe write-fd close-on-exec.
 3. If this is a real child with output forwarding: `prte_iof_base_setup_child`
    to hook up stdout/stderr, then **`prte_odls_base_set(cd, write_fd)`** —
-   the base binding routine (cpu + memory affinity from `child->cpuset`),
-   which proxies any binding error up the pipe. (If there is no child and
-   no output forwarding, stdio is tied to `/dev/null`.)
+   the child half of the base binding routine, which only *issues* the
+   cpu/memory bind syscalls the parent already prepared
+   (`prte_odls_base_prepare_binding`, run pre-fork in `spawn_proc`) and
+   proxies any binding error up the pipe. (If there is no child and no
+   output forwarding, stdio is tied to `/dev/null`.)
 4. A plain `close()` loop over `[3, sysconf(_SC_OPEN_MAX))` — closes
    everything except stdio and the pipe. (It deliberately does **not** call
    `pmix_close_open_file_descriptors()`, which scans `/proc/self/fd` with

--- a/src/mca/odls/pdefault/AGENTS.md
+++ b/src/mca/odls/pdefault/AGENTS.md
@@ -87,8 +87,8 @@ base picked. The design, spelled out in the long header comment, is a
 The pipe is the child→parent error channel: the child sets it
 close-on-exec, so if `execve` succeeds the pipe simply **closes with no
 data** and the parent reads EOF ⇒ success. If anything fails before exec,
-the child writes a rendered `show_help` message up the pipe and the parent
-prints it.
+the child writes a fixed-size code-plus-errno record up the pipe and the
+parent renders and prints the diagnostic.
 
 `pipe()` or `fork()` failure sets `child->state =
 PRTE_PROC_STATE_FAILED_TO_START` and returns `PMIX_ERR_SYS_LIMITS_PIPES` /
@@ -105,8 +105,10 @@ Runs in the forked child; `__prte_attribute_noreturn__`. In order:
    the base binding routine (cpu + memory affinity from `child->cpuset`),
    which proxies any binding error up the pipe. (If there is no child and
    no output forwarding, stdio is tied to `/dev/null`.)
-4. `pmix_close_open_file_descriptors()` — close everything except
-   stdio and the pipe.
+4. A plain `close()` loop over `[3, sysconf(_SC_OPEN_MAX))` — closes
+   everything except stdio and the pipe. (It deliberately does **not** call
+   `pmix_close_open_file_descriptors()`, which scans `/proc/self/fd` with
+   `opendir`/`readdir` and so allocates — unsafe in the post-fork child.)
 5. Restore default signal handlers (`SIGTERM/INT/HUP/PIPE/CHLD`) and
    unblock all signals — the event library may have left them altered, and
    an app must not inherit a blocked SIGTERM.
@@ -114,26 +116,32 @@ Runs in the forked child; `__prte_attribute_noreturn__`. In order:
 7. If `PRTE_JOB_STOP_ON_EXEC`: `ptrace(PRTE_TRACEME, …)` so the app stops at
    `execve` for a debugger to attach.
 8. **`execve(cd->cmd, cd->argv, cd->env)`.** On return (always an error) it
-   distinguishes a bad interpreter (`ENOENT` but the file exists) from other
-   errno values and sends the `"execve error"` help up the pipe, then
-   `_exit`s.
+   simply reports `PRTE_ODLS_CHILD_ERR_EXEC` plus `errno`; the *parent*
+   inspects `errno` and `stat`s the app to distinguish a bad interpreter
+   (`ENOENT` but the file exists) from a missing/failed executable and
+   renders `"execve error"`. (`cd->argv` is defaulted in the *parent*
+   before the fork, so the child never allocates it.)
 
-Errors here go through `send_error_show_help()` (fatal, exits) or
-`send_warn_show_help()` (non-fatal, returns), which serialize a
-`prte_odls_pipe_err_msg_t` header + file/topic/message strings via
-`write_help_msg` — the format `do_parent` expects.
+Every fatal failure calls `prte_odls_base_child_fail()` (writes the fixed
+record, `_exit`s); binding warnings call `prte_odls_base_child_warn()`
+(writes the record, returns). Both live in the base (`odls_base_bind.c`)
+so the component and the binding code share one implementation. The record
+is a fixed-size `prte_odls_pipe_err_msg_t` — no strings, no allocation, no
+`show_help` — carrying a `prte_odls_child_err_t` code and `errno`; the
+parent does all rendering.
 
 ### `do_parent()` — block until the child reports
 
 Runs on the event base. Closes the child ends of the IOF pipes, then loops
-reading `prte_odls_pipe_err_msg_t` records:
+reading fixed-size `prte_odls_pipe_err_msg_t` records:
 
 - **Pipe closed / read timeout** (`PMIX_ERR_TIMEOUT`) ⇒ child exec'd
   successfully: set `child->state = RUNNING`, flag `ALIVE`, return
   `PRTE_SUCCESS`.
-- **A message arrives** ⇒ read the file/topic/msg strings, render with
-  `pmix_show_help_norender`. If `msg.fatal`, set `child->state =
-  FAILED_TO_START`, unset `ALIVE`, and return `PRTE_ERR_SILENT` (the string
+- **A record arrives** ⇒ `render_child_msg()` maps the code + `errno` to the
+  right `pmix_show_help` topic and renders it (allocation and `show_help`
+  are safe here in the parent). If `msg.fatal`, set `child->state =
+  FAILED_TO_START`, unset `ALIVE`, and return `PRTE_ERR_SILENT` (the message
   was already shown). If it was only a warning, keep looping.
 - **Read error** ⇒ set `child->state = UNDEF` and return a converted error.
 
@@ -162,14 +170,17 @@ the *mechanism* (the actual `kill`).
 ## Things to watch when editing
 
 - **`do_child` is post-fork: async-signal-safety rules apply.** It runs in
-  a forked child that has not yet exec'd. Keep it to the existing minimal
-  syscall/`show_help`-over-pipe idiom; do not add malloc-heavy or
-  lock-taking PRRTE calls, and never log through the normal channels — the
-  pipe is the only safe way to report.
-- **Preserve the pipe protocol on both ends.** `write_help_msg` (child) and
-  the read loop in `do_parent` must agree on the `prte_odls_pipe_err_msg_t`
-  layout and the file/topic/msg ordering; the base's `odls_base_bind.c` also
-  writes this same format, so the three must stay in lockstep.
+  a forked child that has not yet exec'd. Keep it to async-signal-safe
+  syscalls and the fixed-record `child_fail`/`child_warn` idiom; do not add
+  malloc-heavy or lock-taking PRRTE calls, do not scan `/proc/self/fd`, and
+  never render `show_help` or log through the normal channels — writing the
+  fixed code-plus-errno record up the pipe is the only safe way to report.
+- **Preserve the pipe protocol on both ends.** The child writers
+  (`prte_odls_base_child_fail`/`_warn` in `odls_base_bind.c`, used by both
+  `do_child` and the binding code) and the read loop in `do_parent` must
+  agree on the fixed `prte_odls_pipe_err_msg_t` layout and the
+  `prte_odls_child_err_t` code set. Adding a new failure point means adding
+  a code to the enum **and** a case to `render_child_msg` in the parent.
 - **`execve` is the point of no return.** Everything the app needs — cwd,
   env (`cd->env`), argv, binding, closed fds, restored handlers — must be
   in place *before* it. The base assembles env/argv/cmd in `spawn_proc`; the
@@ -182,6 +193,6 @@ the *mechanism* (the actual `kill`).
   launch/kill/signal, retries, IOF wiring, waitpid interpretation, or state
   transitions belongs in `base/odls_base_default_fns.c`, shared by any
   future component. Keep `pdefault` to the OS primitives.
-- **`_exit`, not `exit`, in the child.** The child uses `_exit`/
-  `send_error_show_help` (which `_exit`s) so it never runs the parent's
+- **`_exit`, not `exit`, in the child.** The child terminates via
+  `prte_odls_base_child_fail` (which `_exit`s) so it never runs the parent's
   atexit handlers or flushes shared buffers.

--- a/src/mca/odls/pdefault/help-prte-odls-default.txt
+++ b/src/mca/odls/pdefault/help-prte-odls-default.txt
@@ -43,7 +43,23 @@ will now abort.
   Local host:        %s
   Application name:  %s
   Error message:     %s
-  Location:          %s:%d
+#
+[not bound]
+PRTE tried to bind a new process, but something went wrong and the
+process was left unbound.  The job will continue, but performance may
+be degraded.
+
+  Local host:        %s
+  Application name:  %s
+  Error message:     %s
+#
+[incorrectly bound]
+PRTE detected that the daemon is bound, but was unable to determine the
+binding of a new process.  The process was left bound to all available
+processors.  The job will continue, but performance may be degraded.
+
+  Local host:        %s
+  Application name:  %s
 #
 [iof setup failed]
 PRTE tried to launch a child process but the "IOF child setup"
@@ -52,16 +68,6 @@ failed.  This should not happen.  Your job will now abort.
   Local host:        %s
   Application name:  %s
 #
-[syscall fail]
-A system call failed that should not have.  In this particular case,
-a warning or error message was not displayed that should have been.
-Your job may behave unpredictably after this, or abort.
-
-  Local host:        %s
-  Application name:  %s
-  Function:          %s
-  Location:          %s:%d
-#
 [memory binding error]
 PRTE tried to bind memory for a new process but something went
 wrong. The process was killed without launching the target
@@ -69,8 +75,16 @@ application. Your job will now abort.
 
   Local host:        %s
   Application name:  %s
-  Error message: %s
-  Location:  %s:%d
+  Error message:     %s
+#
+[memory not bound]
+PRTE tried to bind memory for a new process, but something went wrong
+and the memory was left unbound.  The job will continue, but
+performance may be degraded.
+
+  Local host:        %s
+  Application name:  %s
+  Error message:     %s
 #
 [set limit]
 Error message received from:

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -150,9 +150,6 @@ static int restart_proc(prte_proc_t *child);
  * Explicitly declared functions so that we can get the noreturn
  * attribute registered with the compiler.
  */
-static void send_error_show_help(int fd, int exit_status, const char *file, const char *topic,
-                                 ...) __prte_attribute_noreturn__;
-
 static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd) __prte_attribute_noreturn__;
 
 /*
@@ -221,78 +218,11 @@ static void set_handler_default(int sig)
     sigaction(sig, &act, (struct sigaction *) 0);
 }
 
-/*
- * Internal function to write a rendered show_help message back up the
- * pipe to the waiting parent.
- */
-static int write_help_msg(int fd, prte_odls_pipe_err_msg_t *msg, const char *file,
-                          const char *topic, va_list ap)
-{
-    int ret;
-    char *str;
-
-    if (NULL == file || NULL == topic) {
-        return PRTE_ERR_BAD_PARAM;
-    }
-
-    str = pmix_show_help_vstring(file, topic, true, ap);
-
-    msg->file_str_len = (int) strlen(file);
-    if (msg->file_str_len > PRTE_ODLS_MAX_FILE_LEN) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-    msg->topic_str_len = (int) strlen(topic);
-    if (msg->topic_str_len > PRTE_ODLS_MAX_TOPIC_LEN) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-    msg->msg_str_len = (int) strlen(str);
-
-    /* Only keep writing if each write() succeeds */
-    if (PRTE_SUCCESS != (ret = pmix_fd_write(fd, sizeof(*msg), msg))) {
-        goto out;
-    }
-    if (msg->file_str_len > 0
-        && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->file_str_len, file))) {
-        goto out;
-    }
-    if (msg->topic_str_len > 0
-        && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->topic_str_len, topic))) {
-        goto out;
-    }
-    if (msg->msg_str_len > 0 && PRTE_SUCCESS != (ret = pmix_fd_write(fd, msg->msg_str_len, str))) {
-        goto out;
-    }
-
-out:
-    free(str);
-    return ret;
-}
-
-/* Called from the child to send an error message up the pipe to the
-   waiting parent. */
-static void send_error_show_help(int fd, int exit_status, const char *file, const char *topic, ...)
-{
-    va_list ap;
-    prte_odls_pipe_err_msg_t msg;
-
-    msg.fatal = true;
-    msg.exit_status = exit_status;
-
-    /* Send it */
-    va_start(ap, topic);
-    write_help_msg(fd, &msg, file, topic, ap);
-    va_end(ap);
-
-    _exit(exit_status);
-}
-
 static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
 {
     int i;
+    long fd, fdmax = sysconf(_SC_OPEN_MAX);
     sigset_t sigs;
-    char dir[PRTE_PATH_MAX];
 
 #if HAVE_SETPGID
     /* Set a new process group for this child, so that any
@@ -300,12 +230,19 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     setpgid(0, 0);
 #endif
 
+    /* Everything from here to execve() runs in the async-signal-safe
+       window after fork(): fork() copied only the calling thread and
+       left any lock another thread held frozen in this child, so calling
+       malloc/stdio/opendir/show_help can deadlock intermittently under
+       load.  We therefore restrict ourselves to async-signal-safe calls
+       and report any failure by writing a fixed-size record up the pipe
+       (prte_odls_base_child_fail / _warn); the parent renders the
+       human-readable diagnostic. */
+
     /* Setup the pipe to be close-on-exec */
     i = pmix_fd_set_cloexec(write_fd);
     if (0 != i) {
-        PRTE_ERROR_LOG(i);
-        send_error_show_help(write_fd, 1, "help-prte-odls-default.txt", "iof setup failed",
-                             prte_process_info.nodename, cd->app->app);
+        prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_IOF_SETUP, errno);
         /* Does not return */
     }
 
@@ -324,10 +261,8 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
            happened
         */
         if (PRTE_FLAG_TEST(cd->jdata, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
-            if (PRTE_SUCCESS != (i = prte_iof_base_setup_child(&cd->opts, &cd->env))) {
-                PRTE_ERROR_LOG(i);
-                send_error_show_help(write_fd, 1, "help-prte-odls-default.txt", "iof setup failed",
-                                     prte_process_info.nodename, cd->app->app);
+            if (PRTE_SUCCESS != prte_iof_base_setup_child(&cd->opts, &cd->env)) {
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_IOF_SETUP, errno);
                 /* Does not return */
             }
         }
@@ -341,10 +276,9 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
         for (i = 0; i < 3; i++) {
             fdnull = open("/dev/null", O_RDONLY, 0);
             if (0 > fdnull) {
-               send_error_show_help(write_fd, 1, "help-prte-odls-default.txt", "neg-fd",
-                                     prte_process_info.nodename, "/dev/null");
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_NEG_FD, errno);
                 /* Does not return */
-             }
+            }
             if (fdnull > i && i != write_fd) {
                 dup2(fdnull, i);
             }
@@ -352,15 +286,15 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
         }
     }
 
-    /* close all open file descriptors w/ exception of stdin/stdout/stderr,
-       the pipe used for the IOF INTERNAL messages, and the pipe up to
-       the parent. */
-    pmix_close_open_file_descriptors(write_fd);
-
-    if (cd->argv == NULL) {
-        cd->argv = malloc(sizeof(char *) * 2);
-        cd->argv[0] = strdup(cd->app->app);
-        cd->argv[1] = NULL;
+    /* Close all open file descriptors except stdin/stdout/stderr and the
+       pipe up to the parent.  We use a plain close() loop rather than
+       scanning /proc/self/fd with opendir/readdir (as
+       pmix_close_open_file_descriptors does): those allocate, and we are
+       in the async-signal-safe window between fork() and execve(). */
+    for (fd = 3; fd < fdmax; fd++) {
+        if (fd != write_fd) {
+            close((int) fd);
+        }
     }
 
     /* Set signal handlers back to the default.  Do this close to
@@ -386,9 +320,7 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
     /* take us to the correct wdir */
     if (NULL != cd->wdir) {
         if (0 != chdir(cd->wdir)) {
-            send_error_show_help(write_fd, 1, "help-prun.txt", "prun:wdir-not-found", "prted",
-                                 cd->wdir, prte_process_info.nodename,
-                                 (NULL == cd->child) ? 0 : cd->child->app_rank);
+            prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_WDIR, errno);
             /* Does not return */
         }
     }
@@ -399,9 +331,8 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
             errno = 0;
             i = ptrace(PRTE_TRACEME, 0, 0, 0);
             if (0 != errno) {
-                send_error_show_help(write_fd, 1, "help-prun.txt", "prun:stop-on-exec", "prted",
-                                     strerror(errno), prte_process_info.nodename,
-                                     (NULL == cd->child) ? 0 : cd->child->app_rank);
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_STOP_ON_EXEC, errno);
+                /* Does not return */
             }
         }
     }
@@ -409,27 +340,110 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
 
     /* Exec the new executable */
     execve(cd->cmd, cd->argv, cd->env);
-    /* If we get here, an error has occurred. */
-    pmix_getcwd(dir, sizeof(dir));
-    struct stat stats;
-    char *msg;
-    /* If errno is ENOENT, that indicates either cd->cmd does not exist, or
-     * cd->cmd is a script, but has a bad interpreter specified. */
-    if (ENOENT == errno && 0 == stat(cd->app->app, &stats)) {
-        pmix_asprintf(&msg, "%s has a bad interpreter on the first line.", cd->app->app);
-    } else {
-        msg = strdup(strerror(errno));
+    /* If we get here, an error has occurred.  We cannot render the
+       diagnostic here (it would require stat/getcwd/strerror/allocation);
+       the parent inspects errno and the app to distinguish, e.g., a
+       missing executable from a bad interpreter line. */
+    prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_EXEC, errno);
+    /* Does not return */
+}
+
+/* Map a captured errno onto a human-readable binding failure string. The
+   child cannot format this itself (it is between fork() and execve()), so
+   it sends only the errno and we render here in the parent. */
+static const char *bind_errmsg(int errnum)
+{
+    switch (errnum) {
+    case 0:
+        return "unable to apply the requested binding";
+    case ENOSYS:
+        return "hwloc indicates binding is not supported on this system";
+    case EXDEV:
+        return "hwloc indicates binding cannot be enforced on this system";
+    default:
+        return strerror(errnum);
     }
-    send_error_show_help(write_fd, 1, "help-prte-odls-default.txt", "execve error",
-                         prte_process_info.nodename, dir, cd->app->app, msg);
-    // does not return
+}
+
+/* Render, in the parent, the diagnostic for a failure the child reported
+   as a fixed-size code + errno record.  All allocation, stat(), getcwd(),
+   and show_help happen here where they are safe. */
+static void render_child_msg(prte_odls_spawn_caddy_t *cd, prte_odls_pipe_err_msg_t *msg)
+{
+    unsigned long rank = (NULL == cd->child) ? 0UL : (unsigned long) cd->child->app_rank;
+
+    switch (msg->which) {
+    case PRTE_ODLS_CHILD_ERR_IOF_SETUP:
+        pmix_show_help("help-prte-odls-default.txt", "iof setup failed", true,
+                       prte_process_info.nodename, cd->app->app);
+        break;
+    case PRTE_ODLS_CHILD_ERR_NEG_FD:
+        pmix_show_help("help-prte-odls-default.txt", "neg-fd", true,
+                       prte_process_info.nodename, "/dev/null");
+        break;
+    case PRTE_ODLS_CHILD_ERR_WDIR:
+        pmix_show_help("help-prun.txt", "prun:wdir-not-found", true, "prted",
+                       (NULL == cd->wdir) ? "<none>" : cd->wdir,
+                       prte_process_info.nodename, rank);
+        break;
+    case PRTE_ODLS_CHILD_ERR_STOP_ON_EXEC:
+        pmix_show_help("help-prun.txt", "prun:stop-on-exec", true, "prted",
+                       strerror(msg->errnum), prte_process_info.nodename, rank);
+        break;
+    case PRTE_ODLS_CHILD_ERR_BIND:
+        pmix_show_help("help-prte-odls-default.txt", "binding generic error", true,
+                       prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
+        break;
+    case PRTE_ODLS_CHILD_ERR_BIND_MEM:
+        pmix_show_help("help-prte-odls-default.txt", "memory binding error", true,
+                       prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
+        break;
+    case PRTE_ODLS_CHILD_WARN_NOT_BOUND:
+        pmix_show_help("help-prte-odls-default.txt", "not bound", true,
+                       prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
+        break;
+    case PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND:
+        pmix_show_help("help-prte-odls-default.txt", "memory not bound", true,
+                       prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
+        break;
+    case PRTE_ODLS_CHILD_WARN_INCORRECT:
+        pmix_show_help("help-prte-odls-default.txt", "incorrectly bound", true,
+                       prte_process_info.nodename, cd->app->app);
+        break;
+    case PRTE_ODLS_CHILD_ERR_EXEC:
+    default: {
+        char dir[PRTE_PATH_MAX];
+        const char *wdir;
+        const char *errmsg;
+        struct stat statbuf;
+
+        /* the child's working dir at exec time is the app's wdir if one
+           was given, otherwise the daemon's cwd (it never chdir'd) */
+        if (NULL != cd->wdir) {
+            wdir = cd->wdir;
+        } else if (NULL != getcwd(dir, sizeof(dir))) {
+            wdir = dir;
+        } else {
+            wdir = "<unknown>";
+        }
+        /* ENOENT with an existing file means cd->cmd is a script with a
+           bad interpreter on its first line, not a missing executable */
+        if (ENOENT == msg->errnum && 0 == stat(cd->app->app, &statbuf)) {
+            errmsg = "the executable has a bad interpreter on its first line";
+        } else {
+            errmsg = strerror(msg->errnum);
+        }
+        pmix_show_help("help-prte-odls-default.txt", "execve error", true,
+                       prte_process_info.nodename, wdir, cd->app->app, errmsg);
+        break;
+    }
+    }
 }
 
 static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
 {
     int rc;
     prte_odls_pipe_err_msg_t msg;
-    char file[PRTE_ODLS_MAX_FILE_LEN + 1], topic[PRTE_ODLS_MAX_TOPIC_LEN + 1], *str = NULL;
 
     if (cd->opts.connect_stdin) {
         close(cd->opts.p_stdin[0]);
@@ -437,7 +451,9 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
     close(cd->opts.p_stdout[1]);
     close(cd->opts.p_stderr[1]);
 
-    /* Block reading a message from the pipe */
+    /* Block reading fixed-size records from the pipe.  The child may send
+       zero or more non-fatal warnings before either exec'ing successfully
+       (the pipe closes with no further data) or reporting a fatal error. */
     while (1) {
         rc = pmix_fd_read(read_fd, sizeof(msg), &msg);
 
@@ -467,67 +483,9 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
             }
         }
 
-        /* Read in the strings; ensure to terminate them with \0 */
-        if (msg.file_str_len > 0) {
-            rc = pmix_fd_read(read_fd, msg.file_str_len, file);
-            if (PMIX_SUCCESS != rc) {
-                pmix_show_help("help-prte-odls-default.txt", "syscall fail", true,
-                               prte_process_info.nodename, cd->app->app, "pmix_fd_read",
-                               __FILE__, __LINE__);
-                if (NULL != cd->child) {
-                    cd->child->state = PRTE_PROC_STATE_UNDEF;
-                }
-                rc = prte_pmix_convert_status(rc);
-                return rc;
-            }
-            file[msg.file_str_len] = '\0';
-        }
-        if (msg.topic_str_len > 0) {
-            rc = pmix_fd_read(read_fd, msg.topic_str_len, topic);
-            if (PMIX_SUCCESS != rc) {
-                pmix_show_help("help-prte-odls-default.txt", "syscall fail", true,
-                               prte_process_info.nodename, cd->app->app, "pmix_fd_read",
-                               __FILE__, __LINE__);
-                if (NULL != cd->child) {
-                    cd->child->state = PRTE_PROC_STATE_UNDEF;
-                }
-                rc = prte_pmix_convert_status(rc);
-                return rc;
-            }
-            topic[msg.topic_str_len] = '\0';
-        }
-        if (msg.msg_str_len > 0) {
-            str = calloc(1, msg.msg_str_len + 1);
-            if (NULL == str) {
-                pmix_show_help("help-prte-odls-default.txt", "syscall fail", true,
-                               prte_process_info.nodename, cd->app->app, "calloc",
-                               __FILE__, __LINE__);
-                if (NULL != cd->child) {
-                    cd->child->state = PRTE_PROC_STATE_UNDEF;
-                }
-                rc = prte_pmix_convert_status(rc);
-                return rc;
-            }
-            rc = pmix_fd_read(read_fd, msg.msg_str_len, str);
-            if (PMIX_SUCCESS != rc) {
-                pmix_show_help("help-prte-odls-default.txt", "syscall fail", true,
-                               prte_process_info.nodename, cd->app->app, "pmix_fd_read",
-                               __FILE__, __LINE__);
-                if (NULL != cd->child) {
-                    cd->child->state = PRTE_PROC_STATE_UNDEF;
-                }
-                rc = prte_pmix_convert_status(rc);
-                return rc;
-            }
-         }
-
-        /* Print out what we got.  We already have a rendered string,
-           so use pmix_show_help_norender(). */
-        if (msg.msg_str_len > 0) {
-            pmix_show_help_norender(file, topic, str);
-            free(str);
-            str = NULL;
-        }
+        /* Render the human-readable diagnostic here in the parent, where
+           allocation and show_help are safe. */
+        render_child_msg(cd, &msg);
 
         /* If msg.fatal is true, then the child exited with an error.
            Otherwise, whatever we just printed was a warning, so loop
@@ -565,6 +523,24 @@ static int fork_local_proc(void *cdptr)
     int p[2];
     pid_t pid;
     prte_proc_t *child = cd->child;
+
+    /* Default the argv if the app didn't provide one.  Do this here in
+       the parent, before the fork, so the child - which runs in the
+       async-signal-safe window before execve() - does not have to
+       allocate. */
+    if (NULL == cd->argv) {
+        cd->argv = malloc(sizeof(char *) * 2);
+        if (NULL == cd->argv) {
+            PRTE_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            if (NULL != child) {
+                child->state = PRTE_PROC_STATE_FAILED_TO_START;
+                child->exit_code = PMIX_ERR_OUT_OF_RESOURCE;
+            }
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        cd->argv[0] = strdup(cd->app->app);
+        cd->argv[1] = NULL;
+    }
 
     /* A pipe is used to communicate between the parent and child to
        indicate whether the exec ultimately succeeded or failed.  The


### PR DESCRIPTION
Makes the `odls` fork/exec child path async-signal-safe. Two commits, two logical changes.

## 1. Error reporting (`Make the odls fork/exec child path async-signal-safe`)

The `odls` code that runs in the forked child, between `fork()` and `execve()`, did several things that are not async-signal-safe: it rendered `show_help` in the child (`pmix_show_help_vstring` — allocates, reads the help file, scans directories); closed fds by scanning `/proc/self/fd` with `opendir`/`readdir`; `malloc`/`strdup`d `argv`; called `getcwd`/`stat`/`asprintf`/`strerror` after a failed `execve`; and in the binding path even terminated the child with `exit()` instead of `_exit()`. `fork()` copies only the calling thread and leaves any lock another thread held frozen in the child, so any of these can deadlock the child intermittently under load — which then blocks the parent on the error pipe. Same class of bug as openpmix/openpmix#4005.

Fix: restrict the child to async-signal-safe operations and render in the parent.
- Replace the variable-length `show_help`-string pipe protocol with a fixed-size `{fatal, exit_status, which, errnum}` record plus a `prte_odls_child_err_t` code enum.
- Add `prte_odls_base_child_fail` (fatal, `_exit`s) / `prte_odls_base_child_warn` (non-fatal, returns), shared by `do_child` and the binding code.
- `do_child` reports codes only; closes fds with a plain `close()` loop; `argv` is defaulted in the parent before the fork; nothing rendered after `execve`.
- `do_parent` reads the record and renders (`render_child_msg`), including the bad-interpreter `stat()` check and working-dir reconstruction.
- Register the three binding-warning help topics (`not bound`, `memory not bound`, `incorrectly bound`) that were referenced but missing from every help file — a pre-existing latent bug where those warnings rendered as "help not found".

## 2. Binding mechanism (`Compute process binding in the parent, not the forked child`)

Even after (1), `prte_odls_base_set()` still ran in the child and, to bind, called `hwloc_bitmap_alloc`, parsed the cpuset with `hwloc_bitmap_list_sscanf`, called `hwloc_set_cpubind`/`hwloc_set_membind`, and rendered `--report-bindings` output. hwloc allocates, and on Linux `hwloc_set_cpubind` `CPU_ALLOC`s once the logical-CPU count exceeds the fixed `cpu_set_t` size — exactly the large-node case. The fork runs on an odls spawn-pool worker thread while other threads allocate, so the same deadlock applies.

Fix: split the work.
- `prte_odls_base_prepare_binding()` runs in the **parent** (in `spawn_proc`, pre-fork): parses the cpuset, classifies the binding, precomputes the membind policy, emits `--report-bindings` + the "incorrectly bound" warning, and stashes a ready-to-apply result on the caddy.
- `prte_odls_base_set()` runs in the **child** and only issues the bind syscalls.
- **CPU affinity**: the child issues a bare `sched_setaffinity()` with a `cpu_set_t` the parent precomputed — a syscall is async-signal-safe. Gated on a new `PRTE_HAVE_SCHED_SETAFFINITY` configure check (`config/prte_check_setaffinity.m4`); where absent (e.g. macOS) an `#else` clause falls back to `hwloc_set_cpubind`.
- **Memory binding** still uses `hwloc_set_membind` in the child on all platforms; a bare `set_mempolicy`/`mbind` path would mean reproducing hwloc's NUMA nodeset handling and is left for a follow-up.
- Consequence: `--report-bindings` now renders the binding the mapper *requested* rather than the value read back after binding. For a successful bind these are identical, and it keeps the allocating render out of the child.

## Testing

- Warning-free build with picky compilers (`--enable-debug`), `-Wundef` clean (the capability macro is always defined 0/1).
- `make check` passes; `make -C test/offline check-offline` passes all 1176 mapper cases (no mapping/binding regression).
- Live DVM: normal `prun -n 4 hostname` launches cleanly through the rewritten fork + prepare/apply path; a bad-interpreter script triggers a real `execve` failure rendered correctly by the parent (bad-interpreter message + reconstructed wdir); `pterm` shuts down cleanly.
- **Platform note:** developed/tested on macOS, where `sched_setaffinity` is absent, so the **`#else` hwloc fallback** path is what ran here; macOS also rejects binding at map time, so the Linux `sched_setaffinity` branch and live binding enforcement still need validation on Linux/CI.