### PR TITLE
Plug the memory leaks a Linux valgrind run reports

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -89,7 +89,8 @@ build_linux() {
                 echo ">>>> PMIx from bind-mounted /pmix-src -> $PMIX_PREFIX"
                 mkdir -p /opt/prte/vpath-linux-pmix && cd /opt/prte/vpath-linux-pmix
                 [ -f config.status ] || /pmix-src/configure --prefix="$PMIX_PREFIX"
-                make -j"$jobs" && make install
+                make -j"$jobs"
+                make install
             else
                 PMIX_PREFIX=/usr/local
                 echo ">>>> PMIx: using baked $PMIX_PREFIX"
@@ -99,7 +100,8 @@ build_linux() {
             mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
             [ -f config.status ] || /prrte-src/configure \
                 --prefix=/opt/prte/prte --with-pmix="$PMIX_PREFIX" --enable-debug
-            make -j"$jobs" && make install
+            make -j"$jobs"
+            make install
 
             echo ">>>> elastic test client"
             gcc -O0 -g -o /opt/prte/prte/bin/elastic \
@@ -127,7 +129,8 @@ build_macos() {
         ( cd "$psrc" && { [ -x configure ] || ./autogen.pl; } )
         mkdir -p "$root/vpath-macos-pmix" && cd "$root/vpath-macos-pmix"
         [ -f config.status ] || "$psrc/configure" --prefix="$pfx"
-        make -j"$(sysctl -n hw.ncpu)" && make install
+        make -j"$(sysctl -n hw.ncpu)"
+        make install
         pmix_arg="--with-pmix=$pfx"
     elif [ -n "$PMIX_HOME" ]; then
         pmix_arg="--with-pmix=$PMIX_HOME"
@@ -157,7 +160,8 @@ build_macos() {
         "$root/configure" $cfg_args
         printf '%s' "$cfg_args" > .prte-configure-args
     fi
-    make -j"$(sysctl -n hw.ncpu)" && make install
+    make -j"$(sysctl -n hw.ncpu)"
+    make install
     echo ">>> macOS build complete: $root/vpath-macos/install"
     # Report what the tools actually resolved against. A mismatch here is the
     # first thing to check when the macOS suite starts skipping everything.

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -280,6 +280,14 @@ PRTE_EXPORT hwloc_obj_t prte_hwloc_base_get_obj_by_type(hwloc_topology_t topo,
 PRTE_EXPORT void prte_hwloc_base_reset_counters(void);
 
 /**
+ * Release the cached data objects PRRTE attaches to the userdata of a
+ * topology's objects, and to the topology's root. Must be called before
+ * the topology itself is destroyed - hwloc does not know these pointers
+ * are ours to free.
+ */
+PRTE_EXPORT void prte_hwloc_base_release_userdata(hwloc_topology_t topo);
+
+/**
  * Get the number of pu's under a given hwloc object.
  */
 PRTE_EXPORT unsigned int prte_hwloc_base_get_npus(hwloc_topology_t topo, bool use_hwthread_cpus,

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -279,6 +279,7 @@ void prte_hwloc_base_close(void)
 
     /* destroy the topology */
     if (NULL != prte_hwloc_topology) {
+        prte_hwloc_base_release_userdata(prte_hwloc_topology);
         hwloc_topology_destroy(prte_hwloc_topology);
         prte_hwloc_topology = NULL;
     }

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -2217,3 +2217,41 @@ void prte_hwloc_base_reset_counters(void)
         }
     }
 }
+
+/* release the userdata hanging off every object at one level of a topology */
+static void release_level_userdata(hwloc_topology_t topo, int depth)
+{
+    hwloc_obj_t obj;
+    unsigned width, w;
+
+    width = hwloc_get_nbobjs_by_depth(topo, depth);
+    for (w = 0; w < width; w++) {
+        obj = hwloc_get_obj_by_depth(topo, depth, w);
+        if (NULL != obj && NULL != obj->userdata) {
+            /* both of the things we attach - the topology summary on the
+             * root and the per-object placement counters - are PMIx
+             * objects, so a release is correct either way */
+            PMIX_RELEASE(obj->userdata);
+            obj->userdata = NULL;
+        }
+    }
+}
+
+void prte_hwloc_base_release_userdata(hwloc_topology_t topo)
+{
+    int depth, d;
+
+    if (NULL == topo) {
+        return;
+    }
+
+    /* the normal levels, root (depth 0) included */
+    depth = hwloc_topology_get_depth(topo);
+    for (d = 0; d < depth; d++) {
+        release_level_userdata(topo, d);
+    }
+    /* NUMA nodes are not part of the normal depth hierarchy in hwloc 2.x,
+     * so they have to be swept separately - binding can attach counters to
+     * them just as it does to packages and cores */
+    release_level_userdata(topo, HWLOC_TYPE_DEPTH_NUMANODE);
+}

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -704,6 +704,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
         tmp = strdup(full_orted_cmd);
     }
     PMIx_Argv_append_nosize(&final_argv, tmp);
+    free(tmp); /* the append copied it */
     free(full_orted_cmd);
 
     /* now add the final cmd to the argv array */

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -314,6 +314,26 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
  * reflects any reset to BIND_TO_NONE the mapper made for a genuinely
  * oversubscribed node. These are stored as job-local attributes and are never
  * packed or sent off-node. */
+/* return the per-node scratch cpusets a mapper computed into an options
+ * struct. The mappers recycle these as they walk the node list, so the
+ * final node's pair is still held when the map returns. */
+static void free_target(prte_rmaps_options_t *opts)
+{
+    if (NULL != opts->target) {
+        hwloc_bitmap_free(opts->target);
+        opts->target = NULL;
+    }
+}
+
+static void free_cpusets(prte_rmaps_options_t *opts)
+{
+    if (NULL != opts->job_cpuset) {
+        hwloc_bitmap_free(opts->job_cpuset);
+        opts->job_cpuset = NULL;
+    }
+    free_target(opts);
+}
+
 static void record_resolved_app_policy(prte_app_context_t *app,
                                        prte_mapping_policy_t jobmap,
                                        prte_ranking_policy_t jobrank,
@@ -375,6 +395,9 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     bool colocate = false;
     prte_schizo_base_module_t *schizo;
     prte_rmaps_options_t options;
+    /* per-app scratch for the MPMD dispatch path - at function scope so the
+     * cleanup label can reclaim the cpusets a mapper left in it */
+    prte_rmaps_options_t app_options;
     pmix_data_array_t *darray = NULL;
     pmix_list_t nodes;
     int slots, len;
@@ -386,6 +409,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(caddy);
     // init options
     memset(&options, 0, sizeof(prte_rmaps_options_t));
+    memset(&app_options, 0, sizeof(prte_rmaps_options_t));
     options.app_idx = -1;   /* -1 = map all apps (default) */
     options.stream = prte_rmaps_base_framework.framework_output;
     options.verbosity = 5;  // usual value for base-level functions
@@ -1270,7 +1294,14 @@ ranking:
                 continue;
             }
 
-            prte_rmaps_options_t app_options = options;   /* shallow copy of job defaults */
+            /* hand back whatever the previous app's map left behind before
+             * this app overwrites it */
+            free_cpusets(&app_options);
+            app_options = options;   /* shallow copy of job defaults */
+            /* the copy must not inherit ownership of the job-level cpusets -
+             * the mappers compute their own per node */
+            app_options.job_cpuset = NULL;
+            app_options.target = NULL;
             app_options.app_idx = n;
             /* the default-binding nprocs rule keys off this app's own proc
              * count, not the job-wide total inherited from options.nprocs.
@@ -1397,14 +1428,8 @@ cleanup:
             PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_MAPPED);
         }
     }
-    if (NULL != options.job_cpuset) {
-        hwloc_bitmap_free(options.job_cpuset);
-        options.job_cpuset = NULL;
-    }
-    if (NULL != options.target) {
-        hwloc_bitmap_free(options.target);
-        options.target = NULL;
-    }
+    free_cpusets(&options);
+    free_cpusets(&app_options);
     /* cleanup */
     PMIX_RELEASE(caddy);
 }
@@ -1567,6 +1592,7 @@ static int map_colocate(prte_job_t *jdata,
             // setup the mapping options
             options->ncpus = prte_rmaps_base_get_ncpus(nptr, NULL, options);
             /* the available cpus are in the scratch location */
+            free_target(options);
             options->target = hwloc_bitmap_dup(prte_rmaps_base.available);
             options->nprocs = procs_per_target;
            // Assign N procs per node for each app_context
@@ -1631,6 +1657,7 @@ static int map_colocate(prte_job_t *jdata,
         // setup the mapping options
         options->ncpus = prte_rmaps_base_get_ncpus(nptr, NULL, options);
         /* the available cpus are in the scratch location */
+        free_target(options);
         options->target = hwloc_bitmap_dup(prte_rmaps_base.available);
         // count the number of target procs on this node
         cnt = 0;

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -68,6 +68,7 @@ static void buffer_cleanup(void *value)
         for (i = 0; i < PRTE_RMAPS_PRINT_NUM_BUFS; i++) {
             free(ptr->buffers[i]);
         }
+        free(ptr);
     }
 }
 

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -752,6 +752,17 @@ int prte_rmaps_base_get_ncpus(prte_node_t *node,
     return ncpus;
 }
 
+/* the target cpuset is recomputed for every node we consider, so the one
+ * left over from the previous node has to go back before we build a new
+ * one - the mappers free only the final target when they are done */
+static void free_target(prte_rmaps_options_t *options)
+{
+    if (NULL != options->target) {
+        hwloc_bitmap_free(options->target);
+        options->target = NULL;
+    }
+}
+
 bool prte_rmaps_base_check_avail(prte_job_t *jdata,
                                  prte_app_context_t *app,
                                  prte_node_t *node,
@@ -788,10 +799,9 @@ bool prte_rmaps_base_check_avail(prte_job_t *jdata,
     }
 
     if (PRTE_BIND_TO_NONE == options->bind) {
+        free_target(options);
         if (NULL != options->job_cpuset) {
             options->target = hwloc_bitmap_dup(options->job_cpuset);
-        } else {
-            options->target = NULL;
         }
         avail = true;
         goto done;
@@ -799,6 +809,7 @@ bool prte_rmaps_base_check_avail(prte_job_t *jdata,
 
     options->ncpus = prte_rmaps_base_get_ncpus(node, obj, options);
     /* the available cpus are in the scratch location */
+    free_target(options);
     options->target = hwloc_bitmap_dup(prte_rmaps_base.available);
 
     // compute how many procs we can support on this object
@@ -840,6 +851,13 @@ void prte_rmaps_base_get_cpuset(prte_job_t *jdata,
                                 prte_rmaps_options_t *options)
 {
     PRTE_HIDE_UNUSED_PARAMS(jdata);
+
+    /* mappers call this once per candidate node, so drop the cpuset computed
+     * for the previous node before computing this one's */
+    if (NULL != options->job_cpuset) {
+        hwloc_bitmap_free(options->job_cpuset);
+        options->job_cpuset = NULL;
+    }
 
     if (NULL != options->cpuset) {
         options->job_cpuset = prte_hwloc_base_generate_cpuset(node->topology->topo,

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -68,6 +68,8 @@ static void job_info(pmix_cli_result_t *results,
 static int set_default_rto(prte_job_t *jdata,
                            prte_rmaps_options_t *options);
 
+char *prte_schizo_prte_version = NULL;
+
 prte_schizo_base_module_t prte_schizo_prte_module = {
     .name = "prte",
     .parse_cli = parse_cli,
@@ -538,8 +540,16 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     }
     pmix_tool_msg = "Report bugs to: https://github.com/openpmix/prrte";
     pmix_tool_org = "PRRTE";
-    pmix_tool_version = prte_util_make_version_string("all", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,
-                                                      PRTE_RELEASE_VERSION, PRTE_GREEK_VERSION, NULL);
+    /* PMIx only borrows this string, and a tool can parse more than one
+     * command line (prte parses its own, then each app's), so build it
+     * once and hand out the same copy - the component close releases it */
+    if (NULL == prte_schizo_prte_version) {
+        prte_schizo_prte_version = prte_util_make_version_string("all", PRTE_MAJOR_VERSION,
+                                                                 PRTE_MINOR_VERSION,
+                                                                 PRTE_RELEASE_VERSION,
+                                                                 PRTE_GREEK_VERSION, NULL);
+    }
+    pmix_tool_version = prte_schizo_prte_version;
     if (NULL == prte_process_info.sessdir_prefix) {
         prte_process_info.sessdir_prefix = strdup(sdprefix);
     }

--- a/src/mca/schizo/prte/schizo_prte.h
+++ b/src/mca/schizo/prte/schizo_prte.h
@@ -33,6 +33,10 @@ typedef struct {
 PRTE_MODULE_EXPORT extern prte_schizo_prte_component_t prte_mca_schizo_prte_component;
 extern prte_schizo_base_module_t prte_schizo_prte_module;
 
+/* the version string handed to PMIx for command-line output - built on
+ * first use by the module, released when the component closes */
+extern char *prte_schizo_prte_version;
+
 END_C_DECLS
 
 #endif /* MCA_SCHIZO_PRTE_H_ */

--- a/src/mca/schizo/prte/schizo_prte_component.c
+++ b/src/mca/schizo/prte/schizo_prte_component.c
@@ -26,6 +26,7 @@
 
 static int component_query(pmix_mca_base_module_t **module, int *priority);
 static int component_register(void);
+static int component_close(void);
 
 /*
  * Struct of function pointers and all that to let us be initialized
@@ -40,6 +41,7 @@ prte_schizo_prte_component_t prte_mca_schizo_prte_component = {
                                    PMIX_RELEASE_VERSION),
         .pmix_mca_query_component = component_query,
         .pmix_mca_register_component_params = component_register,
+        .pmix_mca_close_component = component_close,
     },
     .priority = 5,
     .warn_deprecations = true,
@@ -57,6 +59,16 @@ static int component_register(void)
                                                 PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                                 &prte_mca_schizo_prte_component.warn_deprecations);
 
+    return PRTE_SUCCESS;
+}
+
+static int component_close(void)
+{
+    /* the version string we handed PMIx is ours to reclaim */
+    if (NULL != prte_schizo_prte_version) {
+        free(prte_schizo_prte_version);
+        prte_schizo_prte_version = NULL;
+    }
     return PRTE_SUCCESS;
 }
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -310,10 +310,15 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, (void **) &cache, PMIX_POINTER)
         && NULL != cache) {
         while (NULL != (kv = (prte_info_item_t *) pmix_list_remove_first(cache))) {
+            /* the xfer copies the value, so we are done with the item
+             * regardless of whether it succeeded */
             PMIX_INFO_LIST_XFER(ret, info, &kv->info);
+            PMIX_RELEASE(kv);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_INFO_LIST_RELEASE(info);
+                prte_remove_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE);
+                PMIX_RELEASE(cache);
                 rc = prte_pmix_convert_status(ret);
                 return rc;
             }

--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -196,6 +196,12 @@ static void peer_des(prte_oob_tcp_peer_t *peer)
         CLOSE_THE_SOCKET(peer->sd);
     }
     PMIX_LIST_DESTRUCT(&peer->addrs);
+    /* the on-deck message is not in the send queue, so it has to be
+     * disposed of separately - along with anything still queued behind
+     * it, each of which still owns its RML message */
+    if (NULL != peer->send_msg) {
+        PMIX_RELEASE(peer->send_msg);
+    }
     PMIX_LIST_DESTRUCT(&peer->send_queue);
 }
 PMIX_CLASS_INSTANCE(prte_oob_tcp_peer_t, pmix_list_item_t, peer_cons, peer_des);

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -1161,6 +1161,7 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
     PMIX_LIST_FOREACH_SAFE(send, next, &peer->send_queue, prte_oob_tcp_send_t){
         send->msg->status = err;
         PRTE_RML_SEND_COMPLETE(send->msg);
+        send->msg = NULL; // completion released it
         pmix_list_remove_item(&peer->send_queue, &send->super);
         PMIX_RELEASE(send);
     }

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -254,6 +254,7 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
                                         (int) ntohl(msg->hdr.nbytes), peer->sd);
                     msg->msg->status = PRTE_SUCCESS;
                     PRTE_RML_SEND_COMPLETE(msg->msg);
+                    msg->msg = NULL; // completion released it
                     PMIX_RELEASE(msg);
                     peer->send_msg = NULL;
                 }
@@ -598,14 +599,17 @@ static void snd_cons(prte_oob_tcp_send_t *ptr)
     ptr->sdptr = NULL;
     ptr->sdbytes = 0;
 }
-/* we don't destruct any RML msg that is
- * attached to our send as the RML owns
- * that memory. However, if we relay a
- * msg, the data in the relay belongs to
- * us and must be free'd
+/* an OOB send owns the RML message attached to it until that message is
+ * completed - completion clears the pointer, so anything still attached
+ * here (a send abandoned when its peer was torn down) is ours to release.
+ * If we relay a msg, the data in the relay belongs to us as well and must
+ * be free'd
  */
 static void snd_des(prte_oob_tcp_send_t *ptr)
 {
+    if (NULL != ptr->msg) {
+        PMIX_RELEASE(ptr->msg);
+    }
     if (NULL != ptr->data) {
         free(ptr->data);
     }

--- a/src/rml/relm/state_machine.c
+++ b/src/rml/relm/state_machine.c
@@ -461,8 +461,10 @@ static void sm_cons(prte_relm_state_machine_t* sm){
 static void sm_dest(prte_relm_state_machine_t* sm){
     pmix_rank_t key;
     prte_relm_rank_t* val;
+    /* the ranks were allocated with PMIX_NEW, so they have to be released -
+     * destructing them runs the destructor but leaves the object itself */
     PMIX_HASH_TABLE_FOREACH(key, uint32, val, &sm->ranks){
-        PMIX_DESTRUCT(val);
+        PMIX_RELEASE(val);
     }
     PMIX_DESTRUCT(&sm->ranks);
     PMIX_DESTRUCT(&sm->cached_messages);

--- a/src/rml/relm/types.c
+++ b/src/rml/relm/types.c
@@ -38,8 +38,10 @@ static void rank_cons(prte_relm_rank_t* rank){
 static void rank_des(prte_relm_rank_t* rank){
     prte_relm_guid_t guid;
     prte_relm_msg_t* msg;
+    /* likewise, the cached messages came from PMIX_NEW and must be released
+     * rather than merely destructed */
     PMIX_HASH_TABLE_FOREACH(guid, uint64, msg, &rank->msgs){
-        PMIX_DESTRUCT(msg);
+        PMIX_RELEASE(msg);
     }
     PMIX_DESTRUCT(&rank->msgs);
 }

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -377,7 +377,10 @@ static void recv_cons(prte_rml_recv_t *ptr)
 }
 static void recv_des(prte_rml_recv_t *ptr)
 {
-    if (ptr->dbuf != NULL && 0 < ptr->dbuf->bytes_allocated) {
+    /* the buffer object is ours even when the recv callback unloaded its
+     * payload - releasing only when payload remains left the (now empty)
+     * buffer itself behind on every message whose handler took the data */
+    if (NULL != ptr->dbuf) {
         PMIX_DATA_BUFFER_RELEASE(ptr->dbuf);
     }
 }

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -301,15 +301,26 @@ PRTE_EXPORT bool prte_rml_is_node_up(pmix_rank_t node);
         PRTE_RML_ACTIVATE_MESSAGE(_msg);                                                    \
     } while (0);
 
+/* Complete a send: hand the message to its callback and dispose of the
+ * send object. The callback owns the data buffer, so the send's reference
+ * to it is dropped before release - otherwise the destructor would free a
+ * buffer the callback has already released. Nobody else holds a reference
+ * to the send object at this point, so the caller must not touch it after
+ * completing it.
+ */
 #define PRTE_RML_SEND_COMPLETE(m)                                                             \
     do {                                                                                      \
+        prte_rml_send_t *_snd = (m);                                                          \
+        pmix_data_buffer_t *_dbuf = _snd->dbuf;                                               \
         pmix_output_verbose(5, prte_rml_base.rml_output,                                      \
                             "%s-%s Send message complete at %s:%d",                           \
-                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&((m)->dst)), \
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(_snd->dst)),\
                             __FILE__, __LINE__);                                              \
+        _snd->dbuf = NULL;                                                                    \
             /* non-blocking buffer send */                                                    \
-        (m)->cbfunc((m)->status, &((m)->dst),                                                 \
-                    (m)->dbuf, (m)->tag, (m)->cbdata);                                        \
+        _snd->cbfunc(_snd->status, &(_snd->dst),                                              \
+                     _dbuf, _snd->tag, _snd->cbdata);                                         \
+        PMIX_RELEASE(_snd);                                                                   \
     } while (0);
 
 

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -116,12 +116,16 @@ int prte_finalize(void)
         if (NULL == jdata) {
             continue;
         }
-        // Remove all children from the list
-        // We do not want to destruct this list here since that occurs in the
-        // prte_job_t destructor - which will happen in the next loop.
+        // Empty the children list before any job object is destroyed: a job
+        // released while still linked into another job's children list trips
+        // the list-item assert. Each entry carries the reference taken when
+        // it was appended, so removing it means releasing it - the job pool
+        // still holds the reference that keeps the child alive until this
+        // loop reaches it.
         PMIX_LIST_FOREACH_SAFE(child_jdata, next_jdata, &jdata->children, prte_job_t)
         {
             pmix_list_remove_item(&jdata->children, &child_jdata->super);
+            PMIX_RELEASE(child_jdata);
         }
         /* clean up any app contexts as they refcount the jdata object */
         for (i=0; i < jdata->apps->size; i++) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1010,13 +1010,11 @@ static void tcon(prte_topology_t *t)
 }
 static void tdes(prte_topology_t *t)
 {
-    hwloc_obj_t root;
-
     if (NULL != t->topo) {
-        root = hwloc_get_root_obj(t->topo);
-        if (NULL != root->userdata) {
-            PMIX_RELEASE(root->userdata);
-        }
+        /* the root carries a topology summary, but placement also attaches
+         * a counter object to every object it considers - all of them have
+         * to go back before hwloc frees the objects holding them */
+        prte_hwloc_base_release_userdata(t->topo);
         hwloc_topology_destroy(t->topo);
     }
 }
@@ -1079,10 +1077,14 @@ static void session_des(prte_session_t *s)
     }
     PMIX_RELEASE(s->nodes);
 
+    /* Unlike the node array, s->jobs holds BORROWED references: a job is
+     * added to it without a retain and removed from it without a release
+     * when the job terminates. A job's lifetime is governed by the global
+     * job pool, not by the session it ran in, so releasing here would drop
+     * a reference this session never took. */
     for (n=0; n < s->jobs->size; n++) {
         job = (prte_job_t*)pmix_pointer_array_get_item(s->jobs, n);
         if (NULL != job) {
-            PMIX_RELEASE(job);
             pmix_pointer_array_set_item(s->jobs, n, NULL);
         }
     }

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -540,12 +540,18 @@ int prte_register_params(void)
     pmix_sprintf(&prte_param_files, "%s" PMIX_PATH_SEP "prte-mca-params.conf",
                   prte_install_dirs.sysconfdir);
 #endif
+    /* the var system takes the current value as the default and then hands
+     * back a string of its own, so keep a handle on ours to release - the
+     * same pattern used for every other computed string param here */
+    string = prte_param_files;
 
    (void) pmix_mca_base_var_register("prte", "prte", NULL, "param_files",
                                       "Path for MCA configuration files containing "
                                       "variable values",
                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &prte_param_files);
+    free(string);
+    string = NULL;
 
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "override_param_file",
                                       "Variables set in this file will override any value "


### PR DESCRIPTION
## Problem

A four-node `prterun` under valgrind reported **18,770 bytes definitely lost in
38 blocks** (plus 1,034 indirect). Most of it was per-message, so it scaled with
traffic rather than being a fixed startup cost. This series takes that to
**zero**.

Also fixed here: a session destructor that released job objects it never
retained — an over-release rather than a leak, and the more dangerous of the
two problems.

## The changes, largest first

- **`rml: release the send object once a message completes`** (~17KB). Every
  daemon-to-daemon message leaked its `prte_rml_send_t`. The original ORTE macro
  ended with a release of the send object; the 2022 RML rework (`3ea46d117f`)
  dropped it while *adding* a destructor that frees the message's data buffer.
  The callback owns the buffer, so the send's reference to it is cleared before
  release or the destructor would free it twice. The OOB wrapper is also given
  the ownership it actually has, and the peer destructor now disposes of the
  on-deck message, which sat outside the send queue and was dropped on the floor.

- **`runtime: stop a session from releasing jobs it never retained`.** A
  session's job array is filled without a retain and emptied without a release —
  it is borrowed, and a job's lifetime belongs to the global job pool. The
  destructor released every job still listed, so tearing down a session holding
  a live job would drop a reference it never took. Note the node array
  immediately above it *does* take a reference on insert; the comment now says
  which is which.

- **`rmaps: reclaim the per-node cpusets a map leaves behind`.** `job_cpuset`
  and `target` were overwritten for every node considered, and the per-app
  (MPMD) `app_options` shallow copy was never cleaned at all.

- **`hwloc: release the data we attach to a topology's objects`.** Only the
  root's userdata was released; the per-object placement counters went away with
  the topology, which frees the objects holding them but knows nothing about
  what hangs off them. NUMA nodes need a separate sweep — hwloc 2.x keeps them
  off the normal depth hierarchy.

- **`pmix_server: release the info items cached for job registration`**,
  **`rml/relm: release the reliability state rather than destructing it`**
  (`PMIX_DESTRUCT` on `PMIX_NEW`'d objects runs the destructor and leaves the
  object), **`rml: release a received message's buffer even when it was
  emptied`**, **`runtime: release the child-job reference that finalize drops`**,
  plus four small ones: the rmaps print-buffer holder, the ssh daemon command
  string, the MCA param-file path, and the schizo tool-version string (rebuilt
  on every command line parsed).

- **`dockerswarm: stop reporting success after a failed build`.** `make -j &&
  make install` hides the failure from `set -e`, so a compile error printed
  ">>> Linux build complete" and the suite then ran against a stale image. This
  one is worth reading on its own — it silently invalidates test results.

## Testing

- warning-free `--enable-debug` build; `make check` 8/8;
  `make -C test/offline check-offline` 1176/1176
- `contrib/dockerswarm/run-tests.sh linux` 46 passed / 0 failed
- valgrind on a 4-node launch, a `--bind-to core` launch and an MPMD launch:
  0 bytes definitely lost, 0 indirectly lost, 0 invalid frees
- macOS `leaks`: 20 leaks / 15,536 bytes → 10 / 13,152 (the remainder is
  outside PRRTE)
- live DVM lifecycle (`prte --daemonize` → `prun` → `pterm`)

The MPMD valgrind case additionally required openpmix/prrte#2549 and
openpmix/openpmix#4030 to reach zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
