### PR TITLE
Reinitialize the event base after the daemonize fork

### DIFF
--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -618,6 +618,14 @@ int prte(int argc, char *argv[])
         prte_state_base.parent_fd = wait_pipe[1];
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);
+        /* the event base was opened before we forked, and some
+         * backends (e.g., kqueue on macOS) do not survive a fork.
+         * Reinitialize the base so the child gets a functional
+         * backend - otherwise the event loop spins on a dead
+         * kernel queue and the DVM never reports ready */
+        if (0 != prte_event_reinit(prte_event_base)) {
+            return PRTE_ERROR;
+        }
     } else {
 #if defined(HAVE_SETSID)
         /* see if we were directed to separate from current session */


### PR DESCRIPTION
## Problem

prte --daemonize hung: the parent never received the readiness byte and the daemonized child spun forever on kevent() failure warnings. Commit ea0f4455d4 moved prte_event_base_open() ahead of command line processing (for singleton support), which placed it ahead of the --daemonize fork - and kernel event backends are not required to survive a fork. Reproduced on macOS (kqueue) and in a Linux/epoll container environment, so this is cross-platform, not a kqueue quirk.

## Fix

Call libevent's event_reinit() - which exists precisely to rebuild the kernel structures in a forked child - immediately after the daemonize fork. prted is unaffected: it forks before the event base opens.

## Verification

prte --daemonize now returns immediately and serves jobs on macOS (10/10 daemonize/prun/pterm cycles) and in the Linux container swarm (was a reproducible 100% hang in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)