### PR TITLE
plm: framework review - elastic grow completion/scoping, leaks, and crash fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ test/unit/odls/Makefile
 test/unit/odls/test_odls
 test/unit/iof/Makefile
 test/unit/iof/test_iof
+test/unit/plm/Makefile
+test/unit/plm/test_plm
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -38,5 +38,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/grpcomm/Makefile
         test/unit/odls/Makefile
         test/unit/iof/Makefile
+        test/unit/plm/Makefile
     ])
 ])

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -219,24 +219,35 @@ safe.
 | rebuild the base image (new baked PMIx) | `./build.sh image` (or `PMIX_REF=v6.1.0 ./build.sh image`) |
 | tear down the swarm | `docker compose down` (the `prte-build` volume persists) |
 
-## 9. Known issue
+## 9. Grow after a shrink
 
-Re-growing a node **immediately after** shrinking it can fail its TCP
-connect-back (`prted` exits 255) — the just-killed daemon/session may not have
-fully torn down. Tracked as
-[openpmix/prrte#2491](https://github.com/openpmix/prrte/issues/2491). Start a
-fresh DVM between grow/shrink cycles; a single grow→shrink cycle on a fresh DVM
-is the reliable smoke test.
+Historically this was the harness's standing known issue: re-growing a node
+immediately after shrinking it was reported to fail its TCP connect-back
+(`prted` exits 255) — [openpmix/prrte#2491](https://github.com/openpmix/prrte/issues/2491) —
+and the advice was to start a fresh DVM between grow/shrink cycles.
 
-**Any** grow after a shrink on the same DVM appears to be affected, not just a
-re-grow of the same node, and the second symptom is a **hang** rather than a
-failed connect-back: `grow node2,node3` → `shrink node2` → `grow node4` leaves
-a healthy `prted` running on node4 but never delivers the phase-two completion
-event, so the client times out after 60s and the DVM is left wedged (a
-subsequent `prun` does not return either). Reproduced on master, with and
-without `--uniform-nodes`, so it is not specific to the homogeneous-topology
-path. Until this is fixed, any test that grows after a shrink must bound every
-command with `timeout` or it will wedge the whole suite.
+What was actually reproducible here was a **hang**, and it applied to growing
+*any* node after a shrink, not just re-growing the same one: `grow
+node2,node3` → `shrink node2` → `grow node4` left a healthy `prted` on node4,
+but no phase-two completion event ever arrived, so the client timed out after
+60s and the DVM was wedged (a later `prun` never returned either).
+
+The cause was in the grow campaign, not in the launch: a grow starts a daemon
+on **every** node that lacks one, and a shrunk node reverts to the default
+pool with its `->session` cleared, so the re-absorbed node takes the lowest
+new vpid and lands in the `daemon_vpid_start` slot. The campaign read its
+requester from only that first target, found no session, recorded no
+requester — and so emitted no completion event even though the grow had
+succeeded. `prte_plm_base_setup_virtual_machine` now scans all of a
+campaign's targets for the first one carrying a requestor.
+
+`run-tests.sh` covers both variants (re-grow the same node, grow a different
+one afterwards). Note that a grow after a shrink will also silently re-absorb
+the previously shrunk node — that is pre-existing behavior of "launch a
+daemon wherever one is missing", and worth knowing when you count `prted`s.
+
+Still bound elastic commands with `timeout` in any new test: a grow that does
+not complete otherwise wedges the whole suite rather than failing one case.
 
 ## 10. Topology reference
 

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -100,6 +100,25 @@ docker compose up -d       # start prte-node1 .. prte-node10
 ./run-tests.sh macos       # build + single-host launch smoke
 ```
 
+**On macOS, say which dependencies to build against.** Unlike the container,
+this host is whatever you have installed, and the two knobs are:
+
+```sh
+PMIX_HOME=/path/to/pmix \
+EXTRA_CONFIGURE_ARGS="--with-libevent=/path/to/libevent --with-hwloc=/path/to/hwloc" \
+  ./build.sh macos
+```
+
+Leaving `PMIX_HOME`/`PMIX_SRC` unset lets configure autodetect PMIx, and if
+the host has more than one installed it may not pick the one you meant.
+PRRTE uses PMIx *internals*, so a mismatch is not a link error — it builds,
+installs, and then segfaults the instant a tool starts. That failure reaches
+`run-tests.sh macos` as a wall of "native Darwin DVM is unstable" skips,
+which is why the build now prints the libraries `prted` actually resolved
+against; check those first when the macOS suite goes quiet. (Most of the
+"Darwin instability" this suite used to report on at least one host was
+exactly this — a build against a stale second PMIx.)
+
 Rebuild after editing PRRTE: just rerun `./build.sh` (incremental). No image
 rebuild, no `docker compose` restart needed — the nodes read the shared volume.
 To also test an openpmix change, add `PMIX_SRC=/path/to/openpmix`.

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -143,6 +143,27 @@ Both `grow` and `shrink` should print
 >     --prtemca plm_base_verbose 5 --prtemca ras_base_verbose 5 >/tmp/prte.out 2>&1'
 > ```
 
+### Leak checking under Linux
+
+The image carries `valgrind`, so the Linux swarm is the place to look for
+leaks on the paths a single host cannot reach — anything involving real
+daemons, xcast, or the RML wire. Run the HNP under it:
+
+```sh
+docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+  prte-node1 bash -lc '. /opt/prte/env.sh; cd /tmp && \
+    valgrind --leak-check=full --show-leak-kinds=definite,indirect \
+             --num-callers=25 --log-file=/tmp/vg-hnp.txt \
+      prterun --host node1:1,node2:1,node3:1,node4:1 -np 4 --map-by node hostname'
+docker cp prte-node1:/tmp/vg-hnp.txt .
+```
+
+A daemon can be traced the same way by pointing `prte_launch_agent` at a
+wrapper script that execs `valgrind prted`. Note this is deliberately **not**
+part of `run-tests.sh`: a valgrind run is many times slower than the suite it
+would be embedded in. Compare totals before and after a change rather than
+chasing an absolute number — PMIx and hwloc contribute their own.
+
 ## 6. What "success" looks like
 
 **`prterun`** (`prterun --host node1:2,node2:2,node3:2,node4:2 -np 8 --map-by

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -228,6 +228,16 @@ fully torn down. Tracked as
 fresh DVM between grow/shrink cycles; a single grow→shrink cycle on a fresh DVM
 is the reliable smoke test.
 
+**Any** grow after a shrink on the same DVM appears to be affected, not just a
+re-grow of the same node, and the second symptom is a **hang** rather than a
+failed connect-back: `grow node2,node3` → `shrink node2` → `grow node4` leaves
+a healthy `prted` running on node4 but never delivers the phase-two completion
+event, so the client times out after 60s and the DVM is left wedged (a
+subsequent `prun` does not return either). Reproduced on master, with and
+without `--uniform-nodes`, so it is not specific to the homogeneous-topology
+path. Until this is fixed, any test that grows after a shrink must bound every
+command with `timeout` or it will wedge the whole suite.
+
 ## 10. Topology reference
 
 | Container | hostname | role |

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -241,10 +241,16 @@ requester — and so emitted no completion event even though the grow had
 succeeded. `prte_plm_base_setup_virtual_machine` now scans all of a
 campaign's targets for the first one carrying a requestor.
 
-`run-tests.sh` covers both variants (re-grow the same node, grow a different
-one afterwards). Note that a grow after a shrink will also silently re-absorb
-the previously shrunk node — that is pre-existing behavior of "launch a
-daemon wherever one is missing", and worth knowing when you count `prted`s.
+Chasing that turned up the related defect that a grow was **not scoped to
+the nodes it was given**: the extend path built its candidate list from the
+whole node pool, so any node lacking a daemon joined — which after a shrink
+meant `grow node4` also relaunched a daemon on the node you had just shrunk
+away. A grow now selects only nodes its own request marked
+`PRTE_NODE_STATE_ADDED`, and RAS carries that mark onto a pool entry that
+already exists (re-growing a shrunk node relies on it).
+
+`run-tests.sh` covers re-growing the same node, growing a different one
+afterwards, and that a grow leaves every node it was not given alone.
 
 Still bound elastic commands with `timeout` in any new test: a grow that does
 not complete otherwise wedges the whole suite rather than failing one case.

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libevent-dev libhwloc-dev zlib1g-dev \
         openssh-server openssh-client \
         iproute2 iputils-ping procps less vim ca-certificates \
+        valgrind \
     && rm -rf /var/lib/apt/lists/*
 
 # ---- baked PMIx (default) ----

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -141,11 +141,31 @@ build_macos() {
     #   EXTRA_CONFIGURE_ARGS="--with-libevent=... --with-hwloc=..."
     # (values with spaces, like an -isysroot in CFLAGS, should be exported as
     # CFLAGS/CPPFLAGS in the environment instead -- configure inherits them.)
+    #
+    # Reconfigure whenever those arguments change. An incremental build that
+    # silently keeps an older configuration is worse than a slow one: PRRTE
+    # uses PMIx internals, so a tree left pointing at a different PMIx than
+    # you asked for builds cleanly and then dies at startup, which reads as
+    # "this host is flaky" rather than "you built against the wrong PMIx".
+    local cfg_args="--prefix=$root/vpath-macos/install $pmix_arg --enable-debug ${EXTRA_CONFIGURE_ARGS:-}"
+    if [ -f config.status ] && [ "$(cat .prte-configure-args 2>/dev/null)" != "$cfg_args" ]; then
+        echo ">>> configure arguments changed - reconfiguring"
+        rm -f config.status
+    fi
     # shellcheck disable=SC2086
-    [ -f config.status ] || "$root/configure" \
-        --prefix="$root/vpath-macos/install" $pmix_arg --enable-debug ${EXTRA_CONFIGURE_ARGS:-}
+    if [ ! -f config.status ]; then
+        "$root/configure" $cfg_args
+        printf '%s' "$cfg_args" > .prte-configure-args
+    fi
     make -j"$(sysctl -n hw.ncpu)" && make install
     echo ">>> macOS build complete: $root/vpath-macos/install"
+    # Report what the tools actually resolved against. A mismatch here is the
+    # first thing to check when the macOS suite starts skipping everything.
+    if command -v otool >/dev/null 2>&1; then
+        echo ">>> linked dependencies:"
+        otool -L "$root/vpath-macos/install/bin/prted" 2>/dev/null \
+            | grep -iE "libpmix|libevent|libhwloc" | sed 's/^/>>>>   /'
+    fi
     echo ">>> next: ./run-tests.sh macos"
 }
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -355,11 +355,15 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         out=$(RUN 'timeout 90 elastic shrink node3' 2>&1); sleep 3
         echo "$out" | grep -q PMIX_DVM_IS_READY && ok "shrink node3 completed" \
                                                || bad "shrink node3 did not complete"
-        # re-grow the SAME node that was just shrunk
+        # re-grow the SAME node that was just shrunk. The pool entry for that
+        # node survived the shrink, so this only works if the ADDED mark the
+        # request puts on it is carried onto the existing pool object.
         out=$(RUN 'timeout 90 elastic grow node3:2' 2>&1)
         echo "$out" | grep -q PMIX_DVM_IS_READY \
             && ok "re-grow of the shrunk node completed (phase-two event delivered)" \
             || bad "re-grow of the shrunk node never completed"
+        [ "$(prted_count 3)" = 1 ] && ok "daemon relaunched on the re-grown node" \
+                                   || bad "re-grown node has no daemon"
         # and grow a DIFFERENT node afterwards
         out=$(RUN 'timeout 90 elastic grow node5:2' 2>&1)
         echo "$out" | grep -q PMIX_DVM_IS_READY \
@@ -374,6 +378,33 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         RUN 'timeout 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the re-grow test"
+    fi
+    cleanup_swarm
+
+    banner "elastic DVM: a grow launches ONLY on the nodes it was given"
+    # An allocation request naming node4 must start a daemon on node4 and
+    # nowhere else. Shrink node2 first so the DVM holds a node that is in the
+    # pool, has no daemon, and is NOT part of the next request: selecting on
+    # "any node missing a daemon" rather than on the nodes the request added
+    # silently relaunches a daemon on the node the user just shrank away.
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'timeout 90 elastic grow node2:2,node3:2' >/dev/null 2>&1
+        RUN 'timeout 90 elastic shrink node2' >/dev/null 2>&1; sleep 3
+        [ "$(prted_count 2)" = 0 ] && ok "node2 shrunk out of the DVM" || bad "node2 still has a daemon"
+        out=$(RUN 'timeout 90 elastic grow node4:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY && ok "grow node4 completed" \
+                                               || bad "grow node4 did not complete"
+        [ "$(prted_count 4)" = 1 ] && ok "daemon started on the requested node (node4)" \
+                                   || bad "no daemon on the requested node"
+        [ "$(prted_count 2)" = 0 ] \
+            && ok "the shrunk node was NOT dragged back into the grow" \
+            || bad "grow node4 also relaunched a daemon on the shrunk node2"
+        [ "$(prted_count 5 6 7)" = 0 ] && ok "no unrelated node was grown" \
+                                      || bad "grow touched a node it was not given"
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the grow-scope test"
     fi
     cleanup_swarm
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -336,6 +336,47 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     [ "$out" = node1 ] && ok "prun works post-shrink" || bad "prun broken post-shrink"
     RUN 'pterm' >/dev/null 2>&1; cleanup_swarm
 
+    banner "elastic DVM: grow AFTER a shrink completes (phase-two event)"
+    # A grow launches a daemon onto every node that lacks one -- which after a
+    # shrink includes the shrunk node, since releasing the reservation reverts
+    # it to the default pool with its ->session cleared. That node takes the
+    # LOWEST new vpid, so it lands in the daemon_vpid_start slot; a grow
+    # campaign that read its requester from only that first target found no
+    # session, recorded no requester, and emitted no phase-two completion
+    # event at all -- the grow succeeded but the requester waited forever and
+    # the DVM was left wedged. Both variants are covered: growing a DIFFERENT
+    # node after a shrink, and re-growing the SAME one (openpmix/prrte#2491).
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 90 elastic grow node2:2,node3:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY && ok "baseline grow node2,node3 completed" \
+                                               || bad "baseline grow did not complete"
+        out=$(RUN 'timeout 90 elastic shrink node3' 2>&1); sleep 3
+        echo "$out" | grep -q PMIX_DVM_IS_READY && ok "shrink node3 completed" \
+                                               || bad "shrink node3 did not complete"
+        # re-grow the SAME node that was just shrunk
+        out=$(RUN 'timeout 90 elastic grow node3:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "re-grow of the shrunk node completed (phase-two event delivered)" \
+            || bad "re-grow of the shrunk node never completed"
+        # and grow a DIFFERENT node afterwards
+        out=$(RUN 'timeout 90 elastic grow node5:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "subsequent grow of a different node completed" \
+            || bad "subsequent grow never completed"
+        [ "$(prted_count 2 3 5)" = 3 ] && ok "daemons present on node2, node3, node5" \
+                                       || bad "expected daemons missing after re-grow"
+        # a wedged DVM would not answer this
+        out=$(RUN 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+        [ "$(echo "$out" | tr -d '\r')" = node1 ] && ok "DVM still responsive after the re-grow" \
+                                                  || bad "DVM wedged after re-grow: $out"
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the re-grow test"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: radix-2 deep tree grow + shrink (multi-hop relay)"
     RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --prtemca prte_rml_radix 2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
     out=$(RUN 'elastic grow node2:2,node3:2,node4:2,node5:2,node6:2,node7:2,node8:2,node9:2' 2>&1)

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -53,9 +53,14 @@ ON()  { docker exec "prte-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:
 
 cleanup_swarm() {
     for n in $(seq 1 10); do
+        # NOTE: prterun's session dir is /tmp/prtrn.<pid>, NOT /tmp/prte.<pid>.
+        # Leaving those behind is what makes a later prun report "multiple
+        # possible servers ... connection handles have been read from files
+        # named pmix.*" and fail to find the DVM, so clear both patterns.
         docker exec "prte-node$n" sh -c \
             'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
-             rm -rf /tmp/prte.* /tmp/prun.session.* 2>/dev/null; true'
+             pkill -9 -x prterun 2>/dev/null;
+             rm -rf /tmp/prte.* /tmp/prtrn.* /tmp/prun.session.* 2>/dev/null; true'
     done
 }
 prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
@@ -175,6 +180,136 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         RUN 'timeout 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM for the stdin tests"
+    fi
+    cleanup_swarm
+
+    banner "plm/ssh: tree-spawn fan-out (radix 2, multi-level)"
+    # With tree-spawn (the default) the HNP does NOT ssh to every node: it
+    # launches only its own routing children, each of which calls the ssh
+    # module's remote_spawn() to launch ITS children, and so on. Forcing
+    # radix 2 makes the tree several levels deep, so daemons on the deeper
+    # nodes exist only if the fan-out actually recursed -- something a
+    # single-host or flat launch can never prove. Every daemon still reports
+    # directly to the HNP, so a wrong routing/child list shows up as a launch
+    # that hangs at DAEMONS_LAUNCHED rather than a wrong answer.
+    cleanup_swarm
+    out=$(RUN 'prterun --prtemca prte_rml_radix 2 \
+                 --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1 \
+                 -np 8 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-8]$')
+    [ "$rc" = 0 ] && [ "$n" = 8 ] \
+        && ok "radix-2 tree-spawn launched 8 daemons (fan-out recursed)" \
+        || bad "radix-2 tree-spawn failed (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+    c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after tree-spawn launch" || bad "$c stray prted after tree-spawn"
+
+    banner "plm/ssh: flat launch (no_tree_spawn) and throttled launch"
+    # The same job with the fan-out disabled: now the HNP ssh's to all seven
+    # remote nodes itself. num_concurrent=1 additionally forces the launch
+    # list to drain one fork at a time, so the metering path
+    # (process_launch_list <-> ssh_wait_daemon, and the per-daemon caddy
+    # lifecycle) is exercised serially rather than all at once.
+    out=$(RUN 'prterun --prtemca plm_ssh_no_tree_spawn 1 \
+                 --host node1:1,node2:1,node3:1,node4:1 \
+                 -np 4 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-4]$')
+    [ "$rc" = 0 ] && [ "$n" = 4 ] \
+        && ok "flat (no_tree_spawn) launch reached all 4 nodes" \
+        || bad "flat launch failed (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+
+    out=$(RUN 'prterun --prtemca plm_ssh_no_tree_spawn 1 --prtemca plm_ssh_num_concurrent 1 \
+                 --host node1:1,node2:1,node3:1,node4:1,node5:1 \
+                 -np 5 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-5]$')
+    [ "$rc" = 0 ] && [ "$n" = 5 ] \
+        && ok "throttled launch (num_concurrent=1) completed all 5 daemons" \
+        || bad "throttled launch failed (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+    c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after flat/throttled launches" || bad "$c stray prted"
+
+    banner "plm/ssh: prted cmd line survives an mca value containing '='"
+    # prte_plm_base_prted_append_basic_args replicates PRTE_MCA_*/PMIX_MCA_*
+    # env vars onto the prted command line. Splitting those on every '='
+    # (rather than the first) silently truncates any value that contains one,
+    # so the daemon would be started with a DIFFERENT value than the HNP has.
+    # Ask for a value with an embedded '=' and require the daemons to come up
+    # and run; a truncated/garbled value makes the prted reject its cmd line.
+    out=$(RUN 'PRTE_MCA_prte_base_env_list="FOO=bar=baz" prterun \
+                 --host node1:1,node2:1 -np 2 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[12]$')
+    [ "$rc" = 0 ] && [ "$n" = 2 ] \
+        && ok "daemons launched with an '='-bearing mca value" \
+        || bad "launch broke on an '='-bearing mca value (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+
+    banner "plm/ssh: environ mca params can be dropped from the prted cmd line"
+    # plm_ssh_pass_environ_mca_params=0 is what the "cmd-line-too-long" help
+    # text tells users to set. It must actually take effect AND still leave a
+    # working command line (the required daemon options do not come from the
+    # environment).
+    out=$(RUN 'PRTE_MCA_plm_base_verbose=0 prterun --prtemca plm_ssh_pass_environ_mca_params 0 \
+                 --host node1:1,node2:1,node3:1 -np 3 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-3]$')
+    [ "$rc" = 0 ] && [ "$n" = 3 ] \
+        && ok "launch works with pass_environ_mca_params=0" \
+        || bad "pass_environ_mca_params=0 broke the launch (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+    cleanup_swarm
+
+    banner "plm: --uniform-nodes topology inheritance"
+    # Under prte_homo_nodes (--uniform-nodes) ONLY daemon rank 1 reports a
+    # topology; every other daemon's node inherits it in progress_daemons()
+    # before mapping runs. A node whose topology stayed NULL cannot be mapped
+    # onto (the mapper fails the job), so a job that must place a proc on the
+    # third and fourth nodes -- whose daemons are ranks 2 and 3, and reported
+    # no topology of their own -- is the test. Contrast with the same launch
+    # without the flag, where every daemon reports its own.
+    cleanup_swarm
+    out=$(RUN 'prterun --uniform-nodes --host node1:1,node2:1,node3:1,node4:1 \
+                 -np 4 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-4]$')
+    [ "$rc" = 0 ] && [ "$n" = 4 ] \
+        && ok "uniform-nodes launch mapped onto the nodes that report no topology" \
+        || bad "uniform-nodes launch failed (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
+    c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after uniform-nodes launch" || bad "$c stray prted"
+    # NOTE: the variant where the inheritance has to come from a SURVIVOR --
+    # shrink the rank-1 node on an elastic DVM, then grow -- cannot be
+    # asserted yet: growing after a shrink on the same DVM hangs (no
+    # phase-two completion event), on master as well as here. See the "Known
+    # issue" section of AGENTS.md and openpmix/prrte#2491.
+
+    banner "plm: node names reconciled with what the daemons report"
+    # Allocate by IP address. Each daemon reports its gethostname() result
+    # ("nodeN") plus its own aliases, and the HNP replaces the allocation's
+    # name with the reported one -- keeping the ORIGINAL name as an alias.
+    # If that alias set is overwritten rather than merged, the address the
+    # user allocated with no longer matches any node in the DVM, and a
+    # subsequent --host by that same address fails with "not in allocation".
+    ip2=$(RUN 'getent hosts node2 | awk "{print \$1}" | head -1' | tr -d '\r')
+    ip3=$(RUN 'getent hosts node3 | awk "{print \$1}" | head -1' | tr -d '\r')
+    if [ -n "$ip2" ] && [ -n "$ip3" ]; then
+        RUN "nohup prte --daemonize --host node1:1,$ip2:1,$ip3:1 >/tmp/prte.out 2>&1 & sleep 8" >/dev/null
+        if RUN 'pgrep -x prte >/dev/null'; then
+            out=$(RUN 'prun -n 3 --map-by node hostname' 2>&1)
+            n=$(echo "$out" | grep -cE '^node[1-3]$')
+            [ "$n" = 3 ] && ok "daemons allocated by IP report their real hostnames" \
+                         || bad "IP-allocated DVM did not report node names: $(echo "$out" | tr '\n' ' ')"
+            # by the daemon-reported name...
+            out=$(RUN 'prun --host node2:1 -n 1 hostname' 2>&1)
+            [ "$(echo "$out" | tr -d '\r')" = node2 ] \
+                && ok "--host by reported name resolves to the IP-allocated node" \
+                || bad "--host node2 failed on an IP-allocated DVM: $(echo "$out" | tr '\n' ' ')"
+            # ...and by the address it was allocated with, which must survive
+            # as an alias
+            out=$(RUN "prun --host $ip3:1 -n 1 hostname" 2>&1)
+            [ "$(echo "$out" | tr -d '\r')" = node3 ] \
+                && ok "--host by original address still matches (alias retained)" \
+                || bad "--host $ip3 no longer matches its node (alias lost): $(echo "$out" | tr '\n' ' ')"
+            RUN 'timeout 30 pterm' >/dev/null 2>&1
+        else
+            bad "could not start a DVM allocated by IP address"
+        fi
+    else
+        skp "could not resolve node2/node3 addresses -- skipping alias test"
     fi
     cleanup_swarm
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -402,6 +402,15 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             || bad "grow node4 also relaunched a daemon on the shrunk node2"
         [ "$(prted_count 5 6 7)" = 0 ] && ok "no unrelated node was grown" \
                                       || bad "grow touched a node it was not given"
+        # A grow of a node that is already in the DVM needs no daemon at all.
+        # The request is still satisfied, so it must still report completion -
+        # with nothing to launch there is no campaign and no launch fence, so
+        # the completion has to be reported directly or the requester waits
+        # out its timeout on an operation that already succeeded.
+        out=$(RUN 'timeout 90 elastic grow node4:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "a grow needing no new daemon still completes" \
+            || bad "redundant grow never completed"
         RUN 'timeout 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the grow-scope test"
@@ -504,6 +513,63 @@ test_macos() {
                                   || ok "pterm cleanly terminated the DVM"
     else
         skp "prte --daemonize did not come up -- native Darwin DVM is unstable on this host (pre-existing); build is verified"
+    fi
+    rm -f "$BOUT"; macpk
+
+    banner "macOS: a rejected spawn request must not take the DVM down"
+    # The HNP unpacks a job object from a spawn request before validating
+    # anything about it, so a request it then rejects exercises the error path
+    # that answers the requester and disposes of that half-built job. The DVM
+    # has to survive it: a persistent DVM that dies on one bad prun takes
+    # every other job on the machine with it. Single host is enough - the
+    # request is rejected at the HNP, before any daemon is involved.
+    macpk; sleep 1
+    bounded 60 prte --daemonize; sleep 3
+    if pgrep -x prte >/dev/null; then
+        for badarg in "--map-by NOSUCHPOLICY" "--bind-to NOSUCHOBJECT" "--rank-by NOSUCHTHING"; do
+            bounded 30 sh -c "prun $badarg -np 1 hostname" >/dev/null 2>&1
+            if pgrep -x prte >/dev/null; then
+                ok "DVM survived a rejected 'prun $badarg'"
+            else
+                bad "DVM died on 'prun $badarg'"
+                break
+            fi
+        done
+        # and it must still be able to run a job afterwards
+        if pgrep -x prte >/dev/null; then
+            if bounded 30 prun -np 2 hostname && [ "$(grep -Fc "$hn" "$BOUT")" = 2 ]; then
+                ok "DVM still launches jobs after the rejected requests"
+            else
+                skp "post-rejection prun timed out (native Darwin DVM unstable)"
+            fi
+        fi
+        bounded 20 pterm >/dev/null 2>&1 || true; sleep 1; macpk
+    else
+        skp "prte --daemonize did not come up -- cannot test spawn rejection"
+    fi
+    rm -f "$BOUT"; macpk
+
+    banner "macOS: uniform-nodes launch and an mca value containing '='"
+    # --uniform-nodes drives the homogeneous-topology path, and an MCA value
+    # with an embedded '=' is the case that used to be truncated when the
+    # daemon command line was assembled. One host cannot exercise the daemon
+    # side of either, but both must at least remain launchable.
+    macpk; sleep 1
+    if bounded 60 prterun --uniform-nodes -np 2 hostname; then
+        [ "$(grep -Fc "$hn" "$BOUT")" = 2 ] \
+            && ok "prterun --uniform-nodes -> 2 procs on $hn" \
+            || bad "uniform-nodes launch wrong output: $(tr '\n' ' ' <"$BOUT")"
+    else
+        skp "uniform-nodes prterun timed out (native Darwin DVM unstable)"; macpk
+    fi
+    rm -f "$BOUT"
+    macpk; sleep 1
+    if bounded 60 sh -c "PRTE_MCA_prte_test_kv='a=b' prterun -np 2 hostname"; then
+        [ "$(grep -Fc "$hn" "$BOUT")" = 2 ] \
+            && ok "launch works with an '='-bearing mca value in the environment" \
+            || bad "'='-bearing mca value broke the launch: $(tr '\n' ' ' <"$BOUT")"
+    else
+        skp "'='-bearing mca value run timed out (native Darwin DVM unstable)"; macpk
     fi
     rm -f "$BOUT"; macpk
 }

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -361,6 +361,8 @@ static int rte_init(int argc, char **argv)
     t = PMIX_NEW(prte_topology_t);
     t->topo = prte_hwloc_topology;
     t->index = pmix_pointer_array_add(prte_node_topologies, t);
+    /* the node holds a counted reference to the topology */
+    PMIX_RETAIN(t);
     node->topology = t;
     node->available = prte_hwloc_base_filter_cpus(prte_hwloc_topology);
     if (15 < pmix_output_get_verbosity(prte_ess_base_framework.framework_output)) {

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -207,7 +207,7 @@ static int rte_init(int argc, char **argv)
     PMIX_LOAD_PROCID(&proc->name, PRTE_PROC_MY_NAME->nspace, PRTE_PROC_MY_NAME->rank);
     proc->pid = prte_process_info.pid;
     proc->state = PRTE_PROC_STATE_RUNNING;
-    PMIX_RETAIN(node); /* keep accounting straight */
+    /* the node backpointer is borrowed, not retained */
     proc->node = node;
     pmix_pointer_array_set_item(jdata->procs, PRTE_PROC_MY_NAME->rank, proc);
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -650,8 +650,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
                         PMIX_DATA_BUFFER_DESTRUCT(&jdbuf);
                         goto REPORT_ERROR;
                     }
-                    /* connect the two */
-                    PMIX_RETAIN(dmn->node);
+                    /* connect the two - the node backpointer is borrowed */
                     pptr->node = dmn->node;
 
                     /* add the node to the job map, if needed */
@@ -856,7 +855,7 @@ next:
                 rc = PRTE_ERR_NOT_FOUND;
                 goto REPORT_ERROR;
             }
-            PMIX_RETAIN(dmn->node);
+            /* the node backpointer is borrowed, not retained */
             pptr->node = dmn->node;
             /* add the node to the job map, if needed */
             if (!PRTE_FLAG_TEST(pptr->node, PRTE_NODE_FLAG_MAPPED)) {

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -221,14 +221,22 @@ This is the crux of the whole framework. After a component starts a
    matches an existing one. Under `prte_homo_nodes` only daemon rank 1
    sends a topology and everyone else inherits it — `progress_daemons()`
    points every other daemon's node at that same `prte_topology_t`
-   (nothing is duplicated). It must come from a **daemon**, never from
-   our own node
+   (nothing is duplicated; each node takes a **counted reference**, see
+   below). It must come from a **daemon**, never from our own node
    (`prterun` may be on a login node with a different topology), and rank
    1 may no longer exist (an elastic shrink can remove it), so the source
    is the first daemon that *has* a topology — the survivors already
    inherited rank 1's, so a daemon added by a later grow (which reports
    none of its own, not being rank 1) still inherits the right one.
 
+   **Topology ownership:** `node->topology` is a reference-counted
+   pointer into the shared `prte_node_topologies` array, never a copy.
+   Assigning one means `PMIX_RETAIN(t)` (and releasing whatever the node
+   held before); `prte_node_destruct` drops the node's reference. That is
+   what lets the topology outlive any individual node — it goes away only
+   when the last node using it, and the array entry, are gone — and it is
+   what makes a node safe to destroy at any point in an elastic
+   shrink/grow.
 5. Bumps `jdatorted->num_reported`. When the count reaches
    `num_procs`, `progress_daemons()` sets the daemon job to
    `DAEMONS_REPORTED` and activates that state for every application job

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -63,7 +63,7 @@ plm/
   plm_types.h                 # **job / proc / node / app STATE codes** + PLM command codes (tree-wide!)
   base/
     base.h                    # public base API (state-machine handlers, spawn_response, ...)
-    plm_private.h             # framework-internal API + prte_plm_globals_t + proxy/prted-cmd helpers
+    plm_private.h             # framework-internal API + prte_plm_globals_t + prted-cmd helpers
     plm_base_frame.c          # framework open/close/register; the DEFAULT "local-only" module
     plm_base_select.c         # pick-ONE-component selection (highest priority wins)
     plm_base_receive.c        # the HNP command processor: tools/daemons → HNP (PRTE_RML_TAG_PLM)
@@ -211,11 +211,24 @@ This is the crux of the whole framework. After a component starts a
 3. Unpacks the **node name** (+ aliases), reconciling it with the
    allocation's name (the daemon's `gethostname` result wins; the
    original becomes an alias). Sets `PRTE_NODE_FLAG_DAEMON_LAUNCHED` and
-   node state `UP`.
+   node state `UP`. The daemon-reported aliases must be **merged** into
+   `node->aliases`, never assigned over it: the HNP has already recorded
+   the allocation's own name (and its non-FQDN form) there, and those
+   are exactly the names a hostfile/`--host` spec uses to refer to the
+   node — dropping them makes `prte_nptr_match` stop matching it.
 4. Unpacks the node **topology** (possibly compressed), de-duplicating
    against `prte_node_topologies` and recording an hwloc diff when it
    matches an existing one. Under `prte_homo_nodes` only daemon rank 1
-   sends a topology and everyone else inherits it.
+   sends a topology and everyone else inherits it — `progress_daemons()`
+   points every other daemon's node at that same `prte_topology_t`
+   (nothing is duplicated). It must come from a **daemon**, never from
+   our own node
+   (`prterun` may be on a login node with a different topology), and rank
+   1 may no longer exist (an elastic shrink can remove it), so the source
+   is the first daemon that *has* a topology — the survivors already
+   inherited rank 1's, so a daemon added by a later grow (which reports
+   none of its own, not being rank 1) still inherits the right one.
+
 5. Bumps `jdatorted->num_reported`. When the count reaches
    `num_procs`, `progress_daemons()` sets the daemon job to
    `DAEMONS_REPORTED` and activates that state for every application job
@@ -275,7 +288,13 @@ base provides the shared pieces:
   relevant `PMIX_MCA_`/`PRTE_MCA_` env var and cmd-line MCA param —
   while **deliberately skipping** the `rmaps`, `ras`, and `plm`
   frameworks (the daemons must not re-run mapping/allocation, and only
-  open the PLM if explicitly told to).
+  open the PLM if explicitly told to). An env var is split at its
+  **first** `=` only: MCA values may themselves contain `=`, and
+  splitting on all of them silently truncates the value. Replicating the
+  environment can be suppressed entirely via
+  `prte_plm_globals.pass_environ_mca_params` (the `ssh` component sets
+  it from `plm_ssh_pass_environ_mca_params`, the documented remedy for
+  `cmd-line-too-long`).
 - **`prte_plm_base_wrap_args(argv)`** — quotes multi-word `...mca`
   argument values so shells/launchers don't split them.
 
@@ -374,6 +393,22 @@ placed daemons) or wireup stalls.
   (`PRTE_JOB_PREFIX` / `PRTE_JOB_PMIX_PREFIX`); launchers read it there
   and rewrite `PATH`/`LD_LIBRARY_PATH` (and export `PRTE_PREFIX` /
   `PMIX_PREFIX`) so the remote `prted` and its PMIx can be found.
+- **Launch caddies are owned by the SIGCHLD callback.** A component that
+  hands a caddy to `prte_wait_cb(child, cb, caddy)` still owns it: the
+  `prte_wait_tracker_t` destructor releases only its `child`, never
+  `cbdata`. The callback must `PMIX_RELEASE` the caddy on **every** path
+  (including the success path), or every launched daemon leaks a copy of
+  its full remote command line.
+- **A per-launch failure flag must be re-armed per launch.** Components
+  funnel errors to a `cleanup:` label guarded by a `failed_launch` flag;
+  where that flag is a file-static (because the launcher's `wait_cb`
+  also reads it) it must be set `true` at the *top* of `launch_daemons`,
+  not merely initialized once — otherwise the cleanup path can never
+  report a failure.
+- **`map->nodes` entries may have a NULL `daemon`.** Check
+  `node->daemon` before reading `node->daemon->name.rank` — including in
+  a tree-spawn "is this one of my children?" filter, which runs before
+  the per-node launch checks.
 - **The version macro is `PRTE_PLM_BASE_VERSION_2_0_0`** (`plm` 2.0.0).
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on
   every block, `NULL ==`/constant-on-left comparisons, no new compiler
@@ -398,6 +433,21 @@ progress toward `DAEMONS_REPORTED` — start there when a launch hangs.
 A launch that "hangs at DAEMONS_LAUNCHED" almost always means a daemon
 failed to connect back (firewall, wrong prefix, missing library) — check
 for the `daemon failed to report back` message from `ssh_wait_daemon`.
+
+---
+
+## Testing
+
+Launching daemons needs real nodes, so the coverage is split in three:
+
+| Layer | What it covers |
+|-------|----------------|
+| [`test/unit/plm/test_plm.c`](../../../test/unit/plm/) (`make check`) | Everything the launch path builds *before* it forks: `plm_types.h` state/command-code uniqueness and the UNTERMINATED/TERMINATED/ERROR boundaries, the module vtable contract (default + `ssh`), `prte_plm_base_wrap_args`, `prte_plm_base_setup_prted_cmd` (plain / wrapped / custom agent), the full `prte_plm_base_prted_append_basic_args` command line (vpid template slot, rmaps/ras/plm suppression, `=`-bearing MCA values, the `pass_environ_mca_params` opt-out), and `set_hnp_name`/`create_jobid` nspace assignment. |
+| [`test/offline`](../../../test/offline/) (`make -C test/offline check-offline`) | `setup_virtual_machine` on the `DO_NOT_LAUNCH` path, via the mapper matrix. |
+| [`contrib/dockerswarm`](../../../contrib/dockerswarm/) (`run-tests.sh linux`) | The real launch: radix-2 **tree-spawn** fan-out across 8 nodes (only a multi-level tree proves `remote_spawn` recursed), flat `no_tree_spawn` launch, `num_concurrent=1` throttled launch, an `=`-bearing MCA value surviving onto the prted cmd line, `pass_environ_mca_params 0`, and node-name/alias reconciliation (allocate by IP, then `--host` by both the reported name and the original address). |
+
+Add a new pure/structural check to the unit test; anything that needs a
+daemon to actually come up belongs in the dockerswarm suite.
 
 ---
 

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -323,6 +323,15 @@ and for each node needing a daemon it:
 - once daemons are added, recomputes the RML routing tree
   (`prte_rml_compute_routing_tree`) so the HNP can tree-spawn/xcast.
 
+A grow starts a daemon on **every** node that lacks one — which after a
+shrink includes the shrunk node, since releasing its reservation reverts it
+to the default pool. That re-absorbed node takes the *lowest* new vpid, so
+it, not one of the newly reserved nodes, occupies `map->daemon_vpid_start`;
+this is why the grow campaign scans **all** its targets for the requestor
+rather than reading the first one (a session-less first target used to leave
+the campaign with no requester, so a successful grow emitted no phase-two
+completion event and the requester hung).
+
 `map->num_new_daemons` is the key output: `== 0` means every node
 already has a daemon, so the component fast-forwards to
 `DAEMONS_REPORTED`. It also records elastic **grow campaigns** and the

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -323,14 +323,23 @@ and for each node needing a daemon it:
 - once daemons are added, recomputes the RML routing tree
   (`prte_rml_compute_routing_tree`) so the HNP can tree-spawn/xcast.
 
-A grow starts a daemon on **every** node that lacks one — which after a
-shrink includes the shrunk node, since releasing its reservation reverts it
-to the default pool. That re-absorbed node takes the *lowest* new vpid, so
-it, not one of the newly reserved nodes, occupies `map->daemon_vpid_start`;
-this is why the grow campaign scans **all** its targets for the requestor
-rather than reading the first one (a session-less first target used to leave
-the campaign with no requester, so a successful grow emitted no phase-two
-completion event and the requester hung).
+A **grow** (`PRTE_JOB_EXTEND_DVM`) is scoped to the nodes that request
+brought in, and nothing else: an allocation request naming `node4` starts a
+daemon on `node4` alone. Every producer of a grow — the no-scheduler
+`ras_base_insert_node_string`, `ras/slurm`'s extend, and `ras/hosts` for
+`add-host`/`add-hostfile` — marks its nodes `PRTE_NODE_STATE_ADDED` for
+exactly this purpose, and the extend path selects on that mark (as the
+dynamic-spawn path does). Do **not** revert it to scanning the whole node
+pool for nodes lacking a daemon: after a shrink the pool holds exactly such
+a node — the one just removed — and it would be silently dragged back into
+an unrelated grow. `ras_base_node_insert` propagates the mark onto a pool
+entry that already exists, which is what makes re-growing a previously
+shrunk node work at all.
+
+Relatedly, the grow campaign scans **all** its targets for the requestor
+rather than reading `map->daemon_vpid_start`: a target whose session is gone
+would otherwise leave the campaign with no requester, and a successful grow
+would emit no phase-two completion event at all.
 
 `map->num_new_daemons` is the key output: `== 0` means every node
 already has a daemon, so the component fast-forwards to

--- a/src/mca/plm/base/base.h
+++ b/src/mca/plm/base/base.h
@@ -53,9 +53,6 @@ PRTE_EXPORT int prte_plm_base_select(void);
  * Specifically, the ODLS needs to access some of these
  * to avoid recursive callbacks
  */
-PRTE_EXPORT void prte_plm_base_app_report_launch(int fd, short event, void *data);
-PRTE_EXPORT void prte_plm_base_receive_process_msg(int fd, short event, void *data);
-
 PRTE_EXPORT void prte_plm_base_set_slots(prte_node_t *node);
 PRTE_EXPORT void prte_plm_base_setup_job(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_setup_job_complete(int fd, short args, void *cbdata);

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -58,6 +58,7 @@ prte_plm_globals_t prte_plm_globals = {
     .daemonlaunchstart = {0, 0},
     .tree_spawn_cmd = PMIX_DATA_BUFFER_STATIC_INIT,
     .daemon_nodes_assigned_at_launch = true,
+    .pass_environ_mca_params = true,
     .node_regex_threshold = 0
 };
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -144,6 +144,8 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
                 continue;
             }
             if (NULL == node->topology) {
+                /* the node holds a counted reference to the topology */
+                PMIX_RETAIN(t);
                 node->topology = t;
                 node->available = prte_hwloc_base_filter_cpus(node->topology->topo);
             }
@@ -1336,6 +1338,12 @@ static void progress_daemons(prte_job_t *daemons,
                     // the same topology would just yield the same bitmap
                     continue;
                 }
+                /* the node holds a counted reference to its topology, so
+                 * drop the old one and take a reference on the new */
+                if (NULL != daemon->node->topology) {
+                    PMIX_RELEASE(daemon->node->topology);
+                }
+                PMIX_RETAIN(t);
                 daemon->node->topology = t;
                 /* update the node's available processors */
                 if (NULL != daemon->node->available) {
@@ -1591,6 +1599,13 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                                         "%s TOPOLOGY ALREADY RECORDED IN POSN %d - %s DIFFS FOUND",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), i,
                                         (NULL == diff) ? "NO" : "SOME");
+                    /* the node holds a counted reference to its topology -
+                     * a daemon can report in more than once (bootstrap
+                     * unheal), so release any prior reference first */
+                    if (NULL != daemon->node->topology) {
+                        PMIX_RELEASE(daemon->node->topology);
+                    }
+                    PMIX_RETAIN(t);
                     daemon->node->topology = t;
                     found = true;
                     /* update the node's available processors */
@@ -1616,6 +1631,12 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                 pmix_output_verbose(5, prte_plm_base_framework.framework_output,
                                     "%s ADDING NEW TOPOLOGY AT POSN %d",
                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), t->index);
+                /* the array above holds the creation reference; the node
+                 * takes a counted reference of its own */
+                if (NULL != daemon->node->topology) {
+                    PMIX_RELEASE(daemon->node->topology);
+                }
+                PMIX_RETAIN(t);
                 daemon->node->topology = t;
                 daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
                 prte_hwloc_base_setup_summary(t->topo);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2632,21 +2632,35 @@ process:
         /* Record the requester for the spec's phase-two completion event.  The
          * RAS reservation machinery sets each reserved node's ->session
          * backpointer (add_nodes_to_session), and that session carries the
-         * requestor and the allocation ids; take them from the first new
-         * daemon's node.  The initial DVM bring-up and a scheduler-driven push
-         * have no such requestor (the default session, or an invalid requestor
+         * requestor and the allocation ids.
+         *
+         * Scan ALL the targets for the first one carrying a requestor rather
+         * than trusting the first: a grow launches a daemon onto every node
+         * that lacks one, which is not necessarily limited to the nodes this
+         * request reserved.  In particular a node that was shrunk out of the
+         * DVM reverts to the default pool with its ->session cleared, and the
+         * next grow re-absorbs it - taking the lowest new vpid, and hence the
+         * daemon_vpid_start slot.  Reading only that node left the campaign
+         * with no requester, so a perfectly successful grow emitted no
+         * completion event at all and the requester waited forever.
+         *
+         * The initial DVM bring-up and a scheduler-driven push have no
+         * requestor on any node (the default session, or an invalid requestor
          * rank), so have_requester stays false and grow_drain() emits no event
-         * for them. */
+         * for them - which is correct, as nobody asked for those. */
         {
-            prte_proc_t *dproc = (prte_proc_t *)
-                pmix_pointer_array_get_item(daemons->procs, map->daemon_vpid_start);
-            prte_session_t *sess =
-                (NULL != dproc && NULL != dproc->node) ? dproc->node->session : NULL;
-            if (NULL != sess && PMIX_RANK_INVALID != sess->requestor.rank) {
-                PMIX_XFER_PROCID(&gcamp->requester, &sess->requestor);
-                gcamp->alloc_id = (NULL != sess->alloc_refid) ? strdup(sess->alloc_refid) : NULL;
-                gcamp->req_id = (NULL != sess->user_refid) ? strdup(sess->user_refid) : NULL;
-                gcamp->have_requester = true;
+            int gt;
+            for (gt = 0; gt < gcamp->ntargets && !gcamp->have_requester; gt++) {
+                prte_proc_t *dproc = (prte_proc_t *)
+                    pmix_pointer_array_get_item(daemons->procs, gcamp->targets[gt]);
+                prte_session_t *sess =
+                    (NULL != dproc && NULL != dproc->node) ? dproc->node->session : NULL;
+                if (NULL != sess && PMIX_RANK_INVALID != sess->requestor.rank) {
+                    PMIX_XFER_PROCID(&gcamp->requester, &sess->requestor);
+                    gcamp->alloc_id = (NULL != sess->alloc_refid) ? strdup(sess->alloc_refid) : NULL;
+                    gcamp->req_id = (NULL != sess->user_refid) ? strdup(sess->user_refid) : NULL;
+                    gcamp->have_requester = true;
+                }
             }
         }
         pmix_list_append(&prte_grow_campaigns, &gcamp->super);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -340,7 +340,23 @@ static void spawn_timeout_cb(int fd, short event, void *cbdata)
          *something* if it does */
         timeout = -1;
     }
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, (void **) &timer, PMIX_POINTER)) {
+    /* we are aborting the job, so clear BOTH of its timers. The one that
+     * just fired is the SPAWN timeout - clearing only the job timeout (as
+     * this used to) left our own timer registered on the job while
+     * silently cancelling the user's --timeout */
+    timer = NULL;
+    if (prte_get_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT_EVENT, (void **) &timer, PMIX_POINTER) &&
+        NULL != timer) {
+        prte_event_evtimer_del(timer->ev);
+        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                             "%s plm:base:launch deleting spawn timeout for job %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdata->nspace)));
+        PMIX_RELEASE(timer);
+        prte_remove_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT_EVENT);
+    }
+    timer = NULL;
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, (void **) &timer, PMIX_POINTER) &&
+        NULL != timer) {
         prte_event_evtimer_del(timer->ev);
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                              "%s plm:base:launch deleting timeout for job %s",
@@ -506,7 +522,8 @@ static void stack_trace_timeout(int sd, short args, void *cbdata)
     int rc;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    /* clear the timer */
+    /* clear the job timer - it fired to get us here, but job_timeout_cb
+     * leaves its timer object attached to the job */
     timer = NULL;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT, (void **) &timer, PMIX_POINTER)
         && NULL != timer) {
@@ -514,6 +531,15 @@ static void stack_trace_timeout(int sd, short args, void *cbdata)
         /* timer is an prte_timer_t object */
         PMIX_RELEASE(timer);
         prte_remove_attribute(&jdata->attributes, PRTE_JOB_TIMEOUT_EVENT);
+    }
+    /* and clear OUR timer - the stack-trace wait - so it is neither leaked
+     * nor left dangling on the job */
+    timer = NULL;
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_TRACE_TIMEOUT_EVENT, (void **) &timer,
+                           PMIX_POINTER) && NULL != timer) {
+        prte_event_evtimer_del(timer->ev);
+        PMIX_RELEASE(timer);
+        prte_remove_attribute(&jdata->attributes, PRTE_JOB_TRACE_TIMEOUT_EVENT);
     }
 
     /* abort the job */
@@ -1051,7 +1077,8 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
             PMIX_ERROR_LOG(rc);
             PRTE_UPDATE_EXIT_STATUS(rc);
             PMIX_INFO_LIST_RELEASE(tinfo);
-            PMIX_PROC_RELEASE(nptr);
+            /* NOTE: nptr was already released when it was added to the
+             * info list above - do NOT release it again here */
             return rc;
         } else {
             iptr = (pmix_info_t *) darray.array;
@@ -1236,7 +1263,7 @@ static void progress_daemons(prte_job_t *daemons,
     prte_job_t *jdata;
     prte_proc_t *daemon;
     prte_topology_t *t;
-    pmix_rank_t j;
+    pmix_rank_t j, src;
 
     if (show_progress &&
         (0 == daemons->num_reported % 100 ||
@@ -1269,17 +1296,44 @@ static void progress_daemons(prte_job_t *daemons,
             PRTE_ACTIVATE_JOB_STATE(daemons, PRTE_JOB_STATE_DAEMONS_REPORTED);
         }
         if (prte_homo_nodes && 1 < daemons->num_procs) {
-            // ensure that all topologies point to the one
-            // returned by daemon rank=1 as it might be different
-            // from where prterun is executing (e.g., login node)
-            daemon = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, 1);
-            if (NULL == daemon->node->topology) {
-                // should never happen
-            }
-            t = daemon->node->topology;
-            for (j=2; j < daemons->num_procs; j++) {
+            // all the daemon nodes are declared identical, so they must all
+            // point at the topology reported by a DAEMON - not at our own,
+            // as prterun may be executing somewhere else entirely (e.g., a
+            // login node). Normally that is daemon rank=1, the only daemon
+            // that reports a topology under homo_nodes. However, rank 1 need
+            // not still exist - an elastic shrink can remove it - so take the
+            // topology from the first daemon that has one. The survivors
+            // inherited rank 1's topology when they reported in, so a daemon
+            // launched by a later grow (which reports no topology of its own,
+            // as it is not rank 1) still inherits the correct one.
+            t = NULL;
+            src = PMIX_RANK_INVALID;
+            for (j = 1; j < daemons->num_procs; j++) {
                 daemon = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, j);
-                if (NULL == daemon) {
+                if (NULL == daemon || NULL == daemon->node || NULL == daemon->node->topology) {
+                    continue;
+                }
+                t = daemon->node->topology;
+                src = j;
+                break;
+            }
+            if (NULL == t) {
+                // no daemon has a topology - we have nothing to propagate and
+                // must not substitute our own, so leave things be
+                PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+                return;
+            }
+            for (j = 1; j < daemons->num_procs; j++) {
+                if (j == src) {
+                    continue;
+                }
+                daemon = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, j);
+                if (NULL == daemon || NULL == daemon->node) {
+                    continue;
+                }
+                if (daemon->node->topology == t) {
+                    // already inherited it - recomputing the cpu filter from
+                    // the same topology would just yield the same bitmap
                     continue;
                 }
                 daemon->node->topology = t;
@@ -1372,6 +1426,11 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             prted_failed_launch = true;
             goto CLEANUP;
         }
+        /* a daemon can report in more than once (the bootstrap unheal path),
+         * so release any prior URI before recording the new one */
+        if (NULL != daemon->rml_uri) {
+            free(daemon->rml_uri);
+        }
         daemon->rml_uri = strdup(cnctinfo.data.string);
         PMIX_VALUE_DESTRUCT(&cnctinfo);
 
@@ -1424,7 +1483,19 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             goto CLEANUP;
         }
         if (NULL != alias) {
-            daemon->node->aliases = PMIx_Argv_split(alias, ',');
+            char **dalias;
+            int na;
+            /* MERGE the daemon's aliases into whatever we already recorded -
+             * do NOT overwrite the array. We may have just added the
+             * allocation's name for this node (and/or its non-fqdn form)
+             * above, and those are exactly the names a hostfile/dash-host
+             * spec will use to refer to this node. Replacing the array would
+             * both leak it and lose those names, breaking node matching */
+            dalias = PMIx_Argv_split(alias, ',');
+            for (na = 0; NULL != dalias && NULL != dalias[na]; na++) {
+                PMIx_Argv_append_unique_nosize(&daemon->node->aliases, dalias[na]);
+            }
+            PMIx_Argv_free(dalias);
             free(alias);
         }
 
@@ -1630,7 +1701,9 @@ void prte_plm_base_daemon_failed(int st, pmix_proc_t *sender, pmix_data_buffer_t
 
 finish:
     if (NULL == daemon) {
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_PROC_STATE_FAILED_TO_START);
+        /* we don't know which daemon this was, so fail the daemon job -
+         * note that this takes a JOB state, not a PROC state */
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FAILED_TO_START);
         return;
     } else {
         PRTE_ACTIVATE_PROC_STATE(&daemon->name, PRTE_PROC_STATE_FAILED_TO_START);
@@ -1664,8 +1737,9 @@ int prte_plm_base_setup_prted_cmd(int *argc, char ***argv)
  */
 int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, int *proc_vpid_index)
 {
-    char *param = NULL, **tmpv;
+    char *param = NULL, *ptr, *name, *value;
     int i, j, cnt, offset;
+    size_t nlen;
     prte_job_t *jdata;
     unsigned long num_procs;
     bool ignore;
@@ -1711,7 +1785,6 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     pmix_argv_append(argc, argv, "--prtemca");
     pmix_argv_append(argc, argv, "ess_base_nspace");
     pmix_argv_append(argc, argv, prte_process_info.myproc.nspace);
-    free(param);
 
     /* setup to pass the vpid */
     if (NULL != proc_vpid_index) {
@@ -1747,43 +1820,59 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     }
 
     /* look for any envars that relate to us and pass
-     * them along on the cmd line */
+     * them along on the cmd line - unless we were told not to */
     offset = strlen("PRTE_MCA_");
-    for (i=0; NULL != environ[i]; i++) {
+    for (i=0; prte_plm_globals.pass_environ_mca_params && NULL != environ[i]; i++) {
         if (0 == strncmp(environ[i], "PMIX_MCA_", offset) ||
             0 == strncmp(environ[i], "PRTE_MCA_", offset)) {
-            tmpv = PMIx_Argv_split(environ[i], '=');
+            /* split at the FIRST '=' only - the value itself is allowed to
+             * contain '=' signs, and splitting on all of them would silently
+             * truncate the value (and hand us a NULL value for an empty one) */
+            ptr = strchr(environ[i], '=');
+            if (NULL == ptr) {
+                /* not an assignment - nothing we can pass along */
+                continue;
+            }
+            nlen = (size_t)(ptr - environ[i]);
+            name = (char *) malloc(nlen + 1);
+            if (NULL == name) {
+                continue;
+            }
+            memcpy(name, environ[i], nlen);
+            name[nlen] = '\0';
+            value = ptr + 1;
             ignore = false;
             for (j=0; NULL != skips[j]; j++) {
-                if (0 == strncmp(&tmpv[0][offset], skips[j], strlen(skips[j])) ||
-                    0 == strcmp(&tmpv[0][offset], "plm")) {
-                    ignore = true;;
+                if (0 == strncmp(&name[offset], skips[j], strlen(skips[j])) ||
+                    0 == strcmp(&name[offset], "plm")) {
+                    ignore = true;
                     break;
                 }
             }
             if (ignore) {
+                free(name);
                 continue;
             }
 
             /* check for duplicate */
             ignore = false;
             for (j = 0; j < *argc; j++) {
-                if (0 == strcmp((*argv)[j], &tmpv[0][offset])) {
+                if (0 == strcmp((*argv)[j], &name[offset])) {
                     ignore = true;
                     break;
                 }
             }
             if (!ignore) {
                 /* pass it along */
-                if (0 == strncmp(tmpv[0], "PRTE_MCA_", offset)) {
+                if (0 == strncmp(name, "PRTE_MCA_", offset)) {
                     pmix_argv_append(argc, argv, "--prtemca");
                 } else {
                     pmix_argv_append(argc, argv, "--pmixmca");
                 }
-                pmix_argv_append(argc, argv, &tmpv[0][offset]);
-                pmix_argv_append(argc, argv, tmpv[1]);
+                pmix_argv_append(argc, argv, &name[offset]);
+                pmix_argv_append(argc, argv, value);
             }
-            PMIx_Argv_free(tmpv);
+            free(name);
         }
     }
 
@@ -1939,6 +2028,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
             if (NULL == node) {
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+                PMIX_LIST_DESTRUCT(&nodes);
                 return PRTE_ERR_NOT_FOUND;
             }
             pmix_pointer_array_add(map->nodes, (void *) node);
@@ -2037,6 +2127,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
             if (NULL == node) {
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+                PMIX_LIST_DESTRUCT(&nodes);
                 return PRTE_ERR_NOT_FOUND;
             }
             if (0 < node->num_procs) {
@@ -2053,6 +2144,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
              * anyone else...then we have a big problem
              */
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+            PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_FATAL;
         }
         goto process;
@@ -2070,6 +2162,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
         node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
         if (NULL == node) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_NOT_FOUND;
         }
         pmix_pointer_array_add(map->nodes, (void *) node);
@@ -2103,6 +2196,8 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&tnodes, hosts))) {
                 PRTE_ERROR_LOG(rc);
                 free(hosts);
+                PMIX_LIST_DESTRUCT(&tnodes);
+                PMIX_LIST_DESTRUCT(&nodes);
                 return rc;
             }
             free(hosts);
@@ -2122,6 +2217,8 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
                         != (rc = prte_util_add_dash_host_nodes(&tnodes, hosts, false))) {
                         PRTE_ERROR_LOG(rc);
                         free(hosts);
+                        PMIX_LIST_DESTRUCT(&tnodes);
+                        PMIX_LIST_DESTRUCT(&nodes);
                         return rc;
                     }
                     free(hosts);
@@ -2134,6 +2231,8 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
                     if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&tnodes, hosts))) {
                         PRTE_ERROR_LOG(rc);
                         free(hosts);
+                        PMIX_LIST_DESTRUCT(&tnodes);
+                        PMIX_LIST_DESTRUCT(&nodes);
                         return rc;
                     }
                     free(hosts);
@@ -2148,6 +2247,8 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
                             != (rc = prte_util_add_hostfile_nodes(&tnodes,
                                                                   prte_default_hostfile))) {
                             PRTE_ERROR_LOG(rc);
+                            PMIX_LIST_DESTRUCT(&tnodes);
+                            PMIX_LIST_DESTRUCT(&nodes);
                             return rc;
                         }
                         /* only include it once */
@@ -2284,6 +2385,7 @@ construct:
         node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
         if (NULL == node) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_NOT_FOUND;
         }
         PMIX_RETAIN(node);
@@ -2296,6 +2398,7 @@ construct:
         if (PRTE_SUCCESS != (rc = prte_rmaps_base_filter_nodes(app, &nodes, false))
             && rc != PRTE_ERR_TAKE_NEXT_OPTION) {
             PRTE_ERROR_LOG(rc);
+            PMIX_LIST_DESTRUCT(&nodes);
             return rc;
         }
         if (PRTE_SUCCESS == rc) {
@@ -2396,6 +2499,7 @@ process:
         proc = PMIX_NEW(prte_proc_t);
         if (NULL == proc) {
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         PMIX_LOAD_NSPACE(proc->name.nspace, PRTE_PROC_MY_NAME->nspace);
@@ -2403,6 +2507,7 @@ process:
             /* no more daemons available */
             pmix_show_help("help-prte-rmaps-base.txt", "out-of-vpids", true);
             PMIX_RELEASE(proc);
+            PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         proc->name.rank = daemons->num_procs; /* take the next available vpid */
@@ -2413,6 +2518,8 @@ process:
         if (0
             > (rc = pmix_pointer_array_set_item(daemons->procs, proc->name.rank, (void *) proc))) {
             PRTE_ERROR_LOG(rc);
+            PMIX_RELEASE(proc);
+            PMIX_LIST_DESTRUCT(&nodes);
             return rc;
         }
         ++daemons->num_procs;
@@ -2444,6 +2551,10 @@ process:
             }
         }
     }
+
+    /* the loop above normally drains the list, but it breaks out early once
+     * prte_max_vm_size nodes have been counted - so release whatever is left */
+    PMIX_LIST_DESTRUCT(&nodes);
 
     if (prte_process_info.num_daemons != daemons->num_procs) {
         /* more daemons are being launched - update the routing tree to

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2024,13 +2024,60 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
         // nodes have been added, so extend the DVM
         prte_remove_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM);
         /* Reset the per-launch daemon accounting. The initial-VM path zeroes
-         * these further below, but the grow path jumps straight to construct:
-         * and would otherwise accumulate num_new_daemons across successive
-         * grows and reuse a stale daemon_vpid_start - corrupting the grow
-         * campaign's target list and suppressing its completion event (#2491). */
+         * these further below, but the grow path skips that code and would
+         * otherwise accumulate num_new_daemons across successive grows and
+         * reuse a stale daemon_vpid_start - corrupting the grow campaign's
+         * target list and suppressing its completion event (#2491). */
         map->num_new_daemons = 0;
         map->daemon_vpid_start = PMIX_RANK_INVALID;
-        goto construct;
+        /* A grow launches daemons on the nodes THIS request added, and only
+         * those: an allocation request naming node4 must start a daemon on
+         * node4 alone. Every producer of a grow (the no-scheduler
+         * ras_base_insert_node_string, ras/slurm's extend, and the
+         * add-host/add-hostfile path in ras/hosts) marks its new nodes
+         * PRTE_NODE_STATE_ADDED for exactly this purpose, so select on that
+         * - the same rule the dynamic-spawn branch below applies.
+         *
+         * Scanning the whole node pool instead (as this used to, by falling
+         * into the construct: label) silently absorbed any other daemon-less
+         * node into the grow. A shrink is the way that happens: releasing a
+         * reservation reverts its nodes to the default pool as UP with no
+         * daemon, so the next grow - of some entirely unrelated node -
+         * relaunched a daemon on the node the user had just shrunk away.
+         *
+         * Note this deliberately does NOT apply the app-context filtering
+         * done under construct:. A grown node is granted by an explicit
+         * request and must join regardless of any static -host/hostfile
+         * spec given when the DVM was started. */
+        for (i = 1; i < prte_node_pool->size; i++) {
+            node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
+            if (NULL == node) {
+                continue;
+            }
+            if (PRTE_NODE_STATE_ADDED != node->state) {
+                PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
+                                     "%s plm_base:setup_vm NODE %s NOT PART OF THIS GROW",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
+                continue;
+            }
+            PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
+                                 "%s plm_base:setup_vm GROW ADDING NODE %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
+            PMIX_RETAIN(node);
+            pmix_list_append(&nodes, &node->super);
+        }
+        if (0 == pmix_list_get_size(&nodes)) {
+            /* the grow brought in no node needing a daemon */
+            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                                 "%s plm:base:setup_vm no new daemons required",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+            PMIX_DESTRUCT(&nodes);
+            /* mark that the daemons have reported so we can proceed */
+            daemons->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
+            PRTE_FLAG_UNSET(daemons, PRTE_JOB_FLAG_UPDATED);
+            return PRTE_SUCCESS;
+        }
+        goto process;
     }
 
     /* if this is a dynamic spawn, then we don't make any changes to
@@ -2345,8 +2392,9 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
         goto process;
     }
 
-construct:
-    /* construct a list of available nodes */
+    /* construct a list of available nodes - the managed-allocation path
+     * falls into this; the grow and dynamic-spawn paths do not, as they
+     * select only the nodes their request brought in */
     for (i = 1; i < prte_node_pool->size; i++) {
         if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i))) {
             /* ignore nodes that are marked as do-not-use for this mapping */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2599,9 +2599,8 @@ process:
         /* point the node to the daemon */
         node->daemon = proc;
         PMIX_RETAIN(proc); /* maintain accounting */
-        /* point the proc to the node and maintain accounting */
+        /* point the proc at the node - borrowed, not retained */
         proc->node = node;
-        PMIX_RETAIN(node);
         if (prte_plm_globals.daemon_nodes_assigned_at_launch) {
             PRTE_FLAG_SET(node, PRTE_NODE_FLAG_LOC_VERIFIED);
         } else {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1995,6 +1995,10 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     char *hosts = NULL;
     bool singleton = false;
     bool multi_sim = false;
+    bool grow_request = false;
+    bool have_grow_requester = false;
+    pmix_proc_t grow_requester;
+    char *grow_alloc_id = NULL, *grow_req_id = NULL;
 
     PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                          "%s plm:base:setup_vm",
@@ -2065,6 +2069,24 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
             PMIX_RETAIN(node);
             pmix_list_append(&nodes, &node->super);
+        }
+        /* Remember who asked, before the process: loop drains the list. A
+         * grow that turns out to need no new daemon at all - every node it
+         * was granted already has one - still has to tell its requester that
+         * the DVM now reflects the request. Nothing will be launched, so no
+         * campaign is recorded and the launch fence never rises, which means
+         * grow_drain() would never run and the requester would wait out its
+         * timeout on an operation that had in fact already succeeded. */
+        grow_request = true;
+        PMIX_LIST_FOREACH(nptr, &nodes, prte_node_t) {
+            if (NULL != nptr->session &&
+                PMIX_RANK_INVALID != nptr->session->requestor.rank) {
+                PMIX_XFER_PROCID(&grow_requester, &nptr->session->requestor);
+                grow_alloc_id = nptr->session->alloc_refid;
+                grow_req_id = nptr->session->user_refid;
+                have_grow_requester = true;
+                break;
+            }
         }
         if (0 == pmix_list_get_size(&nodes)) {
             /* the grow brought in no node needing a daemon */
@@ -2651,6 +2673,20 @@ process:
             PRTE_ERROR_LOG(rc);
             return rc;
         }
+    }
+
+    if (prte_elastic_mode && grow_request && 0 == map->num_new_daemons) {
+        /* the grow needed no daemon - the DVM already reflects the request,
+         * so report completion now rather than leaving the requester to time
+         * out waiting for a fence that will never be raised */
+        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                             "%s plm:base:setup_vm grow required no new daemons",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        if (have_grow_requester) {
+            prte_plm_base_dvm_mod_notify(&grow_requester, grow_alloc_id,
+                                         grow_req_id, true, PMIX_SUCCESS);
+        }
+        return PRTE_SUCCESS;
     }
 
     /* The launch fence only operates when the DVM is permitted to grow/shrink.

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1701,16 +1701,17 @@ void prte_plm_base_daemon_failed(int st, pmix_proc_t *sender, pmix_data_buffer_t
         goto finish;
     }
 
-    /* unpack the exit status */
+    /* unpack the exit status. This is already a plain status - the senders
+     * on this tag report either a decoded exit status (ssh_wait_daemon) or a
+     * PRTE error code (remote_spawn), never a raw waitpid() status, so it
+     * must NOT be run through WEXITSTATUS */
     n = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &status, &n, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         status = PRTE_ERROR_DEFAULT_EXIT_CODE;
-        PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
-    } else {
-        PRTE_UPDATE_EXIT_STATUS(WEXITSTATUS(status));
     }
+    PRTE_UPDATE_EXIT_STATUS(status);
 
     /* find the daemon and update its state/status */
     if (NULL == (daemon = (prte_proc_t *) pmix_pointer_array_get_item(jdatorted->procs, vpid))) {

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -340,7 +340,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
                 rc = PRTE_ERR_NOT_FOUND;
                 goto CLEANUP;
             }
-            PMIX_RETAIN(node);
+            /* the node backpointer is borrowed, not retained */
             proc->node = node;
             jdata->num_procs = 1;
         }

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -203,7 +203,10 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     int32_t count;
     pmix_nspace_t job;
     prte_session_t *session;
-    prte_job_t *jdata, *parent;
+    /* jdata MUST start NULL: the ANSWER_LAUNCH error path reads it, and we
+     * can reach that path before (or without) it ever being assigned - e.g.,
+     * when the job object fails to unpack */
+    prte_job_t *jdata = NULL, *parent;
     pmix_data_buffer_t *answer;
     pmix_rank_t vpid;
     prte_proc_t *proc;
@@ -213,7 +216,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     int32_t rc = PRTE_SUCCESS, ret;
     uint32_t ui32, *ui32_ptr;
     prte_app_context_t *app, *child_app;
-    pmix_proc_t name, *nptr;
+    pmix_proc_t name, *nptr = NULL;
     pid_t pid;
     bool debugging, found;
     int i, room, *rmptr = &room;
@@ -548,6 +551,7 @@ moveon:
             }
         }
         PMIX_PROC_RELEASE(nptr);
+        nptr = NULL;
 
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                              "%s plm:base:receive adding hosts",
@@ -598,6 +602,12 @@ moveon:
                              "%s plm:base:receive - error on launch: %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), rc));
 
+        /* release the launch proxy procID if we retrieved one */
+        if (NULL != nptr) {
+            PMIX_PROC_RELEASE(nptr);
+            nptr = NULL;
+        }
+
         /* setup the response */
         PMIX_DATA_BUFFER_CREATE(answer);
 
@@ -614,8 +624,10 @@ moveon:
             PMIX_ERROR_LOG(rc);
         }
 
-        /* pack the room number of the request */
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_ROOM_NUM, (void **) &rmptr, PMIX_INT)) {
+        /* pack the room number of the request - note that we may not have a
+         * job object at all here (e.g., if it failed to unpack) */
+        if (NULL != jdata &&
+            prte_get_attribute(&jdata->attributes, PRTE_JOB_ROOM_NUM, (void **) &rmptr, PMIX_INT)) {
             rc = PMIx_Data_pack(NULL, answer, &room, 1, PMIX_INT);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -722,12 +734,15 @@ moveon:
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(job)));
 
             PMIX_LOAD_NSPACE(name.nspace, job);
-            /* get the job object */
+            /* get the job object - the job may already have completed, so
+             * this is not necessarily an error, but we cannot process the
+             * report without it */
             jdata = prte_get_job_data_object(job);
             debugging = false;
-            if (prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL) ||
-                prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, NULL, PMIX_BOOL) ||
-                prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL)) {
+            if (NULL != jdata &&
+                (prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL) ||
+                 prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_INIT, NULL, PMIX_BOOL) ||
+                 prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL))) {
                 debugging = true;
             }
             count = 1;
@@ -750,19 +765,24 @@ moveon:
                      "%s plm:base:receive got ready for debug for vpid %u",
                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), vpid));
 
-                /* get the proc data object */
-                proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, vpid);
-                if (NULL == proc) {
-                    PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-                    PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FORCED_EXIT);
-                    goto CLEANUP;
-                }
-                /* NEVER update the proc state before activating the state machine - let
-                 * the state cbfunc update it as it may need to compare this
-                 * state against the prior proc state */
-                proc->pid = pid;
-                if (debugging) {
-                    jdata->num_ready_for_debug++;
+                /* get the proc data object - if the job itself is gone (it
+                 * may have completed before this report arrived), there is
+                 * nothing to record, but we must keep unpacking so the rest
+                 * of the buffer stays parseable */
+                if (NULL != jdata) {
+                    proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, vpid);
+                    if (NULL == proc) {
+                        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+                        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FORCED_EXIT);
+                        goto CLEANUP;
+                    }
+                    /* NEVER update the proc state before activating the state machine - let
+                     * the state cbfunc update it as it may need to compare this
+                     * state against the prior proc state */
+                    proc->pid = pid;
+                    if (debugging) {
+                        jdata->num_ready_for_debug++;
+                    }
                 }
                 /* get entry from next rank */
                 rc = PMIx_Data_unpack(NULL, buffer, &vpid, &count, PMIX_PROC_RANK);
@@ -928,9 +948,3 @@ CLEANUP:
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 }
 
-/* where HNP messages come */
-void prte_plm_base_receive_process_msg(int fd, short event, void *data)
-{
-    PRTE_HIDE_UNUSED_PARAMS(fd, event, data);
-    assert(0);
-}

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -207,6 +207,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
      * can reach that path before (or without) it ever being assigned - e.g.,
      * when the job object fails to unpack */
     prte_job_t *jdata = NULL, *parent;
+    /* true while the freshly unpacked job object belongs to nobody but us -
+     * cleared once it has been handed to a session/parent/the job pool */
+    bool own_jdata = false;
     pmix_data_buffer_t *answer;
     pmix_rank_t vpid;
     prte_proc_t *proc;
@@ -389,6 +392,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             goto ANSWER_LAUNCH;
         }
 
+        /* we own it until it is handed to a container below */
+        own_jdata = true;
+
         /* record the sender so we know who to respond to */
         PMIX_LOAD_PROCID(&jdata->originator, sender->nspace, sender->rank);
 
@@ -503,6 +509,10 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
         }
 
 moveon:
+        /* from here on the job is referenced by the session (and shortly by
+         * the parent's child list and the global job pool), so the error
+         * paths below must NOT free it out from under them */
+        own_jdata = false;
         jdata->session = session;
         pmix_pointer_array_add(jdata->session->jobs, jdata);
 
@@ -606,6 +616,15 @@ moveon:
         if (NULL != nptr) {
             PMIX_PROC_RELEASE(nptr);
             nptr = NULL;
+        }
+
+        /* if we unpacked a job object and never handed it to anyone - a
+         * malformed request, an unknown session, a rejected ownership check -
+         * then we are the only holder and it would otherwise leak */
+        if (own_jdata && NULL != jdata) {
+            PMIX_RELEASE(jdata);
+            jdata = NULL;
+            own_jdata = false;
         }
 
         /* setup the response */

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -63,17 +63,16 @@ typedef struct {
     pmix_data_buffer_t tree_spawn_cmd;
     /* daemon nodes assigned at launch */
     bool daemon_nodes_assigned_at_launch;
+    /* include MCA params found in our environment on the prted cmd line.
+     * Set false by a component (e.g., ssh, via plm_ssh_pass_environ_mca_params)
+     * when the resulting command line would be too long for the launcher */
+    bool pass_environ_mca_params;
     size_t node_regex_threshold;
 } prte_plm_globals_t;
 /**
  * Global instance of PLM framework data
  */
 PRTE_EXPORT extern prte_plm_globals_t prte_plm_globals;
-
-/**
- * Utility routine to set progress engine schedule
- */
-PRTE_EXPORT int prte_plm_base_set_progress_sched(int sched);
 
 /*
  * Launch support
@@ -90,9 +89,7 @@ PRTE_EXPORT void prte_plm_base_stack_trace_recv(int status, pmix_proc_t *sender,
 
 PRTE_EXPORT int prte_plm_base_create_jobid(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_set_hnp_name(void);
-PRTE_EXPORT void prte_plm_base_reset_job(prte_job_t *jdata);
 PRTE_EXPORT int prte_plm_base_setup_prted_cmd(int *argc, char ***argv);
-PRTE_EXPORT void prte_plm_base_check_all_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT int prte_plm_base_setup_virtual_machine(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_fence_release(void);
 PRTE_EXPORT void prte_plm_base_abort_premap_held(void);
@@ -131,14 +128,6 @@ PRTE_EXPORT void prte_plm_base_recv(int status, pmix_proc_t *sender, pmix_data_b
  */
 PRTE_EXPORT int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess_module,
                                                       int *proc_vpid_index);
-
-/*
- * Proxy functions for use by daemons and application procs
- * needing dynamic operations
- */
-PRTE_EXPORT int prte_plm_proxy_init(void);
-PRTE_EXPORT int prte_plm_proxy_spawn(prte_job_t *jdata);
-PRTE_EXPORT int prte_plm_proxy_finalize(void);
 
 END_C_DECLS
 

--- a/src/mca/plm/lsf/AGENTS.md
+++ b/src/mca/plm/lsf/AGENTS.md
@@ -101,3 +101,7 @@ All the base defaults: `terminate_orteds` → `prte_plm_base_prted_exit`,
 - **Test builds.** Code must keep compiling under
   `PRTE_TESTBUILD_LAUNCHERS` against `testbuild_lsf.h`; don't reach for
   LSF symbols not stubbed there.
+- **`nodelist_argv` is ours to free.** `lsb_launch` does not take
+  ownership of the host list, so it is freed on the `cleanup:` path along
+  with `argv`/`env`. An empty host list is an error
+  (`no-hosts-in-list`), not something to hand to `lsb_launch`.

--- a/src/mca/plm/lsf/help-plm-lsf.txt
+++ b/src/mca/plm/lsf/help-plm-lsf.txt
@@ -30,3 +30,10 @@ This may mean that one or more of the nodes in the LSF allocation is
 not setup properly. Below is a list of the %d nodes that were passed
 to lsb_launch:
 %s
+#
+[no-hosts-in-list]
+The LSF process starter for PRTE didn't find any hosts in
+the map for this application. This can be caused by a lack of
+an allocation, or by an error in the PRTE code. Please check
+to ensure you have an LSF allocation. If you do, then please pass
+the error to the PRTE user's mailing list for assistance.

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -188,6 +188,8 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char *newenv;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
+    nodelist_argv = NULL;
+
     PMIX_ACQUIRE_OBJECT(state);
     jdata = state->jdata;
 
@@ -257,6 +259,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
          * we need to launch a daemon
          */
         pmix_argv_append(&nodelist_argc, &nodelist_argv, node->name);
+    }
+    if (0 == PMIx_Argv_count(nodelist_argv)) {
+        /* every node in the map already has a daemon - there is nothing
+         * for lsb_launch to do, and handing it an empty host list is not
+         * something we should ask of it */
+        pmix_show_help("help-plm-lsf.txt", "no-hosts-in-list", true);
+        rc = PRTE_ERR_FAILED_TO_START;
+        goto cleanup;
     }
 
     /*
@@ -412,6 +422,9 @@ cleanup:
     }
     if (NULL != env) {
         PMIx_Argv_free(env);
+    }
+    if (NULL != nodelist_argv) {
+        PMIx_Argv_free(nodelist_argv);
     }
 
     /* check for failed launch - if so, force terminate */

--- a/src/mca/plm/pals/AGENTS.md
+++ b/src/mca/plm/pals/AGENTS.md
@@ -116,3 +116,14 @@ exit command; `plm_pals_signal_job` signals `palsrun` directly via
 - **Environment already stripped.** `prte_launch_environ` is the pristine,
   `PRTE_`/`PMIX_`-free copy — keep the daemon settings on the command
   line, not in the forwarded env.
+- **`failed_launch` is a file-static, and must be re-armed.** Unlike the
+  other components (where it is a local initialized to `true`), pals
+  keeps it at file scope because `pals_wait_cb` reads it to tell "aprun
+  never started the daemons" (`FAILED_TO_START`) from "a daemon died
+  after launch" (`ABORTED`). `launch_daemons` therefore sets it `true` on
+  entry — without that the `cleanup:` path can never report a failure and
+  a broken launch just hangs.
+- **Register the waitpid callback in the parent only.** `palsrun` and its
+  `prte_wait_cb` belong to the forking process; doing it before the
+  parent/child branch means the child registers a callback on a proc with
+  pid 0 moments before `execve` replaces it.

--- a/src/mca/plm/pals/plm_pals_module.c
+++ b/src/mca/plm/pals/plm_pals_module.c
@@ -179,13 +179,20 @@ static void launch_daemons(int fd, short args, void *cbdata)
     char *vpid_string;
     char **custom_strings;
     int num_args, i;
-    char *cur_prefix, *pmix_prefix;
+    char *cur_prefix = NULL, *pmix_prefix = NULL;
     int proc_vpid_index;
     prte_job_t *daemons;
     prte_state_caddy_t *state = (prte_state_caddy_t *) cbdata;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(state);
+
+    /* arm the failure flag for THIS launch. It is a file-static (rather than
+     * a local, as in the other components) because pals_wait_cb consults it
+     * to tell "aprun never started the daemons" from "a daemon died after
+     * launch" - but that means it must be re-armed on every launch, else the
+     * cleanup path below can never report a failure */
+    failed_launch = true;
 
     /* start by setting up the virtual machine */
     daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
@@ -393,6 +400,8 @@ cleanup:
     if (NULL != env) {
         PMIx_Argv_free(env);
     }
+    free(cur_prefix);
+    free(pmix_prefix);
 
     /* check for failed launch - if so, force terminate */
     if (failed_launch) {
@@ -521,12 +530,17 @@ static int plm_pals_start_proc(int argc, char **argv, char **env,
         return PRTE_ERR_SYS_LIMITS_CHILDREN;
     }
 
-    palsrun = PMIX_NEW(prte_proc_t);
-    palsrun->pid = pals_pid;
-    /* be sure to mark it as alive so we don't instantly fire */
-    PRTE_FLAG_SET(palsrun, PRTE_PROC_FLAG_ALIVE);
-    /* setup the waitpid so we can find out if pals succeeds! */
-    prte_wait_cb(palsrun, pals_wait_cb, NULL);
+    if (0 < pals_pid) { /* parent */
+        /* track the launcher process - do this ONLY in the parent: in the
+         * child pals_pid is 0, so we would register a waitpid callback on
+         * a bogus proc moments before execve replaces us anyway */
+        palsrun = PMIX_NEW(prte_proc_t);
+        palsrun->pid = pals_pid;
+        /* be sure to mark it as alive so we don't instantly fire */
+        PRTE_FLAG_SET(palsrun, PRTE_PROC_FLAG_ALIVE);
+        /* setup the waitpid so we can find out if pals succeeds! */
+        prte_wait_cb(palsrun, pals_wait_cb, NULL);
+    }
 
     if (0 == pals_pid) { /* child */
         char *bin_base = NULL, *lib_base = NULL;

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -144,3 +144,15 @@ the daemons, not srun).
 - **Environment purge in the child is mandatory** — SLURM forwards the
   full environment; leaving `PMIX_`/`PRTE_` vars in breaks tool
   connections and duplicates command-line settings.
+- **Known wart: the "are we using the whole allocation?" test compares a
+  count against a capacity.** `map->num_new_daemons < session->nodes->size`
+  reads `size` from a `pmix_pointer_array_t`, which is the *allocated*
+  slot count, not the number of nodes in the session. The effect today is
+  benign (the explicit `--nodes`/`--nodelist` is emitted more often than
+  intended, which srun accepts), but anyone fixing it must re-test the
+  elastic grow path on a real SLURM system — dropping the explicit node
+  list changes which nodes srun picks.
+- Multi-node behavior that does not need SLURM (tree-spawn, throttling,
+  the prted command line) is covered by
+  [`contrib/dockerswarm`](../../../../contrib/dockerswarm/); the
+  SLURM-specific paths still require an allocation.

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -404,6 +404,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
 
     nodelist_flat = PMIx_Argv_join(nodelist_argv, ',');
     PMIx_Argv_free(nodelist_argv);
+    nodelist_argv = NULL;
 
     /* find job ID of first node to launch; we make the assumption here that
      * all other nodes in the launch share that job ID */
@@ -429,6 +430,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     if(UINT32_MAX == job_id) {
         rc = PRTE_ERR_NOT_FOUND;
         PRTE_ERROR_LOG(rc);
+        free(nodelist_flat);
         goto cleanup;
     }
 
@@ -437,6 +439,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     if(NULL == session) {
         rc = PRTE_ERR_NOT_FOUND;
         PRTE_ERROR_LOG(rc);
+        free(nodelist_flat);
         goto cleanup;
     }
 
@@ -767,6 +770,10 @@ static int plm_slurm_start_proc(int argc, char **argv,
         if (NULL != tmp) {
             for (n=0; NULL != tmp[n]; n++) {
                 p = strchr(tmp[n], '=');
+                if (NULL == p) {
+                    /* not an assignment - nothing to unset */
+                    continue;
+                }
                 *p = '\0';
                 unsetenv(tmp[n]);
             }

--- a/src/mca/plm/ssh/AGENTS.md
+++ b/src/mca/plm/ssh/AGENTS.md
@@ -252,7 +252,8 @@ process exits — see the ownership note below.
 - **`ssh_probe` forks.** If you touch it, keep the pipe fds closed on the
   error paths and keep reaping the probe child — PRRTE's SIGCHLD handler
   knows nothing about it.
-- **`plm_ssh_delay` is parsed but never applied.** The value lands in
-  `component.delay` and nothing reads it; either wire it into
-  `process_launch_list` or retire the parameter — don't assume it
-  throttles anything today.
+- **Launch pacing is `num_concurrent`, nothing else.** There used to be a
+  `plm_ssh_delay` parameter that was parsed into `component.delay` and
+  never read by anything; it was retired rather than left advertising a
+  throttle that did not exist. If inter-launch pacing is ever wanted, it
+  belongs in `process_launch_list`.

--- a/src/mca/plm/ssh/AGENTS.md
+++ b/src/mca/plm/ssh/AGENTS.md
@@ -212,7 +212,8 @@ their MCA vars (`plm_ssh_*`):
 
 `prte_plm_ssh_caddy_t` — the per-daemon launch item on `launch_list`:
 carries `argc`/`argv` (the fully-substituted command) and the `daemon`
-proc (retained; released when it starts).
+proc (retained). It is released by `ssh_wait_daemon` when the agent
+process exits — see the ownership note below.
 
 ---
 
@@ -235,3 +236,23 @@ proc (retained; released when it starts).
   touching prefix/library-path emission.
 - **Command-length limit.** Long environments blow past `_SC_ARG_MAX`;
   the fix the help text suggests is `plm_ssh_pass_environ_mca_params 0`.
+  That knob is a *component* var but the code it controls lives in the
+  base, so `ssh_init` copies it into
+  `prte_plm_globals.pass_environ_mca_params`; keep that assignment or the
+  documented remedy silently does nothing.
+- **The caddy belongs to `ssh_wait_daemon`.** `process_launch_list` hands
+  each `prte_plm_ssh_caddy_t` to `prte_wait_cb` as `cbdata`, and the wait
+  tracker frees only its `child` — so the callback must `PMIX_RELEASE`
+  the caddy on every exit path, not just the early ones. Each caddy holds
+  a full copy of the remote command line and a retained daemon proc.
+- **Check `node->daemon` before the tree-spawn filter.** The
+  "is this daemon one of my routing children?" loop in `launch_daemons`
+  reads `node->daemon->name.rank`, so it must come *after* the NULL
+  check, not before it.
+- **`ssh_probe` forks.** If you touch it, keep the pipe fds closed on the
+  error paths and keep reaping the probe child — PRRTE's SIGCHLD handler
+  knows nothing about it.
+- **`plm_ssh_delay` is parsed but never applied.** The value lands in
+  `component.delay` and nothing reads it; either wire it into
+  `process_launch_list` or retire the parameter — don't assume it
+  throttles anything today.

--- a/src/mca/plm/ssh/plm_ssh.h
+++ b/src/mca/plm/ssh/plm_ssh.h
@@ -60,7 +60,6 @@ struct prte_mca_plm_ssh_component_t {
     bool daemonize_llspawn;
     bool disable_tmrsh;
     bool using_tmrsh;
-    struct timespec delay;
     int priority;
     bool no_tree_spawn;
     int num_concurrent;

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -73,7 +73,6 @@ static int ssh_component_close(void);
 static int ssh_launch_agent_lookup(const char *agent_list, char *path);
 
 /* Local variables */
-static char *prte_plm_ssh_delay_string = NULL;
 static int agent_var_id = -1;
 
 /*
@@ -153,12 +152,6 @@ static int ssh_component_register(void)
                                                 PMIX_MCA_BASE_VAR_TYPE_INT,
                                                 &prte_mca_plm_ssh_component.priority);
 
-    prte_plm_ssh_delay_string = NULL;
-    (void) pmix_mca_base_component_var_register(c, "delay",
-                                                "Delay between invocations of the remote agent (sec[:usec])",
-                                                PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                                &prte_plm_ssh_delay_string);
-
     prte_mca_plm_ssh_component.no_tree_spawn = false;
     (void) pmix_mca_base_component_var_register(c, "no_tree_spawn",
                                                 "If set to true, do not launch via a tree-based topology",
@@ -215,8 +208,6 @@ static int ssh_component_register(void)
 
 static int ssh_component_open(void)
 {
-    char *ctmp;
-
     /* initialize globals */
     prte_mca_plm_ssh_component.using_qrsh = false;
     prte_mca_plm_ssh_component.using_llspawn = false;
@@ -228,16 +219,6 @@ static int ssh_component_open(void)
         pmix_show_help("help-plm-ssh.txt", "concurrency-less-than-zero", true,
                        prte_mca_plm_ssh_component.num_concurrent);
         prte_mca_plm_ssh_component.num_concurrent = 1;
-    }
-
-    if (NULL != prte_plm_ssh_delay_string) {
-        prte_mca_plm_ssh_component.delay.tv_sec = strtol(prte_plm_ssh_delay_string, &ctmp, 10);
-        if (ctmp == prte_plm_ssh_delay_string) {
-            prte_mca_plm_ssh_component.delay.tv_sec = 0;
-        }
-        if (':' == ctmp[0]) {
-            prte_mca_plm_ssh_component.delay.tv_nsec = 1000 * strtol(ctmp + 1, NULL, 10);
-        }
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -220,6 +220,7 @@ static int ssh_component_open(void)
     /* initialize globals */
     prte_mca_plm_ssh_component.using_qrsh = false;
     prte_mca_plm_ssh_component.using_llspawn = false;
+    prte_mca_plm_ssh_component.using_tmrsh = false;
     prte_mca_plm_ssh_component.agent_argv = NULL;
 
     /* lookup parameters */
@@ -375,10 +376,10 @@ char **prte_plm_ssh_search(const char *agent_list, const char *path)
         line = lines[i];
 
         /* Trim whitespace at the beginning and end of the line */
-        for (j = 0; '\0' != line[j] && isspace(line[j]); ++line) {
-            continue;
+        while ('\0' != *line && isspace((int) *line)) {
+            ++line;
         }
-        for (j = strlen(line) - 2; j > 0 && isspace(line[j]); ++j) {
+        for (j = (int) strlen(line) - 1; j >= 0 && isspace((int) line[j]); --j) {
             line[j] = '\0';
         }
         if (strlen(line) <= 0) {

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -251,6 +251,12 @@ static int ssh_init(void)
     /* we assign daemon nodes at launch */
     prte_plm_globals.daemon_nodes_assigned_at_launch = true;
 
+    /* tell the base whether or not to replicate the MCA params found in our
+     * environment onto the prted command line - dropping them is the
+     * documented remedy for the "cmd-line-too-long" error */
+    prte_plm_globals.pass_environ_mca_params
+        = prte_mca_plm_ssh_component.pass_environ_mca_params;
+
     return rc;
 }
 
@@ -355,7 +361,12 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
         /* trigger continuation of the launch */
         prte_event_active(&launch_event, EV_WRITE, 1);
     }
-    /* cleanup */
+    /* cleanup - the caddy was handed to us by process_launch_list and
+     * nobody else owns it (the wait tracker only releases its child), so
+     * releasing it here is what frees the launch argv and the retained
+     * daemon proc. Missing this leaks one copy of the full remote command
+     * line for every daemon we start */
+    PMIX_RELEASE(caddy);
     PMIX_RELEASE(t2);
 }
 
@@ -423,6 +434,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     /* setup the correct shell info */
     if (PRTE_SUCCESS != (rc = setup_shell(&remote_shell, &local_shell, nodename, &argc, &argv))) {
         PRTE_ERROR_LOG(rc);
+        PMIx_Argv_free(argv);
         return rc;
     }
 
@@ -735,6 +747,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
         pmix_show_help("help-plm-ssh.txt", "cmd-line-too-long", true, strlen(value),
                        sysconf(_SC_ARG_MAX));
         free(value);
+        PMIx_Argv_free(argv);
         return PRTE_ERR_SILENT;
     }
     free(value);
@@ -997,8 +1010,6 @@ static void process_launch_list(int fd, short args, void *cbdata)
     prte_plm_ssh_caddy_t *caddy;
     PRTE_HIDE_UNUSED_PARAMS(fd, args, cbdata);
 
-    PMIX_ACQUIRE_OBJECT(caddy);
-
     while (num_in_progress < prte_mca_plm_ssh_component.num_concurrent) {
         item = pmix_list_remove_first(&launch_list);
         if (NULL == item) {
@@ -1015,6 +1026,9 @@ static void process_launch_list(int fd, short args, void *cbdata)
         if (pid < 0) {
             PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_CHILDREN);
             prte_wait_cb_cancel(caddy->daemon);
+            /* the callback that would have released this caddy will now
+             * never fire */
+            PMIX_RELEASE(caddy);
             continue;
         }
 
@@ -1215,6 +1229,18 @@ static void launch_daemons(int fd, short args, void *cbdata)
             continue;
         }
 
+        /* if the node's daemon has not been defined, then we
+         * have an error! Check this FIRST - the tree-spawn filter
+         * below reads node->daemon->name.rank
+         */
+        if (NULL == node->daemon) {
+            PRTE_ERROR_LOG(PRTE_ERR_FATAL);
+            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                 "%s plm:ssh:launch daemon failed to be defined on node %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
+            continue;
+        }
+
         /* if we are tree launching, only launch our own children */
         if (!prte_mca_plm_ssh_component.no_tree_spawn) {
             pmix_rank_t *children = (pmix_rank_t*) prte_rml_base.children.array;
@@ -1236,17 +1262,6 @@ static void launch_daemons(int fd, short args, void *cbdata)
         if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_DAEMON_LAUNCHED)) {
             PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                  "%s plm:ssh:launch daemon already exists on node %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
-            continue;
-        }
-
-        /* if the node's daemon has not been defined, then we
-         * have an error!
-         */
-        if (NULL == node->daemon) {
-            PRTE_ERROR_LOG(PRTE_ERR_FATAL);
-            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                                 "%s plm:ssh:launch daemon failed to be defined on node %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
             continue;
         }
@@ -1318,9 +1333,14 @@ static void launch_daemons(int fd, short args, void *cbdata)
      */
     PMIX_RELEASE(state);
     PMIx_Argv_free(argv);
+    free(prefix_dir);
+    free(pmix_prefix);
     return;
 
 cleanup:
+    PMIx_Argv_free(argv);
+    free(prefix_dir);
+    free(pmix_prefix);
     PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_START);
     PMIX_RELEASE(state);
 }
@@ -1514,6 +1534,8 @@ static int ssh_probe(char *nodename, prte_plm_ssh_shell_t *shell)
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:ssh: fork failed with errno=%d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), errno));
+        close(fd[0]);
+        close(fd[1]);
         return PRTE_ERR_IN_ERRNO;
     } else if (pid == 0) { /* child */
         if (dup2(fd[1], 1) < 0) {
@@ -1535,6 +1557,7 @@ static int ssh_probe(char *nodename, prte_plm_ssh_shell_t *shell)
         PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                              "%s plm:ssh: close failed with errno=%d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), errno));
+        close(fd[0]);
         return PRTE_ERR_IN_ERRNO;
     }
 
@@ -1562,6 +1585,11 @@ static int ssh_probe(char *nodename, prte_plm_ssh_shell_t *shell)
         *ptr = '\0';
     }
     close(fd[0]);
+    /* reap the probe so it does not linger as a zombie - our SIGCHLD
+     * handler knows nothing about this child */
+    while (0 > waitpid(pid, NULL, 0) && EINTR == errno) {
+        continue;
+    }
 
     if (outbuf[0] != '\0') {
         char *sh_name = rindex(outbuf, '/');
@@ -1592,7 +1620,7 @@ static int setup_shell(prte_plm_ssh_shell_t *sshell, prte_plm_ssh_shell_t *lshel
                        int *argc, char ***argv)
 {
     prte_plm_ssh_shell_t remote_shell, local_shell;
-    char *param;
+    char *param = NULL;
     int rc;
 
     /* What is our local shell? */

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -270,6 +270,7 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
     prte_plm_ssh_caddy_t *caddy = (prte_plm_ssh_caddy_t *) t2->cbdata;
     prte_proc_t *daemon = caddy->daemon;
     pmix_status_t rc;
+    int32_t xstat;
     PRTE_HIDE_UNUSED_PARAMS(sd, flags);
 
     if (prte_prteds_term_ordered || prte_abnormal_term_ordered) {
@@ -301,7 +302,14 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
                 PMIX_RELEASE(t2);
                 return;
             }
-            rc = PMIx_Data_pack(NULL, buf, &daemon->exit_code, 1, PMIX_INT32);
+            /* send a plain exit status - the HNP records what it is given.
+             * daemon->exit_code is a raw waitpid() status here, so decode it
+             * rather than putting a wait status on the wire (remote_spawn's
+             * failure report on this same tag sends a PRTE error code, so the
+             * receiver cannot know which it was handed) */
+            xstat = WIFEXITED(daemon->exit_code) ? WEXITSTATUS(daemon->exit_code)
+                                                 : PRTE_ERROR_DEFAULT_EXIT_CODE;
+            rc = PMIx_Data_pack(NULL, buf, &xstat, 1, PMIX_INT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buf);

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -363,7 +363,7 @@ static void ssh_wait_daemon(int sd, short flags, void *cbdata)
         }
     }
 
-    /* release any delay */
+    /* one fewer ssh in flight - admit the next from the launch list */
     --num_in_progress;
     if (num_in_progress < prte_mca_plm_ssh_component.num_concurrent) {
         /* trigger continuation of the launch */

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -272,7 +272,7 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 daemon = PMIX_NEW(prte_proc_t);
                 PMIX_LOAD_PROCID(&daemon->name, PRTE_PROC_MY_NAME->nspace, node->index);
                 daemon->state = PRTE_PROC_STATE_RUNNING;
-                PMIX_RETAIN(node);
+                /* the node backpointer is borrowed, not retained */
                 daemon->node = node;
                 pmix_pointer_array_set_item(djob->procs, daemon->name.rank, daemon);
                 djob->num_procs++;

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -222,6 +222,18 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 }
                 if (prte_nptr_match(nptr, node)) {
                     found = true;
+                    /* The incoming entry is discarded in favor of the one
+                     * already in the pool, so anything the caller marked on
+                     * it has to be carried across. A dynamic addition marks
+                     * its nodes PRTE_NODE_STATE_ADDED precisely so the DVM
+                     * extension will launch a daemon on them; dropping that
+                     * for a node the pool already knows about makes the grow
+                     * a no-op. That is the normal case when re-growing a node
+                     * that was previously shrunk out of the DVM: the shrink
+                     * removes its daemon, but the pool entry survives. */
+                    if (PRTE_NODE_STATE_ADDED == node->state) {
+                        nptr->state = PRTE_NODE_STATE_ADDED;
+                    }
                     if (prte_get_attribute(&node->attributes, PRTE_NODE_ADD_SLOTS, NULL, PMIX_BOOL)) {
                         nptr->slots += node->slots;
                         if (0 > nptr->slots) {

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -1189,6 +1189,8 @@ ranking:
                 continue;
             }
             if (NULL == node->topology) {
+                /* the node holds a counted reference to the topology */
+                PMIX_RETAIN(t0);
                 node->topology = t0;
             }
         }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -651,9 +651,8 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata,
         proc->parent = node->daemon->name.rank;
     }
 
-    // point the proc at its node
+    // point the proc at its node - borrowed, not retained
     proc->node = node;
-    PMIX_RETAIN(node); /* maintain accounting on object */
 
     /* point the proc to its locale */
     proc->obj = obj;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -885,7 +885,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         return PRTE_ERR_NOT_FOUND;
     }
-    PMIX_RETAIN(node);
+    /* the node backpointer is borrowed, not retained */
     proc->node = node;
     jdata->num_procs = 1;
 

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1578,8 +1578,7 @@ static int prep_singleton(const char *name)
     PMIX_RETAIN(proc);
     pmix_pointer_array_set_item(&app->procs, rank, proc);
     app->first_rank = rank;
-    /* link it to the node */
-    PMIX_RETAIN(node);
+    /* link it to the node - the backpointer is borrowed, not retained */
     proc->node = node;
     /* add it to the job */
     pmix_pointer_array_set_item(jdata->procs, rank, proc);

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -59,6 +59,10 @@ int prte_node_copy(prte_node_t **dest, prte_node_t *src)
     node->slots = src->slots;
     node->slots_inuse = src->slots_inuse;
     node->slots_max = src->slots_max;
+    if (NULL != src->topology) {
+        /* the copy holds its own counted reference to the topology */
+        PMIX_RETAIN(src->topology);
+    }
     node->topology = src->topology;
     node->flags = src->flags;
     (*dest) = node;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -872,6 +872,12 @@ static void prte_node_destruct(prte_node_t *node)
     for (i = 0; i < node->procs->size; i++) {
         if (NULL != (proc = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, i))) {
             pmix_pointer_array_set_item(node->procs, i, NULL);
+            /* the proc borrows its backpointer to us, so clear it before we
+             * go away - a proc can outlive its node (its job holds a
+             * reference too) */
+            if (proc->node == node) {
+                proc->node = NULL;
+            }
             PMIX_RELEASE(proc);
         }
     }
@@ -923,10 +929,14 @@ static void prte_proc_construct(prte_proc_t *proc)
 
 static void prte_proc_destruct(prte_proc_t *proc)
 {
-    if (NULL != proc->node) {
-        PMIX_RELEASE(proc->node);
-        proc->node = NULL;
-    }
+    /* proc->node is a BORROWED backpointer - the node is owned by
+     * prte_node_pool (and by any job map that retained it), and it is
+     * cleared by prte_node_destruct on the procs it knows about. Retaining
+     * it here would form a reference cycle with node->daemon /
+     * node->procs, which both hold real references: neither object could
+     * then ever reach a zero count, so neither destructor would run and
+     * every node and proc would leak. */
+    proc->node = NULL;
     if (NULL != proc->cpuset) {
         free(proc->cpuset);
         proc->cpuset = NULL;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -877,7 +877,13 @@ static void prte_node_destruct(prte_node_t *node)
     }
     PMIX_RELEASE(node->procs);
 
-    /* do NOT destroy the topology */
+    /* release our reference to the topology - the topology object itself
+     * lives until the last node pointing at it (and the entry in
+     * prte_node_topologies) has been released */
+    if (NULL != node->topology) {
+        PMIX_RELEASE(node->topology);
+        node->topology = NULL;
+    }
 
     // release any diffs
     if (NULL != node->topodiff) {

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -461,7 +461,8 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
             daemons->num_procs++;
             pmix_pointer_array_set_item(daemons->procs, proc->name.rank, proc);
         }
-        PMIX_RETAIN(nd);
+        /* the node backpointer is borrowed, not retained (see
+         * prte_proc_destruct) */
         proc->node = nd;
         PMIX_RETAIN(proc);
         nd->daemon = proc;

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -447,7 +447,9 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
             nd->aliases = PMIx_Argv_split(aliases[n], ',');
         }
         /* set the topology - always default to homogeneous
-         * as that is the most common scenario */
+         * as that is the most common scenario. Retain it: the node holds a
+         * counted reference so the topology cannot go away underneath it */
+        PMIX_RETAIN(t);
         nd->topology = t;
         /* record the daemon on it */
         proc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, vpid[n]);

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm

--- a/test/unit/plm/Makefile.am
+++ b/test/unit/plm/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_plm
+
+test_plm_SOURCES = \
+    test_plm.c
+
+test_plm_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_plm

--- a/test/unit/plm/test_plm.c
+++ b/test/unit/plm/test_plm.c
@@ -1,0 +1,570 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the plm (Process Launch Manager) framework.
+ *
+ * The substantive work of plm -- standing up prted daemons and driving the
+ * job state machine as they report back -- needs a live DVM (and, for the
+ * RM components, a live resource manager), so it is covered by the
+ * integration and dockerswarm harnesses. What can be checked in isolation
+ * is everything the launch path *builds* before it ever forks anything,
+ * plus the invariants the rest of the tree depends on:
+ *
+ *   1. plm_types.h. The job/proc/node/app state codes and the PLM command
+ *      codes are hand-assigned integers consumed tree-wide, and the
+ *      top-level AGENTS.md rule is that every value must stay unique
+ *      within its family -- a duplicate silently makes two distinct codes
+ *      compare equal. We check uniqueness mechanically, plus the
+ *      "boundary" relationships (UNTERMINATED / TERMINATED / ERROR) that
+ *      code all over the tree tests with < and >.
+ *
+ *   2. The module contract. Every component fills in the same vtable and
+ *      the selected one is copied wholesale into prte_plm, so a NULL slot
+ *      is a crash at first use. The default (local-only) module and the
+ *      ssh module -- the always-built fallback -- are checked here.
+ *
+ *   3. prte_plm_base_wrap_args: quotes the value of a "...mca" option so
+ *      launchers/shells do not split multi-word values.
+ *
+ *   4. prte_plm_base_setup_prted_cmd: splits prte_launch_agent and reports
+ *      where the "prted" word landed, which is what lets a wrapper
+ *      ("valgrind ... prted") be handled.
+ *
+ *   5. prte_plm_base_prted_append_basic_args: the daemon command line.
+ *      This is the one every launcher hands to ssh/srun/aprun/lsb_launch,
+ *      so its content matters: the vpid template must be recorded, the
+ *      frameworks the daemons must not open (rmaps/ras/plm) must be
+ *      dropped, MCA values must survive intact (including values that
+ *      themselves contain '='), and the pass_environ_mca_params opt-out
+ *      must actually suppress the environment-derived params.
+ *
+ *   6. prte_plm_base_set_hnp_name / prte_plm_base_create_jobid: the DVM
+ *      base nspace and the monotonic "base@N" job nspaces derived from it.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/runtime.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/plm/base/base.h"
+#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/plm.h"
+#include "src/mca/plm/plm_types.h"
+#include "src/mca/plm/ssh/plm_ssh.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/* find "needle" in an argv array, returning its index or -1 */
+static int idx_of(char **argv, const char *needle)
+{
+    int i;
+
+    for (i = 0; NULL != argv && NULL != argv[i]; i++) {
+        if (0 == strcmp(argv[i], needle)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/* does argv contain the three-word sequence <flag> <name> <value>? */
+static bool has_mca(char **argv, const char *flag, const char *name, const char *value)
+{
+    int i;
+
+    for (i = 0; NULL != argv && NULL != argv[i] && NULL != argv[i + 1] && NULL != argv[i + 2];
+         i++) {
+        if (0 == strcmp(argv[i], flag) &&
+            0 == strcmp(argv[i + 1], name) &&
+            0 == strcmp(argv[i + 2], value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* is "name" present as the value of any --prtemca/--pmixmca option? */
+static bool has_mca_name(char **argv, const char *name)
+{
+    int i;
+
+    for (i = 0; NULL != argv && NULL != argv[i] && NULL != argv[i + 1]; i++) {
+        if ((0 == strcmp(argv[i], "--prtemca") || 0 == strcmp(argv[i], "--pmixmca")) &&
+            0 == strcmp(argv[i + 1], name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * The state codes are hand-assigned offsets and MUST stay unique within
+ * their family: a collision makes two distinct states compare equal, which
+ * is a miserable bug to track down at runtime.
+ */
+static int test_state_code_uniqueness(void)
+{
+    int failures = 0;
+    size_t i, j;
+
+    int32_t jobstates[] = {
+        PRTE_JOB_STATE_UNDEF, PRTE_JOB_STATE_INIT, PRTE_JOB_STATE_INIT_COMPLETE,
+        PRTE_JOB_STATE_ALLOCATE, PRTE_JOB_STATE_ALLOCATION_COMPLETE, PRTE_JOB_STATE_MAP,
+        PRTE_JOB_STATE_MAP_COMPLETE, PRTE_JOB_STATE_SYSTEM_PREP, PRTE_JOB_STATE_LAUNCH_DAEMONS,
+        PRTE_JOB_STATE_DAEMONS_LAUNCHED, PRTE_JOB_STATE_DAEMONS_REPORTED, PRTE_JOB_STATE_VM_READY,
+        PRTE_JOB_STATE_LAUNCH_APPS, PRTE_JOB_STATE_SEND_LAUNCH_MSG, PRTE_JOB_STATE_RUNNING,
+        PRTE_JOB_STATE_SUSPENDED, PRTE_JOB_STATE_REGISTERED, PRTE_JOB_STATE_WAITING_FOR_DAEMONS,
+        PRTE_JOB_STATE_LOCAL_LAUNCH_COMPLETE, PRTE_JOB_STATE_READY_FOR_DEBUG,
+        PRTE_JOB_STATE_STARTED, PRTE_JOB_STATE_UNTERMINATED, PRTE_JOB_STATE_TERMINATED,
+        PRTE_JOB_STATE_ALL_JOBS_COMPLETE, PRTE_JOB_STATE_DAEMONS_TERMINATED,
+        PRTE_JOB_STATE_NOTIFY_COMPLETED, PRTE_JOB_STATE_NOTIFIED, PRTE_JOB_STATE_ERROR,
+        PRTE_JOB_STATE_KILLED_BY_CMD, PRTE_JOB_STATE_ABORTED, PRTE_JOB_STATE_FAILED_TO_START,
+        PRTE_JOB_STATE_ABORTED_BY_SIG, PRTE_JOB_STATE_ABORTED_WO_SYNC, PRTE_JOB_STATE_COMM_FAILED,
+        PRTE_JOB_STATE_SENSOR_BOUND_EXCEEDED, PRTE_JOB_STATE_CALLED_ABORT,
+        PRTE_JOB_STATE_HEARTBEAT_FAILED, PRTE_JOB_STATE_NEVER_LAUNCHED,
+        PRTE_JOB_STATE_ABORT_ORDERED, PRTE_JOB_STATE_NON_ZERO_TERM,
+        PRTE_JOB_STATE_FAILED_TO_LAUNCH, PRTE_JOB_STATE_FORCED_EXIT,
+        PRTE_JOB_STATE_SILENT_ABORT, PRTE_JOB_STATE_REPORT_PROGRESS,
+        PRTE_JOB_STATE_ALLOC_FAILED, PRTE_JOB_STATE_MAP_FAILED, PRTE_JOB_STATE_CANNOT_LAUNCH,
+        PRTE_JOB_STATE_FILES_POSN_FAILED, PRTE_JOB_STATE_FT_CHECKPOINT,
+        PRTE_JOB_STATE_FT_CONTINUE, PRTE_JOB_STATE_FT_RESTART
+    };
+    int32_t procstates[] = {
+        PRTE_PROC_STATE_UNDEF, PRTE_PROC_STATE_INIT, PRTE_PROC_STATE_RESTART,
+        PRTE_PROC_STATE_TERMINATE, PRTE_PROC_STATE_RUNNING, PRTE_PROC_STATE_REGISTERED,
+        PRTE_PROC_STATE_IOF_COMPLETE, PRTE_PROC_STATE_WAITPID_FIRED,
+        PRTE_PROC_STATE_MODEX_READY, PRTE_PROC_STATE_READY_FOR_DEBUG,
+        PRTE_PROC_STATE_UNTERMINATED, PRTE_PROC_STATE_TERMINATED, PRTE_PROC_STATE_ERROR,
+        PRTE_PROC_STATE_KILLED_BY_CMD, PRTE_PROC_STATE_ABORTED, PRTE_PROC_STATE_FAILED_TO_START,
+        PRTE_PROC_STATE_ABORTED_BY_SIG, PRTE_PROC_STATE_TERM_WO_SYNC,
+        PRTE_PROC_STATE_COMM_FAILED, PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED,
+        PRTE_PROC_STATE_CALLED_ABORT, PRTE_PROC_STATE_HEARTBEAT_FAILED,
+        PRTE_PROC_STATE_MIGRATING, PRTE_PROC_STATE_CANNOT_RESTART,
+        PRTE_PROC_STATE_TERM_NON_ZERO, PRTE_PROC_STATE_FAILED_TO_LAUNCH,
+        PRTE_PROC_STATE_UNABLE_TO_SEND_MSG, PRTE_PROC_STATE_LIFELINE_LOST,
+        PRTE_PROC_STATE_NO_PATH_TO_TARGET, PRTE_PROC_STATE_FAILED_TO_CONNECT,
+        PRTE_PROC_STATE_PEER_UNKNOWN
+    };
+    int32_t nodestates[] = {
+        PRTE_NODE_STATE_UNDEF, PRTE_NODE_STATE_UNKNOWN, PRTE_NODE_STATE_DOWN,
+        PRTE_NODE_STATE_UP, PRTE_NODE_STATE_REBOOT, PRTE_NODE_STATE_DO_NOT_USE,
+        PRTE_NODE_STATE_NOT_INCLUDED, PRTE_NODE_STATE_ADDED
+    };
+    int32_t appstates[] = {
+        PRTE_APP_STATE_UNDEF, PRTE_APP_STATE_INIT, PRTE_APP_STATE_ALL_MAPPED,
+        PRTE_APP_STATE_RUNNING, PRTE_APP_STATE_COMPLETED
+    };
+    int32_t cmds[] = {
+        PRTE_PLM_LAUNCH_JOB_CMD, PRTE_PLM_UPDATE_PROC_STATE, PRTE_PLM_REGISTERED_CMD,
+        PRTE_PLM_TOOL_ATTACHED_CMD, PRTE_PLM_READY_FOR_DEBUG_CMD, PRTE_PLM_LOCAL_LAUNCH_COMP_CMD
+    };
+    struct {
+        const char *name;
+        int32_t *vals;
+        size_t n;
+    } families[] = {
+        {"job state", jobstates, sizeof(jobstates) / sizeof(jobstates[0])},
+        {"proc state", procstates, sizeof(procstates) / sizeof(procstates[0])},
+        {"node state", nodestates, sizeof(nodestates) / sizeof(nodestates[0])},
+        {"app state", appstates, sizeof(appstates) / sizeof(appstates[0])},
+        {"plm cmd", cmds, sizeof(cmds) / sizeof(cmds[0])}
+    };
+    size_t f;
+
+    for (f = 0; f < sizeof(families) / sizeof(families[0]); f++) {
+        for (i = 0; i < families[f].n; i++) {
+            for (j = i + 1; j < families[f].n; j++) {
+                if (families[f].vals[i] == families[f].vals[j]) {
+                    fprintf(stderr, "FAIL [%s]: duplicate value %d at entries %d and %d\n",
+                            families[f].name, (int) families[f].vals[i], (int) i, (int) j);
+                    failures++;
+                }
+            }
+        }
+    }
+
+    /* the boundaries are load-bearing: code all over the tree decides
+     * "still running?" and "abnormal?" by comparing against them */
+    CHECK("job running states below UNTERMINATED",
+          PRTE_JOB_STATE_STARTED < PRTE_JOB_STATE_UNTERMINATED &&
+          PRTE_JOB_STATE_RUNNING < PRTE_JOB_STATE_UNTERMINATED &&
+          PRTE_JOB_STATE_READY_FOR_DEBUG < PRTE_JOB_STATE_UNTERMINATED);
+    CHECK("job TERMINATED above UNTERMINATED",
+          PRTE_JOB_STATE_UNTERMINATED < PRTE_JOB_STATE_TERMINATED);
+    CHECK("job errors above ERROR",
+          PRTE_JOB_STATE_TERMINATED < PRTE_JOB_STATE_ERROR &&
+          PRTE_JOB_STATE_ERROR < PRTE_JOB_STATE_FAILED_TO_START &&
+          PRTE_JOB_STATE_ERROR < PRTE_JOB_STATE_NEVER_LAUNCHED);
+    CHECK("proc running states below UNTERMINATED",
+          PRTE_PROC_STATE_RUNNING < PRTE_PROC_STATE_UNTERMINATED &&
+          PRTE_PROC_STATE_REGISTERED < PRTE_PROC_STATE_UNTERMINATED);
+    CHECK("proc TERMINATED above UNTERMINATED",
+          PRTE_PROC_STATE_UNTERMINATED < PRTE_PROC_STATE_TERMINATED);
+    CHECK("proc errors above ERROR",
+          PRTE_PROC_STATE_TERMINATED < PRTE_PROC_STATE_ERROR &&
+          PRTE_PROC_STATE_ERROR < PRTE_PROC_STATE_FAILED_TO_START &&
+          PRTE_PROC_STATE_ERROR < PRTE_PROC_STATE_COMM_FAILED);
+    /* external developers key off these starting points */
+    CHECK("job DYNAMIC above every defined job state",
+          PRTE_JOB_STATE_FT_RESTART < PRTE_JOB_STATE_DYNAMIC);
+    CHECK("proc DYNAMIC above every defined proc state",
+          PRTE_PROC_STATE_PEER_UNKNOWN < PRTE_PROC_STATE_DYNAMIC);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_state_code_uniqueness\n");
+    }
+    return failures;
+}
+
+/*
+ * The selected module is copied wholesale into prte_plm and called without
+ * NULL checks, so every slot a launcher relies on must be wired. Only
+ * remote_spawn is genuinely optional (ssh alone implements the tree
+ * fan-out) and finalize is optional for the default module.
+ */
+static int test_module_contract(void)
+{
+    int failures = 0;
+
+    /* the default "local only" module installed by the framework */
+    CHECK("default init set", NULL != prte_plm.init);
+    CHECK("default set_hnp_name set", NULL != prte_plm.set_hnp_name);
+    CHECK("default spawn set", NULL != prte_plm.spawn);
+    CHECK("default terminate_job set", NULL != prte_plm.terminate_job);
+    CHECK("default terminate_orteds set", NULL != prte_plm.terminate_orteds);
+    CHECK("default terminate_procs set", NULL != prte_plm.terminate_procs);
+    CHECK("default signal_job set", NULL != prte_plm.signal_job);
+    CHECK("default set_hnp_name identity",
+          prte_plm_base_set_hnp_name == prte_plm.set_hnp_name);
+    CHECK("default terminate_job identity",
+          prte_plm_base_prted_terminate_job == prte_plm.terminate_job);
+    CHECK("default terminate_procs identity",
+          prte_plm_base_prted_kill_local_procs == prte_plm.terminate_procs);
+    CHECK("default signal_job identity",
+          prte_plm_base_prted_signal_local_procs == prte_plm.signal_job);
+
+    /* ssh: the always-available fallback and the only tree-spawner */
+    CHECK("ssh init set", NULL != prte_plm_ssh_module.init);
+    CHECK("ssh set_hnp_name set", NULL != prte_plm_ssh_module.set_hnp_name);
+    CHECK("ssh spawn set", NULL != prte_plm_ssh_module.spawn);
+    CHECK("ssh remote_spawn set", NULL != prte_plm_ssh_module.remote_spawn);
+    CHECK("ssh terminate_job set", NULL != prte_plm_ssh_module.terminate_job);
+    CHECK("ssh terminate_orteds set", NULL != prte_plm_ssh_module.terminate_orteds);
+    CHECK("ssh terminate_procs set", NULL != prte_plm_ssh_module.terminate_procs);
+    CHECK("ssh signal_job set", NULL != prte_plm_ssh_module.signal_job);
+    CHECK("ssh finalize set", NULL != prte_plm_ssh_module.finalize);
+    CHECK("ssh set_hnp_name identity",
+          prte_plm_base_set_hnp_name == prte_plm_ssh_module.set_hnp_name);
+    CHECK("ssh component name",
+          0 == strcmp(prte_mca_plm_ssh_component.super.pmix_mca_component_name, "ssh"));
+
+    /* the base defaults every component inherits */
+    CHECK("nodes assigned at launch defaults true",
+          prte_plm_globals.daemon_nodes_assigned_at_launch);
+    CHECK("environ mca params passed by default", prte_plm_globals.pass_environ_mca_params);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_module_contract\n");
+    }
+    return failures;
+}
+
+/*
+ * wrap_args quotes the VALUE of any option whose name ends in "mca" so a
+ * multi-word value survives the trip through a shell or a launcher.
+ */
+static int test_wrap_args(void)
+{
+    int failures = 0;
+    char **argv = NULL;
+
+    PMIx_Argv_append_nosize(&argv, "prted");
+    PMIx_Argv_append_nosize(&argv, "--prtemca");
+    PMIx_Argv_append_nosize(&argv, "prte_base_help_aggregate");
+    PMIx_Argv_append_nosize(&argv, "one two");
+    PMIx_Argv_append_nosize(&argv, "--pmixmca");
+    PMIx_Argv_append_nosize(&argv, "pmix_foo");
+    PMIx_Argv_append_nosize(&argv, "\"already quoted\"");
+    PMIx_Argv_append_nosize(&argv, "--leave-session-attached");
+
+    prte_plm_base_wrap_args(argv);
+
+    CHECK("value after --prtemca is quoted", 0 == strcmp(argv[3], "\"one two\""));
+    CHECK("mca option name untouched", 0 == strcmp(argv[2], "prte_base_help_aggregate"));
+    CHECK("already-quoted value left alone", 0 == strcmp(argv[6], "\"already quoted\""));
+    CHECK("non-mca args untouched", 0 == strcmp(argv[0], "prted"));
+    CHECK("trailing non-mca arg untouched",
+          0 == strcmp(argv[7], "--leave-session-attached"));
+    PMIx_Argv_free(argv);
+
+    /* a truncated tail must not run off the end of the array */
+    argv = NULL;
+    PMIx_Argv_append_nosize(&argv, "--prtemca");
+    PMIx_Argv_append_nosize(&argv, "dangling");
+    prte_plm_base_wrap_args(argv);
+    CHECK("dangling mca option survives", 0 == strcmp(argv[1], "dangling"));
+    PMIx_Argv_free(argv);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_wrap_args\n");
+    }
+    return failures;
+}
+
+/*
+ * setup_prted_cmd splits the launch agent and returns the index of the
+ * "prted" word, which is what lets ssh separate a wrapper prefix
+ * ("valgrind --tool=memcheck prted") from the daemon command itself.
+ */
+static int test_setup_prted_cmd(void)
+{
+    int failures = 0;
+    char *save = prte_launch_agent;
+    char **argv;
+    int argc, loc;
+
+    prte_launch_agent = "prted";
+    argv = NULL;
+    argc = 0;
+    loc = prte_plm_base_setup_prted_cmd(&argc, &argv);
+    CHECK("plain prted -> index 0", 0 == loc);
+    CHECK("plain prted -> one word", 1 == argc && 0 == strcmp(argv[0], "prted"));
+    PMIx_Argv_free(argv);
+
+    prte_launch_agent = "valgrind --tool=memcheck prted";
+    argv = NULL;
+    argc = 0;
+    loc = prte_plm_base_setup_prted_cmd(&argc, &argv);
+    CHECK("wrapped prted -> index of prted", 2 == loc);
+    CHECK("wrapped prted -> all words kept", 3 == argc);
+    CHECK("wrapped prted -> wrapper first", 0 == strcmp(argv[0], "valgrind"));
+    CHECK("wrapped prted -> prted at loc", 0 == strcmp(argv[loc], "prted"));
+    PMIx_Argv_free(argv);
+
+    /* a custom daemon: no "prted" word at all, so nothing to prefix */
+    prte_launch_agent = "my_daemon";
+    argv = NULL;
+    argc = 0;
+    loc = prte_plm_base_setup_prted_cmd(&argc, &argv);
+    CHECK("custom daemon -> index 0", 0 == loc);
+    CHECK("custom daemon -> kept verbatim", 0 == strcmp(argv[0], "my_daemon"));
+    PMIx_Argv_free(argv);
+
+    prte_launch_agent = save;
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_setup_prted_cmd\n");
+    }
+    return failures;
+}
+
+/*
+ * The daemon command line every launcher hands to its launch mechanism.
+ * We drive it as a non-master so it reads the daemon count from
+ * prte_process_info rather than needing a daemon job object.
+ */
+static int test_append_basic_args(void)
+{
+    int failures = 0;
+    char **argv = NULL;
+    int argc = 0, vpid_index = -1;
+    prte_proc_type_t save_type = prte_process_info.proc_type;
+    char *save_uri = prte_process_info.my_hnp_uri;
+
+    PRTE_PROC_MY_NAME->rank = 0;
+    prte_process_info.proc_type = PRTE_PROC_DAEMON;
+    prte_process_info.num_daemons = 7;
+    prte_process_info.my_hnp_uri = strdup("prte-test@0.0;tcp://10.0.0.1:1234");
+
+    /* a normal param, one whose VALUE contains '=', and three that must be
+     * dropped because the daemons must not re-run mapping/allocation or
+     * open a PLM they were not told to open */
+    setenv("PRTE_MCA_plm_base_verbose", "5", 1);
+    setenv("PRTE_MCA_prte_test_kv", "a=b", 1);
+    setenv("PRTE_MCA_rmaps_base_mapping_policy", "byslot", 1);
+    setenv("PRTE_MCA_ras_base_verbose", "5", 1);
+    setenv("PRTE_MCA_plm", "ssh", 1);
+
+    CHECK("append_basic_args succeeds",
+          PRTE_SUCCESS == prte_plm_base_prted_append_basic_args(&argc, &argv, "env", &vpid_index));
+
+    /* the vpid slot must be recorded so the launcher can substitute the
+     * real vpid per node */
+    CHECK("vpid index recorded", 0 <= vpid_index && vpid_index < argc);
+    if (0 <= vpid_index && vpid_index < argc) {
+        CHECK("vpid slot holds the template", 0 == strcmp(argv[vpid_index], "<template>"));
+        CHECK("vpid slot follows ess_base_vpid",
+              0 == strcmp(argv[vpid_index - 1], "ess_base_vpid"));
+    }
+
+    CHECK("ess module passed", has_mca(argv, "--prtemca", "ess", "env"));
+    CHECK("daemon nspace passed",
+          has_mca(argv, "--prtemca", "ess_base_nspace", prte_process_info.myproc.nspace));
+    CHECK("daemon count passed", has_mca(argv, "--prtemca", "ess_base_num_procs", "7"));
+    CHECK("hnp uri passed",
+          has_mca(argv, "--prtemca", "prte_hnp_uri", prte_process_info.my_hnp_uri));
+
+    /* environment-derived params: forwarded, with the value intact */
+    CHECK("environ mca param forwarded",
+          has_mca(argv, "--prtemca", "plm_base_verbose", "5"));
+    CHECK("mca value containing '=' is not truncated",
+          has_mca(argv, "--prtemca", "prte_test_kv", "a=b"));
+
+    /* ... except the frameworks the daemons must never open */
+    CHECK("rmaps param dropped", !has_mca_name(argv, "rmaps_base_mapping_policy"));
+    CHECK("ras param dropped", !has_mca_name(argv, "ras_base_verbose"));
+    CHECK("plm selection dropped", !has_mca_name(argv, "plm"));
+
+    PMIx_Argv_free(argv);
+
+    /* the documented remedy for an over-long command line: drop the
+     * environment-derived params entirely, keeping everything else */
+    prte_plm_globals.pass_environ_mca_params = false;
+    argv = NULL;
+    argc = 0;
+    vpid_index = -1;
+    CHECK("append_basic_args succeeds (no environ params)",
+          PRTE_SUCCESS == prte_plm_base_prted_append_basic_args(&argc, &argv, "env", &vpid_index));
+    CHECK("environ mca param suppressed", !has_mca_name(argv, "plm_base_verbose"));
+    CHECK("required params still present", has_mca(argv, "--prtemca", "ess", "env"));
+    CHECK("vpid slot still recorded", 0 <= vpid_index && 0 <= idx_of(argv, "<template>"));
+    PMIx_Argv_free(argv);
+    prte_plm_globals.pass_environ_mca_params = true;
+
+    unsetenv("PRTE_MCA_plm_base_verbose");
+    unsetenv("PRTE_MCA_prte_test_kv");
+    unsetenv("PRTE_MCA_rmaps_base_mapping_policy");
+    unsetenv("PRTE_MCA_ras_base_verbose");
+    unsetenv("PRTE_MCA_plm");
+    free(prte_process_info.my_hnp_uri);
+    prte_process_info.my_hnp_uri = save_uri;
+    prte_process_info.proc_type = save_type;
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_append_basic_args\n");
+    }
+    return failures;
+}
+
+/*
+ * The DVM's base nspace and the "base@N" job nspaces derived from it. Every
+ * job in the DVM -- and the routing that finds it -- keys off these names.
+ */
+static int test_naming(void)
+{
+    int failures = 0;
+    char *save_base = prte_plm_globals.base_nspace;
+    uint32_t save_next = prte_plm_globals.next_jobid;
+    pmix_proc_t save_me, save_hnp;
+    prte_job_t *jdata;
+    char expect[PMIX_MAX_NSLEN + 1];
+
+    memcpy(&save_me, PRTE_PROC_MY_NAME, sizeof(pmix_proc_t));
+    memcpy(&save_hnp, PRTE_PROC_MY_HNP, sizeof(pmix_proc_t));
+
+    /* create_jobid registers the job, so we need the global job array that
+     * a full prte_init() would have built for us */
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
+                                PRTE_GLOBAL_ARRAY_MAX_SIZE, PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
+    }
+
+    /* set_hnp_name honors an inherited PMIx server nspace */
+    setenv("PMIX_SERVER_NSPACE", "inherited-nspace", 1);
+    prte_plm_globals.base_nspace = NULL;
+    CHECK("set_hnp_name (inherited) succeeds", PRTE_SUCCESS == prte_plm_base_set_hnp_name());
+    CHECK("inherited nspace adopted",
+          NULL != prte_plm_globals.base_nspace &&
+          0 == strcmp(prte_plm_globals.base_nspace, "inherited-nspace"));
+    CHECK("inherited nspace is my nspace",
+          0 == strcmp(PRTE_PROC_MY_NAME->nspace, "inherited-nspace"));
+    CHECK("HNP is me", 0 == strcmp(PRTE_PROC_MY_HNP->nspace, PRTE_PROC_MY_NAME->nspace) &&
+                       PRTE_PROC_MY_HNP->rank == PRTE_PROC_MY_NAME->rank);
+    free(prte_plm_globals.base_nspace);
+    unsetenv("PMIX_SERVER_NSPACE");
+
+    /* otherwise it derives one and hangs the HNP off it at "@0" */
+    prte_plm_globals.base_nspace = strdup("prte-testhost-1234");
+    CHECK("set_hnp_name succeeds", PRTE_SUCCESS == prte_plm_base_set_hnp_name());
+    CHECK("HNP nspace is base@0",
+          0 == strcmp(PRTE_PROC_MY_NAME->nspace, "prte-testhost-1234@0"));
+    CHECK("HNP rank is 0", 0 == PRTE_PROC_MY_NAME->rank);
+    CHECK("HNP field mirrors my name",
+          0 == strcmp(PRTE_PROC_MY_HNP->nspace, PRTE_PROC_MY_NAME->nspace));
+
+    /* jobids are handed out monotonically from the same base */
+    prte_plm_globals.next_jobid = 1;
+    jdata = PMIX_NEW(prte_job_t);
+    CHECK("create_jobid succeeds", PRTE_SUCCESS == prte_plm_base_create_jobid(jdata));
+    snprintf(expect, sizeof(expect), "%s@1", prte_plm_globals.base_nspace);
+    CHECK("first jobid is base@1", 0 == strcmp(jdata->nspace, expect));
+    CHECK("job is registered", jdata == prte_get_job_data_object(jdata->nspace));
+    CHECK("next_jobid advanced", 2 == prte_plm_globals.next_jobid);
+
+    /* a restarting job keeps the nspace it already has */
+    PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_RESTART);
+    CHECK("create_jobid on restart succeeds", PRTE_SUCCESS == prte_plm_base_create_jobid(jdata));
+    CHECK("restart kept its nspace", 0 == strcmp(jdata->nspace, expect));
+    CHECK("restart did not consume a jobid", 2 == prte_plm_globals.next_jobid);
+    PRTE_FLAG_UNSET(jdata, PRTE_JOB_FLAG_RESTART);
+
+    free(prte_plm_globals.base_nspace);
+    prte_plm_globals.base_nspace = save_base;
+    prte_plm_globals.next_jobid = save_next;
+    memcpy(PRTE_PROC_MY_NAME, &save_me, sizeof(pmix_proc_t));
+    memcpy(PRTE_PROC_MY_HNP, &save_hnp, sizeof(pmix_proc_t));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_naming\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_state_code_uniqueness();
+    failures += test_module_contract();
+    failures += test_wrap_args();
+    failures += test_setup_prted_cmd();
+    failures += test_append_basic_args();
+    failures += test_naming();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all plm unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d plm unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
A review of the whole of `src/mca/plm`, and the fixes that came out of it. Two
of them are elastic-DVM bugs that made a grow hang; the rest are defects on
paths that a single-node smoke test never reaches — a launcher failing, a
daemon reporting twice, a job that has already completed, a shrink having
removed a daemon.

Reviewed with fresh eyes rather than against a symptom, so the framework
`AGENTS.md` files were corrected where they described behavior that turned out
not to be what the code does.

### Elastic DVM: two reasons a grow never completed

**A grow after a shrink hung.** The daemons launched, reported home, and the
DVM reached `VM_READY` — the launch was entirely healthy — but the phase-two
completion event was never emitted, so the requester timed out and the DVM was
left wedged behind an unresolved fence. Releasing a reservation returns its
nodes to the default pool with `->session` cleared, so the node a shrink just
removed is re-absorbed by the next grow and, being already in the pool, takes
the *lowest* new vpid — the `map->daemon_vpid_start` slot the campaign read its
requester from. No session there, no requester recorded, no event emitted.

**A grow that needed no new daemon never completed either.** Growing by a node
already in the DVM records no campaign at all, so nothing ever told the
requester that what it asked for was already true.

### Elastic DVM: a grow was not scoped to the nodes it was granted

An allocation request naming `node4` started a daemon on every node in the pool
that lacked one. After a shrink that includes the node just removed, so `grow
node4` quietly relaunched a daemon on the node the user had shrunk away. Every
producer of a grow already marks its nodes `PRTE_NODE_STATE_ADDED` "so the DVM
extension will include it" — nothing on the plm side read that mark. It does
now, as the dynamic-spawn path always has. `prte_ras_base_node_insert` also
carries the mark onto a pool entry that already exists, which is what makes
re-growing a previously shrunk node work.

### Leaks

`node->topology` and `proc->node` were both bare pointers into
reference-counted objects. The topology one meant a node's lifetime depended on
global teardown order; the proc one formed a genuine cycle with `node->daemon`
/ `node->procs`, so neither destructor could ever run and every node and proc
in a DVM leaked. Both are now correct: the topology is retained, the node
backpointer is borrowed and cleared by the node that owns it. Measured with
`leaks` on a two-proc `prterun`: 38 leaks / 20528 bytes → 20 leaks / 15536
bytes.

Smaller ones: `ssh` leaked a launch caddy — a full copy of the remote command
line plus a retained proc — for *every* daemon it started, because
`ssh_wait_daemon` released it only on its early-return path; `setup_vm` leaked
its node lists on error returns and on the max-vm-size path; `lsf` never freed
its nodelist; `slurm` leaked its flattened nodelist; `ssh`/`pals` leaked the
prefix strings each launch; a re-reporting daemon leaked its previous contact
URI; and a rejected spawn request leaked the job object it had unpacked.

### Crashes and wrong answers

- `ssh` dereferenced `node->daemon` in the tree-spawn filter, ahead of the NULL
  check the very next block performs.
- `pals` could never report a failed launch: `failed_launch` is a file-static
  that was only ever assigned `false`, so a broken launch hung instead of
  aborting. **Wants validation on real hardware — see #2547.**
- A job object that failed to unpack left `jdata` uninitialized for the error
  path that then dereferenced it, and a ready-for-debug report naming a
  completed job dereferenced NULL — either one crashes the HNP on input from a
  tool.
- Under `prte_homo_nodes`, the topology was read from daemon rank 1
  unconditionally; rank 1 need not still exist once a shrink can remove it.
- MCA values were split on *every* `=` when building the daemon command line,
  silently truncating any value containing one.
- `plm_ssh_pass_environ_mca_params` — the remedy the `cmd-line-too-long` help
  text tells users to apply — was registered and never read.
- The daemon-failure wire carried a raw `waitpid` status from one sender and a
  PRTE error code from another, with `WEXITSTATUS` applied to both.

Also removed six declarations with no implementation, an `assert(0)` stub
nothing calls, and `plm_ssh_delay` (parsed, never read).

### Testing

- **`test/unit/plm`** (new, in `make check`): state/command-code uniqueness and
  the UNTERMINATED/TERMINATED/ERROR boundaries, the module vtable contract,
  `wrap_args`, `setup_prted_cmd`, the full `prted_append_basic_args` command
  line, and jobid assignment.
- **dockerswarm**: tree-spawn fan-out (radix 2, so the fan-out has to recurse),
  flat and throttled launch, `=`-bearing MCA values, `pass_environ_mca_params
  0`, node-name/alias reconciliation by IP, `--uniform-nodes` topology
  inheritance, and the grow-after-shrink cases above including that a grow
  leaves nodes it was not given alone. valgrind is now in the image, since the
  paths worth leak-checking need real daemons.
- macOS: a rejected `prun` must not take the DVM down, plus `--uniform-nodes`
  and an `=`-bearing MCA value.

Verified: warning-free `--enable-debug` build, `make check` 8/8,
`check-offline` 1176/1176, dockerswarm linux 46/0, macOS 10/0/3.

### Known gaps

- slurm/lsf/pals changes are compile-tested only (`--enable-testbuild-launchers`).
  #2547 asks for PALS validation; #2546 tracks a slurm count-vs-capacity
  comparison I deliberately did not change.
- A 4-node valgrind run still shows ~17KB lost in RML send objects and ~1.4KB
  in child-job references never dropped by `prte_finalize` — both outside plm,
  both untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
