### PR TITLE
ci: update the PR commit checker action to v1.0.2

### DIFF
--- a/.github/workflows/pr-target.yaml
+++ b/.github/workflows/pr-target.yaml
@@ -23,6 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Pull Request Commit Checker
-        uses: open-mpi/pr-git-commit-checker@v1.0.1
+        uses: open-mpi/pr-git-commit-checker@v1.0.2
         with:
           token: "${{ secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
Pick up the latest release of the open-mpi pr-git-commit-checker action used by the pull-request target workflow.