### PR TITLE
Fix DVM growth via the add-host options

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2291,13 +2291,16 @@ construct:
 
     if (one_filter) {
         /* at least one filtering option was executed, so
-         * remove all nodes that were not mapped
-         */
+         * remove all nodes that were not mapped. Retain nodes that
+         * were dynamically added after the DVM started - they were
+         * granted by an explicit grow request, so the static specs
+         * (which predate them) cannot speak to their inclusion */
         item = pmix_list_get_first(&nodes);
         while (item != pmix_list_get_end(&nodes)) {
             next = pmix_list_get_next(item);
             node = (prte_node_t *) item;
-            if (!PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_MAPPED)) {
+            if (!PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_MAPPED) &&
+                PRTE_NODE_STATE_ADDED != node->state) {
                 pmix_list_remove_item(&nodes, item);
                 PMIX_RELEASE(item);
             } else {
@@ -2355,6 +2358,11 @@ process:
             break;
         }
         node = (prte_node_t *) item;
+        /* if this node was dynamically added, reset its state now
+         * that it is being absorbed into the DVM */
+        if (PRTE_NODE_STATE_ADDED == node->state) {
+            node->state = PRTE_NODE_STATE_UP;
+        }
         /* if this node is already in the map, skip it */
         if (NULL != node->daemon) {
             num_nodes++;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1292,6 +1292,25 @@ static void ras_base_complete_grow_request(prte_pmix_server_req_t *req)
     size_t n;
     bool found = false;
 
+    /* an add-host/add-hostfile request (from the --add-host and
+     * --add-hostfile cmd line options) grows the DVM's general pool.
+     * The nodes were already inserted by the module that claimed the
+     * request, and there is no reservation to route them to - so all
+     * that remains is to extend the DVM across the new nodes. The
+     * grow must be activated even if the request only adjusted slots
+     * on existing nodes: initiating the request marked the DVM as
+     * not-ready and parked the requesting job in the job cache, and
+     * it is the VM_READY re-entry at the end of the (possibly empty)
+     * daemon launch that marks the DVM ready again and releases the
+     * cached jobs */
+    for (n = 0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOST) ||
+            PMIx_Check_key(req->info[n].key, PMIX_ADD_HOSTFILE)) {
+            prte_ras_base_activate_dvm_grow();
+            return;
+        }
+    }
+
     rc = ras_base_prepare_grow(req, &dest);
     if (PMIX_SUCCESS != rc) {
         req->pstatus = rc;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1226,6 +1226,10 @@ static int ras_base_insert_node_string(char *ndstring, prte_session_t *dest)
      * phase-two completion event). */
     PMIX_LIST_FOREACH(snap, &ndlist, prte_node_t) {
         PMIx_Argv_append_nosize(&rsv_names, snap->name);
+        /* mark as newly added so the DVM extension will include it
+         * despite any static -host filter given when the DVM was
+         * started */
+        snap->state = PRTE_NODE_STATE_ADDED;
     }
 
     ret = prte_ras_base_node_insert(&ndlist, NULL);

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -365,14 +365,28 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
             handled = true;
         }
         if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOST)) {
+            pmix_list_t dhnodes;
+            prte_node_t *nd;
+
             // comma-delimited list of hosts to add or delete
-            rc = prte_util_add_dash_host_nodes(&nodes, req->info[n].value.data.string, true);
+            PMIX_CONSTRUCT(&dhnodes, pmix_list_t);
+            rc = prte_util_add_dash_host_nodes(&dhnodes, req->info[n].value.data.string, true);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
+                PMIX_LIST_DESTRUCT(&dhnodes);
                 PMIX_LIST_DESTRUCT(&nodes);
                 req->pstatus = prte_pmix_convert_rc(rc);
                 return req->pstatus;
             }
+            /* mark these as newly added so the DVM extension will
+             * include them despite any static -host filter given
+             * when the DVM was started - the hostfile parser above
+             * already does this for its new nodes */
+            while (NULL != (nd = (prte_node_t *) pmix_list_remove_first(&dhnodes))) {
+                nd->state = PRTE_NODE_STATE_ADDED;
+                pmix_list_append(&nodes, &nd->super);
+            }
+            PMIX_DESTRUCT(&dhnodes);
             handled = true;
         }
     }


### PR DESCRIPTION
## Problem

Growing an unmanaged DVM with prun --add-host (or --add-hostfile) hung forever. Two stacked defects: (1) initiating the request parks the submitted job and marks the DVM not-ready, but the grow completion only recognized requests carrying PMIX_ALLOC_NODE_LIST - the add-host flavor names no reservation, so reservation routing rejected it before the DVM extension was ever activated, and the readiness signal the parked job was waiting on could never come; (2) once activated, the daemon-launch setup filters candidate nodes against the daemon job's static -host/hostfile specs, which predate - and therefore exclude - any node granted by a later add-host or scheduler extension, so no daemon was ever launched on the new node.

## Fix

The grow completion recognizes the add-host flavor and proceeds directly to activating the DVM extension (even for slots-only adjustments, since the VM_READY re-entry is what releases the parked jobs). Nodes granted through the modify path - both the dash-host flavor and a scheduler-provided node list - are marked with the ADDED node state (the add-hostfile parser already did so), retained through the static-spec filter, and reset as they are absorbed, mirroring the dynamic-spawn path.

## Verification

Local single-node resume test (formerly hung); multi-node container swarm: 2-node DVM with a running job, add-host of a third node launched a daemon there and ran the new job on it with the prior job undisturbed and a clean pterm afterward. make check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)