### PR TITLE
Fix tool exit statuses and pterm option handling

### DIFF
--- a/src/mca/schizo/prte/help-pterm.txt
+++ b/src/mca/schizo/prte/help-pterm.txt
@@ -63,6 +63,10 @@ Terminate an instance of the PMIx Reference RTE (PRRTE) DVM
 | "--wait-to-connect   | Delay specified number of seconds before      |
 | <seconds>"           | trying to connect                             |
 +----------------------+-----------------------------------------------+
+| "--allow-run-as-     | Accepted for symmetry with the other PRRTE    |
+| root"                | tools - pterm launches nothing, so no         |
+|                      | root-execution guard applies                  |
++----------------------+-----------------------------------------------+
 
 Report bugs to %s
 #
@@ -71,6 +75,11 @@ Report bugs to %s
 %s (%s) %s
 
 Report bugs to %s
+#
+[allow-run-as-root]
+
+Accepted for symmetry with the other PRRTE tools - pterm launches
+nothing, so no root-execution guard applies
 #
 [dvm-uri]
 

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -439,6 +439,9 @@ static struct option ptermoptions[] = {
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_HELP, PMIX_ARG_OPTIONAL, 'h'),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_VERSION, PMIX_ARG_NONE, 'V'),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_VERBOSE, PMIX_ARG_NONE, 'v'),
+    /* accepted for symmetry with the other tools - pterm launches
+     * nothing, so there is no root-execution hazard to guard */
+    PMIX_OPTION_DEFINE(PRTE_CLI_RUN_AS_ROOT, PMIX_ARG_NONE),
 
     // MCA parameters
     PMIX_OPTION_DEFINE(PRTE_CLI_PMIXMCA, PMIX_ARG_REQD),

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -313,6 +313,8 @@ int prun(int argc, char *argv[])
 
 
     rc = prun_common(&results, schizo, pargc, pargv);
+    /* reflect the job's outcome in our exit status */
+    PRTE_UPDATE_EXIT_STATUS(rc);
 
 DONE:
     // cleanup and leave

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -294,10 +294,11 @@ int main(int argc, char *argv[])
         }
         if (PRTE_ERR_SILENT != rc) {
             fprintf(stderr, "%s: command line error (%s)\n", prte_tool_basename, prte_strerror(rc));
-        } else {
-            rc = PRTE_SUCCESS;
         }
-        return rc;
+        /* the error has been reported - exit with a failed status
+         * so callers do not mistake a rejected command line for a
+         * successful termination request */
+        return 1;
     }
 
     // we do NOT accept arguments other than our own


### PR DESCRIPTION
## Problem

Three tool-correctness defects that compound badly in scripts and CI: (1) prun computed the job's termination status but exited with the never-updated global prte_exit_status, so a job exiting nonzero produced a prun exit status of zero (prterun propagates correctly); (2) pterm mapped silent command-line parse errors to a success exit status; and (3) pterm rejected --allow-run-as-root as an unrecognized option while every sibling tool accepts it. Together, (2)+(3) made every root-context pterm invocation a silent no-op: it exited 0 without ever contacting the DVM, which presents convincingly as "pterm succeeded but the DVM is still running."

## Fix

prun feeds the returned job status through PRTE_UPDATE_EXIT_STATUS (note: losing the DVM connection now also exits nonzero rather than claiming success); pterm exits 1 once a command-line error has been reported; and pterm accepts --allow-run-as-root as an inert option (it launches nothing, so no root-execution guard applies), with the help text updated.

## Verification

Local: exit-7 job propagates through prun under a DVM, bogus options exit 1, pterm with the flag terminates a DVM. Multi-node swarm: exit-9 propagation and full teardown with the flag (zero processes left on any node). make check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)