### PR TITLE
plm: source the homogeneous topology from a live daemon, and cover it

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -220,6 +220,12 @@ line with `--stdin all` to check the wildcard/xcast delivery.
 > allocation is node1's base pool, not the reservation. Confirm a grow by
 > `prted` presence on the targets and the `PMIX_DVM_IS_READY` event, not by
 > plain-`prun` placement.
+>
+> To actually **run something on a grown node**, spawn into the reservation:
+> `elastic grow node4:2 -- <cmd>` takes the `PMIX_ALLOC_ID` the request handed
+> back and spawns `<cmd>` with `PMIX_SPAWN_TARGET` naming it. The grow and the
+> spawn must happen in one `elastic` invocation — the HNP only lets a namespace
+> target a reservation it owns, and the owner is the tool that created it.
 
 **Shrink** (`elastic shrink node3`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, plus a **"PRRTE has lost communication with a remote

--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -20,6 +20,13 @@
  *
  * (extend/release are accepted as aliases for grow/shrink.)
  *
+ * A grow may be followed by "-- <cmd> [args...]", in which case the tool
+ * spawns that command INTO THE RESERVATION the grow just created, using the
+ * PMIX_ALLOC_ID the request handed back and PMIX_SPAWN_TARGET to name it.
+ * That is the only way to place a job on a freshly grown node: grown nodes
+ * join the new reservation rather than the default pool, so a plain
+ * "prun --host <grown-node>" has no allocation to map onto and fails.
+ *
  * Build: gcc -o elastic elastic.c -lpmix
  */
 
@@ -64,7 +71,11 @@ static void lock_wake(lock_t *l, pmix_status_t st) {
 }
 
 static lock_t complete_lock;     /* fired by the DVM_IS_READY / ERR_DVM_MOD handler */
+static lock_t jobend_lock;       /* fired by the PMIX_EVENT_JOB_END handler */
 static pmix_proc_t myproc;
+/* PMIX_ALLOC_ID of the reservation the grow created - the handle a later
+ * spawn needs in order to target those nodes */
+static char alloc_id[PMIX_MAX_KEYLEN + 1];
 
 /* handler registration callback */
 static void reg_cb(pmix_status_t status, size_t evref, void *cbdata) {
@@ -84,6 +95,12 @@ static void alloc_cb(pmix_status_t status, pmix_info_t *info, size_t ninfo,
         if (PMIX_STRING == info[n].value.type) {
             fprintf(stderr, "      info[%zu] %s = %s\n", n, info[n].key,
                     info[n].value.data.string);
+            /* remember the reservation handle so we can spawn into it */
+            if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_ID) &&
+                NULL != info[n].value.data.string) {
+                snprintf(alloc_id, sizeof(alloc_id), "%s",
+                         info[n].value.data.string);
+            }
         } else {
             fprintf(stderr, "      info[%zu] key=%s\n", n, info[n].key);
         }
@@ -118,6 +135,82 @@ static void completion_evh(size_t evhdlr_id, pmix_status_t status,
     lock_wake(&complete_lock, status);
 }
 
+/* the spawned job finished */
+static void jobend_evh(size_t evhdlr_id, pmix_status_t status,
+                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata) {
+    (void) evhdlr_id; (void) source; (void) info; (void) ninfo;
+    (void) results; (void) nresults;
+    fprintf(stderr, ">>> spawned job ended: %s\n", PMIx_Error_string(status));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    lock_wake(&jobend_lock, status);
+}
+
+/* Spawn a job onto the nodes of the reservation this tool just created.
+ * Returns 0 on success. The reservation is named by PMIX_SPAWN_TARGET; the
+ * HNP validates that we own it, resolves it to the session, and maps only
+ * onto its nodes - so a proc landing at all proves those nodes are usable
+ * (in particular, that they have a topology). */
+static int spawn_into_reservation(char **cmd) {
+    pmix_app_t app;
+    pmix_info_t jinfo[2];
+    pmix_nspace_t nspace;
+    pmix_status_t rc, code = PMIX_EVENT_JOB_END;
+    lock_t reglock;
+    bool flag = true;
+    int n;
+
+    if ('\0' == alloc_id[0]) {
+        fprintf(stderr, ">>> FAILURE: the grow returned no PMIX_ALLOC_ID to spawn into\n");
+        return 1;
+    }
+
+    lock_init(&jobend_lock);
+    lock_init(&reglock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, jobend_evh, reg_cb, &reglock);
+    lock_wait(&reglock);
+
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup(cmd[0]);
+    for (n = 0; NULL != cmd[n]; n++) {
+        PMIx_Argv_append_nosize(&app.argv, cmd[n]);
+    }
+    app.maxprocs = 1;
+
+    PMIX_INFO_LOAD(&jinfo[0], PMIX_SPAWN_TARGET, alloc_id, PMIX_STRING);
+    PMIX_INFO_LOAD(&jinfo[1], PMIX_NOTIFY_COMPLETION, &flag, PMIX_BOOL);
+
+    fprintf(stderr, "spawning [%s] into reservation %s ...\n", cmd[0], alloc_id);
+    rc = PMIx_Spawn(jinfo, 2, &app, 1, nspace);
+    PMIX_APP_DESTRUCT(&app);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, ">>> FAILURE: spawn into %s returned %s\n",
+                alloc_id, PMIx_Error_string(rc));
+        return 1;
+    }
+    fprintf(stderr, ">>> SPAWNED %s into reservation %s\n", nspace, alloc_id);
+
+    /* bounded wait for the job to finish so a caller can inspect its work */
+    {
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 60;
+        pthread_mutex_lock(&jobend_lock.mtx);
+        while (jobend_lock.active) {
+            if (ETIMEDOUT == pthread_cond_timedwait(&jobend_lock.cond,
+                                                    &jobend_lock.mtx, &ts)) {
+                fprintf(stderr, ">>> TIMEOUT: spawned job did not end within 60s\n");
+                break;
+            }
+        }
+        pthread_mutex_unlock(&jobend_lock.mtx);
+    }
+    return 0;
+}
+
 int main(int argc, char **argv) {
     pmix_status_t rc;
     pmix_info_t *info;
@@ -126,13 +219,26 @@ int main(int argc, char **argv) {
     lock_t reglock;
     lock_t alloclock;
     const char *op, *nodelist;
+    char **spawn_cmd = NULL;
+    int rcexit = 0, i;
 
     if (argc < 3) {
-        fprintf(stderr, "usage: %s <grow|shrink> <node1,node2,...>\n", argv[0]);
+        fprintf(stderr,
+                "usage: %s <grow|shrink> <node1,node2,...> [-- <cmd> [args...]]\n",
+                argv[0]);
         return 1;
     }
     op = argv[1];
     nodelist = argv[2];
+    /* anything after "--" is a command to run on the grown nodes */
+    for (i = 3; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--")) {
+            if (i + 1 < argc) {
+                spawn_cmd = &argv[i + 1];
+            }
+            break;
+        }
+    }
     /* A grow is a NEW reservation that names the nodes to add: PRRTE adds them
      * to the pool and extends the DVM.  PMIX_ALLOC_EXTEND only adds to an
      * already-existing reservation, so it is not the right trigger here. */
@@ -192,7 +298,17 @@ int main(int argc, char **argv) {
         pthread_mutex_unlock(&complete_lock.mtx);
     }
 
+    /* only meaningful once the DVM actually reflects the new nodes */
+    if (NULL != spawn_cmd) {
+        if (PMIX_DVM_IS_READY == complete_lock.status) {
+            rcexit = spawn_into_reservation(spawn_cmd);
+        } else {
+            fprintf(stderr, ">>> skipping spawn: the grow did not complete\n");
+            rcexit = 1;
+        }
+    }
+
 done:
     PMIx_tool_finalize();
-    return 0;
+    return rcexit;
 }

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -271,11 +271,62 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         || bad "uniform-nodes launch failed (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ')"
     c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
     [ "$c" = 0 ] && ok "no daemons linger after uniform-nodes launch" || bad "$c stray prted"
-    # NOTE: the variant where the inheritance has to come from a SURVIVOR --
-    # shrink the rank-1 node on an elastic DVM, then grow -- cannot be
-    # asserted yet: growing after a shrink on the same DVM hangs (no
-    # phase-two completion event), on master as well as here. See the "Known
-    # issue" section of AGENTS.md and openpmix/prrte#2491.
+
+    banner "plm: a grown node inherits its topology from a survivor"
+    # Under --uniform-nodes only daemon rank 1 reports a topology; every other
+    # daemon inherits it in progress_daemons() before mapping runs, and a node
+    # whose topology stayed NULL cannot be mapped onto. Shrink the rank-1 node
+    # out of an elastic DVM and then grow a new one: the added daemon is not
+    # rank 1, so it reports no topology of its own and has to inherit from a
+    # daemon that is still alive.
+    #
+    # A shrink keeps the departed daemon's proc object (its vpid is never
+    # reused) and leaves that proc pointing at a node that still holds a
+    # topology, so this only discriminates because progress_daemons() skips
+    # daemons that are no longer ALIVE. Take that aliveness test out - or go
+    # back to sourcing the topology from rank 1 unconditionally - and the
+    # spawn below fails with "All nodes which are allocated for this job are
+    # already filled", which is what a NULL topology on the grown node looks
+    # like from the outside.
+    #
+    # Proving the node is usable means running something on it, and a grown
+    # node joins the reservation the grow created rather than the default
+    # pool -- so "prun --host node4" has no allocation to map onto no matter
+    # what its topology says. The elastic client therefore spawns INTO that
+    # reservation, naming it with the PMIX_ALLOC_ID the grow handed back
+    # (PMIX_SPAWN_TARGET). The grow and the spawn have to happen in one tool
+    # session: the HNP only lets a namespace target a reservation it owns.
+    cleanup_swarm
+    ON 4 'rm -f /tmp/survivor.out' >/dev/null 2>&1
+    RUN 'nohup prte --daemonize --uniform-nodes --prtemca prte_elastic_mode 1 \
+             >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 90 elastic grow node2:2,node3:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "uniform DVM grown onto the topology reporter (rank 1) and a peer" \
+            || bad "baseline grow of node2,node3 did not complete"
+        out=$(RUN 'timeout 90 elastic shrink node2' 2>&1); sleep 3
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "the topology-reporting daemon was shrunk out of the DVM" \
+            || bad "shrink of the rank-1 node did not complete"
+        [ "$(prted_count 2)" = 0 ] && ok "no daemon left on the shrunk node" \
+                                   || bad "daemon still running on the shrunk node"
+        out=$(RUN "timeout 120 elastic grow node4:2 -- /bin/sh -c 'hostname > /tmp/survivor.out'" 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "grow completed with the original topology reporter gone" \
+            || bad "grow after shrinking rank 1 did not complete"
+        echo "$out" | grep -q '>>> SPAWNED' \
+            && ok "job spawned into the grown node's reservation" \
+            || bad "spawn into the reservation failed: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        marker=$(ON 4 'cat /tmp/survivor.out 2>/dev/null' | tr -d '\r')
+        [ "$marker" = node4 ] \
+            && ok "the grown node ran the job - it inherited from a survivor" \
+            || bad "grown node never ran the job (marker='$marker')"
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the survivor-topology test"
+    fi
+    cleanup_swarm
 
     banner "plm: node names reconciled with what the daemons report"
     # Allocate by IP address. Each daemon reports its gethostname() result

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1304,15 +1304,26 @@ static void progress_daemons(prte_job_t *daemons,
             // login node). Normally that is daemon rank=1, the only daemon
             // that reports a topology under homo_nodes. However, rank 1 need
             // not still exist - an elastic shrink can remove it - so take the
-            // topology from the first daemon that has one. The survivors
-            // inherited rank 1's topology when they reported in, so a daemon
-            // launched by a later grow (which reports no topology of its own,
-            // as it is not rank 1) still inherits the correct one.
+            // topology from the first daemon that is still ALIVE and has one.
+            // The survivors inherited rank 1's topology when they reported in,
+            // so a daemon launched by a later grow (which reports no topology
+            // of its own, as it is not rank 1) still inherits the correct one.
+            //
+            // The aliveness test is what makes that fallback mean anything. A
+            // shrink deliberately keeps the departed daemon's proc object in
+            // the array - daemon vpids are never reused, so its rank stays
+            // reserved - and only unsets ALIVE and marks it TERMINATED. It
+            // leaves the proc's ->node back-pointer, and that node keeps the
+            // topology it was given. Scanning without checking ALIVE would
+            // therefore keep sourcing the topology from a daemon that left the
+            // DVM, which is both wrong in principle and indistinguishable from
+            // the hardcoded rank-1 behavior this replaced.
             t = NULL;
             src = PMIX_RANK_INVALID;
             for (j = 1; j < daemons->num_procs; j++) {
                 daemon = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, j);
-                if (NULL == daemon || NULL == daemon->node || NULL == daemon->node->topology) {
+                if (NULL == daemon || !PRTE_FLAG_TEST(daemon, PRTE_PROC_FLAG_ALIVE) ||
+                    NULL == daemon->node || NULL == daemon->node->topology) {
                     continue;
                 }
                 t = daemon->node->topology;
@@ -1330,7 +1341,10 @@ static void progress_daemons(prte_job_t *daemons,
                     continue;
                 }
                 daemon = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, j);
-                if (NULL == daemon || NULL == daemon->node) {
+                if (NULL == daemon || !PRTE_FLAG_TEST(daemon, PRTE_PROC_FLAG_ALIVE) ||
+                    NULL == daemon->node) {
+                    /* a departed daemon's node is no longer part of the DVM -
+                     * do not hand it a topology reference to hold */
                     continue;
                 }
                 if (daemon->node->topology == t) {


### PR DESCRIPTION
## Problem

Under `--uniform-nodes` only daemon rank 1 reports a topology; every other
daemon's node inherits it in `progress_daemons()` before mapping runs, and a
node whose topology stayed NULL cannot be mapped onto. Rank 1 need not still
exist — an elastic shrink can remove it — so the source was changed from
"rank 1" to "the first daemon that has one". That scan never asked whether the
daemon it picked was still in the DVM.

A shrink **deliberately** keeps the departed daemon's proc object: daemon vpids
are never reused, so the rank stays permanently reserved and the routing layer
records it as dead (openpmix/prrte#2491). It clears the things that say the
daemon is running — unsets `ALIVE`, marks the proc `TERMINATED`, drops
`node->daemon`, returns the node to the default pool, resets the node's launch
flags. What it leaves is the proc's `->node` back-pointer, and that node still
holds the topology it was handed.

So the scan kept selecting rank 1 and sourcing the topology from a daemon that
had left the DVM. Nothing visibly broke, because that stale node still holds a
valid (reference-counted) topology — but it is wrong in principle, and it made
the "first daemon that has one" behavior **indistinguishable from the hardcoded
rank 1 it replaced**: the fallback could not fire in the one situation it
exists for. I confirmed that by reverting to the hardcoded version, which left
the behavior identical.

## Fix

Skip daemons that are not `ALIVE`, in the scan and in the propagation loop
both, so a grown node inherits from a survivor and no departed node is handed a
topology reference to hold. `ALIVE` is set in the daemon callback well before
`progress_daemons()` runs, so it is reliable there.

## Test

The reason this went uncovered is that **nothing in the harness could run
anything on a node added by a grow**, and mapping is the only way to observe a
node's topology. A plain `prun --host <grown-node>` cannot do it either: grown
nodes join the reservation the request created rather than the default pool, so
the job has no allocation to map onto regardless of topology.

The pieces to do it properly already existed — the grow response carries a
`PMIX_ALLOC_ID`, and the HNP resolves `PMIX_SPAWN_TARGET` into the session to
map onto — so the `elastic` test client now uses them. A grow may be followed
by `-- <cmd>`, which spawns that command into the reservation just created and
waits for it. The grow and the spawn must be one invocation: the HNP only lets
a namespace target a reservation it owns, and the owner is the tool that
created it.

The new case grows a `--uniform-nodes` DVM onto the topology reporter and a
peer, shrinks the reporter away, grows a fresh node, and runs a command on it.

## Testing

- warning-free `--enable-debug` build; `make check` 8/8;
  `make -C test/offline check-offline` 1176/1176
- `contrib/dockerswarm/run-tests.sh linux` **52 passed / 0 failed** (was 46)
- negative controls, both of which make the new case fail with "All nodes which
  are allocated for this job are already filled" — the outside view of a NULL
  topology on the grown node:
  - reverting to the hardcoded rank-1 source
  - suppressing topology propagation entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)