### PR TITLE
Complete launch-path PMIx operations asynchronously

### DIFF
--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -78,6 +78,9 @@ PRTE_EXPORT extern pmix_mca_base_framework_t prte_odls_base_framework;
  */
 PRTE_EXPORT int prte_odls_base_select(void);
 
+/* define a function that will fork a local proc */
+typedef int (*prte_odls_base_fork_local_proc_fn_t)(void *cd);
+
 /*
  * Default functions that are common to most environments - can
  * be overridden by specific environments if they need something
@@ -87,12 +90,10 @@ PRTE_EXPORT int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *da
                                                           pmix_nspace_t job);
 
 PRTE_EXPORT int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *data,
-                                                            pmix_nspace_t *job);
+                                                            pmix_nspace_t *job,
+                                                            prte_odls_base_fork_local_proc_fn_t fork_local);
 
 PRTE_EXPORT void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata);
-
-/* define a function that will fork a local proc */
-typedef int (*prte_odls_base_fork_local_proc_fn_t)(void *cd);
 
 /* define an object for fork/exec the local proc */
 typedef struct {

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -97,6 +97,8 @@ typedef struct {
     size_t ninfo;
     pmix_byte_object_t pbo;
     prte_odls_base_fork_local_proc_fn_t fork_local;
+    int pending;
+    pmix_status_t rstatus;
 } prte_odls_jcaddy_t;
 static void jccon(prte_odls_jcaddy_t *p)
 {
@@ -105,6 +107,8 @@ static void jccon(prte_odls_jcaddy_t *p)
     p->ninfo = 0;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->pbo);
     p->fork_local = NULL;
+    p->pending = 0;
+    p->rstatus = PMIX_SUCCESS;
 }
 static void jcdes(prte_odls_jcaddy_t *p)
 {
@@ -451,6 +455,78 @@ static void ls_cbunc(pmix_status_t status, void *cbdata)
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
 }
 
+/* join point for the nspace registrations - once they have all
+ * reported, proceed with the local support setup and launch.
+ * Executes on the PRRTE progress thread */
+static void job_reg_join(prte_odls_jcaddy_t *cd)
+{
+    pmix_status_t ret;
+
+    cd->pending--;
+    if (0 < cd->pending) {
+        return;
+    }
+
+    /* all registrations have reported */
+    if (PMIX_SUCCESS != cd->rstatus) {
+        /* report an error back to the HNP so we don't just hang
+         * while it waits to hear that our local procs launched */
+        PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    /* if we have local support setup info, then execute it here - we
+     * have to do so AFTER we register the nspace so the PMIx server
+     * has the nspace info it needs */
+    if (0 < cd->ninfo) {
+        /* do not block waiting for the answer - the callback will
+         * thread-shift and activate the local launch once the
+         * support is in place */
+        ret = PMIx_server_setup_local_support(cd->jdata->nspace, cd->info, cd->ninfo,
+                                              ls_cbunc, cd);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+            PMIX_RELEASE(cd);
+            return;
+        }
+        /* spin up the spawn threads */
+        prte_odls_base_start_threads(cd->jdata);
+        return;
+    }
+
+    /* spin up the spawn threads */
+    prte_odls_base_start_threads(cd->jdata);
+
+    /* no local support setup is required, so we can proceed
+     * directly to launching the local procs */
+    PRTE_ACTIVATE_LOCAL_LAUNCH(cd->jdata->nspace, cd->fork_local);
+    PMIX_RELEASE(cd);
+}
+
+static void _prior_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        /* not fatal - the job is already running elsewhere */
+        PMIX_ERROR_LOG(status);
+    }
+    job_reg_join(cd);
+}
+
+static void _job_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        PMIX_ERROR_LOG(status);
+        cd->rstatus = status;
+    }
+    job_reg_join(cd);
+}
+
 int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix_nspace_t *job,
                                                 prte_odls_base_fork_local_proc_fn_t fork_local)
 {
@@ -465,6 +541,8 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
     prte_app_context_t *app;
     int8_t flag;
     prte_odls_jcaddy_t *cd;
+    pmix_pointer_array_t priorjobs;
+    prte_job_t *jptr;
     pmix_info_t *info = NULL;
     size_t ninfo = 0;
     pmix_status_t ret;
@@ -479,6 +557,11 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
 
     /* set a default response */
     PMIX_LOAD_NSPACE(*job, NULL);
+
+    /* setup to track any prior jobs that must be registered
+     * with the PMIx server */
+    PMIX_CONSTRUCT(&priorjobs, pmix_pointer_array_t);
+    pmix_pointer_array_init(&priorjobs, 1, INT_MAX, 8);
 
     /* get the daemon job object */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
@@ -591,11 +674,9 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
                     }
 
                 }
-                // now register this job
-                rc = prte_pmix_server_register_nspace(jdata);
-                if (PRTE_SUCCESS != rc) {
-                    PRTE_ERROR_LOG(rc);
-                }
+                // stash this job for registration with the PMIx
+                // server once we reach the registration point below
+                pmix_pointer_array_add(&priorjobs, jdata);
             }
             /* release the buffer */
             PMIX_DATA_BUFFER_DESTRUCT(&jdbuf);
@@ -830,49 +911,51 @@ next:
         }
     }
 
-    /* register this job with the PMIx server - need to wait until after we
-     * have computed the #local_procs before calling the function */
-    if (PRTE_SUCCESS != (rc = prte_pmix_server_register_nspace(jdata))) {
-        PRTE_ERROR_LOG(rc);
-        goto REPORT_ERROR;
-    }
+    /* create the caddy that carries the launch through the
+     * asynchronous registrations and local support setup */
+    cd = PMIX_NEW(prte_odls_jcaddy_t);
+    cd->jdata = jdata;
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->fork_local = fork_local;
+    info = NULL; // the caddy now owns the info array
 
-    /* if we have local support setup info, then execute it here - we
-     * have to do so AFTER we register the nspace so the PMIx server
-     * has the nspace info it needs */
-    if (0 < ninfo) {
-        /* do not block waiting for the answer - the callback will
-         * thread-shift and activate the local launch once the
-         * support is in place */
-        cd = PMIX_NEW(prte_odls_jcaddy_t);
-        cd->jdata = jdata;
-        cd->info = info;
-        cd->ninfo = ninfo;
-        cd->fork_local = fork_local;
-        ret = PMIx_server_setup_local_support(jdata->nspace, info, ninfo,
-                                              ls_cbunc, cd);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            /* the caddy now owns the info array */
-            info = NULL;
-            PMIX_RELEASE(cd);
-            rc = PRTE_ERROR;
-            goto REPORT_ERROR;
+    /* register this job - and any prior jobs a newly-launched
+     * daemon needs to know about - with the PMIx server. We have
+     * to wait until after we computed the #local_procs before
+     * registering this job. The registrations complete
+     * asynchronously, and the launch proceeds once all have
+     * reported. Hold a sentinel on the join so it cannot fire
+     * before we finish initiating the registrations */
+    cd->pending = 1;
+    for (n = 0; n < priorjobs.size; n++) {
+        jptr = (prte_job_t *) pmix_pointer_array_get_item(&priorjobs, n);
+        if (NULL == jptr) {
+            continue;
         }
-        /* spin up the spawn threads */
-        prte_odls_base_start_threads(jdata);
-        return PRTE_SUCCESS;
+        rc = prte_pmix_server_register_nspace(jptr, _prior_reg_complete, cd);
+        if (PRTE_SUCCESS == rc) {
+            cd->pending++;
+        } else {
+            /* not fatal - just note it */
+            PRTE_ERROR_LOG(rc);
+        }
     }
-
-    /* spin up the spawn threads */
-    prte_odls_base_start_threads(jdata);
-
-    /* no local support setup is required, so we can proceed
-     * directly to launching the local procs */
-    PRTE_ACTIVATE_LOCAL_LAUNCH(jdata->nspace, fork_local);
+    PMIX_DESTRUCT(&priorjobs);
+    rc = prte_pmix_server_register_nspace(jdata, _job_reg_complete, cd);
+    if (PRTE_SUCCESS == rc) {
+        cd->pending++;
+    } else {
+        PRTE_ERROR_LOG(rc);
+        cd->rstatus = PMIX_ERROR;
+    }
+    /* release our sentinel - if everything already reported,
+     * this progresses the launch */
+    job_reg_join(cd);
     return PRTE_SUCCESS;
 
 REPORT_ERROR:
+    PMIX_DESTRUCT(&priorjobs);
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -96,6 +96,7 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
     pmix_byte_object_t pbo;
+    prte_odls_base_fork_local_proc_fn_t fork_local;
 } prte_odls_jcaddy_t;
 static void jccon(prte_odls_jcaddy_t *p)
 {
@@ -103,6 +104,7 @@ static void jccon(prte_odls_jcaddy_t *p)
     p->info = NULL;
     p->ninfo = 0;
     PMIX_BYTE_OBJECT_CONSTRUCT(&p->pbo);
+    p->fork_local = NULL;
 }
 static void jcdes(prte_odls_jcaddy_t *p)
 {
@@ -422,14 +424,35 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
     return PRTE_SUCCESS;
 }
 
-static void ls_cbunc(pmix_status_t status, void *cbdata)
+static void _local_support_complete(int sd, short args, void *cbdata)
 {
-    prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(status);
-    PRTE_PMIX_WAKEUP_THREAD(lock);
+    prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* the local support is in place - we can now launch the
+     * local procs */
+    PRTE_ACTIVATE_LOCAL_LAUNCH(cd->jdata->nspace, cd->fork_local);
+
+    /* releasing the caddy also releases the setup info */
+    PMIX_RELEASE(cd);
 }
 
-int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix_nspace_t *job)
+static void ls_cbunc(pmix_status_t status, void *cbdata)
+{
+    prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(status);
+
+    /* this callback executes on the PMIx progress thread - shift
+     * to our progress thread before proceeding with the launch */
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, _local_support_complete, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+}
+
+int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix_nspace_t *job,
+                                                prte_odls_base_fork_local_proc_fn_t fork_local)
 {
     int rc;
     int32_t cnt;
@@ -441,7 +464,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
     prte_proc_t *pptr, *dmn;
     prte_app_context_t *app;
     int8_t flag;
-    prte_pmix_lock_t lock;
+    prte_odls_jcaddy_t *cd;
     pmix_info_t *info = NULL;
     size_t ninfo = 0;
     pmix_status_t ret;
@@ -459,7 +482,6 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
 
     /* get the daemon job object */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
 
     /* unpack the flag to see if new daemons were launched */
     cnt = 1;
@@ -819,35 +841,38 @@ next:
      * have to do so AFTER we register the nspace so the PMIx server
      * has the nspace info it needs */
     if (0 < ninfo) {
+        /* do not block waiting for the answer - the callback will
+         * thread-shift and activate the local launch once the
+         * support is in place */
+        cd = PMIX_NEW(prte_odls_jcaddy_t);
+        cd->jdata = jdata;
+        cd->info = info;
+        cd->ninfo = ninfo;
+        cd->fork_local = fork_local;
         ret = PMIx_server_setup_local_support(jdata->nspace, info, ninfo,
-                                              ls_cbunc, &lock);
+                                              ls_cbunc, cd);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
+            /* the caddy now owns the info array */
+            info = NULL;
+            PMIX_RELEASE(cd);
             rc = PRTE_ERROR;
             goto REPORT_ERROR;
         }
-    } else {
-        lock.active = false; // we won't get a callback
+        /* spin up the spawn threads */
+        prte_odls_base_start_threads(jdata);
+        return PRTE_SUCCESS;
     }
 
     /* spin up the spawn threads */
     prte_odls_base_start_threads(jdata);
 
-    /* to save memory, purge the job map of all procs other than
-     * our own - for daemons, this will completely release the
-     * proc structures. For the HNP, the proc structs will
-     * remain in the prte_job_t array */
-
-    /* wait here until the local support has been setup */
-    PRTE_PMIX_WAIT_THREAD(&lock);
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    if (NULL != info) {
-        PMIX_INFO_FREE(info, ninfo);
-    }
+    /* no local support setup is required, so we can proceed
+     * directly to launching the local procs */
+    PRTE_ACTIVATE_LOCAL_LAUNCH(jdata->nspace, fork_local);
     return PRTE_SUCCESS;
 
 REPORT_ERROR:
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
     }

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -90,28 +90,63 @@
 #include "src/mca/odls/base/base.h"
 
 typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
     prte_job_t *jdata;
     pmix_info_t *info;
     size_t ninfo;
-    prte_pmix_lock_t lock;
+    pmix_byte_object_t pbo;
 } prte_odls_jcaddy_t;
+static void jccon(prte_odls_jcaddy_t *p)
+{
+    p->jdata = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
+    PMIX_BYTE_OBJECT_CONSTRUCT(&p->pbo);
+}
+static void jcdes(prte_odls_jcaddy_t *p)
+{
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    PMIX_BYTE_OBJECT_DESTRUCT(&p->pbo);
+}
+static PMIX_CLASS_INSTANCE(prte_odls_jcaddy_t, pmix_object_t, jccon, jcdes);
+
+static void _setup_complete(int sd, short args, void *cbdata)
+{
+    prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) cbdata;
+    int rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* add the results to the launch msg */
+    rc = PMIx_Data_pack(NULL, &cd->jdata->launch_msg, &cd->pbo, 1, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+
+    /* move to next stage */
+    PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_SEND_LAUNCH_MSG);
+
+    /* releasing the caddy also releases the app-setup info
+     * we passed to the PMIx server */
+    PMIX_RELEASE(cd);
+}
 
 static void setup_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
                          void *provided_cbdata, pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     prte_odls_jcaddy_t *cd = (prte_odls_jcaddy_t *) provided_cbdata;
-    prte_job_t *jdata = cd->jdata;
     pmix_data_buffer_t pbuf;
-    pmix_byte_object_t pbo;
     int rc = PRTE_SUCCESS;
     PRTE_HIDE_UNUSED_PARAMS(status);
 
-    /* release any info */
-    if (NULL != cd->info) {
-        PMIX_INFO_FREE(cd->info, cd->ninfo);
-    }
-
-    PMIX_BYTE_OBJECT_CONSTRUCT(&pbo);
+    /* this callback executes on the PMIx progress thread, so we
+     * cannot touch the job object here - capture the returned
+     * info by serializing it into a byte object, then shift to
+     * our progress thread */
     if (NULL != info) {
         PMIX_DATA_BUFFER_CONSTRUCT(&pbuf);
         /* pack the provided info */
@@ -126,29 +161,21 @@ static void setup_cbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
             goto done;
         }
         /* unload it */
-        rc = PMIx_Data_unload(&pbuf, &pbo);
+        rc = PMIx_Data_unload(&pbuf, &cd->pbo);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }
     }
-    /* add the results */
-    rc = PMIx_Data_pack(NULL, &jdata->launch_msg, &pbo, 1, PMIX_BYTE_OBJECT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-    }
 
 done:
-    PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-    /* release our caller */
+    /* release our caller - we are done with the provided info */
     if (NULL != cbfunc) {
         cbfunc(rc, cbdata);
     }
 
-    /* move to next stage */
-    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_SEND_LAUNCH_MSG);
-
-    /* release the original thread */
-    PRTE_PMIX_WAKEUP_THREAD(&cd->lock);
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, _setup_complete, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
 }
 
 /* IT IS CRITICAL THAT ANY CHANGE IN THE ORDER OF THE INFO PACKED IN
@@ -166,7 +193,7 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
     prte_node_t *node;
     int i, k;
     char **list, **procs, **micro, *tmp, *regex;
-    prte_odls_jcaddy_t cd = {0};
+    prte_odls_jcaddy_t *cd;
     prte_proc_t *pptr;
     uint32_t uid;
     uint32_t gid;
@@ -372,30 +399,27 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
     }
     /* convert the job info into an array */
     PMIX_INFO_LIST_CONVERT(ret, ilist, &darray);
-    cd.info = (pmix_info_t *) darray.array;
-    cd.ninfo = darray.size;
     PMIX_INFO_LIST_RELEASE(ilist);
 
-    /* we don't want to block here because it could
-     * take some indeterminate time to get the info */
-    rc = PRTE_SUCCESS;
-    cd.jdata = jdata;
-    PRTE_PMIX_CONSTRUCT_LOCK(&cd.lock);
-    ret = PMIx_server_setup_application(jdata->nspace, cd.info, cd.ninfo,
-                                        setup_cbfunc, &cd);
+    /* do not block waiting for the answer as it could take some
+     * indeterminate time to get the info - the callback will
+     * thread-shift, complete the launch message, and activate
+     * the next state */
+    cd = PMIX_NEW(prte_odls_jcaddy_t);
+    cd->jdata = jdata;
+    cd->info = (pmix_info_t *) darray.array;
+    cd->ninfo = darray.size;
+    ret = PMIx_server_setup_application(jdata->nspace, cd->info, cd->ninfo,
+                                        setup_cbfunc, cd);
     if (PMIX_SUCCESS != ret) {
         pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__,
                     PMIx_Error_string(ret));
-        /* the callback that would have freed cd.info will never fire */
-        if (NULL != cd.info) {
-            PMIX_INFO_FREE(cd.info, cd.ninfo);
-        }
-        rc = PRTE_ERROR;
-    } else {
-        PRTE_PMIX_WAIT_THREAD(&cd.lock);
+        /* the callback will never fire - releasing the caddy
+         * also releases the info array */
+        PMIX_RELEASE(cd);
+        return PRTE_ERROR;
     }
-    PRTE_PMIX_DESTRUCT_LOCK(&cd.lock);
-    return rc;
+    return PRTE_SUCCESS;
 }
 
 static void ls_cbunc(pmix_status_t status, void *cbdata)

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -593,17 +593,16 @@ static int launch_local_procs(pmix_data_buffer_t *data)
     int rc;
     pmix_nspace_t job;
 
-    /* construct the list of children we are to launch */
-    rc = prte_odls_base_default_construct_child_list(data, &job);
+    /* construct the list of children we are to launch - the base
+     * function activates the local launch once any required local
+     * support setup has asynchronously completed */
+    rc = prte_odls_base_default_construct_child_list(data, &job, fork_local_proc);
     if (PRTE_SUCCESS != rc) {
         PMIX_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
                              "%s odls:pdefault:launch:local failed to construct child list on error %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(rc)));
         return rc;
     }
-
-    /* launch the local procs */
-    PRTE_ACTIVATE_LOCAL_LAUNCH(job, fork_local_proc);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -907,6 +907,25 @@ void prte_plm_base_launch_apps(int fd, short args, void *cbdata)
     return;
 }
 
+/* completion of the nspace registration for a do-not-launch job -
+ * executes on the PRRTE progress thread */
+static void donotlaunch_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_job_t *jdata = (prte_job_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        PRTE_ERROR_LOG(prte_pmix_convert_status(status));
+    }
+    /* if we are persistent, then we remain alive - otherwise, declare
+     * all jobs complete and terminate */
+    if (prte_persistent) {
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
+    } else {
+        prte_never_launched = true;
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALL_JOBS_COMPLETE);
+    }
+}
+
 void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
@@ -923,18 +942,14 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
 
     /* if we don't want to launch the apps, now is the time to leave */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
-        /* go ahead and register the job */
-        rc = prte_pmix_server_register_nspace(jdata);
+        /* go ahead and register the job - the completion callback
+         * advances the job state once the registration is done */
+        rc = prte_pmix_server_register_nspace(jdata, donotlaunch_reg_complete, jdata);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
-        }
-        /* if we are persistent, then we remain alive - otherwise, declare
-         * all jobs complete and terminate */
-        if (prte_persistent) {
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
-        } else {
-            prte_never_launched = true;
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALL_JOBS_COMPLETE);
+            /* the callback will never fire - advance the state
+             * ourselves */
+            donotlaunch_reg_complete(PMIX_SUCCESS, jdata);
         }
         PMIX_RELEASE(caddy);
         return;

--- a/src/prted/pmix/pmix_server.h
+++ b/src/prted/pmix/pmix_server.h
@@ -36,7 +36,8 @@ PRTE_EXPORT void pmix_server_start(void);
 PRTE_EXPORT void pmix_server_finalize(void);
 PRTE_EXPORT void pmix_server_register_params(void);
 
-PRTE_EXPORT int prte_pmix_server_register_nspace(prte_job_t *jdata);
+PRTE_EXPORT int prte_pmix_server_register_nspace(prte_job_t *jdata,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 PRTE_EXPORT void prte_pmix_server_clear(pmix_proc_t *pname);
 

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -70,6 +70,19 @@ pmix_status_t pmix_server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 }
 
 
+/* completion of the nspace registration for a wildcard dmodex
+ * request - executes on the PRRTE progress thread */
+static void wildcard_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+
+    /* let the server know that the data is now available */
+    if (NULL != req->mdxcbfunc) {
+        req->mdxcbfunc(status, NULL, 0, req->cbdata, NULL, NULL);
+    }
+    PMIX_RELEASE(req);
+}
+
 static void dmodex_req(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
@@ -155,18 +168,14 @@ static void dmodex_req(int sd, short args, void *cbdata)
     /* if this is a request for rank=WILDCARD, then they want the job-level data
      * for this job. It was probably not stored locally because we aren't hosting
      * any local procs. There is no need to request the data as we already have
-     * it - so just register the nspace so the local PMIx server gets it */
+     * it - so just register the nspace so the local PMIx server gets it. The
+     * registration completes asynchronously */
     if (PMIX_RANK_WILDCARD == req->tproc.rank) {
-        rc = prte_pmix_server_register_nspace(jdata);
+        rc = prte_pmix_server_register_nspace(jdata, wildcard_reg_complete, req);
         if (PRTE_SUCCESS != rc) {
             prc = prte_pmix_convert_rc(rc);
             goto callback;
         }
-        /* let the server know that the data is now available */
-        if (NULL != req->mdxcbfunc) {
-            req->mdxcbfunc(rc, NULL, 0, req->cbdata, NULL, NULL);
-        }
-        PMIX_RELEASE(req);
         return;
     }
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -344,6 +344,22 @@ pmix_status_t pmix_server_abort_fn(const pmix_proc_t *proc, void *server_object,
     return PRTE_SUCCESS;
 }
 
+/* completion of a tool registration - executes on the PRRTE
+ * progress thread */
+static void tconn_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        PMIX_ERROR_LOG(status);
+        // we can live without it
+    }
+    req->toolcbfunc(req->pstatus, &req->target, req->cbdata);
+
+    /* cleanup */
+    PMIX_RELEASE(req);
+}
+
 void pmix_server_tconn_return(int status, pmix_proc_t *sender,
                               pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                               void *cbdata)
@@ -391,18 +407,34 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
             return;
         }
         PMIX_LOAD_NSPACE(req->target.nspace, jobid);
-        /* the tool is not a client of ours, but we can provide at least some information */
-        rc = prte_pmix_server_register_tool(req);
-        if (PRTE_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            // we can live without it
+        /* the tool is not a client of ours, but we can provide at
+         * least some information - the registration completes
+         * asynchronously */
+        req->pstatus = ret;
+        rc = prte_pmix_server_register_tool(req, tconn_reg_complete, req);
+        if (PRTE_SUCCESS == rc) {
+            return;
         }
+        PMIX_ERROR_LOG(rc);
+        // we can live without it
     }
 
     req->toolcbfunc(ret, &req->target, req->cbdata);
 
     /* cleanup */
     PMIX_RELEASE(req);
+}
+
+/* completion of the local tool registration - executes on the
+ * PRRTE progress thread */
+static void toolconn_reg_complete(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_server_req_t *cd = (prte_pmix_server_req_t *) cbdata;
+
+    if (NULL != cd->toolcbfunc) {
+        cd->toolcbfunc(status, &cd->target, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
 }
 
 static void _toolconn(int sd, short args, void *cbdata)
@@ -548,11 +580,13 @@ static void _toolconn(int sd, short args, void *cbdata)
             free(tmp);
             prte_plm_globals.next_jobid++;
         }
-        // register this job - will add to our array of jobs
-        rc = prte_pmix_server_register_tool(cd);
-        if (PMIX_SUCCESS != rc) {
-            rc = prte_pmix_convert_rc(rc);
+        // register this job - will add to our array of jobs. The
+        // registration completes asynchronously
+        rc = prte_pmix_server_register_tool(cd, toolconn_reg_complete, cd);
+        if (PRTE_SUCCESS == rc) {
+            return;
         }
+        rc = prte_pmix_convert_rc(rc);
         goto complete;
     }
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -356,7 +356,8 @@ PRTE_EXPORT extern void pmix_server_tconn_return(int status, pmix_proc_t *sender
                                                  pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                                  void *cbdata);
 
-PRTE_EXPORT extern int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd);
+PRTE_EXPORT extern int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
+                                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 PRTE_EXPORT extern int pmix_server_cache_job_info(prte_job_t *jdata, pmix_info_t *info);
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -59,10 +59,180 @@
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 
-static void opcbfunc(pmix_status_t status, void *cbdata);
+/* caddy for carrying a registration through its asynchronous
+ * completion chain */
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    pmix_info_t *pinfo;
+    size_t ninfo;
+    bool publish;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+    pmix_status_t status;
+} prte_pmix_reg_caddy_t;
+static void regcon(prte_pmix_reg_caddy_t *p)
+{
+    p->pinfo = NULL;
+    p->ninfo = 0;
+    p->publish = false;
+    p->cbfunc = NULL;
+    p->cbdata = NULL;
+    p->status = PMIX_SUCCESS;
+}
+static void regdes(prte_pmix_reg_caddy_t *p)
+{
+    if (NULL != p->pinfo) {
+        PMIX_INFO_FREE(p->pinfo, p->ninfo);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_pmix_reg_caddy_t, pmix_object_t, regcon, regdes);
 
-/* stuff proc attributes for sending back to a proc */
-int prte_pmix_server_register_nspace(prte_job_t *jdata)
+/* invoke the caller's callback (on the PRRTE progress thread)
+ * and cleanup */
+static void complete_reg(prte_pmix_reg_caddy_t *cd)
+{
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(cd->status, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+}
+
+static void _pub_done(int sd, short args, void *cbdata)
+{
+    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+    complete_reg(cd);
+}
+
+static void pubcbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
+
+    /* shift to be safe against whatever context completed
+     * the publish operation */
+    cd->status = status;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, _pub_done, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+}
+
+static void _nspace_reg_done(int sd, short args, void *cbdata)
+{
+    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
+    pmix_status_t ret;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    if (PMIX_SUCCESS != cd->status) {
+        complete_reg(cd);
+        return;
+    }
+
+    /* when the user has connected us to an external data server, we
+     * must assume there is going to be some cross-mpirun exchange,
+     * and so we protect against that situation by publishing the
+     * job info for this job - this allows any subsequent "connect"
+     * to retrieve the job info */
+    if (cd->publish && NULL != prte_data_server_uri) {
+        pmix_data_buffer_t pbkt;
+        pmix_byte_object_t pbo;
+        uid_t euid;
+        pmix_data_range_t range = PMIX_RANGE_SESSION;
+        pmix_persistence_t persist = PMIX_PERSIST_APP;
+        pmix_info_t *pinfo;
+        size_t n;
+
+        PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
+        ret = PMIx_Data_pack(NULL, &pbkt, &cd->ninfo, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            cd->status = ret;
+            complete_reg(cd);
+            return;
+        }
+        ret = PMIx_Data_pack(NULL, &pbkt, cd->pinfo, cd->ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            cd->status = ret;
+            complete_reg(cd);
+            return;
+        }
+        PMIX_INFO_FREE(cd->pinfo, cd->ninfo);
+        cd->pinfo = NULL;
+        cd->ninfo = 0;
+        ret = PMIx_Data_unload(&pbkt, &pbo);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            cd->status = ret;
+            complete_reg(cd);
+            return;
+        }
+
+        cd->ninfo = 4;
+        PMIX_INFO_CREATE(pinfo, cd->ninfo);
+
+        /* first pass the packed values with a key of the nspace */
+        n = 0;
+        PMIX_INFO_LOAD(&pinfo[n], prte_process_info.myproc.nspace, &pbo, PMIX_BYTE_OBJECT);
+        PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+        ++n;
+
+        /* set the range to be session */
+        PMIX_INFO_LOAD(&pinfo[n], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+        ++n;
+
+        /* set the persistence to be app */
+        PMIX_INFO_LOAD(&pinfo[n], PMIX_PERSISTENCE, &persist, PMIX_PERSIST);
+        ++n;
+
+        /* add our effective userid to the directives */
+        euid = geteuid();
+        PMIX_INFO_LOAD(&pinfo[n], PMIX_USERID, &euid, PMIX_UINT32);
+        ++n;
+
+        /* now publish it */
+        cd->pinfo = pinfo;
+        ret = pmix_server_publish_fn(&prte_process_info.myproc, cd->pinfo, cd->ninfo,
+                                     pubcbfunc, cd);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            cd->status = ret;
+            complete_reg(cd);
+            return;
+        }
+        /* the publish callback completes the chain */
+        return;
+    }
+
+    complete_reg(cd);
+}
+
+static void regcbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
+
+    /* this executes on the PMIx progress thread - shift to our
+     * event base before continuing */
+    cd->status = status;
+    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, _nspace_reg_done, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
+}
+
+/* stuff proc attributes for sending back to a proc. The
+ * registration completes asynchronously: a PRTE_SUCCESS return
+ * means the provided callback will be invoked (on the PRRTE
+ * progress thread) when the registration is done; an error
+ * return means the callback will never fire */
+int prte_pmix_server_register_nspace(prte_job_t *jdata,
+                                     pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     int rc;
     prte_proc_t *pptr;
@@ -80,9 +250,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
     hwloc_obj_t machine;
     pmix_proc_t pproc, *parentproc, *procptr;
     pmix_status_t ret;
-    pmix_info_t *pinfo, devinfo[2];
-    size_t ninfo;
-    prte_pmix_lock_t lock;
+    pmix_info_t devinfo[2];
+    prte_pmix_reg_caddy_t *cd;
     pmix_list_t local_procs, members;
     prte_namelist_t *nm;
     size_t nmsize;
@@ -638,120 +807,38 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata)
 
     /* register it */
     PMIX_INFO_LIST_CONVERT(ret, info, &darray);
-    pinfo = (pmix_info_t*)darray.array;
-    ninfo = darray.size;
     PMIX_INFO_LIST_RELEASE(info);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    ret = PMIx_server_register_nspace(pproc.nspace, jdata->num_local_procs, pinfo, ninfo, opcbfunc,
-                                      &lock);
+
+    /* do not block waiting for the registration - the callback
+     * chain will thread-shift, perform any required data-server
+     * publication, and then invoke the caller's callback on our
+     * progress thread */
+    cd = PMIX_NEW(prte_pmix_reg_caddy_t);
+    cd->pinfo = (pmix_info_t *) darray.array;
+    cd->ninfo = darray.size;
+    cd->publish = true;
+    cd->cbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    ret = PMIx_server_register_nspace(pproc.nspace, jdata->num_local_procs,
+                                      cd->pinfo, cd->ninfo, regcbfunc, cd);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         rc = prte_pmix_convert_status(ret);
-        PMIX_INFO_FREE(pinfo, ninfo);
-        PRTE_PMIX_DESTRUCT_LOCK(&lock);
+        /* the callback will never fire - releasing the caddy
+         * also releases the info array */
+        PMIX_RELEASE(cd);
         return rc;
     }
-    PRTE_PMIX_WAIT_THREAD(&lock);
-    rc = lock.status;
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    if (PRTE_SUCCESS != rc) {
-        PMIX_INFO_FREE(pinfo, ninfo);
-        return rc;
-    }
-
-    /* if the user has connected us to an external server, then we must
-     * assume there is going to be some cross-mpirun exchange, and so
-     * we protect against that situation by publishing the job info
-     * for this job - this allows any subsequent "connect" to retrieve
-     * the job info */
-    if (NULL != prte_data_server_uri) {
-        pmix_data_buffer_t pbkt;
-        pmix_byte_object_t pbo;
-        uid_t euid;
-        pmix_data_range_t range = PMIX_RANGE_SESSION;
-        pmix_persistence_t persist = PMIX_PERSIST_APP;
-
-        PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
-        ret = PMIx_Data_pack(NULL, &pbkt, &ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            rc = prte_pmix_convert_status(ret);
-            PMIX_INFO_FREE(pinfo, ninfo);
-            return rc;
-        }
-        ret = PMIx_Data_pack(NULL, &pbkt, pinfo, ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            rc = prte_pmix_convert_status(ret);
-            PMIX_INFO_FREE(pinfo, ninfo);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            return rc;
-        }
-        PMIX_INFO_FREE(pinfo, ninfo);
-        ret = PMIx_Data_unload(&pbkt, &pbo);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            rc = prte_pmix_convert_status(ret);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            return rc;
-        }
-
-        ninfo = 4;
-        PMIX_INFO_CREATE(pinfo, ninfo);
-
-        /* first pass the packed values with a key of the nspace */
-        n = 0;
-        PMIX_INFO_LOAD(&pinfo[n], prte_process_info.myproc.nspace, &pbo, PMIX_BYTE_OBJECT);
-        PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-        ++n;
-
-        /* set the range to be session */
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_RANGE, &range, PMIX_DATA_RANGE);
-        ++n;
-
-        /* set the persistence to be app */
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_PERSISTENCE, &persist, PMIX_PERSIST);
-        ++n;
-
-        /* add our effective userid to the directives */
-        euid = geteuid();
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_USERID, &euid, PMIX_UINT32);
-        ++n;
-
-        /* now publish it */
-        PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-        if (PMIX_SUCCESS
-            != (ret = pmix_server_publish_fn(&prte_process_info.myproc, pinfo, ninfo, opcbfunc,
-                                             &lock))) {
-            PMIX_ERROR_LOG(ret);
-            rc = prte_pmix_convert_status(ret);
-            PMIX_INFO_FREE(pinfo, ninfo);
-            PMIX_LIST_RELEASE(info);
-            PRTE_PMIX_DESTRUCT_LOCK(&lock);
-            return rc;
-        }
-        PRTE_PMIX_WAIT_THREAD(&lock);
-        rc = lock.status;
-        PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    }
-    PMIX_INFO_FREE(pinfo, ninfo);
-
-    return rc;
+    return PRTE_SUCCESS;
 }
 
-static void opcbfunc(pmix_status_t status, void *cbdata)
-{
-    prte_pmix_lock_t *lock = (prte_pmix_lock_t *) cbdata;
-
-    lock->status = prte_pmix_convert_status(status);
-    PRTE_PMIX_WAKEUP_THREAD(lock);
-}
-
-/* add any info that the tool couldn't self-assign */
-int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd)
+/* add any info that the tool couldn't self-assign. Follows the
+ * same asynchronous completion contract as
+ * prte_pmix_server_register_nspace above */
+int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
+                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_status_t ret;
-    prte_pmix_lock_t lock;
     int rc;
     uint32_t u32;
     uint16_t u16;
@@ -761,14 +848,17 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd)
     prte_node_t *node;
     void *ilist, *joblist;
     pmix_data_array_t darray;
-    pmix_info_t *pinfo;
-    size_t ninfo;
+    prte_pmix_reg_caddy_t *rcd;
 
     // see if we already did this
     jdata = prte_get_job_data_object(cd->target.nspace);
     if (NULL != jdata) {
-        // we did
-        return PMIX_SUCCESS;
+        // we did - the caller must tolerate the callback being
+        // invoked prior to our return
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, cbdata);
+        }
+        return PRTE_SUCCESS;
     }
 
     // create a job tracker for it
@@ -1039,23 +1129,26 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd)
         rc = prte_pmix_convert_status(ret);
         return rc;
     }
-    pinfo = (pmix_info_t*)darray.array;
-    ninfo = darray.size;
     PMIX_INFO_LIST_RELEASE(joblist);
-    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+
+    /* do not block waiting for the registration - the callback
+     * will thread-shift and then invoke the caller's callback on
+     * our progress thread */
+    rcd = PMIX_NEW(prte_pmix_reg_caddy_t);
+    rcd->pinfo = (pmix_info_t *) darray.array;
+    rcd->ninfo = darray.size;
+    rcd->cbfunc = cbfunc;
+    rcd->cbdata = cbdata;
     ret = PMIx_server_register_nspace(cd->target.nspace, 1,
-                                      pinfo, ninfo,
-                                      opcbfunc, &lock);
+                                      rcd->pinfo, rcd->ninfo,
+                                      regcbfunc, rcd);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         rc = prte_pmix_convert_status(ret);
-        PRTE_PMIX_DESTRUCT_LOCK(&lock);
-        PMIX_INFO_FREE(pinfo, ninfo);
+        /* the callback will never fire - releasing the caddy
+         * also releases the info array */
+        PMIX_RELEASE(rcd);
         return rc;
     }
-    PRTE_PMIX_WAIT_THREAD(&lock);
-    rc = lock.status;
-    PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PMIX_INFO_FREE(pinfo, ninfo);
-    return rc;
+    return PRTE_SUCCESS;
 }

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1516,6 +1516,7 @@ static int prep_singleton(const char *name)
     pmix_rank_t rank;
     prte_app_context_t *app;
     char cwd[PRTE_PATH_MAX];
+    prte_pmix_lock_t lock;
 
     ptr = strdup(name);
     p1 = strrchr(ptr, '.');
@@ -1582,8 +1583,22 @@ static int prep_singleton(const char *name)
     node->num_procs = 1;
     node->slots_inuse = 1;
 
-    // register the info with our PMIx server
-    rc = prte_pmix_server_register_nspace(jdata);
+    // register the info with our PMIx server - the registration
+    // completes asynchronously, with the callback firing on our
+    // own progress thread, so we must cycle the event library
+    // while we wait for it
+    PRTE_PMIX_CONSTRUCT_LOCK(&lock);
+    rc = prte_pmix_server_register_nspace(jdata, opcbfunc, &lock);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_PMIX_DESTRUCT_LOCK(&lock);
+        return rc;
+    }
+    while (lock.active) {
+        prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+    }
+    PMIX_ACQUIRE_OBJECT(&lock);
+    rc = prte_pmix_convert_status(lock.status);
+    PRTE_PMIX_DESTRUCT_LOCK(&lock);
 
     return rc;
 }


### PR DESCRIPTION
## Problem

The launch path blocked the PRRTE progress thread on condvar waits for PMIx operations: building the launch message waited for PMIx_server_setup_application (with the callback packing into the job object and activating the next state from the PMIx thread), constructing the child list waited for PMIx_server_setup_local_support, and every nspace/tool registration blocked until PMIx_server_register_nspace completed - on every daemon, on every launch. The data-server publication inside registration additionally waited for a response that arrives over the RML, which only the blocked thread could deliver - a latent deadlock on that path.

## Fix

Expresses the ordering as continuations instead of blocks. The setup-application callback serializes its results and shifts; the handler completes the launch message and activates SEND_LAUNCH_MSG. The component now passes its fork primitive into construct_child_list, and the base activates the local launch either directly or from the shifted local-support callback. prte_pmix_server_register_nspace/register_tool gain an asynchronous completion contract (PRTE_SUCCESS means the callback will fire on the progress thread; error means it never fires), with all seven call sites converted - including a counter-joined registration set in the odls child-list construction covering the target job plus any prior jobs a newly launched daemon must learn.

## Verification

Warning-free builds, make check, DVM cycles, 20/20 spawn stress, nonzero-exit propagation, do-not-launch smoke, the full offline mapper harness (1176/1176 cases), and multi-node swarm validation including live exercise of the prior-job counter-join via DVM growth.

Stacks on #2537 - review the last 3 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)