### PR TITLE
errmgr: fix latent handler defects, caddy leaks, and add a unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ test/Makefile
 test/unit/Makefile
 test/unit/rmaps/Makefile
 test/unit/rmaps/test_rmaps
+test/unit/errmgr/Makefile
+test/unit/errmgr/test_errmgr
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -32,5 +32,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/offline/Makefile
         test/unit/Makefile
         test/unit/rmaps/Makefile
+        test/unit/errmgr/Makefile
     ])
 ])

--- a/src/mca/errmgr/AGENTS.md
+++ b/src/mca/errmgr/AGENTS.md
@@ -269,6 +269,38 @@ new events, rather than calling termination logic inline.
 
 ---
 
+## Testing
+
+Most of this framework is only reachable with a live DVM: the handlers
+mutate global runtime state and drive termination through `prte_plm` /
+`prte_grpcomm`, so their real behavior is exercised by the integration
+and dockerswarm grow/shrink harnesses (see the repo memory on elastic-DVM
+testing), not by an in-process unit test.
+
+What *is* unit-testable is the framework's structural contract, and
+[`test/unit/errmgr/test_errmgr.c`](../../../test/unit/errmgr/) covers it
+(wired into `make check`):
+
+- **Module invariants.** Every module struct — `prte_errmgr_default_fns`,
+  the live `prte_errmgr`, and the two role modules
+  (`prte_errmgr_dvm_module`, `prte_errmgr_prted_module`) — must carry a
+  non-NULL `logfn` (the load-bearing early-failure invariant described in
+  "The `logfn` gotcha" above). The default module must leave
+  `init`/`finalize` NULL; each real component must wire both. A
+  regression that zero-initializes one of these structs — the exact
+  "clean-up" the gotcha warns against — is caught here.
+- **`prte_errmgr_base_log` robustness.** The default `logfn` is driven
+  with a normal code, `PRTE_SUCCESS`, and an out-of-range code so the
+  "silent error" (`prte_strerror` returns NULL) guard is exercised
+  without dereferencing NULL.
+
+Run it from a built tree with `make check` (or
+`make -C test/unit/errmgr check`). When you add a new component or change
+the module contract, extend this test rather than relying solely on a
+live-DVM smoke test.
+
+---
+
 ## Debugging
 
 ```sh

--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -217,3 +217,14 @@ application uses to learn a peer died without the whole job being killed.
   true — which silently forced the `FAILED_TO_LAUNCH` case down the
   `FAILED_TO_START` branch. When you extend a state switch, always
   compare `state` explicitly.
+- **In a liveness loop, test the iterated child, not the failed peer.**
+  The daemon ordered-termination arm of `proc_errors` walks
+  `prte_local_children` looking for one still `PRTE_PROC_FLAG_ALIVE`
+  before it decides the node is empty and activates
+  `DAEMONS_TERMINATED`. That test must read the loop variable
+  (`proct`) — an earlier version tested the *failed daemon* `pptr`,
+  whose `ALIVE` flag had just been cleared a few lines above, so the
+  guard was always false and the DVM could declare itself done while a
+  local child was still alive. The two sibling loops (the application
+  arm here, and the daemon `proc_errors` loop in the `prted` component)
+  both correctly test the iterated child; keep all three consistent.

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -325,7 +325,7 @@ static void proc_errors(int fd, short args, void *cbdata)
                     for (i = 0; i < prte_local_children->size; i++) {
                         proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
                         if (NULL != proct &&
-                            PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_ALIVE) &&
+                            PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_ALIVE) &&
                             proct->state < PRTE_PROC_STATE_UNTERMINATED) {
                             /* at least one is still alive */
                             PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
@@ -360,23 +360,34 @@ static void proc_errors(int fd, short args, void *cbdata)
                                    PRTE_NAME_PRINT(proc), pptr->node->name);
                 }
 
-                if(PRTE_SUCCESS == prte_rml_route_lost(proc->rank)){
-                    if(0 != PRTE_PROC_MY_NAME->rank) goto cleanup;
+                if (PRTE_SUCCESS == prte_rml_route_lost(proc->rank)) {
+                    if (0 != PRTE_PROC_MY_NAME->rank) {
+                        goto cleanup;
+                    }
                     /* HNP marks all procs on the lost daemon's node as gone */
-                    for(int ji = 0; ji < prte_job_data->size; ji++){
-                        prte_job_t* j = (prte_job_t*)
+                    for (int ji = 0; ji < prte_job_data->size; ji++) {
+                        prte_job_t *j = (prte_job_t *)
                             pmix_pointer_array_get_item(prte_job_data, ji);
-                        if(NULL == j || NULL == j->procs) continue;
-                        if(PMIX_CHECK_NSPACE(j->nspace, proc->nspace)) continue;
-                        for(int pi = 0; pi < j->procs->size; pi++){
-                            prte_proc_t* p = (prte_proc_t*)
+                        if (NULL == j || NULL == j->procs) {
+                            continue;
+                        }
+                        if (PMIX_CHECK_NSPACE(j->nspace, proc->nspace)) {
+                            continue;
+                        }
+                        for (int pi = 0; pi < j->procs->size; pi++) {
+                            prte_proc_t *p = (prte_proc_t *)
                                 pmix_pointer_array_get_item(j->procs, pi);
-                            if(NULL == p || NULL == p->node) continue;
-                            if(NULL == p->node->daemon) continue;
-                            if(p->node->daemon->name.rank != proc->rank) continue;
-                            PRTE_ACTIVATE_PROC_STATE(
-                                &p->name, PRTE_PROC_STATE_TERM_WO_SYNC
-                            );
+                            if (NULL == p || NULL == p->node) {
+                                continue;
+                            }
+                            if (NULL == p->node->daemon) {
+                                continue;
+                            }
+                            if (p->node->daemon->name.rank != proc->rank) {
+                                continue;
+                            }
+                            PRTE_ACTIVATE_PROC_STATE(&p->name,
+                                                     PRTE_PROC_STATE_TERM_WO_SYNC);
                         }
                     }
                     goto cleanup;
@@ -658,7 +669,7 @@ static void check_send_notification(prte_job_t *jdata,
     pmix_data_buffer_t pbkt;
     pmix_data_range_t range = PMIX_RANGE_CUSTOM;
 
-    pmix_output_verbose(5, prte_state_base_framework.framework_output,
+    pmix_output_verbose(5, prte_errmgr_base_framework.framework_output,
                         "%s errmgr:dvm:sending notification %s affected proc %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         PMIx_Error_string(event),

--- a/src/mca/errmgr/prted/AGENTS.md
+++ b/src/mca/errmgr/prted/AGENTS.md
@@ -195,17 +195,19 @@ daemon must die but a bare `exit()` would give the user no message. It:
   The 5-second `wakeup` timer is the only guarantee of exit when
   messaging is itself broken; a refactor that skips it on some path can
   wedge a daemon forever.
-- **Watch the send-failure error paths.** Several branches inside the
+- **Every `proc_errors` exit now routes through `cleanup`; keep it that
+  way.** The handler acquires the caddy up front and every exit must
+  release it. All exits — including the *pack*-error branches inside the
   per-proc report blocks (`CALLED_ABORT`, `TERM_NON_ZERO`, the
   `keep_going:` abnormal-termination report, and the all-terminated
-  block) still `return` directly on a *pack* error without releasing the
-  caddy — they predate the `goto cleanup` convention and leak the caddy
-  on those rare error paths. If you touch those blocks, route them
-  through `cleanup` instead. Two leaks that were *not* on error paths
-  have already been repaired and should stay that way: the
-  `prte_finalizing` early return in `job_errors` now releases the caddy
-  (it mirrors the same fix made in the `dvm` component), and the normal
-  "all procs terminated" completion path in `proc_errors` now
-  `goto cleanup`s rather than bare-`return`ing after releasing `jdata`.
+  block), which formerly bare-`return`ed and leaked the caddy — now
+  `goto cleanup`. So do the `prte_finalizing` early return in
+  `job_errors` (which releases the caddy inline, mirroring the same fix
+  in the `dvm` component) and the normal "all procs terminated"
+  completion path (which `goto cleanup`s *after* releasing `jdata`).
   When adding a new exit, prefer `goto cleanup` unless you have already
-  released or transferred ownership of the caddy on that path.
+  released or transferred ownership of the caddy on that path. The
+  send-failure paths (`PMIX_RELEASE(alert)` after a failed
+  `PRTE_RML_RELIABLE_SEND`) deliberately fall through rather than jump —
+  they still reach `cleanup`. Note `prted_abort` is a different function
+  with no caddy; its bare `return`s are correct.

--- a/src/mca/errmgr/prted/AGENTS.md
+++ b/src/mca/errmgr/prted/AGENTS.md
@@ -195,9 +195,17 @@ daemon must die but a bare `exit()` would give the user no message. It:
   The 5-second `wakeup` timer is the only guarantee of exit when
   messaging is itself broken; a refactor that skips it on some path can
   wedge a daemon forever.
-- **Watch the send-failure error paths.** Several branches `return`
-  directly on a pack error *without* releasing the caddy (they predate
-  the `goto cleanup` convention). If you touch those blocks, prefer
-  routing through `cleanup` so the caddy is released — but verify against
-  the current code, since a few paths intentionally `return` after
-  already having released or transferred ownership.
+- **Watch the send-failure error paths.** Several branches inside the
+  per-proc report blocks (`CALLED_ABORT`, `TERM_NON_ZERO`, the
+  `keep_going:` abnormal-termination report, and the all-terminated
+  block) still `return` directly on a *pack* error without releasing the
+  caddy — they predate the `goto cleanup` convention and leak the caddy
+  on those rare error paths. If you touch those blocks, route them
+  through `cleanup` instead. Two leaks that were *not* on error paths
+  have already been repaired and should stay that way: the
+  `prte_finalizing` early return in `job_errors` now releases the caddy
+  (it mirrors the same fix made in the `dvm` component), and the normal
+  "all procs terminated" completion path in `proc_errors` now
+  `goto cleanup`s rather than bare-`return`ing after releasing `jdata`.
+  When adding a new exit, prefer `goto cleanup` unless you have already
+  released or transferred ownership of the caddy on that path.

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -249,6 +249,7 @@ static void job_errors(int fd, short args, void *cbdata)
      * if prte is trying to shutdown, just let it
      */
     if (prte_finalizing) {
+        PMIX_RELEASE(caddy);
         return;
     }
 
@@ -264,7 +265,7 @@ static void job_errors(int fd, short args, void *cbdata)
     jdata->state = jobstate;
 
     PMIX_OUTPUT_VERBOSE((1, prte_errmgr_base_framework.framework_output,
-                         "%s errmgr:prted: job %s repprted error state %s",
+                         "%s errmgr:prted: job %s reported error state %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdata->nspace),
                          prte_job_state_to_str(jobstate)));
 
@@ -741,7 +742,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             PRTE_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(alert);
         }
-        return;
+        goto cleanup;
     }
 
 cleanup:

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -470,7 +470,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             /* pack only the data for this proc - have to start with the jobid
              * so the receiver can unpack it correctly
@@ -479,14 +479,14 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
 
             /* now pack the child's info */
             if (PMIX_SUCCESS != (rc = pack_state_for_proc(alert, child))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             /* send it */
             PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
@@ -536,7 +536,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             /* pack only the data for this proc - have to start with the jobid
              * so the receiver can unpack it correctly
@@ -545,14 +545,14 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
 
             /* now pack the child's info */
             if (PMIX_SUCCESS != (rc = pack_state_for_proc(alert, child))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             /* send it */
             PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
@@ -652,7 +652,7 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             /* pack only the data for this proc - have to start with the jobid
              * so the receiver can unpack it correctly
@@ -661,14 +661,14 @@ static void proc_errors(int fd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             child->state = state;
             /* now pack the child's info */
             if (PMIX_SUCCESS != (rc = pack_state_for_proc(alert, child))) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(alert);
-                return;
+                goto cleanup;
             }
             pmix_output_verbose(5, prte_errmgr_base_framework.framework_output,
                                 "%s errmgr:prted reporting proc %s aborted to HNP (local procs = %d)",
@@ -708,13 +708,13 @@ static void proc_errors(int fd, short args, void *cbdata)
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(alert);
-            return;
+            goto cleanup;
         }
         /* pack the data for the job */
         if (PMIX_SUCCESS != (rc = pack_state_update(alert, jdata))) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(alert);
-            return;
+            goto cleanup;
         }
 
         PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,

--- a/src/mca/errmgr/prted/errmgr_prted_component.c
+++ b/src/mca/errmgr/prted/errmgr_prted_component.c
@@ -42,7 +42,7 @@ static int errmgr_prted_component_query(pmix_mca_base_module_t **module, int *pr
 prte_errmgr_base_component_t prte_mca_errmgr_prted_component =
 {
     /* Handle the general mca_component_t struct containing
-     *  meta information about the component itprted
+     *  meta information about the component itself
      */
     .base_version = {
         PRTE_ERRMGR_BASE_VERSION_3_0_0,

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps
+SUBDIRS = rmaps errmgr

--- a/test/unit/errmgr/Makefile.am
+++ b/test/unit/errmgr/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_errmgr
+
+test_errmgr_SOURCES = \
+    test_errmgr.c
+
+test_errmgr_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_errmgr

--- a/test/unit/errmgr/test_errmgr.c
+++ b/test/unit/errmgr/test_errmgr.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the errmgr framework's base contract.
+ *
+ * The errmgr's real work lives in state-machine handlers that mutate
+ * global DVM state (prte_local_children, num_daemons, the abort/term
+ * flags, ...) and drive termination through prte_plm / prte_grpcomm.
+ * Those paths cannot be exercised without a live DVM and are covered by
+ * the integration/dockerswarm harnesses instead.  What *can* be checked
+ * in isolation is the framework's structural contract, and in particular
+ * the load-bearing invariant the framework guide calls out: every errmgr
+ * module -- the two role components and the log-only default -- must carry
+ * a non-NULL logfn, because prte_errmgr.logfn can be invoked during a very
+ * early failure before the framework is even opened.  A regression that
+ * zero-initializes one of these structs would turn that early-failure
+ * report into a crash; these tests guard against exactly that.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+
+#include "constants.h"
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/errmgr/base/errmgr_private.h"
+#include "src/mca/errmgr/dvm/errmgr_dvm.h"
+#include "src/mca/errmgr/prted/errmgr_prted.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/*
+ * The default (log-only) module used by tools and during early errors,
+ * and the two role modules, must all satisfy the module contract:
+ *  - logfn is ALWAYS non-NULL (the early-failure invariant);
+ *  - the default module leaves init/finalize NULL (it only logs);
+ *  - each real role module wires up both init and finalize.
+ */
+static int test_errmgr_modules(void)
+{
+    int failures = 0;
+
+    /* the log-only fallback: logfn set, no state-machine wiring */
+    CHECK("default logfn", NULL != prte_errmgr_default_fns.logfn);
+    CHECK("default init", NULL == prte_errmgr_default_fns.init);
+    CHECK("default finalize", NULL == prte_errmgr_default_fns.finalize);
+
+    /* the live global must never present a NULL logfn, regardless of
+     * whether a component has been selected yet */
+    CHECK("live logfn", NULL != prte_errmgr.logfn);
+
+    /* the HNP component */
+    CHECK("dvm logfn", NULL != prte_errmgr_dvm_module.logfn);
+    CHECK("dvm init", NULL != prte_errmgr_dvm_module.init);
+    CHECK("dvm finalize", NULL != prte_errmgr_dvm_module.finalize);
+
+    /* the daemon component */
+    CHECK("prted logfn", NULL != prte_errmgr_prted_module.logfn);
+    CHECK("prted init", NULL != prte_errmgr_prted_module.init);
+    CHECK("prted finalize", NULL != prte_errmgr_prted_module.finalize);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_errmgr_modules\n");
+    }
+    return failures;
+}
+
+/*
+ * prte_errmgr_base_log is the default logfn.  It turns an error code into
+ * a string via prte_strerror and prints it; a "silent" code (one that maps
+ * to NULL) must be handled by printing nothing rather than dereferencing a
+ * NULL string.  We can't easily capture stdout here, but we can drive both
+ * the normal and the silent paths and confirm neither crashes.
+ */
+static int test_errmgr_base_log(void)
+{
+    int failures = 0;
+
+    /* a normal, named error code -> prints a message, must not crash */
+    prte_errmgr_base_log(PRTE_ERR_OUT_OF_RESOURCE, __FILE__, __LINE__);
+
+    /* PRTE_SUCCESS is not an error; prte_strerror still yields a string,
+     * so this simply exercises the common path with a boundary value */
+    prte_errmgr_base_log(PRTE_SUCCESS, __FILE__, __LINE__);
+
+    /* an out-of-range code exercises the "silent" (NULL string) guard -
+     * the function must return without dereferencing the NULL */
+    prte_errmgr_base_log(-99999, __FILE__, __LINE__);
+
+    /* reaching here means none of the calls crashed */
+    fprintf(stdout, "PASSED test_errmgr_base_log\n");
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_errmgr_modules();
+    failures += test_errmgr_base_log();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all errmgr unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d errmgr unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

A review of the `errmgr` framework surfaced several latent defects in the
DVM and daemon error handlers, plus the framework had no unit-test
coverage at all.

## Changes

Three focused commits:

1. **`errmgr/dvm`: correct a proc-error liveness check.** The daemon
   ordered-termination arm of `proc_errors` walked the local children to
   see whether any were still alive before driving `DAEMONS_TERMINATED`,
   but tested `pptr` — the daemon that had just failed, whose `ALIVE`
   flag was cleared a few lines earlier — instead of `proct`, the child
   being iterated. The guard was therefore always false, so the DVM
   could declare itself finished while a local application child was
   still running. The sibling loops (the application arm here and the
   `prted` component) already test the iterated child. The same commit
   reformats the head-node node-death sweep to house brace/spacing
   conventions and routes a `check_send_notification` trace through the
   errmgr framework output so `errmgr_base_verbose` controls it.

2. **`errmgr/prted`: release the state caddy on two exit paths.** The
   `prte_finalizing` early return in `job_errors` (the exact twin of a
   leak already fixed in `dvm`) and the normal "all procs terminated"
   completion path in `proc_errors` both returned without releasing the
   caddy they had acquired. Both now release it.

3. **Add a framework unit test and testing guide.** New
   `test/unit/errmgr`, wired into `make check`, covers the structural
   contract reachable without a live DVM: every module struct carries a
   non-NULL `logfn` (the early-failure invariant), and
   `prte_errmgr_base_log` survives a normal code, `PRTE_SUCCESS`, and an
   out-of-range "silent" code. The handlers themselves need a live DVM
   and remain covered by the integration/dockerswarm harnesses.

The three per-directory `AGENTS.md` guides are updated to match.

## Testing

- Full `make -j` with `--enable-debug` (warnings-as-errors): clean, zero
  warnings.
- `make -C test/unit check`: `test_rmaps` PASS, `test_errmgr` PASS.