### PR TITLE
ess: fix signal forwarding, harden daemon identity setup, add unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ test/unit/rmaps/Makefile
 test/unit/rmaps/test_rmaps
 test/unit/errmgr/Makefile
 test/unit/errmgr/test_errmgr
+test/unit/ess/Makefile
+test/unit/ess/test_ess
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -33,5 +33,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/Makefile
         test/unit/rmaps/Makefile
         test/unit/errmgr/Makefile
+        test/unit/ess/Makefile
     ])
 ])

--- a/src/mca/ess/AGENTS.md
+++ b/src/mca/ess/AGENTS.md
@@ -230,7 +230,12 @@ after setting their name. In order, it:
    `signal_forward_callback` handler per entry on
    `prte_ess_base_signals` (each forwards the signal to local procs by
    sending a `PRTE_DAEMON_SIGNAL_LOCAL_PROCS` command to itself over the
-   RML).
+   RML). That command's payload is `(jobid=wildcard, signal-number)`,
+   and the packed **signal number must be the actual caught signal**
+   (`PRTE_EVENT_SIGNAL(...)`), matching what `prted_comm.c` unpacks — a
+   subtle 2021 regression packed the wildcard nspace here instead,
+   silently turning every forwarded signal into signal `0` (a no-op).
+   Keep the pack type/value in lock-step with the unpack side.
 2. Discovers the local hwloc topology if not already set.
 3. Defines the HNP name (`PRTE_PROC_MY_HNP` = my nspace, rank 0).
 4. Opens and selects `state`, opens `errmgr`.

--- a/src/mca/ess/AGENTS.md
+++ b/src/mca/ess/AGENTS.md
@@ -197,7 +197,13 @@ plus a call to the base's `prted_setup`.
     unknown or non-forwardable signals via `help-ess-base.txt`, and
     appends `prte_ess_base_signal_t` items onto the global
     `prte_ess_base_signals` list. Guarded by a `signals_added` latch so
-    it only runs once.
+    it only runs once. The forwardability (`can_forward`) gate is
+    enforced on **both** input forms — a non-forwardable signal is
+    rejected whether given by name (`SIGTERM`) or by number (`15`); keep
+    the two parse branches in sync. Note the latch is set *before*
+    parsing, so a call that fails partway still latches — the tool
+    callers (`prte.c`, `prun_common.c`) abort on error, so this is
+    benign in practice but worth knowing when testing.
   - `prte_ess_base_signal_t` — a `pmix_list_item_t` subclass
     (`signame`/`signal`/`can_forward`), instantiated here with
     constructor/destructor. The actual libevent signal handlers that

--- a/src/mca/ess/AGENTS.md
+++ b/src/mca/ess/AGENTS.md
@@ -383,6 +383,30 @@ the failing step (e.g. `prte_ess_base_prted_setup`,
 
 ---
 
+## Testing
+
+Almost all of `ess` — `prted_setup`, the HNP module, every `set_name` —
+needs a live DVM (it opens the whole downstream framework stack, starts
+the PMIx server, creates the session directory), so those paths are
+exercised by the integration/dockerswarm harnesses, not by a standalone
+unit test.
+
+The one piece that is pure, DVM-free input parsing —
+`prte_ess_base_setup_signals()` — has a unit test at
+[`test/unit/ess/test_ess.c`](../../../test/unit/ess/), wired into
+`make check`. It drives the `"none"` no-op and a mixed
+name/duplicate parse, and asserts each accepted entry carries a real,
+**non-zero** signal number (the value the forwarding callback packs —
+the exact field the 2021 regression got wrong). Because
+`setup_signals` latches after its first non-`"none"` call (see above), a
+single process can drive only one substantive parse; the test is
+structured around that.
+
+Run it from a build tree with `make check` (whole suite) or
+`make -C test/unit/ess check` (just this one).
+
+---
+
 ## Where to go next
 
 Each component directory has its own `AGENTS.md`:

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -246,6 +246,15 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
             sname = NULL;
             for (int j = 0; NULL != known_signals[j].signame; ++j) {
                 if (sval == known_signals[j].signal) {
+                    /* enforce the same forwardability gate as the name
+                     * branch - a non-forwardable signal must be rejected
+                     * whether it was given by name or by number */
+                    if (!known_signals[j].can_forward) {
+                        pmix_show_help("help-ess-base.txt", "ess-base:cannot-forward", true,
+                                       known_signals[j].signame, mysignals);
+                        PMIx_Argv_free(signals);
+                        return PMIX_ERR_SILENT;
+                    }
                     sname = known_signals[j].signame;
                     break;
                 }

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -530,7 +530,7 @@ static void signal_forward_callback(int fd, short event, void *arg)
     }
 
     /* pack the signal */
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, cmd, &PRTE_JOBID_WILDCARD, 1, PMIX_INT32);
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, cmd, &signum, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(cmd);

--- a/src/mca/ess/env/AGENTS.md
+++ b/src/mca/ess/env/AGENTS.md
@@ -91,10 +91,11 @@ bootstrapped ordinary daemon also comes up through `env`.
 - **No vpid offset here — that is deliberate.** If you find yourself
   wanting to add `+ nodeid`, you are writing an RM module, not editing
   `env`. Keep `env` the verbatim-identity default.
-- **Return codes from `set_name` are swallowed.** `rte_init` calls
-  `env_set_name()` without checking its return (like the other daemon
-  modules). A missing nspace/vpid still logs via `PRTE_ERROR_LOG`, but
-  the subsequent `prted_setup` is what will actually fail loudly. If you
-  tighten this, tighten it consistently across all daemon modules.
+- **`set_name`'s return code is checked.** `rte_init` now aborts to its
+  `error:` label if `env_set_name()` fails (a missing `nspace`/`vpid`
+  yields `PRTE_ERR_NOT_FOUND`), rather than falling through into
+  `prted_setup` with a half-built identity. All four daemon modules
+  (`env`/`slurm`/`pals`/`lsf`) do this consistently — keep it that way if
+  you add another.
 - **This is the model to copy.** A new generic-daemon variant should
   follow this exact shape: `std_prolog` → `set_name` → `prted_setup`.

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -91,7 +91,10 @@ static int rte_init(int argc, char **argv)
     }
 
     /* Start by getting a unique name from the enviro */
-    env_set_name();
+    if (PRTE_SUCCESS != (ret = env_set_name())) {
+        error = "env_set_name";
+        goto error;
+    }
 
     /* if I am a daemon, complete my setup using the
      * default procedure

--- a/src/mca/ess/lsf/AGENTS.md
+++ b/src/mca/ess/lsf/AGENTS.md
@@ -81,12 +81,15 @@ Like `pals` (and unlike `slurm`), `lsf` does **not** rewrite
 - **The `- 1` is not a typo.** `LSF_PM_TASKID` counts from 1; dropping
   the decrement shifts every daemon's rank by one and collides ranks.
   This is the classic bug to avoid here.
+- **`LSF_PM_TASKID` is `NULL`-guarded before `atoi`.** `lsf_set_name`
+  checks `getenv("LSF_PM_TASKID")` for `NULL` and returns
+  `PRTE_ERR_NOT_FOUND` if it is missing, rather than calling
+  `atoi(NULL)` (undefined behavior). The LSF process manager sets the
+  variable when it launches the daemon, so this only fires in a
+  misconfigured launch — keeping it a clean error instead of a crash.
 - **Build gating.** Any new LSF symbol must be covered by
   `PRTE_CHECK_LSF` in `configure.m4`, or the build breaks on non-LSF
   systems. The wrapper flags (`ess_lsf_CPPFLAGS`/`LDFLAGS`/`LIBS`) are
   substituted from there.
-- **Minor quirk:** `rte_finalize` has a stray trailing empty statement
-  (`;` after `return`); harmless dead code, but if you touch the file it
-  is worth cleaning up.
 - Daemon-only. LSF allocation/launch integration lives in the `ras`/`plm`
   frameworks; this component is only the daemon's own RTE bring-up.

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -72,7 +72,10 @@ static int rte_init(int argc, char **argv)
     }
 
     /* Start by getting a unique name */
-    lsf_set_name();
+    if (PRTE_SUCCESS != (ret = lsf_set_name())) {
+        error = "lsf_set_name";
+        goto error;
+    }
 
     if (PRTE_SUCCESS != (ret = prte_ess_base_prted_setup())) {
         PRTE_ERROR_LOG(ret);
@@ -99,13 +102,13 @@ static int rte_finalize(void)
     }
 
     return ret;
-    ;
 }
 
 static int lsf_set_name(void)
 {
     int lsf_nodeid;
     pmix_rank_t vpid;
+    char *tmp;
 
     if (NULL == prte_ess_base_nspace) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
@@ -120,7 +123,11 @@ static int lsf_set_name(void)
     }
     vpid = strtoul(prte_ess_base_vpid, NULL, 10);
 
-    lsf_nodeid = atoi(getenv("LSF_PM_TASKID"));
+    if (NULL == (tmp = getenv("LSF_PM_TASKID"))) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+    lsf_nodeid = atoi(tmp);
     pmix_output_verbose(1, prte_ess_base_framework.framework_output,
                         "ess:lsf found LSF_PM_TASKID set to %d", lsf_nodeid);
     PRTE_PROC_MY_NAME->rank = vpid + lsf_nodeid - 1;

--- a/src/mca/ess/pals/AGENTS.md
+++ b/src/mca/ess/pals/AGENTS.md
@@ -68,8 +68,9 @@ The standard three-step daemon shape:
 3. **`PRTE_PROC_MY_NAME->rank = vpid + atoi(getenv("PALS_NODEID"))`**,
    but only if `PALS_NODEID` is present — if it is **not** set,
    `pals_set_name` returns `PRTE_ERR_NOT_FOUND` rather than defaulting
-   the offset to 0. (Contrast `slurm`, which calls `atoi` on
-   `SLURM_NODEID` unconditionally.)
+   the offset to 0. (`slurm` and `lsf` now `NULL`-guard their node-id
+   env vars the same way, so all three RM modules fail cleanly on a
+   missing offset instead of calling `atoi(NULL)`.)
 4. Set `prte_process_info.num_daemons = prte_ess_base_num_procs`.
 
 Unlike `slurm`, `pals` does **not** rewrite `prte_process_info.nodename`

--- a/src/mca/ess/pals/ess_pals_module.c
+++ b/src/mca/ess/pals/ess_pals_module.c
@@ -73,7 +73,10 @@ static int rte_init(int argc, char **argv)
     }
 
     /* Start by getting a unique name */
-    pals_set_name();
+    if (PRTE_SUCCESS != (ret = pals_set_name())) {
+        error = "pals_set_name";
+        goto error;
+    }
 
     if (PRTE_SUCCESS != (ret = prte_ess_base_prted_setup())) {
         PRTE_ERROR_LOG(ret);

--- a/src/mca/ess/slurm/AGENTS.md
+++ b/src/mca/ess/slurm/AGENTS.md
@@ -87,6 +87,12 @@ unique rank, and by correcting the nodename from SLURM's own value:
   dropping it) collides daemon ranks — a silent, miserable failure. The
   base vpid is the same for every daemon; the node id is what
   disambiguates.
+- **`SLURM_NODEID` is `NULL`-guarded before `atoi`.** `slurm_set_name`
+  checks `getenv("SLURM_NODEID")` for `NULL` and returns
+  `PRTE_ERR_NOT_FOUND` if it is absent, rather than calling `atoi(NULL)`
+  (undefined behavior — a segfault on glibc). `srun` always sets the
+  variable, so this only triggers in a misconfigured launch, but the
+  guard keeps that case a clean error instead of a crash. Don't drop it.
 - **`SLURMD_NODENAME` correction matters for node matching.** The HNP's
   allocation (from `ras/slurm`) uses SLURM's node names; if the daemon
   reports a different hostname (e.g. an FQDN vs short name), node

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -71,7 +71,10 @@ static int rte_init(int argc, char **argv)
     }
 
     /* Start by getting a unique name */
-    slurm_set_name();
+    if (PRTE_SUCCESS != (ret = slurm_set_name())) {
+        error = "slurm_set_name";
+        goto error;
+    }
 
     if (PRTE_SUCCESS != (ret = prte_ess_base_prted_setup())) {
         PRTE_ERROR_LOG(ret);
@@ -122,7 +125,11 @@ static int slurm_set_name(void)
     vpid = strtoul(prte_ess_base_vpid, NULL, 10);
 
     /* fix up the vpid and make it the "real" vpid */
-    slurm_nodeid = atoi(getenv("SLURM_NODEID"));
+    if (NULL == (tmp = getenv("SLURM_NODEID"))) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+    slurm_nodeid = atoi(tmp);
     PRTE_PROC_MY_NAME->rank = vpid + slurm_nodeid;
 
     PMIX_OUTPUT_VERBOSE((1, prte_ess_base_framework.framework_output, "ess:slurm set name to %s",

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr
+SUBDIRS = rmaps errmgr ess

--- a/test/unit/ess/Makefile.am
+++ b/test/unit/ess/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_ess
+
+test_ess_SOURCES = \
+    test_ess.c
+
+test_ess_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_ess

--- a/test/unit/ess/test_ess.c
+++ b/test/unit/ess/test_ess.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the ess framework's signal-forwarding parser.
+ *
+ * The bulk of the ess framework -- daemon/HNP bring-up
+ * (prte_ess_base_prted_setup and the hnp module) -- cannot run without a
+ * live DVM: it opens the entire downstream framework stack, starts the
+ * PMIx server, and creates the session directory.  Those paths are
+ * covered by the integration/dockerswarm harnesses.
+ *
+ * What *can* be exercised in isolation is the piece of the framework that
+ * is pure input parsing: prte_ess_base_setup_signals().  It turns the
+ * user's ess_base_forward_signals list into the global
+ * prte_ess_base_signals list that prted_setup later installs signal
+ * handlers from -- and each entry carries the integer signal number that
+ * the forwarding callback packs and delivers to the application procs.
+ * The correctness of that number is exactly what a recent regression got
+ * wrong (the callback packed a constant instead of the signal), so it is
+ * worth pinning down that the parser produces real, non-zero signal
+ * numbers for the signals it accepts.
+ *
+ * NOTE: prte_ess_base_setup_signals() latches after its first
+ * non-"none" invocation (it may only append to the global list once for
+ * the life of the process).  A single process can therefore drive exactly
+ * one real parse, so the "none" no-op case is checked first (it does not
+ * latch) and the substantive multi-signal parse is checked second.
+ */
+
+#include "prte_config.h"
+#include <signal.h>
+#include <stdio.h>
+
+#include "constants.h"
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/ess/base/base.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/* count how many entries on the global list carry the given signal number */
+static int count_signal(int signum)
+{
+    prte_ess_base_signal_t *sig;
+    int n = 0;
+
+    PMIX_LIST_FOREACH(sig, &prte_ess_base_signals, prte_ess_base_signal_t) {
+        if (signum == sig->signal) {
+            n++;
+        }
+    }
+    return n;
+}
+
+/*
+ * "none" means "forward nothing": the parser must succeed and leave the
+ * global list empty.  This path deliberately does NOT latch the one-shot
+ * guard, so it is safe to run before the real parse below.
+ */
+static int test_setup_signals_none(void)
+{
+    int failures = 0;
+    pmix_status_t rc;
+
+    rc = prte_ess_base_setup_signals("none");
+    CHECK("none returns success", PMIX_SUCCESS == rc);
+    CHECK("none leaves list empty", 0 == pmix_list_get_size(&prte_ess_base_signals));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_setup_signals_none\n");
+    }
+    return failures;
+}
+
+/*
+ * A real, mixed request: three distinct forwardable signals plus a
+ * case-insensitive duplicate of the first.  The parser must accept all
+ * three, drop the duplicate, and record the correct (non-zero) integer
+ * signal number for each -- the very value the forwarding callback packs.
+ */
+static int test_setup_signals_parse(void)
+{
+    int failures = 0;
+    pmix_status_t rc;
+    prte_ess_base_signal_t *sig;
+
+    rc = prte_ess_base_setup_signals("SIGUSR1,SIGUSR2,SIGCONT,sigusr1");
+    CHECK("parse returns success", PMIX_SUCCESS == rc);
+
+    /* the duplicate SIGUSR1 must have been ignored -> exactly three */
+    CHECK("three signals recorded", 3 == pmix_list_get_size(&prte_ess_base_signals));
+
+    /* each requested signal is present exactly once, by its real number */
+    CHECK("SIGUSR1 present once", 1 == count_signal(SIGUSR1));
+    CHECK("SIGUSR2 present once", 1 == count_signal(SIGUSR2));
+    CHECK("SIGCONT present once", 1 == count_signal(SIGCONT));
+
+    /* every recorded entry must carry a valid, non-zero signal number and
+     * a matching name -- a zero here is precisely the failure mode that
+     * makes signal forwarding a silent no-op */
+    PMIX_LIST_FOREACH(sig, &prte_ess_base_signals, prte_ess_base_signal_t) {
+        CHECK("entry has non-zero signal", 0 != sig->signal);
+        CHECK("entry has a name", NULL != sig->signame);
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_setup_signals_parse\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* open the framework so its verbosity channel is valid and the global
+     * signal list is constructed */
+    rc = pmix_mca_base_framework_open(&prte_ess_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "ess framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
+    failures += test_setup_signals_none();
+    failures += test_setup_signals_parse();
+
+    (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all ess unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d ess unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
This is the outcome of a deep review of the `src/mca/ess` framework. It
carries two genuine bug fixes, a robustness pass over the daemon
modules, and the framework's first unit test. Each commit is
self-contained and the `AGENTS.md` updates ride with the code they
describe.

## Signal forwarding was a silent no-op (long-standing regression)

The signal-forwarding callback in `ess_base_std_prted.c` packs a
`PRTE_DAEMON_SIGNAL_LOCAL_PROCS` command, which the daemon unpacks as
`(jobid, int32 signal)` before delivering the signal to local
application procs. The 2021 conversion of PRRTE process names to PMIx
process names replaced the packed signal value with
`PRTE_JOBID_WILDCARD` (a zero-filled nspace) while leaving the pack type
as `PMIX_INT32`. The receiver therefore always saw signal `0`, so every
signal a user asked to forward via `ess_base_forward_signals` was
delivered as the null signal — a no-op. Fixed to pack the caught signal
number as the code originally did.

## `can_forward` gate bypassed for numeric signals

`prte_ess_base_setup_signals` rejects non-forwardable signals (SIGKILL,
SIGTERM, …) when named, but the branch parsing a signal given by integer
never checked `can_forward`. `ess_base_forward_signals=15` thus slipped a
non-forwardable signal onto the forward list. The numeric branch now
applies the same gate.

## Daemon identity setup fails cleanly instead of crashing/ignoring

- The `env`/`slurm`/`pals`/`lsf` modules called `<rm>_set_name()` and
  discarded its return, then proceeded into the shared bring-up with a
  half-built identity. They now check the return and route failures
  through the module error path.
- `slurm` and `lsf` fed `getenv()` straight into `atoi()` when computing
  the per-node vpid offset. `atoi(NULL)` is undefined behavior (crashes
  on glibc); the launchers always set these vars, so the normal path is
  unaffected, but the lookups are now `NULL`-guarded like `pals` already
  did.
- Incidental: dropped a stray empty statement in the `lsf` module's
  `rte_finalize`.

## First ess unit test

Added `test/unit/ess/test_ess.c`, wired into `make check`, covering the
one DVM-free path in the framework — `prte_ess_base_setup_signals()`. It
drives the `"none"` no-op and a mixed name/duplicate parse and asserts
each accepted entry carries a real, non-zero signal number (the field
the forwarding regression corrupted).

## Verification

- Warning-free `--enable-debug` build. `env`/`slurm` compile locally;
  `lsf`/`pals` (not built on the dev host) were reviewed by hand.
- `make check` passes all suites (`rmaps`, `errmgr`, `ess`).
- Behavior changes are confined to error paths; the normal launch path
  is unaffected.