### PR TITLE
rmaps: keep the job proc count intact across a per-app map

### DIFF
--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -159,7 +159,14 @@ static int lsf_map(prte_job_t *jdata,
 
     /* start at the beginning... */
     vpid_start = 0;
-    jdata->num_procs = 0;
+    /* Zero the job-wide count only when we were handed the whole job. The
+     * per-app (MPMD) dispatch calls us once per app, and resetting here
+     * would leave jdata->num_procs holding just the last app's count while
+     * jdata->procs holds every app's procs - a mismatch the job packer and
+     * unpacker disagree about, corrupting the launch message. */
+    if (options->app_idx < 0) {
+        jdata->num_procs = 0;
+    }
     num_ranks = 0;
     PMIX_CONSTRUCT(&rankmap, pmix_pointer_array_t);
     rc = pmix_pointer_array_init(&rankmap,

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -177,7 +177,14 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
 
     /* start at the beginning... */
     vpid_start = 0;
-    jdata->num_procs = 0;
+    /* Zero the job-wide count only when we were handed the whole job. The
+     * per-app (MPMD) dispatch calls us once per app, and resetting here
+     * would leave jdata->num_procs holding just the last app's count while
+     * jdata->procs holds every app's procs - a mismatch the job packer and
+     * unpacker disagree about, corrupting the launch message. */
+    if (options->app_idx < 0) {
+        jdata->num_procs = 0;
+    }
     PMIX_CONSTRUCT(&rankmap, pmix_pointer_array_t);
     rc = pmix_pointer_array_init(&rankmap,
                                  PRTE_GLOBAL_ARRAY_BLOCK_SIZE,

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -97,7 +97,14 @@ static int prte_rmaps_rr_map(prte_job_t *jdata,
     jdata->map->last_mapper = strdup(c->pmix_mca_component_name);
 
     /* start at the beginning... */
-    jdata->num_procs = 0;
+    /* Zero the job-wide count only when we were handed the whole job. The
+     * per-app (MPMD) dispatch calls us once per app, and resetting here
+     * would leave jdata->num_procs holding just the last app's count while
+     * jdata->procs holds every app's procs - a mismatch the job packer and
+     * unpacker disagree about, corrupting the launch message. */
+    if (options->app_idx < 0) {
+        jdata->num_procs = 0;
+    }
 
     /* cycle through the app_contexts, mapping them sequentially */
     for (i = 0; i < jdata->apps->size; i++) {

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -166,7 +166,14 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
 
     /* start at the beginning... */
     vpid = 0;
-    jdata->num_procs = 0;
+    /* Zero the job-wide count only when we were handed the whole job. The
+     * per-app (MPMD) dispatch calls us once per app, and resetting here
+     * would leave jdata->num_procs holding just the last app's count while
+     * jdata->procs holds every app's procs - a mismatch the job packer and
+     * unpacker disagree about, corrupting the launch message. */
+    if (options->app_idx < 0) {
+        jdata->num_procs = 0;
+    }
 
     /* cycle through the app_contexts, mapping them sequentially */
     for (i = 0; i < jdata->apps->size; i++) {


### PR DESCRIPTION
## Problem

An MPMD command line where any app carries its own `--map-by`, `--rank-by` or
`--bind-to` corrupts the launch message sent to the daemons:

```
prterun --host node1:2,node2:2 -np 2 --map-by core hostname : -np 2 hostname

PMIX ERROR: PMIX_ERR_UNPACK_INADEQUATE_SPACE in file prte_dt_unpacking_fns.c at line 223
PMIX ERROR: PMIX_ERR_UNPACK_INADEQUATE_SPACE in file odls_base_default_fns.c at line 697
```

A per-app policy sends the job down the per-app dispatch in
`prte_rmaps_base_map_job`, which runs the mappers once per app instead of once
per job. Four of the five mappers (`round_robin`, `seq`, `rank_file`, `lsf`)
open by zeroing `jdata->num_procs`, so when that loop ends the job-wide count
holds only the *last* app's procs while `jdata->procs` holds every app's.

The two halves of the job packer then disagree about which is the truth:
`prte_job_pack` packs every non-NULL entry it finds in the proc array but
records `num_procs`, and `prte_job_unpack` reads back exactly `num_procs` of
them. Whatever is left over is read as the fields that follow it, and the
daemon fails to construct its child list.

The job still runs — the HNP holds the correct map — so this looks harmless
from the command line. It is not: the launch message is corrupt from the proc
array onward, and because the launch never completes cleanly the spawn
requestor is never sent its response. That also strands the PMIx spawn caddy
(the requestor promised a callback that never arrives), which is how this was
originally found — as an apparent leak in `PMIx_Spawn_nb`.

Verified pre-existing on master (`123f414887`); it is not a regression from
any recent work.

## Fix

Zero the count only when the mapper was handed the whole job, i.e. when
`options->app_idx < 0`. The `ppr` mapper never zeroed it and was already
correct; the per-app accumulation each mapper already does then yields the job
total either way.

## Testing

- warning-free `--enable-debug` build
- `make check` 8/8
- `make -C test/offline check-offline` 1176/1176 (mandatory here — this touches
  the mappers)
- `contrib/dockerswarm/run-tests.sh linux` 46 passed / 0 failed
- the reproducer above, and `--map-by` on both apps, now run clean with correct
  output; valgrind reports 0 bytes lost where the MPMD case previously leaked
- macOS MPMD smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)