### PR TITLE
odls: fix launch-path leaks, prevent multi-app launch hang, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ test/unit/filem/Makefile
 test/unit/filem/test_filem
 test/unit/grpcomm/Makefile
 test/unit/grpcomm/test_grpcomm
+test/unit/odls/Makefile
+test/unit/odls/test_odls
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -36,5 +36,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/ess/Makefile
         test/unit/filem/Makefile
         test/unit/grpcomm/Makefile
+        test/unit/odls/Makefile
     ])
 ])

--- a/src/event/event.c
+++ b/src/event/event.c
@@ -59,7 +59,17 @@ prte_event_t *prte_event_alloc(void)
 {
     prte_event_t *ev;
 
-    ev = (prte_event_t *) malloc(sizeof(prte_event_t));
+    /* Zero-initialize the event.  Callers allocate the event here but
+     * only assign it to an event base later (e.g. the odls launch-local
+     * and prte_timer_t caddies event_assign it when they are activated),
+     * and every such object's destructor frees the event with
+     * prte_event_free() -- libevent's event_free(), which calls
+     * event_del() and dereferences the event's internal fields.  On an
+     * uninitialized (raw malloc'd) event those fields are garbage and the
+     * free crashes; a zeroed event has a NULL base, which event_del()
+     * handles gracefully, and a later event_assign() overwrites the
+     * zeros. */
+    ev = (prte_event_t *) calloc(1, sizeof(prte_event_t));
     return ev;
 }
 

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -432,6 +432,44 @@ computed proc state.
   them onto a worker thread.
 - **`chdir` bookkeeping.** `launch_local`/`restart_proc` bounce the daemon's
   cwd per app and must always `chdir` back to `basedir` before returning.
+  `launch_local` establishes `basedir` with `getcwd` at entry; if that fails
+  it must **not** fall through to the shared `chdir(basedir)` cleanup (the
+  buffer is uninitialized) — bail directly.
+- **Every fatal launch error aborts the whole job.** All fatal paths in
+  `launch_local` — `setup_path`, `setup_fork`, `filem`, `check_context_app`,
+  `init_sys_limits`, the `chdir(basedir)`-back failure, the sys-limit
+  giveups, **and** the per-child IOF-setup failures — use the same idiom:
+  flag the directly-affected procs with `PRTE_ODLS_SET_ERROR(job, rc, j)`
+  (or activate the single failing child) **and then**
+  `PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH)` before
+  `goto GETOUT`. Failing only *this app's* procs is **not** enough: `goto
+  GETOUT` skips every later app, whose procs stay in `INIT` forever, and on
+  a real daemon the errmgr only reports `FAILED_TO_LAUNCH` once
+  `num_terminated == num_local_procs` — so the job hangs. The job-state
+  activation is what drives the prompt, uniform teardown. Keep new fatal
+  paths on this idiom.
+- **The `child` loop variable is only valid inside the per-child loop.** In
+  `launch_local`, `child` is `NULL` at function entry and, in the per-*app*
+  loop (before the inner per-child loop runs), is either `NULL` (first app)
+  or a **stale** proc left over from the previous app. Error paths in the
+  per-app section (e.g. the `chdir(basedir)`-back failure) must **not**
+  dereference `child` — use the job-abort idiom above.
+- **Every exit from `spawn_proc` must `PMIX_RELEASE(cd)`.** The spawn caddy
+  is `PMIX_NEW`'d in `launch_local` and owned by `spawn_proc`; the success
+  tail, the `errorout:` path, **and** the early `PRTE_JOB_DO_NOT_SPAWN`
+  return all have to release it, or every donotlaunch/mapping-only proc
+  leaks a caddy (plus its `wdir` string).
+- **`setup_path` writes through to `app->cwd`.** `launch_local` calls it as
+  `setup_path(jobdat, app, &app->cwd)`, so it overwrites (and must first
+  free) the app's existing `cwd`; `restart_proc` instead passes a local
+  temp. Don't assume `*wdir` starts NULL.
+- **Blocking base fns own their lock.** `get_add_procs_data` and
+  `construct_child_list` construct a `prte_pmix_lock_t` up front; **every**
+  exit must destruct it (and free any `pmix_info_t`/`PMIX_INFO_LIST` it
+  built). Prefer a single `goto REPORT_ERROR`/cleanup label over a bare
+  `return` in the middle — a stray `return` there both leaks the lock and,
+  on the daemon side, skips the `NEVER_LAUNCHED` activation that keeps the
+  HNP from hanging.
 - Standard PRRTE rules apply: `prte_config.h` first, braces on every block,
   `NULL ==`/constant-on-left comparisons, `PRTE_ERROR_LOG` for unexpected
   errors, no new compiler warnings.
@@ -454,6 +492,30 @@ Useful tuning params: `--prtemca odls_base_num_threads N` /
 `--prtemca odls_base_exec_agent CMD` (wrap every exec),
 `--prtemca odls_base_signal_direct_children_only 1` (don't signal the
 child's whole process group).
+
+---
+
+## Testing
+
+The fork/exec/waitpid/kill lifecycle runs only against real child
+processes inside a live DVM, so most of odls is covered by the
+integration harness — e.g. `prterun -n 4 hostname` (basic launch),
+MPMD (`prterun -n 2 echo a : -n 2 hostname`, which walks the per-app
+`setup_path` loop), and a non-zero exit (`prterun -n 2 sh -c 'exit 3'`,
+which exercises `wait_local_proc`'s status decode).
+
+What runs without a DVM is the **structural** contract, in
+[`test/unit/odls/test_odls.c`](../../../test/unit/odls/) (wired into
+`make check`): the pdefault module vtable is fully wired and reuses the
+base `get_add_procs_data`; the component names itself `"pdefault"`; the
+`PRTE_DAEMON_*` command bytes are pairwise unique; the
+`prte_odls_child_err_t` fatal/warn split holds (NONE == 0, every warn
+code sorts after every fatal code); and the two caddy classes
+(`prte_odls_spawn_caddy_t`, `prte_odls_launch_local_t`) construct with
+the documented NULL/zero defaults and destruct cleanly (both the
+all-NULL and the fully-populated paths). Add structural regression
+guards here; anything that needs a running launch belongs in the
+integration harness.
 
 ---
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -311,7 +311,10 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
         if (PMIX_SUCCESS != (ret = PMIx_generate_regex(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
-            PMIX_INFO_FREE(cd.info, cd.ninfo);
+            if (NULL != procs) {
+                PMIx_Argv_free(procs);
+            }
+            PMIX_INFO_LIST_RELEASE(ilist);
             return prte_pmix_convert_status(ret);
         }
         free(tmp);
@@ -327,7 +330,8 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
         if (PMIX_SUCCESS != (ret = PMIx_generate_ppn(tmp, &regex))) {
             PMIX_ERROR_LOG(ret);
             free(tmp);
-            PMIX_INFO_FREE(cd.info, cd.ninfo);
+            /* list and procs were already freed above */
+            PMIX_INFO_LIST_RELEASE(ilist);
             return prte_pmix_convert_status(ret);
         }
         free(tmp);
@@ -382,6 +386,10 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
     if (PMIX_SUCCESS != ret) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(ret));
+        /* the callback that would have freed cd.info will never fire */
+        if (NULL != cd.info) {
+            PMIX_INFO_FREE(cd.info, cd.ninfo);
+        }
         rc = PRTE_ERROR;
     } else {
         PRTE_PMIX_WAIT_THREAD(&cd.lock);
@@ -467,6 +475,8 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 rc = prte_pmix_convert_status(rc);
+                PMIX_DATA_BUFFER_DESTRUCT(&jdbuf);
+                PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
                 goto REPORT_ERROR;
             }
             /* unpack each job and add it to the local prte_job_data array */
@@ -593,7 +603,8 @@ next:
         if (NULL == jdata->schizo) {
             pmix_show_help("help-schizo-base.txt", "no-proxy", true,
                            prte_tool_basename, "NULL");
-            return 1;
+            rc = PRTE_ERR_NOT_FOUND;
+            goto REPORT_ERROR;
         }
     } else {
         prte_set_job_data_object(jdata);
@@ -615,7 +626,8 @@ next:
             if (NULL != tmp) {
                 free(tmp);
             }
-            return 1;
+            rc = PRTE_ERR_NOT_FOUND;
+            goto REPORT_ERROR;
         }
         if (NULL != tmp) {
             free(tmp);
@@ -856,6 +868,11 @@ static int setup_path(prte_job_t *job, prte_app_context_t *app, char **wdir)
         if (NULL == getcwd(dir, sizeof(dir))) {
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
+        /* free any prior value before overwriting - our caller may pass
+         * &app->cwd, which already holds an owned string */
+        if (NULL != *wdir) {
+            free(*wdir);
+        }
         *wdir = strdup(dir);
         PMIx_Setenv("PWD", dir, true, &app->env);
     } else {
@@ -887,6 +904,10 @@ static int setup_path(prte_job_t *job, prte_app_context_t *app, char **wdir)
          */
         if (NULL == getcwd(dir, sizeof(dir))) {
             return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        /* free any prior value before overwriting (see note above) */
+        if (NULL != *wdir) {
+            free(*wdir);
         }
         *wdir = strdup(dir);
         PMIx_Setenv("PWD", dir, true, &app->env);
@@ -965,6 +986,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         // if we aren't spawning the apps, then just mark them as
         // terminated and return
         PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_TERMINATED);
+        PMIX_RELEASE(cd);
         return;
     }
 
@@ -1300,8 +1322,15 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
      * to this place as our default directory
      */
     if (NULL == getcwd(basedir, sizeof(basedir))) {
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
-        goto ERROR_OUT;
+        /* basedir is unusable, so do NOT fall through to ERROR_OUT (which
+         * would chdir() to an uninitialized buffer). Fail the job we were
+         * asked to launch and release the caddy directly. */
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        if (NULL != (jobdat = prte_get_job_data_object(job))) {
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
+        }
+        PMIX_RELEASE(caddy);
+        return;
     }
     /* find the jobdat for this job */
     if (NULL == (jobdat = prte_get_job_data_object(job))) {

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -1289,7 +1289,6 @@ static void process_envars(prte_job_t *jdata,
     }
 }
 
-
 void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
 {
     prte_app_context_t *app;
@@ -1434,7 +1433,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
              * to flag all the other procs from the app_context as having "not failed"
              * so we can report things out correctly
              */
-            PRTE_ODLS_SET_ERROR(job, PMIX_ERR_SYS_LIMITS_FILES, j);
+            PRTE_ODLS_SET_ERROR(job, rc, j);
             PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
@@ -1458,57 +1457,33 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                                  "%s odls:launch:setup_fork failed with error %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
 
-            /* do not ERROR_LOG this failure - it will be reported
-             * elsewhere. The launch is going to fail. Since we could have
-             * multiple app_contexts, we need to ensure that we flag only
-             * the correct one that caused this operation to fail. We then have
-             * to flag all the other procs from the app_context as having "not failed"
-             * so we can report things out correctly
-             */
-            /* cycle through children to find those for this jobid */
-            for (idx = 0; idx < prte_local_children->size; idx++) {
-                child = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, idx);
-                if (NULL == child) {
-                    continue;
-                }
-                if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
-                    child->exit_code = PRTE_PROC_STATE_FAILED_TO_LAUNCH;
-                    PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
-                }
-            }
+            /* do not ERROR_LOG this failure - it will be reported elsewhere.
+             * Flag this app's procs as failed (with the correct error code),
+             * then drive the whole job down. Aborting the job as a whole -
+             * rather than just failing this app's procs - is what keeps a
+             * multi-app launch from hanging: any procs belonging to apps we
+             * have not reached yet would otherwise be left in INIT forever,
+             * and on a real daemon the errmgr only reports FAILED_TO_LAUNCH
+             * once every local proc has been accounted for. */
+            PRTE_ODLS_SET_ERROR(job, rc, j);
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
 
         /* setup any local files that were prepositioned for us */
         if (PRTE_SUCCESS != (rc = prte_filem.link_local_files(jobdat, app))) {
-            /* cycle through children to find those for this jobid */
-            for (idx = 0; idx < prte_local_children->size; idx++) {
-                child = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, idx);
-                if (NULL == child) {
-                    continue;
-                }
-                if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
-                    child->exit_code = rc;
-                    PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
-                }
-            }
+            /* flag this app's procs and abort the whole job (see setup_fork) */
+            PRTE_ODLS_SET_ERROR(job, rc, j);
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
 
         rc = pmix_util_check_context_app(&app->app, app->cwd, app->env);
         /* do not ERROR_LOG - it will be reported elsewhere */
         if (PMIX_SUCCESS != rc) {
-            /* cycle through children to find those for this jobid */
-            for (idx = 0; idx < prte_local_children->size; idx++) {
-                child = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, idx);
-                if (NULL == child) {
-                    continue;
-                }
-                if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
-                    child->exit_code = rc;
-                    PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
-                }
-            }
+            /* flag this app's procs and abort the whole job (see setup_fork) */
+            PRTE_ODLS_SET_ERROR(job, rc, j);
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
 
@@ -1516,17 +1491,9 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_util_init_sys_limits(&msg))) {
             pmix_show_help("help-prte-odls-default.txt", "set limit", true,
                            prte_process_info.nodename, app, __FILE__, __LINE__, msg);
-            /* cycle through children to find those for this jobid */
-            for (idx = 0; idx < prte_local_children->size; idx++) {
-                child = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, idx);
-                if (NULL == child) {
-                    continue;
-                }
-                if (PMIX_CHECK_NSPACE(job, child->name.nspace) && j == (int) child->app_idx) {
-                    child->exit_code = rc;
-                    PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
-                }
-            }
+            /* flag this app's procs and abort the whole job (see setup_fork) */
+            PRTE_ODLS_SET_ERROR(job, rc, j);
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
 
@@ -1538,7 +1505,12 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
          * to their current location
          */
         if (0 != chdir(basedir)) {
-            PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
+            /* NOTE: we are still in the per-app loop, before the per-child
+             * loop that assigns "child", so "child" may be NULL (first app)
+             * or a stale proc from a prior app - do not dereference it. Fail
+             * the job as a whole. */
+            PRTE_ODLS_SET_ERROR(job, PRTE_ERR_NOT_FOUND, j);
+            PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
             goto GETOUT;
         }
 
@@ -1644,6 +1616,10 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                 child->exit_code = rc;
                 PMIX_RELEASE(cd);
                 PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
+                /* abort the whole job (see setup_fork): other children of
+                 * this app - and later apps - that we will now never launch
+                 * must not be left to strand it */
+                PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
                 goto GETOUT;
             }
             if (PRTE_FLAG_TEST(jobdat, PRTE_JOB_FLAG_FORWARD_OUTPUT)) {
@@ -1651,8 +1627,11 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                 rc = prte_iof_base_setup_parent(&child->name, &cd->opts);
                 if (PRTE_SUCCESS != rc) {
                     PRTE_ERROR_LOG(rc);
+                    child->exit_code = rc;
                     PMIX_RELEASE(cd);
                     PRTE_ACTIVATE_PROC_STATE(&child->name, PRTE_PROC_STATE_FAILED_TO_LAUNCH);
+                    /* abort the whole job (see setup_fork) */
+                    PRTE_ACTIVATE_JOB_STATE(jobdat, PRTE_JOB_STATE_FAILED_TO_LAUNCH);
                     goto GETOUT;
                 }
             }

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -298,6 +298,14 @@ def parse_map(raw):
         if pm and cur is not None:
             cur.procs.append(Proc(int(pm.group(1)), int(pm.group(2)),
                                   _parse_bound(pm.group(3))))
+    if not nodes:
+        # a JOB MAP block was present (checked above) but not a single node
+        # line matched NODE_RE - the output format is not the simple
+        # user-facing map we parse (e.g. the verbose --display-devel-map
+        # form). Treat that as a parse failure so the caller reports a clean
+        # FAIL rather than handing an empty map to the checkers (which would
+        # divide by zero on the node count).
+        raise ParseError("JOB MAP block present but no node lines parsed")
     return ParsedMap(map_base, map_mods, hm.group(2), hm.group(3), cpu_type,
                      nodes)
 
@@ -655,6 +663,11 @@ def _expected_rank_by_node(node_order, counts_by_name, n):
     rem = dict(counts_by_name)
     sets = {name: set() for name in node_order}
     order = list(node_order)
+    if not order:
+        # no nodes to place onto - nothing to expect (a malformed parse
+        # should already have been caught upstream; guard so we FAIL the
+        # single case cleanly rather than dividing by zero)
+        return sets
     r = 0
     idx = 0
     placed = 0
@@ -1013,7 +1026,14 @@ def main(argv=None):
             n_fail += 1
             continue
 
-        violations = check_case(c, pmap)
+        try:
+            violations = check_case(c, pmap)
+        except Exception as e:  # noqa - one broken case must not abort the run
+            print("FAIL %s checker-error: %s: %s"
+                  % (c.id, type(e).__name__, e))
+            _dump(res)
+            n_fail += 1
+            continue
 
         if (args.update_golden or args.golden) and is_curated_golden(c):
             gp = golden_path(golden_dir, c)

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm
+SUBDIRS = rmaps errmgr ess filem grpcomm odls

--- a/test/unit/odls/Makefile.am
+++ b/test/unit/odls/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_odls
+
+test_odls_SOURCES = \
+    test_odls.c
+
+test_odls_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_odls

--- a/test/unit/odls/test_odls.c
+++ b/test/unit/odls/test_odls.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the odls (daemon local launch subsystem) framework.
+ *
+ * The substantive work of odls -- serializing the launch message on the
+ * HNP, decoding it on each daemon, and the fork/exec/waitpid/kill/signal
+ * lifecycle -- runs only inside a live DVM against real child processes
+ * and cannot be exercised without one; it is covered by the integration
+ * and offline-mapper harnesses.
+ *
+ * What *can* be exercised in isolation is the framework's structural
+ * contract and the constructor/destructor invariants its launch code
+ * relies on:
+ *
+ *   1. The module contract.  odls.h defines a 5-pointer vtable; the sole
+ *      component, pdefault, is what every daemon selects, so a regression
+ *      that left one of its five slots NULL would crash at first use.  We
+ *      confirm all five are wired and that get_add_procs_data is the base
+ *      function the component is documented to reuse verbatim.
+ *
+ *   2. The component identity: name "pdefault" (selection depends on it).
+ *
+ *   3. The daemon command flags (odls_types.h).  Every PRTE_DAEMON_*
+ *      command byte leads an RML control message to a prted; a duplicate
+ *      value would silently route one command to another's handler.  The
+ *      project's coding rules require these hand-assigned codes be unique,
+ *      so we assert pairwise distinctness.
+ *
+ *   4. The child->parent error-code enum (prte_odls_child_err_t).  The
+ *      pipe protocol splits codes into "fatal" (child _exit()s) and
+ *      "warn" (child continues to execve).  NONE must be 0 and every warn
+ *      code must sort after every fatal code, or the child/parent halves
+ *      would disagree about whether a report is terminal.
+ *
+ *   5. The reference-counted caddy classes (base.h).  Their constructors
+ *      must establish the documented NULL/zero defaults that the launch
+ *      path assumes, and their destructors must free every owned member
+ *      -- including the all-NULL case -- without crashing.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "constants.h"
+#include "src/hwloc/hwloc-internal.h"
+#include "src/runtime/runtime.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/odls/odls.h"
+#include "src/mca/odls/odls_types.h"
+#include "src/mca/odls/base/base.h"
+#include "src/mca/odls/pdefault/odls_pdefault.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/*
+ * Every slot of the pdefault module's vtable must be non-NULL.  The
+ * launch/kill/signal/restart entry points are file-static in the
+ * component, so we can only assert they are wired, not their identity;
+ * get_add_procs_data, however, is documented to be the base function used
+ * verbatim, so we pin that.
+ */
+static int test_module_contract(void)
+{
+    int failures = 0;
+    prte_odls_base_module_t *m = &prte_odls_pdefault_module;
+
+    CHECK("get_add_procs_data set", NULL != m->get_add_procs_data);
+    CHECK("launch_local_procs set", NULL != m->launch_local_procs);
+    CHECK("kill_local_procs set", NULL != m->kill_local_procs);
+    CHECK("signal_local_procs set", NULL != m->signal_local_procs);
+    CHECK("restart_proc set", NULL != m->restart_proc);
+
+    /* the HNP-side message builder has nothing OS-specific, so the
+     * component reuses the base function directly */
+    CHECK("get_add_procs_data identity",
+          m->get_add_procs_data == prte_odls_base_default_get_add_procs_data);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_module_contract\n");
+    }
+    return failures;
+}
+
+/*
+ * The pdefault component identifies itself as the odls component named
+ * "pdefault".  Selection depends on that name, so guard it.
+ */
+static int test_component_identity(void)
+{
+    int failures = 0;
+    prte_odls_base_component_t *c = &prte_mca_odls_pdefault_component;
+
+    CHECK("component name", 0 == strcmp(c->pmix_mca_component_name, "pdefault"));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_component_identity\n");
+    }
+    return failures;
+}
+
+/*
+ * Every PRTE_DAEMON_* command flag must be a distinct value -- these are
+ * hand-assigned, and a collision would silently deliver one daemon
+ * command to another's handler.
+ */
+static int test_daemon_cmd_uniqueness(void)
+{
+    int failures = 0;
+    /* every command byte defined in odls_types.h */
+    prte_daemon_cmd_flag_t cmds[] = {
+        PRTE_DAEMON_CONTACT_QUERY_CMD, PRTE_DAEMON_KILL_LOCAL_PROCS,
+        PRTE_DAEMON_SIGNAL_LOCAL_PROCS, PRTE_DAEMON_ADD_LOCAL_PROCS,
+        PRTE_DAEMON_HEARTBEAT_CMD, PRTE_DAEMON_EXIT_CMD,
+        PRTE_DAEMON_PROCESS_AND_RELAY_CMD, PRTE_DAEMON_NULL_CMD,
+        PRTE_DAEMON_REPORT_JOB_INFO_CMD, PRTE_DAEMON_REPORT_NODE_INFO_CMD,
+        PRTE_DAEMON_REPORT_PROC_INFO_CMD, PRTE_DAEMON_SPAWN_JOB_CMD,
+        PRTE_DAEMON_TERMINATE_JOB_CMD, PRTE_DAEMON_HALT_VM_CMD,
+        PRTE_DAEMON_HALT_DVM_CMD, PRTE_DAEMON_REPORT_JOB_COMPLETE,
+        PRTE_DAEMON_DEFINE_PSET, PRTE_DAEMON_TOP_CMD,
+        PRTE_DAEMON_NAME_REQ_CMD, PRTE_DAEMON_CHECKIN_CMD,
+        PRTE_TOOL_CHECKIN_CMD, PRTE_DAEMON_PROCESS_CMD,
+        PRTE_DAEMON_ABORT_PROCS_CALLED, PRTE_DAEMON_DVM_ADD_PROCS,
+        PRTE_DAEMON_GET_STACK_TRACES, PRTE_DAEMON_GET_MEMPROFILE,
+        PRTE_DAEMON_DVM_CLEANUP_JOB_CMD, PRTE_DAEMON_SHRINK_CMD,
+    };
+    size_t i, j, n = sizeof(cmds) / sizeof(cmds[0]);
+
+    for (i = 0; i < n; i++) {
+        for (j = i + 1; j < n; j++) {
+            if (cmds[i] == cmds[j]) {
+                fprintf(stderr, "FAIL [daemon cmd uniqueness]: cmds[%zu] == cmds[%zu] == %d\n",
+                        i, j, (int) cmds[i]);
+                failures++;
+            }
+        }
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_daemon_cmd_uniqueness\n");
+    }
+    return failures;
+}
+
+/*
+ * The child->parent error protocol splits its codes into a fatal group
+ * (the child _exit()s after reporting) and a warn group (the child keeps
+ * going toward execve).  NONE must be 0, and every warn code must sort
+ * strictly after every fatal code -- do_child()/render_child_msg() and
+ * the binding code all rely on that split.
+ */
+static int test_child_err_enum(void)
+{
+    int failures = 0;
+
+    CHECK("NONE is zero", 0 == PRTE_ODLS_CHILD_ERR_NONE);
+
+    /* the last fatal code precedes the first warn code */
+    CHECK("fatal group before warn group",
+          PRTE_ODLS_CHILD_ERR_EXEC < PRTE_ODLS_CHILD_WARN_NOT_BOUND);
+    CHECK("warn NOT_BOUND ordered",
+          PRTE_ODLS_CHILD_WARN_NOT_BOUND < PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND);
+    CHECK("warn MEM ordered",
+          PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND < PRTE_ODLS_CHILD_WARN_INCORRECT);
+
+    /* every fatal code is a real, non-NONE value */
+    CHECK("fatal IOF nonzero", PRTE_ODLS_CHILD_ERR_NONE != PRTE_ODLS_CHILD_ERR_IOF_SETUP);
+    CHECK("fatal EXEC nonzero", PRTE_ODLS_CHILD_ERR_NONE != PRTE_ODLS_CHILD_ERR_EXEC);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_child_err_enum\n");
+    }
+    return failures;
+}
+
+/*
+ * Constructor defaults and destructor safety for the two caddy classes
+ * the framework defines.  The defaults are load-bearing: the launch path
+ * checks these NULL/false fields before allocating or applying bindings,
+ * and the destructors are the only place the caddy's owned strings and
+ * hwloc bitmap are freed.
+ */
+static int test_classes(void)
+{
+    int failures = 0;
+
+    /* spawn caddy: all owned pointers NULL, binding flags clear */
+    prte_odls_spawn_caddy_t *cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    CHECK("spawn cmd NULL", NULL == cd->cmd);
+    CHECK("spawn wdir NULL", NULL == cd->wdir);
+    CHECK("spawn argv NULL", NULL == cd->argv);
+    CHECK("spawn env NULL", NULL == cd->env);
+    CHECK("spawn bind_cpuset NULL", NULL == cd->bind_cpuset);
+    CHECK("spawn bind_fatal false", !cd->bind_fatal);
+    CHECK("spawn do_membind false", !cd->do_membind);
+#if PRTE_HAVE_SCHED_SETAFFINITY
+    CHECK("spawn bind_mask NULL", NULL == cd->bind_mask);
+    CHECK("spawn bind_masksize 0", 0 == cd->bind_masksize);
+#endif
+    /* exercise the destructor's free paths for every owned member */
+    cd->cmd = strdup("/bin/true");
+    cd->wdir = strdup("/tmp");
+    cd->argv = PMIx_Argv_split("a b c", ' ');
+    cd->env = PMIx_Argv_split("X=1 Y=2", ' ');
+    cd->bind_cpuset = hwloc_bitmap_alloc();
+    PMIX_RELEASE(cd);
+
+    /* spawn caddy again, released untouched: the all-NULL destructor path
+     * must also be safe */
+    cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    PMIX_RELEASE(cd);
+
+    /* launch-local caddy: event allocated, job cleared, no fork fn, no
+     * retries */
+    prte_odls_launch_local_t *ll = PMIX_NEW(prte_odls_launch_local_t);
+    CHECK("launch ev set", NULL != ll->ev);
+    CHECK("launch fork_local NULL", NULL == ll->fork_local);
+    CHECK("launch retries 0", 0 == ll->retries);
+    /* the constructor loads the job nspace with NULL - it must be empty */
+    CHECK("launch job empty", PMIX_NSPACE_INVALID(ll->job));
+    /* NB: releasing the caddy frees a raw event that was never assigned to
+     * an event base (in real use PRTE_ACTIVATE_LOCAL_LAUNCH assigns it
+     * before use), so libevent prints a benign "event has no event_base
+     * set" line here - the destructor path is still correct. */
+    PMIX_RELEASE(ll);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_classes\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_module_contract();
+    failures += test_component_identity();
+    failures += test_daemon_cmd_uniqueness();
+    failures += test_child_err_enum();
+    failures += test_classes();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all odls unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d odls unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Hardening of the `odls` (daemon local launch subsystem) framework, from a
deep review of the base and the `pdefault` component. Five focused commits:

1. **Fix memory leaks and crashes in the local-launch path** — leaks in the
   launch-message build (`get_add_procs_data`) and parse (`construct_child_list`),
   a per-child caddy leak on the `DO_NOT_SPAWN` mapping-only path, an
   `app->cwd` overwrite leak in `setup_path`, and an uninitialized-buffer
   `chdir()` when `getcwd()` fails at entry to `launch_local`.
2. **Abort the whole job on any fatal local-launch error** — `setup_fork`,
   file pre-positioning, the executable/cwd check, the resource-limit setup,
   and the per-child IOF setup previously failed only the current app's procs
   and jumped out of the launch loop, stranding later apps' procs in `INIT`.
   Since a daemon reports `FAILED_TO_LAUNCH` only once every local proc is
   accounted for, this **hung multi-app launches** (and single-app launches
   for the IOF case). All fatal paths now uniformly activate
   `PRTE_JOB_STATE_FAILED_TO_LAUNCH`, matching the already-correct
   `setup_path` handling. Also corrects an `exit_code` set to a proc-state
   constant in `setup_fork`, and a misleading error code in `setup_path`.
3. **Add a structural unit test** (`test/unit/odls/test_odls.c`, wired into
   `make check`): module-vtable contract, component identity, `PRTE_DAEMON_*`
   command-byte uniqueness, the child-error fatal/warn ordering, and caddy
   constructor/destructor invariants.
4. **Document the launch-path invariants** in the framework `AGENTS.md`,
   plus a Testing section.
5. **Harden the offline mapper harness** (`test/offline/run_offline_maps.py`)
   so unparseable map output fails a single case cleanly instead of aborting
   the whole run with a `ZeroDivisionError`.

## Testing

- Clean `--enable-debug` (warnings-as-errors) build.
- `make check` — all unit tests pass, including the new `test_odls`.
- `make check-offline` — 1176 pass, 0 fail.
- Live `prterun`: normal launch, MPMD, env forwarding, and non-zero-exit
  decode all correct; failure cases (bad exe, bad wdir, bad-app-first +
  long-running second app) abort promptly with no hang and no leaked daemons.
- First commit verified to build in isolation (bisectable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
