### PR TITLE
Make the dockerswarm guide an AGENTS.md orientation file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,16 @@ prun -n 4 hostname                  # basic launch smoke test
 pterm                               # shut down DVM
 ```
 
+**Multi-node testing without a cluster.**  Use the container harness in
+[`contrib/dockerswarm/`](contrib/dockerswarm/) — its
+[`AGENTS.md`](contrib/dockerswarm/AGENTS.md) is the authoritative guide.
+Its `build.sh` bind-mounts your live working tree into a builder
+container and compiles it out-of-tree into a shared volume the ten
+"node" containers read, so the swarm always runs your uncommitted
+changes; `run-tests.sh` drives the multi-node suite (launch, IOF,
+preload, elastic grow/shrink, relay).  Do not invent an ad-hoc
+container flow — use the harness.
+
 For resource-manager integration (SLURM, PBS, LSF), test within an actual
 allocation on the relevant system.
 

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -1,4 +1,12 @@
-# PRRTE DVM test "swarm"
+# AGENTS.md — the dockerswarm multi-node test harness
+
+Orientation for AI agents and human contributors who need to run PRRTE
+across multiple nodes without a cluster. **This directory is the
+canonical multi-node harness** — if you are about to hand-craft
+containers, tar a source tree into a volume, or patch files inside a
+running node, stop: `build.sh` below already does the right thing
+(bind-mounts your live working tree into a builder and compiles it
+out-of-tree into the shared volume the nodes read).
 
 A small, self-contained harness for exercising PRRTE across several container
 "nodes" — a persistent DVM, one-shot `prterun`, and the **elastic DVM**

--- a/contrib/dockerswarm/CLAUDE.md
+++ b/contrib/dockerswarm/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Problem

The dockerswarm harness README already documents the correct multi-node workflow - build.sh bind-mounts the live working tree into a builder container and compiles it out-of-tree into the shared volume the node containers read - but nothing agent-facing pointed at it. Agents (and people) kept reinventing ad-hoc container flows: tarring source trees into volumes, patching files inside containers, and tripping over the stale-state failure modes the harness already solves.

## Fix

Converts the README to an AGENTS.md with the conventional CLAUDE.md symlink so coding agents load it as orientation, adds an explicit "this is the canonical harness - do not invent your own flow" preamble, and points at it from the Testing section of the top-level AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)