### PR TITLE
plm/server: mark local completion events prte.notify.donotloop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,6 +631,45 @@ Here the handler performs the work, invokes the caller's callback, and
 releases the caddy with `PMIX_RELEASE(cd)` — there is **no**
 `PRTE_PMIX_WAKEUP_THREAD` because no one is waiting on a lock.
 
+### GOLDEN RULE: mark locally-originated event notifications `prte.notify.donotloop`
+
+When PRRTE itself originates an event notification with
+`PMIx_Notify_event` — a grow/shrink completion, a job-start or
+ready-for-debug event, an allocation-timeout relay, a job-end, etc. —
+add a `"prte.notify.donotloop"` boolean to the event's info array:
+
+```c
+PMIX_INFO_LOAD(&info[idx++], "prte.notify.donotloop", NULL, PMIX_BOOL);
+```
+
+PMIx loops any event it is handed back through this daemon's **own**
+`notify_event` server upcall (`pmix_server_notify_event`) so the daemon
+can propagate it to its peers. That upcall thread-shifts its work
+(state activation, pack, xcast) onto `prte_event_base` and returns
+`PMIX_SUCCESS`. So if you originate the event with the **blocking** form
+of `PMIx_Notify_event` (a `NULL` completion callback, which waits on an
+internal condition) **from the progress thread**, you deadlock the
+process: the progress thread parks inside `PMIx_Notify_event` waiting for
+a completion that can only be produced by the thread-shifted upcall
+handler — which cannot run until the progress thread is free. The
+`notify_event` upcall checks for the `prte.notify.donotloop` marker
+**first** and, when present, returns `PMIX_OPERATION_SUCCEEDED`
+synchronously without thread-shifting; the blocking call then completes
+at once and PMIx still delivers the event to any locally-registered tool
+or process. The marker also serves its original purpose of breaking the
+xcast echo loop (an event broadcast to every daemon must not be
+re-injected and re-broadcast when it arrives).
+
+The requesters/targets of these notifications are tools connected to
+**this** HNP, so local delivery is sufficient and the marker is always
+correct. Omit it only when the event genuinely must reach processes on
+**other** daemons — and in that case never originate it with a blocking
+`PMIx_Notify_event` on the progress thread (use the non-blocking form
+with a real completion callback instead). Getting this wrong produces an
+intermittent, hard-to-trace hang: the symptom is a wedged progress
+thread (`futex_wait_queue`, event base idle) that stops servicing
+everything, including new `PMIx_tool_init` connections.
+
 ---
 
 ## Performance Considerations

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2542,8 +2542,15 @@ void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
      * mirroring the PMIX_ALLOC_TIMEOUT_WARNING delivery: custom range plus the
      * allocation id, the requester's own request id when one was supplied, and
      * — on failure — the underlying cause so the requester can distinguish
-     * what went wrong rather than only that something did. */
-    nrinfo = 2;
+     * what went wrong rather than only that something did.  The event also
+     * carries "prte.notify.donotloop" so our own notify_event server upcall
+     * short-circuits instead of thread-shifting and re-xcasting it: the
+     * requester is a tool local to this HNP, so PMIx delivers the event
+     * locally and no broadcast is needed.  Without the marker the upcall
+     * would defer its work onto this progress thread while the blocking
+     * PMIx_Notify_event below is parked here waiting for it -- a self-deadlock
+     * (see the AGENTS.md rule on locally-originated event notifications). */
+    nrinfo = 3;  /* custom range + alloc id + donotloop marker */
     if (NULL != req_id) {
         nrinfo++;
     }
@@ -2559,6 +2566,8 @@ void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
     /* PMIX_INFO_LOAD deep-copies the data, so the stack copies are fine */
     PMIX_INFO_LOAD(&rinfo[idx++], PMIX_EVENT_CUSTOM_RANGE, &parray, PMIX_DATA_ARRAY);
     PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, (void *) alloc_id, PMIX_STRING);
+    /* keep delivery local: do not loop back through our own server upcall */
+    PMIX_INFO_LOAD(&rinfo[idx++], "prte.notify.donotloop", NULL, PMIX_BOOL);
     if (NULL != req_id) {
         PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_REQ_ID, (void *) req_id, PMIX_STRING);
     }

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -667,8 +667,14 @@ static void _alloc_timeout_warning(int sd, short args, void *cbdata)
         goto done;
     }
 
-    /* assemble a directed (custom-range) notification to the requestor only */
-    nrinfo = 2;  /* custom range + alloc id */
+    /* assemble a directed (custom-range) notification to the requestor only.
+     * The event carries "prte.notify.donotloop" so our own notify_event
+     * server upcall short-circuits instead of thread-shifting and re-xcasting
+     * it -- the requestor is a tool local to this HNP, so PMIx delivers the
+     * event locally.  Without the marker the blocking PMIx_Notify_event below
+     * (on the progress thread) would deadlock against the deferred upcall
+     * handler (see the AGENTS.md rule on locally-originated notifications). */
+    nrinfo = 3;  /* custom range + alloc id + donotloop marker */
     if (NULL != session->user_refid) {
         nrinfo++;
     }
@@ -684,6 +690,8 @@ static void _alloc_timeout_warning(int sd, short args, void *cbdata)
     /* PMIX_INFO_LOAD deep-copies the data array, so the stack copy is fine */
     PMIX_INFO_LOAD(&rinfo[idx++], PMIX_EVENT_CUSTOM_RANGE, &parray, PMIX_DATA_ARRAY);
     PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, session->alloc_refid, PMIX_STRING);
+    /* keep delivery local: do not loop back through our own server upcall */
+    PMIX_INFO_LOAD(&rinfo[idx++], "prte.notify.donotloop", NULL, PMIX_BOOL);
     if (NULL != session->user_refid) {
         PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_REQ_ID, session->user_refid, PMIX_STRING);
     }


### PR DESCRIPTION
## Problem

After an elastic **grow**, the DVM master's PMIx server stops completing new tool connections: a subsequent `prun`, `elastic grow`, or `elastic shrink` all hang in `PMIx_tool_init()`, and the shrink target's `prted` never dies. The HNP is idle-blocked (main/progress thread in `futex_wait_queue`, event base idle), not spinning. Everything up to and including the grow itself works.

The regression bisects to `0fd0cd00d5` ("server: thread-shift the event notification upcall").

## Root cause

`prte_plm_base_dvm_mod_notify()` delivers the grow/shrink completion event to the requesting tool with the **blocking** form of `PMIx_Notify_event` (a `NULL` completion callback, which waits on an internal condition) while running **on the progress thread**.

PMIx loops that event back through this daemon's own `notify_event` server upcall so the daemon can propagate it to peers. Since `0fd0cd00d5`, that upcall thread-shifts its work onto `prte_event_base` and returns `PMIX_SUCCESS`. The progress thread, already parked inside the blocking `PMIx_Notify_event`, can never run the shifted handler, so the call never returns — the progress thread is wedged for good and stops servicing everything else, including new `PMIx_tool_init` handshakes.

The allocation-timeout-warning relay (`_alloc_timeout_warning` in `pmix_server.c`) makes the identical blocking, custom-range call from the progress thread and carries the same latent deadlock.

## Fix

Every other locally-originated notification in the tree (job-start, ready-for-debug, launch-complete, job-end, allocation-complete) already tags its event with `"prte.notify.donotloop"`, which the `notify_event` upcall checks first and, when present, returns `PMIX_OPERATION_SUCCEEDED` synchronously — no thread-shift, no re-broadcast. These two sites simply omitted it.

Add the marker to both. The requester/requestor is a tool connected to this HNP, so PMIx still delivers the event locally and no xcast is needed; the blocking notify completes immediately and the deadlock is gone. A new rule in `AGENTS.md` (Thread Safety section) records the requirement so future notifications follow the same pattern.

## Verification

- Clean `--enable-debug` build (warnings-as-errors).
- Full `contrib/dockerswarm` multi-node suite: **21 passed / 0 failed** against PMIx master — grow, shrink, post-shrink `prun`, and radix-2 deep-tree grow/shrink relay all green (previously hung at the first post-grow tool connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)