### PR TITLE
Release the prted daemonize parent once up and running

### DIFF
--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -763,6 +763,15 @@ bootstrap_wait:
     }
     ret = PRTE_SUCCESS;
 
+    /* if we daemonized, then the parent from the fork is blocked
+     * waiting to hear that we are up and running - release it */
+    if (0 <= prte_state_base.parent_fd) {
+        char ok = 'K';
+        pmix_fd_write(prte_state_base.parent_fd, 1, &ok);
+        close(prte_state_base.parent_fd);
+        prte_state_base.parent_fd = -1;
+    }
+
     /* loop the event lib until an exit event is detected */
     while (prte_event_base_active) {
         prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);


### PR DESCRIPTION
## Problem

When a prted daemonizes, the parent from the fork blocks reading the readiness pipe, expecting a byte once the daemon is functional - but nothing on the daemon side ever wrote it. The parent sat in that read for the daemon's entire life, leaving two prted processes on every node and holding the launcher's ssh session open until the daemon finally exited and the pipe returned EOF.

## Fix

Write the readiness byte just before entering the event loop, mirroring what the DVM master does when it reaches VM_READY, so the parent (and the ssh session carrying it) exits as soon as the daemon is operational.

## Verification

Container swarm with daemonized prteds: one prted per node during the run (was two), jobs run normally, clean full teardown at pterm. make check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)