### PR TITLE
grpcomm/direct: fix collective-path memory-safety bugs, add a unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ test/unit/ess/Makefile
 test/unit/ess/test_ess
 test/unit/filem/Makefile
 test/unit/filem/test_filem
+test/unit/grpcomm/Makefile
+test/unit/grpcomm/test_grpcomm
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -35,5 +35,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/errmgr/Makefile
         test/unit/ess/Makefile
         test/unit/filem/Makefile
+        test/unit/grpcomm/Makefile
     ])
 ])

--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -214,9 +214,42 @@ the framework makes sense:
   which succeeds when the installed PMIx advertises `PMIX_CAP_GROUP_FT`.
   Any new group-FT code must live behind that guard, and you must build
   against a new-enough PMIx (and re-run `autogen.pl`) to exercise it.
+- **Every entry-point handler owns its caddy/op — release it on *all*
+  paths.** `fence`/`group`/`xcast_nb` each allocate a heap object
+  (`prte_pmix_fence_caddy_t`, `prte_pmix_grp_caddy_t`, or the xcast `op_t`),
+  thread-shift it to the handler, and cache only the *callback pointers*
+  (`cbfunc`/`cbdata`) into the long-lived tracker. The caddy/op itself is
+  therefore consumed by the handler and must be `PMIX_RELEASE`d before it
+  returns — on the success path just as much as the error paths. It is not
+  parked on any list and the tracker does not own it, so a missing release
+  is a per-collective leak in a hot path (this exact bug existed in
+  `begin_xcast`, the non-cancel `group()` returns, and `fence_recv`'s
+  `info` array). When you add a return to one of these handlers, ask "what
+  did I allocate that nothing else owns yet?" and free it.
+- **Unpack failures must bail, not fall through.** The recv handlers start
+  by unpacking a signature into a NULL-initialized pointer; on failure the
+  unpack helper leaves that pointer NULL. Every such failure must `return`
+  immediately — the very next step dereferences the signature, so a logged
+  error without a return is a NULL-deref crash on a truncated/corrupt RML
+  message.
 - **Standard PRRTE rules apply:** `prte_config.h` first, constant-on-left
   comparisons, braces on every block, `PRTE_ERROR_LOG`/`PMIX_ERROR_LOG`
   for unexpected errors, no new compiler warnings.
+
+---
+
+## Testing
+
+A structural unit test lives at
+[`test/unit/grpcomm/test_grpcomm.c`](../../../test/unit/grpcomm/) and is
+wired into `make check`. It cannot drive a real collective (that needs a
+live DVM — use the integration/dockerswarm harnesses), but it guards the
+invariants that hold with no DVM: the direct module's vtable is fully
+wired, the component is named `direct`, `prte_grpcomm_base.context_id`
+starts at `UINT32_MAX`, and every signature/tracker/caddy class
+constructs with the documented defaults (all rollup counters zero, the
+group tracker's info-lists opened) and destructs without leaking or
+crashing. Extend it when you add a class or change a constructor default.
 
 ---
 

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -312,5 +312,19 @@ deletes the tracker — so a cancel/abort tears down the collective cleanly
   in-flight fence when a daemon fails (TODO to make it resilient). If you
   are adding fence resilience, that is the place — do not weaken it into a
   silent no-op.
+- **Free every allocation the handler still owns before it returns.** The
+  entry-point handlers (`begin_xcast`, `fence`, `group`) own the caddy/op
+  they were thread-shifted; the recv handlers own the info arrays / darrays
+  they unpack. The tracker caches only `cbfunc`/`cbdata`, never the caddy,
+  so the handler is the last owner. Historic leaks here — `begin_xcast`
+  never releasing the initiating `op_t`, the `group()` success returns
+  never releasing `cd`, and `fence_recv` never freeing its unpacked `info`
+  on the HNP-complete and intermediate paths — were all "return added, free
+  forgotten" mistakes. Trace each new `return` back to what it strands.
+- **`fence_recv`/`grp_recv` must `return` on a signature unpack failure.**
+  The signature pointer is NULL-initialized and left NULL on failure, and
+  the code immediately below dereferences it (`get_tracker(sig, …)`,
+  `sig->op`). Logging without returning turns a corrupt RML message into a
+  daemon crash.
 - Standard PRRTE rules: `prte_config.h` first, constant-on-left, braces
   everywhere, `PMIX_ERROR_LOG`/`PRTE_ERROR_LOG`, no new warnings.

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -70,7 +70,7 @@ PMIX_CLASS_INSTANCE(prte_grpcomm_direct_fence_signature_t,
                     pmix_object_t,
                     scon, sdes);
 
-static void sgcon(prte_grpcomm_direct_group_signature_t *p)\
+static void sgcon(prte_grpcomm_direct_group_signature_t *p)
 {
     p->op = PMIX_GROUP_NONE;
     p->groupID = NULL;

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -207,6 +207,8 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
     rc = fence_sig_unpack(buffer, &sig);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        /* sig is NULL on failure - bail rather than deref it in get_tracker */
+        return;
     }
 
     /* check for the tracker and create it if not found */

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -370,6 +370,12 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
             }
         }
     }
+    /* free the unpacked info.  The non-HNP rollup path above already freed and
+     * NULLed it before forwarding; on the HNP-complete path and on every
+     * intermediate (not-yet-complete) contribution it is still live here.
+     * PMIX_INFO_FREE is a no-op on a NULL pointer, so this covers all of them
+     * without double-freeing. */
+    PMIX_INFO_FREE(info, ninfo);
 }
 
 static void relcb(void *cbdata)

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -292,6 +292,7 @@ static void group(int sd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DESTRUCT(&sig);
+                goto error;
             }
 
         } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_LOCAL_COLLECTIVE_STATUS)) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -515,6 +515,8 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     rc = unpack_signature(buffer, &sig);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        /* sig is NULL on failure - bail rather than deref it below */
+        return;
     }
 
 #if PRTE_PMIX_HAVE_GROUP_FT

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -424,6 +424,10 @@ static void group(int sd, short args, void *cbdata)
     }
     PMIx_Info_list_release(grpinfo);
     PMIx_Info_list_release(endpts);
+    /* consumed - NULL them so the error label below does not double-release
+     * if a send fails past this point */
+    grpinfo = NULL;
+    endpts = NULL;
 
     /* if this is a bootstrap operation, send it directly to the HNP */
     if (coll->bootstrap) {
@@ -440,6 +444,7 @@ static void group(int sd, short args, void *cbdata)
             goto error;
         }
         PMIX_DESTRUCT(&sig);
+        PMIX_RELEASE(cd);
         return;
     }
     PMIX_DESTRUCT(&sig);
@@ -456,9 +461,20 @@ static void group(int sd, short args, void *cbdata)
         rc = prte_pmix_convert_rc(rc);
         goto error;
     }
+    PMIX_RELEASE(cd);
     return;
 
 error:
+    /* the grpinfo/endpts trackers are released (and NULLed) on the success
+     * path above; on any error jump to here before that point they are still
+     * open, so release them now.  The NULL guard makes this safe for the
+     * post-release send-failure jumps too. */
+    if (NULL != grpinfo) {
+        PMIx_Info_list_release(grpinfo);
+    }
+    if (NULL != endpts) {
+        PMIx_Info_list_release(endpts);
+    }
     if (NULL != cd->cbfunc) {
         cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
     }

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -168,6 +168,7 @@ int prte_grpcomm_direct_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIx_Data_buffer_destruct(&msg_copy);
+            PMIX_RELEASE(op);
             return rc;
         }
 
@@ -452,6 +453,7 @@ static void begin_xcast(int sd, short args, void* cbdata){
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
+        PMIX_RELEASE(op);
         return;
     }
 
@@ -484,8 +486,14 @@ static void begin_xcast(int sd, short args, void* cbdata){
             PMIX_RELEASE(pc);
         }
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
+        PMIX_RELEASE(op);
         return;
     }
+
+    /* the initiating op has now been packed and relayed to the master; it is
+     * not the op we track and complete (that one is built fresh on receipt),
+     * so discard it here */
+    PMIX_RELEASE(op);
 }
 
 static void send_ack_msg(

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem
+SUBDIRS = rmaps errmgr ess filem grpcomm

--- a/test/unit/grpcomm/Makefile.am
+++ b/test/unit/grpcomm/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_grpcomm
+
+test_grpcomm_SOURCES = \
+    test_grpcomm.c
+
+test_grpcomm_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_grpcomm

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the grpcomm framework.
+ *
+ * The substantive work of grpcomm -- the reliable xcast broadcast, the
+ * up-tree fence allgather, and the PMIx group construct/destruct/cancel
+ * collectives -- all rides the RML radix routing tree across a live DVM
+ * and cannot run without one; it is covered by the integration and
+ * dockerswarm harnesses.
+ *
+ * What *can* be exercised in isolation is the framework's structural
+ * contract and the constructor/destructor invariants that its collective
+ * code relies on:
+ *
+ *   1. The module contract.  grpcomm.h states that every function pointer
+ *      in prte_grpcomm_base_module_t "MUST be provided"; the sole
+ *      component, direct, is what the DVM always selects, so a regression
+ *      that left one of its seven slots NULL would crash at first use
+ *      (exactly the failure the errmgr logfn test guards against).  We
+ *      confirm all seven are wired and that the public entry points are
+ *      the ones the module advertises.
+ *
+ *   2. The component identity: name "direct", grpcomm v4 component.
+ *
+ *   3. The base globals: prte_grpcomm_base.context_id must start at
+ *      UINT32_MAX -- group construct hands it out and *decrements*, so a
+ *      wrong initial value would collide with bottom-up context ids.
+ *
+ *   4. The reference-counted signature/tracker/caddy classes: their
+ *      constructors must establish the documented defaults (the group
+ *      tracker in particular must open its grpinfo/endpts info-lists, and
+ *      every counter must start at zero so a rollup cannot complete
+ *      early), and their destructors must free their owned members --
+ *      including the NULL case -- without crashing.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "constants.h"
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/grpcomm/grpcomm.h"
+#include "src/mca/grpcomm/base/base.h"
+#include "src/mca/grpcomm/direct/grpcomm_direct.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/*
+ * Every slot of the direct module's vtable must be non-NULL, and the
+ * collective entry points must be the public functions the rest of the
+ * tree calls.  init/finalize/fault_handler are file-static in the
+ * component, so we can only assert they are wired, not their identity.
+ */
+static int test_module_contract(void)
+{
+    int failures = 0;
+    prte_grpcomm_base_module_t *m = &prte_grpcomm_direct_module;
+
+    CHECK("init set", NULL != m->init);
+    CHECK("finalize set", NULL != m->finalize);
+    CHECK("fault_handler set", NULL != m->fault_handler);
+    CHECK("xcast set", NULL != m->xcast);
+    CHECK("xcast_nb set", NULL != m->xcast_nb);
+    CHECK("fence set", NULL != m->fence);
+    CHECK("group set", NULL != m->group);
+
+    /* the public entry points must be exactly what the module advertises */
+    CHECK("xcast identity", m->xcast == prte_grpcomm_direct_xcast);
+    CHECK("xcast_nb identity", m->xcast_nb == prte_grpcomm_direct_xcast_nb);
+    CHECK("fence identity", m->fence == prte_grpcomm_direct_fence);
+    CHECK("group identity", m->group == prte_grpcomm_direct_group);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_module_contract\n");
+    }
+    return failures;
+}
+
+/*
+ * The direct component identifies itself as the grpcomm component named
+ * "direct".  Selection depends on that name, so guard it.
+ */
+static int test_component_identity(void)
+{
+    int failures = 0;
+    prte_grpcomm_base_component_t *c = &prte_mca_grpcomm_direct_component.super;
+
+    CHECK("component name", 0 == strcmp(c->pmix_mca_component_name, "direct"));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_component_identity\n");
+    }
+    return failures;
+}
+
+/*
+ * The group context-id pool counts DOWN from UINT32_MAX so DVM-assigned
+ * ids never collide with ids handed out from the bottom of the range.
+ * The static initializer in grpcomm_base_frame.c must establish that.
+ */
+static int test_base_context_id(void)
+{
+    int failures = 0;
+
+    CHECK("context_id pool start", UINT32_MAX == prte_grpcomm_base.context_id);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_base_context_id\n");
+    }
+    return failures;
+}
+
+/*
+ * Constructor defaults and destructor safety for every reference-counted
+ * class the component defines.  The defaults are load-bearing: a rollup
+ * completes when nreported == nexpected, so a non-zero counter default
+ * would let a collective finish before anyone reported.
+ */
+static int test_classes(void)
+{
+    int failures = 0;
+
+    /* fence signature: empty proc set */
+    prte_grpcomm_direct_fence_signature_t *fsig =
+        PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
+    CHECK("fence sig signature NULL", NULL == fsig->signature);
+    CHECK("fence sig sz 0", 0 == fsig->sz);
+    /* exercise the destructor's free(signature) path */
+    fsig->sz = 2;
+    fsig->signature = (pmix_proc_t *) malloc(fsig->sz * sizeof(pmix_proc_t));
+    PMIX_RELEASE(fsig);
+
+    /* group signature: NONE op, no members, all flags clear */
+    prte_grpcomm_direct_group_signature_t *gsig =
+        PMIX_NEW(prte_grpcomm_direct_group_signature_t);
+    CHECK("grp sig op NONE", PMIX_GROUP_NONE == gsig->op);
+    CHECK("grp sig groupID NULL", NULL == gsig->groupID);
+    CHECK("grp sig assignID false", !gsig->assignID);
+    CHECK("grp sig ctxid_assigned false", !gsig->ctxid_assigned);
+    CHECK("grp sig members NULL", NULL == gsig->members);
+    CHECK("grp sig nmembers 0", 0 == gsig->nmembers);
+    CHECK("grp sig bootstrap 0", 0 == gsig->bootstrap);
+    CHECK("grp sig follower false", !gsig->follower);
+    CHECK("grp sig addmembers NULL", NULL == gsig->addmembers);
+    CHECK("grp sig naddmembers 0", 0 == gsig->naddmembers);
+    CHECK("grp sig final_order NULL", NULL == gsig->final_order);
+    CHECK("grp sig nfinal 0", 0 == gsig->nfinal);
+    /* exercise the destructor's free(groupID)/free(members)/free(addmembers) */
+    gsig->groupID = strdup("test-group");
+    gsig->nmembers = 1;
+    gsig->members = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
+    gsig->naddmembers = 1;
+    gsig->addmembers = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
+    PMIX_RELEASE(gsig);
+
+    /* fence tracker: clean rollup counters, constructed bucket */
+    prte_grpcomm_fence_t *fc = PMIX_NEW(prte_grpcomm_fence_t);
+    CHECK("fence trk sig NULL", NULL == fc->sig);
+    CHECK("fence trk status SUCCESS", PMIX_SUCCESS == fc->status);
+    CHECK("fence trk dmns NULL", NULL == fc->dmns);
+    CHECK("fence trk ndmns 0", 0 == fc->ndmns);
+    CHECK("fence trk nexpected 0", 0 == fc->nexpected);
+    CHECK("fence trk nreported 0", 0 == fc->nreported);
+    CHECK("fence trk timeout 0", 0 == fc->timeout);
+    CHECK("fence trk cbfunc NULL", NULL == fc->cbfunc);
+    PMIX_RELEASE(fc);
+
+    /* group tracker: every counter zero, both info-lists opened */
+    prte_grpcomm_group_t *gc = PMIX_NEW(prte_grpcomm_group_t);
+    CHECK("grp trk sig NULL", NULL == gc->sig);
+    CHECK("grp trk status SUCCESS", PMIX_SUCCESS == gc->status);
+    CHECK("grp trk dmns NULL", NULL == gc->dmns);
+    CHECK("grp trk ndmns 0", 0 == gc->ndmns);
+    CHECK("grp trk bootstrap false", !gc->bootstrap);
+    CHECK("grp trk nexpected 0", 0 == gc->nexpected);
+    CHECK("grp trk nreported 0", 0 == gc->nreported);
+    CHECK("grp trk nleaders 0", 0 == gc->nleaders);
+    CHECK("grp trk nleaders_reported 0", 0 == gc->nleaders_reported);
+    CHECK("grp trk nfollowers 0", 0 == gc->nfollowers);
+    CHECK("grp trk nfollowers_reported 0", 0 == gc->nfollowers_reported);
+    CHECK("grp trk assignID false", !gc->assignID);
+    CHECK("grp trk grpinfo opened", NULL != gc->grpinfo);
+    CHECK("grp trk endpts opened", NULL != gc->endpts);
+    PMIX_RELEASE(gc);
+
+    /* fence caddy: all borrowed pointers NULL, sizes zero */
+    prte_pmix_fence_caddy_t *fcd = PMIX_NEW(prte_pmix_fence_caddy_t);
+    CHECK("fence caddy sig NULL", NULL == fcd->sig);
+    CHECK("fence caddy buf NULL", NULL == fcd->buf);
+    CHECK("fence caddy procs NULL", NULL == fcd->procs);
+    CHECK("fence caddy nprocs 0", 0 == fcd->nprocs);
+    CHECK("fence caddy data NULL", NULL == fcd->data);
+    CHECK("fence caddy cbfunc NULL", NULL == fcd->cbfunc);
+    PMIX_RELEASE(fcd);
+
+    /* group caddy (lives in the framework header): NONE op, empty */
+    prte_pmix_grp_caddy_t *gcd = PMIX_NEW(prte_pmix_grp_caddy_t);
+    CHECK("grp caddy op NONE", PMIX_GROUP_NONE == gcd->op);
+    CHECK("grp caddy grpid NULL", NULL == gcd->grpid);
+    CHECK("grp caddy procs NULL", NULL == gcd->procs);
+    CHECK("grp caddy nprocs 0", 0 == gcd->nprocs);
+    CHECK("grp caddy directives NULL", NULL == gcd->directives);
+    CHECK("grp caddy cbfunc NULL", NULL == gcd->cbfunc);
+    /* exercise the destructor's free(grpid) path */
+    gcd->grpid = strdup("test-group");
+    PMIX_RELEASE(gcd);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_classes\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_module_contract();
+    failures += test_component_identity();
+    failures += test_base_context_id();
+    failures += test_classes();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all grpcomm unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d grpcomm unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

A deep review of the `grpcomm` framework (the sole `direct` component) turned
up several memory-safety and robustness bugs, all on the collective
success/error paths. This PR fixes them, adds a structural unit test, and
records the invariants they violated in the framework guides. Each fix is a
separate commit for reviewability/bisection.

## Fixes

- **xcast: initiating `op_t` leaked on every broadcast.** `begin_xcast()`
  packs and relays the initiating op to the HNP but never released it (its
  own comment says it is "discarded"). Since xcast underlies every launch,
  wireup, and daemon command, this leaked an `op_t` plus its payload on the
  hottest collective path. Also fixed a sibling leak on the `xcast_nb()`
  copy-payload failure path.
- **group: request caddy leaked on success.** `group()` caches only the
  caddy's callback pointers into the tracker, so it owns the caddy — but its
  two success returns never released it, leaking the caddy and its `strdup`'d
  groupID per group construct/destruct. Also closed the matching
  `grpinfo`/`endpts` info-list leak on the error label.
- **group: use-after-free on a malformed bootstrap directive.** A failed
  `PMIX_GROUP_BOOTSTRAP` conversion `PMIX_DESTRUCT`'d the signature but fell
  through and kept using it. Now jumps to the error label like every other
  directive-parse failure.
- **fence: unpacked `info` array leaked** on the HNP-complete path and on
  every intermediate contribution (freed only on the non-HNP rollup path).
- **fence/group: NULL-deref on a corrupt message.** `fence_recv()` and
  `grp_recv()` logged a signature-unpack failure but fell through to
  dereference the (NULL) signature; a truncated/garbled RML message crashed
  the daemon. Both now return, matching the release handlers.
- Cosmetic: removed a stray line-continuation after `sgcon()`.

## Test

New `test/unit/grpcomm/test_grpcomm.c`, wired into `make check`. It guards the
DVM-independent contract: the direct module vtable is fully wired, the
component is named `direct`, `context_id` starts at `UINT32_MAX`, and every
signature/tracker/caddy class constructs with documented defaults (all rollup
counters zero, group info-lists opened) and destructs without leaking.

## Docs

Both `grpcomm` AGENTS.md guides gain the caddy/op-ownership rule and the
"unpack failure must return" rule.

## Not addressed here

The fence fault handler still tears down the whole job on daemon loss during
an in-flight fence, rather than repairing like xcast/group do. That is a
larger, separate piece of work tracked in #2528.

## Testing done

- Warning-free `--enable-debug` build.
- `make check` passes (including the new `test_grpcomm`).
- Full multi-node `contrib/dockerswarm` suite passes 19/19 — non-elastic
  `prterun`, `--preload-binary` cross-node staging, elastic grow/shrink
  (flat and radix-2 deep-tree relay), exercising the xcast completion-callback
  and fence relay paths end-to-end.
