### PR TITLE
Close the prterun spawn-time race by thread-shifting lock wakeups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,6 +535,37 @@ or upcall must therefore thread-shift into the PRRTE progress thread
 performing any operations — the function body that PMIx calls should do
 nothing beyond capturing its arguments and posting the event.
 
+This applies even to a callback that does nothing but complete a
+blocking request: a `prte_pmix_lock_t` is a PRRTE object, so do **not**
+call `PRTE_PMIX_WAKEUP_THREAD` (or touch the lock in any other way)
+directly from the PMIx thread.  Capture the arguments, thread-shift,
+and perform the wakeup in the handler running on the PRRTE progress
+thread.  The bare-wakeup shortcut loses races: a waiter on the thread
+that drives `prte_event_base` waits by re-checking `lock.active`
+between `prte_event_loop(PRTE_EVLOOP_ONCE)` iterations rather than
+blocking in the lock's condition variable, so a direct cross-thread
+signal delivered while the loop is parked inside the event backend is
+never observed and the process hangs (this was the cause of an
+intermittent `prterun` spawn hang).  Posting the wakeup as an event
+both wakes the event loop and serializes the flag update.  The
+`prte_pmix_shifted_wakeup()` helper (declared in
+[`src/pmix/pmix-internal.h`](src/pmix/pmix-internal.h)) packages this
+pattern for completion callbacks whose only job is to record a status
+(and optionally a message string) and wake a waiter.
+
+The corollary on the waiting side: code that must block on the thread
+that drives `prte_event_base` (for example, `prte()` itself while
+waiting for a spawn to complete) must wait with the loop-driving idiom —
+
+```c
+while (prte_event_base_active && lock.active) {
+    prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+}
+```
+
+— never with `PRTE_PMIX_WAIT_THREAD`, which would park the only thread
+able to run the thread-shifted wakeup handler.
+
 ### Thread-shifting with caddies
 
 A **caddy** is a short-lived heap object whose sole job is to carry a request's parameters across states within the progress thread.  Every caddy struct must contain at minimum:

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -187,6 +187,33 @@ static inline __prte_attribute_always_inline__ void pmix_proc_hton_intr(pmix_pro
         pmix_mutex_unlock(&(lck)->mutex);     \
     } while (0)
 
+/* Caddy for shifting a lock wakeup from the PMIx progress thread
+ * onto the PRRTE progress thread. A prte_pmix_lock_t is a PRRTE
+ * object, so a callback executing on the PMIx progress thread must
+ * not wake it directly - a waiter that drives prte_event_base while
+ * polling the lock's active flag would never observe a wakeup
+ * signaled while the event loop is parked in the backend. Posting
+ * the wakeup as an event both wakes the loop and serializes the
+ * flag update. */
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    prte_pmix_lock_t *lock;
+    pmix_status_t status;
+    char *msg;
+} prte_pmix_wakeup_caddy_t;
+PMIX_CLASS_DECLARATION(prte_pmix_wakeup_caddy_t);
+
+/* Post a wakeup of the given lock to prte_event_base. The handler
+ * running on the PRRTE progress thread stores status in
+ * lock->status, transfers ownership of msg (which must be NULL or
+ * heap-allocated) to lock->msg, and then wakes the waiter. Call
+ * this - never PRTE_PMIX_WAKEUP_THREAD - from any callback that
+ * PMIx invokes in a process hosting a PRRTE event base. */
+PRTE_EXPORT void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
+                                          pmix_status_t status,
+                                          char *msg);
+
 /*
  * Count the hash for the the external RM
  */

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -494,6 +494,40 @@ int prte_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
     return ret;
 }
 
+/* handler side of prte_pmix_shifted_wakeup - executes on the
+ * PRRTE progress thread */
+static void shifted_wakeup(int fd, short args, void *cbdata)
+{
+    prte_pmix_wakeup_caddy_t *cd = (prte_pmix_wakeup_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+    cd->lock->status = cd->status;
+    if (NULL != cd->msg) {
+        /* transfer ownership to the lock - the caddy destructor
+         * must not free it */
+        cd->lock->msg = cd->msg;
+        cd->msg = NULL;
+    }
+    PRTE_PMIX_WAKEUP_THREAD(cd->lock);
+    PMIX_RELEASE(cd);
+}
+
+void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
+                              pmix_status_t status,
+                              char *msg)
+{
+    prte_pmix_wakeup_caddy_t *cd;
+
+    cd = PMIX_NEW(prte_pmix_wakeup_caddy_t);
+    cd->lock = lock;
+    cd->status = status;
+    cd->msg = msg;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, shifted_wakeup, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+}
+
 /* CLASS INSTANTIATIONS */
 static void acon(prte_pmix_app_t *p)
 {
@@ -536,3 +570,17 @@ static void pvdes(prte_value_t *p)
     PMIX_VALUE_DESTRUCT(&p->value);
 }
 PRTE_EXPORT PMIX_CLASS_INSTANCE(prte_value_t, pmix_list_item_t, pvcon, pvdes);
+
+static void wkcon(prte_pmix_wakeup_caddy_t *p)
+{
+    p->lock = NULL;
+    p->status = PMIX_SUCCESS;
+    p->msg = NULL;
+}
+static void wkdes(prte_pmix_wakeup_caddy_t *p)
+{
+    if (NULL != p->msg) {
+        free(p->msg);
+    }
+}
+PRTE_EXPORT PMIX_CLASS_INSTANCE(prte_pmix_wakeup_caddy_t, pmix_object_t, wkcon, wkdes);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -135,25 +135,27 @@ static void epipe_signal_callback(int fd, short args, void *cbdata);
 static int prep_singleton(const char *name);
 static bool keepalive = false;
 
+/* NOTE: these callbacks execute on the PMIx progress thread. They
+ * therefore capture their arguments and shift the wakeup onto our
+ * event base - the waiters below drive prte_event_base while
+ * polling the lock, so a wakeup signaled directly from the PMIx
+ * thread could be missed while the loop is parked in the backend */
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(status);
 
-    PMIX_ACQUIRE_OBJECT(lock);
-    PRTE_PMIX_WAKEUP_THREAD(lock);
+    prte_pmix_shifted_wakeup(lock, status, NULL);
 }
 
 static void spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
 {
     prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
+    char *msg = NULL;
 
-    PMIX_ACQUIRE_OBJECT(lock);
-    lock->status = status;
     if (PMIX_SUCCESS == status) {
-        lock->msg = strdup(nspace);
+        msg = strdup(nspace);
     }
-    PRTE_PMIX_WAKEUP_THREAD(lock);
+    prte_pmix_shifted_wakeup(lock, status, msg);
 }
 
 static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
@@ -178,8 +180,9 @@ static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, voi
     mylock_t *lock = (mylock_t *) cbdata;
     PRTE_HIDE_UNUSED_PARAMS(evhandler_ref);
 
-    lock->status = status;
-    PRTE_PMIX_WAKEUP_THREAD(&lock->lock);
+    /* executes on the PMIx progress thread - record the status in
+     * the embedded lock and shift the wakeup onto our event base */
+    prte_pmix_shifted_wakeup(&lock->lock, status, NULL);
 }
 
 
@@ -755,7 +758,14 @@ int prte(int argc, char *argv[])
     PMIX_INFO_LOAD(&info, PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
     PMIx_Register_event_handler(&code, 1, &info, 1, parent_died_fn, evhandler_reg_callbk,
                                 (void *) &mylock);
-    PRTE_PMIX_WAIT_THREAD(&mylock.lock);
+    /* the registration callback shifts its wakeup onto our event
+     * base, so we must cycle the event library while we wait. Do
+     * not add an escape from this loop - the callback references
+     * the stack-based lock, so we cannot leave until it has fired */
+    while (mylock.lock.active) {
+        prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+    }
+    PMIX_ACQUIRE_OBJECT(&mylock.lock);
     PMIX_INFO_DESTRUCT(&info);
     PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
 
@@ -1328,7 +1338,15 @@ int prte(int argc, char *argv[])
         if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
             pmix_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
         } else if (PMIX_SUCCESS == ret) {
-            PRTE_PMIX_WAIT_THREAD(&lock);
+            /* the callback shifts its wakeup onto our event base,
+             * so we must cycle the event library while we wait. Do
+             * not add an escape from this loop - the callback
+             * references the stack-based lock, so we cannot leave
+             * until it has fired */
+            while (lock.active) {
+                prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+            }
+            PMIX_ACQUIRE_OBJECT(&lock);
         }
         PRTE_PMIX_DESTRUCT_LOCK(&lock);
         PMIX_INFO_FREE(iptr2, 1);
@@ -1349,7 +1367,15 @@ proceed:
     if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
         pmix_output(0, "IOF close of stdin failed: %s", PMIx_Error_string(ret));
     } else if (PMIX_SUCCESS == ret) {
-        PRTE_PMIX_WAIT_THREAD(&lock);
+        /* the callback shifts its wakeup onto our event base. The
+         * main event loop above has already exited, so we must
+         * cycle the event library ourselves until the wakeup
+         * arrives - the callback references the stack-based lock,
+         * so we cannot leave until it has fired */
+        while (lock.active) {
+            prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+        }
+        PMIX_ACQUIRE_OBJECT(&lock);
     }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_DESTRUCT(&info);


### PR DESCRIPTION
## Problem

prterun intermittently hung at spawn time before ever pushing stdin to the job. The spawn completion callback registered with PMIx_Spawn_nb executes on the PMIx progress thread and woke the waiter's lock directly - but the waiter drives prte_event_base while re-checking the lock's active flag between event loop iterations, never blocking in the lock's condition variable. A wakeup signaled while the loop was parked inside the event backend was never observed. Reproduced at a substantial rate under repeated runs; supersedes the earlier event_base_loopexit approach on topic/prterun-stdin-spawn-race.

## Fix

Adds `prte_pmix_shifted_wakeup()`, which posts a small caddy to prte_event_base so the status is recorded and the wakeup performed on the PRRTE progress thread - the event post itself wakes the loop, closing the race. Converts prte's spawn/IOF/event-registration completion callbacks to it, and converts their condvar waits to the loop-driving idiom (deliberately with no escape condition, since the callbacks reference stack-based locks). Also extends the thread-shift golden rule in AGENTS.md: a prte_pmix_lock_t is a PRRTE object, so even wakeup-only callbacks must shift, and waiters on the event-driving thread must wait by driving the loop.

## Verification

Warning-free --enable-debug build, make check, 100/100 spawn-stress iterations with zero hangs (previously ~20-33% hang rate), full prte/prun/pterm DVM cycle, and multi-node validation on a 10-node container swarm (20/20 spawn stress, cross-node IOF).

This is the first PR of the thread-shift series; the follow-on PRs stack on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)