### PR TITLE
filem: fix preload staging (create_link, EXE placement, UAF) and two related segfaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ test/unit/errmgr/Makefile
 test/unit/errmgr/test_errmgr
 test/unit/ess/Makefile
 test/unit/ess/test_ess
+test/unit/filem/Makefile
+test/unit/filem/test_filem
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -34,5 +34,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/rmaps/Makefile
         test/unit/errmgr/Makefile
         test/unit/ess/Makefile
+        test/unit/filem/Makefile
     ])
 ])

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -141,6 +141,18 @@ Both `grow` and `shrink` should print
 node hostname`): stands up a transient DVM, runs the job, and exits cleanly with
 no daemons left behind — the non-elastic launch path.
 
+**Preload (`filem`)** (`--preload-binary`): the harness compiles a marker binary
+on **node1 only**, then runs it under `--preload-binary` on node2+node3. Because
+the executable does not exist on the target nodes, a successful run proves
+`filem` actually staged the bytes across daemons (xcast → `recv_files` →
+`write_handler`) and linked them into the job session dir that
+`--preload-binary`'s session-cwd points at. This is the one path a single-host
+build can't validate — locally the source file is already present, so the app
+would run even if staging did nothing. (Data-file preload, `--preload-files`,
+is **not** asserted here: staged data files land in the per-proc session dir but
+the default cwd is elsewhere, so they are not reachable by a bare relative path —
+a separate, pre-existing gap.)
+
 **Grow** (`elastic grow node2:2,node3:2`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, and `prted` now running on node2 and node3.
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -86,6 +86,37 @@ test_linux() {
     c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
     [ "$c" = 0 ] && ok "no daemons linger after prterun" || bad "$c stray prted after prterun"
 
+    banner "filem: --preload-binary cross-node staging (binary only on node1)"
+    # Compile a marker binary on node1 ONLY. If it runs on node2/node3 -- where
+    # the file does not exist -- then filem actually staged the bytes there and
+    # linked them into the job session dir that --preload-binary's session cwd
+    # points at. This exercises the real cross-daemon delivery path (xcast ->
+    # recv_files -> write_handler -> link_local_files), which a single-host run
+    # cannot prove because the source file is already present locally.
+    docker exec prte-node1 bash -lc '. /opt/prte/env.sh 2>/dev/null; cat > /root/staged_marker.c <<"CEOF"
+#include <unistd.h>
+#include <stdio.h>
+int main(void){ char h[64]; gethostname(h, sizeof(h)); printf("STAGED-BIN-OK %s\n", h); return 0; }
+CEOF
+gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
+    if RUN 'test -x /root/staged_marker'; then
+        leaked=0
+        for n in 2 3; do ON "$n" 'test -e /root/staged_marker' && leaked=1; done
+        [ "$leaked" = 0 ] && ok "marker binary exists only on node1 (staging test is valid)" \
+                          || bad "marker binary leaked onto a target node -- test would be meaningless"
+        out=$(RUN 'cd /root && prterun --host node2:1,node3:1 -np 2 --map-by node --preload-binary -- ./staged_marker' 2>&1); rc=$?
+        n2=$(echo "$out" | grep -c 'STAGED-BIN-OK node2')
+        n3=$(echo "$out" | grep -c 'STAGED-BIN-OK node3')
+        [ "$rc" = 0 ] && [ "$n2" = 1 ] && [ "$n3" = 1 ] \
+            && ok "preload-binary staged from node1 and ran on node2+node3" \
+            || bad "preload-binary cross-node failed (rc=$rc, n2=$n2, n3=$n3): $(echo "$out" | tr '\n' ' ')"
+        c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
+        [ "$c" = 0 ] && ok "no daemons linger after preload-binary run" || bad "$c stray prted after preload run"
+    else
+        bad "could not compile the marker binary on node1 (need gcc in the image)"
+    fi
+    docker exec prte-node1 sh -c 'rm -f /root/staged_marker /root/staged_marker.c' 2>/dev/null
+
     banner "elastic DVM: grow + shrink (radix 64, flat tree)"
     cleanup_swarm
     RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null

--- a/src/mca/filem/AGENTS.md
+++ b/src/mca/filem/AGENTS.md
@@ -175,6 +175,15 @@ module made entirely of the `prte_filem_base_none_*` functions from
 when file staging is disabled or unselected — pre-positioning simply
 does nothing and the job proceeds.
 
+**Every slot must be wired, including `fault_handler`.** The none module
+carries a `prte_filem_base_none_fault_handler` no-op, because
+`routed_radix.c` calls `prte_filem.fault_handler(status)`
+**unconditionally** on every daemon-fault recovery — with no NULL guard.
+A none module that left the slot NULL (as it historically did) crashed
+the DVM the first time a daemon failed while filem was unselected. If you
+add a field to the module vtable, give the none module a no-op for it and
+confirm no unconditional caller dereferences a NULL slot.
+
 ### The dormant base RML service (`filem_base_receive.c`)
 
 `base.h` declares a small RML service — `prte_filem_base_comm_start()`,
@@ -198,6 +207,15 @@ effectively dead today — accurate to note, and a place to be careful:
 if the base service were ever started. The global
 `prte_filem_base_is_active` bool is likewise defined but currently
 unused.
+
+Because it is dead code it accumulated latent bugs; two were recently
+corrected and are worth knowing if you ever revive it. `comm_stop`'s
+"already stopped?" guard was inverted (`if (recv_issued)` instead of
+`if (!recv_issued)`), so it early-returned without ever cancelling the
+recv. And `filem_base_process_get_remote_path_cmd` leaked the unpacked
+`filename` on the `getcwd`-failure path (it `return`ed instead of
+`goto CLEANUP`). If you start posting this service for real, audit its
+error paths first.
 
 ---
 
@@ -256,6 +274,30 @@ positioning and every chunk sent/received; ≥10 traces per-proc symlink
 creation and archive path enumeration. A stuck job at `VM_READY` almost
 always means a preposition callback that never fired or an ack that never
 arrived from a daemon.
+
+---
+
+## Testing
+
+The staging machinery (`raw_preposition_files`, the daemon receive/write
+path, `raw_link_local_files`) is asynchronous, progress-thread,
+multi-node I/O and needs a live DVM — exercise it with the
+`--preload-binary`/`--preload-files` smoke tests above and the
+integration harnesses.
+
+What *is* unit-testable with no DVM lives in
+[`test/unit/filem/test_filem.c`](../../../test/unit/filem/) (wired into
+`make check`):
+
+- the three request classes (`process_set`/`file_set`/`request`) —
+  construct-to-defaults and clean destruct/drain;
+- the default **"none" module** — every slot is a success-returning
+  no-op, `preposition_files` fires its completion callback, and
+  `fault_handler` is non-NULL and callable (the regression pin for the
+  `routed_radix.c` crash described above).
+
+The test opens the framework but deliberately does **not** run
+`prte_filem_base_select()`, so `prte_filem` stays the none module.
 
 ---
 

--- a/src/mca/filem/base/base.h
+++ b/src/mca/filem/base/base.h
@@ -65,6 +65,7 @@ PRTE_EXPORT extern bool prte_filem_base_is_active;
 int prte_filem_base_module_init(void);
 int prte_filem_base_module_finalize(void);
 
+void prte_filem_base_none_fault_handler(const prte_rml_recovery_status_t *status);
 PRTE_EXPORT int prte_filem_base_none_put(prte_filem_base_request_t *request);
 PRTE_EXPORT int prte_filem_base_none_put_nb(prte_filem_base_request_t *request);
 PRTE_EXPORT int prte_filem_base_none_get(prte_filem_base_request_t *request);

--- a/src/mca/filem/base/filem_base_fns.c
+++ b/src/mca/filem/base/filem_base_fns.c
@@ -159,6 +159,11 @@ int prte_filem_base_module_finalize(void)
     return PRTE_SUCCESS;
 }
 
+void prte_filem_base_none_fault_handler(const prte_rml_recovery_status_t *status)
+{
+    PRTE_HIDE_UNUSED_PARAMS(status);
+}
+
 int prte_filem_base_none_put(prte_filem_base_request_t *request)
 {
     PRTE_HIDE_UNUSED_PARAMS(request);

--- a/src/mca/filem/base/filem_base_frame.c
+++ b/src/mca/filem/base/filem_base_frame.c
@@ -39,6 +39,7 @@
 PRTE_EXPORT prte_filem_base_module_t prte_filem
     = {.filem_init = prte_filem_base_module_init,
        .filem_finalize = prte_filem_base_module_finalize,
+       .fault_handler = prte_filem_base_none_fault_handler,
        .put = prte_filem_base_none_put,
        .put_nb = prte_filem_base_none_put_nb,
        .get = prte_filem_base_none_get,

--- a/src/mca/filem/base/filem_base_receive.c
+++ b/src/mca/filem/base/filem_base_receive.c
@@ -95,7 +95,7 @@ int prte_filem_base_comm_stop(void)
     if (!PRTE_PROC_IS_MASTER && !PRTE_PROC_IS_DAEMON) {
         return PRTE_SUCCESS;
     }
-    if (recv_issued) {
+    if (!recv_issued) {
         return PRTE_SUCCESS;
     }
 
@@ -243,7 +243,7 @@ static void filem_base_process_get_remote_path_cmd(pmix_proc_t *sender, pmix_dat
      */
     if (filename[0] != '/') { /* if it is not an absolute path already */
         if (NULL == getcwd(cwd, sizeof(cwd))) {
-            return;
+            goto CLEANUP;
         }
         pmix_asprintf(&tmp_name, "%s/%s", cwd, filename);
     } else {

--- a/src/mca/filem/raw/AGENTS.md
+++ b/src/mca/filem/raw/AGENTS.md
@@ -260,3 +260,76 @@ already resilient for the not-in-flight case.
   `raw_init` rather than using the base `filem_base_receive.c` service;
   don't start the base comm service alongside it or the two will collide
   on the tag.
+- **On an error, unlink an object from its list *before* releasing it.**
+  Several receive-side error paths add an `incoming` (or `xfer`) to a
+  file-scoped list and, on a later failure, must both
+  `pmix_list_remove_item` it and `PMIX_RELEASE` it — releasing without
+  removing leaves a dangling pointer that the next chunk walks. The
+  chunk-0 `recv_files` failure paths (dirpath-create and fd-open) now do
+  this consistently; keep new bailouts consistent too. Likewise
+  `recv_ack` must `free()` the unpacked filename on the no-match fall-off,
+  and the `write_handler` EOF marker output must be `PMIX_RELEASE`d before
+  finalize — both were leaks.
+
+- **On open failure, `raw_preposition_files` records the error and lets
+  the async path report it — it must NOT free the `outbound`.** Files are
+  threadshifted to `send_chunk` as the loop walks them, so an already-
+  queued `xfer` has a live `send_chunk` event on the progress thread and
+  an open fd. If a *later* file fails to `open()`, the fix sets
+  `outbound->status = PRTE_ERR_FILE_OPEN_FAILURE` and `break`s; the queued
+  xfers finish and the completion callback delivers that status (or, if no
+  xfer was queued, the empty-`xfers` tail fires the callback with it).
+  **Do not restore the old behavior of `PMIX_RELEASE`-ing the outbound and
+  returning `PRTE_ERROR` mid-loop** — its destructor drains the queued
+  xfers, so the pending events fire against freed memory (use-after-free,
+  reproducible with `--preload-files good.dat,/nonexistent`), the xfers'
+  fds leak, and the synchronous error return *plus* the eventual callback
+  both drive `PRTE_JOB_STATE_FILES_POSN_FAILED`.
+
+## `create_link` returns SUCCESS only when it means it
+
+`raw_link_local_files` aborts the whole launch if `create_link` returns
+non-success, so two things there are load-bearing:
+
+- **Reset `rc` after tolerating `PMIX_ERR_EXISTS`.** `pmix_os_dirpath_create`
+  returns `PMIX_ERR_EXISTS` (== `-11`) whenever the proc session dir
+  already exists — the normal case. The code tolerates that in the guard,
+  but must then set `rc = PRTE_SUCCESS` before the `symlink()`; otherwise a
+  perfectly good link returns the stale `-11` (which surfaces as
+  `PRTE_ERR_IN_ERRNO`) and every preload launch fails.
+- **The symlink *source* is `top_session_dir`, not `jdata->session_dir`.**
+  `recv_files` writes staged bytes under `prte_process_info.top_session_dir`
+  (per-node, shared across jobs), so `raw_link_local_files` passes that as
+  `create_link`'s `my_dir`. Passing the job dir as the source builds a
+  dangling link one level too deep.
+
+Both were live bugs that made `--preload-files`/`--preload-binary` fail
+outright.
+
+### Link *target*: proc dir for data, **job dir for the binary**
+
+The link *target* (`create_link`'s `path` arg) is normally the per-proc
+session dir `jdata->session_dir/<rank>`, so each proc finds a staged file
+in its own directory. The **EXE is the exception**: `--preload-binary`
+sets `PRTE_APP_SSNDIR_CWD`, and `setup_path` (in `odls`) resolves that to
+the **job** session dir as the cwd shared by every one of the app's procs.
+So a staged binary must be linked into `jdata->session_dir` (not the proc
+dir) for `./<binary>` to resolve. `raw_link_local_files` selects the
+target by `inbnd->type == PRTE_FILEM_TYPE_EXE`; the link is job-wide, and
+`create_link`'s existence check makes the per-proc repeat a no-op.
+
+If you ever change the cwd model (e.g. make `SSNDIR_CWD` per-proc), this
+EXE-target choice has to move in lockstep — the binary must live wherever
+the proc's cwd ends up.
+
+### Verifying true delivery
+
+A single-host run **cannot** prove staging works: the source file is
+already present locally, so the app runs even if `filem` did nothing. The
+real cross-daemon path is covered by the dockerswarm harness
+(`contrib/dockerswarm/run-tests.sh`, the "`--preload-binary` cross-node
+staging" case): it compiles a marker binary on node1 only and runs it on
+node2+node3, where it can only work if the bytes were actually staged and
+linked. Run that (or an equivalent multi-node test) after touching the
+send/receive/link paths — the `test/unit/filem` unit test only exercises
+the base classes and the "none" module, not delivery.

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -234,6 +234,10 @@ static void recv_ack(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer
             }
         }
     }
+    /* no matching xfer found (e.g. the file was already fully positioned
+     * and removed) - avoid leaking the unpacked filename
+     */
+    free(file);
 }
 
 static int raw_preposition_files(prte_job_t *jdata,
@@ -1027,6 +1031,10 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
             send_complete(file, PRTE_ERR_FILE_WRITE_FAILURE);
             free(file);
             free(tmp);
+            /* drop this file from the incoming list before releasing it,
+             * else a later chunk would walk a dangling pointer
+             */
+            pmix_list_remove_item(&incoming_files, &incoming->super);
             PMIX_RELEASE(incoming);
             return;
         }
@@ -1039,6 +1047,8 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
                 send_complete(file, PRTE_ERR_FILE_WRITE_FAILURE);
                 free(file);
                 free(tmp);
+                pmix_list_remove_item(&incoming_files, &incoming->super);
+                PMIX_RELEASE(incoming);
                 return;
             }
         } else {
@@ -1049,6 +1059,8 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
                 send_complete(file, PRTE_ERR_FILE_WRITE_FAILURE);
                 free(file);
                 free(tmp);
+                pmix_list_remove_item(&incoming_files, &incoming->super);
+                PMIX_RELEASE(incoming);
                 return;
             }
         }
@@ -1110,6 +1122,10 @@ static void write_handler(int fd, short event, void *cbdata)
             /* close the file descriptor */
             close(sink->fd);
             sink->fd = -1;
+            /* we are done with this EOF marker - release it so it isn't
+             * leaked on the finalize paths below
+             */
+            PMIX_RELEASE(output);
             if (PRTE_FILEM_TYPE_FILE == sink->type || PRTE_FILEM_TYPE_EXE == sink->type) {
                 /* just link to the top as this will be the
                  * name we will want in each proc's session dir
@@ -1132,12 +1148,15 @@ static void write_handler(int fd, short event, void *cbdata)
                 if (NULL == getcwd(homedir, sizeof(homedir))) {
                     PRTE_ERROR_LOG(PRTE_ERROR);
                     send_complete(sink->file, PRTE_ERR_FILE_WRITE_FAILURE);
+                    free(cmd);
                     return;
                 }
                 dirname = pmix_dirname(sink->fullpath);
                 if (0 != chdir(dirname)) {
                     PRTE_ERROR_LOG(PRTE_ERROR);
                     send_complete(sink->file, PRTE_ERR_FILE_WRITE_FAILURE);
+                    free(cmd);
+                    free(dirname);
                     return;
                 }
                 PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
@@ -1146,11 +1165,21 @@ static void write_handler(int fd, short event, void *cbdata)
                 if (0 != system(cmd)) {
                     PRTE_ERROR_LOG(PRTE_ERROR);
                     send_complete(sink->file, PRTE_ERR_FILE_WRITE_FAILURE);
+                    /* best-effort restore of our working directory before
+                     * bailing; log but don't mask the original failure
+                     */
+                    if (0 != chdir(homedir)) {
+                        PRTE_ERROR_LOG(PRTE_ERROR);
+                    }
+                    free(cmd);
+                    free(dirname);
                     return;
                 }
                 if (0 != chdir(homedir)) {
                     PRTE_ERROR_LOG(PRTE_ERROR);
                     send_complete(sink->file, PRTE_ERR_FILE_WRITE_FAILURE);
+                    free(cmd);
+                    free(dirname);
                     return;
                 }
                 free(dirname);

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -605,6 +605,11 @@ static int create_link(char *my_dir, char *path, char *link_pt)
             return rc;
         }
         free(basedir);
+        /* the directory now exists (freshly created or already present) -
+         * clear the PMIX_ERR_EXISTS that dirpath_create may have left in
+         * rc, else a successful link is reported to the caller as a failure
+         */
+        rc = PRTE_SUCCESS;
         /* do the symlink */
         if (0 != symlink(mypath, fullname)) {
             pmix_output(0, "%s Failed to symlink %s to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
@@ -708,12 +713,26 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
                         PMIX_OUTPUT_VERBOSE((10, prte_filem_base_framework.framework_output,
                                              "%s filem:raw: creating links for file %s",
                                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), inbnd->file));
-                        /* cycle thru the link points and create symlinks to them */
+                        /* Decide where the link lives. The staged bytes were
+                         * written under the node's top_session_dir (see
+                         * recv_files), so that - not the job session_dir - is
+                         * always the symlink *source*. The link *target* is
+                         * normally the per-proc session dir, so each proc finds
+                         * the file in its own cwd. A preloaded binary (EXE) is
+                         * the exception: --preload-binary sets
+                         * PRTE_APP_SSNDIR_CWD, which makes every proc's cwd the
+                         * *job* session dir (see setup_path in odls), so the
+                         * executable must be linked there for "./<binary>" to
+                         * resolve. That link is job-wide, so create_link's
+                         * existence check makes the repeat across procs a no-op.
+                         */
+                        char *linkdir = (PRTE_FILEM_TYPE_EXE == inbnd->type) ? session_dir : path;
                         for (j = 0; NULL != inbnd->link_pts[j]; j++) {
                             if (PRTE_SUCCESS
-                                != (rc = create_link(session_dir, path, inbnd->link_pts[j]))) {
+                                != (rc = create_link(prte_process_info.top_session_dir, linkdir,
+                                                     inbnd->link_pts[j]))) {
                                 PRTE_ERROR_LOG(rc);
-                                free(files);
+                                PMIx_Argv_free(files);
                                 free(path);
                                 return rc;
                             }

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -478,9 +478,20 @@ static int raw_preposition_files(prte_job_t *jdata,
             pmix_output(0, "%s CANNOT ACCESS FILE %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         fs->local_target);
             PMIX_RELEASE(item);
-            pmix_list_remove_item(&outbound_files, &outbound->super);
-            PMIX_RELEASE(outbound);
-            return PRTE_ERROR;
+            /* record the failure and stop queueing further files, but do NOT
+             * tear down the outbound here: files already handed to send_chunk
+             * still have live events queued on the progress thread, and their
+             * xfers hold open fds. Freeing the outbound now would drain those
+             * xfers (use-after-free on the queued events, leaked fds) and
+             * would also double-drive FILES_POSN_FAILED, since the caller
+             * treats our error return as a failure *and* the completion
+             * callback would fire again. Instead let the async path report
+             * the error: the callback delivers outbound->status once every
+             * queued xfer has acked (or immediately below if none were
+             * queued).
+             */
+            outbound->status = PRTE_ERR_FILE_OPEN_FAILURE;
+            break;
         }
         /* set the flags to non-blocking */
         if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
@@ -545,19 +556,26 @@ static int raw_preposition_files(prte_job_t *jdata,
         PRTE_PMIX_THREADSHIFT(xfer, prte_event_base, send_chunk);
         PMIX_RELEASE(item);
     }
-    PMIX_DESTRUCT(&fsets);
+    /* a mid-loop break (open failure) can leave entries on fsets, so use
+     * PMIX_LIST_DESTRUCT to release any that remain
+     */
+    PMIX_LIST_DESTRUCT(&fsets);
 
-    /* check to see if anything remains to be sent - if everything
-     * is a duplicate, then the list will be empty
+    /* check to see if anything remains to be sent - the list is empty if
+     * every file was a duplicate, or if the very first file failed to open
      */
     if (0 == pmix_list_get_size(&outbound->xfers)) {
+        /* capture the status before releasing the outbound: it is a failure
+         * only if an open() failed above, success if all were duplicates
+         */
+        int st = outbound->status;
         PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
-                             "%s filem:raw: all duplicate files - no positioning reqd",
+                             "%s filem:raw: nothing to position (all duplicates or open failed)",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
         pmix_list_remove_item(&outbound_files, &outbound->super);
         PMIX_RELEASE(outbound);
         if (NULL != cbfunc) {
-            cbfunc(PRTE_SUCCESS, cbdata);
+            cbfunc(st, cbdata);
         }
         return PRTE_SUCCESS;
     }

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -401,6 +401,14 @@ computed proc state.
 - **Locality is `parent == my vpid`.** A proc is "local" iff its `parent`
   daemon vpid equals this daemon's rank. Getting the wireup wrong silently
   launches procs on the wrong node or not at all.
+- **Raw back-pointers on unpacked objects are NULL on the daemon.** Fields
+  like `prte_app_context_t.job` are only set on the HNP (in `ess/hnp` and
+  the dynamic-spawn path); they are not serialized into the launch message,
+  so on any daemon that rebuilt the job via `construct_child_list` they are
+  NULL. Never dereference `app->job` (or similar back-pointers) in a
+  daemon-side path — `setup_path` did, and `--preload-binary` (which sets
+  `PRTE_APP_SSNDIR_CWD`) segfaulted on it. Get the job from the caller,
+  which already holds `jobdat`, or via `prte_get_job_data_object(nspace)`.
 - **`prte_local_children` is the single source of truth** on a daemon.
   Adding/removing a child there, and its `PRTE_PROC_FLAG_*` flags
   (`LOCAL`, `ALIVE`, `WAITPID`, `IOF_COMPLETE`, `REG`), gate the whole

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -825,17 +825,22 @@ REPORT_ERROR:
     return rc;
 }
 
-static int setup_path(prte_app_context_t *app, char **wdir)
+static int setup_path(prte_job_t *job, prte_app_context_t *app, char **wdir)
 {
     int rc = PRTE_SUCCESS;
     char dir[PRTE_PATH_MAX];
     char *session_dir;
     bool usercwd = false;
-    prte_job_t *job;
 
     if (prte_get_attribute(&app->attributes, PRTE_APP_SSNDIR_CWD, NULL, PMIX_BOOL)) {
-        /* move us to that location */
-        job = (prte_job_t*)app->job;
+        /* move us to that location. Use the job handed in by our caller: the
+         * app->job back-pointer is a raw pointer that is never serialized into
+         * the launch message, so it is NULL on any daemon that unpacked this
+         * job - dereferencing it segfaults (it is only set on the HNP).
+         */
+        if (NULL == job) {
+            return PRTE_ERROR;
+        }
         session_dir = job->session_dir;
         if (NULL == session_dir) {
             // cannot do it
@@ -1389,7 +1394,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         /* setup the working directory for this app - will jump us
          * to that directory
          */
-        if (PRTE_SUCCESS != (rc = setup_path(app, &app->cwd))) {
+        if (PRTE_SUCCESS != (rc = setup_path(jobdat, app, &app->cwd))) {
             PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
                                  "%s odls:launch:setup_path failed with error %s(%d)",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc), rc));
@@ -2234,7 +2239,7 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
     }
 
     /* setup the path */
-    if (PRTE_SUCCESS != (rc = setup_path(app, &wdir))) {
+    if (PRTE_SUCCESS != (rc = setup_path(jobdat, app, &wdir))) {
         PRTE_ERROR_LOG(rc);
         if (NULL != wdir) {
             free(wdir);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1253,7 +1253,11 @@ int prte(int argc, char *argv[])
         papps[n].cmd = strdup(app->app.cmd);
         papps[n].argv = PMIx_Argv_copy(app->app.argv);
         papps[n].env = PMIx_Argv_copy(app->app.env);
-        papps[n].cwd = strdup(app->app.cwd);
+        /* cwd is deliberately left NULL when --set-cwd-to-session-dir was
+         * given (the session dir becomes the cwd on the backend via the
+         * PMIX_SET_SESSION_CWD directive), so guard against strdup(NULL)
+         */
+        papps[n].cwd = (NULL == app->app.cwd) ? NULL : strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);
         if (PMIX_SUCCESS != ret) {

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess
+SUBDIRS = rmaps errmgr ess filem

--- a/test/unit/filem/Makefile.am
+++ b/test/unit/filem/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_filem
+
+test_filem_SOURCES = \
+    test_filem.c
+
+test_filem_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_filem

--- a/test/unit/filem/test_filem.c
+++ b/test/unit/filem/test_filem.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the filem framework.
+ *
+ * The substantive work of filem -- staging bytes across a live DVM
+ * (raw_preposition_files / recv_files / write_handler) and symlinking
+ * them into per-proc session directories (raw_link_local_files) -- is
+ * asynchronous, progress-thread, multi-node I/O and cannot run without a
+ * live DVM; it is covered by the integration harnesses.
+ *
+ * What *can* be exercised in isolation are the two pieces the base owns
+ * with no I/O:
+ *
+ *   1. The three reference-counted request classes
+ *      (prte_filem_base_process_set_t / _file_set_t / _request_t): their
+ *      constructors must establish the documented defaults and their
+ *      destructors must drain their lists and free their strings without
+ *      crashing.
+ *
+ *   2. The default "none" module that filem_base_frame.c installs into
+ *      the global prte_filem when no component is selected.  Every one of
+ *      its entry points must be a safe no-op that returns PRTE_SUCCESS,
+ *      preposition must still fire its completion callback (or the job
+ *      would wedge forever at VM_READY), and -- the point of a recent
+ *      fix -- the fault_handler slot must be non-NULL and callable, since
+ *      routed_radix.c invokes prte_filem.fault_handler() unconditionally
+ *      on every daemon-fault recovery even when filem is "none".
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/runtime/runtime.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/filem/base/base.h"
+#include "src/mca/filem/filem.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/* completion-callback bookkeeping for the preposition no-op test */
+static bool cb_fired = false;
+static int cb_status = -1;
+static void completion_cb(int status, void *cbdata)
+{
+    cb_fired = true;
+    cb_status = status;
+    *((bool *) cbdata) = true;
+}
+
+/*
+ * The request classes must construct to their documented defaults and
+ * tear down cleanly.  A file_set owns its two path strings; the
+ * destructor must free them (run under a leak checker to confirm).  A
+ * request owns two lists; appending to them and releasing the request
+ * must drain and release every member.
+ */
+static int test_classes(void)
+{
+    int failures = 0;
+    prte_filem_base_process_set_t *pset;
+    prte_filem_base_file_set_t *fset;
+    prte_filem_base_request_t *req;
+
+    /* process_set: source and sink both start INVALID */
+    pset = PMIX_NEW(prte_filem_base_process_set_t);
+    CHECK("process_set source rank invalid", PMIX_RANK_INVALID == pset->source.rank);
+    CHECK("process_set sink rank invalid", PMIX_RANK_INVALID == pset->sink.rank);
+    PMIX_RELEASE(pset);
+
+    /* file_set: NULL targets, NONE hints, UNKNOWN type; destructor frees
+     * the strings we hand it */
+    fset = PMIX_NEW(prte_filem_base_file_set_t);
+    CHECK("file_set local_target NULL", NULL == fset->local_target);
+    CHECK("file_set remote_target NULL", NULL == fset->remote_target);
+    CHECK("file_set local hint NONE", PRTE_FILEM_HINT_NONE == fset->local_hint);
+    CHECK("file_set remote hint NONE", PRTE_FILEM_HINT_NONE == fset->remote_hint);
+    CHECK("file_set type UNKNOWN", PRTE_FILEM_TYPE_UNKNOWN == fset->target_flag);
+    fset->local_target = strdup("/some/local/path");
+    fset->remote_target = strdup("some/remote/path");
+    PMIX_RELEASE(fset);
+
+    /* request: empty lists, UNKNOWN movement type; appending members and
+     * releasing must drain both lists */
+    req = PMIX_NEW(prte_filem_base_request_t);
+    CHECK("request process_sets empty", 0 == pmix_list_get_size(&req->process_sets));
+    CHECK("request file_sets empty", 0 == pmix_list_get_size(&req->file_sets));
+    CHECK("request movement UNKNOWN", PRTE_FILEM_MOVE_TYPE_UNKNOWN == req->movement_type);
+
+    pset = PMIX_NEW(prte_filem_base_process_set_t);
+    pmix_list_append(&req->process_sets, &pset->super);
+    fset = PMIX_NEW(prte_filem_base_file_set_t);
+    fset->local_target = strdup("f");
+    pmix_list_append(&req->file_sets, &fset->super);
+    CHECK("request holds one process_set", 1 == pmix_list_get_size(&req->process_sets));
+    CHECK("request holds one file_set", 1 == pmix_list_get_size(&req->file_sets));
+    /* releasing the request must drain and release both members */
+    PMIX_RELEASE(req);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_classes\n");
+    }
+    return failures;
+}
+
+/*
+ * With no component selected, the global prte_filem is the "none" module
+ * from filem_base_frame.c.  Every slot must be a safe no-op.  Most
+ * importantly the fault_handler must be present and callable -- a NULL
+ * there is a crash on daemon-fault recovery -- and preposition must fire
+ * its completion callback so the state machine can advance.
+ */
+static int test_none_module(void)
+{
+    int failures = 0;
+    bool done = false;
+
+    /* every function pointer must be wired */
+    CHECK("none init set", NULL != prte_filem.filem_init);
+    CHECK("none finalize set", NULL != prte_filem.filem_finalize);
+    CHECK("none fault_handler set", NULL != prte_filem.fault_handler);
+    CHECK("none put set", NULL != prte_filem.put);
+    CHECK("none get set", NULL != prte_filem.get);
+    CHECK("none rm set", NULL != prte_filem.rm);
+    CHECK("none wait set", NULL != prte_filem.wait);
+    CHECK("none wait_all set", NULL != prte_filem.wait_all);
+    CHECK("none preposition set", NULL != prte_filem.preposition_files);
+    CHECK("none link_local set", NULL != prte_filem.link_local_files);
+
+    /* the no-op transfer slots all return success */
+    CHECK("none put succeeds", PRTE_SUCCESS == prte_filem.put(NULL));
+    CHECK("none put_nb succeeds", PRTE_SUCCESS == prte_filem.put_nb(NULL));
+    CHECK("none get succeeds", PRTE_SUCCESS == prte_filem.get(NULL));
+    CHECK("none get_nb succeeds", PRTE_SUCCESS == prte_filem.get_nb(NULL));
+    CHECK("none rm succeeds", PRTE_SUCCESS == prte_filem.rm(NULL));
+    CHECK("none rm_nb succeeds", PRTE_SUCCESS == prte_filem.rm_nb(NULL));
+    CHECK("none wait succeeds", PRTE_SUCCESS == prte_filem.wait(NULL));
+    CHECK("none wait_all succeeds", PRTE_SUCCESS == prte_filem.wait_all(NULL));
+    CHECK("none link_local succeeds", PRTE_SUCCESS == prte_filem.link_local_files(NULL, NULL));
+
+    /* the fault handler must be safe to invoke (it is a no-op for none) */
+    prte_filem.fault_handler(NULL);
+    CHECK("none fault_handler returns", true);
+
+    /* preposition must fire the completion callback with SUCCESS even
+     * though it stages nothing -- otherwise the DVM hangs at VM_READY */
+    cb_fired = false;
+    cb_status = -1;
+    CHECK("none preposition succeeds",
+          PRTE_SUCCESS == prte_filem.preposition_files(NULL, completion_cb, &done));
+    CHECK("none preposition fired callback", cb_fired);
+    CHECK("none preposition callback status SUCCESS", PRTE_SUCCESS == cb_status);
+    CHECK("none preposition passed cbdata", done);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_none_module\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* open the framework so its verbosity channel is valid and the
+     * request classes are registered.  We deliberately do NOT run
+     * prte_filem_base_select(), so the global prte_filem remains the
+     * default "none" module that frame.c installs.
+     */
+    rc = pmix_mca_base_framework_open(&prte_filem_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "filem framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
+    failures += test_classes();
+    failures += test_none_module();
+
+    (void) pmix_mca_base_framework_close(&prte_filem_base_framework);
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all filem unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d filem unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

A review of `src/mca/filem` turned up a chain of bugs that made file
pre-positioning (`--preload-files` / `--preload-binary`) unusable, plus a
latent crash unrelated to preloading. End to end, a preloaded binary never
launched, and several error paths leaked or corrupted state.

The individual problems:

- **NULL `fault_handler` in the "none" filem module.** `routed_radix.c` calls
  `prte_filem.fault_handler()` unconditionally on every daemon-fault recovery.
  When no filem component is selected (a supported configuration) the default
  "none" module left that slot NULL, so the first daemon fault crashed the DVM.
- **`create_link` returned a stale error on success.** `pmix_os_dirpath_create`
  returns `PMIX_ERR_EXISTS` (-11) for the already-existing proc session dir --
  the normal case -- and the code tolerated it but never reset `rc`, so a
  successful symlink returned -11 and aborted the launch. It also built the
  symlink source from the job session dir instead of `top_session_dir` (where
  the bytes are actually written), producing a dangling link.
- **Preloaded binary linked in the wrong place.** `--preload-binary` sets
  `PRTE_APP_SSNDIR_CWD`, which makes every proc's cwd the *job* session dir, but
  the binary was linked into the *per-proc* dir, so `./<binary>` never resolved.
- **`setup_path` dereferenced `app->job`.** That back-pointer is only set on the
  HNP and is never serialized into the launch message, so it is NULL on any
  daemon -- and `--preload-binary` (which sets `SSNDIR_CWD`) segfaulted the
  daemon on it.
- **`strdup(NULL)` in the spawn path.** `--set-cwd-to-session-dir` deliberately
  leaves `app->app.cwd` NULL (the cwd is chosen on the backend), but `prte()`
  copied it into the PMIx app array with an unguarded `strdup`, crashing the
  launcher before submit.
- **A use-after-free in `raw_preposition_files`** when a later preload file
  failed to open (the outbound was freed with live `send_chunk` events still
  queued), plus assorted receive-side leaks and one dangling-list-pointer
  latent use-after-free.

## What this does

Nine focused commits, one logical fix each: the "none" fault_handler no-op; the
dormant base RML service's inverted stop-guard and a path leak; the receive-path
leaks/dangling pointers; the `create_link` return-code/source/EXE-target fixes;
the preposition open-failure use-after-free; the `odls setup_path` `app->job`
segfault; the `prte` `strdup(NULL)` segfault; a new `test/unit/filem` unit test;
and a `--preload-binary` cross-node test for the dockerswarm harness.

## Verification

- Clean warning-free build (`--enable-debug`); `make check` passes all four
  unit suites, including the new `test_filem`.
- The dockerswarm harness suite is **19/19**, including the new preload-binary
  cross-node test: a marker binary compiled on node1 only runs on node2+node3,
  which can only work if staging actually delivered and linked the bytes.
- `--preload-binary` and `--set-cwd-to-session-dir` verified end to end on a
  single host and across the swarm.

## Not fixed here (filed for follow-up)

- openpmix/prrte#2525 -- `--preload-files` **data** files still land in the
  per-proc session dir while the cwd is elsewhere, so they're unreachable by a
  bare relative path. Needs a decision on the intended cwd/link semantics.
- openpmix/prrte#2526 -- the dockerswarm `cleanup_swarm` helper doesn't purge
  `pmix.*` rendezvous files, which can cause spurious elastic-test failures
  after manual runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
