### PR TITLE
ras/slurm: coordinate elastic DVM release and regrow

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -65,7 +65,8 @@ EXAMPLES = \
 	client-threaded \
 	dynamic-dep \
 	abort \
-	elastic
+	elastic \
+	slurm/elastic-coordination
 
 all: $(EXAMPLES)
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -73,4 +73,6 @@ EXTRA_DIST += \
         examples/client-threaded.c \
         examples/dynamic-dep.c \
         examples/abort.c \
-        examples/elastic.c
+        examples/elastic.c \
+        examples/slurm/README \
+        examples/slurm/elastic-coordination.c

--- a/examples/slurm/README
+++ b/examples/slurm/README
@@ -1,0 +1,52 @@
+# Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+#                         All rights reserved.
+# $COPYRIGHT$
+
+The files in this directory demonstrate PRRTE elastic DVM coordination in a
+Slurm allocation. They require a PRRTE build with the Slurm RAS component,
+Jansson support, and elastic mode enabled.
+
+elastic-coordination.c:
+A Slurm-specific PMIx client for exercising dynamic allocation changes. It
+accepts interactive requests to extend by node count and to shrink by node
+count, allocation ID, or node list. After every request it queries PRRTE's
+allocation state, displays the corresponding Slurm jobs, and uses prun to
+verify reachability across the active DVM.
+
+The client treats the PMIx allocation callback as request acceptance and uses
+allocation queries to observe the resulting state. It does not require the
+application to wait for a PMIX_DVM_IS_READY event because PRRTE coordinates
+launches internally with the DVM launch fence.
+
+Build from the examples directory with:
+
+    make slurm/elastic-coordination
+
+Place the executable on a filesystem shared with the Slurm compute nodes. For
+example:
+
+    cp slurm/elastic-coordination $HOME/slurm-elastic-coordination
+
+Then run inside a Slurm allocation with one initial node:
+
+    export PRTE_MCA_prte_elastic_mode=1
+    salloc -N1
+    srun -N1 -n1 \
+        prterun -np 1 $HOME/slurm-elastic-coordination
+
+At the coord prompt, available commands are:
+
+    extend count N
+    shrink count N
+    shrink alloc SLURM_JOB_ID
+    shrink list NODE1,NODE2
+    prun [ARGS...]
+    refresh
+    quit
+
+The program invokes squeue and prun for diagnostics, so both commands must be
+available in PATH.
+
+The program may not tolerate delays while acquiring additional resources. It
+is therefore best run in a containerized Slurm environment where requested
+resources are available immediately.

--- a/examples/slurm/elastic-coordination.c
+++ b/examples/slurm/elastic-coordination.c
@@ -1,0 +1,1097 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <pmix.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define VERIFY_TIMEOUT 10
+#define REQUEST_TIMEOUT 10
+#define PRUN_TIMEOUT 10
+#define LINE_MAX_LEN 1024
+
+static void record_message(const char *fmt, ...);
+static int line_seen(char **lines, const char *line);
+
+static void trace_point(const char *msg)
+{
+    printf("[tester] %s\n", msg);
+    fflush(stdout);
+}
+
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    int done;
+    pmix_status_t status;
+} wait_t;
+
+typedef struct {
+    char *id;
+    char **nodes;
+    size_t nnodes;
+} alloc_record_t;
+
+typedef struct {
+    alloc_record_t *allocs;
+    size_t nallocs;
+    size_t size;
+} alloc_snapshot_t;
+
+static void wait_init(wait_t *w)
+{
+    pthread_mutex_init(&w->lock, NULL);
+    pthread_cond_init(&w->cond, NULL);
+    w->done = 0;
+    w->status = PMIX_SUCCESS;
+}
+
+static void wait_destroy(wait_t *w)
+{
+    pthread_cond_destroy(&w->cond);
+    pthread_mutex_destroy(&w->lock);
+}
+
+static int wait_for_callback(wait_t *w, int seconds)
+{
+    struct timespec ts;
+
+    if (0 != clock_gettime(CLOCK_REALTIME, &ts)) {
+        return -1;
+    }
+    ts.tv_sec += seconds;
+
+    pthread_mutex_lock(&w->lock);
+    while (!w->done) {
+        int rc = pthread_cond_timedwait(&w->cond, &w->lock, &ts);
+        if (ETIMEDOUT == rc) {
+            pthread_mutex_unlock(&w->lock);
+            return -1;
+        }
+        if (0 != rc) {
+            pthread_mutex_unlock(&w->lock);
+            return -2;
+        }
+    }
+    pthread_mutex_unlock(&w->lock);
+    return 0;
+}
+
+static int status_is_accepted(pmix_status_t status)
+{
+    if (PMIX_SUCCESS == status) {
+        return 1;
+    }
+#ifdef PMIX_OPERATION_SUCCEEDED
+    if (PMIX_OPERATION_SUCCEEDED == status) {
+        return 1;
+    }
+#endif
+#ifdef PMIX_OPERATION_IN_PROGRESS
+    if (PMIX_OPERATION_IN_PROGRESS == status) {
+        return 1;
+    }
+#endif
+    return 0;
+}
+
+static void alloc_cbfunc(pmix_status_t status, pmix_info_t *results,
+                         size_t nresults, void *cbdata,
+                         pmix_release_cbfunc_t release_fn,
+                         void *release_cbdata)
+{
+    wait_t *w = (wait_t *) cbdata;
+
+    record_message("PMIx allocation callback: %s (%zu result%s)\n",
+                   PMIx_Error_string(status), nresults,
+                   1 == nresults ? "" : "s");
+    for (size_t n = 0; n < nresults; n++) {
+        if (PMIX_STRING == results[n].value.type) {
+            record_message("  %s = %s\n", results[n].key,
+                           results[n].value.data.string);
+        } else {
+            record_message("  %s type=%d\n", results[n].key,
+                           (int) results[n].value.type);
+        }
+    }
+
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    pthread_mutex_lock(&w->lock);
+    w->status = status;
+    w->done = 1;
+    pthread_cond_signal(&w->cond);
+    pthread_mutex_unlock(&w->lock);
+}
+
+static void snapshot_init(alloc_snapshot_t *snap)
+{
+    snap->allocs = NULL;
+    snap->nallocs = 0;
+    snap->size = 0;
+}
+
+static void snapshot_free(alloc_snapshot_t *snap)
+{
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        free(snap->allocs[i].id);
+        if (NULL != snap->allocs[i].nodes) {
+            PMIx_Argv_free(snap->allocs[i].nodes);
+        }
+    }
+    free(snap->allocs);
+    snapshot_init(snap);
+}
+
+static alloc_record_t *snapshot_add_alloc(alloc_snapshot_t *snap,
+                                          const char *id)
+{
+    alloc_record_t *tmp;
+
+    if (snap->nallocs == snap->size) {
+        size_t newsize = 0 == snap->size ? 4 : 2 * snap->size;
+
+        tmp = realloc(snap->allocs, newsize * sizeof(*snap->allocs));
+        if (NULL == tmp) {
+            return NULL;
+        }
+        snap->allocs = tmp;
+        snap->size = newsize;
+    }
+
+    tmp = &snap->allocs[snap->nallocs++];
+    tmp->id = strdup(id);
+    tmp->nodes = NULL;
+    tmp->nnodes = 0;
+    if (NULL == tmp->id) {
+        snap->nallocs--;
+        return NULL;
+    }
+    return tmp;
+}
+
+static void snapshot_remove_last_alloc(alloc_snapshot_t *snap)
+{
+    alloc_record_t *rec;
+
+    if (0 == snap->nallocs) {
+        return;
+    }
+
+    rec = &snap->allocs[snap->nallocs - 1];
+    free(rec->id);
+    if (NULL != rec->nodes) {
+        PMIx_Argv_free(rec->nodes);
+    }
+    snap->nallocs--;
+}
+
+static alloc_record_t *snapshot_find_alloc(const alloc_snapshot_t *snap,
+                                           const char *id)
+{
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        if (0 == strcmp(snap->allocs[i].id, id)) {
+            return &((alloc_snapshot_t *) snap)->allocs[i];
+        }
+    }
+    return NULL;
+}
+
+static size_t snapshot_total_nodes(const alloc_snapshot_t *snap)
+{
+    size_t total = 0;
+
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        total += snap->allocs[i].nnodes;
+    }
+    return total;
+}
+
+static int snapshot_has_node(const alloc_snapshot_t *snap, const char *node)
+{
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        for (size_t j = 0; NULL != snap->allocs[i].nodes &&
+                           NULL != snap->allocs[i].nodes[j]; j++) {
+            if (0 == strcmp(snap->allocs[i].nodes[j], node)) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static char **snapshot_unique_nodes(const alloc_snapshot_t *snap)
+{
+    char **nodes = NULL;
+
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        for (size_t j = 0; NULL != snap->allocs[i].nodes &&
+                           NULL != snap->allocs[i].nodes[j]; j++) {
+            int arc;
+
+            if (NULL != nodes && line_seen(nodes, snap->allocs[i].nodes[j])) {
+                continue;
+            }
+            PMIX_ARGV_APPEND(arc, nodes, snap->allocs[i].nodes[j]);
+            if (PMIX_SUCCESS != arc) {
+                PMIx_Argv_free(nodes);
+                return NULL;
+            }
+        }
+    }
+
+    return nodes;
+}
+
+static void record_message(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+}
+
+static pmix_status_t query_one(const char *key, const char *allocid,
+                               pmix_info_t **results, size_t *nresults)
+{
+    pmix_query_t *query;
+    pmix_status_t rc;
+    int arc;
+
+    PMIX_QUERY_CREATE(query, 1);
+    PMIX_ARGV_APPEND(arc, query[0].keys, key);
+    if (PMIX_SUCCESS != arc) {
+        PMIX_QUERY_FREE(query, 1);
+        return (pmix_status_t) arc;
+    }
+
+    if (NULL != allocid) {
+        PMIX_QUERY_QUALIFIERS_CREATE(&query[0], 1);
+        PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_ALLOC_ID, allocid,
+                       PMIX_STRING);
+    }
+
+    printf("[tester] query begin: %s%s%s\n", key,
+           NULL == allocid ? "" : " alloc=", NULL == allocid ? "" : allocid);
+    fflush(stdout);
+    rc = PMIx_Query_info(query, 1, results, nresults);
+    printf("[tester] query end: %s -> %s (%zu result%s)\n", key,
+           PMIx_Error_string(rc), NULL == nresults ? 0 : *nresults,
+           NULL != nresults && 1 == *nresults ? "" : "s");
+    fflush(stdout);
+    PMIX_QUERY_FREE(query, 1);
+    return rc;
+}
+
+static int append_node(char ***nodes, const char *node)
+{
+    int rc;
+
+    if (NULL == node) {
+        return 0;
+    }
+    PMIX_ARGV_APPEND(rc, *nodes, node);
+    return PMIX_SUCCESS == rc ? 0 : -1;
+}
+
+static int fill_alloc_nodes(alloc_record_t *rec)
+{
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    rc = query_one(PMIX_QUERY_ALLOCATION, rec->id, &results, &nresults);
+    if (PMIX_ERR_NOT_FOUND == rc) {
+        printf("PMIx query %s for %s: expected not found; allocation is gone\n",
+               PMIX_QUERY_ALLOCATION, rec->id);
+        return 1;
+    }
+    if (PMIX_SUCCESS != rc && PMIX_ERR_PARTIAL_SUCCESS != rc) {
+        fprintf(stderr, "PMIx query %s for %s failed: %s\n",
+                PMIX_QUERY_ALLOCATION, rec->id, PMIx_Error_string(rc));
+        return -1;
+    }
+
+    for (size_t i = 0; i < nresults; i++) {
+        pmix_data_array_t *darray;
+        pmix_info_t *info;
+
+        if (!PMIx_Check_key(results[i].key, PMIX_QUERY_ALLOCATION) ||
+            PMIX_DATA_ARRAY != results[i].value.type) {
+            continue;
+        }
+
+        darray = results[i].value.data.darray;
+        if (NULL == darray || PMIX_INFO != darray->type) {
+            continue;
+        }
+
+        info = (pmix_info_t *) darray->array;
+        for (size_t j = 0; j < darray->size; j++) {
+            pmix_data_array_t *nodearray;
+            pmix_info_t *nodeinfo;
+
+            if (!PMIx_Check_key(info[j].key, PMIX_NODE_INFO) ||
+                PMIX_DATA_ARRAY != info[j].value.type) {
+                continue;
+            }
+
+            nodearray = info[j].value.data.darray;
+            if (NULL == nodearray || PMIX_INFO != nodearray->type) {
+                continue;
+            }
+
+            nodeinfo = (pmix_info_t *) nodearray->array;
+            for (size_t k = 0; k < nodearray->size; k++) {
+                if (PMIx_Check_key(nodeinfo[k].key, PMIX_HOSTNAME) &&
+                    PMIX_STRING == nodeinfo[k].value.type) {
+                    if (0 != append_node(&rec->nodes,
+                                         nodeinfo[k].value.data.string)) {
+                        PMIX_INFO_FREE(results, nresults);
+                        return -1;
+                    }
+                    rec->nnodes++;
+                    break;
+                }
+            }
+        }
+    }
+
+    PMIX_INFO_FREE(results, nresults);
+    return 0;
+}
+
+static int query_snapshot(alloc_snapshot_t *snap)
+{
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    snapshot_init(snap);
+
+    rc = query_one(PMIX_QUERY_ALLOC_IDS, NULL, &results, &nresults);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_PARTIAL_SUCCESS != rc) {
+        fprintf(stderr, "PMIx query %s failed: %s\n", PMIX_QUERY_ALLOC_IDS,
+                PMIx_Error_string(rc));
+        return -1;
+    }
+
+    for (size_t i = 0; i < nresults; i++) {
+        pmix_data_array_t *darray;
+        pmix_info_t *info;
+
+        if (!PMIx_Check_key(results[i].key, PMIX_QUERY_ALLOC_IDS) ||
+            PMIX_DATA_ARRAY != results[i].value.type) {
+            continue;
+        }
+
+        darray = results[i].value.data.darray;
+        if (NULL == darray || PMIX_INFO != darray->type) {
+            continue;
+        }
+
+        info = (pmix_info_t *) darray->array;
+        for (size_t j = 0; j < darray->size; j++) {
+            alloc_record_t *rec;
+
+            if (!PMIx_Check_key(info[j].key, PMIX_ALLOC_ID) ||
+                PMIX_STRING != info[j].value.type) {
+                continue;
+            }
+
+            rec = snapshot_add_alloc(snap, info[j].value.data.string);
+            if (NULL == rec) {
+                PMIX_INFO_FREE(results, nresults);
+                snapshot_free(snap);
+                return -1;
+            }
+            int fill_rc = fill_alloc_nodes(rec);
+            if (0 < fill_rc) {
+                snapshot_remove_last_alloc(snap);
+                continue;
+            }
+            if (0 > fill_rc) {
+                PMIX_INFO_FREE(results, nresults);
+                snapshot_free(snap);
+                return -1;
+            }
+        }
+    }
+
+    PMIX_INFO_FREE(results, nresults);
+    return 0;
+}
+
+static void print_snapshot(const alloc_snapshot_t *snap)
+{
+    printf("\nPRRTE allocations: %zu allocation%s, %zu node%s total\n",
+           snap->nallocs, 1 == snap->nallocs ? "" : "s",
+           snapshot_total_nodes(snap),
+           1 == snapshot_total_nodes(snap) ? "" : "s");
+    for (size_t i = 0; i < snap->nallocs; i++) {
+        printf("  alloc %s: %zu node%s", snap->allocs[i].id,
+               snap->allocs[i].nnodes, 1 == snap->allocs[i].nnodes ? "" : "s");
+        for (size_t j = 0; NULL != snap->allocs[i].nodes &&
+                           NULL != snap->allocs[i].nodes[j]; j++) {
+            printf(" %s", snap->allocs[i].nodes[j]);
+        }
+        printf("\n");
+    }
+}
+
+static int run_command(const char *title, const char *cmd)
+{
+    FILE *fp;
+    char full_cmd[2 * LINE_MAX_LEN];
+    char line[LINE_MAX_LEN];
+    int rc;
+
+    printf("\n== %s ==\n$ %s\n", title, cmd);
+    printf("(deduplicating parsed rank/pid/host output)\n");
+    fflush(stdout);
+    snprintf(full_cmd, sizeof(full_cmd), "timeout -k 5s %ds %s </dev/null 2>&1",
+             PRUN_TIMEOUT, cmd);
+    fp = popen(full_cmd, "r");
+    if (NULL == fp) {
+        fprintf(stderr, "failed to run command: %s\n", strerror(errno));
+        return -1;
+    }
+
+    while (NULL != fgets(line, sizeof(line), fp)) {
+        fputs(line, stdout);
+    }
+
+    rc = pclose(fp);
+    if (-1 == rc) {
+        fprintf(stderr, "failed to close command: %s\n", strerror(errno));
+        return -1;
+    }
+    return rc;
+}
+
+static void run_prun_command(const char *cmd)
+{
+    char full_cmd[2 * LINE_MAX_LEN];
+    int rc;
+
+    printf("\n$ %s\n", cmd);
+    fflush(stdout);
+    snprintf(full_cmd, sizeof(full_cmd), "(%s) >/dev/null 2>&1", cmd);
+    rc = system(full_cmd);
+    if (-1 == rc) {
+        fprintf(stderr, "failed to run prun: %s\n", strerror(errno));
+    }
+}
+
+static int all_digits(const char *s)
+{
+    if (NULL == s || '\0' == s[0]) {
+        return 0;
+    }
+    for (size_t i = 0; '\0' != s[i]; i++) {
+        if (!isdigit((unsigned char) s[i])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int squeue_job_exists(const char *jobid)
+{
+    char cmd[256];
+    char line[LINE_MAX_LEN];
+    FILE *fp;
+    int exists = 0;
+
+    if (!all_digits(jobid)) {
+        return -1;
+    }
+
+    snprintf(cmd, sizeof(cmd), "squeue -h -j %s 2>/dev/null", jobid);
+    fp = popen(cmd, "r");
+    if (NULL == fp) {
+        return -1;
+    }
+    if (NULL != fgets(line, sizeof(line), fp)) {
+        exists = 1;
+    }
+    pclose(fp);
+    return exists;
+}
+
+static void print_squeue(void)
+{
+    const char *user = getenv("USER");
+    char cmd[512];
+
+    if (NULL != user && '\0' != user[0]) {
+        snprintf(cmd, sizeof(cmd),
+                 "squeue -u %s -o '%%.18i %%.9T %%.12j %%.40N'", user);
+    } else {
+        snprintf(cmd, sizeof(cmd),
+                 "squeue -o '%%.18i %%.9T %%.12j %%.40N'");
+    }
+    run_command("Slurm queue", cmd);
+}
+
+static int line_seen(char **lines, const char *line)
+{
+    for (int i = 0; NULL != lines && NULL != lines[i]; i++) {
+        if (0 == strcmp(lines[i], line)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void make_prun_output_key(const char *line, char *key, size_t keylen)
+{
+    char rank[64];
+    char pid[64];
+    char host[256];
+    const char *start;
+
+    start = strstr(line, "rank=");
+    if (NULL != start &&
+        3 == sscanf(start, "rank=%63[0-9] pid=%63[0-9] host=%255[A-Za-z0-9_.-]",
+                    rank, pid, host)) {
+        snprintf(key, keylen, "rank=%s pid=%s host=%s", rank, pid, host);
+        return;
+    }
+
+    snprintf(key, keylen, "%s", line);
+}
+
+static int run_unique_command(const char *title, const char *cmd)
+{
+    FILE *fp;
+    char full_cmd[2 * LINE_MAX_LEN];
+    char line[LINE_MAX_LEN];
+    char key[LINE_MAX_LEN];
+    char **seen = NULL;
+    int suppressed = 0;
+    int unique = 0;
+    int rc;
+
+    printf("\n== %s ==\n$ %s\n", title, cmd);
+    fflush(stdout);
+    snprintf(full_cmd, sizeof(full_cmd), "timeout -k 5s %ds %s </dev/null 2>&1",
+             PRUN_TIMEOUT, cmd);
+    fp = popen(full_cmd, "r");
+    if (NULL == fp) {
+        fprintf(stderr, "failed to run command: %s\n", strerror(errno));
+        return -1;
+    }
+
+    while (NULL != fgets(line, sizeof(line), fp)) {
+        int arc;
+
+        make_prun_output_key(line, key, sizeof(key));
+        if (line_seen(seen, key)) {
+            suppressed++;
+            continue;
+        }
+        PMIX_ARGV_APPEND(arc, seen, key);
+        if (PMIX_SUCCESS == arc) {
+            unique++;
+        }
+    }
+
+    rc = pclose(fp);
+    printf("reachability: %d unique rank/pid/host line%s",
+           unique, 1 == unique ? "" : "s");
+    if (0 < suppressed) {
+        printf(" (%d duplicate IOF line%s)",
+               suppressed, 1 == suppressed ? "" : "s");
+    }
+    printf("\n");
+    if (NULL != seen) {
+        PMIx_Argv_free(seen);
+    }
+    if (-1 == rc) {
+        fprintf(stderr, "failed to close command: %s\n", strerror(errno));
+        return -1;
+    }
+    if (WIFEXITED(rc) && 124 == WEXITSTATUS(rc)) {
+        printf("reachability probe timed out after %d seconds\n", PRUN_TIMEOUT);
+    }
+    return rc;
+}
+
+static void run_prun_hostname(const alloc_snapshot_t *snap)
+{
+    char cmd[512];
+    char **nodes;
+    int nnodes;
+
+    nodes = snapshot_unique_nodes(snap);
+    nnodes = PMIx_Argv_count(nodes);
+    if (0 == nnodes) {
+        printf("\n== prun hostname ==\n(no known PRRTE nodes)\n");
+        PMIx_Argv_free(nodes);
+        return;
+    }
+
+    printf("\n== prun hostname across DVM ==\n");
+    snprintf(cmd, sizeof(cmd),
+             "prun -np %d --map-by ppr:1:node sh -c "
+             "'echo rank=${PMIX_RANK:-?} pid=$$ host=$(hostname)'",
+             nnodes);
+    run_unique_command("prun hostname", cmd);
+    PMIx_Argv_free(nodes);
+}
+
+static void show_state(void)
+{
+    alloc_snapshot_t snap;
+
+    trace_point("show_state: begin");
+    print_squeue();
+    trace_point("show_state: querying PRRTE snapshot");
+    if (0 == query_snapshot(&snap)) {
+        trace_point("show_state: printing PRRTE snapshot");
+        print_snapshot(&snap);
+        trace_point("show_state: running reachability probe");
+        run_prun_hostname(&snap);
+        snapshot_free(&snap);
+    } else {
+        printf("\nPRRTE allocation query failed\n");
+    }
+    trace_point("show_state: end");
+}
+
+static pmix_status_t submit_alloc_request(pmix_alloc_directive_t directive,
+                                          pmix_info_t *info, size_t ninfo,
+                                          const char *description)
+{
+    pmix_status_t rc;
+    wait_t w;
+
+    wait_init(&w);
+    record_message("\nSubmitting %s\n", description);
+    trace_point("allocation request: submit");
+    rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cbfunc, &w);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Allocation_request_nb failed immediately: %s\n",
+                PMIx_Error_string(rc));
+        wait_destroy(&w);
+        return rc;
+    }
+
+    trace_point("allocation request: waiting for callback");
+    if (0 != wait_for_callback(&w, REQUEST_TIMEOUT)) {
+        fprintf(stderr, "timed out waiting for PMIx allocation callback\n");
+        wait_destroy(&w);
+        return PMIX_ERR_TIMEOUT;
+    }
+    trace_point("allocation request: callback received");
+
+    rc = w.status;
+    wait_destroy(&w);
+    return rc;
+}
+
+static void make_reqid(char *buf, size_t size, const char *prefix)
+{
+    static unsigned int next_id = 1;
+
+    snprintf(buf, size, "%s-%ld-%u", prefix, (long) getpid(), next_id++);
+}
+
+static int wait_until_alloc_count_at_least(size_t min_count)
+{
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+        int ok = 0;
+
+        if (0 == query_snapshot(&snap)) {
+            ok = snapshot_total_nodes(&snap) >= min_count;
+            snapshot_free(&snap);
+        }
+        if (ok) {
+            return 0;
+        }
+        sleep(1);
+    }
+    return -1;
+}
+
+static int wait_until_alloc_removed(const char *allocid)
+{
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+        int gone = 0;
+
+        if (0 == query_snapshot(&snap)) {
+            gone = NULL == snapshot_find_alloc(&snap, allocid);
+            snapshot_free(&snap);
+        }
+        if (gone) {
+            return 0;
+        }
+        sleep(1);
+    }
+    return -1;
+}
+
+static int wait_until_nodes_absent(char **nodes)
+{
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+        int absent = 1;
+
+        if (0 == query_snapshot(&snap)) {
+            for (int n = 0; NULL != nodes[n]; n++) {
+                if (snapshot_has_node(&snap, nodes[n])) {
+                    absent = 0;
+                    break;
+                }
+            }
+            snapshot_free(&snap);
+        } else {
+            absent = 0;
+        }
+        if (absent) {
+            return 0;
+        }
+        sleep(1);
+    }
+    return -1;
+}
+
+static int wait_until_total_nodes_at_most(size_t max_count)
+{
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+        int ok = 0;
+
+        if (0 == query_snapshot(&snap)) {
+            ok = snapshot_total_nodes(&snap) <= max_count;
+            snapshot_free(&snap);
+        }
+        if (ok) {
+            return 0;
+        }
+        sleep(1);
+    }
+    return -1;
+}
+
+static void handle_extend_count(uint64_t count)
+{
+    alloc_snapshot_t before;
+    size_t before_nodes = 0;
+    pmix_info_t *info;
+    pmix_status_t rc;
+    char reqid[128];
+
+    if (0 == query_snapshot(&before)) {
+        before_nodes = snapshot_total_nodes(&before);
+        snapshot_free(&before);
+    }
+
+    make_reqid(reqid, sizeof(reqid), "coord-extend");
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &count, PMIX_UINT64);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    rc = submit_alloc_request(PMIX_ALLOC_EXTEND, info, 2, "extend count");
+    PMIX_INFO_FREE(info, 2);
+
+    if (status_is_accepted(rc)) {
+        size_t expected = before_nodes + (size_t) count;
+
+        if (0 == wait_until_alloc_count_at_least(expected)) {
+            record_message("VERIFY extend count: PASS (PRRTE knows at least %zu nodes)\n",
+                           expected);
+        } else {
+            record_message("VERIFY extend count: WARN expected at least %zu PRRTE nodes\n",
+                           expected);
+        }
+    } else {
+        record_message("VERIFY extend count: request was rejected with %s\n",
+                       PMIx_Error_string(rc));
+    }
+}
+
+static void handle_shrink_count(uint64_t count)
+{
+    alloc_snapshot_t before;
+    size_t before_nodes = 0;
+    pmix_info_t *info;
+    pmix_status_t rc;
+    char reqid[128];
+
+    if (0 == query_snapshot(&before)) {
+        before_nodes = snapshot_total_nodes(&before);
+        snapshot_free(&before);
+    }
+
+    make_reqid(reqid, sizeof(reqid), "coord-shrink-count");
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &count, PMIX_UINT64);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink count");
+    PMIX_INFO_FREE(info, 2);
+
+    if (status_is_accepted(rc)) {
+        size_t expected_max = count >= before_nodes ? 0 : before_nodes - count;
+
+        if (0 == wait_until_total_nodes_at_most(expected_max)) {
+            record_message("VERIFY shrink count: PASS (PRRTE total nodes <= %zu)\n",
+                           expected_max);
+        } else {
+            record_message("VERIFY shrink count: WARN expected PRRTE total nodes <= %zu\n",
+                           expected_max);
+        }
+    } else {
+        record_message("VERIFY shrink count: request was rejected with %s\n",
+                       PMIx_Error_string(rc));
+    }
+}
+
+static void handle_shrink_alloc(const char *allocid)
+{
+    pmix_info_t *info;
+    pmix_status_t rc;
+    int before_squeue;
+    char reqid[128];
+
+    before_squeue = squeue_job_exists(allocid);
+    make_reqid(reqid, sizeof(reqid), "coord-shrink-alloc");
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, allocid, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink alloc");
+    PMIX_INFO_FREE(info, 2);
+
+    if (status_is_accepted(rc)) {
+        int after_squeue;
+
+        if (0 == wait_until_alloc_removed(allocid)) {
+            record_message("VERIFY shrink alloc: PASS (PRRTE allocation %s gone)\n",
+                           allocid);
+        } else {
+            record_message("VERIFY shrink alloc: WARN PRRTE allocation %s still visible\n",
+                           allocid);
+        }
+
+        after_squeue = squeue_job_exists(allocid);
+        if (1 == before_squeue && 0 == after_squeue) {
+            record_message("VERIFY shrink alloc: PASS (squeue job %s disappeared)\n",
+                           allocid);
+        } else if (0 == before_squeue) {
+            record_message("VERIFY shrink alloc: INFO job %s was not visible in squeue before request\n",
+                           allocid);
+        } else {
+            record_message("VERIFY shrink alloc: WARN job %s still visible in squeue\n",
+                           allocid);
+        }
+    } else {
+        record_message("VERIFY shrink alloc: request was rejected with %s\n",
+                       PMIx_Error_string(rc));
+    }
+}
+
+static void handle_shrink_list(const char *list)
+{
+    pmix_info_t *info;
+    pmix_status_t rc;
+    char **nodes;
+    char reqid[128];
+
+    nodes = PMIx_Argv_split(list, ',');
+    make_reqid(reqid, sizeof(reqid), "coord-shrink-list");
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, list, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink list");
+    PMIX_INFO_FREE(info, 2);
+
+    if (status_is_accepted(rc)) {
+        if (NULL != nodes && 0 == wait_until_nodes_absent(nodes)) {
+            record_message("VERIFY shrink list: PASS (requested nodes absent from PRRTE)\n");
+        } else {
+            record_message("VERIFY shrink list: WARN requested nodes still visible in PRRTE\n");
+        }
+    } else {
+        record_message("VERIFY shrink list: request was rejected with %s\n",
+                       PMIx_Error_string(rc));
+    }
+
+    if (NULL != nodes) {
+        PMIx_Argv_free(nodes);
+    }
+}
+
+static void usage(const char *argv0)
+{
+    printf("Usage: %s\n\n", argv0);
+    printf("Run inside a Slurm job and under PRRTE/PMIx, then enter commands:\n");
+    printf("  extend count N\n");
+    printf("  shrink count N\n");
+    printf("  shrink alloc SLURM_JOB_ID\n");
+    printf("  shrink list NODE1,NODE2\n");
+    printf("  prun [ARGS...]\n");
+    printf("  refresh\n");
+    printf("  quit\n");
+}
+
+static int parse_u64(const char *s, uint64_t *out)
+{
+    char *end = NULL;
+    unsigned long long value;
+
+    if (NULL == s || '\0' == s[0]) {
+        return -1;
+    }
+    errno = 0;
+    value = strtoull(s, &end, 10);
+    if (0 != errno || NULL == end || '\0' != *end) {
+        return -1;
+    }
+    *out = (uint64_t) value;
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_status_t rc;
+    char line[LINE_MAX_LEN];
+    const char *slurm_jobid;
+
+    if (1 < argc && 0 == strcmp(argv[1], "--help")) {
+        usage(argv[0]);
+        return 0;
+    }
+
+    slurm_jobid = getenv("SLURM_JOB_ID");
+    if (NULL == slurm_jobid || '\0' == slurm_jobid[0]) {
+        fprintf(stderr, "This program must run inside a Slurm job (SLURM_JOB_ID is unset).\n");
+        return 1;
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    printf("PMIx client %s:%u inside Slurm job %s\n",
+           myproc.nspace, myproc.rank, slurm_jobid);
+    usage(argv[0]);
+    show_state();
+
+    while (1) {
+        char *cmd;
+        char *input;
+        char *type;
+        char *arg;
+
+        printf("\ncoord> ");
+        fflush(stdout);
+        if (NULL == fgets(line, sizeof(line), stdin)) {
+            break;
+        }
+        line[strcspn(line, "\n")] = '\0';
+
+        input = line;
+        while (isspace((unsigned char) *input)) {
+            input++;
+        }
+        if (0 == strncmp(input, "prun", 4) &&
+            ('\0' == input[4] || isspace((unsigned char) input[4]))) {
+            run_prun_command(input);
+            continue;
+        }
+
+        cmd = strtok(input, " \t");
+        if (NULL == cmd) {
+            continue;
+        }
+
+        if (0 == strcmp(cmd, "quit") || 0 == strcmp(cmd, "exit")) {
+            break;
+        }
+        if (0 == strcmp(cmd, "refresh")) {
+            show_state();
+            continue;
+        }
+        if (0 == strcmp(cmd, "extend")) {
+            uint64_t count;
+
+            type = strtok(NULL, " \t");
+            arg = strtok(NULL, " \t");
+            if (NULL == type || NULL == arg || 0 != strcmp(type, "count") ||
+                0 != parse_u64(arg, &count)) {
+                printf("usage: extend count N\n");
+                continue;
+            }
+            handle_extend_count(count);
+            show_state();
+            continue;
+        }
+        if (0 == strcmp(cmd, "shrink")) {
+            type = strtok(NULL, " \t");
+            arg = strtok(NULL, " \t");
+            if (NULL == type || NULL == arg) {
+                printf("usage: shrink count N | shrink alloc ID | shrink list NODE1,NODE2\n");
+                continue;
+            }
+            if (0 == strcmp(type, "count")) {
+                uint64_t count;
+
+                if (0 != parse_u64(arg, &count)) {
+                    printf("usage: shrink count N\n");
+                    continue;
+                }
+                handle_shrink_count(count);
+            } else if (0 == strcmp(type, "alloc")) {
+                handle_shrink_alloc(arg);
+            } else if (0 == strcmp(type, "list")) {
+                handle_shrink_list(arg);
+            } else {
+                printf("usage: shrink count N | shrink alloc ID | shrink list NODE1,NODE2\n");
+                continue;
+            }
+            show_state();
+            continue;
+        }
+
+        printf("unknown command: %s\n", cmd);
+        usage(argv[0]);
+    }
+
+    rc = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -74,6 +74,7 @@
 #include "src/runtime/prte_wait.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
+#include "src/util/proc_info.h"
 #include "src/util/pmix_show_help.h"
 #include "types.h"
 
@@ -94,7 +95,8 @@ static int plm_slurm_signal_job(pmix_nspace_t jobid, int32_t signal);
 static int plm_slurm_finalize(void);
 
 static int plm_slurm_start_proc(int argc, char **argv,
-                                char *prefix, char *pmix_prefix);
+                                char *prefix, char *pmix_prefix,
+                                uint32_t job_id);
 
 /*
  * Global variable
@@ -116,6 +118,58 @@ prte_plm_base_module_1_0_0_t prte_plm_slurm_module = {
 static pid_t primary_srun_pid = 0;
 static bool primary_pid_set = false;
 static void launch_daemons(int fd, short args, void *cbdata);
+
+/*
+ * An elastic shrink can make an srun launcher exit non-zero without indicating
+ * an unexpected daemon failure. If the Slurm session is gone, PRRTE has already
+ * destroyed the session for that job ID, so the launcher termination is
+ * expected. If the session remains but only the HNP node survives, the shrink
+ * removed every daemon task launched by this srun step while leaving the
+ * controlling node alive.
+ */
+static bool srun_exit_expected(uint32_t job_id)
+{
+    prte_session_t *session;
+    prte_node_t *node, *remaining = NULL;
+    int count = 0;
+
+    if (!prte_elastic_mode) {
+        return false;
+    }
+
+    session = prte_get_session_object(job_id);
+    if (NULL == session) {
+        return true;
+    }
+
+    if (!PRTE_PROC_IS_MASTER || NULL == session->nodes) {
+        return false;
+    }
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+        if (NULL == node) {
+            continue;
+        }
+        remaining = node;
+        count++;
+        if (1 < count) {
+            return false;
+        }
+    }
+
+    if (1 != count || NULL == remaining) {
+        return false;
+    }
+
+    if (NULL != remaining->daemon &&
+        remaining->daemon->name.rank == PRTE_PROC_MY_NAME->rank) {
+        return true;
+    }
+
+    return NULL != remaining->name && NULL != prte_process_info.nodename &&
+           0 == strcmp(remaining->name, prte_process_info.nodename);
+}
 
 /**
  * Init the module
@@ -443,7 +497,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
     }
 
     /* exec the daemon(s) */
-    if (PRTE_SUCCESS != (rc = plm_slurm_start_proc(argc, argv, cur_prefix, pmix_prefix))) {
+    if (PRTE_SUCCESS != (rc = plm_slurm_start_proc(argc, argv, cur_prefix,
+                                                   pmix_prefix, job_id))) {
         PRTE_ERROR_LOG(rc);
         goto cleanup;
     }
@@ -535,6 +590,7 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
 {
     prte_wait_tracker_t *t2 = (prte_wait_tracker_t *) cbdata;
     prte_proc_t *proc = t2->child;
+    uint32_t *job_id = (uint32_t *) t2->cbdata;
     prte_job_t *jdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, fd);
 
@@ -546,6 +602,7 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
                        prte_mca_plm_slurm_component.major,
                        prte_mca_plm_slurm_component.minor);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+        free(job_id);
         PMIX_RELEASE(t2);
         return;
     }
@@ -575,6 +632,17 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
      * the orteds exited with an error
      */
     if (0 != proc->exit_code) {
+        if (NULL != job_id && srun_exit_expected(*job_id)) {
+            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                 "%s plm:slurm: srun for elastic job %" PRIu32
+                                 " exited with status %d",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 *job_id, proc->exit_code));
+            free(job_id);
+            PMIX_RELEASE(t2);
+            return;
+        }
+
         /* an orted must have died unexpectedly - report
          * that the daemon has failed so we exit
          */
@@ -597,11 +665,13 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
     }
 
     /* done with this dummy */
+    free(job_id);
     PMIX_RELEASE(t2);
 }
 
 static int plm_slurm_start_proc(int argc, char **argv,
-                                char *prefix, char *pmix_prefix)
+                                char *prefix, char *pmix_prefix,
+                                uint32_t job_id)
 {
     int fd;
     int srun_pid;
@@ -610,6 +680,7 @@ static int plm_slurm_start_proc(int argc, char **argv,
     char *exec_argv = pmix_path_findv(argv[0], 0, environ, NULL);
     prte_proc_t *dummy;
     char *oldenv, *newenv;
+    uint32_t *tracked_job_id;
     PRTE_HIDE_UNUSED_PARAMS(argc);
 
     if (NULL == exec_argv) {
@@ -631,13 +702,28 @@ static int plm_slurm_start_proc(int argc, char **argv,
         primary_pid_set = true;
     }
 
-    /* setup a dummy proc object to track the srun */
-    dummy = PMIX_NEW(prte_proc_t);
-    dummy->pid = srun_pid;
-    /* be sure to mark it as alive so we don't instantly fire */
-    PRTE_FLAG_SET(dummy, PRTE_PROC_FLAG_ALIVE);
-    /* setup the waitpid so we can find out if srun succeeds! */
-    prte_wait_cb(dummy, srun_wait_cb, NULL);
+    if (0 < srun_pid) {
+        /* setup a dummy proc object to track the srun */
+        dummy = PMIX_NEW(prte_proc_t);
+        if (NULL == dummy) {
+            kill(srun_pid, SIGTERM);
+            free(exec_argv);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        tracked_job_id = malloc(sizeof(*tracked_job_id));
+        if (NULL == tracked_job_id) {
+            kill(srun_pid, SIGTERM);
+            PMIX_RELEASE(dummy);
+            free(exec_argv);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        *tracked_job_id = job_id;
+        dummy->pid = srun_pid;
+        /* be sure to mark it as alive so we don't instantly fire */
+        PRTE_FLAG_SET(dummy, PRTE_PROC_FLAG_ALIVE);
+        /* setup the waitpid so we can find out if srun succeeds! */
+        prte_wait_cb(dummy, srun_wait_cb, tracked_job_id);
+    }
 
     if (0 == srun_pid) { /* child */
         char *bin_base = NULL, *lib_base = NULL;

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -97,6 +97,7 @@ static int plm_slurm_finalize(void);
 static int plm_slurm_start_proc(int argc, char **argv,
                                 char *prefix, char *pmix_prefix,
                                 uint32_t job_id);
+static void clear_parent_slurm_allocation_env(void);
 
 /*
  * Global variable
@@ -118,6 +119,28 @@ prte_plm_base_module_1_0_0_t prte_plm_slurm_module = {
 static pid_t primary_srun_pid = 0;
 static bool primary_pid_set = false;
 static void launch_daemons(int fd, short args, void *cbdata);
+
+/* Remove allocation-shape values inherited from the Slurm job containing the
+ * DVM master.  A later elastic grow can launch srun against a different job ID
+ * whose node count and node list differ from that parent allocation.  Leaving
+ * these values set makes srun validate the explicit --nodes/--nodelist request
+ * against the old allocation.  Slurm regenerates the corresponding values for
+ * the remote tasks in the newly-created step. */
+static void clear_parent_slurm_allocation_env(void)
+{
+    static const char *const vars[] = {
+        "SLURM_JOB_NUM_NODES",
+        "SLURM_NNODES",
+        "SLURM_JOB_NODELIST",
+        "SLURM_NODELIST",
+        "SLURM_TASKS_PER_NODE",
+        NULL
+    };
+
+    for (int i = 0; NULL != vars[i]; i++) {
+        unsetenv(vars[i]);
+    }
+}
 
 /*
  * An elastic shrink can make an srun launcher exit non-zero without indicating
@@ -727,6 +750,8 @@ static int plm_slurm_start_proc(int argc, char **argv,
 
     if (0 == srun_pid) { /* child */
         char *bin_base = NULL, *lib_base = NULL;
+
+        clear_parent_slurm_allocation_env();
 
         /* Slurm forwards the entire environment, which we
          * REALLY don't want them to do as it might contain

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -116,6 +116,17 @@ PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
 
 PRTE_EXPORT char *prte_ras_base_flag_string(prte_node_t *node);
 
+PRTE_EXPORT void prte_ras_base_activate_dvm_grow(void);
+
+PRTE_EXPORT int prte_ras_base_prepare_dvm_shrink(prte_pmix_server_req_t *req,
+                                                 pmix_rank_t *ranks,
+                                                 int32_t nranks,
+                                                 prte_shrink_campaign_t **campaign);
+
+PRTE_EXPORT int prte_ras_base_commit_dvm_shrink(prte_shrink_campaign_t *campaign);
+
+PRTE_EXPORT void prte_ras_base_abort_dvm_shrink(prte_shrink_campaign_t *campaign);
+
 PRTE_EXPORT void prte_ras_base_complete_request(prte_pmix_server_req_t *req);
 
 END_C_DECLS

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1062,21 +1062,48 @@ void prte_ras_base_check_reservations_on_term(prte_job_t *jdata)
     }
 }
 
-void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
+static pmix_status_t ras_base_parse_node_list(pmix_info_t *info, char **ndstring)
 {
-    prte_job_t *daemons;
     pmix_status_t rc;
-    pmix_data_buffer_t msg;
-    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+    char **nodes = NULL;
+
+    *ndstring = NULL;
+    if (PMIX_STRING == info->value.type ||
+        PMIX_REGEX == info->value.type) {
+        rc = pmix_preg.parse_nodes(info->value.data.string, &nodes);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+        *ndstring = PMIx_Argv_join(nodes, ',');
+        PMIx_Argv_free(nodes);
+        if (NULL == *ndstring) {
+            return PMIX_ERR_NOMEM;
+        }
+        return PMIX_SUCCESS;
+    }
+
+#if PRTE_PMIX_HAVE_REGEX2
+    if (PMIX_REGEX2 == info->value.type) {
+        /* this is a regex value identifying the nodes that were allocated by
+         * the scheduler (may match what we requested) */
+        rc = PMIx_parse_regex2(info->value.data.regex2, NULL, 0, ndstring);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        return rc;
+    }
+#endif
+
+    /* we only support those options */
+    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+    return PMIX_ERR_BAD_PARAM;
+}
+
+static pmix_status_t ras_base_prepare_grow(prte_pmix_server_req_t *req,
+                                           prte_session_t **dest_out)
+{
     size_t n;
-    char **nodes, *ndstring;
-    char **rsv_names = NULL;
-    int32_t cnt=0, m;
-    int ret;
-    prte_node_t *node;
-    pmix_rank_t *ranks;
-    pmix_list_t ndlist;
-    bool found;
     char *target = NULL;        /* PMIX_ALLOC_TARGET namespace, if any */
     bool share = false;         /* default: reserve (do not share) */
     bool have_share = false;
@@ -1089,380 +1116,522 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
     prte_job_t *reqjob;
     bool is_tool;
 
-    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-    if (PMIX_ALLOC_EXTEND == req->allocdir ||
-        PMIX_ALLOC_NEW == req->allocdir) {
-        /* scan the request for the reservation-routing directives so we can
-         * resolve which session the new nodes will join before inserting
-         * them. The PMIX_ALLOC_NODE_LIST entries are handled in the loop
-         * below; PMIX_ALLOC_WARN_TIMEOUT is intentionally left in req->info
-         * to be forwarded verbatim to the scheduler. */
-        for (n=0; n < req->ninfo; n++) {
+    /* scan the request for the reservation-routing directives so we can
+     * resolve which session the new nodes will join before inserting
+     * them. The PMIX_ALLOC_NODE_LIST entries are handled in the loop
+     * below; PMIX_ALLOC_WARN_TIMEOUT is intentionally left in req->info
+     * to be forwarded verbatim to the scheduler. */
+    for (n = 0; n < req->ninfo; n++) {
 #if defined(PMIX_ALLOC_TARGET)
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_TARGET)) {
-                target = req->info[n].value.data.string;
-                continue;
-            }
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_TARGET)) {
+            target = req->info[n].value.data.string;
+            continue;
+        }
 #endif
 #if defined(PMIX_ALLOC_SHARE)
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_SHARE)) {
-                share = PMIX_INFO_TRUE(&req->info[n]);
-                have_share = true;
-                continue;
-            }
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_SHARE)) {
+            share = PMIX_INFO_TRUE(&req->info[n]);
+            have_share = true;
+            continue;
+        }
 #endif
 #if defined(PMIX_ALLOC_INHERITANCE)
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_INHERITANCE)) {
-                inherit = req->info[n].value.data.uint8;
-                have_inherit = true;
-                continue;
-            }
-#endif
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
-                alloc_id = req->info[n].value.data.string;
-                continue;
-            }
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
-                req_id = req->info[n].value.data.string;
-                continue;
-            }
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_INHERITANCE)) {
+            inherit = req->info[n].value.data.uint8;
+            have_inherit = true;
+            continue;
         }
-        (void) have_share;
+#endif
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+            alloc_id = req->info[n].value.data.string;
+            continue;
+        }
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+            req_id = req->info[n].value.data.string;
+        }
+    }
+    (void) have_share;
 
-        /* an inheritance value this build cannot honor is rejected rather than
-         * silently dropped (it may have arrived over the wire from a newer
-         * peer) */
 #if !defined(PMIX_ALLOC_INHERITANCE)
-        if (have_inherit && PRTE_INHERIT_DEFAULT_VALUE != inherit) {
-            req->pstatus = PMIX_ERR_NOT_SUPPORTED;
-            return;
-        }
+    /* an inheritance value this build cannot honor is rejected rather than
+     * silently dropped (it may have arrived over the wire from a newer
+     * peer) */
+    if (have_inherit && PRTE_INHERIT_DEFAULT_VALUE != inherit) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
 #endif
 
-        reqjob = prte_get_job_data_object(req->tproc.nspace);
-        is_tool = (NULL == reqjob) || PRTE_FLAG_TEST(reqjob, PRTE_JOB_FLAG_TOOL);
-        /* the namespace the reservation is created for / must be owned by */
-        owner_nspace = (NULL != target) ? target : req->tproc.nspace;
+    reqjob = prte_get_job_data_object(req->tproc.nspace);
+    is_tool = (NULL == reqjob) || PRTE_FLAG_TEST(reqjob, PRTE_JOB_FLAG_TOOL);
+    /* the namespace the reservation is created for / must be owned by */
+    owner_nspace = (NULL != target) ? target : req->tproc.nspace;
 
-        if (have_share && share) {
-            dest = prte_default_session;            /* general use */
-        } else if (NULL != target && !is_tool) {
-            req->pstatus = PMIX_ERR_NO_PERMISSIONS; /* app may not retarget */
-            return;
-        } else if (PMIX_ALLOC_EXTEND == req->allocdir) {
-            /* extend an existing reservation named by either identifier */
-            if (NULL == alloc_id && NULL == req_id) {
-                req->pstatus = PMIX_ERR_BAD_PARAM;  /* nothing names the target */
-                return;
-            }
-            dest = (NULL != alloc_id) ? prte_get_session_object_from_id(alloc_id)
-                                      : NULL;
-            if (NULL == dest && NULL != req_id) {
-                dest = prte_get_session_object_from_refid(req_id);
-            }
-            if (NULL == dest ||
-                !prte_session_is_owned_by(dest, req->tproc.nspace)) {
-                req->pstatus = (NULL == dest) ? PMIX_ERR_NOT_FOUND
-                                              : PMIX_ERR_NO_PERMISSIONS;
-                return;
-            }
-            /* a new inheritance value on EXTEND updates the disposition */
-            if (have_inherit) {
-                dest->inheritance = inherit;
-            }
-            /* refresh the requestor so a timeout warning follows the most
-             * recent requester */
-            PMIX_XFER_PROCID(&dest->requestor, &req->tproc);
-        } else {                                    /* PMIX_ALLOC_NEW */
-            dest = create_reservation(owner_nspace, inherit, &req->tproc,
-                                      alloc_id, req_id);
-            if (NULL == dest) {
-                req->pstatus = PMIX_ERR_OUT_OF_RESOURCE;
-                return;
-            }
+    if (have_share && share) {
+        dest = prte_default_session;            /* general use */
+    } else if (NULL != target && !is_tool) {
+        return PMIX_ERR_NO_PERMISSIONS;         /* app may not retarget */
+    } else if (PMIX_ALLOC_EXTEND == req->allocdir) {
+        /* extend an existing reservation named by either identifier */
+        if (NULL == alloc_id && NULL == req_id) {
+            return PMIX_ERR_BAD_PARAM;          /* nothing names the target */
         }
-
-        found = false;
-        for (n=0; n < req->ninfo; n++) {
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
-                if (PMIX_STRING == req->info[n].value.type ||
-                    PMIX_REGEX == req->info[n].value.type) {
-                    rc = pmix_preg.parse_nodes(req->info[n].value.data.string, &nodes);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        req->pstatus = rc;
-                        return;
-                    }
-                    ndstring = PMIx_Argv_join(nodes, ',');
-                    PMIx_Argv_free(nodes);
-
-#if PRTE_PMIX_HAVE_REGEX2
-                } else if (PMIX_REGEX2 == req->info[n].value.type) {
-                    // this is a regex value identifying the nodes that were
-                    // allocated by the scheduler (may match what we requested)
-                    rc = PMIx_parse_regex2(req->info[n].value.data.regex2, NULL, 0, &ndstring);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        req->pstatus = rc;
-                        return;
-                    }
-#endif
-
-                } else {
-                    // we only support those options
-                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                    req->pstatus = PMIX_ERR_BAD_PARAM;
-                    return;
-                }
-                // add these nodes to our node pool
-                PMIX_CONSTRUCT(&ndlist, pmix_list_t);
-                ret = prte_util_add_dash_host_nodes(&ndlist, ndstring, true);
-                if (PRTE_SUCCESS != ret) {
-                    PRTE_ERROR_LOG(ret);
-                    req->pstatus = prte_pmix_convert_rc(ret);
-                    free(ndstring);
-                    PMIX_LIST_DESTRUCT(&ndlist);
-                    return;
-                }
-                free(ndstring);
-                /* prte_ras_base_node_insert() drains ndlist into the global
-                 * pool, so snapshot the node names first: add_nodes_to_session()
-                 * below needs them to re-find the pool objects and set their
-                 * session backpointer (which carries the requestor for the
-                 * phase-two completion event). */
-                {
-                    prte_node_t *snap;
-                    PMIX_LIST_FOREACH(snap, &ndlist, prte_node_t) {
-                        PMIx_Argv_append_nosize(&rsv_names, snap->name);
-                    }
-                }
-                ret = prte_ras_base_node_insert(&ndlist, NULL);
-                if (PRTE_SUCCESS != ret) {
-                    PRTE_ERROR_LOG(ret);
-                    PMIX_LIST_DESTRUCT(&ndlist);
-                    PMIx_Argv_free(rsv_names);
-                    req->pstatus = prte_pmix_convert_rc(ret);
-                    return;
-                }
-                /* when reserving, withhold these nodes from the default pool by
-                 * registering them with the destination session */
-                add_nodes_to_session(rsv_names, dest);
-                PMIx_Argv_free(rsv_names);
-                rsv_names = NULL;
-                PMIX_LIST_DESTRUCT(&ndlist);
-                found = true;
-            }
+        dest = (NULL != alloc_id) ? prte_get_session_object_from_id(alloc_id)
+                                  : NULL;
+        if (NULL == dest && NULL != req_id) {
+            dest = prte_get_session_object_from_refid(req_id);
         }
-        if (found) {
-            // mark that we need to extend the DVM
-            prte_set_attribute(&daemons->attributes, PRTE_JOB_EXTEND_DVM, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
-            /* mark that an updated nidmap must be communicated to existing daemons */
-            prte_nidmap_communicated = false;
-            PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
+        if (NULL == dest ||
+            !prte_session_is_owned_by(dest, req->tproc.nspace)) {
+            return (NULL == dest) ? PMIX_ERR_NOT_FOUND : PMIX_ERR_NO_PERMISSIONS;
         }
-
-        /* report the destination allocation id back to the requester so it can
-         * later target, extend, or release the reservation. The default
-         * (shared) session carries no allocation id, so nothing is reported. */
-        if (NULL != dest && dest != prte_default_session &&
-            NULL != dest->alloc_refid) {
-            pmix_info_t *rinfo;
-            size_t rn = (NULL != dest->user_refid) ? 2 : 1;
-
-            PMIX_INFO_CREATE(rinfo, rn);
-            PMIX_INFO_LOAD(&rinfo[0], PMIX_ALLOC_ID, dest->alloc_refid, PMIX_STRING);
-            if (2 == rn) {
-                PMIX_INFO_LOAD(&rinfo[1], PMIX_ALLOC_REQ_ID, dest->user_refid, PMIX_STRING);
-            }
-            /* the original req->info is borrowed from the PMIx caller; repoint
-             * to our response array and let the req destructor free it */
-            req->info = rinfo;
-            req->ninfo = rn;
-            req->copy = true;
+        /* a new inheritance value on EXTEND updates the disposition */
+        if (have_inherit) {
+            dest->inheritance = inherit;
         }
-
-    } else if (PMIX_ALLOC_RELEASE == req->allocdir) {
-
-        /* a release naming an allocation id tears down that whole reservation:
-         * any owner may release it, the scheduler may release any. The nodes
-         * are returned to the scheduler (the legacy disposition for an explicit
-         * release). */
-        char *rel_alloc_id = NULL;
-        for (n=0; n < req->ninfo; n++) {
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
-                rel_alloc_id = req->info[n].value.data.string;
-                break;
-            }
+        /* refresh the requestor so a timeout warning follows the most
+         * recent requester */
+        PMIX_XFER_PROCID(&dest->requestor, &req->tproc);
+    } else {                                    /* PMIX_ALLOC_NEW */
+        dest = create_reservation(owner_nspace, inherit, &req->tproc,
+                                  alloc_id, req_id);
+        if (NULL == dest) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
         }
-        if (NULL != rel_alloc_id) {
-            prte_session_t *rsession = prte_get_session_object_from_id(rel_alloc_id);
-            if (NULL == rsession || rsession == prte_default_session) {
-                req->pstatus = PMIX_ERR_NOT_FOUND;
-                return;
-            }
-            if (!prte_session_is_owned_by(rsession, req->tproc.nspace)) {
-                req->pstatus = PMIX_ERR_NO_PERMISSIONS;
-                return;
-            }
-            prte_ras_base_teardown_reservation(rsession, true);
-            req->pstatus = PMIX_SUCCESS;
-            return;
-        }
-
-        // create the request
-        PMIX_DATA_BUFFER_CONSTRUCT(&msg);
-        /* pack the command */
-        rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&msg);
-            req->pstatus = rc;
-            return;
-        }
-        // pack the daemon ranks to be removed from DVM
-        for (n=0; n < req->ninfo; n++) {
-            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
-                if (PMIX_STRING == req->info[n].value.type ||
-                    PMIX_REGEX == req->info[n].value.type) {
-                    rc = pmix_preg.parse_nodes(req->info[n].value.data.string, &nodes);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        req->pstatus = rc;
-                        return;
-                    }
-                    ndstring = PMIx_Argv_join(nodes, ',');
-                    PMIx_Argv_free(nodes);
-
-#if PRTE_PMIX_HAVE_REGEX2
-                } else if (PMIX_REGEX2 == req->info[n].value.type) {
-                    // this is a regex value identifying the nodes that were
-                    // allocated by the scheduler (may match what we requested)
-                    rc = PMIx_parse_regex2(req->info[n].value.data.regex2, NULL, 0, &ndstring);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        req->pstatus = prte_pmix_convert_rc(rc);
-                        return;
-                    }
-#endif
-
-                } else {
-                    // we only support those two options
-                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                    req->pstatus = PMIX_ERR_BAD_PARAM;
-                    return;
-                }
-                nodes = PMIx_Argv_split(ndstring, ',');
-                free(ndstring);
-                cnt = PMIx_Argv_count(nodes);
-                break;
-            }
-        }
-        if (0 == cnt) {
-            PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-            PMIX_DATA_BUFFER_DESTRUCT(&msg);
-            req->pstatus = PMIX_ERR_NOT_FOUND;
-            return;
-        }
-        // setup the array of ranks
-        ranks = (pmix_rank_t*)malloc(cnt * sizeof(pmix_rank_t));
-        m = 0;
-        for (n=0; NULL != nodes[n]; n++) {
-            // find this node in our global resource pool
-            node = prte_node_match(NULL, nodes[n]);
-            if (NULL == node) {
-                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-                PMIX_DATA_BUFFER_DESTRUCT(&msg);
-                PMIx_Argv_free(nodes);
-                free(ranks);
-                req->pstatus = PMIX_ERR_NOT_FOUND;
-                return;
-            }
-            if (NULL == node->daemon) {
-                // node doesn't have a daemon yet
-                continue;
-            }
-            ranks[m] = node->daemon->name.rank;
-            ++m;
-        }
-        PMIx_Argv_free(nodes);
-        rc = PMIx_Data_pack(NULL, &msg, &m, 1, PMIX_INT32);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&msg);
-            free(ranks);
-            req->pstatus = rc;
-            return;
-        }
-        rc = PMIx_Data_pack(NULL, &msg, ranks, m, PMIX_PROC_RANK);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&msg);
-            free(ranks);
-            req->pstatus = rc;
-            return;
-        }
-        /* Record the shrink campaign before freeing the ranks array.  Only in
-         * elastic mode: outside it the DVM is fixed-size, so the release still
-         * xcasts the shrink command below but no campaign is recorded and the
-         * fence is never raised — the legacy fire-and-forget behavior.  Also
-         * skip when the release removes no daemons (m == 0): an empty campaign
-         * would never drain (no target ever departs on the comm-failure path),
-         * so prte_shrink_campaigns would stay non-empty forever and stall every
-         * later job at the LAUNCH_APPS hold, and no completion event would fire.
-         * This mirrors the grow path's num_new_daemons > 0 guard and the spec's
-         * "no event when nothing changes" clause. */
-        prte_shrink_campaign_t *camp = NULL;
-        if (prte_elastic_mode && 0 < m) {
-            camp = PMIX_NEW(prte_shrink_campaign_t);
-            camp->targets = (pmix_rank_t *) malloc(m * sizeof(pmix_rank_t));
-            memcpy(camp->targets, ranks, m * sizeof(pmix_rank_t));
-            camp->ntargets = m;
-            camp->pending  = m;
-            /* record the requester so the phase-two completion event can be
-             * directed at the process that issued this PMIX_ALLOC_RELEASE */
-            PMIX_XFER_PROCID(&camp->requester, &req->tproc);
-            for (n = 0; n < req->ninfo; n++) {
-                if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
-                    camp->alloc_id = strdup(req->info[n].value.data.string);
-                } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
-                    camp->req_id = strdup(req->info[n].value.data.string);
-                }
-            }
-            camp->have_requester = true;
-            pmix_list_append(&prte_shrink_campaigns, &camp->super);
-            prte_dvm_launch_fence += m;
-        }
-        free(ranks);
-
-        /* goes to all daemons.  When a campaign was recorded, request a
-         * completion callback so the collective shrink-completion handler runs
-         * exactly once — when the whole DVM has received the command — driving a
-         * single routing-tree repair and one completion event, rather than
-         * discovering the departures one daemon at a time. */
-        if (NULL != camp) {
-            rc = prte_grpcomm.xcast_nb(PRTE_RML_TAG_DAEMON, &msg,
-                                       shrink_xcast_complete, camp);
-        } else {
-            rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg);
-        }
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            /* undo the campaign we just added (only if one was created), and
-             * tell the requester the DVM modification failed */
-            if (NULL != camp) {
-                pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
-                prte_dvm_launch_fence -= camp->pending;
-                if (camp->have_requester) {
-                    prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
-                                                 camp->req_id, false,
-                                                 prte_pmix_convert_rc(rc));
-                }
-                PMIX_RELEASE(camp);
-            }
-        }
-        PMIX_DATA_BUFFER_DESTRUCT(&msg);
     }
 
+    *dest_out = dest;
+    return PMIX_SUCCESS;
+}
+
+static int ras_base_insert_node_string(char *ndstring, prte_session_t *dest)
+{
+    pmix_list_t ndlist;
+    prte_node_t *snap;
+    char **rsv_names = NULL;
+    int ret;
+
+    /* add these nodes to our node pool */
+    PMIX_CONSTRUCT(&ndlist, pmix_list_t);
+    ret = prte_util_add_dash_host_nodes(&ndlist, ndstring, true);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_LIST_DESTRUCT(&ndlist);
+        return ret;
+    }
+
+    /* prte_ras_base_node_insert() drains ndlist into the global
+     * pool, so snapshot the node names first: add_nodes_to_session()
+     * below needs them to re-find the pool objects and set their
+     * session backpointer (which carries the requestor for the
+     * phase-two completion event). */
+    PMIX_LIST_FOREACH(snap, &ndlist, prte_node_t) {
+        PMIx_Argv_append_nosize(&rsv_names, snap->name);
+    }
+
+    ret = prte_ras_base_node_insert(&ndlist, NULL);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_LIST_DESTRUCT(&ndlist);
+        PMIx_Argv_free(rsv_names);
+        return ret;
+    }
+
+    /* when reserving, withhold these nodes from the default pool by
+     * registering them with the destination session */
+    add_nodes_to_session(rsv_names, dest);
+    PMIx_Argv_free(rsv_names);
+    PMIX_LIST_DESTRUCT(&ndlist);
+    return PRTE_SUCCESS;
+}
+
+void prte_ras_base_activate_dvm_grow(void)
+{
+    prte_job_t *daemons;
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    /* mark that we need to extend the DVM */
+    prte_set_attribute(&daemons->attributes, PRTE_JOB_EXTEND_DVM,
+                       PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+    /* mark that an updated nidmap must be communicated to existing daemons */
+    prte_nidmap_communicated = false;
+    PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
+}
+
+static void ras_base_set_alloc_response(prte_pmix_server_req_t *req,
+                                        prte_session_t *dest)
+{
+    pmix_info_t *rinfo;
+    size_t rn;
+
+    if (NULL == dest || dest == prte_default_session ||
+        NULL == dest->alloc_refid) {
+        return;
+    }
+
+    /* report the destination allocation id back to the requester so it can
+     * later target, extend, or release the reservation. The default
+     * (shared) session carries no allocation id, so nothing is reported. */
+    rn = (NULL != dest->user_refid) ? 2 : 1;
+    PMIX_INFO_CREATE(rinfo, rn);
+    PMIX_INFO_LOAD(&rinfo[0], PMIX_ALLOC_ID, dest->alloc_refid, PMIX_STRING);
+    if (2 == rn) {
+        PMIX_INFO_LOAD(&rinfo[1], PMIX_ALLOC_REQ_ID, dest->user_refid,
+                       PMIX_STRING);
+    }
+    /* the original req->info is borrowed from the PMIx caller; repoint
+     * to our response array and let the req destructor free it */
+    req->info = rinfo;
+    req->ninfo = rn;
+    req->copy = true;
+}
+
+static void ras_base_complete_grow_request(prte_pmix_server_req_t *req)
+{
+    prte_session_t *dest = NULL;
+    pmix_status_t rc;
+    size_t n;
+    bool found = false;
+
+    rc = ras_base_prepare_grow(req, &dest);
+    if (PMIX_SUCCESS != rc) {
+        req->pstatus = rc;
+        return;
+    }
+
+    for (n = 0; n < req->ninfo; n++) {
+        char *ndstring = NULL;
+        int ret;
+
+        if (!PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
+            continue;
+        }
+
+        rc = ras_base_parse_node_list(&req->info[n], &ndstring);
+        if (PMIX_SUCCESS != rc) {
+            req->pstatus = rc;
+            return;
+        }
+
+        ret = ras_base_insert_node_string(ndstring, dest);
+        free(ndstring);
+        if (PRTE_SUCCESS != ret) {
+            req->pstatus = prte_pmix_convert_rc(ret);
+            return;
+        }
+        found = true;
+    }
+
+    if (found) {
+        prte_ras_base_activate_dvm_grow();
+    }
+    ras_base_set_alloc_response(req, dest);
+}
+
+static int ras_base_find_shrink_targets(char **nodes, pmix_rank_t **ranks_out,
+                                        int32_t *nranks_out)
+{
+    pmix_rank_t *ranks;
+    int32_t cnt, m;
+    prte_node_t *node;
+
+    cnt = PMIx_Argv_count(nodes);
+    if (0 == cnt) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    ranks = (pmix_rank_t *) malloc(cnt * sizeof(pmix_rank_t));
+    if (NULL == ranks) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    m = 0;
+    for (int32_t n = 0; NULL != nodes[n]; n++) {
+        /* find this node in our global resource pool */
+        node = prte_node_match(NULL, nodes[n]);
+        if (NULL == node) {
+            free(ranks);
+            return PRTE_ERR_NOT_FOUND;
+        }
+        if (NULL == node->daemon) {
+            /* node doesn't have a daemon yet */
+            continue;
+        }
+        ranks[m++] = node->daemon->name.rank;
+    }
+
+    *ranks_out = ranks;
+    *nranks_out = m;
+    return PRTE_SUCCESS;
+}
+
+static int ras_base_create_shrink_campaign(prte_pmix_server_req_t *req,
+                                           pmix_rank_t *ranks, int32_t nranks,
+                                           prte_shrink_campaign_t **campaign)
+{
+    prte_shrink_campaign_t *camp;
+
+    *campaign = NULL;
+    if (!prte_elastic_mode || 0 >= nranks) {
+        return PRTE_SUCCESS;
+    }
+
+    /* Record the shrink campaign before freeing the ranks array.  Only in
+     * elastic mode: outside it the DVM is fixed-size, so the release still
+     * xcasts the shrink command below but no campaign is recorded and the
+     * fence is never raised — the legacy fire-and-forget behavior.  Also
+     * skip when the release removes no daemons (nranks == 0): an empty
+     * campaign would never drain (no target ever departs on the comm-failure
+     * path), so prte_shrink_campaigns would stay non-empty forever and stall
+     * every later job at the LAUNCH_APPS hold, and no completion event would
+     * fire. This mirrors the grow path's num_new_daemons > 0 guard and the
+     * spec's "no event when nothing changes" clause. */
+    camp = PMIX_NEW(prte_shrink_campaign_t);
+    if (NULL == camp) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    camp->targets = (pmix_rank_t *) malloc(nranks * sizeof(pmix_rank_t));
+    if (NULL == camp->targets) {
+        PMIX_RELEASE(camp);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    memcpy(camp->targets, ranks, nranks * sizeof(pmix_rank_t));
+    camp->ntargets = nranks;
+    camp->pending = nranks;
+    /* record the requester so the phase-two completion event can be
+     * directed at the process that issued this PMIX_ALLOC_RELEASE */
+    PMIX_XFER_PROCID(&camp->requester, &req->tproc);
+    for (size_t n = 0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+            camp->alloc_id = strdup(req->info[n].value.data.string);
+        } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+            camp->req_id = strdup(req->info[n].value.data.string);
+        }
+    }
+    camp->have_requester = true;
+    pmix_list_append(&prte_shrink_campaigns, &camp->super);
+    prte_dvm_launch_fence += nranks;
+
+    *campaign = camp;
+    return PRTE_SUCCESS;
+}
+
+static void ras_base_abort_dvm_shrink(prte_shrink_campaign_t *camp,
+                                      bool notify, pmix_status_t status)
+{
+    if (NULL == camp) {
+        return;
+    }
+
+    pmix_list_remove_item(&prte_shrink_campaigns, &camp->super);
+    prte_dvm_launch_fence -= camp->pending;
+    if (notify && camp->have_requester) {
+        prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
+                                     camp->req_id, false, status);
+    }
+    PMIX_RELEASE(camp);
+}
+
+static int ras_base_send_dvm_shrink(prte_shrink_campaign_t *camp,
+                                    pmix_rank_t *ranks, int32_t nranks,
+                                    bool report_xcast_failure)
+{
+    pmix_data_buffer_t msg;
+    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+    pmix_status_t rc;
+
+    /* create the request */
+    PMIX_DATA_BUFFER_CONSTRUCT(&msg);
+    /* pack the command */
+    rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS == rc) {
+        /* pack the daemon ranks to be removed from DVM */
+        rc = PMIx_Data_pack(NULL, &msg, &nranks, 1, PMIX_INT32);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &msg, ranks, nranks, PMIX_PROC_RANK);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&msg);
+        if (NULL != camp) {
+            ras_base_abort_dvm_shrink(camp, false, PMIX_SUCCESS);
+        }
+        return prte_pmix_convert_status(rc);
+    }
+
+    /* goes to all daemons.  When a campaign was recorded, request a
+     * completion callback so the collective shrink-completion handler runs
+     * exactly once — when the whole DVM has received the command — driving a
+     * single routing-tree repair and one completion event, rather than
+     * discovering the departures one daemon at a time. */
+    if (NULL != camp) {
+        rc = prte_grpcomm.xcast_nb(PRTE_RML_TAG_DAEMON, &msg,
+                                   shrink_xcast_complete, camp);
+    } else {
+        rc = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&msg);
+
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        /* undo the campaign we just added (only if one was created), and
+         * tell the requester the DVM modification failed */
+        if (NULL != camp) {
+            ras_base_abort_dvm_shrink(camp, true, prte_pmix_convert_rc(rc));
+        }
+        return report_xcast_failure ? rc : PRTE_SUCCESS;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+int prte_ras_base_prepare_dvm_shrink(prte_pmix_server_req_t *req,
+                                     pmix_rank_t *ranks, int32_t nranks,
+                                     prte_shrink_campaign_t **campaign)
+{
+    if (NULL == campaign) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    return ras_base_create_shrink_campaign(req, ranks, nranks, campaign);
+}
+
+int prte_ras_base_commit_dvm_shrink(prte_shrink_campaign_t *campaign)
+{
+    if (NULL == campaign) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    return ras_base_send_dvm_shrink(campaign, campaign->targets,
+                                   campaign->ntargets, true);
+}
+
+void prte_ras_base_abort_dvm_shrink(prte_shrink_campaign_t *campaign)
+{
+    ras_base_abort_dvm_shrink(campaign, false, PMIX_SUCCESS);
+}
+
+static int ras_base_start_dvm_shrink(prte_pmix_server_req_t *req,
+                                     pmix_rank_t *ranks, int32_t nranks,
+                                     prte_shrink_campaign_t **campaign,
+                                     bool report_xcast_failure)
+{
+    prte_shrink_campaign_t *camp = NULL;
+    int ret;
+
+    if (NULL != campaign) {
+        *campaign = NULL;
+    }
+
+    ret = ras_base_create_shrink_campaign(req, ranks, nranks, &camp);
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = ras_base_send_dvm_shrink(camp, ranks, nranks, report_xcast_failure);
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
+
+    if (NULL != campaign) {
+        *campaign = camp;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+static bool ras_base_teardown_by_alloc_id(prte_pmix_server_req_t *req)
+{
+    char *rel_alloc_id = NULL;
+    prte_session_t *rsession;
+
+    for (size_t n = 0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+            rel_alloc_id = req->info[n].value.data.string;
+            break;
+        }
+    }
+    if (NULL == rel_alloc_id) {
+        return false;
+    }
+
+    /* a release naming an allocation id tears down that whole reservation:
+     * any owner may release it, the scheduler may release any. The nodes
+     * are returned to the scheduler (the legacy disposition for an explicit
+     * release). */
+    rsession = prte_get_session_object_from_id(rel_alloc_id);
+    if (NULL == rsession || rsession == prte_default_session) {
+        req->pstatus = PMIX_ERR_NOT_FOUND;
+        return true;
+    }
+    if (!prte_session_is_owned_by(rsession, req->tproc.nspace)) {
+        req->pstatus = PMIX_ERR_NO_PERMISSIONS;
+        return true;
+    }
+    prte_ras_base_teardown_reservation(rsession, true);
+    req->pstatus = PMIX_SUCCESS;
+    return true;
+}
+
+static void ras_base_complete_release_request(prte_pmix_server_req_t *req)
+{
+    char *ndstring = NULL;
+    char **nodes = NULL;
+    pmix_rank_t *ranks = NULL;
+    int32_t nranks = 0;
+    pmix_status_t rc;
+    int ret;
+
+    if (ras_base_teardown_by_alloc_id(req)) {
+        return;
+    }
+
+    for (size_t n = 0; n < req->ninfo; n++) {
+        if (!PMIx_Check_key(req->info[n].key, PMIX_ALLOC_NODE_LIST)) {
+            continue;
+        }
+
+        rc = ras_base_parse_node_list(&req->info[n], &ndstring);
+        if (PMIX_SUCCESS != rc) {
+            req->pstatus = rc;
+            return;
+        }
+        nodes = PMIx_Argv_split(ndstring, ',');
+        free(ndstring);
+        break;
+    }
+
+    if (NULL == nodes) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+        req->pstatus = PMIX_ERR_NOT_FOUND;
+        return;
+    }
+
+    ret = ras_base_find_shrink_targets(nodes, &ranks, &nranks);
+    PMIx_Argv_free(nodes);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        req->pstatus = prte_pmix_convert_rc(ret);
+        return;
+    }
+
+    ret = ras_base_start_dvm_shrink(req, ranks, nranks, NULL, false);
+    free(ranks);
+    if (PRTE_SUCCESS != ret) {
+        req->pstatus = prte_pmix_convert_rc(ret);
+    }
+}
+
+void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
+{
+    if (PMIX_ALLOC_EXTEND == req->allocdir ||
+        PMIX_ALLOC_NEW == req->allocdir) {
+        ras_base_complete_grow_request(req);
+    } else if (PMIX_ALLOC_RELEASE == req->allocdir) {
+        ras_base_complete_release_request(req);
+    }
 }
 
 int prte_ras_base_add_hosts(prte_job_t *jdata)

--- a/src/mca/ras/slurm/Makefile.am
+++ b/src/mca/ras/slurm/Makefile.am
@@ -34,7 +34,9 @@ sources = \
         ras_slurm_modify_common.c \
         ras_slurm_modify_cancel.c \
         ras_slurm_modify_extend.c \
-        ras_slurm_modify_release.c 
+        ras_slurm_modify_release.c \
+        ras_slurm_modify_release_tracker.c \
+        ras_slurm_modify_release_tracker.h
 
 if PRTE_HAVE_JANSSON
 sources += \

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -83,7 +83,8 @@ int prte_ras_slurm_drain_cmd_output(FILE *fp, char *output, size_t output_size);
 int prte_ras_slurm_validate_jobid(const char *slurm_jobid);
 int prte_ras_slurm_validate_hostname(const char *hostname);
 int prte_ras_slurm_convert_jobid(const char *slurm_jobid, uint32_t *slurm_jobid_numeric);
-int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_refid, pmix_list_t *node_list);
+int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_refid,
+                                      pmix_list_t *node_list, bool dynamic);
 int prte_ras_slurm_tag_node_allocation(const char *slurm_jobid, pmix_list_t *node_list);
 
 typedef struct {

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -68,6 +68,8 @@ int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req);
 int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req);
 
 /* Features to serve release requests */
+int prte_ras_slurm_modify_release_init(void);
+int prte_ras_slurm_modify_release_finalize(void);
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req);
 
 /* Common modify extend/release features */

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -71,6 +71,8 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req);
 int prte_ras_slurm_modify_release_init(void);
 int prte_ras_slurm_modify_release_finalize(void);
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req);
+void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign);
+int prte_ras_slurm_release_allocation(prte_session_t *session);
 
 /* Common modify extend/release features */
 int prte_ras_slurm_kill_job(const char *slurm_jobid, char *err_msg, size_t err_msg_size);

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -55,7 +55,8 @@ typedef struct {
 /*
  * Parse a numeric-object field from JSON and store it as a string in a hash table.
  *
- * Expects the the JSON object at key in job to have
+ * If the field is absent or null, returns PRTE_ERR_NOT_FOUND so optional job
+ * attributes can be omitted. Otherwise, expects the JSON object at key to have
  * "set", "infinite", and "number" fields. Stores the result
  * in values_table:
  * - unset -> string determined by PRTE_SLURM_UNSET_NUM_MARKER
@@ -75,7 +76,10 @@ static int prte_ras_slurm_get_json_numobj_field(json_t *job, const char *key, pm
     int pmix_err = PMIX_SUCCESS;
 
     json_t *field = json_object_get(job, key);
-    if (NULL == field || !json_is_object(field)) {
+    if (NULL == field || json_is_null(field)) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+    if (!json_is_object(field)) {
         return PRTE_ERR_JSON_PARSE_FAILURE;
     }
 
@@ -345,7 +349,8 @@ bool prte_ras_slurm_have_jansson(void)
  * parses the returned JSON using Jansson, and inserts selected numeric and
  * string fields into the provided hash table.
  *
- * String fields are validated to ensure they do not contain control characters.
+ * Missing, null, and empty optional fields are skipped. String fields that are
+ * present are validated to ensure they do not contain control characters.
  *
  * @param[in,out] values_table Pointer to a PMIx hash table to populate with extracted values.
 
@@ -379,8 +384,12 @@ int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table)
 
     /* We've extracted a valid "jobs" section. now extract the complex numeric
     * fields that have "set", "infinite", and "number" subfields */
-    for(size_t i = 0; i < NUM_OBJ_SUBFIELD_COUNT; i++) {
+    for(size_t i = 0; i < NUM_OBJ_FIELD_COUNT; i++) {
         err = prte_ras_slurm_get_json_numobj_field(job, num_obj_fields[i], values_table);
+        if (PRTE_ERR_NOT_FOUND == err) {
+            err = PRTE_SUCCESS;
+            continue;
+        }
         if (PRTE_SUCCESS != err) {
             PRTE_ERROR_LOG(err);
             goto cleanup;
@@ -393,7 +402,10 @@ int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table)
 
         json_t *str_field = json_object_get(job, str_fields[i]);
 
-        if(NULL == str_field || !json_is_string(str_field)) {
+        if(NULL == str_field || json_is_null(str_field)) {
+            continue;
+        }
+        if(!json_is_string(str_field)) {
             err = PRTE_ERR_JSON_PARSE_FAILURE;
             PRTE_ERROR_LOG(err);
             goto cleanup;
@@ -402,6 +414,10 @@ int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table)
         const char *str = json_string_value(str_field);
         size_t str_len = json_string_length(str_field);
         bool has_control_chars;
+
+        if (0 == str_len) {
+            continue;
+        }
 
         /* Do not accept string if contains control characters */
         err = prte_ras_slurm_token_has_control_chars(str, str_len, &has_control_chars);

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -54,6 +54,12 @@ static int prte_ras_slurm_make_sbatch_arg(pmix_hash_table_t *fields, const char 
 static int prte_ras_slurm_exec_sbatch(char * const *argv, char *job_id);
 static int prte_ras_slurm_launch_expander_job(pmix_hash_table_t *fields);
 static int prte_ras_slurm_reject_node_duplicates(pmix_list_t *node_list);
+static int prte_ras_slurm_extract_reused_nodes(const char *slurm_jobid,
+                                               pmix_list_t *node_list,
+                                               pmix_pointer_array_t *reused_nodes);
+static int prte_ras_slurm_add_reused_nodes_to_session(const char *slurm_jobid,
+                                                      pmix_pointer_array_t *reused_nodes);
+static void prte_ras_slurm_rollback_session(const char *slurm_jobid);
 static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata);
 
 PMIX_CLASS_INSTANCE(prte_slurm_wait_tracker_t, pmix_object_t, swt_con, swt_des);
@@ -620,6 +626,151 @@ static int prte_ras_slurm_reject_node_duplicates(pmix_list_t *node_list)
 }
 
 /**
+ * @brief Move reusable node duplicates out of the new-node list.
+ *
+ * If Slurm regrants a node that PRRTE already knows about from an earlier
+ * shrink, reuse the existing global node object instead of treating the
+ * Slurm-discovered node as a duplicate. Only daemon-less nodes can be reused.
+ *
+ * @param[in] slurm_jobid    Slurm job ID for the new allocation.
+ * @param[in,out] node_list  Newly discovered Slurm nodes.
+ * @param[out] reused_nodes  Existing nodes to add back to the DVM.
+ */
+static int prte_ras_slurm_extract_reused_nodes(const char *slurm_jobid,
+                                               pmix_list_t *node_list,
+                                               pmix_pointer_array_t *reused_nodes)
+{
+    if (NULL == slurm_jobid || NULL == node_list || NULL == reused_nodes) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int err;
+    uint32_t slurm_id_uint;
+    prte_node_t *node, *next, *existing;
+
+    err = prte_ras_slurm_convert_jobid(slurm_jobid, &slurm_id_uint);
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
+        existing = prte_node_match(NULL, node->name);
+        if (NULL == existing) {
+            continue;
+        }
+
+        if (NULL != existing->daemon ||
+            PRTE_FLAG_TEST(existing, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
+            return PRTE_EXISTS;
+        }
+    }
+
+    PMIX_LIST_FOREACH_SAFE(node, next, node_list, prte_node_t) {
+        existing = prte_node_match(NULL, node->name);
+        if (NULL == existing) {
+            continue;
+        }
+
+        err = prte_set_attribute(&existing->attributes, PRTE_NODE_ALLOC_ID,
+                                 PRTE_ATTR_LOCAL, &slurm_id_uint, PMIX_UINT32);
+        if (PRTE_SUCCESS != err) {
+            return err;
+        }
+
+        existing->slots = node->slots;
+        existing->slots_max = node->slots_max;
+        existing->slots_inuse = 0;
+        existing->state = PRTE_NODE_STATE_ADDED;
+
+        if (0 > pmix_pointer_array_add(reused_nodes, existing)) {
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+
+        pmix_list_remove_item(node_list, &node->super);
+        PMIX_RELEASE(node);
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Add reused global nodes to the dynamic Slurm session.
+ *
+ * @param[in] slurm_jobid   Slurm job ID for the destination session.
+ * @param[in] reused_nodes  Existing nodes to attach to the session.
+ */
+static int prte_ras_slurm_add_reused_nodes_to_session(const char *slurm_jobid,
+                                                      pmix_pointer_array_t *reused_nodes)
+{
+    if (NULL == slurm_jobid || NULL == reused_nodes) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    int err = PRTE_SUCCESS;
+    int pmix_err;
+    int added = 0;
+    prte_session_t *session;
+    prte_session_stack_item_t *item;
+    prte_node_t *node;
+
+    session = prte_get_session_object_from_id(slurm_jobid);
+    if (NULL == session) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    for (int i = 0; i < reused_nodes->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(reused_nodes, i);
+        if (NULL == node) {
+            continue;
+        }
+
+        PMIX_RETAIN(node);
+        pmix_err = pmix_pointer_array_add(session->nodes, node);
+        if (0 > pmix_err) {
+            PMIX_RELEASE(node);
+            err = prte_pmix_convert_status(pmix_err);
+            return err;
+        }
+        added++;
+    }
+
+    PMIX_LIST_FOREACH(item, prte_slurm_session_stack, prte_session_stack_item_t) {
+        if (item->session == session) {
+            item->nodes_in_session += added;
+            return PRTE_SUCCESS;
+        }
+    }
+
+    return PRTE_ERR_NOT_FOUND;
+}
+
+/**
+ * @brief Remove a newly-created Slurm session after extend failure.
+ *
+ * @param[in] slurm_jobid Slurm job ID for the session to roll back.
+ */
+static void prte_ras_slurm_rollback_session(const char *slurm_jobid)
+{
+    prte_session_t *session;
+    prte_session_stack_item_t *item, *next;
+
+    session = prte_get_session_object_from_id(slurm_jobid);
+    if (NULL == session) {
+        return;
+    }
+
+    PMIX_LIST_FOREACH_SAFE(item, next, prte_slurm_session_stack, prte_session_stack_item_t) {
+        if (item->session == session) {
+            pmix_list_remove_item(prte_slurm_session_stack, &item->super);
+            PMIX_RELEASE(item);
+            break;
+        }
+    }
+
+    PMIX_RELEASE(session);
+}
+
+/**
  * @brief Finalize a Slurm resource extension request.
  *
  * Processes newly allocated Slurm resources after the wait phase completes.
@@ -632,8 +783,12 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
  
     pmix_list_t added_nodes;
+    pmix_pointer_array_t reused_nodes;
     bool have_added_nodes = false;
+    bool have_reused_nodes = false;
     bool resources_added = false;
+    int added_node_count = 0;
+    int reused_node_count = 0;
     
     prte_slurm_wait_tracker_t *trk = cbdata;
     prte_pmix_server_req_t *req = trk->req;
@@ -649,6 +804,8 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     PMIX_CONSTRUCT(&added_nodes, pmix_list_t);
     have_added_nodes = true;
+    PMIX_CONSTRUCT(&reused_nodes, pmix_pointer_array_t);
+    have_reused_nodes = true;
 
     err = prte_ras_slurm_add_modified_resources(job_id, &added_nodes);
 
@@ -656,10 +813,16 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
         goto complete;
     }
 
-    /* Reject nodes that are already present in prte_node_pool.
-    * This avoids duplicate node entries, as merge semantics
-    * are not currently implemented. We already enforce an 
-    * --exclusive flag, so this is just a fallback. */
+    err = prte_ras_slurm_extract_reused_nodes(job_id, &added_nodes, &reused_nodes);
+
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        goto complete;
+    }
+
+    /* Reject any remaining nodes that are already present in prte_node_pool.
+     * Nodes that are safe to relaunch are removed above and tracked
+     * separately as reused nodes. */
     err = prte_ras_slurm_reject_node_duplicates(&added_nodes);
 
     if(PRTE_SUCCESS != err) {
@@ -674,6 +837,13 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
         goto complete;
     }
 
+    added_node_count = pmix_list_get_size(&added_nodes);
+    for (int i = 0; i < reused_nodes.size; i++) {
+        if (NULL != pmix_pointer_array_get_item(&reused_nodes, i)) {
+            reused_node_count++;
+        }
+    }
+
     /* Create a session  */
     err = prte_ras_slurm_assign_new_session(job_id,
                                             trk->user_request_id_provided ? request_id : NULL,
@@ -682,31 +852,25 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     if(PRTE_SUCCESS != err) {
         goto complete;
     }
+
+    err = prte_ras_slurm_add_reused_nodes_to_session(job_id, &reused_nodes);
+
+    if (PRTE_SUCCESS != err) {
+        prte_ras_slurm_rollback_session(job_id);
+        PRTE_ERROR_LOG(err);
+        goto complete;
+    }
     
     /* Insert into global node list. This consumes the list. */
     err = prte_ras_base_node_insert(&added_nodes, NULL);
 
     if(PRTE_SUCCESS != err) {
-        prte_session_t *session = prte_get_session_object_from_id(job_id);
-
-        /* Roll back session changes to avoid inconsistent state */
-        if (NULL != session) {
-            prte_session_stack_item_t *item, *next;
-            PMIX_LIST_FOREACH_SAFE(item, next, prte_slurm_session_stack, prte_session_stack_item_t) {
-                if (item->session == session) {
-                    pmix_list_remove_item(prte_slurm_session_stack, &item->super);
-                    PMIX_RELEASE(item);
-                    break;
-                }
-            }
-            PMIX_RELEASE(session);
-        }
-
+        prte_ras_slurm_rollback_session(job_id);
         PRTE_ERROR_LOG(err);
         goto complete;
     }
 
-    prte_num_allocated_nodes += pmix_list_get_size(&added_nodes);
+    prte_num_allocated_nodes += added_node_count + reused_node_count;
     resources_added = true;
 
     int pending_err = prte_ras_slurm_remove_pending_req(request_id);
@@ -725,6 +889,11 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     if(have_added_nodes) {
         PMIX_DESTRUCT(&added_nodes);
         have_added_nodes = false;
+    }
+
+    if (have_reused_nodes) {
+        PMIX_DESTRUCT(&reused_nodes);
+        have_reused_nodes = false;
     }
 
     req->pstatus = prte_pmix_convert_rc(err);

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -27,7 +27,6 @@
 
 #include "ras_slurm.h"
 #include "src/mca/ras/base/base.h"
-#include "src/mca/state/state.h"
 
 #define PRTE_SLURM_MAX_SBATCH_ARGS 32
 #define PRTE_SLURM_WAIT_MIN_USEC 1000        /* 1 ms */
@@ -751,9 +750,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     /* Launch daemons on the newly secured resources */
     if (PMIX_SUCCESS == req->pstatus) {
-        prte_job_t *daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_LAUNCH_DAEMONS);
-        prte_set_attribute(&daemons->attributes, PRTE_JOB_EXTEND_DVM, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+        prte_ras_base_activate_dvm_grow();
     }
 
     /* Execute callback if necessary */

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -678,7 +678,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     /* Create a session  */
     err = prte_ras_slurm_assign_new_session(job_id,
                                             trk->user_request_id_provided ? request_id : NULL,
-                                            &added_nodes);
+                                            &added_nodes, true);
 
     if(PRTE_SUCCESS != err) {
         goto complete;

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -155,7 +155,8 @@ static void localrelease(void *cbdata)
  *
  * Looks up a value in the provided hash table and, if present and usable,
  * formats it according to the given format string and appends it to the
- * sbatch argv array.
+ * sbatch argv array. Missing and empty values return PRTE_ERR_NOT_FOUND so
+ * callers can omit optional Slurm attributes.
  *
  * @param[in] fields
  *     Hash table containing job configuration data.
@@ -199,7 +200,7 @@ static int prte_ras_slurm_make_sbatch_arg(pmix_hash_table_t *fields,
     }
 
     if(NULL == stored_val || '\0' == stored_val[0]) {
-        return PRTE_ERR_DATA_VALUE_NOT_FOUND;
+        return PRTE_ERR_NOT_FOUND;
     }
 
     if(obj_num) {

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -14,6 +14,7 @@
 #include "types.h"
 
 #include "ras_slurm.h"
+#include "src/mca/preg/preg.h"
 #include "src/mca/ras/base/base.h"
 
 typedef enum {
@@ -51,9 +52,21 @@ static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *ses
 static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid);
 static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
                                                  const char *launching_jobid);
+static int prte_ras_slurm_remove_nodes_by_name(char **nodes);
+static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id);
 static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
+static int prte_ras_slurm_parse_release_node_list(pmix_info_t *info, char ***nodes);
+static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_alloc_id(const char *alloc_id);
+static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_node(const char *node_name);
+static bool prte_ras_slurm_node_in_argv(char **nodes, const char *node_name);
+static int prte_ras_slurm_count_matching_session_nodes(prte_session_t *session, char **nodes);
+static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove,
+                                              char ***survivors);
 static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
+static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes,
+                                                  char *err_msg, size_t err_msg_size);
 static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
+static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid);
 
 PMIX_CLASS_INSTANCE(prte_ras_slurm_release_action_t,
                     pmix_list_item_t,
@@ -318,31 +331,59 @@ int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
     int err = PRTE_SUCCESS;
 
     uint64_t num_nodes = 0;
-    bool found = false;
+    const char *alloc_id = NULL;
+    char **nodes = NULL;
+    bool found_num_nodes = false;
+    bool found_alloc_id = false;
+    bool found_node_list = false;
 
     for (size_t i = 0; i < req->ninfo; i++) {
-        if (0 != strcmp(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
+        if (0 == strcmp(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
+
+            if (PMIX_UINT64 != req->info[i].value.type) {
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            num_nodes = req->info[i].value.data.uint64;
+            found_num_nodes = true;
+        } else if (0 == strcmp(req->info[i].key, PMIX_ALLOC_ID)) {
+
+            if (PMIX_STRING != req->info[i].value.type) {
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            alloc_id = req->info[i].value.data.string;
+            found_alloc_id = true;
+        } else if (0 == strcmp(req->info[i].key, PMIX_ALLOC_NODE_LIST)) {
+
+            err = prte_ras_slurm_parse_release_node_list(&req->info[i], &nodes);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
+            found_node_list = true;
+        } else if (0 == strcmp(req->info[i].key, PMIX_ALLOC_REQ_ID)) {
             continue;
         }
-
-        if (PMIX_UINT64 != req->info[i].value.type) {
-            err = PRTE_ERR_BAD_PARAM;
-            goto cleanup;
-        }
-    
-        num_nodes = req->info[i].value.data.uint64;
-        found = true;
-        break;
     }
 
-    if(!found) {
+    if (1 != (int) found_num_nodes + (int) found_alloc_id + (int) found_node_list) {
         pmix_output(0, "ras:slurm:modify: modify request invalid or unsupported.\n"
-                       "Supported options: PMIX_ALLOC_NUM_NODES");
+                       "Supported options: exactly one of PMIX_ALLOC_NODE_LIST, "
+                       "PMIX_ALLOC_ID, or PMIX_ALLOC_NUM_NODES");
         err = PRTE_ERR_REQUEST;
         goto cleanup;
     }
 
-    err = prte_ras_slurm_remove_nodes_by_count(num_nodes);
+    if (found_node_list) {
+        err = prte_ras_slurm_remove_nodes_by_name(nodes);
+    } else if (found_alloc_id) {
+        err = prte_ras_slurm_remove_allocation_by_id(alloc_id);
+    } else {
+        err = prte_ras_slurm_remove_nodes_by_count(num_nodes);
+    }
 
     if(err != PRTE_SUCCESS) {
         goto cleanup;
@@ -350,7 +391,442 @@ int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
 
 cleanup:
 
+    if (NULL != nodes) {
+        PMIx_Argv_free(nodes);
+    }
+
     return err;
+}
+
+/**
+ * @brief Parse a PMIX_ALLOC_NODE_LIST release selector.
+ *
+ * @param[in] info PMIx info carrying the node-list value.
+ * @param[out] nodes Parsed node names.
+ */
+static int prte_ras_slurm_parse_release_node_list(pmix_info_t *info, char ***nodes)
+{
+    char **parsed_nodes = NULL;
+    char *ndstring = NULL;
+    int rc;
+
+    if (NULL == info || NULL == nodes) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    *nodes = NULL;
+
+    if (PMIX_STRING == info->value.type ||
+        PMIX_REGEX == info->value.type) {
+        rc = pmix_preg.parse_nodes(info->value.data.string, &parsed_nodes);
+        if (PMIX_SUCCESS != rc) {
+            return prte_pmix_convert_status(rc);
+        }
+        ndstring = PMIx_Argv_join(parsed_nodes, ',');
+        PMIx_Argv_free(parsed_nodes);
+        parsed_nodes = NULL;
+
+#if PRTE_PMIX_HAVE_REGEX2
+    } else if (PMIX_REGEX2 == info->value.type) {
+        rc = PMIx_parse_regex2(info->value.data.regex2, NULL, 0, &ndstring);
+        if (PMIX_SUCCESS != rc) {
+            return prte_pmix_convert_status(rc);
+        }
+#endif
+
+    } else {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (NULL == ndstring || '\0' == ndstring[0]) {
+        free(ndstring);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    *nodes = PMIx_Argv_split(ndstring, ',');
+    free(ndstring);
+
+    if (NULL == *nodes || 0 == PMIx_Argv_count(*nodes)) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Find the Slurm session stack item for an allocation ID.
+ *
+ * @param[in] alloc_id Slurm allocation/job ID.
+ */
+static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_alloc_id(const char *alloc_id)
+{
+    prte_session_stack_item_t *item;
+
+    if (NULL == prte_slurm_session_stack || NULL == alloc_id) {
+        return NULL;
+    }
+
+    PMIX_LIST_FOREACH(item, prte_slurm_session_stack, prte_session_stack_item_t) {
+        if (NULL != item->session && NULL != item->session->alloc_refid &&
+            0 == strcmp(item->session->alloc_refid, alloc_id)) {
+            return item;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Find the Slurm session stack item containing a node.
+ *
+ * @param[in] node_name Node name to find.
+ */
+static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_node(const char *node_name)
+{
+    prte_session_stack_item_t *item;
+
+    if (NULL == prte_slurm_session_stack || NULL == node_name) {
+        return NULL;
+    }
+
+    PMIX_LIST_FOREACH(item, prte_slurm_session_stack, prte_session_stack_item_t) {
+        prte_session_t *session = item->session;
+
+        if (NULL == session || NULL == session->nodes) {
+            continue;
+        }
+
+        for (int i = 0; i < session->nodes->size; i++) {
+            prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+            if (NULL != node && NULL != node->name &&
+                0 == strcmp(node->name, node_name)) {
+                return item;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Check whether a node name appears in an argv.
+ *
+ * @param[in] nodes NULL-terminated node-name array.
+ * @param[in] node_name Node name to find.
+ */
+static bool prte_ras_slurm_node_in_argv(char **nodes, const char *node_name)
+{
+    if (NULL == nodes || NULL == node_name) {
+        return false;
+    }
+
+    for (int i = 0; NULL != nodes[i]; i++) {
+        if (0 == strcmp(nodes[i], node_name)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Count requested nodes that belong to a Slurm session.
+ *
+ * @param[in] session Session to inspect.
+ * @param[in] nodes Requested node names.
+ */
+static int prte_ras_slurm_count_matching_session_nodes(prte_session_t *session, char **nodes)
+{
+    int matches = 0;
+
+    if (NULL == session || NULL == session->nodes || NULL == nodes) {
+        return 0;
+    }
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL != node && NULL != node->name &&
+            prte_ras_slurm_node_in_argv(nodes, node->name)) {
+            matches++;
+        }
+    }
+
+    return matches;
+}
+
+/**
+ * @brief Build survivor node names for an exact node removal.
+ *
+ * @param[in] session Slurm session to inspect.
+ * @param[in] nodes_to_remove Node names selected for release.
+ * @param[out] survivors Nodes that should remain in the Slurm allocation.
+ */
+static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove,
+                                              char ***survivors)
+{
+    pmix_status_t pmix_err;
+
+    if (NULL == session || NULL == session->nodes || NULL == survivors) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    *survivors = NULL;
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL == node || NULL == node->name ||
+            prte_ras_slurm_node_in_argv(nodes_to_remove, node->name)) {
+            continue;
+        }
+
+        pmix_err = PMIx_Argv_append_nosize(survivors, node->name);
+        if (PMIX_SUCCESS != pmix_err) {
+            PMIx_Argv_free(*survivors);
+            *survivors = NULL;
+            return prte_pmix_convert_status(pmix_err);
+        }
+    }
+
+    if (NULL == *survivors || 0 == PMIx_Argv_count(*survivors)) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Remove nodes from Slurm allocations by exact node name.
+ *
+ * @param[in] nodes Node names to remove.
+ */
+static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
+{
+    int err = PRTE_SUCCESS;
+    int nodes_removed = 0;
+    int node_count;
+    char *launching_jobid;
+    char *protected_node = NULL;
+    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
+
+    if (NULL == nodes || 0 == (node_count = PMIx_Argv_count(nodes))) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (node_count >= prte_num_allocated_nodes) {
+        pmix_output(0, "ras:slurm:remove_nodes_by_name: cannot remove all allocated nodes or more.");
+        return PRTE_ERR_REQUEST;
+    }
+
+    if (NULL == (launching_jobid = getenv("SLURM_JOBID"))) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    for (int i = 0; NULL != nodes[i]; i++) {
+        prte_session_stack_item_t *session_item;
+
+        err = prte_ras_slurm_validate_hostname(nodes[i]);
+        if (PRTE_SUCCESS != err) {
+            return err;
+        }
+
+        for (int j = i + 1; NULL != nodes[j]; j++) {
+            if (0 == strcmp(nodes[i], nodes[j])) {
+                return PRTE_ERR_BAD_PARAM;
+            }
+        }
+
+        session_item = prte_ras_slurm_find_session_item_by_node(nodes[i]);
+        if (NULL == session_item || NULL == session_item->session ||
+            NULL == session_item->session->alloc_refid) {
+            return PRTE_ERR_NOT_FOUND;
+        }
+
+        if (prte_ras_slurm_jobid_has_active_shrink(session_item->session->alloc_refid)) {
+            return PRTE_ERR_RESOURCE_BUSY;
+        }
+
+        if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
+            if (NULL == protected_node) {
+                protected_node = getenv("SLURMD_NODENAME");
+                if (NULL == protected_node) {
+                    return PRTE_ERR_BAD_PARAM;
+                }
+            }
+
+            if (0 == strcmp(nodes[i], protected_node)) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to remove current node %s",
+                            protected_node);
+                return PRTE_ERR_BAD_PARAM;
+            }
+        }
+    }
+
+    char **processed_jobs = NULL;
+
+    for (int i = 0; NULL != nodes[i]; i++) {
+        prte_session_stack_item_t *session_item;
+        prte_session_t *session;
+        int selected;
+        pmix_status_t pmix_err;
+
+        session_item = prte_ras_slurm_find_session_item_by_node(nodes[i]);
+        if (NULL == session_item || NULL == session_item->session ||
+            NULL == session_item->session->alloc_refid) {
+            err = PRTE_ERR_NOT_FOUND;
+            goto cleanup;
+        }
+
+        session = session_item->session;
+        if (prte_ras_slurm_node_in_argv(processed_jobs, session->alloc_refid)) {
+            continue;
+        }
+
+        pmix_err = PMIx_Argv_append_nosize(&processed_jobs, session->alloc_refid);
+        if (PMIX_SUCCESS != pmix_err) {
+            err = prte_pmix_convert_status(pmix_err);
+            goto cleanup;
+        }
+
+        selected = prte_ras_slurm_count_matching_session_nodes(session, nodes);
+        if (0 == selected) {
+            continue;
+        }
+
+        if (selected == session_item->nodes_in_session) {
+            if (prte_ras_slurm_session_contains_invoker(session, launching_jobid)) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to kill job %s "
+                               "because it contains the invoking process",
+                            session->alloc_refid);
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg,
+                                          PRTE_SLURM_ERR_STR_MAX_LEN+1);
+            if (PRTE_SUCCESS != err) {
+                if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
+                    pmix_output(0, "ras:slurm:remove_nodes_by_name: failed to kill job %s: %s.",
+                                session->alloc_refid, err_msg);
+                } else {
+                    PRTE_ERROR_LOG(err);
+                }
+                goto cleanup;
+            }
+
+            pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
+            nodes_removed += session_item->nodes_in_session;
+            PMIX_RELEASE(session);
+            PMIX_RELEASE(session_item);
+        } else {
+            pmix_pointer_array_t nodes_in_removal;
+            char **survivors = NULL;
+
+            err = prte_ras_slurm_build_survivor_list(session, nodes, &survivors);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
+            err = prte_ras_slurm_shrink_job_to_survivors(session->alloc_refid, survivors,
+                                                         err_msg,
+                                                         PRTE_SLURM_ERR_STR_MAX_LEN+1);
+            PMIx_Argv_free(survivors);
+            if (PRTE_SUCCESS != err) {
+                if(PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
+                    pmix_output(0, "ras:slurm:remove_nodes_by_name: failed to shrink job %s"
+                                   ": %s.", session->alloc_refid, err_msg);
+                } else {
+                    PRTE_ERROR_LOG(err);
+                }
+                goto cleanup;
+            }
+
+            PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
+            err = prte_ras_slurm_detach_nodes(session->alloc_refid, session, &nodes_in_removal);
+            PMIX_DESTRUCT(&nodes_in_removal);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
+            session_item->nodes_in_session -= selected;
+            nodes_removed += selected;
+        }
+    }
+
+cleanup:
+    if (NULL != processed_jobs) {
+        PMIx_Argv_free(processed_jobs);
+    }
+    prte_num_allocated_nodes -= nodes_removed;
+    if (PRTE_SUCCESS != err && nodes_removed > 0) {
+        err = PRTE_ERR_PARTIAL_SUCCESS;
+    }
+    return err;
+}
+
+/**
+ * @brief Remove a whole Slurm allocation by allocation ID.
+ *
+ * @param[in] alloc_id Slurm allocation/job ID.
+ */
+static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id)
+{
+    prte_session_stack_item_t *session_item;
+    char *launching_jobid;
+    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
+    int err;
+
+    if (NULL == alloc_id || '\0' == alloc_id[0]) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    session_item = prte_ras_slurm_find_session_item_by_alloc_id(alloc_id);
+    if (NULL == session_item || NULL == session_item->session) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    if (session_item->nodes_in_session >= prte_num_allocated_nodes) {
+        pmix_output(0, "ras:slurm:remove_allocation_by_id: cannot remove all allocated nodes.");
+        return PRTE_ERR_REQUEST;
+    }
+
+    if (prte_ras_slurm_jobid_has_active_shrink(alloc_id)) {
+        return PRTE_ERR_RESOURCE_BUSY;
+    }
+
+    if (NULL == (launching_jobid = getenv("SLURM_JOBID"))) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
+        pmix_output(0, "ras:slurm:remove_allocation_by_id: refusing to kill job %s "
+                       "because it contains the invoking process", alloc_id);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    err = prte_ras_slurm_kill_job(alloc_id, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
+    if (PRTE_SUCCESS != err) {
+        if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
+            pmix_output(0, "ras:slurm:remove_allocation_by_id: failed to kill job %s: %s.",
+                        alloc_id, err_msg);
+        } else {
+            PRTE_ERROR_LOG(err);
+        }
+        return err;
+    }
+
+    pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
+    prte_num_allocated_nodes -= session_item->nodes_in_session;
+
+    /* This also removes from prte_sessions */
+    PMIX_RELEASE(session_item->session);
+    PMIX_RELEASE(session_item);
+
+    return PRTE_SUCCESS;
 }
 
 /**
@@ -518,6 +994,145 @@ cleanup:
     if(PRTE_SUCCESS != err && nodes_removed > 0) {
         err = PRTE_ERR_PARTIAL_SUCCESS;
     }
+
+    return err;
+}
+
+static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid)
+{
+    char *resize_script_sh = NULL;
+    char *resize_script_csh = NULL;
+    static const char *resize_script_format = "slurm_job_%s_resize.%s";
+
+    if (NULL == slurm_jobid) {
+        return;
+    }
+
+    if (0 <= asprintf(&resize_script_sh, resize_script_format, slurm_jobid, "sh")) {
+        if (0 != remove(resize_script_sh)) {
+            int saved_errno = errno;
+            if (ENOENT != saved_errno) {
+                pmix_output(0,
+                            "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
+                            resize_script_sh, strerror(saved_errno));
+            }
+        }
+    }
+
+    if (0 <= asprintf(&resize_script_csh, resize_script_format, slurm_jobid, "csh")) {
+        if (0 != remove(resize_script_csh)) {
+            int saved_errno = errno;
+            if (ENOENT != saved_errno) {
+                pmix_output(0,
+                            "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
+                            resize_script_csh, strerror(saved_errno));
+            }
+        }
+    }
+
+    free(resize_script_sh);
+    free(resize_script_csh);
+}
+
+/**
+ * @brief Shrink a Slurm job to an exact survivor node list.
+ *
+ * @param[in] slurm_jobid Slurm job ID to resize.
+ * @param[in] survivor_nodes Nodes that must remain in the job.
+ * @param[out] err_msg Optional buffer for Slurm error output.
+ * @param[in] err_msg_size Size of err_msg buffer, if applicable.
+ */
+static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes,
+                                                  char *err_msg, size_t err_msg_size)
+{
+    int err = PRTE_SUCCESS;
+    char *survivor_string = NULL;
+    char *req_nodes_arg = NULL;
+    char *cmd = NULL;
+    FILE *fp = NULL;
+    static const char *cmd_format = "scontrol update job %s %s 2>&1";
+
+    if (NULL == slurm_jobid || NULL == survivor_nodes ||
+        0 == PMIx_Argv_count(survivor_nodes)) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (NULL != err_msg) {
+        err_msg[0] = '\0';
+    }
+
+    err = prte_ras_slurm_validate_jobid(slurm_jobid);
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    for (int i = 0; NULL != survivor_nodes[i]; i++) {
+        err = prte_ras_slurm_validate_hostname(survivor_nodes[i]);
+        if (PRTE_SUCCESS != err) {
+            return err;
+        }
+    }
+
+    survivor_string = PMIx_Argv_join(survivor_nodes, ',');
+    if (NULL == survivor_string) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    if (0 > asprintf(&req_nodes_arg, "ReqNodeList=%s", survivor_string)) {
+        req_nodes_arg = NULL;
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
+
+    if (0 > asprintf(&cmd, cmd_format, slurm_jobid, req_nodes_arg)) {
+        cmd = NULL;
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
+
+    PMIX_OUTPUT_VERBOSE((20, prte_ras_base_framework.framework_output,
+                        "%s ras:slurm:shrink_job: shrink command is:\n%s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cmd));
+
+    fp = popen(cmd, "r");
+    if (NULL == fp) {
+        err = PRTE_ERR_FILE_OPEN_FAILURE;
+        goto cleanup;
+    }
+
+    err = prte_ras_slurm_drain_cmd_output(fp, err_msg, err_msg_size);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+    int status = pclose(fp);
+    fp = NULL;
+
+    if (-1 == status) {
+        pmix_output(0, "ras:slurm:shrink_job: pclose failed: %s.", strerror(errno));
+        err = PRTE_ERR_IN_ERRNO;
+        goto cleanup;
+    }
+
+    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+        err = PRTE_ERR_SLURM_SHRINK_FAILURE;
+        goto cleanup;
+    }
+
+    prte_ras_slurm_cleanup_resize_scripts(slurm_jobid);
+
+cleanup:
+    if (NULL != err_msg && PRTE_ERR_SLURM_SHRINK_FAILURE != err) {
+        err_msg[0] = '\0';
+    }
+
+    if (NULL != fp) {
+        pclose(fp);
+    }
+
+    free(survivor_string);
+    free(req_nodes_arg);
+    free(cmd);
 
     return err;
 }

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -54,6 +54,8 @@ PMIX_CLASS_INSTANCE(prte_ras_slurm_shrink_tracker_t,
                     shrink_tracker_con,
                     shrink_tracker_des);
 
+static pmix_list_t *prte_slurm_shrink_trackers = NULL;
+
 static void release_action_con(prte_ras_slurm_release_action_t *p)
 {
     p->job_id = NULL;
@@ -84,6 +86,33 @@ static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p)
         PMIX_RELEASE(action);
     }
     PMIX_DESTRUCT(&p->actions);
+}
+
+int prte_ras_slurm_modify_release_init(void)
+{
+    prte_slurm_shrink_trackers = PMIX_NEW(pmix_list_t);
+    if (NULL == prte_slurm_shrink_trackers) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    return PRTE_SUCCESS;
+}
+
+int prte_ras_slurm_modify_release_finalize(void)
+{
+    prte_ras_slurm_shrink_tracker_t *tracker;
+
+    if (NULL == prte_slurm_shrink_trackers) {
+        return PRTE_SUCCESS;
+    }
+
+    while (NULL != (tracker = (prte_ras_slurm_shrink_tracker_t *)
+                                  pmix_list_remove_first(prte_slurm_shrink_trackers))) {
+        PMIX_RELEASE(tracker);
+    }
+    PMIX_RELEASE(prte_slurm_shrink_trackers);
+    prte_slurm_shrink_trackers = NULL;
+
+    return PRTE_SUCCESS;
 }
 
 /**

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -22,40 +22,27 @@
 #include "src/mca/ras/base/base.h"
 
 /* Local functions */
-static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session,
-                                                    const char *launching_jobid);
-static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item,
-                                                  const char *launching_jobid);
-static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid,
-                                                                         char **excluded_jobids);
-static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
-                                                 const char *launching_jobid);
+static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session, const char *launching_jobid);
+static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item, const char *launching_jobid);
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid, char **excluded_jobids);
+static int prte_ras_slurm_validate_count_release(int nodes_to_remove, const char *launching_jobid);
 static void localrelease(void *cbdata);
 static bool prte_ras_slurm_session_is_dynamic(prte_session_t *session);
 static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char **nodes);
 static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, const char *alloc_id);
 static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count);
 static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes);
-static int prte_ras_slurm_append_release_targets(prte_session_t *session,
-                                                 char **requested_nodes,
-                                                 char ***target_nodes);
-static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
-                                                       const char *protected_node,
-                                                       int nodes_to_remove,
-                                                       char ***target_nodes);
-static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
-                                       prte_ras_slurm_shrink_tracker_t *tracker,
-                                       char **target_nodes);
+static int prte_ras_slurm_append_release_targets(prte_session_t *session, char **requested_nodes, char ***target_nodes);
+static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, const char *protected_node, int nodes_to_remove, char ***target_nodes);
+static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req, prte_ras_slurm_shrink_tracker_t *tracker, char **target_nodes);
 static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req);
 static int prte_ras_slurm_parse_release_node_list(pmix_info_t *info, char ***nodes);
 static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_alloc_id(const char *alloc_id);
 static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_node(const char *node_name);
 static bool prte_ras_slurm_node_in_argv(char **nodes, const char *node_name);
 static int prte_ras_slurm_count_matching_session_nodes(prte_session_t *session, char **nodes);
-static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove,
-                                              char ***survivors);
-static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes,
-                                                  char *err_msg, size_t err_msg_size);
+static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove, char ***survivors);
+static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes, char *err_msg, size_t err_msg_size);
 static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid);
 
 static void localrelease(void *cbdata)

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -44,8 +44,13 @@ static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p);
 static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
                                              const char *jobid);
 static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid);
-static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void);
-static int prte_ras_slurm_validate_count_release(int nodes_to_remove);
+static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session,
+                                                    const char *launching_jobid);
+static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item,
+                                                  const char *launching_jobid);
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid);
+static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
+                                                 const char *launching_jobid);
 static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
 static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
 static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
@@ -168,9 +173,48 @@ static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid)
 }
 
 /**
- * @brief Find the newest Slurm session without an active shrink.
+ * @brief Check whether a session contains the requesting Slurm job.
+ *
+ * @param[in] session Slurm-backed session to inspect.
+ * @param[in] launching_jobid Slurm job ID of the requester.
  */
-static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void)
+static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session,
+                                                    const char *launching_jobid)
+{
+    return NULL != session && NULL != session->alloc_refid &&
+           NULL != launching_jobid &&
+           0 == strcmp(session->alloc_refid, launching_jobid);
+}
+
+/**
+ * @brief Return how many nodes may be removed from a session.
+ *
+ * @param[in] session_item Slurm session stack item.
+ * @param[in] launching_jobid Slurm job ID whose current node must survive.
+ */
+static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item,
+                                                  const char *launching_jobid)
+{
+    if (NULL == session_item || NULL == session_item->session) {
+        return 0;
+    }
+
+    if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
+        if (1 >= session_item->nodes_in_session) {
+            return 0;
+        }
+        return session_item->nodes_in_session - 1;
+    }
+
+    return session_item->nodes_in_session;
+}
+
+/**
+ * @brief Find the newest Slurm session with removable nodes.
+ *
+ * @param[in] launching_jobid Slurm job ID whose current node must survive.
+ */
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid)
 {
     pmix_list_item_t *item;
 
@@ -198,6 +242,10 @@ static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void)
             continue;
         }
 
+        if (0 >= prte_ras_slurm_session_removable_count(session_item, launching_jobid)) {
+            continue;
+        }
+
         return session_item;
     }
 
@@ -208,8 +256,10 @@ static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void)
  * @brief Validate that a count release can avoid active shrinks.
  *
  * @param[in] nodes_to_remove Number of nodes requested for release.
+ * @param[in] launching_jobid Slurm job ID whose current node must survive.
  */
-static int prte_ras_slurm_validate_count_release(int nodes_to_remove)
+static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
+                                                 const char *launching_jobid)
 {
     pmix_list_item_t *item;
     int nodes_remaining = nodes_to_remove;
@@ -240,7 +290,8 @@ static int prte_ras_slurm_validate_count_release(int nodes_to_remove)
             continue;
         }
 
-        nodes_remaining -= session_item->nodes_in_session;
+        nodes_remaining -= prte_ras_slurm_session_removable_count(session_item,
+                                                                  launching_jobid);
     }
 
     if (0 < nodes_remaining) {
@@ -334,7 +385,7 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         return PRTE_ERR_NOT_FOUND;
     }
 
-    err = prte_ras_slurm_validate_count_release(nodes_to_remove);
+    err = prte_ras_slurm_validate_count_release(nodes_to_remove, launching_jobid);
     if (PRTE_SUCCESS != err) {
         if (PRTE_ERR_RESOURCE_BUSY == err) {
             pmix_output(0, "ras:slurm:remove_nodes_by_count: insufficient non-conflicting "
@@ -353,7 +404,8 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
             goto cleanup;
         }
 
-        prte_session_stack_item_t *session_item = prte_ras_slurm_find_releasable_session();
+        prte_session_stack_item_t *session_item =
+            prte_ras_slurm_find_releasable_session(launching_jobid);
 
         if(NULL == session_item || NULL == session_item->session) {
             err = PRTE_ERR_NOT_FOUND;
@@ -365,25 +417,14 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
 
         int nodes_left_to_rem = nodes_to_remove-nodes_removed;
 
-        bool contains_invoker = false;
-        
-        if(0 == strcmp(session->alloc_refid, launching_jobid)) {
-            contains_invoker = true;
-        }
+        bool contains_invoker = prte_ras_slurm_session_contains_invoker(session,
+                                                                        launching_jobid);
+        int removable_count = prte_ras_slurm_session_removable_count(session_item,
+                                                                     launching_jobid);
 
         char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
 
-        if(nodes_left_to_rem >= session_item->nodes_in_session) {
-
-            /* we'd be trying cancel ourselves. probably a bad idea */
-            if(contains_invoker) {
-                pmix_output(0, "ras:slurm:remove_nodes_by_count: refusing to kill job %s "
-                               "because it contains the invoking process", session->alloc_refid);
-                err = PRTE_ERR_BAD_PARAM;
-                PRTE_ERROR_LOG(err);
-                goto cleanup;
-            }
-
+        if(!contains_invoker && nodes_left_to_rem >= session_item->nodes_in_session) {
             err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
 
             if (PRTE_SUCCESS != err) {
@@ -410,7 +451,13 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
             PMIX_RELEASE(session_item);
         } else {
 
-            int new_node_count = session_item->nodes_in_session-nodes_left_to_rem;
+            int nodes_to_rem_from_session = nodes_left_to_rem;
+
+            if (nodes_to_rem_from_session > removable_count) {
+                nodes_to_rem_from_session = removable_count;
+            }
+
+            int new_node_count = session_item->nodes_in_session-nodes_to_rem_from_session;
 
             char *whitelist_node = NULL;
 
@@ -460,7 +507,7 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
             PMIX_DESTRUCT(&nodes_in_removal);
 
             session_item->nodes_in_session = new_node_count;
-            nodes_removed += nodes_left_to_rem;
+            nodes_removed += nodes_to_rem_from_session;
         }
     } while (nodes_to_remove > nodes_removed);
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -41,6 +41,11 @@ static void release_action_con(prte_ras_slurm_release_action_t *p);
 static void release_action_des(prte_ras_slurm_release_action_t *p);
 static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p);
 static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p);
+static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
+                                             const char *jobid);
+static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid);
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void);
+static int prte_ras_slurm_validate_count_release(int nodes_to_remove);
 static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
 static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
 static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
@@ -111,6 +116,139 @@ int prte_ras_slurm_modify_release_finalize(void)
     }
     PMIX_RELEASE(prte_slurm_shrink_trackers);
     prte_slurm_shrink_trackers = NULL;
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Check whether a shrink tracker includes a Slurm job ID.
+ *
+ * @param[in] tracker Shrink tracker to inspect.
+ * @param[in] jobid Slurm job ID to find.
+ */
+static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
+                                             const char *jobid)
+{
+    prte_ras_slurm_release_action_t *action;
+
+    if (NULL == tracker || NULL == jobid) {
+        return false;
+    }
+
+    PMIX_LIST_FOREACH(action, &tracker->actions, prte_ras_slurm_release_action_t) {
+        if (NULL != action->job_id && 0 == strcmp(action->job_id, jobid)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Check whether a Slurm job already has an active shrink.
+ *
+ * @param[in] jobid Slurm job ID to find.
+ */
+static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid)
+{
+    prte_ras_slurm_shrink_tracker_t *tracker;
+
+    if (NULL == prte_slurm_shrink_trackers || NULL == jobid) {
+        return false;
+    }
+
+    PMIX_LIST_FOREACH(tracker, prte_slurm_shrink_trackers,
+                      prte_ras_slurm_shrink_tracker_t) {
+        if (prte_ras_slurm_tracker_has_jobid(tracker, jobid)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Find the newest Slurm session without an active shrink.
+ */
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(void)
+{
+    pmix_list_item_t *item;
+
+    if (NULL == prte_slurm_session_stack ||
+        0 == pmix_list_get_size(prte_slurm_session_stack)) {
+        return NULL;
+    }
+
+    for (item = pmix_list_get_last(prte_slurm_session_stack);
+         item != pmix_list_get_end(prte_slurm_session_stack);
+         item = pmix_list_get_prev(item)) {
+        prte_session_stack_item_t *session_item = (prte_session_stack_item_t *) item;
+        prte_session_t *session;
+
+        if (NULL == session_item || NULL == session_item->session) {
+            return NULL;
+        }
+
+        session = session_item->session;
+        if (NULL == session->alloc_refid) {
+            return NULL;
+        }
+
+        if (prte_ras_slurm_jobid_has_active_shrink(session->alloc_refid)) {
+            continue;
+        }
+
+        return session_item;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Validate that a count release can avoid active shrinks.
+ *
+ * @param[in] nodes_to_remove Number of nodes requested for release.
+ */
+static int prte_ras_slurm_validate_count_release(int nodes_to_remove)
+{
+    pmix_list_item_t *item;
+    int nodes_remaining = nodes_to_remove;
+    bool skipped_conflict = false;
+
+    if (NULL == prte_slurm_session_stack ||
+        0 == pmix_list_get_size(prte_slurm_session_stack)) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    for (item = pmix_list_get_last(prte_slurm_session_stack);
+         item != pmix_list_get_end(prte_slurm_session_stack) && 0 < nodes_remaining;
+         item = pmix_list_get_prev(item)) {
+        prte_session_stack_item_t *session_item = (prte_session_stack_item_t *) item;
+        prte_session_t *session;
+
+        if (NULL == session_item || NULL == session_item->session) {
+            return PRTE_ERR_NOT_FOUND;
+        }
+
+        session = session_item->session;
+        if (NULL == session->alloc_refid) {
+            return PRTE_ERR_NOT_FOUND;
+        }
+
+        if (prte_ras_slurm_jobid_has_active_shrink(session->alloc_refid)) {
+            skipped_conflict = true;
+            continue;
+        }
+
+        nodes_remaining -= session_item->nodes_in_session;
+    }
+
+    if (0 < nodes_remaining) {
+        if (skipped_conflict) {
+            return PRTE_ERR_RESOURCE_BUSY;
+        }
+        return PRTE_ERR_NOT_FOUND;
+    }
 
     return PRTE_SUCCESS;
 }
@@ -196,6 +334,16 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         return PRTE_ERR_NOT_FOUND;
     }
 
+    err = prte_ras_slurm_validate_count_release(nodes_to_remove);
+    if (PRTE_SUCCESS != err) {
+        if (PRTE_ERR_RESOURCE_BUSY == err) {
+            pmix_output(0, "ras:slurm:remove_nodes_by_count: insufficient non-conflicting "
+                           "Slurm resources available for release");
+        }
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
     int nodes_removed = 0;
 
     do {
@@ -205,8 +353,7 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
             goto cleanup;
         }
 
-        /* get the most recently added allocation to remove from */
-        prte_session_stack_item_t *session_item = (prte_session_stack_item_t *) pmix_list_get_last(prte_slurm_session_stack);
+        prte_session_stack_item_t *session_item = prte_ras_slurm_find_releasable_session();
 
         if(NULL == session_item || NULL == session_item->session) {
             err = PRTE_ERR_NOT_FOUND;
@@ -251,7 +398,7 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
                 goto cleanup;
             }
 
-            pmix_list_remove_last(prte_slurm_session_stack);
+            pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
             
             /* TODO: nodes in session need to be detached
              * from PRRTE. */

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -42,6 +42,7 @@ static int prte_ras_slurm_count_matching_session_nodes(prte_session_t *session, 
 static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove, char ***survivors);
 static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes, char *err_msg, size_t err_msg_size);
 static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid);
+static void prte_ras_slurm_exclude_shrunk_nodes(prte_shrink_campaign_t *campaign);
 
 static void localrelease(void *cbdata)
 {
@@ -60,6 +61,39 @@ static bool prte_ras_slurm_session_is_dynamic(prte_session_t *session)
 {
     return NULL != session &&
            PRTE_FLAG_TEST(session, PRTE_SESSION_FLAG_DYNAMIC);
+}
+
+/**
+ * @brief Withhold scheduler-released nodes from later DVM grows.
+ *
+ * Generic DVM shrink leaves detached nodes in the global node pool because a
+ * RAS implementation may retain the underlying allocation. Slurm release
+ * campaigns relinquish those resources, so keep their persistent node objects
+ * out of the usable pool until a later allocation explicitly adds them again.
+ *
+ * @param[in] campaign Completed Slurm-backed shrink campaign.
+ */
+static void prte_ras_slurm_exclude_shrunk_nodes(prte_shrink_campaign_t *campaign)
+{
+    prte_job_t *daemons;
+    prte_proc_t *dproc;
+
+    if (NULL == campaign) {
+        return;
+    }
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL == daemons) {
+        return;
+    }
+
+    for (int i = 0; i < campaign->ntargets; i++) {
+        dproc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs,
+                                                            campaign->targets[i]);
+        if (NULL != dproc && NULL != dproc->node) {
+            dproc->node->state = PRTE_NODE_STATE_NOT_INCLUDED;
+        }
+    }
 }
 
 /**
@@ -479,6 +513,8 @@ void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
     if (NULL == found) {
         return;
     }
+
+    prte_ras_slurm_exclude_shrunk_nodes(campaign);
 
     PMIX_LIST_FOREACH(action, &found->actions, prte_ras_slurm_release_action_t) {
         prte_session_stack_item_t *session_item;

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -14,47 +14,38 @@
 #include "types.h"
 
 #include "ras_slurm.h"
+#include "ras_slurm_modify_release_tracker.h"
+#include "src/mca/grpcomm/grpcomm.h"
+#include "src/mca/odls/odls_types.h"
+#include "src/mca/plm/base/plm_private.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ras/base/base.h"
 
-typedef enum {
-    PRTE_RAS_SLURM_RELEASE_FULL_JOB,
-    PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB
-} prte_ras_slurm_release_action_type_t;
-
-typedef struct {
-    pmix_list_item_t super;
-    char *job_id;
-    prte_ras_slurm_release_action_type_t action;
-    char **survivor_nodes;
-} prte_ras_slurm_release_action_t;
-PMIX_CLASS_DECLARATION(prte_ras_slurm_release_action_t);
-
-typedef struct {
-    pmix_list_item_t super;
-    prte_shrink_campaign_t *campaign;
-    pmix_list_t actions;
-} prte_ras_slurm_shrink_tracker_t;
-PMIX_CLASS_DECLARATION(prte_ras_slurm_shrink_tracker_t);
-
 /* Local functions */
-static void release_action_con(prte_ras_slurm_release_action_t *p);
-static void release_action_des(prte_ras_slurm_release_action_t *p);
-static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p);
-static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p);
-static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
-                                             const char *jobid);
-static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid);
 static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session,
                                                     const char *launching_jobid);
 static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item,
                                                   const char *launching_jobid);
-static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid);
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid,
+                                                                         char **excluded_jobids);
 static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
                                                  const char *launching_jobid);
-static int prte_ras_slurm_remove_nodes_by_name(char **nodes);
-static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id);
-static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
+static void localrelease(void *cbdata);
+static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char **nodes);
+static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, const char *alloc_id);
+static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count);
+static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes);
+static int prte_ras_slurm_append_release_targets(prte_session_t *session,
+                                                 char **requested_nodes,
+                                                 char ***target_nodes);
+static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
+                                                       const char *protected_node,
+                                                       int nodes_to_remove,
+                                                       char ***target_nodes);
+static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
+                                       prte_ras_slurm_shrink_tracker_t *tracker,
+                                       char **target_nodes);
+static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req);
 static int prte_ras_slurm_parse_release_node_list(pmix_info_t *info, char ***nodes);
 static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_alloc_id(const char *alloc_id);
 static prte_session_stack_item_t *prte_ras_slurm_find_session_item_by_node(const char *node_name);
@@ -62,127 +53,16 @@ static bool prte_ras_slurm_node_in_argv(char **nodes, const char *node_name);
 static int prte_ras_slurm_count_matching_session_nodes(prte_session_t *session, char **nodes);
 static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **nodes_to_remove,
                                               char ***survivors);
-static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
 static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char **survivor_nodes,
                                                   char *err_msg, size_t err_msg_size);
-static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
 static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid);
 
-PMIX_CLASS_INSTANCE(prte_ras_slurm_release_action_t,
-                    pmix_list_item_t,
-                    release_action_con,
-                    release_action_des);
-PMIX_CLASS_INSTANCE(prte_ras_slurm_shrink_tracker_t,
-                    pmix_list_item_t,
-                    shrink_tracker_con,
-                    shrink_tracker_des);
-
-static pmix_list_t *prte_slurm_shrink_trackers = NULL;
-
-static void release_action_con(prte_ras_slurm_release_action_t *p)
+static void localrelease(void *cbdata)
 {
-    p->job_id = NULL;
-    p->action = PRTE_RAS_SLURM_RELEASE_FULL_JOB;
-    p->survivor_nodes = NULL;
-}
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
 
-static void release_action_des(prte_ras_slurm_release_action_t *p)
-{
-    free(p->job_id);
-    if (NULL != p->survivor_nodes) {
-        PMIx_Argv_free(p->survivor_nodes);
-    }
-}
-
-static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p)
-{
-    p->campaign = NULL;
-    PMIX_CONSTRUCT(&p->actions, pmix_list_t);
-}
-
-static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p)
-{
-    prte_ras_slurm_release_action_t *action;
-
-    while (NULL != (action = (prte_ras_slurm_release_action_t *)
-                               pmix_list_remove_first(&p->actions))) {
-        PMIX_RELEASE(action);
-    }
-    PMIX_DESTRUCT(&p->actions);
-}
-
-int prte_ras_slurm_modify_release_init(void)
-{
-    prte_slurm_shrink_trackers = PMIX_NEW(pmix_list_t);
-    if (NULL == prte_slurm_shrink_trackers) {
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-    return PRTE_SUCCESS;
-}
-
-int prte_ras_slurm_modify_release_finalize(void)
-{
-    prte_ras_slurm_shrink_tracker_t *tracker;
-
-    if (NULL == prte_slurm_shrink_trackers) {
-        return PRTE_SUCCESS;
-    }
-
-    while (NULL != (tracker = (prte_ras_slurm_shrink_tracker_t *)
-                                  pmix_list_remove_first(prte_slurm_shrink_trackers))) {
-        PMIX_RELEASE(tracker);
-    }
-    PMIX_RELEASE(prte_slurm_shrink_trackers);
-    prte_slurm_shrink_trackers = NULL;
-
-    return PRTE_SUCCESS;
-}
-
-/**
- * @brief Check whether a shrink tracker includes a Slurm job ID.
- *
- * @param[in] tracker Shrink tracker to inspect.
- * @param[in] jobid Slurm job ID to find.
- */
-static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
-                                             const char *jobid)
-{
-    prte_ras_slurm_release_action_t *action;
-
-    if (NULL == tracker || NULL == jobid) {
-        return false;
-    }
-
-    PMIX_LIST_FOREACH(action, &tracker->actions, prte_ras_slurm_release_action_t) {
-        if (NULL != action->job_id && 0 == strcmp(action->job_id, jobid)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
- * @brief Check whether a Slurm job already has an active shrink.
- *
- * @param[in] jobid Slurm job ID to find.
- */
-static bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid)
-{
-    prte_ras_slurm_shrink_tracker_t *tracker;
-
-    if (NULL == prte_slurm_shrink_trackers || NULL == jobid) {
-        return false;
-    }
-
-    PMIX_LIST_FOREACH(tracker, prte_slurm_shrink_trackers,
-                      prte_ras_slurm_shrink_tracker_t) {
-        if (prte_ras_slurm_tracker_has_jobid(tracker, jobid)) {
-            return true;
-        }
-    }
-
-    return false;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
 }
 
 /**
@@ -223,11 +103,13 @@ static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *ses
 }
 
 /**
- * @brief Find the newest Slurm session with removable nodes.
+ * @brief Find the newest removable session outside an exclusion list.
  *
  * @param[in] launching_jobid Slurm job ID whose current node must survive.
+ * @param[in] excluded_jobids Slurm job IDs already planned for release.
  */
-static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid)
+static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid,
+                                                                         char **excluded_jobids)
 {
     pmix_list_item_t *item;
 
@@ -249,6 +131,10 @@ static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const c
         session = session_item->session;
         if (NULL == session->alloc_refid) {
             return NULL;
+        }
+
+        if (prte_ras_slurm_node_in_argv(excluded_jobids, session->alloc_refid)) {
+            continue;
         }
 
         if (prte_ras_slurm_jobid_has_active_shrink(session->alloc_refid)) {
@@ -318,6 +204,364 @@ static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
 }
 
 /**
+ * @brief Append every node in a session to a shrink target list.
+ *
+ * @param[in] session Session whose daemons should be removed.
+ * @param[in,out] target_nodes Target node argv.
+ */
+static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes)
+{
+    pmix_status_t pmix_err;
+
+    if (NULL == session || NULL == session->nodes || NULL == target_nodes) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL == node || NULL == node->name) {
+            continue;
+        }
+
+        pmix_err = PMIx_Argv_append_nosize(target_nodes, node->name);
+        if (PMIX_SUCCESS != pmix_err) {
+            return prte_pmix_convert_status(pmix_err);
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Append requested nodes that belong to a session.
+ *
+ * @param[in] session Session to inspect.
+ * @param[in] requested_nodes Requested release node names.
+ * @param[in,out] target_nodes Target node argv.
+ */
+static int prte_ras_slurm_append_release_targets(prte_session_t *session,
+                                                 char **requested_nodes,
+                                                 char ***target_nodes)
+{
+    pmix_status_t pmix_err;
+
+    if (NULL == session || NULL == session->nodes || NULL == requested_nodes ||
+        NULL == target_nodes) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    for (int i = 0; i < session->nodes->size; i++) {
+        prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL == node || NULL == node->name ||
+            !prte_ras_slurm_node_in_argv(requested_nodes, node->name)) {
+            continue;
+        }
+
+        pmix_err = PMIx_Argv_append_nosize(target_nodes, node->name);
+        if (PMIX_SUCCESS != pmix_err) {
+            return prte_pmix_convert_status(pmix_err);
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Append count-selected nodes from a session.
+ *
+ * @param[in] session Session to inspect.
+ * @param[in] protected_node Node that must not be selected.
+ * @param[in] nodes_to_remove Number of nodes to append.
+ * @param[in,out] target_nodes Target node argv.
+ */
+static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
+                                                       const char *protected_node,
+                                                       int nodes_to_remove,
+                                                       char ***target_nodes)
+{
+    pmix_status_t pmix_err;
+    int added = 0;
+
+    if (NULL == session || NULL == session->nodes || NULL == target_nodes ||
+        0 > nodes_to_remove) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    for (int i = session->nodes->size - 1; 0 <= i && added < nodes_to_remove; i--) {
+        prte_node_t *node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
+
+        if (NULL == node || NULL == node->name) {
+            continue;
+        }
+        if (NULL != protected_node && 0 == strcmp(node->name, protected_node)) {
+            continue;
+        }
+
+        pmix_err = PMIx_Argv_append_nosize(target_nodes, node->name);
+        if (PMIX_SUCCESS != pmix_err) {
+            return prte_pmix_convert_status(pmix_err);
+        }
+        added++;
+    }
+
+    if (added != nodes_to_remove) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Start a DVM shrink campaign for planned Slurm release actions.
+ *
+ * @param[in] req PMIx release request.
+ * @param[in] tracker Tracker describing RM-side completion work.
+ * @param[in] target_nodes Nodes whose daemons should leave the DVM.
+ */
+static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
+                                       prte_ras_slurm_shrink_tracker_t *tracker,
+                                       char **target_nodes)
+{
+    pmix_data_buffer_t msg;
+    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
+    pmix_rank_t *ranks = NULL;
+    prte_shrink_campaign_t *campaign = NULL;
+    int32_t nranks;
+    int err = PRTE_SUCCESS;
+    pmix_status_t rc;
+
+    if (NULL == req || NULL == tracker || NULL == target_nodes ||
+        0 == (nranks = PMIx_Argv_count(target_nodes))) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (!prte_elastic_mode) {
+        return PRTE_ERR_NOT_SUPPORTED;
+    }
+
+    ranks = (pmix_rank_t *) malloc(nranks * sizeof(pmix_rank_t));
+    if (NULL == ranks) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (int i = 0; NULL != target_nodes[i]; i++) {
+        prte_node_t *node = prte_node_match(NULL, target_nodes[i]);
+
+        if (NULL == node || NULL == node->daemon) {
+            err = PRTE_ERR_NOT_FOUND;
+            goto cleanup;
+        }
+
+        ranks[i] = node->daemon->name.rank;
+    }
+
+    campaign = PMIX_NEW(prte_shrink_campaign_t);
+    if (NULL == campaign) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
+
+    campaign->targets = (pmix_rank_t *) malloc(nranks * sizeof(pmix_rank_t));
+    if (NULL == campaign->targets) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
+
+    memcpy(campaign->targets, ranks, nranks * sizeof(pmix_rank_t));
+    campaign->ntargets = nranks;
+    campaign->pending = nranks;
+    PMIX_XFER_PROCID(&campaign->requester, &req->tproc);
+    for (size_t n = 0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID) &&
+            PMIX_STRING == req->info[n].value.type) {
+            campaign->alloc_id = strdup(req->info[n].value.data.string);
+        } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID) &&
+                   PMIX_STRING == req->info[n].value.type) {
+            campaign->req_id = strdup(req->info[n].value.data.string);
+        }
+    }
+    campaign->have_requester = true;
+    if (NULL == campaign->alloc_id) {
+        const char *jobid = prte_ras_slurm_tracker_first_jobid(tracker);
+
+        if (NULL != jobid) {
+            campaign->alloc_id = strdup(jobid);
+            if (NULL == campaign->alloc_id) {
+                err = PRTE_ERR_OUT_OF_RESOURCE;
+                goto cleanup;
+            }
+        }
+    }
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&msg);
+    rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &msg, &nranks, 1, PMIX_INT32);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &msg, ranks, nranks, PMIX_PROC_RANK);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DATA_BUFFER_DESTRUCT(&msg);
+        err = prte_pmix_convert_status(rc);
+        goto cleanup;
+    }
+
+    pmix_list_append(&prte_shrink_campaigns, &campaign->super);
+    prte_dvm_launch_fence += nranks;
+    prte_ras_slurm_track_shrink_campaign(tracker, campaign);
+
+    err = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg);
+    PMIX_DATA_BUFFER_DESTRUCT(&msg);
+    if (PRTE_SUCCESS != err) {
+        prte_ras_slurm_untrack_shrink_campaign(tracker);
+        pmix_list_remove_item(&prte_shrink_campaigns, &campaign->super);
+        prte_dvm_launch_fence -= campaign->pending;
+        prte_plm_base_dvm_mod_notify(&campaign->requester, campaign->alloc_id,
+                                     campaign->req_id, false,
+                                     prte_pmix_convert_rc(err));
+        PMIX_RELEASE(campaign);
+        goto cleanup;
+    }
+
+    campaign = NULL;
+
+cleanup:
+    if (NULL != campaign) {
+        PMIX_RELEASE(campaign);
+    }
+    free(ranks);
+
+    return err;
+}
+
+/**
+ * @brief Return phase-one release acceptance to the requester.
+ *
+ * @param[in] req PMIx release request.
+ */
+static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req)
+{
+    req->pstatus = PMIX_OPERATION_IN_PROGRESS;
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
+                        localrelease, req);
+        return PRTE_SUCCESS;
+    }
+
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index,
+                                NULL);
+    PMIX_RELEASE(req);
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Release a Slurm-backed session allocation.
+ *
+ * @param[in] session Session being destroyed.
+ */
+int prte_ras_slurm_release_allocation(prte_session_t *session)
+{
+    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN + 1] = {0};
+    int err;
+
+    if (NULL == session || NULL == session->alloc_refid ||
+        NULL == prte_ras_slurm_find_session_item_by_alloc_id(session->alloc_refid)) {
+        return PRTE_ERR_TAKE_NEXT_OPTION;
+    }
+
+    err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg,
+                                  sizeof(err_msg));
+    if (PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
+        pmix_output(0, "ras:slurm:release_allocation: failed to kill job %s: %s.",
+                    session->alloc_refid, err_msg);
+    } else if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+    }
+
+    return err;
+}
+
+/**
+ * @brief Release Slurm resources after a DVM shrink completes.
+ *
+ * @param[in] campaign Completed shrink campaign.
+ */
+void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
+{
+    prte_ras_slurm_shrink_tracker_t *found;
+    prte_ras_slurm_release_action_t *action;
+
+    found = prte_ras_slurm_find_tracker_by_campaign(campaign);
+    if (NULL == found) {
+        return;
+    }
+
+    PMIX_LIST_FOREACH(action, &found->actions, prte_ras_slurm_release_action_t) {
+        prte_session_stack_item_t *session_item;
+        char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN + 1] = {0};
+        int err;
+
+        if (NULL == action->job_id) {
+            continue;
+        }
+
+        session_item = prte_ras_slurm_find_session_item_by_alloc_id(action->job_id);
+        if (NULL == session_item || NULL == session_item->session) {
+            continue;
+        }
+
+        if (PRTE_RAS_SLURM_RELEASE_FULL_JOB == action->action) {
+            int node_count = session_item->nodes_in_session;
+
+            PMIX_RELEASE(session_item->session);
+            pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
+            prte_num_allocated_nodes -= node_count;
+            PMIX_RELEASE(session_item);
+        } else if (PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB == action->action) {
+            pmix_pointer_array_t nodes_in_removal;
+            int old_count = session_item->nodes_in_session;
+            int new_count = PMIx_Argv_count(action->survivor_nodes);
+
+            if (0 >= new_count || old_count <= new_count) {
+                continue;
+            }
+
+            err = prte_ras_slurm_shrink_job_to_survivors(action->job_id,
+                                                         action->survivor_nodes,
+                                                         err_msg, sizeof(err_msg));
+            if (PRTE_SUCCESS != err) {
+                if (PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
+                    pmix_output(0, "ras:slurm:shrink_complete: failed to shrink job %s: %s.",
+                                action->job_id, err_msg);
+                } else {
+                    PRTE_ERROR_LOG(err);
+                }
+                continue;
+            }
+
+            PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
+            err = prte_ras_slurm_detach_nodes(action->job_id, session_item->session,
+                                              &nodes_in_removal);
+            PMIX_DESTRUCT(&nodes_in_removal);
+            if (PRTE_SUCCESS != err) {
+                PRTE_ERROR_LOG(err);
+                continue;
+            }
+
+            session_item->nodes_in_session = new_count;
+            prte_num_allocated_nodes -= old_count - new_count;
+        }
+    }
+
+    prte_ras_slurm_untrack_shrink_campaign(found);
+    PMIX_RELEASE(found);
+}
+
+/**
  * @brief Process a PMIx resource release request.
  */
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
@@ -378,11 +622,11 @@ int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
     }
 
     if (found_node_list) {
-        err = prte_ras_slurm_remove_nodes_by_name(nodes);
+        err = prte_ras_slurm_remove_nodes_by_name(req, nodes);
     } else if (found_alloc_id) {
-        err = prte_ras_slurm_remove_allocation_by_id(alloc_id);
+        err = prte_ras_slurm_remove_allocation_by_id(req, alloc_id);
     } else {
-        err = prte_ras_slurm_remove_nodes_by_count(num_nodes);
+        err = prte_ras_slurm_remove_nodes_by_count(req, num_nodes);
     }
 
     if(err != PRTE_SUCCESS) {
@@ -602,14 +846,15 @@ static int prte_ras_slurm_build_survivor_list(prte_session_t *session, char **no
  *
  * @param[in] nodes Node names to remove.
  */
-static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
+static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char **nodes)
 {
     int err = PRTE_SUCCESS;
-    int nodes_removed = 0;
     int node_count;
     char *launching_jobid;
     char *protected_node = NULL;
-    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
+    char **target_nodes = NULL;
+    char **processed_jobs = NULL;
+    prte_ras_slurm_shrink_tracker_t *tracker = NULL;
 
     if (NULL == nodes || 0 == (node_count = PMIx_Argv_count(nodes))) {
         return PRTE_ERR_BAD_PARAM;
@@ -665,7 +910,11 @@ static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
         }
     }
 
-    char **processed_jobs = NULL;
+    tracker = PMIX_NEW(prte_ras_slurm_shrink_tracker_t);
+    if (NULL == tracker) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
 
     for (int i = 0; NULL != nodes[i]; i++) {
         prte_session_stack_item_t *session_item;
@@ -696,6 +945,11 @@ static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
             continue;
         }
 
+        err = prte_ras_slurm_append_release_targets(session, nodes, &target_nodes);
+        if (PRTE_SUCCESS != err) {
+            goto cleanup;
+        }
+
         if (selected == session_item->nodes_in_session) {
             if (prte_ras_slurm_session_contains_invoker(session, launching_jobid)) {
                 pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to kill job %s "
@@ -705,24 +959,13 @@ static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
                 goto cleanup;
             }
 
-            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg,
-                                          PRTE_SLURM_ERR_STR_MAX_LEN+1);
+            err = prte_ras_slurm_add_release_action(tracker, session->alloc_refid,
+                                                    PRTE_RAS_SLURM_RELEASE_FULL_JOB,
+                                                    NULL);
             if (PRTE_SUCCESS != err) {
-                if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_nodes_by_name: failed to kill job %s: %s.",
-                                session->alloc_refid, err_msg);
-                } else {
-                    PRTE_ERROR_LOG(err);
-                }
                 goto cleanup;
             }
-
-            pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
-            nodes_removed += session_item->nodes_in_session;
-            PMIX_RELEASE(session);
-            PMIX_RELEASE(session_item);
         } else {
-            pmix_pointer_array_t nodes_in_removal;
             char **survivors = NULL;
 
             err = prte_ras_slurm_build_survivor_list(session, nodes, &survivors);
@@ -730,39 +973,33 @@ static int prte_ras_slurm_remove_nodes_by_name(char **nodes)
                 goto cleanup;
             }
 
-            err = prte_ras_slurm_shrink_job_to_survivors(session->alloc_refid, survivors,
-                                                         err_msg,
-                                                         PRTE_SLURM_ERR_STR_MAX_LEN+1);
+            err = prte_ras_slurm_add_release_action(tracker, session->alloc_refid,
+                                                    PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB,
+                                                    survivors);
             PMIx_Argv_free(survivors);
             if (PRTE_SUCCESS != err) {
-                if(PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_nodes_by_name: failed to shrink job %s"
-                                   ": %s.", session->alloc_refid, err_msg);
-                } else {
-                    PRTE_ERROR_LOG(err);
-                }
                 goto cleanup;
             }
-
-            PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
-            err = prte_ras_slurm_detach_nodes(session->alloc_refid, session, &nodes_in_removal);
-            PMIX_DESTRUCT(&nodes_in_removal);
-            if (PRTE_SUCCESS != err) {
-                goto cleanup;
-            }
-
-            session_item->nodes_in_session -= selected;
-            nodes_removed += selected;
         }
     }
+
+    err = prte_ras_slurm_start_shrink(req, tracker, target_nodes);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+    tracker = NULL;
+    err = prte_ras_slurm_complete_release_request(req);
 
 cleanup:
     if (NULL != processed_jobs) {
         PMIx_Argv_free(processed_jobs);
     }
-    prte_num_allocated_nodes -= nodes_removed;
-    if (PRTE_SUCCESS != err && nodes_removed > 0) {
-        err = PRTE_ERR_PARTIAL_SUCCESS;
+    if (NULL != target_nodes) {
+        PMIx_Argv_free(target_nodes);
+    }
+    if (NULL != tracker) {
+        PMIX_RELEASE(tracker);
     }
     return err;
 }
@@ -772,11 +1009,12 @@ cleanup:
  *
  * @param[in] alloc_id Slurm allocation/job ID.
  */
-static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id)
+static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, const char *alloc_id)
 {
     prte_session_stack_item_t *session_item;
     char *launching_jobid;
-    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
+    char **target_nodes = NULL;
+    prte_ras_slurm_shrink_tracker_t *tracker = NULL;
     int err;
 
     if (NULL == alloc_id || '\0' == alloc_id[0]) {
@@ -808,25 +1046,40 @@ static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id)
         return PRTE_ERR_BAD_PARAM;
     }
 
-    err = prte_ras_slurm_kill_job(alloc_id, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
-    if (PRTE_SUCCESS != err) {
-        if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
-            pmix_output(0, "ras:slurm:remove_allocation_by_id: failed to kill job %s: %s.",
-                        alloc_id, err_msg);
-        } else {
-            PRTE_ERROR_LOG(err);
-        }
-        return err;
+    tracker = PMIX_NEW(prte_ras_slurm_shrink_tracker_t);
+    if (NULL == tracker) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
-    pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
-    prte_num_allocated_nodes -= session_item->nodes_in_session;
+    err = prte_ras_slurm_add_release_action(tracker, alloc_id,
+                                            PRTE_RAS_SLURM_RELEASE_FULL_JOB,
+                                            NULL);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
 
-    /* This also removes from prte_sessions */
-    PMIX_RELEASE(session_item->session);
-    PMIX_RELEASE(session_item);
+    err = prte_ras_slurm_append_session_targets(session_item->session, &target_nodes);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
 
-    return PRTE_SUCCESS;
+    err = prte_ras_slurm_start_shrink(req, tracker, target_nodes);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+    tracker = NULL;
+    err = prte_ras_slurm_complete_release_request(req);
+
+cleanup:
+    if (NULL != target_nodes) {
+        PMIx_Argv_free(target_nodes);
+    }
+    if (NULL != tracker) {
+        PMIX_RELEASE(tracker);
+    }
+
+    return err;
 }
 
 /**
@@ -838,14 +1091,16 @@ static int prte_ras_slurm_remove_allocation_by_id(const char *alloc_id)
  *
  * @param[in] node_count Number of nodes to remove.
  */
-static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
+static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count) {
+    prte_ras_slurm_shrink_tracker_t *tracker = NULL;
+    char **processed_jobs = NULL;
+    char **target_nodes = NULL;
+    int err = PRTE_SUCCESS;
 
     if(0 == node_count || node_count > INT_MAX) {
         pmix_output(0, "ras:slurm:remove_nodes_by_count: invalid node count.");
         return PRTE_ERR_REQUEST;
     }
-
-    int err = PRTE_SUCCESS;
 
     int nodes_initial = prte_num_allocated_nodes;
     int nodes_to_remove = (int)node_count;
@@ -871,6 +1126,11 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         return err;
     }
 
+    tracker = PMIX_NEW(prte_ras_slurm_shrink_tracker_t);
+    if (NULL == tracker) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
     int nodes_removed = 0;
 
     do {
@@ -881,7 +1141,7 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         }
 
         prte_session_stack_item_t *session_item =
-            prte_ras_slurm_find_releasable_session(launching_jobid);
+            prte_ras_slurm_find_releasable_session(launching_jobid, processed_jobs);
 
         if(NULL == session_item || NULL == session_item->session) {
             err = PRTE_ERR_NOT_FOUND;
@@ -898,49 +1158,44 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
         int removable_count = prte_ras_slurm_session_removable_count(session_item,
                                                                      launching_jobid);
 
-        char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN+1] = {0};
-
         if(!contains_invoker && nodes_left_to_rem >= session_item->nodes_in_session) {
-            err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
+            pmix_status_t pmix_err;
 
+            err = prte_ras_slurm_add_release_action(tracker, session->alloc_refid,
+                                                    PRTE_RAS_SLURM_RELEASE_FULL_JOB,
+                                                    NULL);
             if (PRTE_SUCCESS != err) {
-
-                if(PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_nodes_by_count: failed to kill job %s: %s.",
-                                    session->alloc_refid, err_msg);
-                } else {
-                    PRTE_ERROR_LOG(err);
-                }
-
                 goto cleanup;
             }
 
-            pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
-            
-            /* TODO: nodes in session need to be detached
-             * from PRRTE. */
+            err = prte_ras_slurm_append_session_targets(session, &target_nodes);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
+            pmix_err = PMIx_Argv_append_nosize(&processed_jobs, session->alloc_refid);
+            if (PMIX_SUCCESS != pmix_err) {
+                err = prte_pmix_convert_status(pmix_err);
+                goto cleanup;
+            }
 
             nodes_removed += session_item->nodes_in_session;
-
-            /* This also removes from prte_sessions */
-            PMIX_RELEASE(session);
-            PMIX_RELEASE(session_item);
         } else {
-
+            char **session_targets = NULL;
+            char **survivors = NULL;
+            pmix_status_t pmix_err;
             int nodes_to_rem_from_session = nodes_left_to_rem;
 
             if (nodes_to_rem_from_session > removable_count) {
                 nodes_to_rem_from_session = removable_count;
             }
 
-            int new_node_count = session_item->nodes_in_session-nodes_to_rem_from_session;
-
-            char *whitelist_node = NULL;
+            char *protected_node = NULL;
 
             if(contains_invoker) {
-                whitelist_node = getenv("SLURMD_NODENAME");
+                protected_node = getenv("SLURMD_NODENAME");
 
-                if (NULL == whitelist_node) {
+                if (NULL == protected_node) {
                     pmix_output(0,
                                 "ras:slurm:remove_nodes_by_count: SLURMD_NODENAME is not set. "
                                 "Refusing to shrink job %s because the current node cannot be "
@@ -952,47 +1207,66 @@ static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count) {
                 }
             }
 
-            err = prte_ras_slurm_shrink_job(session->alloc_refid, whitelist_node, new_node_count, err_msg, PRTE_SLURM_ERR_STR_MAX_LEN+1);
-
+            err = prte_ras_slurm_append_count_session_targets(session, protected_node,
+                                                             nodes_to_rem_from_session,
+                                                             &session_targets);
             if (PRTE_SUCCESS != err) {
+                PMIx_Argv_free(session_targets);
+                goto cleanup;
+            }
 
-                if(PRTE_ERR_SLURM_SHRINK_FAILURE == err) {
-                    pmix_output(0, "ras:slurm:remove_nodes_by_count: failed to shrink job %s" 
-                                    ": %s.", session->alloc_refid, err_msg);
-                } else {
-                    PRTE_ERROR_LOG(err);
+            for (int i = 0; NULL != session_targets[i]; i++) {
+                pmix_err = PMIx_Argv_append_nosize(&target_nodes,
+                                                   session_targets[i]);
+                if (PMIX_SUCCESS != pmix_err) {
+                    err = prte_pmix_convert_status(pmix_err);
+                    PMIx_Argv_free(session_targets);
+                    goto cleanup;
                 }
-
-                goto cleanup;
             }
 
-            pmix_pointer_array_t nodes_in_removal;
-            PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
-
-            /* Remove target nodes from session and add to nodes_in_removal */
-            err = prte_ras_slurm_detach_nodes(session->alloc_refid, session, &nodes_in_removal);
-
+            err = prte_ras_slurm_build_survivor_list(session, session_targets, &survivors);
             if (PRTE_SUCCESS != err) {
-                PMIX_DESTRUCT(&nodes_in_removal);
+                PMIx_Argv_free(session_targets);
                 goto cleanup;
             }
-            
-            /* TODO: use nodes_in_removal 
-             * to detach removed nodes from PRRTE */
 
-            PMIX_DESTRUCT(&nodes_in_removal);
+            err = prte_ras_slurm_add_release_action(tracker, session->alloc_refid,
+                                                    PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB,
+                                                    survivors);
+            PMIx_Argv_free(survivors);
+            PMIx_Argv_free(session_targets);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
 
-            session_item->nodes_in_session = new_node_count;
+            pmix_err = PMIx_Argv_append_nosize(&processed_jobs, session->alloc_refid);
+            if (PMIX_SUCCESS != pmix_err) {
+                err = prte_pmix_convert_status(pmix_err);
+                goto cleanup;
+            }
+
             nodes_removed += nodes_to_rem_from_session;
         }
     } while (nodes_to_remove > nodes_removed);
 
+    err = prte_ras_slurm_start_shrink(req, tracker, target_nodes);
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
+    tracker = NULL;
+    err = prte_ras_slurm_complete_release_request(req);
+
 cleanup:
-
-    prte_num_allocated_nodes-=nodes_removed;
-
-    if(PRTE_SUCCESS != err && nodes_removed > 0) {
-        err = PRTE_ERR_PARTIAL_SUCCESS;
+    if (NULL != processed_jobs) {
+        PMIx_Argv_free(processed_jobs);
+    }
+    if (NULL != target_nodes) {
+        PMIx_Argv_free(target_nodes);
+    }
+    if (NULL != tracker) {
+        PMIX_RELEASE(tracker);
     }
 
     return err;
@@ -1133,353 +1407,6 @@ cleanup:
     free(survivor_string);
     free(req_nodes_arg);
     free(cmd);
-
-    return err;
-}
-
-/**
- * @brief Shrink a Slurm job to a new node count.
- *
- * Runs scontrol to resize the given Slurm job. On Slurm resize failure,
- * err_msg is populated with the command output when provided. This failure
- * mode is indicated by a return of PRTE_ERR_SLURM_SHRINK_FAILURE.
- *
- * @param[in] slurm_jobid Slurm job ID to resize.
- * @param[in] exclude_hostname Hostname to exclude from resize.
- * @param[in] new_node_count New number of nodes for the job.
- * @param[out] err_msg Optional buffer for Slurm error output.
- * @param[in] err_msg_size Size of err_msg buffer, if applicable.
- */
-static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size) {
-
-    if(NULL == slurm_jobid || 0 >= new_node_count) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-
-    if(NULL != err_msg) {
-        err_msg[0] = '\0';
-    }
-
-    int err = PRTE_SUCCESS;
-
-    /* Make sure the job ID given is something reasonable */
-    err = prte_ras_slurm_validate_jobid(slurm_jobid);
-
-    if(PRTE_SUCCESS != err) {
-        PRTE_ERROR_LOG(err);
-        return err;
-    }
-
-    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
-                        "%s ras:slurm:shrink_job: shrink job %s to %d nodes",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), slurm_jobid, new_node_count));
-
-    char *resize_script_sh = NULL;
-    char *resize_script_csh = NULL;
-
-    char *req_nodes_arg = NULL; 
-    char *num_nodes_arg = NULL;
-
-    char *cmd = NULL;
-
-    static const char *cmd_format = "scontrol update job %s %s 2>&1";
-
-    FILE *fp = NULL;
-
-    /* if we want to exclude a node from the shrink,
-     * then we have to specify all nodes to keep explicitly */
-    if(NULL != exclude_hostname) {
-
-        err = prte_ras_slurm_build_req_nodelist(slurm_jobid, exclude_hostname, new_node_count, &req_nodes_arg);
-
-        if (err != PRTE_SUCCESS) {
-            goto cleanup;
-        }
-
-        if(0 > asprintf(&cmd, cmd_format, slurm_jobid, req_nodes_arg)) {
-            cmd = NULL;
-            err = PRTE_ERR_OUT_OF_RESOURCE;
-            PRTE_ERROR_LOG(err);
-            goto cleanup;
-        }
-
-        free(req_nodes_arg);
-        req_nodes_arg = NULL;
-
-    } else {
-
-        static const char *num_nodes_format = "NumNodes=%d";
-
-        if(0 > asprintf(&num_nodes_arg, num_nodes_format, new_node_count)) {
-            num_nodes_arg = NULL;
-            err = PRTE_ERR_OUT_OF_RESOURCE;
-            PRTE_ERROR_LOG(err);
-            goto cleanup;
-        }
-
-        if(0 > asprintf(&cmd, cmd_format, slurm_jobid, num_nodes_arg)) {
-            cmd = NULL;
-            err = PRTE_ERR_OUT_OF_RESOURCE;
-            PRTE_ERROR_LOG(err);
-            goto cleanup;
-        }
-
-        free(num_nodes_arg);
-        num_nodes_arg = NULL;
-    }
-
-    PMIX_OUTPUT_VERBOSE((20, prte_ras_base_framework.framework_output,
-                        "%s ras:slurm:shrink_job: shrink command is:\n%s",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cmd));
-
-    fp = popen(cmd, "r");
-
-    if(NULL == fp) {
-        err = PRTE_ERR_FILE_OPEN_FAILURE;
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
-    }
-
-    err = prte_ras_slurm_drain_cmd_output(fp, err_msg, err_msg_size);
-
-    if (PRTE_SUCCESS != err) {
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
-    }
-
-    int status = pclose(fp);
-    fp = NULL;
-
-    if (-1 == status) {
-        pmix_output(0, "ras:slurm:shrink_job: pclose failed: %s.", strerror(errno));
-        err = PRTE_ERR_IN_ERRNO;
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
-    }
-
-    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
-        err = PRTE_ERR_SLURM_SHRINK_FAILURE;
-        goto cleanup;
-    }
-
-    /* On success, the resize operation creates some helper 
-     * scripts to update environment variables which
-     * we do not want cluttering the user environment.
-     * 
-     * NOTE: return success even if we fail here, as the
-     * shrink itself succeeded and the resources are gone. */
-
-    static const char *resize_script_format = "slurm_job_%s_resize.%s";
-
-    int rc = asprintf(&resize_script_sh, resize_script_format, slurm_jobid, "sh");
-
-    if(0 > rc) {
-        pmix_output(0, "ras:slurm:shrink_job: asprintf failed after successful shrink.");
-        resize_script_sh = NULL;
-        goto cleanup;
-    }
-
-    if (0 != remove(resize_script_sh)) {
-        int saved_errno = errno;
-        if (ENOENT != saved_errno) {
-            pmix_output(0,
-                        "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
-                        resize_script_sh, strerror(saved_errno));
-        }
-    }
-
-    rc = asprintf(&resize_script_csh, resize_script_format, slurm_jobid, "csh");
-
-    if(0 > rc) {
-        pmix_output(0, "ras:slurm:shrink_job: asprintf failed after successful shrink.");
-        resize_script_csh = NULL;
-        goto cleanup;
-    }
-
-    if (0 != remove(resize_script_csh)) {
-        int saved_errno = errno;
-        if (ENOENT != saved_errno) {
-            pmix_output(0,
-                        "ras:slurm:shrink_job: failed to remove helper script %s: %s.",
-                        resize_script_csh, strerror(saved_errno));
-        }
-    }
-
-cleanup:
-
-    if(NULL != err_msg && PRTE_ERR_SLURM_SHRINK_FAILURE != err) {
-        err_msg[0] = '\0';
-    }
-
-    if(NULL != fp) {
-        pclose(fp);
-    }
-
-    free(cmd);
-    free(resize_script_sh);
-    free(resize_script_csh);
-    free(req_nodes_arg);
-    free(num_nodes_arg);
-
-    return err;
-}
-
-/**
- * Build a required-node list for a Slurm shrink operation.
- *
- * Ensures that protected_hostname is included in the resulting
- * comma-separated node list. Validates each hostname before it is
- * included in the output string.
- *
- * @param[in]  slurm_jobid         Slurm job ID.
- * @param[in]  protected_hostname  Hostname to preserve.
- * @param[out] req_nodes_arg       Allocated string of the form
- *                                 "ReqNodeList=node0,node1,...".
- */
-static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg)
-{
-    if(!slurm_jobid || !protected_hostname || !req_nodes_arg) {
-        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-        return PRTE_ERR_BAD_PARAM;
-    }
-
-    static const char *req_nodes_prefix = "ReqNodeList=";
-
-    *req_nodes_arg = NULL;
-
-    int err = prte_ras_slurm_validate_hostname(protected_hostname);
-
-    if(PRTE_SUCCESS != err) {
-        PRTE_ERROR_LOG(err);
-        return err;
-    }
-
-    err = prte_ras_slurm_validate_jobid(slurm_jobid);
-
-    if(PRTE_SUCCESS != err) {
-        PRTE_ERROR_LOG(err);
-        return err;
-    }
-
-    prte_session_t *session = prte_get_session_object_from_id(slurm_jobid);
-
-    if (NULL == session) {
-        err = PRTE_ERR_NOT_FOUND;
-        PRTE_ERROR_LOG(err);
-        return err;
-    }
-
-    /* estimate the required size for the nodes */
-    size_t size_for_nodes = strlen(protected_hostname) * new_node_count;
-    const size_t prefix_size = strlen(req_nodes_prefix);
-
-    /* prefix, commas, and nullchar */
-    const size_t size_additional = prefix_size + new_node_count;
-
-    const size_t max_size_for_nodes = PRTE_SLURM_HOSTNAME_MAX_LEN * new_node_count;
-
-    size_t curr_size = size_for_nodes + size_additional;
-    size_t curr_occupied = size_additional; /* pre-reserve space for non-node content */
-
-    *req_nodes_arg = malloc(curr_size);
-    if (NULL == *req_nodes_arg) {
-        err = PRTE_ERR_OUT_OF_RESOURCE;
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
-    }
-
-    char *req_nodes_ptr = *req_nodes_arg;
-
-    /* append the prefix */
-    memcpy(*req_nodes_arg, req_nodes_prefix, prefix_size);
-    req_nodes_ptr += prefix_size;
-
-    bool found_protected = false;
-    int nodecount = 0;
-
-    for (int i = 0; i < session->nodes->size; i++) {
-        prte_node_t *curr = pmix_pointer_array_get_item(session->nodes, i);
-
-        if (NULL == curr || NULL == curr->name) {
-            continue;
-        }
-
-        /* must be included on the list */
-        if (!found_protected && 
-            0 == strcmp(curr->name, protected_hostname)) {
-            found_protected = true;
-        } else if (!found_protected && nodecount >= new_node_count-1) {
-            /* we have enough nodes, only look for node to protect */
-            continue;   
-        }
-
-        err = prte_ras_slurm_validate_hostname(curr->name);
-
-        if(PRTE_SUCCESS != err) {
-            PRTE_ERROR_LOG(err);
-            goto cleanup;
-        }
-        
-        size_t item_size = strlen(curr->name);
-
-        if(curr_occupied+item_size > curr_size) {
-            size_t new_size = curr_size * 2;
-            size_t req_nodes_ptr_offset = req_nodes_ptr - *req_nodes_arg; 
-
-            if(new_size > max_size_for_nodes + size_additional) {
-                new_size = max_size_for_nodes + size_additional;
-            }
-
-            if(curr_occupied+item_size > new_size) {
-                err = PRTE_ERR_OUT_OF_RESOURCE;
-                PRTE_ERROR_LOG(err);
-                goto cleanup;                    
-            }
-
-            char *new_req_nodes_arg = realloc(*req_nodes_arg, new_size);
-
-            if (NULL == new_req_nodes_arg) {
-                err = PRTE_ERR_OUT_OF_RESOURCE;
-                PRTE_ERROR_LOG(err);
-                goto cleanup;
-            }
-
-            *req_nodes_arg = new_req_nodes_arg;
-            req_nodes_ptr = new_req_nodes_arg + req_nodes_ptr_offset;
-            curr_size = new_size;
-        }
-
-        /* insert a comma if not first item */
-        if(nodecount > 0) {
-            *req_nodes_ptr = ',';
-            req_nodes_ptr++;
-        }
-
-        memcpy(req_nodes_ptr, curr->name, item_size);
-
-        req_nodes_ptr += item_size;
-        curr_occupied += item_size;
-
-        if(++nodecount >= new_node_count) {
-            break;
-        }
-    }
-
-    if (nodecount != new_node_count || !found_protected) {
-        err = PRTE_ERR_NOT_FOUND;
-        PRTE_ERROR_LOG(err);
-        goto cleanup;
-    }
-
-    *req_nodes_ptr = '\0';
-
-cleanup:
-
-    if (PRTE_SUCCESS != err) {
-        free(*req_nodes_arg);
-        *req_nodes_arg = NULL;
-    }
 
     return err;
 }

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -337,10 +337,6 @@ static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
         return PRTE_ERR_BAD_PARAM;
     }
 
-    if (!prte_elastic_mode) {
-        return PRTE_ERR_NOT_SUPPORTED;
-    }
-
     ranks = (pmix_rank_t *) malloc(nranks * sizeof(pmix_rank_t));
     if (NULL == ranks) {
         return PRTE_ERR_OUT_OF_RESOURCE;
@@ -570,6 +566,12 @@ int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
         pmix_output(0, "ras:slurm:modify: "
             "Jansson support is required but not enabled in this build");
         return PRTE_ERR_NOT_AVAILABLE;
+    }
+
+    if (!prte_elastic_mode) {
+        pmix_output(0, "ras:slurm:modify: release requests require elastic DVM mode. "
+                       "Set the prte_elastic_mode MCA parameter to 1.");
+        return PRTE_ERR_NOT_SUPPORTED;
     }
 
     int err = PRTE_SUCCESS;

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -31,6 +31,7 @@ static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const c
 static int prte_ras_slurm_validate_count_release(int nodes_to_remove,
                                                  const char *launching_jobid);
 static void localrelease(void *cbdata);
+static bool prte_ras_slurm_session_is_dynamic(prte_session_t *session);
 static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char **nodes);
 static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, const char *alloc_id);
 static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count);
@@ -66,6 +67,17 @@ static void localrelease(void *cbdata)
 }
 
 /**
+ * @brief Check whether a Slurm session was created by a modify request.
+ *
+ * @param[in] session Slurm-backed session to inspect.
+ */
+static bool prte_ras_slurm_session_is_dynamic(prte_session_t *session)
+{
+    return NULL != session &&
+           PRTE_FLAG_TEST(session, PRTE_SESSION_FLAG_DYNAMIC);
+}
+
+/**
  * @brief Check whether a session contains the requesting Slurm job.
  *
  * @param[in] session Slurm-backed session to inspect.
@@ -92,7 +104,8 @@ static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *ses
         return 0;
     }
 
-    if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
+    if (!prte_ras_slurm_session_is_dynamic(session_item->session) ||
+        prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
         if (1 >= session_item->nodes_in_session) {
             return 0;
         }
@@ -469,6 +482,11 @@ int prte_ras_slurm_release_allocation(prte_session_t *session)
         return PRTE_ERR_TAKE_NEXT_OPTION;
     }
 
+    if (!prte_ras_slurm_session_is_dynamic(session)) {
+        /* This allocation was not added by PRRTE, so we do not manage its lifetime. */
+        return PRTE_SUCCESS;
+    }
+
     err = prte_ras_slurm_kill_job(session->alloc_refid, err_msg,
                                   sizeof(err_msg));
     if (PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
@@ -512,6 +530,13 @@ void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
 
         if (PRTE_RAS_SLURM_RELEASE_FULL_JOB == action->action) {
             int node_count = session_item->nodes_in_session;
+
+            if (!prte_ras_slurm_session_is_dynamic(session_item->session)) {
+                pmix_output(0, "ras:slurm:shrink_complete: refusing to terminate job %s "
+                               "because it was not dynamically added by PRRTE.",
+                            action->job_id);
+                continue;
+            }
 
             PMIX_RELEASE(session_item->session);
             pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
@@ -947,17 +972,25 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
             continue;
         }
 
-        err = prte_ras_slurm_append_release_targets(session, nodes, &target_nodes);
-        if (PRTE_SUCCESS != err) {
-            goto cleanup;
-        }
-
         if (selected == session_item->nodes_in_session) {
+            if (!prte_ras_slurm_session_is_dynamic(session)) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to terminate job %s "
+                               "because it was not dynamically added by PRRTE",
+                            session->alloc_refid);
+                err = PRTE_ERR_NOT_SUPPORTED;
+                goto cleanup;
+            }
+
             if (prte_ras_slurm_session_contains_invoker(session, launching_jobid)) {
                 pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to kill job %s "
                                "because it contains the invoking process",
                             session->alloc_refid);
                 err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            err = prte_ras_slurm_append_release_targets(session, nodes, &target_nodes);
+            if (PRTE_SUCCESS != err) {
                 goto cleanup;
             }
 
@@ -969,6 +1002,11 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
             }
         } else {
             char **survivors = NULL;
+
+            err = prte_ras_slurm_append_release_targets(session, nodes, &target_nodes);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
 
             err = prte_ras_slurm_build_survivor_list(session, nodes, &survivors);
             if (PRTE_SUCCESS != err) {
@@ -1026,6 +1064,13 @@ static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, c
     session_item = prte_ras_slurm_find_session_item_by_alloc_id(alloc_id);
     if (NULL == session_item || NULL == session_item->session) {
         return PRTE_ERR_NOT_FOUND;
+    }
+
+    if (!prte_ras_slurm_session_is_dynamic(session_item->session)) {
+        pmix_output(0, "ras:slurm:remove_allocation_by_id: refusing to terminate job %s "
+                       "because it was not dynamically added by PRRTE",
+                    alloc_id);
+        return PRTE_ERR_NOT_SUPPORTED;
     }
 
     if (session_item->nodes_in_session >= prte_num_allocated_nodes) {
@@ -1160,9 +1205,11 @@ static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uin
         int removable_count = prte_ras_slurm_session_removable_count(session_item,
                                                                      launching_jobid);
 
-        if(!contains_invoker && nodes_left_to_rem >= session_item->nodes_in_session) {
+        if(prte_ras_slurm_session_is_dynamic(session) && !contains_invoker &&
+           nodes_left_to_rem >= session_item->nodes_in_session) {
             pmix_status_t pmix_err;
 
+            /* Case 1: remove the whole Slurm job after the DVM shrink. */
             err = prte_ras_slurm_add_release_action(tracker, session->alloc_refid,
                                                     PRTE_RAS_SLURM_RELEASE_FULL_JOB,
                                                     NULL);
@@ -1192,6 +1239,7 @@ static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uin
                 nodes_to_rem_from_session = removable_count;
             }
 
+            /* Case 2: keep the Slurm job alive and shrink it to its survivors. */
             char *protected_node = NULL;
 
             if(contains_invoker) {

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -435,8 +435,16 @@ int prte_ras_slurm_release_allocation(prte_session_t *session)
     char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN + 1] = {0};
     int err;
 
-    if (NULL == session || NULL == session->alloc_refid ||
-        NULL == prte_ras_slurm_find_session_item_by_alloc_id(session->alloc_refid)) {
+    if (NULL == session || NULL == session->alloc_refid) {
+        return PRTE_ERR_TAKE_NEXT_OPTION;
+    }
+
+    /* The session stack is the authoritative record of allocations whose
+     * lifetime is still managed by this component.  A normal full release
+     * removes the entry before destroying the session and cancels the copied
+     * Slurm job ID explicitly afterward.  Do not cancel it a second time from
+     * the session destructor. */
+    if (NULL == prte_ras_slurm_find_session_item_by_alloc_id(session->alloc_refid)) {
         return PRTE_ERR_TAKE_NEXT_OPTION;
     }
 
@@ -487,19 +495,44 @@ void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
         }
 
         if (PRTE_RAS_SLURM_RELEASE_FULL_JOB == action->action) {
+            prte_session_t *session = session_item->session;
+            char *job_id;
             int node_count = session_item->nodes_in_session;
 
-            if (!prte_ras_slurm_session_is_dynamic(session_item->session)) {
+            if (!prte_ras_slurm_session_is_dynamic(session)) {
                 pmix_output(0, "ras:slurm:shrink_complete: refusing to terminate job %s "
                                "because it was not dynamically added by PRRTE.",
                             action->job_id);
                 continue;
             }
 
-            PMIX_RELEASE(session_item->session);
+            job_id = strdup(action->job_id);
+            if (NULL == job_id) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                continue;
+            }
+
+            /* Stop managing the allocation before releasing the session.  Its
+             * destructor calls prte_ras_slurm_release_allocation(), which uses
+             * this stack as the authority for whether it should issue scancel.
+             * Removing the item first therefore lets the session be completely
+             * torn down before the external Slurm job is killed. */
             pmix_list_remove_item(prte_slurm_session_stack, &session_item->super);
+            session_item->session = NULL;
             prte_num_allocated_nodes -= node_count;
+            PMIX_RELEASE(session);
             PMIX_RELEASE(session_item);
+
+            /* Killing the Slurm job is deliberately the final operation: a
+             * resulting daemon departure cannot race with session teardown. */
+            err = prte_ras_slurm_kill_job(job_id, err_msg, sizeof(err_msg));
+            if (PRTE_ERR_SLURM_CANCEL_FAILURE == err) {
+                pmix_output(0, "ras:slurm:shrink_complete: failed to kill job %s: %s.",
+                            job_id, err_msg);
+            } else if (PRTE_SUCCESS != err) {
+                PRTE_ERROR_LOG(err);
+            }
+            free(job_id);
         } else if (PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB == action->action) {
             pmix_pointer_array_t nodes_in_removal;
             int old_count = session_item->nodes_in_session;

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -16,10 +16,75 @@
 #include "ras_slurm.h"
 #include "src/mca/ras/base/base.h"
 
+typedef enum {
+    PRTE_RAS_SLURM_RELEASE_FULL_JOB,
+    PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB
+} prte_ras_slurm_release_action_type_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    char *job_id;
+    prte_ras_slurm_release_action_type_t action;
+    char **survivor_nodes;
+} prte_ras_slurm_release_action_t;
+PMIX_CLASS_DECLARATION(prte_ras_slurm_release_action_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    prte_shrink_campaign_t *campaign;
+    pmix_list_t actions;
+} prte_ras_slurm_shrink_tracker_t;
+PMIX_CLASS_DECLARATION(prte_ras_slurm_shrink_tracker_t);
+
 /* Local functions */
+static void release_action_con(prte_ras_slurm_release_action_t *p);
+static void release_action_des(prte_ras_slurm_release_action_t *p);
+static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p);
+static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p);
 static int prte_ras_slurm_remove_nodes_by_count(uint64_t node_count);
 static int prte_ras_slurm_shrink_job(const char *slurm_jobid, const char *exclude_hostname, int new_node_count, char *err_msg, size_t err_msg_size);
 static int prte_ras_slurm_build_req_nodelist(const char *slurm_jobid, const char *protected_hostname, int new_node_count, char **req_nodes_arg);
+
+PMIX_CLASS_INSTANCE(prte_ras_slurm_release_action_t,
+                    pmix_list_item_t,
+                    release_action_con,
+                    release_action_des);
+PMIX_CLASS_INSTANCE(prte_ras_slurm_shrink_tracker_t,
+                    pmix_list_item_t,
+                    shrink_tracker_con,
+                    shrink_tracker_des);
+
+static void release_action_con(prte_ras_slurm_release_action_t *p)
+{
+    p->job_id = NULL;
+    p->action = PRTE_RAS_SLURM_RELEASE_FULL_JOB;
+    p->survivor_nodes = NULL;
+}
+
+static void release_action_des(prte_ras_slurm_release_action_t *p)
+{
+    free(p->job_id);
+    if (NULL != p->survivor_nodes) {
+        PMIx_Argv_free(p->survivor_nodes);
+    }
+}
+
+static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p)
+{
+    p->campaign = NULL;
+    PMIX_CONSTRUCT(&p->actions, pmix_list_t);
+}
+
+static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p)
+{
+    prte_ras_slurm_release_action_t *action;
+
+    while (NULL != (action = (prte_ras_slurm_release_action_t *)
+                               pmix_list_remove_first(&p->actions))) {
+        PMIX_RELEASE(action);
+    }
+    PMIX_DESTRUCT(&p->actions);
+}
 
 /**
  * @brief Process a PMIx resource release request.

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -415,14 +415,14 @@ static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req)
     if (NULL != req->infocbfunc) {
         req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
                         localrelease, req);
-        return PRTE_SUCCESS;
+        return PRTE_ERR_OP_IN_PROGRESS;
     }
 
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index,
                                 NULL);
     PMIX_RELEASE(req);
 
-    return PRTE_SUCCESS;
+    return PRTE_ERR_OP_IN_PROGRESS;
 }
 
 /**

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -15,9 +15,6 @@
 
 #include "ras_slurm.h"
 #include "ras_slurm_modify_release_tracker.h"
-#include "src/mca/grpcomm/grpcomm.h"
-#include "src/mca/odls/odls_types.h"
-#include "src/mca/plm/base/plm_private.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ras/base/base.h"
 
@@ -34,6 +31,7 @@ static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uin
 static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes);
 static int prte_ras_slurm_append_release_targets(prte_session_t *session, char **requested_nodes, char ***target_nodes);
 static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, const char *protected_node, int nodes_to_remove, char ***target_nodes);
+static int prte_ras_slurm_attach_shrink_tracker(prte_shrink_campaign_t *campaign, prte_ras_slurm_shrink_tracker_t *tracker);
 static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req, prte_ras_slurm_shrink_tracker_t *tracker, char **target_nodes);
 static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req);
 static int prte_ras_slurm_parse_release_node_list(pmix_info_t *info, char ***nodes);
@@ -314,6 +312,34 @@ static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
 }
 
 /**
+ * @brief Attach Slurm release work to a prepared DVM shrink campaign.
+ *
+ * @param[in] campaign DVM shrink campaign created by RAS base.
+ * @param[in] tracker Tracker describing RM-side completion work.
+ */
+static int prte_ras_slurm_attach_shrink_tracker(prte_shrink_campaign_t *campaign,
+                                                prte_ras_slurm_shrink_tracker_t *tracker)
+{
+    if (NULL == campaign || NULL == tracker) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    if (NULL == campaign->alloc_id) {
+        const char *jobid = prte_ras_slurm_tracker_first_jobid(tracker);
+
+        if (NULL != jobid) {
+            campaign->alloc_id = strdup(jobid);
+            if (NULL == campaign->alloc_id) {
+                return PRTE_ERR_OUT_OF_RESOURCE;
+            }
+        }
+    }
+
+    prte_ras_slurm_track_shrink_campaign(tracker, campaign);
+    return PRTE_SUCCESS;
+}
+
+/**
  * @brief Start a DVM shrink campaign for planned Slurm release actions.
  *
  * @param[in] req PMIx release request.
@@ -324,13 +350,11 @@ static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
                                        prte_ras_slurm_shrink_tracker_t *tracker,
                                        char **target_nodes)
 {
-    pmix_data_buffer_t msg;
-    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
-    pmix_rank_t *ranks = NULL;
     prte_shrink_campaign_t *campaign = NULL;
+    pmix_rank_t *ranks = NULL;
     int32_t nranks;
+    bool tracked = false;
     int err = PRTE_SUCCESS;
-    pmix_status_t rc;
 
     if (NULL == req || NULL == tracker || NULL == target_nodes ||
         0 == (nranks = PMIx_Argv_count(target_nodes))) {
@@ -353,81 +377,28 @@ static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req,
         ranks[i] = node->daemon->name.rank;
     }
 
-    campaign = PMIX_NEW(prte_shrink_campaign_t);
-    if (NULL == campaign) {
-        err = PRTE_ERR_OUT_OF_RESOURCE;
-        goto cleanup;
-    }
-
-    campaign->targets = (pmix_rank_t *) malloc(nranks * sizeof(pmix_rank_t));
-    if (NULL == campaign->targets) {
-        err = PRTE_ERR_OUT_OF_RESOURCE;
-        goto cleanup;
-    }
-
-    memcpy(campaign->targets, ranks, nranks * sizeof(pmix_rank_t));
-    campaign->ntargets = nranks;
-    campaign->pending = nranks;
-    PMIX_XFER_PROCID(&campaign->requester, &req->tproc);
-    for (size_t n = 0; n < req->ninfo; n++) {
-        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID) &&
-            PMIX_STRING == req->info[n].value.type) {
-            campaign->alloc_id = strdup(req->info[n].value.data.string);
-        } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID) &&
-                   PMIX_STRING == req->info[n].value.type) {
-            campaign->req_id = strdup(req->info[n].value.data.string);
-        }
-    }
-    campaign->have_requester = true;
-    if (NULL == campaign->alloc_id) {
-        const char *jobid = prte_ras_slurm_tracker_first_jobid(tracker);
-
-        if (NULL != jobid) {
-            campaign->alloc_id = strdup(jobid);
-            if (NULL == campaign->alloc_id) {
-                err = PRTE_ERR_OUT_OF_RESOURCE;
-                goto cleanup;
-            }
-        }
-    }
-
-    PMIX_DATA_BUFFER_CONSTRUCT(&msg);
-    rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
-    if (PMIX_SUCCESS == rc) {
-        rc = PMIx_Data_pack(NULL, &msg, &nranks, 1, PMIX_INT32);
-    }
-    if (PMIX_SUCCESS == rc) {
-        rc = PMIx_Data_pack(NULL, &msg, ranks, nranks, PMIX_PROC_RANK);
-    }
-    if (PMIX_SUCCESS != rc) {
-        PMIX_DATA_BUFFER_DESTRUCT(&msg);
-        err = prte_pmix_convert_status(rc);
-        goto cleanup;
-    }
-
-    pmix_list_append(&prte_shrink_campaigns, &campaign->super);
-    prte_dvm_launch_fence += nranks;
-    prte_ras_slurm_track_shrink_campaign(tracker, campaign);
-
-    err = prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, &msg);
-    PMIX_DATA_BUFFER_DESTRUCT(&msg);
+    err = prte_ras_base_prepare_dvm_shrink(req, ranks, nranks, &campaign);
     if (PRTE_SUCCESS != err) {
-        prte_ras_slurm_untrack_shrink_campaign(tracker);
-        pmix_list_remove_item(&prte_shrink_campaigns, &campaign->super);
-        prte_dvm_launch_fence -= campaign->pending;
-        prte_plm_base_dvm_mod_notify(&campaign->requester, campaign->alloc_id,
-                                     campaign->req_id, false,
-                                     prte_pmix_convert_rc(err));
-        PMIX_RELEASE(campaign);
+        goto cleanup;
+    }
+    if (NULL == campaign) {
+        err = PRTE_ERR_BAD_PARAM;
         goto cleanup;
     }
 
-    campaign = NULL;
+    err = prte_ras_slurm_attach_shrink_tracker(campaign, tracker);
+    if (PRTE_SUCCESS != err) {
+        prte_ras_base_abort_dvm_shrink(campaign);
+        goto cleanup;
+    }
+    tracked = true;
+
+    err = prte_ras_base_commit_dvm_shrink(campaign);
+    if (PRTE_SUCCESS != err && tracked) {
+        prte_ras_slurm_untrack_shrink_campaign(tracker);
+    }
 
 cleanup:
-    if (NULL != campaign) {
-        PMIX_RELEASE(campaign);
-    }
     free(ranks);
 
     return err;

--- a/src/mca/ras/slurm/ras_slurm_modify_release_tracker.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release_tracker.c
@@ -1,0 +1,226 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include "ras_slurm_modify_release_tracker.h"
+
+static void release_action_con(prte_ras_slurm_release_action_t *p);
+static void release_action_des(prte_ras_slurm_release_action_t *p);
+static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p);
+static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p);
+static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
+                                             const char *jobid);
+
+PMIX_CLASS_INSTANCE(prte_ras_slurm_release_action_t,
+                    pmix_list_item_t,
+                    release_action_con,
+                    release_action_des);
+PMIX_CLASS_INSTANCE(prte_ras_slurm_shrink_tracker_t,
+                    pmix_list_item_t,
+                    shrink_tracker_con,
+                    shrink_tracker_des);
+
+static pmix_list_t *prte_slurm_shrink_trackers = NULL;
+
+static void release_action_con(prte_ras_slurm_release_action_t *p)
+{
+    p->job_id = NULL;
+    p->action = PRTE_RAS_SLURM_RELEASE_FULL_JOB;
+    p->survivor_nodes = NULL;
+}
+
+static void release_action_des(prte_ras_slurm_release_action_t *p)
+{
+    free(p->job_id);
+    if (NULL != p->survivor_nodes) {
+        PMIx_Argv_free(p->survivor_nodes);
+    }
+}
+
+static void shrink_tracker_con(prte_ras_slurm_shrink_tracker_t *p)
+{
+    p->campaign = NULL;
+    PMIX_CONSTRUCT(&p->actions, pmix_list_t);
+}
+
+static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p)
+{
+    prte_ras_slurm_release_action_t *action;
+
+    while (NULL != (action = (prte_ras_slurm_release_action_t *)
+                               pmix_list_remove_first(&p->actions))) {
+        PMIX_RELEASE(action);
+    }
+    PMIX_DESTRUCT(&p->actions);
+}
+
+int prte_ras_slurm_modify_release_init(void)
+{
+    prte_slurm_shrink_trackers = PMIX_NEW(pmix_list_t);
+    if (NULL == prte_slurm_shrink_trackers) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    return PRTE_SUCCESS;
+}
+
+int prte_ras_slurm_modify_release_finalize(void)
+{
+    prte_ras_slurm_shrink_tracker_t *tracker;
+
+    if (NULL == prte_slurm_shrink_trackers) {
+        return PRTE_SUCCESS;
+    }
+
+    while (NULL != (tracker = (prte_ras_slurm_shrink_tracker_t *)
+                                  pmix_list_remove_first(prte_slurm_shrink_trackers))) {
+        PMIX_RELEASE(tracker);
+    }
+    PMIX_RELEASE(prte_slurm_shrink_trackers);
+    prte_slurm_shrink_trackers = NULL;
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Check whether a shrink tracker includes a Slurm job ID.
+ *
+ * @param[in] tracker Shrink tracker to inspect.
+ * @param[in] jobid Slurm job ID to find.
+ */
+static bool prte_ras_slurm_tracker_has_jobid(prte_ras_slurm_shrink_tracker_t *tracker,
+                                             const char *jobid)
+{
+    prte_ras_slurm_release_action_t *action;
+
+    if (NULL == tracker || NULL == jobid) {
+        return false;
+    }
+
+    PMIX_LIST_FOREACH(action, &tracker->actions, prte_ras_slurm_release_action_t) {
+        if (NULL != action->job_id && 0 == strcmp(action->job_id, jobid)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Check whether a Slurm job already has an active shrink.
+ *
+ * @param[in] jobid Slurm job ID to find.
+ */
+bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid)
+{
+    prte_ras_slurm_shrink_tracker_t *tracker;
+
+    if (NULL == prte_slurm_shrink_trackers || NULL == jobid) {
+        return false;
+    }
+
+    PMIX_LIST_FOREACH(tracker, prte_slurm_shrink_trackers,
+                      prte_ras_slurm_shrink_tracker_t) {
+        if (prte_ras_slurm_tracker_has_jobid(tracker, jobid)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Add a Slurm release action to a shrink tracker.
+ *
+ * @param[in] tracker Tracker receiving the action.
+ * @param[in] job_id Slurm job ID affected by the action.
+ * @param[in] action Action to complete after the DVM shrink.
+ * @param[in] survivor_nodes Nodes that should survive a partial release.
+ */
+int prte_ras_slurm_add_release_action(prte_ras_slurm_shrink_tracker_t *tracker,
+                                      const char *job_id,
+                                      prte_ras_slurm_release_action_type_t action,
+                                      char **survivor_nodes)
+{
+    prte_ras_slurm_release_action_t *rel_action;
+
+    if (NULL == tracker || NULL == job_id) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    rel_action = PMIX_NEW(prte_ras_slurm_release_action_t);
+    if (NULL == rel_action) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    rel_action->job_id = strdup(job_id);
+    if (NULL == rel_action->job_id) {
+        PMIX_RELEASE(rel_action);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    rel_action->action = action;
+    if (NULL != survivor_nodes) {
+        rel_action->survivor_nodes = PMIx_Argv_copy(survivor_nodes);
+        if (NULL == rel_action->survivor_nodes) {
+            PMIX_RELEASE(rel_action);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+    }
+
+    pmix_list_append(&tracker->actions, &rel_action->super);
+    return PRTE_SUCCESS;
+}
+
+const char *prte_ras_slurm_tracker_first_jobid(prte_ras_slurm_shrink_tracker_t *tracker)
+{
+    prte_ras_slurm_release_action_t *action;
+
+    if (NULL == tracker || pmix_list_is_empty(&tracker->actions)) {
+        return NULL;
+    }
+
+    action = (prte_ras_slurm_release_action_t *) pmix_list_get_first(&tracker->actions);
+    return action->job_id;
+}
+
+void prte_ras_slurm_track_shrink_campaign(prte_ras_slurm_shrink_tracker_t *tracker,
+                                          prte_shrink_campaign_t *campaign)
+{
+    tracker->campaign = campaign;
+    pmix_list_append(prte_slurm_shrink_trackers, &tracker->super);
+}
+
+void prte_ras_slurm_untrack_shrink_campaign(prte_ras_slurm_shrink_tracker_t *tracker)
+{
+    pmix_list_remove_item(prte_slurm_shrink_trackers, &tracker->super);
+    tracker->campaign = NULL;
+}
+
+prte_ras_slurm_shrink_tracker_t *prte_ras_slurm_find_tracker_by_campaign(prte_shrink_campaign_t *campaign)
+{
+    prte_ras_slurm_shrink_tracker_t *tracker;
+
+    if (NULL == campaign || NULL == prte_slurm_shrink_trackers) {
+        return NULL;
+    }
+
+    PMIX_LIST_FOREACH(tracker, prte_slurm_shrink_trackers,
+                      prte_ras_slurm_shrink_tracker_t) {
+        if (tracker->campaign == campaign) {
+            return tracker;
+        }
+    }
+
+    return NULL;
+}

--- a/src/mca/ras/slurm/ras_slurm_modify_release_tracker.h
+++ b/src/mca/ras/slurm/ras_slurm_modify_release_tracker.h
@@ -1,0 +1,52 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_RAS_SLURM_MODIFY_RELEASE_TRACKER_H
+#define PRTE_RAS_SLURM_MODIFY_RELEASE_TRACKER_H
+
+#include "ras_slurm.h"
+
+BEGIN_C_DECLS
+
+typedef enum {
+    PRTE_RAS_SLURM_RELEASE_FULL_JOB,
+    PRTE_RAS_SLURM_RELEASE_PARTIAL_JOB
+} prte_ras_slurm_release_action_type_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    char *job_id;
+    prte_ras_slurm_release_action_type_t action;
+    char **survivor_nodes;
+} prte_ras_slurm_release_action_t;
+PMIX_CLASS_DECLARATION(prte_ras_slurm_release_action_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    prte_shrink_campaign_t *campaign;
+    pmix_list_t actions;
+} prte_ras_slurm_shrink_tracker_t;
+PMIX_CLASS_DECLARATION(prte_ras_slurm_shrink_tracker_t);
+
+bool prte_ras_slurm_jobid_has_active_shrink(const char *jobid);
+int prte_ras_slurm_add_release_action(prte_ras_slurm_shrink_tracker_t *tracker,
+                                      const char *job_id,
+                                      prte_ras_slurm_release_action_type_t action,
+                                      char **survivor_nodes);
+const char *prte_ras_slurm_tracker_first_jobid(prte_ras_slurm_shrink_tracker_t *tracker);
+void prte_ras_slurm_track_shrink_campaign(prte_ras_slurm_shrink_tracker_t *tracker,
+                                          prte_shrink_campaign_t *campaign);
+void prte_ras_slurm_untrack_shrink_campaign(prte_ras_slurm_shrink_tracker_t *tracker);
+prte_ras_slurm_shrink_tracker_t *prte_ras_slurm_find_tracker_by_campaign(prte_shrink_campaign_t *campaign);
+
+END_C_DECLS
+
+#endif /* PRTE_RAS_SLURM_MODIFY_RELEASE_TRACKER_H */

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -266,7 +266,7 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     /* assign the nodes to a new session, allowing us to identify
      * all members of the group later */
-    ret = prte_ras_slurm_assign_new_session(slurm_jobid, NULL, nodes);
+    ret = prte_ras_slurm_assign_new_session(slurm_jobid, NULL, nodes, false);
     
     if(PRTE_SUCCESS != ret) {
         PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
@@ -792,8 +792,10 @@ int prte_ras_slurm_convert_jobid(const char *slurm_jobid, uint32_t *slurm_jobid_
  * @param[in] slurm_jobid  Slurm job ID string (must be convertible to uint32_t)
  * @param[in] user_refid   Optional user-provided allocation reference ID (may be NULL)
  * @param[in] node_list    List of prte_node_t to attach to the session
+ * @param[in] dynamic      Whether the session was created by a modify request
  */
-int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_refid, pmix_list_t *node_list)
+int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_refid,
+                                      pmix_list_t *node_list, bool dynamic)
 {
     if(NULL == slurm_jobid || NULL == node_list) {
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
@@ -859,6 +861,10 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
 
     session->alloc_refid = slurm_jobid_dup;
     slurm_jobid_dup = NULL;
+
+    if (dynamic) {
+        PRTE_FLAG_SET(session, PRTE_SESSION_FLAG_DYNAMIC);
+    }
 
     prte_node_t *node = NULL;
 

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -294,6 +294,11 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
         req->pstatus = prte_pmix_convert_rc(err);
     } else if(PMIX_ALLOC_RELEASE == req->allocdir) {
         err = prte_ras_slurm_serve_release_req(req);
+        if (PRTE_ERR_OP_IN_PROGRESS == err) {
+            /* We don't want to touch req->pstatus at this stage
+             * as it may be freed by the callback */
+            return PMIX_SUCCESS;
+        }
         req->pstatus = prte_pmix_convert_rc(err);
     } else if(PMIX_ALLOC_REQ_CANCEL == req->allocdir) {
         err = prte_ras_slurm_serve_cancel_req(req);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -121,6 +121,11 @@ static int init(void)
         goto cleanup;
     }
 
+    err = prte_ras_slurm_modify_release_init();
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
     err = prte_ras_slurm_modify_cancel_init();
     if (PRTE_SUCCESS != err) {
         goto cleanup;
@@ -129,6 +134,7 @@ static int init(void)
 cleanup:
 
     if (PRTE_SUCCESS != err) {
+        prte_ras_slurm_modify_release_finalize();
         PMIX_RELEASE(prte_slurm_session_stack);
         prte_slurm_session_stack = NULL;
     }
@@ -308,6 +314,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
 static int prte_ras_slurm_finalize(void)
 {
     prte_ras_slurm_modify_cancel_finalize();
+    prte_ras_slurm_modify_release_finalize();
     PMIX_RELEASE(prte_slurm_session_stack);
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -78,6 +78,8 @@ prte_ras_base_module_t prte_ras_slurm_module = {
     .init = init,
     .allocate = prte_ras_slurm_allocate,
     .modify = modify,
+    .shrink_complete = prte_ras_slurm_shrink_complete,
+    .release_allocation = prte_ras_slurm_release_allocation,
     .finalize = prte_ras_slurm_finalize
 };
 


### PR DESCRIPTION
This PR represents my work in collaboration with Codex over the past few weeks to integrate the Slurm RAS changes with the new elastic DVM updates. I've tried to limit the changes to the Slurm RAS component, but two exceptions were necessary:

- The PLM Slurm component was updated to accept terminating `srun` commands.
- The shared DVM resize completion helpers were split into smaller pieces so the Slurm RAS component could reuse the common coordination paths more effectively.

A testing program is included that may be useful for demonstrating the changes.

## Summary

Extend the Slurm RAS component's elastic allocation support by coordinating scheduler-side resource release with PRRTE DVM shrink operations and making subsequent DVM growth robust across dynamic Slurm allocations.

## Changes

- Support Slurm release requests by node count, node list, or allocation ID.
- Protect the requesting Slurm node during count-based release operations.
- Skip allocations that already have an active shrink operation.
- Reject release requests outside elastic DVM mode.
- Prevent complete release of the static allocation that started the DVM.
- Plan scheduler-side release actions before starting a DVM shrink, but defer `scontrol` resize and `scancel` operations until the targeted daemons have exited.
- Track concurrent Slurm shrink operations on a per-allocation basis while allowing independent allocations to be modified concurrently.
- Split the shared RAS DVM grow and shrink helpers so the Slurm RAS component can reuse the common PRRTE coordination paths.
- Report accepted asynchronous release requests as operations in progress while preserving request callback ownership.
- Treat expected non-zero `srun` exit codes during elastic shrink as non-fatal.
- Release Slurm session state before issuing the final `scancel` to avoid a race between daemon departure and stale session data.
- Retain shrunk node objects for possible reuse, but mark released nodes as `NOT_INCLUDED` so subsequent grows cannot select resources that Slurm did not grant.
- Reattach retained nodes only when a later Slurm allocation explicitly grants those nodes again.
- Clear inherited parent allocation shape variables in the forked `srun` process so each dynamic allocation is validated against its own node count and node list.
- Skip missing, `NULL`, unset, and empty optional Slurm attributes when constructing an expander job. Malformed fields that are present are still treated as errors.

## Release Ordering

Slurm resource release now follows this sequence:

1. Validate the requested resources and group them by Slurm allocation.
2. Record the required scheduler-side resize or cancellation actions.
3. Start the shared PRRTE DVM shrink campaign.
4. Wait for collective DVM shrink completion.
5. Mark released nodes as unavailable for subsequent implicit grows.
6. Apply the recorded Slurm allocation updates or cancellations.
7. Return control to PRRTE's shared shrink completion path.

## Known Issue

In my testing, both growing and shrinking work correctly, but the DVM can become stuck when reusing nodes that were previously part of it. The following workflow still reproduces the issue:

```text
Launch the test program with 1 node.
extend count 3
shrink count 2
extend count 1
```

I haven't investigated the issue in depth yet, but the root cause may lie outside the Slurm RAS component.