### PR TITLE
Thread-shift the inline PMIx server module upcalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,6 +535,37 @@ or upcall must therefore thread-shift into the PRRTE progress thread
 performing any operations — the function body that PMIx calls should do
 nothing beyond capturing its arguments and posting the event.
 
+This applies even to a callback that does nothing but complete a
+blocking request: a `prte_pmix_lock_t` is a PRRTE object, so do **not**
+call `PRTE_PMIX_WAKEUP_THREAD` (or touch the lock in any other way)
+directly from the PMIx thread.  Capture the arguments, thread-shift,
+and perform the wakeup in the handler running on the PRRTE progress
+thread.  The bare-wakeup shortcut loses races: a waiter on the thread
+that drives `prte_event_base` waits by re-checking `lock.active`
+between `prte_event_loop(PRTE_EVLOOP_ONCE)` iterations rather than
+blocking in the lock's condition variable, so a direct cross-thread
+signal delivered while the loop is parked inside the event backend is
+never observed and the process hangs (this was the cause of an
+intermittent `prterun` spawn hang).  Posting the wakeup as an event
+both wakes the event loop and serializes the flag update.  The
+`prte_pmix_shifted_wakeup()` helper (declared in
+[`src/pmix/pmix-internal.h`](src/pmix/pmix-internal.h)) packages this
+pattern for completion callbacks whose only job is to record a status
+(and optionally a message string) and wake a waiter.
+
+The corollary on the waiting side: code that must block on the thread
+that drives `prte_event_base` (for example, `prte()` itself while
+waiting for a spawn to complete) must wait with the loop-driving idiom —
+
+```c
+while (prte_event_base_active && lock.active) {
+    prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+}
+```
+
+— never with `PRTE_PMIX_WAIT_THREAD`, which would park the only thread
+able to run the thread-shifted wakeup handler.
+
 ### Thread-shifting with caddies
 
 A **caddy** is a short-lived heap object whose sole job is to carry a request's parameters across states within the progress thread.  Every caddy struct must contain at minimum:

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -553,13 +553,6 @@ void prte_ras_base_release_allocation(prte_session_t *session)
     }
 }
 
-static void localrelease(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
-}
 
 void prte_ras_base_modify(int fd, short args, void *cbdata)
 {
@@ -609,7 +602,7 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
 
     // execute the callback
     if (NULL != req->infocbfunc) {
-        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata, localrelease, req);
+        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);
         return;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -49,7 +49,6 @@ typedef struct {
  */
 static void swt_con(prte_slurm_wait_tracker_t *p);
 static void swt_des(prte_slurm_wait_tracker_t *p);
-static void localrelease(void *cbdata);
 static int prte_ras_slurm_make_sbatch_arg(pmix_hash_table_t *fields, const char *field_name, const char *field_format, bool obj_num, int *argc, char **argv);
 static int prte_ras_slurm_exec_sbatch(char * const *argv, char *job_id);
 static int prte_ras_slurm_launch_expander_job(pmix_hash_table_t *fields);
@@ -136,18 +135,6 @@ static void swt_des(prte_slurm_wait_tracker_t *p)
     if (NULL != p->req) {
         PMIX_RELEASE(p->req);
     }
-}
-
-/*
- * Cleanup function if user provides callback function
- * after new resources are secured
- */
-static void localrelease(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
 }
 
 /*
@@ -926,7 +913,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     /* Execute callback if necessary */
     if (NULL != req->infocbfunc) {
         req->infocbfunc(req->pstatus, req->info, req->ninfo,
-                        req->cbdata, localrelease, req);
+                        req->cbdata, prte_pmix_server_req_release, req);
         PMIX_RELEASE(trk);
         return;
     }

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -23,7 +23,6 @@ static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session, con
 static int prte_ras_slurm_session_removable_count(prte_session_stack_item_t *session_item, const char *launching_jobid);
 static prte_session_stack_item_t *prte_ras_slurm_find_releasable_session(const char *launching_jobid, char **excluded_jobids);
 static int prte_ras_slurm_validate_count_release(int nodes_to_remove, const char *launching_jobid);
-static void localrelease(void *cbdata);
 static bool prte_ras_slurm_session_is_dynamic(prte_session_t *session);
 static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char **nodes);
 static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, const char *alloc_id);
@@ -44,13 +43,6 @@ static int prte_ras_slurm_shrink_job_to_survivors(const char *slurm_jobid, char 
 static void prte_ras_slurm_cleanup_resize_scripts(const char *slurm_jobid);
 static void prte_ras_slurm_exclude_shrunk_nodes(prte_shrink_campaign_t *campaign);
 
-static void localrelease(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
-}
 
 /**
  * @brief Check whether a Slurm session was created by a modify request.
@@ -448,7 +440,7 @@ static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req)
     req->pstatus = PMIX_OPERATION_IN_PROGRESS;
     if (NULL != req->infocbfunc) {
         req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
-                        localrelease, req);
+                        prte_pmix_server_req_release, req);
         return PRTE_ERR_OP_IN_PROGRESS;
     }
 

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -187,6 +187,33 @@ static inline __prte_attribute_always_inline__ void pmix_proc_hton_intr(pmix_pro
         pmix_mutex_unlock(&(lck)->mutex);     \
     } while (0)
 
+/* Caddy for shifting a lock wakeup from the PMIx progress thread
+ * onto the PRRTE progress thread. A prte_pmix_lock_t is a PRRTE
+ * object, so a callback executing on the PMIx progress thread must
+ * not wake it directly - a waiter that drives prte_event_base while
+ * polling the lock's active flag would never observe a wakeup
+ * signaled while the event loop is parked in the backend. Posting
+ * the wakeup as an event both wakes the loop and serializes the
+ * flag update. */
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    prte_pmix_lock_t *lock;
+    pmix_status_t status;
+    char *msg;
+} prte_pmix_wakeup_caddy_t;
+PMIX_CLASS_DECLARATION(prte_pmix_wakeup_caddy_t);
+
+/* Post a wakeup of the given lock to prte_event_base. The handler
+ * running on the PRRTE progress thread stores status in
+ * lock->status, transfers ownership of msg (which must be NULL or
+ * heap-allocated) to lock->msg, and then wakes the waiter. Call
+ * this - never PRTE_PMIX_WAKEUP_THREAD - from any callback that
+ * PMIx invokes in a process hosting a PRRTE event base. */
+PRTE_EXPORT void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
+                                          pmix_status_t status,
+                                          char *msg);
+
 /*
  * Count the hash for the the external RM
  */

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -494,6 +494,40 @@ int prte_pmix_register_cleanup(char *path, bool directory, bool ignore, bool job
     return ret;
 }
 
+/* handler side of prte_pmix_shifted_wakeup - executes on the
+ * PRRTE progress thread */
+static void shifted_wakeup(int fd, short args, void *cbdata)
+{
+    prte_pmix_wakeup_caddy_t *cd = (prte_pmix_wakeup_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+    cd->lock->status = cd->status;
+    if (NULL != cd->msg) {
+        /* transfer ownership to the lock - the caddy destructor
+         * must not free it */
+        cd->lock->msg = cd->msg;
+        cd->msg = NULL;
+    }
+    PRTE_PMIX_WAKEUP_THREAD(cd->lock);
+    PMIX_RELEASE(cd);
+}
+
+void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
+                              pmix_status_t status,
+                              char *msg)
+{
+    prte_pmix_wakeup_caddy_t *cd;
+
+    cd = PMIX_NEW(prte_pmix_wakeup_caddy_t);
+    cd->lock = lock;
+    cd->status = status;
+    cd->msg = msg;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, shifted_wakeup, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+}
+
 /* CLASS INSTANTIATIONS */
 static void acon(prte_pmix_app_t *p)
 {
@@ -536,3 +570,17 @@ static void pvdes(prte_value_t *p)
     PMIX_VALUE_DESTRUCT(&p->value);
 }
 PRTE_EXPORT PMIX_CLASS_INSTANCE(prte_value_t, pmix_list_item_t, pvcon, pvdes);
+
+static void wkcon(prte_pmix_wakeup_caddy_t *p)
+{
+    p->lock = NULL;
+    p->status = PMIX_SUCCESS;
+    p->msg = NULL;
+}
+static void wkdes(prte_pmix_wakeup_caddy_t *p)
+{
+    if (NULL != p->msg) {
+        free(p->msg);
+    }
+}
+PRTE_EXPORT PMIX_CLASS_INSTANCE(prte_pmix_wakeup_caddy_t, pmix_object_t, wkcon, wkdes);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2346,6 +2346,8 @@ static void opcon(prte_pmix_server_op_caddy_t *p)
     memset(&p->proct, 0, sizeof(pmix_proc_t));
     p->procs = NULL;
     p->nprocs = 0;
+    p->channels = 0;
+    p->flag = false;
     p->eprocs = NULL;
     p->neprocs = 0;
     p->info = NULL;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1331,14 +1331,38 @@ error:
     return;
 }
 
-/* the modex_resp function takes place in the local PMIx server's
- * progress thread - we must therefore thread-shift it so we can
- * access our global data */
-static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata)
+/* caddy for shifting a dmodex response - the req's own events may
+ * be armed as timers, so the shift must use its own event */
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    pmix_status_t status;
+    char *data;
+    size_t sz;
+    prte_pmix_server_req_t *req;
+} prte_dmdx_resp_caddy_t;
+static void dmrcon(prte_dmdx_resp_caddy_t *p)
 {
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    p->status = PMIX_SUCCESS;
+    p->data = NULL;
+    p->sz = 0;
+    p->req = NULL;
+}
+static void dmrdes(prte_dmdx_resp_caddy_t *p)
+{
+    if (NULL != p->data) {
+        free(p->data);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_dmdx_resp_caddy_t, pmix_object_t, dmrcon, dmrdes);
 
-    PMIX_ACQUIRE_OBJECT(req);
+static void _modex_resp(int sd, short args, void *cbdata)
+{
+    prte_dmdx_resp_caddy_t *cd = (prte_dmdx_resp_caddy_t *) cbdata;
+    prte_pmix_server_req_t *req = cd->req;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     /* clear any timeout event */
     if (req->event_active) {
@@ -1351,23 +1375,47 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
     }
 
     req->inprogress = false; // we are done processing this request
-    req->pstatus = status;
-    if (PMIX_SUCCESS == status && NULL != data) {
+    req->pstatus = cd->status;
+    /* transfer ownership of the data to the req - the caddy
+     * destructor must not free it */
+    req->data = cd->data;
+    cd->data = NULL;
+    req->sz = cd->sz;
+
+    /* we are already on the progress thread, so just execute
+     * the response directly */
+    _mdxresp(0, 0, req);
+    PMIX_RELEASE(cd);
+}
+
+/* the modex_resp function takes place in the local PMIx server's
+ * progress thread - we must therefore thread-shift it so we can
+ * access our global data. Note that we cannot touch the req at
+ * all here: its fields and its timer events belong to the PRRTE
+ * progress thread, and its own event structures may be armed as
+ * timers, so the shift is carried by a separate caddy */
+static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    prte_dmdx_resp_caddy_t *cd;
+
+    cd = PMIX_NEW(prte_dmdx_resp_caddy_t);
+    cd->status = status;
+    cd->req = req;
+    if (PMIX_SUCCESS == status && NULL != data && 0 < sz) {
         /* we need to preserve the data as the caller
          * will free it upon our return */
-        req->data = (char *) malloc(sz);
-        if (NULL == req->data) {
+        cd->data = (char *) malloc(sz);
+        if (NULL == cd->data) {
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-            req->data = NULL;
-            req->sz = 0;
         } else {
-             memcpy(req->data, data, sz);
-             req->sz = sz;
+            memcpy(cd->data, data, sz);
+            cd->sz = sz;
         }
     }
-    prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, _mdxresp, req);
-    PMIX_POST_OBJECT(req);
-    prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _modex_resp, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 
 static void dmdx_check(int sd, short args, void *cbdata)

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1821,23 +1821,14 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
 }
 
 
-static void log_cbfunc(pmix_status_t status, void *cbdata)
+static void _log_resp(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
     pmix_data_buffer_t *buf;
-    pmix_status_t rc, lstat;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "Logging callback called");
-
-    if (PMIX_SUCCESS != status && PMIX_OPERATION_SUCCEEDED != status) {
-        pmix_output(prte_pmix_server_globals.output, "LOG FAILED");
-    }
-    if (PMIX_OPERATION_SUCCEEDED == status) {
-        lstat = PMIX_SUCCESS;
-    } else {
-        lstat = status;
-    }
+    PMIX_ACQUIRE_OBJECT(req);
 
     PMIX_DATA_BUFFER_CREATE(buf);
 
@@ -1850,7 +1841,7 @@ static void log_cbfunc(pmix_status_t status, void *cbdata)
     }
 
     // pack the operation's status
-    rc = PMIx_Data_pack(NULL, buf, &lstat, 1, PMIX_STATUS);
+    rc = PMIx_Data_pack(NULL, buf, &req->pstatus, 1, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
@@ -1860,7 +1851,7 @@ static void log_cbfunc(pmix_status_t status, void *cbdata)
     /* send the result to the requestor */
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "Logging response %s sent to daemon %u",
-                        PMIx_Error_string(lstat), req->proxy.rank);
+                        PMIx_Error_string(req->pstatus), req->proxy.rank);
 
     PRTE_RML_SEND(rc, req->proxy.rank, buf,
                   PRTE_RML_TAG_LOGGING_RESP);
@@ -1871,6 +1862,29 @@ static void log_cbfunc(pmix_status_t status, void *cbdata)
 
 done:
     PMIX_RELEASE(req);
+}
+
+static void log_cbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "Logging callback called");
+
+    if (PMIX_SUCCESS != status && PMIX_OPERATION_SUCCEEDED != status) {
+        pmix_output(prte_pmix_server_globals.output, "LOG FAILED");
+    }
+    if (PMIX_OPERATION_SUCCEEDED == status) {
+        req->pstatus = PMIX_SUCCESS;
+    } else {
+        req->pstatus = status;
+    }
+
+    /* the PMIx library invokes this on its progress thread, so we
+     * must shift to our event base before responding over the RML */
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, _log_resp, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
 }
 
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2251,7 +2251,12 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
         req->ninfo = ninfo;
         PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
         PMIX_PROC_LOAD(&req->tproc, source.nspace, source.rank);
-        /* add this request to our local request tracker array */
+        /* add this request to our local request tracker array. The
+         * extra retain balances the TWO releases that fire when the
+         * RAS completes this relayed request: it invokes
+         * send_alloc_resp as the callback, whose cleanup tail
+         * releases the req, AND hands it prte_pmix_server_req_release
+         * as the release callback, which releases it again */
         PMIX_RETAIN(req);
         req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
         // point to the proper callback function
@@ -2285,8 +2290,11 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     req->ninfo = ninfo;
     PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
     PMIX_PROC_LOAD(&req->tproc, source.nspace, source.rank);
-    /* add this request to our local request tracker array */
-    PMIX_RETAIN(req);
+    /* add this request to our local request tracker array. Unlike
+     * the allocation branch above, do NOT retain here - only the
+     * cleanup tail of send_alloc_resp releases this req (the
+     * release callback on this path belongs to the PMIx library),
+     * so an extra retain would leak it */
     req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
     rc = PMIx_Session_control(sessionID, req->info, req->ninfo,

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -635,11 +635,9 @@ static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
  * requested the allocation. PRRTE is a pure relay here: it neither sets the
  * timeout nor generates the warning, only re-emits it as a directed event to
  * the recorded requestor. */
-static void alloc_timeout_warning_hdlr(size_t evhdlr_registration_id, pmix_status_t status,
-                                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
-                                       pmix_info_t *results, size_t nresults,
-                                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+static void _alloc_timeout_warning(int sd, short args, void *cbdata)
 {
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     size_t n, idx, nrinfo;
     char *alloc_id = NULL;
     uint32_t time_remaining = 0;
@@ -649,13 +647,15 @@ static void alloc_timeout_warning_hdlr(size_t evhdlr_registration_id, pmix_statu
     pmix_data_array_t parray;
     pmix_proc_t ptarg;
     pmix_status_t rc;
-    PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    for (n = 0; n < ninfo; n++) {
-        if (PMIx_Check_key(info[n].key, PMIX_ALLOC_ID)) {
-            alloc_id = info[n].value.data.string;
-        } else if (PMIx_Check_key(info[n].key, PMIX_TIME_REMAINING)) {
-            time_remaining = info[n].value.data.uint32;
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    for (n = 0; n < cd->ninfo; n++) {
+        if (PMIx_Check_key(cd->info[n].key, PMIX_ALLOC_ID)) {
+            alloc_id = cd->info[n].value.data.string;
+        } else if (PMIx_Check_key(cd->info[n].key, PMIX_TIME_REMAINING)) {
+            time_remaining = cd->info[n].value.data.uint32;
             have_time = true;
         }
     }
@@ -698,9 +698,32 @@ static void alloc_timeout_warning_hdlr(size_t evhdlr_registration_id, pmix_statu
     PMIX_INFO_FREE(rinfo, nrinfo);
 
 done:
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    if (NULL != cd->evcbfunc) {
+        cd->evcbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cd->cbdata);
     }
+    PMIX_RELEASE(cd);
+}
+
+static void alloc_timeout_warning_hdlr(size_t evhdlr_registration_id, pmix_status_t status,
+                                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                       pmix_info_t *results, size_t nresults,
+                                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd;
+    PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, status, source, results, nresults);
+
+    /* this executes on the PMIx progress thread, and we must access
+     * the session tracker - shift to our event base. The info array
+     * remains valid until we invoke the notification callback, so
+     * carry the pointers across */
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->evcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _alloc_timeout_warning, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 #endif
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2245,6 +2245,28 @@ PMIX_CLASS_INSTANCE(prte_pmix_server_op_caddy_t,
                     pmix_object_t,
                     opcon, NULL);
 
+static void _req_release(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(req);
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+void prte_pmix_server_req_release(void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+
+    /* this is invoked on the PMIx progress thread, so we must
+     * shift to our event base before touching the global
+     * request array */
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, _req_release, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+}
+
 static void rqcon(prte_pmix_server_req_t *p)
 {
     p->event_active = false;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2023,19 +2023,18 @@ respond:
 }
 
 /* alloc callback to send the results to the requesting daemon */
-static void send_alloc_resp(pmix_status_t status,
-                            pmix_info_t info[], size_t ninfo,
-                            void *cbdata,
-                            pmix_release_cbfunc_t release_fn,
-                            void *release_cbdata)
+static void _send_alloc_resp(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     pmix_data_buffer_t *buf;
     pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(req);
 
     /* pack the status */
     PMIX_DATA_BUFFER_CREATE(buf);
-    if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &status, 1, PMIX_STATUS))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &req->pstatus, 1, PMIX_STATUS))) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
         return;
@@ -2049,14 +2048,14 @@ static void send_alloc_resp(pmix_status_t status,
     }
 
     /* pack any provided info */
-    if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
         return;
     }
 
-    if (0 < ninfo) {
-        if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, info, ninfo, PMIX_INFO))) {
+    if (0 < req->ninfo) {
+        if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(buf);
             return;
@@ -2071,13 +2070,42 @@ static void send_alloc_resp(pmix_status_t status,
     }
 
     /* Call the provided callback function */
-    if (NULL != release_fn) {
-        release_fn(release_cbdata);
+    if (NULL != req->rlcbfunc) {
+        req->rlcbfunc(req->rlcbdata);
     }
 
     /* Release the server op request data */
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
+}
+
+static void send_alloc_resp(pmix_status_t status,
+                            pmix_info_t info[], size_t ninfo,
+                            void *cbdata,
+                            pmix_release_cbfunc_t release_fn,
+                            void *release_cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+
+    /* this can be invoked on the PMIx progress thread (e.g., as the
+     * callback from PMIx_Session_control), so record the results in
+     * the request and shift the pack/send onto our event base. The
+     * results remain valid until we invoke the release callback,
+     * which now happens at the end of the shifted handler. Beware
+     * that some callers pass the request's own info array back as
+     * the results - do not free it in that case */
+    req->pstatus = status;
+    if (req->copy && NULL != req->info && info != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+        req->copy = false;
+    }
+    req->info = info;
+    req->ninfo = ninfo;
+    req->rlcbfunc = release_fn;
+    req->rlcbdata = release_cbdata;
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, _send_alloc_resp, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
 }
 
 static void pmix_server_sched(int status, pmix_proc_t *sender,

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2347,6 +2347,7 @@ static void opcon(prte_pmix_server_op_caddy_t *p)
     p->procs = NULL;
     p->nprocs = 0;
     p->channels = 0;
+    p->range = PMIX_RANGE_UNDEF;
     p->flag = false;
     p->eprocs = NULL;
     p->neprocs = 0;

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -15,14 +15,6 @@
 #include "src/util/dash_host/dash_host.h"
 #include "src/mca/ras/base/base.h"
 
-static void localrelease(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
-}
-
 void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
                                     pmix_data_buffer_t *buffer,
                                     prte_rml_tag_t tg,
@@ -90,7 +82,7 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
 ANSWER:
     if (NULL != req->infocbfunc) {
         // pass the response back to the requestor
-        req->infocbfunc(ret, req->info, req->ninfo, req, localrelease, req);
+        req->infocbfunc(ret, req->info, req->ninfo, req, prte_pmix_server_req_release, req);
     } else {
         PMIX_RELEASE(req);
     }

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -197,9 +197,45 @@ pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req)
     return PMIX_SUCCESS;
 }
 
+static void _alloc_request(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(req);
+
+    /* add this request to our local request tracker array */
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    if (!PRTE_PROC_IS_MASTER) {
+        /* if we are not the DVM master, then we have to send
+         * this request to the master for processing */
+        rc = prte_server_send_request(PRTE_PMIX_ALLOC_REQ, req);
+        if (PRTE_SUCCESS != rc) {
+            goto callback;
+        }
+        return;
+    }
+
+    /* pass this to the RAS framework for handling - we are
+     * already on the progress thread */
+    prte_ras_base_modify(0, 0, req);
+    return;
+
+callback:
+    /* only executed on error - let the requestor know */
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(rc, NULL, 0, req->cbdata, prte_pmix_server_req_release, req);
+        return;
+    }
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
 /* this is the upcall from the PMIx server for the allocation
  * request support. Since we are going to touch global structures
- * (e.g., the session tracker pointer array), we have to threadshift
+ * (e.g., the local request tracker array), we have to threadshift
  * this request into our own internal progress thread. Note that the
  * allocation request could have come to this host from the
  * scheduler, or a tool, or even an application process. */
@@ -209,7 +245,6 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_server_req_t *req;
-    pmix_status_t rc;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s allocate upcalled on behalf of proc %s:%u with %" PRIsize_t " infos",
@@ -225,23 +260,7 @@ pmix_status_t pmix_server_alloc_fn(const pmix_proc_t *client,
     req->infocbfunc = cbfunc;
     req->cbdata = cbdata;
 
-    /* add this request to our local request tracker array */
-    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
-
-    if (!PRTE_PROC_IS_MASTER) {
-        /* if we are not the DVM master, then we have to send
-         * this request to the master for processing */
-        rc = prte_server_send_request(PRTE_PMIX_ALLOC_REQ, req);
-        if (PRTE_SUCCESS != rc) {
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-            PMIX_RELEASE(req);
-            return rc;
-        }
-        return rc;
-    }
-
-    // pass this to the RAS framework for handling
-    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, prte_ras_base_modify, req);
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, _alloc_request, req);
     PMIX_POST_OBJECT(req);
     prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
     return PMIX_SUCCESS;

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -897,15 +897,51 @@ pmix_status_t pmix_server_log2_fn(const pmix_proc_t *client, const pmix_info_t d
 }
 #endif
 
+static void _iof_pull(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
+    prte_iof_sink_t *sink;
+    size_t i;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* Set up I/O forwarding sinks and handlers for stdout and stderr for each proc
+     * requesting I/O forwarding */
+    for (i = 0; i < cd->nprocs; i++) {
+        if (cd->channels & PMIX_FWD_STDOUT_CHANNEL) {
+            if (cd->flag) {
+                /* ask the IOF to stop forwarding this channel */
+            } else {
+                PRTE_IOF_SINK_DEFINE(&sink, &cd->procs[i], fileno(stdout), PRTE_IOF_STDOUT,
+                                     prte_iof_base_write_handler);
+                PRTE_IOF_SINK_ACTIVATE(sink->wev);
+            }
+        }
+        if (cd->channels & PMIX_FWD_STDERR_CHANNEL) {
+            if (cd->flag) {
+                /* ask the IOF to stop forwarding this channel */
+            } else {
+                PRTE_IOF_SINK_DEFINE(&sink, &cd->procs[i], fileno(stderr), PRTE_IOF_STDERR,
+                                     prte_iof_base_write_handler);
+                PRTE_IOF_SINK_ACTIVATE(sink->wev);
+            }
+        }
+    }
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(PMIX_SUCCESS, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+}
+
 pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
                                       const pmix_info_t directives[], size_t ndirs,
                                       pmix_iof_channel_t channels, pmix_op_cbfunc_t cbfunc,
                                       void *cbdata)
 {
-    prte_iof_sink_t *sink;
+    prte_pmix_server_op_caddy_t *cd;
     size_t i;
     bool stop = false;
-    PRTE_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
 
     /* no really good way to do this - we have to search the directives to
      * see if we are being asked to stop the specified channels before
@@ -917,29 +953,22 @@ pmix_status_t pmix_server_iof_pull_fn(const pmix_proc_t procs[], size_t nprocs,
         }
     }
 
-    /* Set up I/O forwarding sinks and handlers for stdout and stderr for each proc
-     * requesting I/O forwarding */
-    for (i = 0; i < nprocs; i++) {
-        if (channels & PMIX_FWD_STDOUT_CHANNEL) {
-            if (stop) {
-                /* ask the IOF to stop forwarding this channel */
-            } else {
-                PRTE_IOF_SINK_DEFINE(&sink, &procs[i], fileno(stdout), PRTE_IOF_STDOUT,
-                                     prte_iof_base_write_handler);
-                PRTE_IOF_SINK_ACTIVATE(sink->wev);
-            }
-        }
-        if (channels & PMIX_FWD_STDERR_CHANNEL) {
-            if (stop) {
-                /* ask the IOF to stop forwarding this channel */
-            } else {
-                PRTE_IOF_SINK_DEFINE(&sink, &procs[i], fileno(stderr), PRTE_IOF_STDERR,
-                                     prte_iof_base_write_handler);
-                PRTE_IOF_SINK_ACTIVATE(sink->wev);
-            }
-        }
-    }
-    return PMIX_OPERATION_SUCCEEDED;
+    /* this upcall arrives on the PMIx progress thread, and setting up
+     * IOF sinks manipulates framework state and arms events on our
+     * event base - shift it. The procs array remains valid until we
+     * invoke the callback, which happens at the end of the shifted
+     * handler */
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    cd->procs = (pmix_proc_t *) procs;
+    cd->nprocs = nprocs;
+    cd->channels = channels;
+    cd->flag = stop;
+    cd->cbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _iof_pull, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    return PMIX_SUCCESS;
 }
 
 static void pmix_server_stdin_push(int sd, short args, void *cbdata)

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -134,6 +134,7 @@ typedef struct {
     pmix_query_t *queries;
     size_t nqueries;
     pmix_iof_channel_t channels;
+    pmix_data_range_t range;
     bool flag;
     pmix_op_cbfunc_t cbfunc;
     pmix_info_cbfunc_t infocbfunc;

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -216,6 +216,13 @@ PMIX_CLASS_DECLARATION(prte_pmix_server_op_caddy_t);
         prte_event_active(&(_cd->ev), PRTE_EV_WRITE, 1);                           \
     } while (0);
 
+/* Release callback to hand to the PMIx server when relaying the
+ * results of a request tracked in the local request array. The PMIx
+ * library invokes it on the PMIx progress thread once it is done
+ * with the results, so it thread-shifts before clearing the request
+ * from prte_pmix_server_globals.local_reqs and releasing it */
+PRTE_EXPORT void prte_pmix_server_req_release(void *cbdata);
+
 /* define the server module functions */
 PRTE_EXPORT extern pmix_status_t pmix_server_client_connected2_fn(const pmix_proc_t *proc,
                                                                   void *server_object,

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -133,6 +133,8 @@ typedef struct {
     size_t napps;
     pmix_query_t *queries;
     size_t nqueries;
+    pmix_iof_channel_t channels;
+    bool flag;
     pmix_op_cbfunc_t cbfunc;
     pmix_info_cbfunc_t infocbfunc;
     pmix_tool_connection_cbfunc_t toolcbfunc;

--- a/src/prted/pmix/pmix_server_job_ctrl.c
+++ b/src/prted/pmix/pmix_server_job_ctrl.c
@@ -59,9 +59,11 @@
 #include "src/prted/pmix/pmix_server_internal.h"
 
 
-pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_proc_t targets[],
-                                      size_t ntargets, const pmix_info_t directives[], size_t ndirs,
-                                      pmix_info_cbfunc_t cbfunc, void *cbdata)
+/* process a job control request - runs on the PRRTE progress
+ * thread, since it accesses proc objects and drives the PLM
+ * and daemon-command xcasts */
+static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_proc_t targets[],
+                                      size_t ntargets, const pmix_info_t directives[], size_t ndirs)
 {
     int rc, j;
     int32_t signum;
@@ -72,12 +74,7 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_p
     pmix_data_buffer_t *cmd;
     prte_daemon_cmd_flag_t cmmnd;
     pmix_proc_t *proct;
-    PRTE_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
-
-    pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s job control request from %s:%d",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                        requestor->nspace, requestor->rank);
+    PRTE_HIDE_UNUSED_PARAMS(requestor);
 
     for (m = 0; m < ndirs; m++) {
         if (PMIX_CHECK_KEY(&directives[m], PMIX_JOB_CTRL_KILL)) {
@@ -233,4 +230,53 @@ pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_p
     }
 
     return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static void _job_ctrl(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    rc = process_job_ctrl(&cd->proc, cd->procs, cd->nprocs, cd->directives, cd->ndirs);
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;
+    }
+    if (NULL != cd->infocbfunc) {
+        cd->infocbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+    }
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, const pmix_proc_t targets[],
+                                      size_t ntargets, const pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd;
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s job control request from %s:%d",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        requestor->nspace, requestor->rank);
+
+    /* this upcall arrives on the PMIx progress thread - the request
+     * requires access to proc objects, the PLM, and the daemon
+     * command channel, so shift it to our progress thread. The
+     * targets and directives arrays remain valid until we invoke
+     * the callback, which happens at the end of the shifted
+     * handler */
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    memcpy(&cd->proc, requestor, sizeof(pmix_proc_t));
+    cd->procs = (pmix_proc_t *) targets;
+    cd->nprocs = ntargets;
+    cd->directives = (pmix_info_t *) directives;
+    cd->ndirs = ndirs;
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _job_ctrl, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    return PMIX_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -75,6 +75,10 @@ static void mfn(int sd, short args, void *cbdata)
     int ret;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
+    // record the number of daemons that must respond - the DVM can
+    // grow or shrink, so this must be read on the progress thread
+    req->ndaemons = prte_process_info.num_daemons - 1;
+
     // cache the request
     req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
 
@@ -180,7 +184,6 @@ pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *requestor,
     req->ndirs = ndirs;
     req->infocbfunc = cbfunc;
     req->cbdata = cbdata;
-    req->ndaemons = prte_process_info.num_daemons - 1;
 
     // need to threadshift this to our event base
     prte_event_set(prte_event_base, &(req->ev), -1, PRTE_EV_WRITE, mfn, req);

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -66,13 +66,6 @@
  * down to the requestor.
  */
 
-static void rlfn(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
-}
 
 static void mfn(int sd, short args, void *cbdata)
 {
@@ -158,7 +151,7 @@ static void mfn(int sd, short args, void *cbdata)
 errorout:
     // need to alert the PMIx server so nothing hangs
     if (NULL != req->infocbfunc) {
-        req->infocbfunc(rc, NULL, 0, req->cbdata, rlfn, req);
+        req->infocbfunc(rc, NULL, 0, req->cbdata, prte_pmix_server_req_release, req);
     } else {
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_RELEASE(req);
@@ -540,7 +533,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     if (req->ndaemons == req->nreported) {
         if (NULL != req->infocbfunc) {
             req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
-                            rlfn, req);
+                            prte_pmix_server_req_release, req);
         } else {
             // nothing we can do!
             pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);

--- a/src/prted/pmix/pmix_server_notify.c
+++ b/src/prted/pmix/pmix_server_notify.c
@@ -316,42 +316,20 @@ void pmix_server_notify(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
     }
 }
 
-pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *source,
-                                       pmix_data_range_t range, pmix_info_t info[], size_t ninfo,
-                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+static void _notify_event(int sd, short args, void *cbdata)
 {
-    int rc;
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     pmix_data_buffer_t pbkt;
-    pmix_status_t ret;
-    size_t n;
-    PRTE_HIDE_UNUSED_PARAMS(cbfunc, cbdata);
+    pmix_status_t ret = PMIX_SUCCESS;
+    int rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s local process %s generated event code %s range %s",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(source),
-                        PMIx_Error_string(code), PMIx_Data_range_string(range));
-
-    /* we can get events prior to completing prte_init as we have
-     * to init PMIx early so that PRRTE components can use it */
-    PMIX_ACQUIRE_THREAD(&prte_init_lock);
-    if (!prte_initialized) {
-        PMIX_RELEASE_THREAD(&prte_init_lock);
-        goto done;
-    }
-    PMIX_RELEASE_THREAD(&prte_init_lock);
-
-    /* check to see if this is one we sent down */
-    for (n = 0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, "prte.notify.donotloop")) {
-            /* yep - do not process */
-            goto done;
-        }
-    }
+    PMIX_ACQUIRE_OBJECT(cd);
 
     /* if this is notification of procs being ready for debug, then
      * we treat this as a state change */
-    if (PMIX_READY_FOR_DEBUG == code) {
-        PRTE_ACTIVATE_PROC_STATE((pmix_proc_t*)source, PRTE_PROC_STATE_READY_FOR_DEBUG);
+    if (PMIX_READY_FOR_DEBUG == cd->status) {
+        PRTE_ACTIVATE_PROC_STATE(&cd->proc, PRTE_PROC_STATE_READY_FOR_DEBUG);
         goto done;
     }
 
@@ -363,52 +341,101 @@ pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *so
     /* we need to add a flag indicating this came from us as we are going to get it echoed
      * back to us by the broadcast */
     if (PMIX_SUCCESS
-        != (rc = PMIx_Data_pack(NULL, &pbkt, &PRTE_PROC_MY_NAME->rank, 1, PMIX_PROC_RANK))) {
-        PMIX_ERROR_LOG(rc);
+        != (ret = PMIx_Data_pack(NULL, &pbkt, &PRTE_PROC_MY_NAME->rank, 1, PMIX_PROC_RANK))) {
+        PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return rc;
+        goto done;
     }
 
     /* pack the status code */
-    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &code, 1, PMIX_STATUS))) {
+    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &cd->status, 1, PMIX_STATUS))) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return ret;
+        goto done;
     }
     /* pack the source */
-    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, (pmix_proc_t *) source, 1, PMIX_PROC))) {
+    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &cd->proc, 1, PMIX_PROC))) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return ret;
+        goto done;
     }
     /* pack the range */
-    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &range, 1, PMIX_DATA_RANGE))) {
+    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &cd->range, 1, PMIX_DATA_RANGE))) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return ret;
+        goto done;
     }
     /* pack the number of infos */
-    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &ninfo, 1, PMIX_SIZE))) {
+    if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, &cd->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return ret;
+        goto done;
     }
-    if (0 < ninfo) {
-        if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, info, ninfo, PMIX_INFO))) {
+    if (0 < cd->ninfo) {
+        if (PMIX_SUCCESS != (ret = PMIx_Data_pack(NULL, &pbkt, cd->info, cd->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            return ret;
+            goto done;
         }
     }
 
     if (PRTE_SUCCESS != (rc = prte_grpcomm.xcast(PRTE_RML_TAG_NOTIFICATION, &pbkt))) {
         PRTE_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-        return PMIX_ERROR;
+        ret = PMIX_ERROR;
     }
     PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
 
 done:
-    /* we do not need to execute a callback as we did this atomically */
-    return PMIX_OPERATION_SUCCEEDED;
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(ret, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *source,
+                                       pmix_data_range_t range, pmix_info_t info[], size_t ninfo,
+                                       pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd;
+    size_t n;
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s local process %s generated event code %s range %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(source),
+                        PMIx_Error_string(code), PMIx_Data_range_string(range));
+
+    /* we can get events prior to completing prte_init as we have
+     * to init PMIx early so that PRRTE components can use it */
+    PMIX_ACQUIRE_THREAD(&prte_init_lock);
+    if (!prte_initialized) {
+        PMIX_RELEASE_THREAD(&prte_init_lock);
+        return PMIX_OPERATION_SUCCEEDED;
+    }
+    PMIX_RELEASE_THREAD(&prte_init_lock);
+
+    /* check to see if this is one we sent down */
+    for (n = 0; n < ninfo; n++) {
+        if (0 == strcmp(info[n].key, "prte.notify.donotloop")) {
+            /* yep - do not process */
+            return PMIX_OPERATION_SUCCEEDED;
+        }
+    }
+
+    /* this upcall arrives on the PMIx progress thread - activating
+     * a state change or driving the xcast must happen on our own
+     * progress thread, so shift it. The info array remains valid
+     * until we invoke the callback, which happens at the end of
+     * the shifted handler */
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    cd->status = code;
+    memcpy(&cd->proc, source, sizeof(pmix_proc_t));
+    cd->range = range;
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->cbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _notify_event, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    return PMIX_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -17,14 +17,6 @@
 #include "src/mca/rmaps/rmaps.h"
 #include "src/mca/schizo/base/base.h"
 
-static void localrelease(void *cbdata)
-{
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
-
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
-}
-
 /* Process the session control directive from the scheduler */
 static int process_directive(prte_pmix_server_req_t *req)
 {
@@ -267,7 +259,7 @@ static int process_directive(prte_pmix_server_req_t *req)
 // only come here upon error
 ANSWER:
     if (NULL != req->infocbfunc) {
-        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);
     } else {
         PMIX_RELEASE(req);
     }
@@ -376,7 +368,7 @@ callback:
     /* this section gets executed solely upon an error or if this was a
      * directive to us from the scheduler */
     if (NULL != req->infocbfunc) {
-        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, localrelease, req);
+        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);
         return;
     }
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -135,25 +135,27 @@ static void epipe_signal_callback(int fd, short args, void *cbdata);
 static int prep_singleton(const char *name);
 static bool keepalive = false;
 
+/* NOTE: these callbacks execute on the PMIx progress thread. They
+ * therefore capture their arguments and shift the wakeup onto our
+ * event base - the waiters below drive prte_event_base while
+ * polling the lock, so a wakeup signaled directly from the PMIx
+ * thread could be missed while the loop is parked in the backend */
 static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(status);
 
-    PMIX_ACQUIRE_OBJECT(lock);
-    PRTE_PMIX_WAKEUP_THREAD(lock);
+    prte_pmix_shifted_wakeup(lock, status, NULL);
 }
 
 static void spcbfunc(pmix_status_t status, char nspace[], void *cbdata)
 {
     prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
+    char *msg = NULL;
 
-    PMIX_ACQUIRE_OBJECT(lock);
-    lock->status = status;
     if (PMIX_SUCCESS == status) {
-        lock->msg = strdup(nspace);
+        msg = strdup(nspace);
     }
-    PRTE_PMIX_WAKEUP_THREAD(lock);
+    prte_pmix_shifted_wakeup(lock, status, msg);
 }
 
 static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
@@ -178,8 +180,9 @@ static void evhandler_reg_callbk(pmix_status_t status, size_t evhandler_ref, voi
     mylock_t *lock = (mylock_t *) cbdata;
     PRTE_HIDE_UNUSED_PARAMS(evhandler_ref);
 
-    lock->status = status;
-    PRTE_PMIX_WAKEUP_THREAD(&lock->lock);
+    /* executes on the PMIx progress thread - record the status in
+     * the embedded lock and shift the wakeup onto our event base */
+    prte_pmix_shifted_wakeup(&lock->lock, status, NULL);
 }
 
 
@@ -755,7 +758,14 @@ int prte(int argc, char *argv[])
     PMIX_INFO_LOAD(&info, PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
     PMIx_Register_event_handler(&code, 1, &info, 1, parent_died_fn, evhandler_reg_callbk,
                                 (void *) &mylock);
-    PRTE_PMIX_WAIT_THREAD(&mylock.lock);
+    /* the registration callback shifts its wakeup onto our event
+     * base, so we must cycle the event library while we wait. Do
+     * not add an escape from this loop - the callback references
+     * the stack-based lock, so we cannot leave until it has fired */
+    while (mylock.lock.active) {
+        prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+    }
+    PMIX_ACQUIRE_OBJECT(&mylock.lock);
     PMIX_INFO_DESTRUCT(&info);
     PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
 
@@ -1328,7 +1338,15 @@ int prte(int argc, char *argv[])
         if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
             pmix_output(0, "IOF push of stdin failed: %s", PMIx_Error_string(ret));
         } else if (PMIX_SUCCESS == ret) {
-            PRTE_PMIX_WAIT_THREAD(&lock);
+            /* the callback shifts its wakeup onto our event base,
+             * so we must cycle the event library while we wait. Do
+             * not add an escape from this loop - the callback
+             * references the stack-based lock, so we cannot leave
+             * until it has fired */
+            while (lock.active) {
+                prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+            }
+            PMIX_ACQUIRE_OBJECT(&lock);
         }
         PRTE_PMIX_DESTRUCT_LOCK(&lock);
         PMIX_INFO_FREE(iptr2, 1);
@@ -1349,7 +1367,15 @@ proceed:
     if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
         pmix_output(0, "IOF close of stdin failed: %s", PMIx_Error_string(ret));
     } else if (PMIX_SUCCESS == ret) {
-        PRTE_PMIX_WAIT_THREAD(&lock);
+        /* the callback shifts its wakeup onto our event base. The
+         * main event loop above has already exited, so we must
+         * cycle the event library ourselves until the wakeup
+         * arrives - the callback references the stack-based lock,
+         * so we cannot leave until it has fired */
+        while (lock.active) {
+            prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+        }
+        PMIX_ACQUIRE_OBJECT(&lock);
     }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_DESTRUCT(&info);


### PR DESCRIPTION
## Problem

Four PMIx server module upcalls did all of their work inline on the PMIx progress thread: iof_pull built and activated IOF sinks (arming events on prte_event_base), allocate inserted into the global request tracker and relayed to the DVM master over the RML despite its own comment saying it must thread-shift, notify_event activated the READY_FOR_DEBUG proc state and drove the notification xcast, and job_control looked up proc objects, invoked the PLM, and xcast daemon commands.

## Fix

All four now capture their arguments in a caddy and post to prte_event_base, returning PMIX_SUCCESS and completing through the callback at the end of the shifted handler instead of returning PMIX_OPERATION_SUCCEEDED (the argument arrays remain valid until the callback is invoked, per the PMIx contract). The allocate upcall adopts the same deferred pass_request pattern its session-control sibling already used; job_control's directive loop is retained intact as a status-returning helper.

## Verification

Warning-free build per commit, make check, DVM cycles with pterm exercising the now-asynchronous TERMINATE path, and 30/30 spawn-stress runs with output verified (exercising the converted iof_pull end-to-end), locally and on the container swarm.

Stacks on #2536 - review the last 4 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)