### PR TITLE
iof: harden the stdin/stdout forwarding paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ test/unit/grpcomm/Makefile
 test/unit/grpcomm/test_grpcomm
 test/unit/odls/Makefile
 test/unit/odls/test_odls
+test/unit/iof/Makefile
+test/unit/iof/test_iof
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -37,5 +37,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/filem/Makefile
         test/unit/grpcomm/Makefile
         test/unit/odls/Makefile
+        test/unit/iof/Makefile
     ])
 ])

--- a/contrib/dockerswarm/README.md
+++ b/contrib/dockerswarm/README.md
@@ -153,6 +153,17 @@ is **not** asserted here: staged data files land in the per-proc session dir but
 the default cwd is elsewhere, so they are not reachable by a bare relative path —
 a separate, pre-existing gap.)
 
+**Remote stdin (`iof`)**: a large base64 payload is piped into `prterun` on
+node1 for a job whose rank 0 is mapped onto **node2**, running `cat`. Because
+the reading proc is not on the head node, every byte must cross
+HNP → `PRTE_RML_TAG_IOF_PROXY` → `prted` → the proc's stdin pipe and come back
+as forwarded output; an md5 match proves nothing was dropped, truncated, or
+reordered. This is the other path a single-host build cannot validate —
+locally, `push_stdin` writes straight into the proc's sink and the wire format
+is never exercised. The payload is deliberately far larger than the 4096-byte
+read fragment and the 8192-byte write chunk. A companion case pipes a short
+line with `--stdin all` to check the wildcard/xcast delivery.
+
 **Grow** (`elastic grow node2:2,node3:2`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, and `prted` now running on node2 and node3.
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -117,6 +117,67 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     docker exec prte-node1 sh -c 'rm -f /root/staged_marker /root/staged_marker.c' 2>/dev/null
 
+    banner "iof: stdin forwarded to a REMOTE proc (HNP -> prted -> proc)"
+    # Rank 0 is mapped onto node2, not the head node, so every stdin byte must
+    # travel HNP -> RML(PRTE_RML_TAG_IOF_PROXY) -> prted -> the proc's stdin
+    # pipe, and be echoed back prted -> HNP as forwarded output. A single-host
+    # run exercises only the HNP-local sink and proves nothing about the wire
+    # format, which is why this test lives in the swarm.
+    #
+    # The large payload matters: a stdin fragment used to be unpacked into a
+    # fixed PRTE_IOF_BASE_MSG_MAX (4096) buffer on the daemon, so anything
+    # bigger was dropped by the unpack rather than delivered. Any payload well
+    # past 4096 -- and past the 8192 write-chunk size -- guards that path.
+    #
+    # Note the payload is base64 text: printable, newline-terminated, and free
+    # of anything a pipe or tty layer might translate, so a mismatch means IOF
+    # really did lose or reorder bytes.
+    # These run under "prun" against a persistent DVM rather than "prterun".
+    # That is deliberate: prterun's own stdin is read by the HNP acting as a
+    # PMIx *server*, and PMIx's server branch returns early on EOF without
+    # calling push_stdin (pmix_iof_read_local_handler in
+    # src/common/pmix_iof.c) -- so the zero-byte close never reaches PRRTE and
+    # "cat" waits forever. That is an openpmix defect, not a PRRTE one; the
+    # tool path prun uses forwards the zero-byte push correctly. Every command
+    # is wrapped in "timeout" so a delivery regression fails the test instead
+    # of wedging the suite.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --host node1:1,node2:1,node3:1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'head -c 262144 /dev/urandom | base64 > /tmp/iof_stdin_in.txt' >/dev/null 2>&1
+        out=$(RUN 'cd /tmp && timeout 90 prun --host node2:1 -n 1 \
+                     cat < iof_stdin_in.txt > iof_stdin_out.txt 2>iof_stdin_err.txt; echo "rc=$?"')
+        rc=$(echo "$out" | sed -n 's/^rc=//p')
+        insum=$(RUN 'md5sum < /tmp/iof_stdin_in.txt' | awk '{print $1}')
+        outsum=$(RUN 'md5sum < /tmp/iof_stdin_out.txt 2>/dev/null' | awk '{print $1}')
+        insz=$(RUN 'wc -c < /tmp/iof_stdin_in.txt' | tr -d ' ')
+        outsz=$(RUN 'wc -c < /tmp/iof_stdin_out.txt 2>/dev/null' | tr -d ' ')
+        [ "$rc" = 0 ] && [ -n "$insum" ] && [ "$insum" = "$outsum" ] \
+            && ok "large stdin ($insz bytes) round-tripped through a remote proc intact" \
+            || bad "remote stdin corrupted/truncated/hung (rc=$rc, in=$insz out=$outsz, md5 $insum vs $outsum): $(RUN 'head -c 200 /tmp/iof_stdin_err.txt')"
+        # rc=0 also means "cat" saw EOF, so the zero-byte close sentinel made
+        # the trip; rc=124 would be the timeout, i.e. it did not.
+
+        # Wildcard stdin is xcast to every daemon rather than sent to one, and
+        # the xcast comes back to the HNP too -- so this covers delivery to a
+        # proc the HNP hosts (node1) and to a remote proc (node2) at once. With
+        # no receive posted on the proxy tag at the HNP, the node1 proc gets
+        # nothing and the job hangs.
+        out=$(RUN 'cd /tmp && echo WILDCARD-STDIN-OK | timeout 60 prun --host node1:1,node2:1 \
+                     -n 2 --map-by node --stdin all cat 2>&1; echo "rc=$?"')
+        rc=$(echo "$out" | sed -n 's/^rc=//p')
+        n=$(echo "$out" | grep -c 'WILDCARD-STDIN-OK')
+        [ "$rc" = 0 ] && [ "$n" = 2 ] \
+            && ok "wildcard stdin (--stdin all) reached the HNP-local and the remote proc" \
+            || bad "wildcard stdin reached $n/2 procs (rc=$rc): $(echo "$out" | tr '\n' ' ')"
+
+        RUN 'rm -f /tmp/iof_stdin_in.txt /tmp/iof_stdin_out.txt /tmp/iof_stdin_err.txt' >/dev/null 2>&1
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the stdin tests"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: grow + shrink (radix 64, flat tree)"
     cleanup_swarm
     RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
@@ -188,6 +249,39 @@ test_macos() {
         macpk
     fi
     rm -f "$BOUT"
+
+    banner "macOS: stdin delivery (single host, directed and wildcard)"
+    # On one node every proc is local to the HNP, so this covers the two
+    # delivery routes push_stdin takes: a directed rank writes straight into
+    # the proc's sink, while "--stdin all" is xcast on PRTE_RML_TAG_IOF_PROXY
+    # -- and the xcast comes back to the HNP, which must service its own procs
+    # from that receive. When the HNP had no receive on that tag the wildcard
+    # message went unmatched and every proc hung waiting on stdin.
+    # The app is "head -1", not "cat", on purpose: head exits once it has its
+    # line, so the test does not depend on the stdin-close sentinel. prterun's
+    # own stdin is read by the HNP as a PMIx server, and PMIx's server branch
+    # returns early on EOF without calling push_stdin
+    # (pmix_iof_read_local_handler in src/common/pmix_iof.c), so a "cat" here
+    # would never see EOF and would hang on a defect that is not PRRTE's.
+    macpk; sleep 1
+    printf 'STDIN-DELIVERY-OK\n' > "$root/vpath-macos/stdin_probe.txt"
+    if bounded 60 sh -c "prterun -np 2 head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
+        [ "$(grep -Fc STDIN-DELIVERY-OK "$BOUT")" = 1 ] \
+            && ok "directed stdin (default rank 0) -> 1 proc" \
+            || bad "directed stdin: $(tr '\n' ' ' <"$BOUT")"
+    else
+        skp "directed stdin timed out (native Darwin DVM unstable)"; macpk
+    fi
+    rm -f "$BOUT"
+    macpk; sleep 1
+    if bounded 60 sh -c "prterun -np 2 --stdin all head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
+        [ "$(grep -Fc STDIN-DELIVERY-OK "$BOUT")" = 2 ] \
+            && ok "wildcard stdin (--stdin all) -> both procs" \
+            || bad "wildcard stdin reached $(grep -Fc STDIN-DELIVERY-OK "$BOUT")/2 procs: $(tr '\n' ' ' <"$BOUT")"
+    else
+        bad "wildcard stdin hung -- the HNP never delivered its own xcast to the procs it hosts"; macpk
+    fi
+    rm -f "$BOUT" "$root/vpath-macos/stdin_probe.txt"
 
     banner "macOS: persistent DVM + prun + pterm (single host)"
     macpk; sleep 1

--- a/src/mca/iof/AGENTS.md
+++ b/src/mca/iof/AGENTS.md
@@ -214,8 +214,20 @@ This is the heart of the **stdin / output-to-fd** path:
   write event's `outputs` list, and if the write event isn't already
   armed, arm it with `PRTE_IOF_SINK_ACTIVATE`. Returns the current
   backlog size (list length). A `numbytes == 0` call still enqueues a
-  sentinel so the fd is flushed and closed. Callers compare the return
-  against `PRTE_IOF_MAX_INPUT_BUFFERS` (50) to detect back-pressure.
+  sentinel so the fd is flushed and closed. A `NULL` channel is a no-op
+  returning `0`. Callers compare the return against
+  `PRTE_IOF_MAX_INPUT_BUFFERS` (50) to detect back-pressure.
+
+  **Fixed copy buffer — the function splits, callers need not.** The chunk
+  it copies into is a fixed `data[PRTE_IOF_BASE_TAGGED_OUT_MAX]` (8192)
+  array, so an input larger than that is broken across as many chunks as it
+  takes rather than overrunning the buffer (a caller like the HNP's
+  `push_stdin` hands over whatever the PMIx server produced and cannot be
+  assumed to respect our limit). A negative `numbytes` is treated the same
+  as zero — the close sentinel — since there is nothing that could be
+  copied. Note the size constants still differ by role: 4096 per read
+  (`PRTE_IOF_BASE_MSG_MAX`) and 8192 per queued write chunk; the daemon's
+  stdin `recv` allocates to fit the message and imposes no cap of its own.
 
 - **`prte_iof_base_write_handler(fd, event, cbdata)`** — the generic
   libevent write callback. It drains `wev->outputs`, `write()`-ing each
@@ -256,6 +268,16 @@ proc — e.g. `--display-map` / allocation dumps. It wraps the string in a
 `prte_iof_deliver_t` and calls `PMIx_server_IOF_deliver` so the output
 threads through the same PMIx output path as real proc output. It does
 not touch the sink engine.
+
+**Ownership: it frees your string.** `prte_iof_base_output` stores the
+passed `char *string` directly into `deliver->bo.bytes` and the
+`prte_iof_deliver_t` destructor `free()`s it (on both the success path, via
+the delivery completion callback, and the error path). So `string`
+**must be a heap allocation you are handing off** — every current caller
+passes an `pmix_asprintf`/`strdup`/`PMIx_Argv_join`/`prte_map_print`
+result and does *not* free it afterward. Passing a string literal or a
+stack buffer would `free()` non-heap memory. The prototype does not spell
+this out; do not "fix" a caller by adding a `free`.
 
 ### Fork-time setup helpers (`iof_base_setup.[ch]`)
 
@@ -373,12 +395,12 @@ no other thread touching this state. Consequences:
   `PRTE_PROC_STATE_IOF_COMPLETE` — the state machine waits on this before
   fully reaping a proc. Don't null a read-event slot without going through
   that check.
-- **Vestigial declarations.** `prte_iof_base_flush()` (declared in
-  `base.h`), and `prte_iof_hnp_stdin_cb` / `prte_iof_hnp_stdin_check` /
-  the `stdinsig` field (declared in `hnp/iof_hnp.h`) have **no live
-  definitions/uses** — leftovers from when `mpirun` read its own terminal
-  stdin directly. Today stdin arrives via the PMIx server calling
-  `prte_iof.push_stdin`. Don't wire new code to these ghosts.
+- **Stdin does not come from a terminal read here.** Older trees carried
+  declarations (`prte_iof_base_flush`, `prte_iof_hnp_stdin_cb`,
+  `prte_iof_hnp_stdin_check`, the `stdinsig` event) from when `mpirun` read
+  its own terminal stdin directly; they were never defined and have been
+  removed. Stdin arrives via the PMIx server calling
+  `prte_iof.push_stdin` — don't reintroduce a direct-read path.
 - **The version macro is `PRTE_IOF_BASE_VERSION_2_0_0`.** Match it in any
   new component's struct.
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on every
@@ -386,6 +408,33 @@ no other thread touching this state. Consequences:
   `PRTE_ERROR_LOG` for unexpected errors.
 
 ---
+
+## Testing
+
+Self-contained unit coverage lives in
+[`test/unit/iof/test_iof.c`](../../../test/unit/iof/) and is wired into
+`make check`. Because the read/forward/write paths need a live DVM, real
+fds, and a running progress thread, the unit test deliberately stops at
+what *is* exercisable without them:
+
+- the tag-bitmask invariants (`STDMERGE`/`STDOUTALL`/`STDALL` equal the OR
+  of their parts; control flags don't collide with stream bits);
+- the module vtable contract (HNP wires all seven slots; `prted` leaves
+  `push_stdin` `NULL`);
+- the component name strings (`"hnp"`, `"prted"`);
+- constructor defaults / destructor safety for the five core classes;
+- the **producer side** of the sink engine —
+  `prte_iof_base_write_output`'s backlog accounting, byte copy, zero-byte
+  sentinel, and `NULL`-channel no-op — driven with the write event
+  pre-marked `pending` so no event base is needed;
+- the chunk-splitting of an oversized write (every chunk within
+  `PRTE_IOF_BASE_TAGGED_OUT_MAX`, the pieces reassembling to the original
+  bytes) and the negative-count degradation to the close sentinel;
+- the `prte_iof_base_fd_always_ready` predicate (pipe vs. regular file vs.
+  `/dev/null`).
+
+The end-to-end capture/relay/inject behavior is covered by the integration
+harness (`prte --daemonize` → `prun` → `pterm`), not by `make check`.
 
 ## Debugging
 

--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -243,6 +243,14 @@ PRTE_EXPORT int prte_iof_base_flush(void);
 PRTE_EXPORT extern int prte_iof_base_output_limit;
 
 /* base functions */
+
+/* Queue "numbytes" of "data" for writing to the given channel, breaking
+ * it across as many chunks as required, and arm the write event if it is
+ * not already pending. Passing zero bytes queues the sentinel that flushes
+ * any preceding data and then closes the channel. Returns the resulting
+ * number of queued chunks (zero if "channel" is NULL) so the caller can
+ * detect back-pressure.
+ */
 PRTE_EXPORT int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
                                            const unsigned char *data, int numbytes,
                                            prte_iof_write_event_t *channel);

--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -238,8 +238,6 @@ static inline bool prte_iof_base_fd_always_ready(int fd)
         }                                                                                     \
     } while (0);
 
-PRTE_EXPORT int prte_iof_base_flush(void);
-
 PRTE_EXPORT extern int prte_iof_base_output_limit;
 
 /* base functions */
@@ -256,6 +254,11 @@ PRTE_EXPORT int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag
                                            prte_iof_write_event_t *channel);
 PRTE_EXPORT void prte_iof_base_write_handler(int fd, short event, void *cbdata);
 
+/* Emit "string" as though it were output from "source" on the given channel.
+ * NOTE: this takes ownership of "string" - it must be a heap allocation, and
+ * it is free'd once the output has been delivered. Callers must not free it
+ * themselves.
+ */
 PRTE_EXPORT void prte_iof_base_output(const pmix_proc_t *source,
                                       pmix_iof_channel_t channel,
                                       char *string);

--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -65,20 +65,34 @@ int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
         return 0;
     }
 
-    /* setup output object */
-    output = PMIX_NEW(prte_iof_write_output_t);
+    if (0 < numbytes && NULL != data) {
+        int remaining = numbytes;
 
-    /* copy over the data to be written */
-    if (0 < numbytes) {
+        /* the chunk buffer is a fixed size, so break the caller's data
+         * across as many chunks as it takes - we cannot assume the
+         * caller respected our limit
+         */
+        while (0 < remaining) {
+            int nbytes = (PRTE_IOF_BASE_TAGGED_OUT_MAX < remaining)
+                             ? PRTE_IOF_BASE_TAGGED_OUT_MAX : remaining;
+            output = PMIX_NEW(prte_iof_write_output_t);
+            memcpy(output->data, data, nbytes);
+            output->numbytes = nbytes;
+            pmix_list_append(&channel->outputs, &output->super);
+            data += nbytes;
+            remaining -= nbytes;
+        }
+    } else {
         /* don't copy 0 bytes - we just need to pass
          * the zero bytes so the fd can be closed
-         * after it writes everything out
+         * after it writes everything out. A negative
+         * count is treated the same way as there is
+         * nothing we could write
          */
-        memcpy(output->data, data, numbytes);
+        output = PMIX_NEW(prte_iof_write_output_t);
+        output->numbytes = 0;
+        pmix_list_append(&channel->outputs, &output->super);
     }
-    output->numbytes = numbytes;
-    /* add this data to the write list for this fd */
-    pmix_list_append(&channel->outputs, &output->super);
 
     /* record how big the buffer is */
     num_buffered = pmix_list_get_size(&channel->outputs);

--- a/src/mca/iof/hnp/AGENTS.md
+++ b/src/mca/iof/hnp/AGENTS.md
@@ -22,10 +22,9 @@ the module **only when `PRTE_PROC_IS_MASTER`**; otherwise it returns
 `-1`/`PRTE_ERROR` and declines. Since a process is either master or
 daemon, this module and `prted` never compete for real.
 
-The component keeps two pieces of state (in
+The component keeps one piece of state (in
 [`iof_hnp.h`](iof_hnp.h)'s `prte_mca_iof_hnp_component_t`): a
-`pmix_list_t procs` of `prte_iof_proc_t` endpoint bundles, and an
-(unused, vestigial) `stdinsig` event.
+`pmix_list_t procs` of `prte_iof_proc_t` endpoint bundles.
 
 ---
 
@@ -157,14 +156,23 @@ the sink once the last queued byte is written.
   only flips the `activated` flags once `revstdout && revstderr` exist,
   so an immediate EOF on one stream can't declare the proc IOF-complete
   before the other is wired.
-- **The `query` gate is a single `!PRTE_PROC_IS_MASTER` test.** It once
-  carried a copy-paste duplication (`!PRTE_PROC_IS_MASTER &&
-  !PRTE_PROC_IS_MASTER`), which was harmless but has been collapsed to
-  the one clean condition.
+- **The `query` gate is a single `!PRTE_PROC_IS_MASTER` test.** Keep it
+  that way: `PRTE_PROC_MASTER` is its own bit in `proc_type` (it does not
+  include `PRTE_PROC_DAEMON`), so this one predicate is exactly the
+  "am I the HNP" question and needs no companion test.
 - **Zero-byte stdin means close.** `push_stdin` deliberately forwards
   zero-length payloads so a preceding buffer is flushed and the proc's
   stdin fd is then closed. Preserve that.
-- **`stdinsig`, `prte_iof_hnp_stdin_cb`, `prte_iof_hnp_stdin_check` are
-  dead.** Declared in `iof_hnp.h` but unimplemented/unused — remnants of
-  direct terminal-stdin reading. Ignore them; stdin now enters via
-  `push_stdin`.
+- **`push_stdin` to a *local* proc hands `bo->size` straight to
+  `prte_iof_base_write_output`**, whatever size the PMIx server produced.
+  That is safe because `write_output` splits an oversized push across
+  chunks (see the framework guide's sink-engine note) — don't "optimize"
+  by copying into a fixed buffer here instead.
+- **`prte_iof_hnp_recv` must not trust the wire `numbytes`.** It screens
+  `<= 0` before `malloc(numbytes)` and checks the allocation; keep both
+  guards if you touch the unpack sequence. It's internal RML traffic
+  today, but don't widen the trust.
+- **Let the `prte_iof_proc_t` destructor free the stream slots.**
+  `hnp_complete` just removes the proc from `procs` and
+  `PMIX_RELEASE`s it — the destructor releases `stdinev`, `revstdout`, and
+  `revstderr`. Don't reintroduce hand-releases of individual slots.

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -101,6 +101,13 @@ static int init(void)
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_IOF_HNP,
                   PRTE_RML_PERSISTENT, prte_iof_hnp_recv, NULL);
 
+    /* we xcast wildcard stdin to every daemon, and the xcast delivers a
+     * copy back to us - so we must also listen on the proxy tag to service
+     * the procs we host ourselves
+     */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_IOF_PROXY,
+                  PRTE_RML_PERSISTENT, prte_iof_hnp_stdin_recv, NULL);
+
     PMIX_CONSTRUCT(&prte_mca_iof_hnp_component.procs, pmix_list_t);
 
     return PRTE_SUCCESS;
@@ -203,7 +210,11 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(dst_name), sz));
 
     /* if I am the DVM master and this is a wildcard name, then we have to
-     * broadcast this to all daemons */
+     * broadcast this to all daemons. The xcast delivers a copy to us as
+     * well, and our own receive (prte_iof_hnp_stdin_recv) services the
+     * procs we host - so we are done here. Falling through would look up
+     * the daemon hosting a wildcard rank, which cannot resolve
+     */
     if (PMIX_RANK_WILDCARD == dst_name->rank) {
         PMIX_LOAD_PROCID(&p, PRTE_PROC_MY_NAME->nspace, PMIX_RANK_WILDCARD);
         rc = prte_iof_hnp_send_data_to_endpoint(&p, dst_name,
@@ -211,8 +222,8 @@ static int push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
                                                 data, sz);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
-            return rc;
         }
+        return rc;
     }
 
     /* lookup the daemon hosting the target proc */
@@ -400,6 +411,8 @@ static void hnp_complete(const prte_job_t *jdata)
 static int finalize(void)
 {
     PMIX_DESTRUCT(&prte_mca_iof_hnp_component.procs);
+    PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_IOF_HNP);
+    PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_IOF_PROXY);
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -395,14 +395,7 @@ static void hnp_complete(const prte_job_t *jdata)
     {
         if (PMIX_CHECK_NSPACE(jdata->nspace, proct->name.nspace)) {
             pmix_list_remove_item(&prte_mca_iof_hnp_component.procs, &proct->super);
-            if (NULL != proct->revstdout) {
-                PMIX_RELEASE(proct->revstdout);
-            }
-            proct->revstdout = NULL;
-            if (NULL != proct->revstderr) {
-                PMIX_RELEASE(proct->revstderr);
-            }
-            proct->revstderr = NULL;
+            /* the proc destructor releases all three stream slots */
             PMIX_RELEASE(proct);
         }
     }

--- a/src/mca/iof/hnp/iof_hnp.h
+++ b/src/mca/iof/hnp/iof_hnp.h
@@ -64,7 +64,6 @@ BEGIN_C_DECLS
 struct prte_mca_iof_hnp_component_t {
     prte_iof_base_component_t super;
     pmix_list_t procs;
-    prte_event_t stdinsig;
 };
 typedef struct prte_mca_iof_hnp_component_t prte_mca_iof_hnp_component_t;
 
@@ -78,8 +77,6 @@ void prte_iof_hnp_stdin_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t
                              prte_rml_tag_t tag, void *cbdata);
 
 void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata);
-void prte_iof_hnp_stdin_cb(int fd, short event, void *cbdata);
-bool prte_iof_hnp_stdin_check(int fd);
 
 int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
                                        const pmix_proc_t *target,

--- a/src/mca/iof/hnp/iof_hnp.h
+++ b/src/mca/iof/hnp/iof_hnp.h
@@ -74,6 +74,9 @@ extern prte_iof_base_module_t prte_iof_hnp_module;
 void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                        prte_rml_tag_t tag, void *cbdata);
 
+void prte_iof_hnp_stdin_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+                             prte_rml_tag_t tag, void *cbdata);
+
 void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata);
 void prte_iof_hnp_stdin_cb(int fd, short event, void *cbdata);
 bool prte_iof_hnp_stdin_check(int fd);

--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -77,6 +77,12 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(rev);
 
+    if (NULL == proct) {
+        /* this is an error - nothing we can do */
+        PRTE_ERROR_LOG(PRTE_ERR_ADDRESSEE_UNKNOWN);
+        return;
+    }
+
     /* As we may use timer events, fd can be bogus (-1)
      * use the right one here
      */
@@ -92,12 +98,6 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
                          (PRTE_IOF_STDOUT & rev->tag) ? "stdout"
                          : ((PRTE_IOF_STDERR & rev->tag) ? "stderr" : "stddiag"),
                          PRTE_NAME_PRINT(&proct->name)));
-
-    if (NULL == proct) {
-        /* this is an error - nothing we can do */
-        PRTE_ERROR_LOG(PRTE_ERR_ADDRESSEE_UNKNOWN);
-        return;
-    }
 
     if (numbytes <= 0) {
         if (0 > numbytes) {
@@ -128,6 +128,13 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
     p = PMIX_NEW(prte_iof_deliver_t);
     PMIX_XFER_PROCID(&p->source, &proct->name);
     p->bo.bytes = (char*)malloc(numbytes);
+    if (NULL == p->bo.bytes) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        PMIX_RELEASE(p);
+        /* nothing we can do with this data, but keep reading */
+        PRTE_IOF_READ_ACTIVATE(rev);
+        return;
+    }
     memcpy(p->bo.bytes, data, numbytes);
     p->bo.size = numbytes;
     prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, NULL, 0, lkcbfunc, (void*)p);

--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -109,13 +109,20 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
         PMIX_ERROR_LOG(rc);
         goto CLEAN_RETURN;
     }
-    if (0 == numbytes) {
-        /* nothing to do - shouldn't have been sent */
+    if (0 >= numbytes) {
+        /* nothing to do - shouldn't have been sent. A negative
+         * count indicates a corrupted message
+         */
         goto CLEAN_RETURN;
     }
     p = PMIX_NEW(prte_iof_deliver_t);
     PMIX_XFER_PROCID(&p->source, &origin);
     p->bo.bytes = (char*)malloc(numbytes);
+    if (NULL == p->bo.bytes) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        PMIX_RELEASE(p);
+        goto CLEAN_RETURN;
+    }
     rc = PMIx_Data_unpack(NULL, buffer, p->bo.bytes, &numbytes, PMIX_BYTE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);

--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -163,3 +163,115 @@ NSTEP:
 CLEAN_RETURN:
     return;
 }
+
+/*
+ * Stdin arriving on PRTE_RML_TAG_IOF_PROXY.
+ *
+ * The HNP normally writes stdin directly into a local proc's sink from
+ * push_stdin. The exception is a wildcard target: that is xcast to every
+ * daemon, and the xcast machinery delivers a copy to the sender as well -
+ * so the HNP receives its own broadcast here and must service the procs it
+ * hosts, exactly as a prted does for the procs it hosts. Without this
+ * receive the message goes unmatched and every proc local to the HNP is
+ * silently skipped.
+ */
+void prte_iof_hnp_stdin_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
+                             prte_rml_tag_t tag, void *cbdata)
+{
+    unsigned char *data = NULL;
+    prte_iof_tag_t stream;
+    int32_t count, numbytes;
+    pmix_proc_t target;
+    prte_iof_proc_t *proct;
+    int rc;
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    /* see what stream generated this data */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &stream, &count, PMIX_UINT16);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    /* only stdin travels on this tag */
+    if (PRTE_IOF_STDIN != stream) {
+        PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
+        return;
+    }
+
+    /* unpack the intended target */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &target, &count, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    /* unpack the byte count, then storage sized to match it */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &numbytes, &count, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 > numbytes) {
+        /* corrupted message */
+        PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
+        return;
+    }
+    if (0 < numbytes) {
+        data = (unsigned char *) malloc(numbytes);
+        if (NULL == data) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            return;
+        }
+        count = numbytes;
+        rc = PMIx_Data_unpack(NULL, buffer, data, &count, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            free(data);
+            return;
+        }
+        numbytes = count;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s unpacked %d bytes of stdin for local proc %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes, PRTE_NAME_PRINT(&target)));
+
+    /* deliver to every proc we host that matches the target - PMIX_CHECK_RANK
+     * honors the wildcard, which is the case that brought us here
+     */
+    PMIX_LIST_FOREACH(proct, &prte_mca_iof_hnp_component.procs, prte_iof_proc_t)
+    {
+        if (!PMIX_CHECK_NSPACE(target.nspace, proct->name.nspace) ||
+            !PMIX_CHECK_RANK(target.rank, proct->name.rank)) {
+            continue;
+        }
+        /* a proc that never pulled stdin has no sink - the list also holds
+         * entries created for remote procs whose output we forward
+         */
+        if (NULL == proct->stdinev || NULL == proct->stdinev->wev) {
+            continue;
+        }
+        /* a zero-byte write is forwarded too - it flushes what precedes it
+         * and then closes the proc's stdin
+         */
+        if (PRTE_IOF_MAX_INPUT_BUFFERS < prte_iof_base_write_output(&proct->name, stream, data,
+                                                                    numbytes,
+                                                                    proct->stdinev->wev)) {
+            /* we are the source of this stdin, so there is no upstream to
+             * throttle - just note it
+             */
+            PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                                 "%s stdin buffer backed up for %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(&proct->name)));
+        }
+    }
+
+    if (NULL != data) {
+        free(data);
+    }
+}

--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -48,6 +48,7 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
                                        unsigned char *data, int numbytes)
 {
     pmix_data_buffer_t *buf;
+    int32_t nbytes;
     int rc;
 
     /* if the host is a daemon and we are in the process of aborting,
@@ -83,12 +84,26 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
         return rc;
     }
 
-    /* pack the data - if numbytes is zero, we will pack zero bytes */
-    rc = PMIx_Data_pack(NULL, buf, data, numbytes, PMIX_BYTE);
+    /* pack the number of bytes being sent so the receiver can
+     * allocate storage of the correct size for them - a count
+     * of zero tells the receiver to close the target's stdin
+     */
+    nbytes = (0 < numbytes) ? numbytes : 0;
+    rc = PMIx_Data_pack(NULL, buf, &nbytes, 1, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
         return rc;
+    }
+
+    /* pack the data itself */
+    if (0 < nbytes) {
+        rc = PMIx_Data_pack(NULL, buf, data, nbytes, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return rc;
+        }
     }
 
     /* if the target is wildcard, then this needs to go to everyone - xcast it */

--- a/src/mca/iof/prted/AGENTS.md
+++ b/src/mca/iof/prted/AGENTS.md
@@ -99,12 +99,15 @@ Only `PRTE_IOF_STDIN` is supported; anything else returns
 
 `prte_iof_prted_recv` is the persistent `PRTE_RML_TAG_IOF_PROXY` receive
 posted by `init()`. Incoming buffers carry `{ stream (uint16), target
-proc, bytes }`:
+proc, numbytes (int32), bytes }` — the same shape the daemon uses when
+forwarding output HNP-ward:
 
 1. Unpack the stream; if it isn't `PRTE_IOF_STDIN` it's a protocol error
    (`PRTE_ERR_COMM_FAILURE`). (Flow-control tags are handled by the HNP,
    not here.)
-2. Unpack the target proc and the data.
+2. Unpack the target proc, then the byte count, then `malloc` storage of
+   exactly that size and unpack the data into it. A count of zero means
+   "close this proc's stdin" and carries no payload.
 3. Walk `procs`, matching the target by nspace and by rank
    (`PMIX_CHECK_RANK` honors wildcard, so a broadcast reaches every local
    proc that pulled stdin). For each match with a live `stdinev`, call
@@ -177,3 +180,15 @@ tag used for forwarded output, distinguished by the leading tag value.
   matching rules — they're what make wildcard-stdin fan-out work.
 - **Zero-byte stdin means close.** Preserve the zero-length forward path
   through `write_output`.
+- **A stdin fragment is sized by the wire, not by a constant.**
+  `prte_iof_prted_recv` allocates from the packed `numbytes` and frees the
+  buffer on every exit path. It used to unpack into a fixed
+  `data[PRTE_IOF_BASE_MSG_MAX]` (4096), which dropped any larger fragment
+  outright (an over-long unpack fails with
+  `PMIX_ERR_UNPACK_INADEQUATE_SPACE`). Don't reintroduce a fixed-size
+  stdin buffer — the sender is bounded only by what the PMIx server hands
+  the HNP.
+- **The `proct` NULL check comes before the first dereference.** Both read
+  handlers test `rev->proc` immediately after `PMIX_ACQUIRE_OBJECT`, ahead
+  of the verbose trace that prints `proct->name`. Keep that order; the
+  guard was previously placed after the deref and could never fire.

--- a/src/mca/iof/prted/iof_prted_read.c
+++ b/src/mca/iof/prted/iof_prted_read.c
@@ -72,6 +72,12 @@ void prte_iof_prted_read_handler(int fd, short event, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(rev);
 
+    if (NULL == proct) {
+        /* nothing we can do */
+        PRTE_ERROR_LOG(PRTE_ERR_ADDRESSEE_UNKNOWN);
+        return;
+    }
+
     /* As we may use timer events, fd can be bogus (-1)
      * use the right one here
      */
@@ -86,12 +92,6 @@ void prte_iof_prted_read_handler(int fd, short event, void *cbdata)
                          (PRTE_IOF_STDOUT & rev->tag) ? "stdout"
                          : ((PRTE_IOF_STDERR & rev->tag) ? "stderr" : "stddiag"),
                          PRTE_NAME_PRINT(&proct->name)));
-
-    if (NULL == proct) {
-        /* nothing we can do */
-        PRTE_ERROR_LOG(PRTE_ERR_ADDRESSEE_UNKNOWN);
-        return;
-    }
 
     if (numbytes <= 0) {
         if (0 > numbytes) {
@@ -121,12 +121,17 @@ void prte_iof_prted_read_handler(int fd, short event, void *cbdata)
     p = PMIX_NEW(prte_iof_deliver_t);
     PMIX_XFER_PROCID(&p->source, &proct->name);
     p->bo.bytes = (char*)malloc(numbytes);
-    memcpy(p->bo.bytes, data, numbytes);
-    p->bo.size = numbytes;
-    prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, NULL, 0, lkcbfunc, (void*)p);
-    if (PMIX_SUCCESS != prc) {
-        PMIX_ERROR_LOG(prc);
+    if (NULL == p->bo.bytes) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         PMIX_RELEASE(p);
+    } else {
+        memcpy(p->bo.bytes, data, numbytes);
+        p->bo.size = numbytes;
+        prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, NULL, 0, lkcbfunc, (void*)p);
+        if (PMIX_SUCCESS != prc) {
+            PMIX_ERROR_LOG(prc);
+            PMIX_RELEASE(p);
+        }
     }
 
     /* prep the buffer */

--- a/src/mca/iof/prted/iof_prted_receive.c
+++ b/src/mca/iof/prted/iof_prted_receive.c
@@ -30,6 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #    include <unistd.h>
 #endif /* HAVE_UNISTD_H */
+#include <stdlib.h>
 #include <string.h>
 
 #include "src/pmix/pmix-internal.h"
@@ -84,7 +85,7 @@ void prte_iof_prted_send_xonxoff(prte_iof_tag_t tag)
 void prte_iof_prted_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                          prte_rml_tag_t tag, void *cbdata)
 {
-    unsigned char data[PRTE_IOF_BASE_MSG_MAX];
+    unsigned char *data = NULL;
     prte_iof_tag_t stream;
     int32_t count, numbytes;
     pmix_proc_t target;
@@ -114,14 +115,41 @@ void prte_iof_prted_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *bu
         return;
     }
 
-    /* unpack the data */
-    numbytes = PRTE_IOF_BASE_MSG_MAX;
-    rc = PMIx_Data_unpack(NULL, buffer, data, &numbytes, PMIX_BYTE);
+    /* unpack the number of bytes that follow - the HNP sends this ahead
+     * of the data itself as a stdin fragment can be of any size, and we
+     * must not silently truncate it
+     */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &numbytes, &count, PMIX_INT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return;
     }
-    /* numbytes will contain the actual #bytes that were sent */
+    if (0 > numbytes) {
+        /* corrupted message */
+        PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
+        return;
+    }
+
+    /* unpack the data itself - a zero count means we are to close
+     * the target's stdin, so there is nothing to unpack
+     */
+    if (0 < numbytes) {
+        data = (unsigned char *) malloc(numbytes);
+        if (NULL == data) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            return;
+        }
+        count = numbytes;
+        rc = PMIx_Data_unpack(NULL, buffer, data, &count, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            free(data);
+            return;
+        }
+        /* count contains the actual #bytes that were sent */
+        numbytes = count;
+    }
 
     PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                          "%s unpacked %d bytes for local proc %s",
@@ -158,5 +186,9 @@ void prte_iof_prted_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *bu
                 }
             }
         }
+    }
+
+    if (NULL != data) {
+        free(data);
     }
 }

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof

--- a/test/unit/iof/Makefile.am
+++ b/test/unit/iof/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_iof
+
+test_iof_SOURCES = \
+    test_iof.c
+
+test_iof_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_iof

--- a/test/unit/iof/test_iof.c
+++ b/test/unit/iof/test_iof.c
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the iof (I/O forwarding) framework.
+ *
+ * The end-to-end behavior of iof -- capturing a live proc's stdout/stderr,
+ * relaying it over the RML to the HNP, and injecting stdin down a proc's
+ * pipe -- runs only inside a live DVM with real file descriptors and a
+ * running progress thread, and is covered by the integration harness.
+ *
+ * What *can* be exercised in isolation is the framework's structural
+ * contract and the pure, event-loop-independent logic its handlers rely
+ * on:
+ *
+ *   1. The tag model (iof_types.h).  The PRTE_IOF_* stream tags are a
+ *      bitmask, and the composite tags (STDMERGE, STDOUTALL, STDALL) are
+ *      hand-assigned constants that MUST equal the OR of their parts, or
+ *      the many `tag & PRTE_IOF_STDOUT` tests scattered through the
+ *      handlers would silently mis-route a stream.  The control-flag tags
+ *      (EXCLUSIVE, XON/XOFF, PULL/CLOSE) must not collide with the stream
+ *      bits, since a single uint16 carries both.
+ *
+ *   2. The module contract (iof.h).  Both components fill a 7-slot vtable.
+ *      The daemon relay intentionally leaves push_stdin NULL (stdin
+ *      injection is master-only); the HNP hub must implement all seven.  A
+ *      regression that swapped those would crash or silently drop stdin.
+ *
+ *   3. The component identities: "hnp" and "prted" (selection needs them).
+ *
+ *   4. The core reference-counted classes (base.h).  Their constructors
+ *      establish the NULL/zero/INVALID defaults the push/pull paths depend
+ *      on, and their destructors must free every owned member -- including
+ *      the freshly-constructed, never-used case -- without crashing.
+ *
+ *   5. The producer side of the sink write engine
+ *      (prte_iof_base_write_output).  Its backlog accounting is what the
+ *      XON/XOFF flow control keys on, and the zero-byte sentinel is the
+ *      close-this-stream signal every write path must preserve.  We drive
+ *      it with the write event pre-marked pending so no libevent activation
+ *      is needed, exercising the enqueue/accounting logic directly.
+ *
+ *   6. The always-readable/always-writable fd predicate
+ *      (prte_iof_base_fd_always_ready), which decides timer-vs-fd events
+ *      for every stream.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/iof/base/base.h"
+#include "src/mca/iof/iof.h"
+#include "src/mca/iof/iof_types.h"
+#include "src/mca/iof/hnp/iof_hnp.h"
+#include "src/mca/iof/prted/iof_prted.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/*
+ * The stream tags are bit flags OR'd into one uint16.  The composite
+ * values are hand-written literals in iof_types.h; pin them to the OR of
+ * their parts so a future edit can't drift them apart from the
+ * `tag & PRTE_IOF_STDXXX` tests the handlers use.
+ */
+static int test_tag_model(void)
+{
+    int failures = 0;
+
+    /* the three primitive streams are distinct single bits */
+    CHECK("STDIN is a single bit", PRTE_IOF_STDIN == 0x0001);
+    CHECK("STDOUT is a single bit", PRTE_IOF_STDOUT == 0x0002);
+    CHECK("STDERR is a single bit", PRTE_IOF_STDERR == 0x0004);
+    CHECK("STDDIAG is a single bit", PRTE_IOF_STDDIAG == 0x0008);
+
+    /* composites are exactly the OR of their documented parts */
+    CHECK("STDMERGE == STDOUT|STDERR",
+          PRTE_IOF_STDMERGE == (PRTE_IOF_STDOUT | PRTE_IOF_STDERR));
+    CHECK("STDOUTALL == STDOUT|STDERR|STDDIAG",
+          PRTE_IOF_STDOUTALL == (PRTE_IOF_STDOUT | PRTE_IOF_STDERR | PRTE_IOF_STDDIAG));
+    CHECK("STDALL == STDIN|STDOUT|STDERR|STDDIAG",
+          PRTE_IOF_STDALL
+              == (PRTE_IOF_STDIN | PRTE_IOF_STDOUT | PRTE_IOF_STDERR | PRTE_IOF_STDDIAG));
+
+    /* the handlers rely on these implications when masking a tag */
+    CHECK("STDMERGE selects STDOUT", 0 != (PRTE_IOF_STDMERGE & PRTE_IOF_STDOUT));
+    CHECK("STDMERGE selects STDERR", 0 != (PRTE_IOF_STDMERGE & PRTE_IOF_STDERR));
+    CHECK("STDALL selects every stream",
+          (PRTE_IOF_STDALL & PRTE_IOF_STDIN) && (PRTE_IOF_STDALL & PRTE_IOF_STDOUT)
+              && (PRTE_IOF_STDALL & PRTE_IOF_STDERR) && (PRTE_IOF_STDALL & PRTE_IOF_STDDIAG));
+
+    /* control flags must live above the stream bits so a single tag word
+     * can carry a stream selector and a control flag without collision */
+    CHECK("EXCLUSIVE clear of streams", 0 == (PRTE_IOF_EXCLUSIVE & PRTE_IOF_STDALL));
+    CHECK("XON clear of streams", 0 == (PRTE_IOF_XON & PRTE_IOF_STDALL));
+    CHECK("XOFF clear of streams", 0 == (PRTE_IOF_XOFF & PRTE_IOF_STDALL));
+    CHECK("PULL clear of streams", 0 == (PRTE_IOF_PULL & PRTE_IOF_STDALL));
+    CHECK("CLOSE clear of streams", 0 == (PRTE_IOF_CLOSE & PRTE_IOF_STDALL));
+
+    /* and the control flags are pairwise distinct */
+    CHECK("XON != XOFF", PRTE_IOF_XON != PRTE_IOF_XOFF);
+    CHECK("PULL != CLOSE", PRTE_IOF_PULL != PRTE_IOF_CLOSE);
+    CHECK("XON clear of XOFF", 0 == (PRTE_IOF_XON & PRTE_IOF_XOFF));
+    CHECK("PULL clear of CLOSE", 0 == (PRTE_IOF_PULL & PRTE_IOF_CLOSE));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_tag_model\n");
+    }
+    return failures;
+}
+
+/*
+ * Both components publish a prte_iof_base_module_t.  Only the HNP hub
+ * implements push_stdin (injecting stdin is a master-side operation); the
+ * daemon relay must leave it NULL and callers guard on that.  Every other
+ * slot must be wired in both, since the base and its callers only NULL-check
+ * the optional entry points.
+ */
+static int test_module_contract(void)
+{
+    int failures = 0;
+    prte_iof_base_module_t *hnp = &prte_iof_hnp_module;
+    prte_iof_base_module_t *prted = &prte_iof_prted_module;
+
+    /* the HNP hub wires all seven slots */
+    CHECK("hnp init set", NULL != hnp->init);
+    CHECK("hnp push set", NULL != hnp->push);
+    CHECK("hnp pull set", NULL != hnp->pull);
+    CHECK("hnp close set", NULL != hnp->close);
+    CHECK("hnp complete set", NULL != hnp->complete);
+    CHECK("hnp finalize set", NULL != hnp->finalize);
+    CHECK("hnp push_stdin set", NULL != hnp->push_stdin);
+
+    /* the daemon relay wires six and deliberately leaves push_stdin NULL */
+    CHECK("prted init set", NULL != prted->init);
+    CHECK("prted push set", NULL != prted->push);
+    CHECK("prted pull set", NULL != prted->pull);
+    CHECK("prted close set", NULL != prted->close);
+    CHECK("prted complete set", NULL != prted->complete);
+    CHECK("prted finalize set", NULL != prted->finalize);
+    CHECK("prted push_stdin NULL (HNP-only)", NULL == prted->push_stdin);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_module_contract\n");
+    }
+    return failures;
+}
+
+/*
+ * Component selection is keyed on the component name string; guard both.
+ */
+static int test_component_identity(void)
+{
+    int failures = 0;
+
+    CHECK("hnp component name",
+          0 == strcmp(prte_mca_iof_hnp_component.super.pmix_mca_component_name, "hnp"));
+    CHECK("prted component name",
+          0 == strcmp(prte_mca_iof_prted_component.super.pmix_mca_component_name, "prted"));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_component_identity\n");
+    }
+    return failures;
+}
+
+/*
+ * Constructor defaults and destructor safety for the framework's core
+ * classes.  The defaults are load-bearing: the push/pull/close paths test
+ * these NULL/false/INVALID fields before allocating or tearing down, and
+ * the destructors are the only place the owned events, sinks, and byte
+ * buffers are freed.
+ */
+static int test_classes(void)
+{
+    int failures = 0;
+
+    /* proc endpoint bundle: all three stream slots NULL */
+    prte_iof_proc_t *proc = PMIX_NEW(prte_iof_proc_t);
+    CHECK("proc stdinev NULL", NULL == proc->stdinev);
+    CHECK("proc revstdout NULL", NULL == proc->revstdout);
+    CHECK("proc revstderr NULL", NULL == proc->revstderr);
+    /* the all-NULL destructor path must be safe */
+    PMIX_RELEASE(proc);
+
+    /* write event: not pending, no fd, empty output list, event allocated */
+    prte_iof_write_event_t *wev = PMIX_NEW(prte_iof_write_event_t);
+    CHECK("wev not pending", !wev->pending);
+    CHECK("wev not always_writable", !wev->always_writable);
+    CHECK("wev fd unset", -1 == wev->fd);
+    CHECK("wev ev allocated", NULL != wev->ev);
+    CHECK("wev outputs empty", 0 == pmix_list_get_size(&wev->outputs));
+    PMIX_RELEASE(wev);
+
+    /* sink: constructs its own write event, flags clear, daemon INVALID */
+    prte_iof_sink_t *sink = PMIX_NEW(prte_iof_sink_t);
+    CHECK("sink wev allocated", NULL != sink->wev);
+    CHECK("sink not xoff", !sink->xoff);
+    CHECK("sink not exclusive", !sink->exclusive);
+    CHECK("sink not closed", !sink->closed);
+    CHECK("sink daemon rank INVALID", PMIX_RANK_INVALID == sink->daemon.rank);
+    /* destructor must release the owned write event */
+    PMIX_RELEASE(sink);
+
+    /* read event: inactive, no fd, no proc, no sink, event allocated */
+    prte_iof_read_event_t *rev = PMIX_NEW(prte_iof_read_event_t);
+    CHECK("rev proc NULL", NULL == rev->proc);
+    CHECK("rev fd unset", -1 == rev->fd);
+    CHECK("rev not active", !rev->active);
+    CHECK("rev not activated", !rev->activated);
+    CHECK("rev not always_readable", !rev->always_readable);
+    CHECK("rev sink NULL", NULL == rev->sink);
+    CHECK("rev ev allocated", NULL != rev->ev);
+    /* fd == -1 so the destructor takes the free-without-close path */
+    PMIX_RELEASE(rev);
+
+    /* deliver carrier: empty byte object, and the destructor frees a
+     * malloc'd payload */
+    prte_iof_deliver_t *dlv = PMIX_NEW(prte_iof_deliver_t);
+    CHECK("deliver bytes NULL", NULL == dlv->bo.bytes);
+    CHECK("deliver size 0", 0 == dlv->bo.size);
+    dlv->bo.bytes = (char *) malloc(16);
+    dlv->bo.size = 16;
+    PMIX_RELEASE(dlv);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_classes\n");
+    }
+    return failures;
+}
+
+/*
+ * The producer side of the sink write engine.  prte_iof_base_write_output
+ * appends a *copy* of the caller's bytes to the write event's backlog and
+ * returns the new backlog length -- the value XON/XOFF back-pressure keys
+ * on.  A zero-byte call is not a no-op: it enqueues the flush-then-close
+ * sentinel.  A NULL channel is a documented no-op returning 0.
+ *
+ * We pre-mark the write event pending so write_output never tries to arm a
+ * libevent event (there is no progress thread in this test), isolating the
+ * enqueue/accounting logic.
+ */
+static int test_write_output_accounting(void)
+{
+    int failures = 0;
+    pmix_proc_t name;
+    prte_iof_write_output_t *chunk;
+    int n;
+
+    PMIX_LOAD_PROCID(&name, "test-nspace", 0);
+
+    prte_iof_write_event_t *wev = PMIX_NEW(prte_iof_write_event_t);
+    /* suppress event-base activation: pretend the write event is already
+     * armed so write_output only does its enqueue/accounting work */
+    wev->pending = true;
+
+    /* NULL channel is a no-op returning 0 */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, (const unsigned char *) "x", 1, NULL);
+    CHECK("NULL channel returns 0", 0 == n);
+
+    /* first chunk -> backlog of 1 */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, (const unsigned char *) "hello", 5, wev);
+    CHECK("first write backlog 1", 1 == n);
+    CHECK("backlog list size 1", 1 == pmix_list_get_size(&wev->outputs));
+
+    /* the bytes are copied verbatim into a fresh chunk */
+    chunk = (prte_iof_write_output_t *) pmix_list_get_first(&wev->outputs);
+    CHECK("chunk numbytes 5", 5 == chunk->numbytes);
+    CHECK("chunk data copied", 0 == memcmp(chunk->data, "hello", 5));
+
+    /* second chunk -> backlog of 2 */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, (const unsigned char *) "world", 5, wev);
+    CHECK("second write backlog 2", 2 == n);
+
+    /* zero-byte call still enqueues the close sentinel -> backlog of 3 */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, NULL, 0, wev);
+    CHECK("zero-byte write backlog 3", 3 == n);
+    CHECK("backlog list size 3", 3 == pmix_list_get_size(&wev->outputs));
+
+    /* the sentinel is the last item and carries numbytes == 0 */
+    chunk = (prte_iof_write_output_t *) pmix_list_get_last(&wev->outputs);
+    CHECK("sentinel numbytes 0", 0 == chunk->numbytes);
+
+    /* releasing the write event must drain and free the queued chunks */
+    PMIX_RELEASE(wev);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_write_output_accounting\n");
+    }
+    return failures;
+}
+
+/*
+ * The queued chunk carries a fixed PRTE_IOF_BASE_TAGGED_OUT_MAX buffer, but
+ * callers (notably the HNP's push_stdin, which hands us whatever the PMIx
+ * server produced) are under no obligation to respect that limit. An
+ * oversized write must be split across chunks rather than overrun the
+ * buffer, and no byte may be lost in the split.
+ */
+static int test_write_output_chunking(void)
+{
+    int failures = 0;
+    pmix_proc_t name;
+    prte_iof_write_output_t *chunk;
+    prte_iof_write_event_t *wev;
+    unsigned char *big;
+    size_t bigsize = (2 * PRTE_IOF_BASE_TAGGED_OUT_MAX) + 17;
+    size_t i, total = 0;
+    int n;
+
+    PMIX_LOAD_PROCID(&name, "test-nspace", 0);
+
+    big = (unsigned char *) malloc(bigsize);
+    if (NULL == big) {
+        fprintf(stderr, "FAIL [write_output_chunking]: malloc failed\n");
+        return 1;
+    }
+    for (i = 0; i < bigsize; i++) {
+        big[i] = (unsigned char) (i % 251);
+    }
+
+    wev = PMIX_NEW(prte_iof_write_event_t);
+    wev->pending = true;
+
+    /* 2 full chunks + a 17-byte remainder */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, big, (int) bigsize, wev);
+    CHECK("oversized write split into 3 chunks", 3 == n);
+
+    /* every chunk is within the buffer, and the pieces reassemble exactly */
+    PMIX_LIST_FOREACH(chunk, &wev->outputs, prte_iof_write_output_t)
+    {
+        if (PRTE_IOF_BASE_TAGGED_OUT_MAX < chunk->numbytes) {
+            fprintf(stderr, "FAIL [write_output_chunking]: chunk of %d bytes exceeds %d\n",
+                    chunk->numbytes, PRTE_IOF_BASE_TAGGED_OUT_MAX);
+            failures++;
+            break;
+        }
+        if (0 != memcmp(chunk->data, &big[total], chunk->numbytes)) {
+            fprintf(stderr, "FAIL [write_output_chunking]: chunk at offset %lu differs\n",
+                    (unsigned long) total);
+            failures++;
+            break;
+        }
+        total += chunk->numbytes;
+    }
+    CHECK("chunks reassemble to the original length", bigsize == total);
+
+    /* a negative count cannot be copied - it must degrade to the close
+     * sentinel rather than being handed to write() as a huge size
+     */
+    n = prte_iof_base_write_output(&name, PRTE_IOF_STDIN, big, -1, wev);
+    CHECK("negative write enqueues sentinel", 4 == n);
+    chunk = (prte_iof_write_output_t *) pmix_list_get_last(&wev->outputs);
+    CHECK("negative write numbytes 0", 0 == chunk->numbytes);
+
+    PMIX_RELEASE(wev);
+    free(big);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_write_output_chunking\n");
+    }
+    return failures;
+}
+
+/*
+ * prte_iof_base_fd_always_ready decides whether a stream is driven by a
+ * zero-length timer (regular files / non-tty char devs / block devs, which
+ * never signal readiness through the event loop) or by a real fd event.
+ * A pipe -- the normal stdout/stderr/stdin transport -- must be the fd-event
+ * case; a regular file and /dev/null must be the timer case.
+ */
+static int test_fd_always_ready(void)
+{
+    int failures = 0;
+    int pfd[2];
+    int rfd, nulfd;
+
+    /* a pipe is NOT always ready -- it is driven by a real read/write event */
+    if (0 == pipe(pfd)) {
+        CHECK("pipe read end not always-ready", !prte_iof_base_fd_always_ready(pfd[0]));
+        CHECK("pipe write end not always-ready", !prte_iof_base_fd_always_ready(pfd[1]));
+        close(pfd[0]);
+        close(pfd[1]);
+    } else {
+        fprintf(stderr, "FAIL [fd_always_ready]: pipe() failed\n");
+        failures++;
+    }
+
+    /* a regular file IS always ready -- it never blocks, so it is timer-driven */
+    rfd = open("test_iof_tmpfile.dat", O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (0 <= rfd) {
+        CHECK("regular file always-ready", prte_iof_base_fd_always_ready(rfd));
+        close(rfd);
+        unlink("test_iof_tmpfile.dat");
+    } else {
+        fprintf(stderr, "FAIL [fd_always_ready]: could not create temp file\n");
+        failures++;
+    }
+
+    /* /dev/null is a non-tty character device -> always ready */
+    nulfd = open("/dev/null", O_WRONLY);
+    if (0 <= nulfd) {
+        CHECK("/dev/null always-ready", prte_iof_base_fd_always_ready(nulfd));
+        close(nulfd);
+    } else {
+        fprintf(stderr, "FAIL [fd_always_ready]: could not open /dev/null\n");
+        failures++;
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fd_always_ready\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_tag_model();
+    failures += test_module_contract();
+    failures += test_component_identity();
+    failures += test_classes();
+    failures += test_write_output_accounting();
+    failures += test_write_output_chunking();
+    failures += test_fd_always_ready();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all iof unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d iof unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

A review of the IOF framework turned up a cluster of defects in the stdin forwarding path, all rooted in fixed-size buffers and assumptions that no caller ever enforced:

- `prte_iof_base_write_output` copied caller data into a fixed `PRTE_IOF_BASE_TAGGED_OUT_MAX` chunk with an unchecked `memcpy`. Every internal read path respected the bound by convention, but the HNP's `push_stdin` path hands over whatever the PMIx server produced — nothing obliged it to respect a limit the framework never advertised, and exceeding it overran the chunk.
- A daemon unpacked forwarded stdin into a fixed `PRTE_IOF_BASE_MSG_MAX` buffer. When the HNP forwarded a larger fragment (which it will, since `push_stdin` passes the PMIx server's chunk straight through), the unpack failed with `PMIX_ERR_UNPACK_INADEQUATE_SPACE` and the daemon dropped the entire fragment — the proc waiting on stdin never saw those bytes.
- Wildcard stdin (`--stdin all`) is xcast on `PRTE_RML_TAG_IOF_PROXY`, but the HNP posted no receive on that tag, so its own copy of the broadcast matched nothing and no proc hosted by the HNP ever received wildcard stdin. On a single-node job that is every proc, and `--stdin all` simply hung. The wildcard branch of `push_stdin` also fell through to a hostname lookup that cannot resolve a wildcard rank, so a successful push reported `PRTE_ERR_ADDRESSEE_UNKNOWN`.
- The read/receive handlers dereferenced `proct` before the NULL guard meant to protect it, left three payload mallocs unchecked, and let a negative count from a corrupt message reach `malloc` in `prte_iof_hnp_recv`.

## Solution

One commit per defect:

- Split an oversized write across as many chunks as it takes, and treat a non-positive count as the close sentinel. The bound is now the function's own guarantee rather than an obligation on every caller.
- Pack the byte count ahead of the forwarded stdin payload (as the daemon-to-HNP output path already does) and size the receiver's allocation from the wire. Both ends ship together in one install, so no compatibility shim is needed.
- Post the proxy receive on the HNP and service its local procs exactly as a daemon does; return from the wildcard branch once the broadcast is away.
- Move the NULL guards ahead of first use, check the allocations, reject non-positive on-wire counts, and drop dead declarations left over from the HNP reading its own terminal stdin.

The final commit adds the framework's first automated coverage: `test/unit/iof` wired into `make check` (tag invariants, vtable contract, class lifecycle, sink engine chunking and sentinel handling), plus multi-node stdin delivery tests in the dockerswarm harness — one pipes a payload far larger than any internal chunk through to a remote proc and compares checksums, the other verifies wildcard stdin reaches HNP-hosted and remote procs together.

Note: the delivery tests run under `prun` against a persistent DVM rather than `prterun`, because the HNP-as-PMIx-server stdin path drops the zero-byte close — an openpmix defect tracked in openpmix/openpmix#4024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)