### PR TITLE
ras: framework review - node-pool accounting, thread-shift violations, and coverage for the paths nobody compiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ test/unit/plm/Makefile
 test/unit/plm/test_plm
 test/unit/rml/Makefile
 test/unit/rml/test_rml
+test/unit/ras/Makefile
+test/unit/ras/test_ras
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,7 @@ Common configure options:
 | `--with-flux=<dir>` | Enable Flux support |
 | `--enable-debug` | Build with debug symbols and extra assertions |
 | `--enable-devel-check` | Enable strict compiler warnings (treat warnings as errors); on by default when `--enable-debug` is used in a git repo build |
-| `--enable-testbuild-launchers` | **Compile-only.** Build the `plm`/`ras` components that need third-party headers (LSF, Flux, jansson) against declaration-only stubs, so they are syntax-checked on a machine that lacks those libraries. The resulting tree **crashes at startup** — the stubs are unimplemented, and `ras/flux`'s `query` runs during `prte_init`. Never `make check`, run, or install a tree configured this way; keep a second tree without it. See [`src/mca/ras/AGENTS.md`](src/mca/ras/AGENTS.md). |
+| `--enable-testbuild-launchers` | **Compile-only.** Build the `plm`/`ras` components that need third-party headers (LSF, Flux, jansson) against declaration-only stubs, so they are syntax-checked on a machine that lacks those libraries. Those components must be run-time loadable plugins (the default `--enable-mca-dso` list) — a stub's unresolved symbols only fail to `dlopen`, whereas in `libprrte` they break the link of every tool. Such a tree builds and runs, but the stubbed components can do no actual work; don't install one over a good installation. See [`src/mca/ras/AGENTS.md`](src/mca/ras/AGENTS.md). |
 
 Version requirements: PMIx ≥ 6.1.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,7 @@ Common configure options:
 | `--with-flux=<dir>` | Enable Flux support |
 | `--enable-debug` | Build with debug symbols and extra assertions |
 | `--enable-devel-check` | Enable strict compiler warnings (treat warnings as errors); on by default when `--enable-debug` is used in a git repo build |
+| `--enable-testbuild-launchers` | **Compile-only.** Build the `plm`/`ras` components that need third-party headers (LSF, Flux, jansson) against declaration-only stubs, so they are syntax-checked on a machine that lacks those libraries. The resulting tree **crashes at startup** — the stubs are unimplemented, and `ras/flux`'s `query` runs during `prte_init`. Never `make check`, run, or install a tree configured this way; keep a second tree without it. See [`src/mca/ras/AGENTS.md`](src/mca/ras/AGENTS.md). |
 
 Version requirements: PMIx ≥ 6.1.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
 

--- a/config/prte_check_jansson.m4
+++ b/config/prte_check_jansson.m4
@@ -83,6 +83,16 @@ AC_DEFUN([PRTE_CHECK_JANSSON],[
     AM_CONDITIONAL([PRTE_HAVE_JANSSON],
           [test "${prte_check_jansson_happy}" = "yes"])
 
+    # Whether to COMPILE the jansson-dependent sources.  Distinct from
+    # PRTE_HAVE_JANSSON, which says whether they can actually run:
+    # --enable-testbuild-launchers compiles them against stub declarations so
+    # they are syntax-checked on machines with no jansson (they are otherwise
+    # skipped by essentially every developer build, since jansson defaults to
+    # "no").  Such a build must not be run - see src/mca/ras/AGENTS.md.
+    AM_CONDITIONAL([PRTE_WANT_JANSSON_SOURCE],
+          [test "${prte_check_jansson_happy}" = "yes" || \
+           test "${prte_testbuild_launchers}" = "1"])
+
     # Did we find the right stuff?
     AS_IF([test "${prte_check_jansson_happy}" = "yes"],
           [$2],

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -40,5 +40,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/iof/Makefile
         test/unit/plm/Makefile
         test/unit/rml/Makefile
+        test/unit/ras/Makefile
     ])
 ])

--- a/config/prte_mca.m4
+++ b/config/prte_mca.m4
@@ -56,6 +56,17 @@ AC_DEFUN([PRTE_MCA],[
         [AS_HELP_STRING([--enable-mca-no-build=LIST],
                         [Comma-separated list of <type>-<component> pairs
                          that will not be built.  Example: "--enable-mca-no-build=maffinity,btl-portals" will disable building all maffinity components and the "portals" btl components.])])
+    #
+    # The default DSO list is every component that can end up linked
+    # against a third-party library.  Keeping them out of libprrte keeps
+    # that dependency out of every PRRTE tool -- and it is what lets
+    # --enable-testbuild-launchers work at all: a run-time loadable
+    # plugin may carry the unresolved symbols left behind by a
+    # declaration-only stub header (it simply fails to dlopen), while a
+    # shared library linked into an executable may not.  ras-flux and
+    # ras-slurm are here for the latter reason: both compile JSON
+    # parsing against jansson.
+    #
     AC_ARG_ENABLE(mca-dso,
         AS_HELP_STRING([--enable-mca-dso=LIST],
                        [Comma-separated list of types and/or
@@ -63,7 +74,7 @@ AC_DEFUN([PRTE_MCA],[
                         run-time loadable components (as opposed to
                         statically linked in), if supported on this
                         platform.]),
-                        [], [enable_mca_dso=ess-alps,plm-alps,plm-lsf,plm-tm,ras-alps,ras-lsf])
+                        [], [enable_mca_dso=ess-alps,plm-alps,plm-lsf,plm-tm,ras-alps,ras-flux,ras-lsf,ras-slurm])
     AC_ARG_ENABLE(mca-static,
         AS_HELP_STRING([--enable-mca-static=LIST],
                        [Comma-separated list of types and/or

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -68,11 +68,49 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
   builds PMIx from source too; otherwise PMIx is the copy baked into the image
   (Linux) or an installed PMIx (macOS).
 
-> **One-time cost:** a VPATH build refuses to run while the source tree still
-> has an in-tree build, so `build.sh` runs `make distclean` + `./autogen.pl` at
-> the repo root the first time. After that your top-level source dir stays
-> clean and all builds live in `vpath-linux`/`vpath-macos`. If you were building
-> PRRTE in-tree before, your builds now live in `vpath-macos/` instead.
+### When a distclean is actually needed
+
+**The rule: an out-of-tree build cannot share a source tree with an
+in-tree build. If the source tree holds one when `build.sh` runs, it has
+to go — every time, not just the first.**
+
+There are two distinct reasons, and the second is the one that actually
+bites:
+
+1. **A VPATH `configure` refuses to run** while the source tree holds a
+   `config.status`/`Makefile`. This is the obvious one, and it only
+   applies on the first run — afterwards `build.sh` does
+   `[ -f config.status ] || configure` and skips it.
+2. **`VPATH = srcdir` makes an incremental out-of-tree `make` reach into
+   the source tree.** Automake sets `VPATH` to the source directory, so
+   make can satisfy an object target from a stale `src/**/*.lo` +
+   `.libs/*.o` left there by an in-tree build. Between a macOS host tree
+   and the Linux container those objects are not even the same
+   architecture, and the build dies with:
+
+   ```
+   libtool:   error: 'prte_bootstrap.lo' is not a valid libtool object
+   ```
+
+   Reason 2 has no "first run only" escape — it applies to every
+   incremental rebuild.
+
+So `build.sh` distcleans whenever it finds in-tree artifacts, and says
+so. `--no-distclean` skips it (only safe if the tree really is clean);
+`--distclean` forces it.
+
+**The cost, and how to avoid paying it repeatedly.** A distclean destroys
+*your* in-tree build, so the next `make check`, `make -C test/offline
+check-offline`, or `make install` has to reconfigure and rebuild the
+whole tree first. That failure is easy to misread, because a distcleaned
+tree does not announce itself — `make check` just says *"No rule to make
+target `check'"* and `make` at the root exits 0 having done nothing.
+
+If you run the host-side suites often, **stop keeping an in-tree build**:
+build the host side out of tree too (`./build.sh macos`, which installs
+into `vpath-macos/install`) and run `make check` from `vpath-macos`. Then
+the source tree stays pristine, both builds coexist exactly as this
+harness intends, and there is never anything to clean.
 
 ## 3. Prerequisites
 
@@ -90,8 +128,9 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 # from this directory (contrib/dockerswarm/)
 
 # ---- Linux swarm ----
-./build.sh                 # distclean+autogen (once), build image, build PRRTE
-                           #   into the shared volume from your live tree
+./build.sh                 # autogen (+ distclean only if a VPATH configure
+                           #   must run), build image, build PRRTE into the
+                           #   shared volume from your live tree
 docker compose up -d       # start prte-node1 .. prte-node10
 ./run-tests.sh linux       # full suite: prterun, elastic grow/shrink, relay
 

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf automake libtool m4 flex \
         perl python3 git \
         libevent-dev libhwloc-dev zlib1g-dev \
+        libjansson-dev \
         openssh-server openssh-client \
         iproute2 iputils-ping procps less vim ca-certificates \
         valgrind \

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -157,8 +157,14 @@ build_linux() {
 
             echo ">>>> PRRTE VPATH build -> /opt/prte/prte"
             mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
+            # --with-jansson is deliberate: it is off by default, and without
+            # it ras/slurm compiles ras_slurm_jansson_stub.c instead of the
+            # real ras_slurm_jansson.c -- so the ~1000 lines that parse
+            # "scontrol --json" (the whole elastic extend/release surface) are
+            # never even compiled.  libjansson-dev is baked into the image.
             [ -f config.status ] || /prrte-src/configure \
-                --prefix=/opt/prte/prte --with-pmix="$PMIX_PREFIX" --enable-debug
+                --prefix=/opt/prte/prte --with-pmix="$PMIX_PREFIX" \
+                --with-jansson --enable-debug
             # show_help GOLDEN RULE: prte_show_help_content.c embeds every
             # help-*.txt in the tree, but its make rule depends only on the
             # converter script -- so an edited help file is NOT picked up by an

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -18,10 +18,24 @@
 #   ./build.sh macos    # build natively on this host into <repo>/vpath-macos
 #   ./build.sh image    # (re)build just the base container image
 #
-# Because a VPATH configure refuses to run while the source tree still has an
-# in-tree build, this script runs `make distclean` (once) at the repo root and
-# then `./autogen.pl`.  After that, ALL builds are out-of-tree and your
-# top-level source dir stays clean.
+# Distcleaning the source tree
+# ----------------------------
+# An out-of-tree build cannot share a source tree with an in-tree build: VPATH
+# configure refuses to run against one, and (worse) automake sets VPATH=srcdir,
+# so an incremental out-of-tree make will happily link objects it finds in the
+# SOURCE tree -- which for a Linux container reading a macOS host tree are not
+# even the same architecture.  So this script distcleans whenever it finds an
+# in-tree build, not just on the first run.
+#
+# That costs you the in-tree build: the next `make check`, `make -C test/offline
+# check-offline` or `make install` has to reconfigure and rebuild first.  If you
+# run those often, keep the host side out of tree too (./build.sh macos) and
+# there is nothing to clean.
+#
+#   --distclean      force it
+#   --no-distclean   skip it (only safe if the tree really is clean)
+#
+# See AGENTS.md, "When a distclean is actually needed".
 #
 # Optional: point PMIX_SRC at a local openpmix checkout to build PMIx from
 # source too (covering both code bases); otherwise the baked-in PMIx (Linux) or
@@ -41,14 +55,57 @@ PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
 PMIX_SRC="${PMIX_SRC:-}"                # optional openpmix checkout to build
 PMIX_HOME="${PMIX_HOME:-}"              # optional installed PMIx prefix (macOS)
 
-mode="${1:-linux}"
+mode=linux
+distclean=auto                          # auto | always | never
+for arg in "$@"; do
+    case "$arg" in
+        linux|macos|image) mode="$arg" ;;
+        --distclean)       distclean=always ;;
+        --no-distclean)    distclean=never ;;
+        *) echo "usage: $0 [linux|macos|image] [--distclean|--no-distclean]" >&2; exit 2 ;;
+    esac
+done
+
+# Does the source tree hold an in-tree build?  config.status/Makefile are what
+# make a VPATH configure refuse to run, but the object files are the bigger
+# problem -- see prep_srcdir.
+srcdir_has_intree() {
+    [ -f "$root/config.status" ] || [ -f "$root/Makefile" ] || \
+    [ -n "$(find "$root/src" -name '*.lo' -print -quit 2>/dev/null)" ]
+}
 
 # --- make the source tree VPATH-ready (idempotent) --------------------------
 prep_srcdir() {
-    if [ -f "$root/config.status" ] || [ -f "$root/Makefile" ]; then
-        echo ">>> make distclean (source tree had an in-tree build)"
+    if srcdir_has_intree && [ "$distclean" != never ]; then
+        # Two separate reasons, and the second is the one that bites:
+        #
+        #  1. a VPATH configure refuses to run at all while the source tree
+        #     holds an in-tree build; and
+        #  2. even when configure is skipped (incremental rebuild), automake
+        #     sets VPATH = srcdir, so make happily resolves an object target
+        #     out of the SOURCE tree.  An in-tree *.lo / .libs/*.o left there
+        #     is then linked into the out-of-tree build -- and for the Linux
+        #     container against a macOS host tree those objects are not even
+        #     the same architecture, so the build dies with
+        #     "'foo.lo' is not a valid libtool object".
+        #
+        # So this is not a first-run-only cost: any in-tree build present when
+        # an out-of-tree build runs has to go.  The durable fix is to stop
+        # keeping one -- see AGENTS.md, "When a distclean is actually needed".
+        echo ">>> make distclean -- the source tree holds an in-tree build," \
+             "which would poison the out-of-tree build via VPATH"
+        echo ">>> NOTE: this removes your in-tree build; reconfigure before" \
+             "'make check' or 'make -C test/offline check-offline'"
+        echo ">>>       (or build the host side out-of-tree too: ./build.sh macos)"
         make -C "$root" distclean >/dev/null 2>&1 || true
+        # distclean leaves the *.lo behind if the tree was already half-cleaned
+        find "$root/src" -name '*.lo' -delete 2>/dev/null || true
+        find "$root/src" -name '.libs' -type d -exec rm -rf {} + 2>/dev/null || true
+    elif srcdir_has_intree; then
+        echo ">>> WARNING: --no-distclean, but the source tree holds an in-tree" \
+             "build; the out-of-tree build may pick up its objects via VPATH"
     fi
+
     if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then
         echo ">>> autogen.pl"
         ( cd "$root" && ./autogen.pl )
@@ -70,9 +127,11 @@ build_image() {
 
 # --- Linux build (in a builder container, into the shared volume) -----------
 build_linux() {
-    prep_srcdir
+    # image and volume first: prep_srcdir asks them whether the out-of-tree
+    # build has already been configured before deciding to distclean
     build_image
     docker volume create "$VOLUME" >/dev/null
+    prep_srcdir linux
 
     local pmix_mount=()
     [ -n "$PMIX_SRC" ] && pmix_mount=(-v "$(cd "$PMIX_SRC" && pwd)":/pmix-src:ro)
@@ -100,6 +159,13 @@ build_linux() {
             mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
             [ -f config.status ] || /prrte-src/configure \
                 --prefix=/opt/prte/prte --with-pmix="$PMIX_PREFIX" --enable-debug
+            # show_help GOLDEN RULE: prte_show_help_content.c embeds every
+            # help-*.txt in the tree, but its make rule depends only on the
+            # converter script -- so an edited help file is NOT picked up by an
+            # incremental build, and the daemons serve stale (or missing) text
+            # while the .txt looks correct.  This build dir persists in the
+            # volume across runs, so drop the generated file every time.
+            rm -f src/util/prte_show_help_content.c src/util/prte_show_help_content.lo
             make -j"$jobs"
             make install
 
@@ -119,7 +185,7 @@ build_linux() {
 
 # --- macOS build (native, on this host) -------------------------------------
 build_macos() {
-    prep_srcdir
+    prep_srcdir macos
     local pmix_arg=""
     if [ -n "$PMIX_SRC" ]; then
         local psrc pfx
@@ -160,6 +226,8 @@ build_macos() {
         "$root/configure" $cfg_args
         printf '%s' "$cfg_args" > .prte-configure-args
     fi
+    # show_help GOLDEN RULE -- see the note in build_linux
+    rm -f src/util/prte_show_help_content.c src/util/prte_show_help_content.lo
     make -j"$(sysctl -n hw.ncpu)"
     make install
     echo ">>> macOS build complete: $root/vpath-macos/install"
@@ -176,6 +244,7 @@ build_macos() {
 case "$mode" in
     linux) build_linux ;;
     macos) build_macos ;;
-    image) prep_srcdir; build_image force ;;
-    *) echo "usage: $0 [linux|macos|image]" >&2; exit 2 ;;
+    # the image is built from contrib/dockerswarm alone and never reads the
+    # source tree, so it needs no distclean at all
+    image) build_image force ;;
 esac

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -53,14 +53,17 @@ ON()  { docker exec "prte-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:
 
 cleanup_swarm() {
     for n in $(seq 1 10); do
-        # NOTE: prterun's session dir is /tmp/prtrn.<pid>, NOT /tmp/prte.<pid>.
-        # Leaving those behind is what makes a later prun report "multiple
-        # possible servers ... connection handles have been read from files
-        # named pmix.*" and fail to find the DVM, so clear both patterns.
+        # NOTE: each tool has its OWN session-dir prefix -- prte.<pid> for the
+        # HNP, prtrn.<pid> for prterun, and prted.<pid> for a bootstrapped
+        # daemon standing on its own. Every one of them holds a pmix.* server
+        # rendezvous file, and leaving any behind is what makes a later prun
+        # report "multiple possible servers ... connection handles have been
+        # read from files named pmix.*" and fail to find the DVM. Clear them all.
         docker exec "prte-node$n" sh -c \
             'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
              pkill -9 -x prterun 2>/dev/null;
-             rm -rf /tmp/prte.* /tmp/prtrn.* /tmp/prun.session.* 2>/dev/null; true'
+             rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/pmix.* \
+                    /tmp/prun.session.* 2>/dev/null; true'
     done
 }
 prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -23,6 +23,9 @@ set -uo pipefail
 
 mode="${1:-linux}"
 pass=0 fail=0 skip=0
+# must match build.sh -- the bootstrap tests reach into the shared install
+IMAGE="${IMAGE:-prte-swarm:latest}"
+VOLUME="${VOLUME:-prte-build}"
 ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
 skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
@@ -71,6 +74,38 @@ prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/nu
 # one) -- two daemons on a single machine is what a duplicated node-pool
 # entry produces
 prted_procs() { docker exec "prte-node$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
+
+# --- bootstrap-DVM helpers --------------------------------------------------
+# A bootstrapped DVM is configured by <sysconfdir>/prte.conf, which lives in the
+# install the swarm shares.  The node containers mount that volume READ-ONLY, so
+# writing it needs a throwaway container that mounts it read-write.  The file is
+# part of the install, so back it up on first touch and always put it back --
+# leaving a DVMNodes list behind would change how every later run behaves.
+BOOT_CONF=/opt/prte/prte/etc/prte.conf
+bootstrap_vol() { docker run --rm -v "$VOLUME":/opt/prte "$IMAGE" sh -c "$1" 2>/dev/null; }
+
+bootstrap_write_conf() {   # $1 = controller host, $2 = DVMNodes list
+    bootstrap_vol "[ -f $BOOT_CONF.testsave ] || cp $BOOT_CONF $BOOT_CONF.testsave;
+                   printf 'ClusterName=swarm\nDVMControllerHost=%s\nDVMPort=7817\nDVMNodes=%s\nDVMRadix=64\n' \
+                       '$1' '$2' > $BOOT_CONF" || return 1
+    return 0
+}
+bootstrap_restore_conf() {
+    bootstrap_vol "[ -f $BOOT_CONF.testsave ] && mv $BOOT_CONF.testsave $BOOT_CONF; true"
+}
+# start prted --bootstrap on the given nodes, controller first (it has to be
+# listening before the others try to reach it)
+bootstrap_start() {
+    local ctrl=$1; shift
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        "prte-node$ctrl" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
+    sleep 6
+    for n in "$@"; do
+        docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "prte-node$n" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
+    done
+    sleep 14
+}
 
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
@@ -556,6 +591,67 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         bad "could not start a DVM for the add-hostfile test"
     fi
     cleanup_swarm
+
+    banner "bootstrap DVM: daemons come up on their own and agree on their ranks"
+    # A bootstrapped DVM has no launcher: prted is started independently on
+    # every node and each one derives its OWN vpid from prte.conf
+    # (prte_bootstrap_my_identity) before it ever contacts the controller.
+    # The controller has to arrive at the same numbers independently --
+    # ras/bootstrap records each node's canonical rank as its pool index and
+    # plm reads it back out as the daemon's vpid -- because
+    # prted_report_launch looks a reporting daemon up in daemons->procs BY THE
+    # RANK IT CLAIMS. Get that wrong and the HNP either attaches a daemon to
+    # the wrong node or cannot find it at all.
+    #
+    # DVMNodes order is rank order, so "node2,node3,node4" must produce
+    # vpids 1,2,3 in that order. --display map-devel prints the HNP's view.
+    cleanup_swarm
+    if bootstrap_write_conf "node1" "node2,node3,node4"; then
+        bootstrap_start 1 2 3 4
+        if [ "$(prted_count 1 2 3 4)" = 4 ]; then
+            ok "all 4 bootstrap daemons came up"
+            out=$(RUN 'timeout 60 prun --display map-devel -n 3 --map-by node hostname' 2>&1)
+            bad_rank=0
+            # node2 -> 1, node3 -> 2, node4 -> 3
+            for pair in "node2 1" "node3 2" "node4 3"; do
+                set -- $pair
+                # the "Data for node: X" line is followed by that node's "Daemon: [ns,V]"
+                v=$(echo "$out" | grep -A 2 "Data for node: $1[[:space:]]" \
+                        | grep -o 'Daemon: \[[^,]*,[0-9]*\]' | grep -o '[0-9]*\]' \
+                        | tr -d ']' | head -1)
+                [ "$v" = "$2" ] || { bad_rank=1; printf '    %s has vpid "%s", config says %s\n' "$1" "$v" "$2"; }
+            done
+            [ "$bad_rank" = 0 ] \
+                && ok "each daemon's vpid matches its DVMNodes position (1,2,3)" \
+                || bad "HNP vpid assignment disagrees with the config the daemons read"
+            n=$(echo "$out" | grep -cE '^node[234]$')
+            [ "$n" = 3 ] && ok "prun launched 3 procs across the bootstrap DVM" \
+                         || bad "prun over the bootstrap DVM produced $n/3 procs"
+        else
+            bad "bootstrap DVM did not form ($(prted_count 1 2 3 4)/4 daemons)"
+        fi
+        cleanup_swarm
+
+        # A host listed twice cannot work: a node's position in DVMNodes IS its
+        # rank, and rank_of() resolves every occurrence to the FIRST one -- so
+        # the position the repeat would have held is claimed by nobody while
+        # num_daemons still counts it, and the DVM can never finish forming.
+        # prte_bootstrap_parse must reject the file up front rather than let
+        # every daemon hang waiting for one that does not exist.
+        if bootstrap_write_conf "node1" "node2,node3,node2,node4"; then
+            out=$(RUN 'timeout 40 prted --bootstrap 2>&1' || true)
+            echo "$out" | grep -q "same host more than once" \
+                && ok "a duplicate host in DVMNodes is rejected with a diagnostic" \
+                || bad "duplicate DVMNodes entry not reported: $(echo "$out" | tr '\n' ' ' | head -c 200)"
+            [ "$(prted_count 1)" = 0 ] \
+                && ok "the controller refused to start on the bad config" \
+                || bad "controller started anyway on a config that cannot form a DVM"
+        fi
+        bootstrap_restore_conf
+        cleanup_swarm
+    else
+        skp "bootstrap DVM (could not write prte.conf into the shared volume)"
+    fi
 
     banner "elastic DVM: radix-2 deep tree grow + shrink (multi-hop relay)"
     RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --prtemca prte_rml_radix 2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -64,6 +64,10 @@ cleanup_swarm() {
     done
 }
 prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+# how many prted PROCESSES are running on one node (not how many nodes have
+# one) -- two daemons on a single machine is what a duplicated node-pool
+# entry produces
+prted_procs() { docker exec "prte-node$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
 
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
@@ -465,6 +469,88 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         RUN 'timeout 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the grow-scope test"
+    fi
+    cleanup_swarm
+
+    banner "ras: node_insert dedup survives grow/shrink/re-grow (no duplicate daemons)"
+    # prte_ras_base_node_insert() is where every allocation -- initial or
+    # dynamic -- lands in the global node pool, and it decides add-vs-update
+    # against what is already there. A shrink leaves the pool entry for the
+    # departed node in place (only its daemon goes away), so a later grow of
+    # that same node arrives as a duplicate; likewise a redundant grow of a
+    # node already in the DVM.
+    #
+    # If the dedup scan misses, the pool ends up holding two prte_node_t
+    # objects for one machine. Both are marked PRTE_NODE_STATE_ADDED with no
+    # daemon, so the next DVM extension launches a prted onto that machine
+    # TWICE -- which is the directly observable symptom. (The other symptom,
+    # the node's slots being counted twice into
+    # prte_ras_base.total_slots_alloc, is what a managed allocation reports
+    # as PMIX_UNIV_SIZE / PMIX_MAX_PROCS; it is checked in the unit test,
+    # since an unmanaged DVM recomputes the total from the pool at launch.)
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'timeout 90 elastic grow node2:2,node3:2' >/dev/null 2>&1
+        RUN 'timeout 90 elastic shrink node3' >/dev/null 2>&1; sleep 3
+        RUN 'timeout 90 elastic grow node3:2' >/dev/null 2>&1; sleep 3
+        # a redundant grow of a node that is already in the DVM is the other
+        # way a duplicate entry can be introduced
+        RUN 'timeout 90 elastic grow node2:2' >/dev/null 2>&1; sleep 3
+
+        dup=0
+        for n in 2 3; do
+            c=$(prted_procs "$n")
+            [ "$c" = 1 ] || { dup=1; printf '    node%s is running %s prted\n' "$n" "$c"; }
+        done
+        [ "$dup" = 0 ] \
+            && ok "exactly one prted per node after grow/shrink/re-grow/redundant-grow" \
+            || bad "duplicate pool entry launched a second daemon on a node"
+
+        # a wedged or double-daemoned DVM would not answer this
+        out=$(RUN 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+        [ "$(echo "$out" | tr -d '\r')" = node1 ] \
+            && ok "DVM still responsive after the grow/shrink/re-grow cycle" \
+            || bad "DVM wedged after the grow/shrink/re-grow cycle: $out"
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the pool-dedup test"
+    fi
+    cleanup_swarm
+
+    banner "ras/hosts: --add-hostfile brings a remote node into a running DVM"
+    # The ras/hosts component is the DVM's local resource authority when no
+    # scheduler is present: prte_ras_base_add_hosts() turns --add-host /
+    # --add-hostfile into a PMIX_ALLOC_EXTEND request, ras/pmix defers it
+    # (no scheduler), and hosts' own hand-written hostfile parser adds the
+    # nodes before the DVM extension launches daemons on them. That whole
+    # chain only runs multi-node, and its parser is separate from the flex
+    # hostfile parser precisely so it can accept the slots=+N adjust syntax.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --host node1:2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'printf "node2 slots=2\nnode3 slots=2\n" > /tmp/addhosts.txt'
+        out=$(RUN 'timeout 90 prun --add-hostfile /tmp/addhosts.txt --host node2:2,node3:2 -n 4 --map-by node hostname' 2>&1)
+        c=$(echo "$out" | grep -cE '^node[23]$')
+        [ "$c" = 4 ] && ok "--add-hostfile grew the DVM onto node2+node3 (4 procs)" \
+                     || bad "--add-hostfile launch produced $c/4 procs: $(echo "$out" | tr '\n' ' ')"
+        [ "$(prted_count 2 3)" = 2 ] && ok "daemons started on the added nodes" \
+                                     || bad "added nodes have no daemon"
+
+        # slots=+N adjusts an EXISTING pool entry rather than adding a node;
+        # the pool must not gain a second entry for it
+        RUN 'printf "node2 slots=+2\n" > /tmp/addslots.txt'
+        RUN 'timeout 90 prun --add-hostfile /tmp/addslots.txt -n 1 hostname' >/dev/null 2>&1
+        alloc=$(RUN 'timeout 30 prun --display allocation -n 1 hostname' 2>&1)
+        c=$(echo "$alloc" | grep -cE '^[[:space:]]*node2:[[:space:]]+slots=')
+        [ "$c" = 1 ] && ok "slots=+N adjusted node2 in place (no duplicate entry)" \
+                     || bad "slots=+N produced $c pool entries for node2"
+        echo "$alloc" | grep -qE '^[[:space:]]*node2:[[:space:]]+slots=4' \
+            && ok "node2 slots adjusted 2 -> 4" \
+            || bad "node2 slot adjustment not applied: $(echo "$alloc" | grep node2 | tr '\n' ' ')"
+        RUN 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the add-hostfile test"
     fi
     cleanup_swarm
 

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -315,9 +315,21 @@ DVM, dynamic spawn (only "added" nodes), unmanaged allocation
 (`-host`/hostfile union), managed allocation (filter the node pool) —
 and for each node needing a daemon it:
 
-- creates a `prte_proc_t`, assigns it the **next available vpid**
-  (`daemons->num_procs`), records the first as `map->daemon_vpid_start`,
-  and bumps `map->num_new_daemons`;
+- creates a `prte_proc_t` and assigns it a vpid — normally the **next
+  available one** (`daemons->num_procs`), but in a **bootstrapped DVM**
+  the node's canonical rank (`node->index`, recorded by `ras/bootstrap`
+  from `prte.conf`). That is not a preference: a bootstrapped daemon
+  computed its own vpid from the same file before it ever contacted the
+  HNP, and `prted_report_launch` looks a reporting daemon up in
+  `daemons->procs` **by the rank it claims for itself**. Assign it a
+  different one and the HNP either attaches the daemon to the wrong node
+  or cannot find it at all. Records the first as
+  `map->daemon_vpid_start` and bumps `map->num_new_daemons`;
+- maintains `daemons->num_procs` as the vpid **span** (grown to cover the
+  vpid just used, which for a sequential assignment is exactly the
+  increment it replaces) — `num_procs` is the count only because vpids
+  are normally consecutive, and it is read tree-wide as the upper bound
+  of the daemon vpid range;
 - links node↔daemon, sets `PRTE_NODE_FLAG_LOC_VERIFIED` iff
   `prte_plm_globals.daemon_nodes_assigned_at_launch` (see below);
 - once daemons are added, recomputes the RML routing tree

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2012,6 +2012,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     bool multi_sim = false;
     bool grow_request = false;
     bool have_grow_requester = false;
+    pmix_rank_t vpid;
     pmix_proc_t grow_requester;
     char *grow_alloc_id = NULL, *grow_req_id = NULL;
 
@@ -2609,14 +2610,32 @@ process:
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         PMIX_LOAD_NSPACE(proc->name.nspace, PRTE_PROC_MY_NAME->nspace);
-        if (PMIX_RANK_VALID - 1 <= daemons->num_procs) {
+        /* Choose this daemon's vpid.
+         *
+         * Normally we hand out the next unused one. In a BOOTSTRAPPED DVM we
+         * do not get to choose: every daemon computed its own vpid from the
+         * configuration file (prte_bootstrap_my_identity) before it ever
+         * contacted us, and prted_report_launch looks a reporting daemon up in
+         * daemons->procs by the rank it claims for itself. So the HNP has to
+         * arrive at the same answer independently, from the same authority -
+         * ras/bootstrap recorded that canonical rank as the node's pool index.
+         * Handing out a sequential vpid instead only agrees with what the
+         * daemons call themselves by accident of the order the configuration
+         * happens to list nodes in; where it disagrees, the HNP either
+         * attaches a daemon to the wrong node or fails to find it at all. */
+        if (prte_bootstrap_setup && 0 < node->index) {
+            vpid = (pmix_rank_t) node->index;
+        } else {
+            vpid = daemons->num_procs;
+        }
+        if (PMIX_RANK_VALID - 1 <= vpid) {
             /* no more daemons available */
             pmix_show_help("help-prte-rmaps-base.txt", "out-of-vpids", true);
             PMIX_RELEASE(proc);
             PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
-        proc->name.rank = daemons->num_procs; /* take the next available vpid */
+        proc->name.rank = vpid;
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                              "%s plm:base:setup_vm add new daemon %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name)));
@@ -2628,7 +2647,16 @@ process:
             PMIX_LIST_DESTRUCT(&nodes);
             return rc;
         }
-        ++daemons->num_procs;
+        /* num_procs is the vpid SPAN - the count only because vpids are
+         * normally handed out consecutively. Grow it to cover the vpid we just
+         * used rather than blindly incrementing, so a canonical rank cannot
+         * leave num_procs short of the highest daemon in the job (which would
+         * truncate the nidmap span and every daemon-count-derived
+         * computation). For a sequentially assigned vpid this is exactly the
+         * increment it replaces. */
+        if (daemons->num_procs <= proc->name.rank) {
+            daemons->num_procs = proc->name.rank + 1;
+        }
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                              "%s plm:base:setup_vm assigning new daemon %s to node %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name),

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -368,6 +368,51 @@ documented in each component's guide.
 
 ---
 
+## `--enable-testbuild-launchers` — COMPILE ONLY, never run it
+
+Several ras components are gated on third-party headers that most
+machines do not have, so they are silently skipped by nearly every
+developer build and every CI job — which is exactly where an edit can sit
+broken indefinitely. `ras/flux` needs Flux *and* jansson; `ras/slurm`
+compiles a ~1000-line `scontrol --json` parser only when jansson is
+found, and **jansson defaults to `--with-jansson=no`**, so the stub is
+what almost everyone builds.
+
+`--enable-testbuild-launchers` builds them anyway, against
+declaration-only stand-ins:
+
+| Header | Stands in for | Used by |
+|--------|---------------|---------|
+| [`base/testbuild_jansson.h`](base/testbuild_jansson.h) | `<jansson.h>` | `ras/slurm` (`ras_slurm_jansson.c`), `ras/flux` |
+| [`flux/testbuild_flux.h`](flux/testbuild_flux.h) | `<flux/core.h>`, `<flux/hostlist.h>`, `<flux/idset.h>` | `ras/flux` |
+| [`lsf/testbuild_lsf.h`](lsf/testbuild_lsf.h) | `<lsf/lsbatch.h>` | `ras/lsf` |
+
+> **A tree configured this way MUST NOT BE RUN.** Nothing in those headers
+> is implemented, so the symbols resolve to nothing and the first call
+> into one is a jump to address 0. It is not a graceful failure and not
+> confined to the component: `ras/flux` builds *statically*, and its
+> `query` calls `flux_open_ex` unconditionally, so **every PRRTE tool
+> segfaults during `prte_init`**:
+>
+> ```
+> [Mac:73844] Signal: Segmentation fault: 11
+> [Mac:73844] [ 1] libprrte.4.dylib  prte_mca_ras_flux_component_query + 72
+> [Mac:73844] [ 2] libprrte.4.dylib  prte_ras_base_select + 552
+> [Mac:73844] [ 3] libprrte.4.dylib  rte_init + 2868
+> ```
+>
+> Use it to answer "does this still compile?" and nothing else. Configure
+> a **second** tree without it for `make check`, the offline harness, and
+> any live run — and re-check the compile-only tree after touching
+> `ras/flux`, `ras/lsf`, or `ras_slurm_jansson.c`, because a normal build
+> will not tell you that you broke them.
+
+Adding a stub is deliberate work, not boilerplate: declare only what the
+component actually calls, and keep the signatures faithful. A wrong
+prototype here compiles and then mismatches the real library.
+
+---
+
 ## Testing
 
 | Layer | What it covers |

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -213,11 +213,26 @@ input list.** Walk it carefully before touching allocation code:
 - **General dedup.** For every other node, an exhaustive `prte_nptr_match`
   scan of the pool decides add-vs-update. `PRTE_NODE_ADD_SLOTS` means
   "adjust the existing slot count" (clamped to `[0, slots_max]`) rather
-  than replace it.
+  than replace it. **On a match the incoming object is released and the
+  loop moves on**: the pool entry is authoritative, so the duplicate must
+  not be added, must not have its slots counted into
+  `total_slots_alloc` a second time, and must not be multiplied. This is
+  the hot path on every elastic **re-grow** — a shrink removes the
+  daemon but leaves the pool entry, so the regrant always arrives as a
+  duplicate. Only `PRTE_NODE_STATE_ADDED` is carried across, because the
+  DVM extension keys off it to decide where to launch.
 - **Managed = sacred slots.** Under `prte_managed_allocation` (or when a
   node arrives with `PRTE_NODE_FLAG_SLOTS_GIVEN`), the base sets
   `SLOTS_GIVEN` so downstream code treats the slot count as fixed and
-  never recomputes it from core count.
+  never recomputes it from core count. This is also what makes
+  `total_slots_alloc` load-bearing: in a **managed** allocation
+  `plm_base_launch_support` copies `prte_ras_base.total_slots_alloc`
+  straight into `jdata->total_slots_alloc`, which the PMIx server hands
+  out as `PMIX_UNIV_SIZE` and `PMIX_MAX_PROCS`. A miscount here is
+  visible to applications. (In an *unmanaged* allocation the total is
+  recomputed from the pool at launch, which masks the error — so test
+  accounting changes against the managed path or a unit test, not a
+  local `prterun`.)
 - **FQDN normalization.** `normalize_node()` truncates an FQDN to the
   short name, keeping the full name as `rawname` and an alias (unless
   `prte_keep_fqdn_hostnames` or the name is an IP). Sets
@@ -329,6 +344,18 @@ documented in each component's guide.
   DECLARE; there is no separate close file. (An orphaned
   `ras_base_close.c` — never in `base/Makefile.am`, referencing
   long-gone `active_module`/`ras_opened` fields — was removed.)
+- **A `prte_node_t` only acquires a `topology` when its daemon reports
+  in.** Any pool walk that dereferences `node->topology` must NULL-check
+  first — the pool routinely holds allocated-but-not-yet-launched nodes
+  (a node just added by a grow, or the whole allocation before
+  `LAUNCH_DAEMONS`). Both `--display-topo` and `--display-cpus` are pool
+  walks.
+- **A parser reading an RM's file or env must tolerate malformed input.**
+  These run on the HNP, so a NULL deref on a blank line takes the whole
+  DVM down. `strtok_r` returns NULL for a short line; `fgets` does not
+  guarantee a trailing newline; and every `ctype.h` call needs its
+  argument cast to `unsigned char` (a plain `char` is UB for any byte
+  with the high bit set).
 - Standard PRRTE rules apply: `prte_config.h` first, braces on every
   block, `NULL ==`/constant-on-left, no new warnings,
   `PRTE_ERROR_LOG`/`PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED)`
@@ -336,17 +363,38 @@ documented in each component's guide.
 
 ---
 
+## Testing
+
+| Layer | What it covers |
+|-------|----------------|
+| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. |
+| [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), and `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust. |
+| Live RM | SLURM/PBS/LSF/Flux discovery and the SLURM elastic modify surface still need a real scheduler; there is no substitute. |
+
+The unit test builds the global job/node/session arrays by hand (the
+real ones come from `prte_init()`, which wants a live ESS) — follow that
+pattern rather than trying to bring up a DVM in `make check`.
+
+---
+
 ## Debugging
 
 ```sh
 prte --prtemca ras_base_verbose 5 ...     # trace selection + allocation + node_insert
-prun --display-allocation ...              # print the resulting node pool
+prun --display allocation ...             # print the job's node list
 prte --prtemca ras_base_multiplier 8 ...   # fake an 8x-larger cluster
 ```
 
 Verbosity ≥5 prints the final component priority list, each module's
 allocate attempt, and every node inserted with its slot count — start
 there.
+
+Note that `prun --display allocation` renders the **job's** node list
+(`rmaps_base_support_fns.c`), not the global pool: nodes held in a
+reservation created by an elastic grow are withheld from a general job
+and will not appear. The pool dump proper
+(`prte_ras_base_display_alloc`) only fires on the daemon job under
+`ras_base_verbose > 4`.
 
 ---
 

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -444,9 +444,23 @@ prototype here compiles and then mismatches the real library.
 
 | Layer | What it covers |
 |-------|----------------|
-| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. The SLURM half needs symbols in `libprrte` to link against, so it only compiles in when `ras/slurm` is *static* — `ras-slurm` is a DSO by default, so build with `--enable-mca-static=ras-slurm` when you touch those validators. |
+| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and `ras/slurm`'s detect-and-report half — query gating on `SLURM_JOBID` at priority 50, then `allocate()` expanding a compressed `SLURM_NODELIST` and refusing a tainted jobid or an over-length nodelist. That last part is driven **through the framework** (find the component, query it, call the module it returns) rather than by naming its symbols, because `ras-slurm` is a plugin and has none in `libprrte`; keep it that way. It skips with a printed reason when the component is not there to be found. |
 | [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), and `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust. |
-| Live RM | SLURM/PBS/LSF/Flux discovery and the SLURM elastic modify surface still need a real scheduler; there is no substitute. |
+| Live RM | PBS/LSF/Flux discovery still needs a real scheduler; there is no substitute. |
+
+**`ras/slurm`'s `modify` surface has no automated coverage yet, and the
+unit test is not where it goes.** Extend, release and cancel shell out to
+`sbatch`/`scontrol` and only mean anything across several nodes, and each
+of them returns `PRTE_ERR_NOT_AVAILABLE` outright unless jansson was
+found — so a `make check` build, which by default has no jansson, cannot
+reach a line of it. `contrib/dockerswarm` is the right home: it is
+multi-node, and its `build.sh` passes `--with-jansson` deliberately, so
+it is the only automated build anywhere that even compiles
+`ras_slurm_jansson.c`. What it still needs is a faked scheduler — the
+`SLURM_*` environment plus stub `scontrol`/`sbatch`/`scancel` on `PATH`
+returning canned JSON. `validate_hostname` and
+`prte_ras_slurm_drain_cmd_output` live on that path only, so they come
+along with it.
 
 The unit test builds the global job/node/session arrays by hand (the
 real ones come from `prte_init()`, which wants a live ESS) — follow that

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -368,7 +368,7 @@ documented in each component's guide.
 
 ---
 
-## `--enable-testbuild-launchers` — COMPILE ONLY, never run it
+## `--enable-testbuild-launchers` — compile-only, and it requires a DSO
 
 Several ras components are gated on third-party headers that most
 machines do not have, so they are silently skipped by nearly every
@@ -387,25 +387,52 @@ declaration-only stand-ins:
 | [`flux/testbuild_flux.h`](flux/testbuild_flux.h) | `<flux/core.h>`, `<flux/hostlist.h>`, `<flux/idset.h>` | `ras/flux` |
 | [`lsf/testbuild_lsf.h`](lsf/testbuild_lsf.h) | `<lsf/lsbatch.h>` | `ras/lsf` |
 
-> **A tree configured this way MUST NOT BE RUN.** Nothing in those headers
-> is implemented, so the symbols resolve to nothing and the first call
-> into one is a jump to address 0. It is not a graceful failure and not
-> confined to the component: `ras/flux` builds *statically*, and its
-> `query` calls `flux_open_ex` unconditionally, so **every PRRTE tool
-> segfaults during `prte_init`**:
->
-> ```
-> [Mac:73844] Signal: Segmentation fault: 11
-> [Mac:73844] [ 1] libprrte.4.dylib  prte_mca_ras_flux_component_query + 72
-> [Mac:73844] [ 2] libprrte.4.dylib  prte_ras_base_select + 552
-> [Mac:73844] [ 3] libprrte.4.dylib  rte_init + 2868
-> ```
->
-> Use it to answer "does this still compile?" and nothing else. Configure
-> a **second** tree without it for `make check`, the offline harness, and
-> any live run — and re-check the compile-only tree after touching
-> `ras/flux`, `ras/lsf`, or `ras_slurm_jansson.c`, because a normal build
-> will not tell you that you broke them.
+### A stubbed component MUST be a DSO
+
+Nothing behind those declarations is implemented, so the object files
+come out with unresolved `lsb_*`/`flux_*`/`json_*`/`hostlist_*`/`idset_*`
+references. Where they land decides whether the tree even builds:
+
+- **As a run-time loadable plugin** the unresolved references are fine.
+  Creating a shared object does not require them to resolve; the loader
+  refuses the `dlopen` later and the framework simply never sees the
+  component.
+- **Linked statically into `libprrte`** they are fatal. Every PRRTE tool
+  links that library, and the link fails on the first one:
+
+  ```
+  /usr/bin/ld: ../../../src/.libs/libprrte.so: undefined reference to `flux_open_ex'
+  ```
+
+So **every component with a testbuild stub must be in the default
+`--enable-mca-dso` list** in [`config/prte_mca.m4`](../../../config/prte_mca.m4)
+— today `plm-lsf`, `plm-tm`, `ras-lsf`, `ras-flux` and `ras-slurm`
+(`ras/slurm` is on the list because it compiles the jansson parser). That
+is also the right layout regardless of the stubs: it keeps a third-party
+dependency out of `libprrte` and therefore out of every PRRTE tool.
+Adding a stub without adding the component to that list breaks the build
+for everyone.
+
+### It must also not *call* a stub
+
+`dlopen` failing is a Linux-and-friends guarantee, not a universal one.
+On macOS a plugin is a bundle built with a flat namespace: it loads
+happily and the unresolved call becomes a jump to address 0 the moment
+someone makes it. So a stubbed component's `query` must decide whether
+this machine is even its environment **before** it touches the library —
+`getenv("LSB_JOBID")` for `ras/lsf`, `getenv("FLUX_URI")` for `ras/flux`.
+That is the framework convention anyway (see the `allocate()` return
+protocol above); with a stub it is also what keeps `prte_init` from
+segfaulting.
+
+Given both, a tree configured this way builds, links and runs — CI
+depends on that, since every build job configures
+`--enable-testbuild-launchers` and then runs `make check`, `make install`
+and a live `prterun`. What it cannot do is any actual work: nothing is
+parsed and no broker is contacted, so re-check such a tree after touching
+`ras/flux`, `ras/lsf` or `ras_slurm_jansson.c` (a normal build will not
+tell you that you broke them), and do not install one over a good
+installation.
 
 Adding a stub is deliberate work, not boilerplate: declare only what the
 component actually calls, and keep the signatures faithful. A wrong
@@ -417,7 +444,7 @@ prototype here compiles and then mismatches the real library.
 
 | Layer | What it covers |
 |-------|----------------|
-| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. |
+| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. The SLURM half needs symbols in `libprrte` to link against, so it only compiles in when `ras/slurm` is *static* — `ras-slurm` is a DSO by default, so build with `--enable-mca-static=ras-slurm` when you touch those validators. |
 | [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), and `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust. |
 | Live RM | SLURM/PBS/LSF/Flux discovery and the SLURM elastic modify surface still need a real scheduler; there is no substitute. |
 

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -221,6 +221,11 @@ input list.** Walk it carefully before touching allocation code:
   daemon but leaves the pool entry, so the regrant always arrives as a
   duplicate. Only `PRTE_NODE_STATE_ADDED` is carried across, because the
   DVM extension keys off it to decide where to launch.
+- **Pre-assigned pool slots.** A component may choose a node's pool slot
+  by setting `node->index` before handing it over; `node_insert` places
+  it there rather than appending to the lowest free slot (falling back
+  to an append if the slot is occupied). `ras/bootstrap` is the only
+  component that does this, and it needs it — see its guide.
 - **Managed = sacred slots.** Under `prte_managed_allocation` (or when a
   node arrives with `PRTE_NODE_FLAG_SLOTS_GIVEN`), the base sets
   `SLOTS_GIVEN` so downstream code treats the slot count as fixed and
@@ -367,7 +372,7 @@ documented in each component's guide.
 
 | Layer | What it covers |
 |-------|----------------|
-| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. |
+| [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and the SLURM taint validators + bounded output drain. |
 | [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), and `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust. |
 | Live RM | SLURM/PBS/LSF/Flux discovery and the SLURM elastic modify surface still need a real scheduler; there is no substitute. |
 

--- a/src/mca/ras/base/Makefile.am
+++ b/src/mca/ras/base/Makefile.am
@@ -20,7 +20,8 @@
 #
 
 EXTRA_DIST += \
-        base/help-ras-base.txt
+        base/help-ras-base.txt \
+        base/testbuild_jansson.h
 
 headers += \
         base/base.h

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1289,8 +1289,14 @@ static void ras_base_set_alloc_response(prte_pmix_server_req_t *req,
         PMIX_INFO_LOAD(&rinfo[1], PMIX_ALLOC_REQ_ID, dest->user_refid,
                        PMIX_STRING);
     }
-    /* the original req->info is borrowed from the PMIx caller; repoint
-     * to our response array and let the req destructor free it */
+    /* Repoint to our response array and let the req destructor free it.
+     * The original req->info is usually borrowed from the PMIx caller and
+     * needs no action, but a request that already owns its array (one
+     * relayed from a remote peer, or one an RM module replaced with a
+     * scheduler answer) would strand it here. */
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+    }
     req->info = rinfo;
     req->ninfo = rn;
     req->copy = true;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -291,6 +291,10 @@ void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist)
     }
 
     nodes = PMIx_Argv_split(nodelist, ';');
+    if (NULL == nodes) {
+        /* the nodelist held nothing we can resolve */
+        return;
+    }
     for (j=0; NULL != nodes[j]; j++) {
         moveon = false;
         for (i=0; i < prte_node_pool->size && !moveon; i++) {
@@ -299,7 +303,11 @@ void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist)
                 continue;
             }
             if (0 == strcmp(nptr->name, nodes[j])) {
-                display_cpus(nptr->topology, jdata, nodes[j]);
+                /* a node that has not yet been launched upon carries no
+                 * topology - there is nothing to display for it */
+                if (NULL != nptr->topology) {
+                    display_cpus(nptr->topology, jdata, nodes[j]);
+                }
                 break;
             }
             if (NULL == nptr->aliases) {
@@ -309,7 +317,9 @@ void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist)
             for (m = 0; NULL != nptr->aliases[m]; m++) {
                 if (0 == strcmp(nodes[j], nptr->aliases[m])) {
                     /* this is the node! */
-                    display_cpus(nptr->topology, jdata, nodes[j]);
+                    if (NULL != nptr->topology) {
+                        display_cpus(nptr->topology, jdata, nodes[j]);
+                    }
                     moveon = true;
                     break;
                 }
@@ -477,12 +487,13 @@ DISPLAY:
 
         ret = PMIx_Notify_event(PMIX_NOTIFY_ALLOC_COMPLETE, NULL, PMIX_GLOBAL,
                                 &info, 1, NULL, NULL);
+        PMIX_INFO_DESTRUCT(&info);
         if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
             PMIX_ERROR_LOG(ret);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PMIX_RELEASE(caddy);
+            return;
         }
-        PMIX_INFO_DESTRUCT(&info);
     }
 
     /* set total slots alloc */
@@ -495,7 +506,10 @@ DISPLAY:
             free(hosts);
             for (j=0; NULL != hostlist[j]; j++) {
                 node = prte_node_match(NULL, hostlist[j]);
-                if (NULL == node) {
+                /* a node only acquires a topology once its daemon has
+                 * reported in - a node that is allocated but not yet
+                 * launched upon (e.g. one just added by a grow) has none */
+                if (NULL == node || NULL == node->topology) {
                     continue;
                 }
                 pmix_output(prte_clean_output,
@@ -511,7 +525,7 @@ DISPLAY:
         } else {
             for (j=0; j < prte_node_pool->size; j++) {
                 node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, j);
-                if (NULL == node) {
+                if (NULL == node || NULL == node->topology) {
                     continue;
                 }
                 pmix_output(prte_clean_output,

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -77,9 +77,10 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
     int rc, i;
     prte_node_t *node, *hnp_node, *nptr;
     bool skiphnp = false, found;
-    prte_attribute_t *kv;
+    prte_attribute_t *kv, *kv2;
     prte_proc_t *daemon;
     prte_job_t *djob;
+    pmix_status_t prc;
 
     /* get the number of nodes */
     num_nodes = (int32_t) pmix_list_get_size(nodes);
@@ -165,12 +166,22 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
             } else {
                 hnp_node->slots = node->slots;
             }
-            /* copy across any attributes */
+            /* copy across any attributes. Note that prte_set_attribute()
+             * expects a raw C value pointer, NOT a pmix_value_t, so the
+             * attribute is duplicated and spliced in directly rather than
+             * being round-tripped through set_attribute. */
             PMIX_LIST_FOREACH(kv, &node->attributes, prte_attribute_t)
             {
-                prte_set_attribute(&node->attributes, kv->key,
-                                   PRTE_ATTR_LOCAL,
-                                   &kv->data, kv->data.type);
+                prte_remove_attribute(&hnp_node->attributes, kv->key);
+                kv2 = PMIX_NEW(prte_attribute_t);
+                kv2->key = kv->key;
+                kv2->local = kv->local;
+                prc = PMIx_Value_xfer(&kv2->data, &kv->data);
+                if (PMIX_SUCCESS != prc) {
+                    PMIX_RELEASE(kv2);
+                    continue;
+                }
+                pmix_list_append(&hnp_node->attributes, &kv2->super);
             }
             if (prte_managed_allocation || PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
                 /* the slots are always treated as sacred
@@ -245,26 +256,36 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                     break;
                 }
             }
-            if (!found) {
-                if (prte_managed_allocation) {
-                    /* the slots are always treated as sacred
-                     * in managed allocations
-                     */
-                    PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
-                }
-                /* detect FQDN before normalizing, then normalize to short name */
-                if (!pmix_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
-                    prte_have_fqdn_allocation = true;
-                }
-                normalize_node(node);
-                /* insert it into the array */
-                node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
-                if (PRTE_SUCCESS > (rc = node->index)) {
-                    PRTE_ERROR_LOG(rc);
-                    return rc;
-                }
+            if (found) {
+                /* the pool entry is authoritative - drop the duplicate the
+                 * caller handed us. Its slots must NOT be added to the
+                 * running total: that node is already counted, and adding
+                 * it again inflates total_slots_alloc on every re-grow of a
+                 * node the pool already knows about. The multiplier copies
+                 * likewise belong to the original insertion, not to this
+                 * rediscovery of it. */
+                PMIX_RELEASE(node);
+                continue;
             }
-            if (prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
+            if (prte_managed_allocation) {
+                /* the slots are always treated as sacred
+                 * in managed allocations
+                 */
+                PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+            }
+            /* detect FQDN before normalizing, then normalize to short name */
+            if (!pmix_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
+                prte_have_fqdn_allocation = true;
+            }
+            normalize_node(node);
+            /* insert it into the array */
+            node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
+            if (PRTE_SUCCESS > (rc = node->index)) {
+                PRTE_ERROR_LOG(rc);
+                return rc;
+            }
+            if (NULL != djob &&
+                prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&
                 NULL == node->daemon) {
                 /* create a daemon for this node since we won't be launching
                  * and the mapper needs to see a daemon - this is used solely

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -278,11 +278,32 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 prte_have_fqdn_allocation = true;
             }
             normalize_node(node);
-            /* insert it into the array */
-            node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
-            if (PRTE_SUCCESS > (rc = node->index)) {
-                PRTE_ERROR_LOG(rc);
-                return rc;
+            /* Insert it into the array.
+             *
+             * A component may pre-assign the pool slot by setting node->index
+             * before handing us the node; ras/bootstrap does exactly that, so
+             * a node lands at the slot matching its canonical DVM rank (read
+             * from the same config file the daemons read to compute their own
+             * rank). Appending to the lowest free slot would reproduce that
+             * only by accident of the order the config happens to list nodes
+             * in - and would silently overwrite the pre-assignment, making the
+             * correspondence unenforced. A slot that is already taken means a
+             * malformed config; fall back to an append rather than clobber
+             * another node. */
+            if (0 <= node->index &&
+                NULL == pmix_pointer_array_get_item(prte_node_pool, node->index)) {
+                rc = pmix_pointer_array_set_item(prte_node_pool, node->index,
+                                                 (void *) node);
+                if (PRTE_SUCCESS != rc) {
+                    PRTE_ERROR_LOG(rc);
+                    return rc;
+                }
+            } else {
+                node->index = pmix_pointer_array_add(prte_node_pool, (void *) node);
+                if (PRTE_SUCCESS > (rc = node->index)) {
+                    PRTE_ERROR_LOG(rc);
+                    return rc;
+                }
             }
             if (NULL != djob &&
                 prte_get_attribute(&djob->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL) &&

--- a/src/mca/ras/base/testbuild_jansson.h
+++ b/src/mca/ras/base/testbuild_jansson.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Stand-in for <jansson.h>, used only when --enable-testbuild-launchers is
+ * given so that the JSON-parsing paths of ras/slurm and ras/flux can be
+ * COMPILED on a machine that has no jansson installed.  Those are the largest
+ * and least-exercised bodies of code in the ras framework -- ras/slurm's
+ * "scontrol --json" parser alone is ~1000 lines -- and without this they are
+ * silently skipped by every developer build and every CI job, so a typo in
+ * them is not caught until someone with jansson tries to build.
+ *
+ * DECLARATIONS ONLY.  Nothing here is implemented, so a tree configured this
+ * way must not be RUN: see the note in src/mca/ras/AGENTS.md.
+ *
+ * Only the subset actually used by the ras components is declared; add to it
+ * as they grow.
+ */
+
+#ifndef PRTE_RAS_TESTBUILD_JANSSON_H
+#define PRTE_RAS_TESTBUILD_JANSSON_H
+
+#include "prte_config.h"
+
+#include <stddef.h>
+
+BEGIN_C_DECLS
+
+typedef struct prte_testbuild_json_t json_t;
+typedef long long json_int_t;
+#define JSON_INTEGER_FORMAT "lld"
+
+typedef struct {
+    char text[160];
+    char source[80];
+    int line;
+    int column;
+    size_t position;
+} json_error_t;
+
+/* load flags */
+#define JSON_REJECT_DUPLICATES 0x1
+#define JSON_DECODE_ANY        0x2
+
+typedef size_t (*json_load_callback_t)(void *buffer, size_t buflen, void *data);
+
+json_t *json_loads(const char *input, size_t flags, json_error_t *error);
+json_t *json_load_callback(json_load_callback_t callback, void *data,
+                           size_t flags, json_error_t *error);
+int json_unpack(json_t *root, const char *fmt, ...);
+int json_unpack_ex(json_t *root, json_error_t *error, size_t flags,
+                   const char *fmt, ...);
+
+json_t *json_incref(json_t *json);
+void json_decref(json_t *json);
+
+json_t *json_object_get(const json_t *object, const char *key);
+size_t json_array_size(const json_t *array);
+json_t *json_array_get(const json_t *array, size_t index);
+
+int json_is_object(const json_t *json);
+int json_is_array(const json_t *json);
+int json_is_string(const json_t *json);
+int json_is_integer(const json_t *json);
+int json_is_boolean(const json_t *json);
+int json_is_true(const json_t *json);
+int json_is_false(const json_t *json);
+int json_is_null(const json_t *json);
+
+const char *json_string_value(const json_t *string);
+size_t json_string_length(const json_t *string);
+json_int_t json_integer_value(const json_t *integer);
+
+/* jansson defines this as a macro; mirror its shape so the loop bodies in the
+ * components compile identically */
+#define json_array_foreach(array, index, value)                     \
+    for (index = 0;                                                 \
+         index < json_array_size(array) &&                          \
+             (value = json_array_get(array, index));                \
+         index++)
+
+END_C_DECLS
+
+#endif /* PRTE_RAS_TESTBUILD_JANSSON_H */

--- a/src/mca/ras/bootstrap/AGENTS.md
+++ b/src/mca/ras/bootstrap/AGENTS.md
@@ -44,8 +44,15 @@ node is already represented by the HNP at pool index 0. Each node is a
 
 ## Things to watch when editing
 
-- **Node `index` is the canonical bootstrap rank**, not a pool-insertion
-  ordinal — the launch/routing path depends on this correspondence.
+- **`allocate` sets node `index` to the canonical bootstrap rank**, but
+  be aware that `prte_ras_base_node_insert` **overwrites it** with the
+  pool-insertion ordinal (`pmix_pointer_array_add`). The two agree only
+  because the HNP occupies pool slot 0 and `DVMNodes` is listed in rank
+  order, so ranks 1..N land in slots 1..N. Nothing enforces that: a
+  config listing nodes out of rank order, or a pool that already has
+  holes, breaks the correspondence silently. If the launch/routing path
+  ever needs the bootstrap rank after insertion, store it explicitly
+  rather than relying on `index`.
 - Skipping rank 0 avoids double-entering the controller (HNP) node;
   don't remove that guard.
 - Setting `prte_managed_allocation` is intentional and load-bearing for

--- a/src/mca/ras/bootstrap/AGENTS.md
+++ b/src/mca/ras/bootstrap/AGENTS.md
@@ -44,15 +44,25 @@ node is already represented by the HNP at pool index 0. Each node is a
 
 ## Things to watch when editing
 
-- **`allocate` sets node `index` to the canonical bootstrap rank**, but
-  be aware that `prte_ras_base_node_insert` **overwrites it** with the
-  pool-insertion ordinal (`pmix_pointer_array_add`). The two agree only
-  because the HNP occupies pool slot 0 and `DVMNodes` is listed in rank
-  order, so ranks 1..N land in slots 1..N. Nothing enforces that: a
-  config listing nodes out of rank order, or a pool that already has
-  holes, breaks the correspondence silently. If the launch/routing path
-  ever needs the bootstrap rank after insertion, store it explicitly
-  rather than relying on `index`.
+- **`allocate` pre-assigns node `index` to the canonical bootstrap rank,
+  and `prte_ras_base_node_insert` honors it.** This is load-bearing, not
+  cosmetic: a bootstrapped daemon computes its *own* vpid from this same
+  config file (`prte_bootstrap_my_identity`), so the HNP does not get to
+  choose one — it has to arrive at the same answer independently.
+  `node_insert` therefore places a node carrying a pre-assigned
+  `index >= 0` at exactly that pool slot (falling back to an append only
+  if the slot is already taken, which means a malformed config) instead
+  of appending to the lowest free slot. Before that, the assignment was
+  silently overwritten and the correspondence held only by accident of
+  `DVMNodes` being listed in rank order.
+- **The remaining coupling lives in plm, not here.**
+  `prte_plm_base_setup_virtual_machine` still hands out daemon vpids as
+  `daemons->num_procs` — sequentially over pool order — rather than
+  reading `node->index`. For a well-formed config the two coincide
+  (slots 1..N, ranks 1..N). They can diverge if `DVMNodes` names a host
+  more than once: `node_insert` dedups the repeat, so a later node keeps
+  its true rank in the pool while plm still numbers sequentially. If
+  that case ever needs to work, plm is where to fix it.
 - Skipping rank 0 avoids double-entering the controller (HNP) node;
   don't remove that guard.
 - Setting `prte_managed_allocation` is intentional and load-bearing for

--- a/src/mca/ras/bootstrap/AGENTS.md
+++ b/src/mca/ras/bootstrap/AGENTS.md
@@ -55,14 +55,19 @@ node is already represented by the HNP at pool index 0. Each node is a
   of appending to the lowest free slot. Before that, the assignment was
   silently overwritten and the correspondence held only by accident of
   `DVMNodes` being listed in rank order.
-- **The remaining coupling lives in plm, not here.**
-  `prte_plm_base_setup_virtual_machine` still hands out daemon vpids as
-  `daemons->num_procs` — sequentially over pool order — rather than
-  reading `node->index`. For a well-formed config the two coincide
-  (slots 1..N, ranks 1..N). They can diverge if `DVMNodes` names a host
-  more than once: `node_insert` dedups the repeat, so a later node keeps
-  its true rank in the pool while plm still numbers sequentially. If
-  that case ever needs to work, plm is where to fix it.
+- **plm reads that index back out as the daemon's vpid.**
+  `prte_plm_base_setup_virtual_machine` uses `node->index` (not the next
+  sequential vpid) when `prte_bootstrap_setup` is on, closing the loop:
+  config → pool slot → daemon vpid, all from the one authority the
+  daemons themselves used.
+- **Ranks are contiguous, and `prte_bootstrap_parse` enforces it.** A
+  host listed twice in `DVMNodes` resolves to the position of its first
+  occurrence, leaving a rank no daemon will ever claim while
+  `prte_bootstrap_num_daemons` still counts it — the DVM could never
+  finish forming. The parser rejects that file up front
+  (`bootstrap-duplicate-node`), so every daemon fails identically and
+  immediately, and by the time this component runs the name↔rank mapping
+  is a bijection.
 - Skipping rank 0 avoids double-entering the controller (HNP) node;
   don't remove that guard.
 - Setting `prte_managed_allocation` is intentional and load-bearing for

--- a/src/mca/ras/bootstrap/ras_boot.c
+++ b/src/mca/ras/bootstrap/ras_boot.c
@@ -45,7 +45,10 @@ static int allocate(prte_job_t *jdata, pmix_list_t *ndlist)
     int n, rc;
     PRTE_HIDE_UNUSED_PARAMS(jdata);
 
-    /* read the same configuration file the daemons read */
+    /* Read the same configuration file the daemons read.  prte_bootstrap_parse
+     * validates it - including that no host is listed twice, which would leave
+     * a rank no daemon ever claims - so the node/rank mapping used below is a
+     * bijection by the time we get here. */
     rc = prte_bootstrap_parse(&cfg);
     if (PRTE_SUCCESS != rc) {
         return rc;

--- a/src/mca/ras/bootstrap/ras_boot.c
+++ b/src/mca/ras/bootstrap/ras_boot.c
@@ -72,6 +72,13 @@ static int allocate(prte_job_t *jdata, pmix_list_t *ndlist)
         }
         ndptr = PMIX_NEW(prte_node_t);
         ndptr->name = strdup(cfg.nodes[n]);
+        /* Pre-assign the pool slot to the node's canonical DVM rank.  This is
+         * not cosmetic: a bootstrapped daemon computes its OWN vpid from this
+         * same config file (prte_bootstrap_my_identity), so the HNP does not
+         * get to choose one - it has to arrive at the same answer
+         * independently.  prte_ras_base_node_insert() honors a pre-assigned
+         * index precisely so that correspondence is established by the config
+         * rather than by the order nodes happen to be appended in. */
         ndptr->index = (int) rank;
         ndptr->state = PRTE_NODE_STATE_UP;
         ndptr->slots = 1;

--- a/src/mca/ras/flux/AGENTS.md
+++ b/src/mca/ras/flux/AGENTS.md
@@ -56,6 +56,18 @@ with `slots = nslots`. Errors map to `PRTE_ERR_NOT_AVAILABLE`.
   `configure.m4` gate so non-Flux builds still compile the tree.
 - Only R **version 1** is parsed; a different version is a clean
   `PRTE_ERR_NOT_AVAILABLE`, not a crash — preserve that.
-- The parser carefully frees `hostinfo`/`hostlist` on every exit path;
-  mind the `err:` cleanup when adding branches.
+- The parser frees `hostinfo`/`hostlist` on every exit path; mind the
+  `err:` cleanup when adding branches. **Declare anything the cleanup
+  block touches at the top of the function**: `root` was originally
+  declared mid-body, so every early `goto err` jumped over its
+  initializer and the cleanup decref'd an indeterminate pointer.
+- **Use `s?o`, not `s?O`, in `json_unpack_ex`** unless you decref the
+  result — the capital form takes a reference. `scheduling` is unpacked
+  purely to satisfy the format string and is never used.
+- `hostinfo_append_ranks` reports into a caller-supplied buffer rather
+  than allocating, because the caller's `error_str` also holds string
+  literals; a mixed-ownership error pointer can be neither freed nor
+  safely leaked. It returns a **count**, so a caller treating `<= 0` as
+  failure must also set `ret` — falling through to `err:` with `ret`
+  still `PRTE_SUCCESS` returns a partially-built node list as success.
 </content>

--- a/src/mca/ras/flux/AGENTS.md
+++ b/src/mca/ras/flux/AGENTS.md
@@ -11,9 +11,20 @@ Component guide for `src/mca/ras/flux/`. Read the
 and fetching the job's resource set. It is an **optional build**: its
 `configure.m4` requires both Flux (`PRTE_CHECK_FLUX`) and Jansson
 (`PRTE_CHECK_JANSSON`); if either is missing the component is not built.
-Its `query` actually opens a Flux handle (`flux_open_ex`) to test
-availability, selecting at the configurable priority `ras_flux_priority`
-(default **100**) when a broker answers.
+It is also a **run-time loadable plugin** — it is in the default
+`--enable-mca-dso` list in
+[`config/prte_mca.m4`](../../../../config/prte_mca.m4), which keeps
+`libflux-core` and `libjansson` out of `libprrte` and hence out of every
+PRRTE tool. Do not take it off that list: it is what makes
+`--enable-testbuild-launchers` viable (see the framework guide).
+
+`query` gates on `FLUX_URI` (or an explicitly-set `ras_flux_broker_uri`)
+and only then opens a handle (`flux_open_ex`) to confirm a broker is
+really there, selecting at the configurable priority `ras_flux_priority`
+(default **100**) when one answers. The env check is not just an
+optimization — it is what stops the component from calling into a stub
+library in a testbuild tree, and outside a Flux instance the open could
+not have succeeded anyway.
 
 Files:
 

--- a/src/mca/ras/flux/Makefile.am
+++ b/src/mca/ras/flux/Makefile.am
@@ -52,8 +52,8 @@ mcacomponent_LTLIBRARIES = $(component_install)
 prte_mca_ras_flux_la_SOURCES = $(sources)
 prte_mca_ras_flux_la_CPPFLAGS = $(ras_flux_CPPFLAGS) $(ras_flux_jansson_CPPFLAGS)
 prte_mca_ras_flux_la_LDFLAGS = -module -avoid-version $(ras_flux_LDFLAGS) $(ras_flux_jansson_LDFLAGS)
-prte_mca_ras_flux_la_LIBADD = $(ras_flux_LIBS) $(ras_flux_jansson_LIBS)\
-    $(top_builddir)/src/lib@PRTE_BINARY_PREFIX@prrte.la
+prte_mca_ras_flux_la_LIBADD = $(top_builddir)/src/libprrte.la \
+    $(ras_flux_LIBS) $(ras_flux_jansson_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libprtemca_ras_flux_la_SOURCES =$(sources)

--- a/src/mca/ras/flux/Makefile.am
+++ b/src/mca/ras/flux/Makefile.am
@@ -31,7 +31,9 @@ sources = \
         ras_flux_component.c \
         ras_flux_module.c
 
-EXTRA_DIST = help-ras-flux.txt
+# testbuild_flux.h is only #included when --enable-testbuild-launchers
+# is given, so it appears in no _SOURCES list and has to be listed here
+EXTRA_DIST = help-ras-flux.txt testbuild_flux.h
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/src/mca/ras/flux/configure.m4
+++ b/src/mca/ras/flux/configure.m4
@@ -34,8 +34,12 @@ AC_DEFUN([MCA_prte_ras_flux_CONFIG],[
     PRTE_CHECK_JANSSON([ras_flux_jansson], [ras_jansson_good=1], [ras_jansson_good=0])
 
     # if check worked, set wrapper flags if so.
-    # Evaluate succeed / fail
-    AS_IF([test "$ras_flux_good" = "1" -a "$ras_jansson_good" = "1"],
+    # Evaluate succeed / fail.  --enable-testbuild-launchers also builds this
+    # component, against the declarations in testbuild_flux.h, so that a
+    # machine with no Flux installation can still COMPILE it -- see that header
+    # and src/mca/ras/AGENTS.md.  Such a build must not be run.
+    AS_IF([test "$ras_flux_good" = "1" -a "$ras_jansson_good" = "1" || \
+           test "$prte_testbuild_launchers" = "1"],
           [$1],
           [$2])
  

--- a/src/mca/ras/flux/ras_flux_component.c
+++ b/src/mca/ras/flux/ras_flux_component.c
@@ -26,9 +26,16 @@
  * $HEADER$
  */
 
-#include <flux/core.h>
+/* prte_config.h MUST be first - see the top-level AGENTS.md. It also defines
+ * PRTE_TESTBUILD_LAUNCHERS, which selects the header below. */
 #include "prte_config.h"
 #include "constants.h"
+
+#if PRTE_TESTBUILD_LAUNCHERS
+#    include "testbuild_flux.h"
+#else
+#    include <flux/core.h>
+#endif
 
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/base/pmix_mca_base_var.h"

--- a/src/mca/ras/flux/ras_flux_component.c
+++ b/src/mca/ras/flux/ras_flux_component.c
@@ -31,6 +31,8 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#include <stdlib.h>
+
 #if PRTE_TESTBUILD_LAUNCHERS
 #    include "testbuild_flux.h"
 #else
@@ -107,6 +109,20 @@ static int prte_mca_ras_flux_component_query(pmix_mca_base_module_t **module, in
 {
     flux_t *h = NULL;
     flux_error_t error;
+
+    /* Like every other ras component, decide first whether the job is even
+     * ours before doing any work.  Opening a handle is not free, and outside
+     * a Flux instance it cannot succeed anyway: flux_open_ex takes its
+     * default URI from FLUX_URI, which a Flux instance always sets for the
+     * jobs it runs.  So unless the user pointed us at a broker explicitly,
+     * no FLUX_URI means no Flux, and we should not touch the library at
+     * all -- which is also what keeps an --enable-testbuild-launchers tree
+     * (where the library is a set of stubs) from calling into it. */
+    if (NULL == prte_mca_ras_flux_component.flux_broker_uri &&
+        NULL == getenv("FLUX_URI")) {
+        *module = NULL;
+        return PRTE_ERROR;
+    }
 
     /* See if we can contact a Flux broker */
     h = flux_open_ex(prte_mca_ras_flux_component.flux_broker_uri, 

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -30,10 +30,14 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
-#include <flux/core.h>
-#include <flux/hostlist.h>
-#include <flux/idset.h>
-#include <jansson.h>
+#if PRTE_TESTBUILD_LAUNCHERS
+#    include "testbuild_flux.h"
+#else
+#    include <flux/core.h>
+#    include <flux/hostlist.h>
+#    include <flux/idset.h>
+#    include <jansson.h>
+#endif
 #include <stdio.h>
 
 #include "src/util/pmix_net.h"
@@ -191,6 +195,9 @@ out:
 static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
 {
     int i, version, start, nnodes, ret = PRTE_SUCCESS;
+    /* json_array_foreach compares its index against json_array_size(), which
+     * is a size_t - an int index is a signedness mismatch that -Werror rejects */
+    size_t idx;
     /* every assignment to error_str is a string literal - the idset decode
      * helper below reports through a separate buffer so this stays
      * non-owning and needs no free */
@@ -263,7 +270,7 @@ static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
     }
 
     start = 0;
-    json_array_foreach (R_lite, i, entry) {
+    json_array_foreach (R_lite, idx, entry) {
         const char *ranks;
         const char *cores;
         int rc;
@@ -383,8 +390,12 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
                          "%s ras:flux:allocate: flux job id is %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), flux_job_id));
 
     /*
-     * not sure what good this does but here goes
+     * record the job id for error reporting, releasing any previous
+     * value - allocate() can run more than once in a session
      */
+    if (NULL != prte_job_ident) {
+        free(prte_job_ident);
+    }
     prte_job_ident = strdup(flux_job_id);
 
     /*

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -40,6 +40,7 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_os_path.h"
 #include "src/util/pmix_show_help.h"
+#include "src/util/pmix_string_copy.h"
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/runtime/prte_globals.h"
@@ -60,7 +61,8 @@ static struct R_hostinfo *hostinfo_array_create (struct hostlist *hl);
 static void hostinfo_array_destroy (struct R_hostinfo *hostinfo, int n);
 static int hostinfo_append_ranks (struct R_hostinfo *hostinfo, int nnodes,
                                   int start, const char *rankstr,
-                                  const char *corestr, char **error_str);
+                                  const char *corestr, char *error_buf,
+                                  size_t error_buf_size);
 static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist);
 
 /*
@@ -139,12 +141,17 @@ static void hostinfo_array_destroy (struct R_hostinfo *hostinfo, int n)
     }
 }
 
+/* Reports failures through the caller-supplied buffer rather than by
+ * allocating: the caller's error_str also carries string literals from its
+ * own checks, so a mixed-ownership pointer there could neither be freed nor
+ * safely leaked. */
 static int hostinfo_append_ranks (struct R_hostinfo *hostinfo,
                                   int nnodes,
                                   int start,
                                   const char *rankstr,
                                   const char *corestr,
-                                  char **error_str)
+                                  char *error_buf,
+                                  size_t error_buf_size)
 {
     unsigned int i;
     struct idset *ranks = NULL;
@@ -154,20 +161,20 @@ static int hostinfo_append_ranks (struct R_hostinfo *hostinfo,
 
     if (!(ranks = idset_decode (rankstr))
         || !(cores = idset_decode (corestr))) {
-        *error_str = strdup("failed to decode ranks/core idset");
+        pmix_string_copy(error_buf, "failed to decode ranks/core idset", error_buf_size);
         goto out;
     }
 
     if (idset_count (ranks) <= 0
         || (ncores = idset_count (cores)) <= 0) {
-        *error_str = strdup("invalid rank or core count in Rv1");
+        pmix_string_copy(error_buf, "invalid rank or core count in Rv1", error_buf_size);
         goto out;
     }
 
     i = idset_first (ranks);
     while (i != IDSET_INVALID_ID) {
         if (start + count > nnodes - 1) {
-            *error_str = strdup("Rlite ranks exceeds nodelist entries");
+            pmix_string_copy(error_buf, "Rlite ranks exceeds nodelist entries", error_buf_size);
             goto out;
         }
         hostinfo[start + count].broker_rank = i;
@@ -184,7 +191,11 @@ out:
 static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
 {
     int i, version, start, nnodes, ret = PRTE_SUCCESS;
-    char *error_str = NULL;
+    /* every assignment to error_str is a string literal - the idset decode
+     * helper below reports through a separate buffer so this stays
+     * non-owning and needs no free */
+    const char *error_str = NULL;
+    char idset_err[128];
     json_t *entry = NULL;
     json_t *R_lite = NULL;
     json_t *nodelist = NULL;
@@ -197,8 +208,11 @@ static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
     /*
      * unpack the json
     */
+    /* NOTE: "s?o" (borrowed reference), NOT "s?O" - the capital form
+     * increments the refcount and nothing here ever decrefs it, which
+     * leaks the whole "scheduling" subtree on every allocation */
     if (json_unpack_ex (root, &error, 0,
-                        "{s:i s?O s:{s:o s:o s?o}}",
+                        "{s:i s?o s:{s:o s:o s?o}}",
                         "version", &version,
                         "scheduling", &scheduling,
                         "execution",
@@ -262,13 +276,18 @@ static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
             ret = PRTE_ERR_NOT_AVAILABLE;
             goto err;
         }
+        idset_err[0] = '\0';
         if ((rc = hostinfo_append_ranks (hostinfo,
                                          nnodes,
                                          start,
                                          ranks,
                                          cores,
-                                         &error_str)) <= 0)
+                                         idset_err,
+                                         sizeof(idset_err))) <= 0) {
+            error_str = ('\0' == idset_err[0]) ? NULL : idset_err;
+            ret = PRTE_ERR_NOT_AVAILABLE;
             goto err;
+        }
         start += rc;
     }
 
@@ -334,6 +353,10 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     json_error_t json_err;
     char *return_str=NULL;
     const char *flux_job_id=NULL;
+    /* MUST be declared (and NULLed) before the first "goto err": the cleanup
+     * block decrefs it, and every early error path jumps over the point where
+     * json_loads() would otherwise have initialized it */
+    json_t *root = NULL;
 
     if ((jdata == NULL) || (nodes == NULL)) {
         return PRTE_ERR_BAD_PARAM;
@@ -381,7 +404,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     if(flux_kvs_lookup_get (f, (const char **)&return_str) < 0){
         int errno_l = errno;
         pmix_show_help("help-ras-flux.txt", "flux-kvs-lookup-get-failure", 1, strerror(errno_l));
-        return PRTE_ERR_NOT_FOUND;
+        ret = PRTE_ERR_NOT_FOUND;
         goto err;
     }
 
@@ -391,7 +414,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     /*
      *  Parse the returned JSON payload
      */
-    json_t *root = json_loads(return_str, JSON_DECODE_ANY, &json_err);
+    root = json_loads(return_str, JSON_DECODE_ANY, &json_err);
     if (NULL == root) {
         pmix_show_help("help-ras-flux.txt", "flux-json-parse-failure", 1, json_err.text);
         ret = PRTE_ERR_UNPACK_FAILURE;

--- a/src/mca/ras/flux/testbuild_flux.h
+++ b/src/mca/ras/flux/testbuild_flux.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Stand-in for <flux/core.h>, <flux/hostlist.h> and <flux/idset.h>, used only
+ * when --enable-testbuild-launchers is given so this component can be COMPILED
+ * on a machine with no Flux installation.  ras/flux is an optional build gated
+ * on finding Flux *and* jansson, which in practice means almost nobody
+ * compiles it -- so it is exactly the component where an edit can sit broken
+ * indefinitely.
+ *
+ * DECLARATIONS ONLY.  Nothing here is implemented, so a tree configured this
+ * way must not be RUN: see the note in src/mca/ras/AGENTS.md.
+ *
+ * Only the subset this component actually uses is declared; add to it as the
+ * component grows.
+ */
+
+#ifndef PRTE_RAS_FLUX_TESTBUILD_H
+#define PRTE_RAS_FLUX_TESTBUILD_H
+
+#include "prte_config.h"
+
+#include "src/mca/ras/base/testbuild_jansson.h"
+
+BEGIN_C_DECLS
+
+/* --- flux/core.h --- */
+typedef struct prte_testbuild_flux_t flux_t;
+typedef struct prte_testbuild_flux_future_t flux_future_t;
+
+typedef struct {
+    char text[160];
+} flux_error_t;
+
+flux_t *flux_open_ex(const char *uri, int flags, flux_error_t *error);
+void flux_close(flux_t *h);
+const char *flux_attr_get(flux_t *h, const char *name);
+flux_future_t *flux_kvs_lookup(flux_t *h, const char *ns, int flags,
+                               const char *key);
+int flux_kvs_lookup_get(flux_future_t *f, const char **value);
+void flux_future_destroy(flux_future_t *f);
+
+/* --- flux/hostlist.h --- */
+struct hostlist;
+struct hostlist *hostlist_create(void);
+void hostlist_destroy(struct hostlist *hl);
+int hostlist_append(struct hostlist *hl, const char *hosts);
+int hostlist_count(struct hostlist *hl);
+const char *hostlist_first(struct hostlist *hl);
+const char *hostlist_next(struct hostlist *hl);
+
+/* --- flux/idset.h --- */
+#define IDSET_INVALID_ID ((unsigned int) -1)
+struct idset;
+struct idset *idset_decode(const char *s);
+void idset_destroy(struct idset *idset);
+int idset_count(const struct idset *idset);
+unsigned int idset_first(const struct idset *idset);
+unsigned int idset_next(const struct idset *idset, unsigned int prev);
+
+END_C_DECLS
+
+#endif /* PRTE_RAS_FLUX_TESTBUILD_H */

--- a/src/mca/ras/gridengine/AGENTS.md
+++ b/src/mca/ras/gridengine/AGENTS.md
@@ -44,6 +44,9 @@ framework `ras_base_verbose`.
 
 - The parser tokenizes on `" \n"` and reads exactly four fields; only
   `hostname` and `slots` are used (queue/arch are logged, not stored).
+  **`strtok_r` returns NULL for a blank or short line** — a missing
+  hostname or slot count must be skipped, not dereferenced. This runs on
+  the HNP, so a NULL deref here takes the whole DVM down.
 - `query` is strict about **all four** env vars — SGE sets them
   together; loosening the gate risks selecting on a non-SGE machine.
 - `get_slot_count` is `#if 0`-guarded dead code; ignore it.

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -94,7 +94,9 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
                        strerror(errno));
         rc = PRTE_ERROR;
         PRTE_ERROR_LOG(rc);
-        goto cleanup;
+        /* return the open failure: falling through to the shared cleanup
+         * would report "no nodes found" and hide why */
+        return rc;
     }
 
     /* parse the pe_hostfile for hostname, slots, etc, then compare the
@@ -146,10 +148,7 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
         }
     } /* finished reading the $PE_HOSTFILE */
 
-cleanup:
-    if (NULL != fp) {
-        fclose(fp);
-    }
+    fclose(fp);
 
     /* in gridengine, if we didn't find anything, then something
      * is wrong. The user may not have indicated this was a parallel

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -110,6 +110,13 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
         queue = strtok_r(NULL, " \n", &tok);
         arch = strtok_r(NULL, " \n", &tok);
 
+        /* a blank line yields no hostname, and a line missing the slot
+         * count yields no num - either way there is nothing to add, and
+         * dereferencing them would take down the HNP */
+        if (NULL == ptr || NULL == num) {
+            continue;
+        }
+
         /* see if we already have this node */
         found = false;
         PMIX_LIST_FOREACH(node, nodelist, prte_node_t) {

--- a/src/mca/ras/hosts/AGENTS.md
+++ b/src/mca/ras/hosts/AGENTS.md
@@ -85,7 +85,18 @@ handled something, else `PMIX_ERR_TAKE_NEXT_OPTION`.
   rankfile branch.
 - **`process_hostfile` is deliberately a separate parser** from
   `src/util/hostfile` — it supports the `+N`/`-N` slot-adjust syntax the
-  flex parser can't. Keep the two in sync in spirit.
+  flex parser can't. Keep the two in sync in spirit. Being a hand parser,
+  it owns its own hygiene: every `isspace()` call must cast its argument
+  to `unsigned char` (a plain `char` is UB for bytes ≥ 0x80), and a
+  `slots=+N` match adjusts the **pool** entry in place without appending
+  to the working list — so `total_slots_alloc` is not updated for an
+  adjustment.
+- **`modify()` must validate the info values it splits.** A request can
+  arrive over the wire carrying any type; `PMIX_ADD_HOST`/
+  `PMIX_ADD_HOSTFILE` are checked for `PMIX_STRING` with a non-NULL
+  value before `PMIx_Argv_split`. It also destructs its working list on
+  every error return — `prte_ras_base_node_insert` drains only what it
+  reached.
 - Because this is the lowest-priority component, returning a hard error
   (rather than `TAKE_NEXT_OPTION`) from `allocate` will fail the whole
   allocation — reserve hard errors for genuine parse failures.

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -195,6 +195,29 @@ static int finalize(void)
     return PRTE_SUCCESS;
 }
 
+/* Apply a "slots=+N" / "slots=-N" adjustment to a node that is already in the
+ * global pool.
+ *
+ * Two things the open-coded version got wrong. It clamped at zero but not at
+ * slots_max, so an adjustment could push a node above the ceiling the
+ * allocation gave it - unlike every other slot adjustment in the framework
+ * (prte_ras_base_node_insert clamps both ends for PRTE_NODE_ADD_SLOTS). And it
+ * never told prte_ras_base.total_slots_alloc, which is what a managed
+ * allocation reports to applications as PMIX_UNIV_SIZE / PMIX_MAX_PROCS, so
+ * the DVM's idea of its own size drifted from the pool it was describing. */
+static void adjust_slots(prte_node_t *nptr, int slots)
+{
+    int before = nptr->slots;
+
+    nptr->slots += slots;
+    if (0 > nptr->slots) {
+        nptr->slots = 0;
+    } else if (0 < nptr->slots_max && nptr->slots > nptr->slots_max) {
+        nptr->slots = nptr->slots_max;
+    }
+    prte_ras_base.total_slots_alloc += (nptr->slots - before);
+}
+
 static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
 {
     FILE *fp;
@@ -290,22 +313,19 @@ process:
             if (0 == strcmp(nm, nptr->name)) {
                 // we have the node
                 if (addslots) {
-                    nptr->slots += slots;
-                    if (0 > nptr->slots) {
-                        nptr->slots = 0;
-                    }
+                    adjust_slots(nptr, slots);
                 }
                 found = true;
                 break;
             } else if (NULL != nptr->aliases) {
                 /* no choice but an exhaustive search - fortunately, these lists are short! */
                 for (m = 0; NULL != nptr->aliases[m]; m++) {
-                    if (0 == strcmp(cptr, nptr->aliases[m])) {
+                    /* match on nm, not cptr: if the name given refers to this
+                     * host it was resolved to our canonical nodename above, and
+                     * that is the spelling the pool's aliases carry */
+                    if (0 == strcmp(nm, nptr->aliases[m])) {
                         if (addslots) {
-                            nptr->slots += slots;
-                            if (0 > nptr->slots) {
-                                nptr->slots = 0;
-                            }
+                            adjust_slots(nptr, slots);
                         }
                         found = true;
                         break;
@@ -318,10 +338,12 @@ process:
             node = PMIX_NEW(prte_node_t);
             node->name = strdup(cptr);
             node->state = PRTE_NODE_STATE_ADDED;
-            if (0 < slots) {
-                // if they gave us the number of slots, then just
-                // set it - otherwise, we'll compute them once
-                // the daemon reports back the topology
+            if (0 <= slots) {
+                /* they gave us the number of slots, so set it - including an
+                 * explicit "slots=0", which means this node contributes none
+                 * and must NOT be silently re-sized from its core count.
+                 * Only the -1 marker (no slots clause at all) leaves the
+                 * count to be computed when the daemon reports its topology. */
                 node->slots = slots;
                 PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             } else if (0 > slots && -1 != slots) {

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -16,6 +16,8 @@
 #include "constants.h"
 #include "types.h"
 
+#include <ctype.h>
+
 #include "src/class/pmix_list.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/pmix_string_copy.h"
@@ -216,9 +218,12 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
             free(line);
             continue;
         }
-        // remove leading whitespace
+        // remove leading whitespace. NOTE: isspace() takes an int whose
+        // value must be representable as unsigned char (or EOF); passing a
+        // plain char is undefined for any byte with the high bit set, so
+        // every ctype call here casts.
         cptr = line;
-        while (isspace(*cptr)) {
+        while (isspace((unsigned char) *cptr)) {
             ++cptr;
         }
         if ('#' == *cptr) {
@@ -229,7 +234,7 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
         // because there can be arbitrary whitespace around keywords,
         // we manually parse the line to get the directives
         ptr = cptr;
-        while ('\0' != *ptr && !isspace(*ptr)) {
+        while ('\0' != *ptr && !isspace((unsigned char) *ptr)) {
             ++ptr;
         }
         if ('\0' == *ptr) {
@@ -240,7 +245,7 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
         *ptr = '\0'; // terminate the name
         // find the '=' sign
         ++ptr;
-        while ('\0' != *ptr && ('=' != *ptr || isspace(*ptr))) {
+        while ('\0' != *ptr && '=' != *ptr) {
             ++ptr;
         }
         if ('\0' == *ptr) {
@@ -250,7 +255,7 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
         }
         // find the value
         ++ptr;
-        while ('\0' != *ptr && isspace(*ptr)) {
+        while ('\0' != *ptr && isspace((unsigned char) *ptr)) {
             ++ptr;
         }
         if ('\0' == *ptr) {
@@ -350,8 +355,19 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     // look for applicable directives
     for (n=0; n < req->ninfo; n++) {
         if (PMIx_Check_key(req->info[n].key, PMIX_ADD_HOSTFILE)) {
+            /* the value has to be a string we can split - a request that
+             * arrived over the wire may carry anything */
+            if (PMIX_STRING != req->info[n].value.type ||
+                NULL == req->info[n].value.data.string) {
+                PMIX_LIST_DESTRUCT(&nodes);
+                req->pstatus = PMIX_ERR_BAD_PARAM;
+                return req->pstatus;
+            }
             // comma-delimited list of hostfiles to add or delete
             hostfiles = PMIx_Argv_split(req->info[n].value.data.string, ',');
+            if (NULL == hostfiles) {
+                continue;
+            }
             for (k=0; NULL != hostfiles[k]; k++) {
                 rc = process_hostfile(hostfiles[k], &nodes);
                 if (PMIX_SUCCESS != rc) {
@@ -368,6 +384,12 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
             pmix_list_t dhnodes;
             prte_node_t *nd;
 
+            if (PMIX_STRING != req->info[n].value.type ||
+                NULL == req->info[n].value.data.string) {
+                PMIX_LIST_DESTRUCT(&nodes);
+                req->pstatus = PMIX_ERR_BAD_PARAM;
+                return req->pstatus;
+            }
             // comma-delimited list of hosts to add or delete
             PMIX_CONSTRUCT(&dhnodes, pmix_list_t);
             rc = prte_util_add_dash_host_nodes(&dhnodes, req->info[n].value.data.string, true);
@@ -397,6 +419,9 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
         rc = prte_ras_base_node_insert(&nodes, req->jdata);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
+            /* node_insert drains what it consumed; destruct so whatever it
+             * did not reach is not leaked along with the list itself */
+            PMIX_LIST_DESTRUCT(&nodes);
             req->pstatus = prte_pmix_convert_rc(rc);
             return req->pstatus;
         }

--- a/src/mca/ras/lsf/Makefile.am
+++ b/src/mca/ras/lsf/Makefile.am
@@ -20,7 +20,10 @@
 # $HEADER$
 #
 
-EXTRA_DIST = help-ras-lsf.txt
+# testbuild_lsf.h is only #included when --enable-testbuild-launchers
+# is given, so it appears in no _SOURCES list and has to be listed here
+# or it is missing from a distribution tarball
+EXTRA_DIST = help-ras-lsf.txt testbuild_lsf.h
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/src/mca/ras/pbs/AGENTS.md
+++ b/src/mca/ras/pbs/AGENTS.md
@@ -48,7 +48,11 @@ On success it records `prte_num_allocated_nodes` and returns
 ## Things to watch when editing
 
 - The nodefile parser (`pbs_getline`) caps lines at
-  `PBS_FILE_MAX_LINE_LENGTH` (512) and strips the trailing newline.
+  `PBS_FILE_MAX_LINE_LENGTH` (512), strips a trailing `\n`/`\r` **only if
+  one is present** (the last line of a file need not be terminated), and
+  **skips blank lines** rather than returning `""` — an empty hostname
+  would otherwise become an unusable, unresolvable node in the
+  allocation.
 - `discover` ignores any user hostfile/dash-host — PBS is authoritative.
 - The Cobalt variant is a first-class alias throughout; keep both env
   names handled in `query`, `allocate`, and `discover`.

--- a/src/mca/ras/pbs/ras_pbs_module.c
+++ b/src/mca/ras/pbs/ras_pbs_module.c
@@ -242,16 +242,27 @@ static int discover(pmix_list_t *nodelist, char *pbs_jobid)
     return PRTE_SUCCESS;
 }
 
+/* Return the next non-empty line of the nodefile with its trailing newline
+ * stripped, or NULL at end of file.  Blank lines are skipped rather than
+ * turned into a node named "": a nodefile with a stray blank line would
+ * otherwise inject an unusable, unresolvable node into the allocation.
+ * Note also that the final line of a file need not be newline-terminated,
+ * so the newline is removed only if it is actually there. */
 static char *pbs_getline(FILE *fp)
 {
-    char *ret, *buff;
+    char *ret;
+    size_t len;
     char input[PBS_FILE_MAX_LINE_LENGTH];
 
-    ret = fgets(input, PBS_FILE_MAX_LINE_LENGTH, fp);
-    if (NULL != ret) {
-        input[strlen(input) - 1] = '\0'; /* remove newline */
-        buff = strdup(input);
-        return buff;
+    while (NULL != (ret = fgets(input, PBS_FILE_MAX_LINE_LENGTH, fp))) {
+        len = strlen(input);
+        while (0 < len && ('\n' == input[len - 1] || '\r' == input[len - 1])) {
+            input[--len] = '\0';
+        }
+        if (0 == len) {
+            continue;
+        }
+        return strdup(input);
     }
 
     return NULL;

--- a/src/mca/ras/pbs/ras_pbs_module.c
+++ b/src/mca/ras/pbs/ras_pbs_module.c
@@ -82,8 +82,11 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     }
 
     /* save that value in the global job ident string for
-     * later use in any error reporting
-     */
+     * later use in any error reporting. Release any previous value:
+     * allocate() can run more than once in a session. */
+    if (NULL != prte_job_ident) {
+        free(prte_job_ident);
+    }
     prte_job_ident = strdup(pbs_jobid);
 
     if (PRTE_SUCCESS != (ret = discover(nodes, pbs_jobid))) {

--- a/src/mca/ras/pmix/AGENTS.md
+++ b/src/mca/ras/pmix/AGENTS.md
@@ -55,24 +55,31 @@ MCA params (`ras_pmix_*`) configure the scheduler connection: `uri`,
   `PMIX_ERR_TAKE_NEXT_OPTION`-on-no-scheduler behavior is what lets the
   no-scheduler elastic-DVM path (handled by `ras/hosts`) work. See repo
   memory on `PMIX_ERR_UNREACH` regressions.
-- The async result must be processed on the progress thread — don't
-  short-circuit the `infocbfunc` → `passthru` thread-shift.
-- **KNOWN GAP: `infocbfunc` does real work before it thread-shifts.**
-  It runs on the *PMIx* progress thread, and the top-level
-  [`AGENTS.md`](../../../../AGENTS.md) golden rule says such a callback
-  must do nothing beyond capturing its arguments and posting the event.
-  Today it writes `req->status`, calls `PMIX_INFO_FREE` on `req->info`,
-  and rewrites `req->info`/`ninfo`/`rlcbfunc`/`rlcbdata` — all PRRTE
-  object state, mutated off the PRRTE progress thread. It has not been
-  observed to bite (nothing else touches the `req` between the forward
-  and the answer), but the correct shape is a caddy that carries
-  `status`/`info`/`ninfo`/`rel`/`relcbdata` across the shift, with every
-  mutation of `req` moved into `passthru`. Fix this before adding any
-  other writer of the request array.
-- `modify()` sets `req->copy = true` after pointing `req->info` at its
-  own `xfer` array. If a caller ever hands in a request that *already*
-  owns its info (`copy == true` on entry — `prte_ras_base_add_hosts`
-  builds one), the previous array leaks. It is unreachable today only
-  because that request carries `req->key = "hosts"`, which the base's
-  component filter uses to skip this module.
+- **`infocbfunc` must stay trivial.** It runs on the *PMIx* progress
+  thread, so per the top-level [`AGENTS.md`](../../../../AGENTS.md)
+  golden rule it does nothing but fill a `prte_ras_pmix_caddy_t` and
+  `PRTE_PMIX_THREADSHIFT` it; every mutation of the
+  `prte_pmix_server_req_t` happens in `passthru`, on the PRRTE progress
+  thread. Do not "simplify" by writing the answer straight onto the
+  request — that is a cross-thread write to state the PRRTE progress
+  thread owns.
+- **The caddy holds a reference on the request** (released by its
+  destructor) so the request cannot be reclaimed underneath the shift.
+- **`passthru` records the answer in `pstatus`, not just `status`.**
+  `pstatus` is what drives `prte_ras_base_complete_request` and what the
+  requester is told; `prte_ras_base_modify` seeds it with
+  `PMIX_ERR_NOT_SUPPORTED`, so writing only `status` meant a granted
+  allocation was never applied and the requester was told the operation
+  was unsupported.
+- **`passthru` hands the requester `prte_pmix_server_req_release` and
+  returns without releasing the request**, mirroring
+  `prte_ras_base_modify`'s tail. The info the requester is looking at is
+  owned by the request (or by PMIx, released through it), so dropping
+  the request there would pull it out from under a callback that has not
+  finished with it.
+- **Anything that repoints `req->info` must free a previously *owned*
+  array first.** Both `modify()` here and the base's
+  `ras_base_set_alloc_response` do. A request relayed from a remote peer
+  arrives with `copy == true` (see `pmix_server.c`), so this is a live
+  path, not a theoretical one.
 </content>

--- a/src/mca/ras/pmix/AGENTS.md
+++ b/src/mca/ras/pmix/AGENTS.md
@@ -57,4 +57,22 @@ MCA params (`ras_pmix_*`) configure the scheduler connection: `uri`,
   memory on `PMIX_ERR_UNREACH` regressions.
 - The async result must be processed on the progress thread — don't
   short-circuit the `infocbfunc` → `passthru` thread-shift.
+- **KNOWN GAP: `infocbfunc` does real work before it thread-shifts.**
+  It runs on the *PMIx* progress thread, and the top-level
+  [`AGENTS.md`](../../../../AGENTS.md) golden rule says such a callback
+  must do nothing beyond capturing its arguments and posting the event.
+  Today it writes `req->status`, calls `PMIX_INFO_FREE` on `req->info`,
+  and rewrites `req->info`/`ninfo`/`rlcbfunc`/`rlcbdata` — all PRRTE
+  object state, mutated off the PRRTE progress thread. It has not been
+  observed to bite (nothing else touches the `req` between the forward
+  and the answer), but the correct shape is a caddy that carries
+  `status`/`info`/`ninfo`/`rel`/`relcbdata` across the shift, with every
+  mutation of `req` moved into `passthru`. Fix this before adding any
+  other writer of the request array.
+- `modify()` sets `req->copy = true` after pointing `req->info` at its
+  own `xfer` array. If a caller ever hands in a request that *already*
+  owns its info (`copy == true` on entry — `prte_ras_base_add_hosts`
+  builds one), the previous array leaks. It is unreachable today only
+  because that request carries `req->key = "hosts"`, which the base's
+  component filter uses to skip this module.
 </content>

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -55,13 +55,81 @@ static int finalize(void)
     return PRTE_SUCCESS;
 }
 
-/* Callbacks to process an allocate request answer from the scheduler
- * and pass on any results to the requesting client
- */
+/* Caddy carrying a scheduler's answer from the PMIx progress thread over to
+ * the PRRTE progress thread.
+ *
+ * PMIx invokes our completion callback on ITS progress thread, and the
+ * top-level AGENTS.md golden rule is that such a callback must do nothing
+ * beyond capturing its arguments and posting an event: a prte_pmix_server_req_t
+ * is a PRRTE object, so recording the answer directly on it - let alone
+ * freeing the array it was carrying - is a cross-thread write to state the
+ * PRRTE progress thread owns. This caddy is the capture buffer that lets the
+ * callback stay trivial; every mutation of the request happens in the
+ * thread-shifted handler below.
+ *
+ * The caddy holds a reference on the request so the request cannot be
+ * reclaimed out from under the shift. The answer's info array remains owned by
+ * PMIx and stays valid until we invoke rel(relcbdata), which is why that pair
+ * is carried across too. */
+typedef struct {
+    pmix_object_t super;
+    prte_event_t ev;
+    prte_pmix_server_req_t *req;
+    pmix_status_t status;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_release_cbfunc_t rel;
+    void *relcbdata;
+} prte_ras_pmix_caddy_t;
+
+static void rpcon(prte_ras_pmix_caddy_t *p)
+{
+    p->req = NULL;
+    p->status = PMIX_SUCCESS;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->rel = NULL;
+    p->relcbdata = NULL;
+}
+static void rpdes(prte_ras_pmix_caddy_t *p)
+{
+    if (NULL != p->req) {
+        PMIX_RELEASE(p->req);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_ras_pmix_caddy_t, pmix_object_t, rpcon, rpdes);
+
+/* Runs on the PRRTE progress thread: record the scheduler's answer on the
+ * request, apply it, and relay it to whoever asked. */
 static void passthru(int sd, short args, void *cbdata)
 {
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+    prte_ras_pmix_caddy_t *cd = (prte_ras_pmix_caddy_t*)cbdata;
+    prte_pmix_server_req_t *req = cd->req;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* The scheduler's verdict is the request's outcome. Record it in pstatus,
+     * not just status: pstatus is what drives the completion below and what
+     * the requester is told. (Recording only status left pstatus holding the
+     * PMIX_ERR_NOT_SUPPORTED default that prte_ras_base_modify seeds, so a
+     * granted allocation was never applied and the requester was told the
+     * operation was unsupported.) */
+    req->status = cd->status;
+    req->pstatus = cd->status;
+
+    /* the answer replaces whatever the request was carrying; drop our own
+     * copy first if we made one in modify() below. The replacement belongs to
+     * PMIx until we call rel(), so the request must not be marked as owning
+     * it. */
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+    }
+    req->copy = false;
+    req->info = cd->info;
+    req->ninfo = cd->ninfo;
+    req->rlcbfunc = cd->rel;
+    req->rlcbdata = cd->relcbdata;
 
     // if we met the request, then we need to process it
     if (PMIX_SUCCESS == req->pstatus) {
@@ -69,17 +137,30 @@ static void passthru(int sd, short args, void *cbdata)
     }
 
     if (NULL != req->infocbfunc) {
-        // call the requestor's callback with the returned info
-        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
-    } else if (NULL != req->rlcbfunc) {
-        // let them cleanup
+        /* Call the requestor's callback with the returned info, handing it
+         * prte_pmix_server_req_release as the release function and returning
+         * without releasing the request ourselves - this mirrors
+         * prte_ras_base_modify's tail. The info the requester is looking at
+         * is owned by the request (or by PMIx, released through it), so
+         * dropping the request here would pull it out from under a callback
+         * that has not finished with it. */
+        req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
+                        prte_pmix_server_req_release, req);
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    if (NULL != req->rlcbfunc) {
+        // nobody to relay to - let PMIx cleanup
         req->rlcbfunc(req->rlcbdata);
+        req->rlcbfunc = NULL;
+        req->info = NULL;
+        req->ninfo = 0;
     }
     // cleanup our request
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-
-
     PMIX_RELEASE(req);
+    PMIX_RELEASE(cd);
 }
 
 static void infocbfunc(pmix_status_t status,
@@ -88,22 +169,27 @@ static void infocbfunc(pmix_status_t status,
                        pmix_release_cbfunc_t rel, void *relcbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+    prte_ras_pmix_caddy_t *cd;
 
-    // need to pass this into our progress thread for processing
-    // since we touch the global request array
-    req->status = status;
-    if (req->copy && NULL != req->info) {
-        PMIX_INFO_FREE(req->info, req->ninfo);
-        req->copy = false;
+    /* GOLDEN RULE: we are on the PMIx progress thread. Capture the answer and
+     * post it - touch no PRRTE state here. */
+    cd = PMIX_NEW(prte_ras_pmix_caddy_t);
+    if (NULL == cd) {
+        /* nothing we can do but hand the answer back so PMIx can reclaim it */
+        if (NULL != rel) {
+            rel(relcbdata);
+        }
+        return;
     }
-    req->info = info;
-    req->ninfo = ninfo;
-    req->rlcbfunc = rel;
-    req->rlcbdata = relcbdata;
+    PMIX_RETAIN(req);
+    cd->req = req;
+    cd->status = status;
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->rel = rel;
+    cd->relcbdata = relcbdata;
 
-    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
-    PMIX_POST_OBJECT(req);
-    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, passthru);
 }
 
 static pmix_status_t modify(prte_pmix_server_req_t *req)
@@ -131,7 +217,14 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
         PMIX_INFO_XFER(&xfer[n], &req->info[n]);
     }
     PMIX_INFO_LOAD(&xfer[req->ninfo], PMIX_REQUESTOR, &req->tproc, PMIX_PROC);
-    // the current req object points to the caller's info array, so leave it alone
+    /* Repoint the request at our augmented copy. If it merely borrowed the
+     * caller's array we leave that alone, but if it already OWNED one we have
+     * to release it here or repointing strands it - which is exactly what
+     * happens to an allocation request relayed from a remote peer, since
+     * pmix_server.c builds those with copy = true. */
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+    }
     req->copy = true;
     req->info = xfer;
     req->ninfo++;

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -105,6 +105,7 @@ static void passthru(int sd, short args, void *cbdata)
 {
     prte_ras_pmix_caddy_t *cd = (prte_ras_pmix_caddy_t*)cbdata;
     prte_pmix_server_req_t *req = cd->req;
+    size_t n;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -118,18 +119,41 @@ static void passthru(int sd, short args, void *cbdata)
     req->status = cd->status;
     req->pstatus = cd->status;
 
-    /* the answer replaces whatever the request was carrying; drop our own
-     * copy first if we made one in modify() below. The replacement belongs to
-     * PMIx until we call rel(), so the request must not be marked as owning
-     * it. */
+    /* The answer replaces whatever the request was carrying, so drop our own
+     * copy first if we made one in modify() below.
+     *
+     * Take a COPY of the scheduler's array rather than pointing at it. The
+     * array belongs to PMIx until cd->rel() is invoked, and there is no good
+     * moment to invoke it if we keep it: the requester below is handed
+     * prte_pmix_server_req_release (so it never calls cd->rel), and
+     * prte_ras_base_complete_request may repoint req->info at a response of
+     * its own (so we cannot simply forward it either). Copying makes the
+     * request the sole owner of everything downstream - its destructor frees
+     * whatever req->info ends up being - and lets us hand PMIx's array back
+     * immediately, right here, where the lifetime is obvious. */
     if (req->copy && NULL != req->info) {
         PMIX_INFO_FREE(req->info, req->ninfo);
     }
+    req->info = NULL;
+    req->ninfo = 0;
     req->copy = false;
-    req->info = cd->info;
-    req->ninfo = cd->ninfo;
-    req->rlcbfunc = cd->rel;
-    req->rlcbdata = cd->relcbdata;
+    if (0 < cd->ninfo && NULL != cd->info) {
+        PMIX_INFO_CREATE(req->info, cd->ninfo);
+        if (NULL != req->info) {
+            for (n = 0; n < cd->ninfo; n++) {
+                PMIX_INFO_XFER(&req->info[n], &cd->info[n]);
+            }
+            req->ninfo = cd->ninfo;
+            req->copy = true;
+        }
+    }
+    if (NULL != cd->rel) {
+        cd->rel(cd->relcbdata);
+        cd->rel = NULL;
+    }
+    /* nothing of PMIx's is left for anyone to release */
+    req->rlcbfunc = NULL;
+    req->rlcbdata = NULL;
 
     // if we met the request, then we need to process it
     if (PMIX_SUCCESS == req->pstatus) {
@@ -140,24 +164,16 @@ static void passthru(int sd, short args, void *cbdata)
         /* Call the requestor's callback with the returned info, handing it
          * prte_pmix_server_req_release as the release function and returning
          * without releasing the request ourselves - this mirrors
-         * prte_ras_base_modify's tail. The info the requester is looking at
-         * is owned by the request (or by PMIx, released through it), so
-         * dropping the request here would pull it out from under a callback
-         * that has not finished with it. */
+         * prte_ras_base_modify's tail. The info the requester is looking at is
+         * owned by the request, so dropping the request here would pull it out
+         * from under a callback that has not finished with it. */
         req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
                         prte_pmix_server_req_release, req);
         PMIX_RELEASE(cd);
         return;
     }
 
-    if (NULL != req->rlcbfunc) {
-        // nobody to relay to - let PMIx cleanup
-        req->rlcbfunc(req->rlcbdata);
-        req->rlcbfunc = NULL;
-        req->info = NULL;
-        req->ninfo = 0;
-    }
-    // cleanup our request
+    // nobody to relay to - cleanup our request
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
     PMIX_RELEASE(cd);

--- a/src/mca/ras/simulator/AGENTS.md
+++ b/src/mca/ras/simulator/AGENTS.md
@@ -52,7 +52,15 @@ Often paired with `ras_base_multiplier` to inflate node counts further.
 ## Things to watch when editing
 
 - `num_nodes` doubles as the availability gate — clearing it disables the
-  component entirely.
+  component entirely. Note it gates on the string being *set*, not on it
+  splitting to anything: `allocate` re-checks and defers with
+  `TAKE_NEXT_OPTION` if the value is empty.
+- **The back-fill reads `slot_cnt[nslots - 1]`** — guard `nslots > 0`
+  first, or an empty `ras_simulator_slots` value indexes off the front of
+  the array.
+- **Group prefixes are assigned, not accumulated** (`prefix[4] = 'A' + n`).
+  The compound form carried its previous value forward, so groups came
+  out named `nodeA`, `nodeB`, `nodeD`, `nodeG`…
 - The topology is *shared* (`PMIX_RETAIN`) across all synthetic nodes;
   don't free it per node.
 - This path is a primary consumer of the base's `DO_NOT_LAUNCH` daemon

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -61,13 +61,20 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     node_cnt = PMIx_Argv_split(prte_mca_ras_simulator_component.num_nodes, ',');
     num_nodes = PMIx_Argv_count(node_cnt);
+    if (0 == num_nodes) {
+        /* the gating param was set but held nothing usable */
+        PMIx_Argv_free(node_cnt);
+        return PRTE_ERR_TAKE_NEXT_OPTION;
+    }
 
     if (NULL != prte_mca_ras_simulator_component.slots) {
         slot_cnt = PMIx_Argv_split(prte_mca_ras_simulator_component.slots, ',');
         /* if they didn't provide a slot count for each node, then
-         * backfill the slot_cnt so every node has a cnt */
+         * backfill the slot_cnt so every node has a cnt.  An empty param
+         * value splits to nothing, so guard the "last one given" read -
+         * slot_cnt[-1] is an out-of-bounds access. */
         nslots = PMIx_Argv_count(slot_cnt);
-        if (nslots < num_nodes) {
+        if (0 < nslots && nslots < num_nodes) {
             // take the last one given and extend it to cover remaining nodes
             tmp = slot_cnt[nslots - 1];
             for (n = nslots; n < num_nodes; n++) {
@@ -80,7 +87,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         /* if they didn't provide a max slot count for each node, then
          * backfill the slot_cnt so every node has a cnt */
         nslots = PMIx_Argv_count(max_slot_cnt);
-         if (nslots < num_nodes) {
+        if (0 < nslots && nslots < num_nodes) {
             // take the last one given and extend it to cover remaining nodes
             tmp = max_slot_cnt[nslots - 1];
             for (n = nslots; n < num_nodes; n++) {
@@ -108,6 +115,16 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     /* use our topology */
     t = (prte_topology_t *) pmix_pointer_array_get_item(prte_node_topologies, 0);
     if (NULL == t) {
+        if (NULL != max_slot_cnt) {
+            PMIx_Argv_free(max_slot_cnt);
+        }
+        if (NULL != slot_cnt) {
+            PMIx_Argv_free(slot_cnt);
+        }
+        PMIx_Argv_free(node_cnt);
+        if (NULL != job_cpuset) {
+            free(job_cpuset);
+        }
         return PRTE_ERR_NOT_FOUND;
     }
     topo = t->topo;
@@ -127,8 +144,10 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
             val /= 10;
         }
 
-        /* set the prefix for this group of nodes */
-        prefix[4] += n;
+        /* set the prefix for this group of nodes. Assign (not +=): the
+         * compound form accumulates across iterations, so groups came out
+         * as A, B, D, G, K... instead of A, B, C, D. */
+        prefix[4] = 'A' + n;
 
         for (i = 0; i < num_nodes; i++) {
             node = PMIX_NEW(prte_node_t);

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -113,6 +113,23 @@ degrade gracefully.
   validators; `check_taint` also bounds `SLURM_NODELIST` length.
 - **Guard JSON features behind `prte_ras_slurm_have_jansson()`** so the
   no-Jansson build path stays correct.
+- **This component is a plugin** (`ras-slurm` is in the default
+  `--enable-mca-dso` list), so nothing outside it — the ras unit test
+  included — can name its symbols. `test/unit/ras` reaches it the way the
+  DVM does: find the component in the framework's list, `query` it, call
+  the module it returns.
+
+### Where each half is tested
+
+Without jansson the component is **detect-and-report only**: `query` and
+`allocate` work, and `serve_extend_req`/`serve_release_req`/
+`serve_cancel_req` each return `PRTE_ERR_NOT_AVAILABLE` immediately. The
+coverage follows that seam.
+
+| Half | Covered by |
+|------|------------|
+| `query` + `allocate` (nodelist expansion, taint refusal, `PRTE_EXISTS` on re-discovery) | `test/unit/ras/test_ras.c` — no scheduler needed, since both read only the environment |
+| `modify` (extend/release/cancel, the JSON parser, `validate_hostname`, `drain_cmd_output`) | nothing yet. It shells out and is inherently multi-node, so it belongs in `contrib/dockerswarm` — the only automated build that configures `--with-jansson` — once that harness fakes a SLURM environment |
 
 ### Reference ownership across the session/tracker web
 

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -113,4 +113,34 @@ degrade gracefully.
   validators; `check_taint` also bounds `SLURM_NODELIST` length.
 - **Guard JSON features behind `prte_ras_slurm_have_jansson()`** so the
   no-Jansson build path stays correct.
+
+### Reference ownership across the session/tracker web
+
+This component holds nodes and sessions in three places at once; the
+rules are easy to get wrong and the failures are silent leaks.
+
+- **`session->nodes` holds a retained reference per node**
+  (`assign_new_session` does `PMIX_RETAIN` before
+  `pmix_pointer_array_add`). Anything that removes a node from that array
+  must release it.
+- **`prte_ras_slurm_detach_nodes` hands the dropped nodes back through
+  its `removed_nodes` out-parameter and does NOT release them.** That
+  parameter exists precisely so the caller can. `PMIX_DESTRUCT` on a
+  `pmix_pointer_array_t` frees the array, never its items — destructing
+  it without releasing first leaks one reference per detached node on
+  every partial shrink.
+- **`prte_slurm_session_stack` items hold a *borrowed* `prte_session_t
+  *`** (no retain). The stack is the authority for "is this allocation
+  still ours to manage": `release_allocation` consults it from the
+  session destructor to decide whether to `scancel`, which is why the
+  full-release path removes the stack item *before* releasing the
+  session. Keep those two operations in that order, and never leave a
+  stack item pointing at a session someone else may release.
+- `prte_ras_slurm_rollback_session` relies on `session_des` clearing
+  `prte_sessions[index]`, so the released session leaves no dangling
+  global entry. It deliberately does not `scancel` — the `complete:`
+  block in the extend path does that via `cancel_pending_req`.
+- `pmix_pointer_array_add` returns an **index**, not a status. The
+  `0 > rc` tests are correct as failure checks, but feeding that value to
+  `prte_pmix_convert_status()` yields a meaningless error code.
 </content>

--- a/src/mca/ras/slurm/Makefile.am
+++ b/src/mca/ras/slurm/Makefile.am
@@ -38,7 +38,12 @@ sources = \
         ras_slurm_modify_release_tracker.c \
         ras_slurm_modify_release_tracker.h
 
-if PRTE_HAVE_JANSSON
+# PRTE_WANT_JANSSON_SOURCE is true when jansson was found OR when
+# --enable-testbuild-launchers was given.  In the latter case the real parser
+# compiles against the declarations in base/testbuild_jansson.h, so this ~1000
+# line file is at least syntax-checked on machines with no jansson; such a
+# build must not be run (see src/mca/ras/AGENTS.md).
+if PRTE_WANT_JANSSON_SOURCE
 sources += \
         ras_slurm_jansson.c
 else

--- a/src/mca/ras/slurm/configure.m4
+++ b/src/mca/ras/slurm/configure.m4
@@ -36,6 +36,12 @@ AC_DEFUN([MCA_prte_ras_slurm_CONFIG],[
           [$1],
           [$2])
 
+    # Let the unit tests know whether this component's symbols will be
+    # available to link against: it is NOT built on every platform (see
+    # PRTE_CHECK_SLURM) and --without-slurm removes it entirely.
+    AM_CONDITIONAL([PRTE_HAVE_RAS_SLURM],
+          [test "$ras_slurm_good" = "1" || test "$prte_testbuild_launchers" = "1"])
+
     # set build flags to use in makefile
     AC_SUBST([ras_slurm_jansson_CPPFLAGS])
     AC_SUBST([ras_slurm_jansson_LDFLAGS])

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -24,7 +24,11 @@
 #include <limits.h>
 #include <sys/wait.h>
 
-#include <jansson.h>
+#if PRTE_TESTBUILD_LAUNCHERS
+#    include "src/mca/ras/base/testbuild_jansson.h"
+#else
+#    include <jansson.h>
+#endif
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/util/pmix_output.h"

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -586,6 +586,19 @@ void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
             PMIX_CONSTRUCT(&nodes_in_removal, pmix_pointer_array_t);
             err = prte_ras_slurm_detach_nodes(action->job_id, session_item->session,
                                               &nodes_in_removal);
+            /* detach_nodes hands back the nodes it dropped from
+             * session->nodes, each still carrying the reference the session
+             * took in assign_new_session. Destructing the array does not
+             * release them, so drop those references here or the node
+             * objects are never reclaimed. */
+            for (int k = 0; k < nodes_in_removal.size; k++) {
+                prte_node_t *gone = (prte_node_t *)
+                    pmix_pointer_array_get_item(&nodes_in_removal, k);
+                if (NULL != gone) {
+                    pmix_pointer_array_set_item(&nodes_in_removal, k, NULL);
+                    PMIX_RELEASE(gone);
+                }
+            }
             PMIX_DESTRUCT(&nodes_in_removal);
             if (PRTE_SUCCESS != err) {
                 PRTE_ERROR_LOG(err);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -450,6 +450,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
     slots = malloc(sizeof(int) * num_nodes);
     if (NULL == slots) {
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        PMIx_Argv_free(names);
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
     memset(slots, 0, sizeof(int) * num_nodes);
@@ -458,6 +459,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
     if (NULL == begptr) {
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         free(slots);
+        PMIx_Argv_free(names);
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
@@ -499,6 +501,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
             free(slots);
             free(orig);
+            PMIx_Argv_free(names);
             return PRTE_ERR_BAD_PARAM;
         }
     }
@@ -519,6 +522,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         if (NULL == node) {
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
             free(slots);
+            PMIx_Argv_free(names);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         node->name = strdup(names[i]);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -137,8 +137,11 @@ cleanup:
 
     if (PRTE_SUCCESS != err) {
         prte_ras_slurm_modify_release_finalize();
-        PMIX_RELEASE(prte_slurm_session_stack);
-        prte_slurm_session_stack = NULL;
+        prte_ras_slurm_modify_cancel_finalize();
+        if (NULL != prte_slurm_session_stack) {
+            PMIX_RELEASE(prte_slurm_session_stack);
+            prte_slurm_session_stack = NULL;
+        }
     }
 
     return err;
@@ -322,7 +325,10 @@ static int prte_ras_slurm_finalize(void)
 {
     prte_ras_slurm_modify_cancel_finalize();
     prte_ras_slurm_modify_release_finalize();
-    PMIX_RELEASE(prte_slurm_session_stack);
+    if (NULL != prte_slurm_session_stack) {
+        PMIX_RELEASE(prte_slurm_session_stack);
+        prte_slurm_session_stack = NULL;
+    }
     return PRTE_SUCCESS;
 }
 
@@ -812,7 +818,6 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
     }
 
     int err = PRTE_SUCCESS;
-    int pmix_err = PMIX_SUCCESS;
 
     err = prte_ras_slurm_validate_jobid(slurm_jobid);
 
@@ -892,9 +897,10 @@ int prte_ras_slurm_assign_new_session(const char *slurm_jobid, const char *user_
          * a per-Slurm-jobid tracking handle used to identify and release the
          * group later; it is not a reservation. */
         PMIX_RETAIN(node);
-        pmix_err = pmix_pointer_array_add(session->nodes, node);
-        if (0 > pmix_err) {
-            err = prte_pmix_convert_status(pmix_err);
+        /* NOTE: pmix_pointer_array_add returns the assigned INDEX, not a
+         * status - a negative value just means the array could not grow */
+        if (0 > pmix_pointer_array_add(session->nodes, node)) {
+            err = PRTE_ERR_OUT_OF_RESOURCE;
             PMIX_RELEASE(node);
             PRTE_ERROR_LOG(err);
             goto cleanup;

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2078,43 +2078,98 @@ respond:
     }
 }
 
-/* alloc callback to send the results to the requesting daemon */
+/* Caddy carrying an allocation result from the PMIx progress thread over to
+ * the PRRTE progress thread.
+ *
+ * send_alloc_resp below can be invoked on the PMIx progress thread (e.g. as
+ * the callback from PMIx_Session_control), and the golden rule for such a
+ * callback is that it captures its arguments and posts an event, nothing more:
+ * a prte_pmix_server_req_t is a PRRTE object owned by the PRRTE progress
+ * thread, so recording the result on it there - let alone freeing the array it
+ * was carrying - is a cross-thread write. This caddy is the capture buffer;
+ * every mutation of the request happens in the shifted handler.
+ *
+ * It holds a reference on the request so it cannot be reclaimed underneath the
+ * shift, and carries PMIx's release callback because the result array stays
+ * valid only until that is invoked. */
+typedef struct {
+    pmix_object_t super;
+    prte_event_t ev;
+    prte_pmix_server_req_t *req;
+    pmix_status_t status;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_release_cbfunc_t rel;
+    void *relcbdata;
+} prte_alloc_resp_caddy_t;
+
+static void arcon(prte_alloc_resp_caddy_t *p)
+{
+    p->req = NULL;
+    p->status = PMIX_SUCCESS;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->rel = NULL;
+    p->relcbdata = NULL;
+}
+static void ardes(prte_alloc_resp_caddy_t *p)
+{
+    if (NULL != p->req) {
+        PMIX_RELEASE(p->req);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_alloc_resp_caddy_t, pmix_object_t, arcon, ardes);
+
+/* alloc callback to send the results to the requesting daemon.
+ * Runs on the PRRTE progress thread. */
 static void _send_alloc_resp(int sd, short args, void *cbdata)
 {
-    prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+    prte_alloc_resp_caddy_t *cd = (prte_alloc_resp_caddy_t*)cbdata;
+    prte_pmix_server_req_t *req = cd->req;
     pmix_data_buffer_t *buf;
     pmix_status_t rc;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(req);
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* now safe to touch the request: record the result on it. Beware that some
+     * callers pass the request's OWN info array back as the result (the RAS
+     * base does) - do not free it in that case */
+    req->pstatus = cd->status;
+    if (req->copy && NULL != req->info && cd->info != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+        req->copy = false;
+    }
+    req->info = cd->info;
+    req->ninfo = cd->ninfo;
 
     /* pack the status */
     PMIX_DATA_BUFFER_CREATE(buf);
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &req->pstatus, 1, PMIX_STATUS))) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        return;
+        goto cleanup;
     }
 
     /* pack the remote daemon's request index */
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &req->remote_index, 1, PMIX_INT))) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        return;
+        goto cleanup;
     }
 
     /* pack any provided info */
     if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        return;
+        goto cleanup;
     }
 
     if (0 < req->ninfo) {
         if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(buf);
-            return;
+            goto cleanup;
         }
     }
 
@@ -2125,14 +2180,20 @@ static void _send_alloc_resp(int sd, short args, void *cbdata)
         PMIX_DATA_BUFFER_RELEASE(buf);
     }
 
-    /* Call the provided callback function */
-    if (NULL != req->rlcbfunc) {
-        req->rlcbfunc(req->rlcbdata);
+cleanup:
+    /* Call the provided callback function. Every exit path comes through here:
+     * a pack failure used to return early, leaking the request and never
+     * releasing the results back to PMIx. */
+    if (NULL != cd->rel) {
+        cd->rel(cd->relcbdata);
     }
+    req->info = NULL;
+    req->ninfo = 0;
 
     /* Release the server op request data */
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
+    PMIX_RELEASE(cd);
 }
 
 static void send_alloc_resp(pmix_status_t status,
@@ -2142,26 +2203,27 @@ static void send_alloc_resp(pmix_status_t status,
                             void *release_cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+    prte_alloc_resp_caddy_t *cd;
 
-    /* this can be invoked on the PMIx progress thread (e.g., as the
-     * callback from PMIx_Session_control), so record the results in
-     * the request and shift the pack/send onto our event base. The
-     * results remain valid until we invoke the release callback,
-     * which now happens at the end of the shifted handler. Beware
-     * that some callers pass the request's own info array back as
-     * the results - do not free it in that case */
-    req->pstatus = status;
-    if (req->copy && NULL != req->info && info != req->info) {
-        PMIX_INFO_FREE(req->info, req->ninfo);
-        req->copy = false;
+    /* GOLDEN RULE: this can be invoked on the PMIx progress thread, so capture
+     * the result and post it - touch no PRRTE state here. */
+    cd = PMIX_NEW(prte_alloc_resp_caddy_t);
+    if (NULL == cd) {
+        /* nothing we can do but hand the results back */
+        if (NULL != release_fn) {
+            release_fn(release_cbdata);
+        }
+        return;
     }
-    req->info = info;
-    req->ninfo = ninfo;
-    req->rlcbfunc = release_fn;
-    req->rlcbdata = release_cbdata;
-    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, _send_alloc_resp, req);
-    PMIX_POST_OBJECT(req);
-    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+    PMIX_RETAIN(req);
+    cd->req = req;
+    cd->status = status;
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->rel = release_fn;
+    cd->relcbdata = release_cbdata;
+
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, _send_alloc_resp);
 }
 
 static void pmix_server_sched(int status, pmix_proc_t *sender,

--- a/src/runtime/help-prte-runtime.txt
+++ b/src/runtime/help-prte-runtime.txt
@@ -87,6 +87,21 @@ on at least one node is missing a required entry:
 
 Please provide the missing information.
 #
+[bootstrap-duplicate-node]
+
+Bootstrap startup was requested, but the configuration file lists the
+same host more than once in DVMNodes:
+
+   file:   %s
+   host:   %s
+
+A host's position in DVMNodes determines its rank in the DVM, and every
+daemon computes its own rank from this same file. A repeated entry
+therefore leaves a rank that no daemon will ever claim, and the DVM can
+never finish forming.
+
+Please list each host exactly once and try again.
+#
 [bootstrap-bad-nodelist]
 
 Bootstrap startup was requested, but we were unable to parse the regex

--- a/src/util/prte_bootstrap.c
+++ b/src/util/prte_bootstrap.c
@@ -120,6 +120,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
     FILE *fp;
     char *dvmnodes = NULL;
     int rc = PRTE_ERR_SILENT;
+    int i, j;
     pmix_status_t ret;
 
     /* set the defaults */
@@ -285,6 +286,28 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
         pmix_show_help("help-prte-runtime.txt", "bootstrap-bad-entry", true,
                        prte_process_info.nodename, path, "DVMIPVersion");
         goto cleanup;
+    }
+    /* Every host may appear in DVMNodes only once.  A node's position in the
+     * list IS its DVM rank (see prte_bootstrap_rank_of), and both the
+     * controller and each daemon derive ranks from this same file - so the
+     * listing has to be a bijection.  A repeated name resolves to the position
+     * of its FIRST occurrence, which leaves the position it would otherwise
+     * have held unclaimed by anybody while prte_bootstrap_num_daemons() still
+     * counts it: the DVM would then wait forever to form, expecting a daemon
+     * that no node will ever identify itself as.  Checking here means every
+     * daemon rejects the bad file identically and immediately, rather than the
+     * controller alone noticing later. */
+    for (i = 0; NULL != cfg->nodes[i]; i++) {
+        for (j = i + 1; NULL != cfg->nodes[j]; j++) {
+            if (host_match(cfg->nodes[i], cfg->nodes[j], cfg->keep_fqdn)) {
+                /* no nodename here: this runs before the hostname is
+                 * established, which is why the sibling messages in this
+                 * function report it as "(null)" */
+                pmix_show_help("help-prte-runtime.txt", "bootstrap-duplicate-node", true,
+                               path, cfg->nodes[i]);
+                goto cleanup;
+            }
+        }
     }
 
     free(path);

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml ras

--- a/test/unit/ras/Makefile.am
+++ b/test/unit/ras/Makefile.am
@@ -14,8 +14,18 @@ test_ras_SOURCES = \
 
 # ras/slurm is not built on every platform and can be removed with
 # --without-slurm, so its symbols are not always there to link against.
+# It is also in the default --enable-mca-dso list (config/prte_mca.m4),
+# and a run-time loadable plugin puts nothing in libprrte for a test
+# program to reference - on Darwin the module is a bundle, which cannot
+# be linked into an executable at all.  Configure with
+# --enable-mca-static=ras-slurm to build it into libprrte and get the
+# Slurm coverage below.
 if PRTE_HAVE_RAS_SLURM
+if MCA_BUILD_prte_ras_slurm_DSO
+test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=0
+else
 test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=1
+endif
 else
 test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=0
 endif

--- a/test/unit/ras/Makefile.am
+++ b/test/unit/ras/Makefile.am
@@ -12,20 +12,14 @@ check_PROGRAMS = test_ras
 test_ras_SOURCES = \
     test_ras.c
 
-# ras/slurm is not built on every platform and can be removed with
-# --without-slurm, so its symbols are not always there to link against.
-# It is also in the default --enable-mca-dso list (config/prte_mca.m4),
-# and a run-time loadable plugin puts nothing in libprrte for a test
-# program to reference - on Darwin the module is a bundle, which cannot
-# be linked into an executable at all.  Configure with
-# --enable-mca-static=ras-slurm to build it into libprrte and get the
-# Slurm coverage below.
+# The test names no component symbol - it reaches ras/slurm through the
+# framework, so it works whether that component was linked statically or
+# loaded as a plugin, and needs nothing from this Makefile to do it.  All
+# this conditional buys is a precise message when the component turns out
+# not to be there: "not built on this platform" is expected, "built but the
+# framework has not got it" is worth saying out loud.
 if PRTE_HAVE_RAS_SLURM
-if MCA_BUILD_prte_ras_slurm_DSO
-test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=0
-else
 test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=1
-endif
 else
 test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=0
 endif

--- a/test/unit/ras/Makefile.am
+++ b/test/unit/ras/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_ras
+
+test_ras_SOURCES = \
+    test_ras.c
+
+test_ras_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_ras

--- a/test/unit/ras/Makefile.am
+++ b/test/unit/ras/Makefile.am
@@ -12,6 +12,14 @@ check_PROGRAMS = test_ras
 test_ras_SOURCES = \
     test_ras.c
 
+# ras/slurm is not built on every platform and can be removed with
+# --without-slurm, so its symbols are not always there to link against.
+if PRTE_HAVE_RAS_SLURM
+test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=1
+else
+test_ras_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_HAVE_RAS_SLURM=0
+endif
+
 test_ras_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_ras

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -38,11 +38,13 @@
  *   4. prte_ras_base_flag_string, which renders the node flag bitmask for
  *      --display-allocation.
  *
- *   5. The SLURM taint validators. ras/slurm shells out to
- *      scancel/scontrol/sbatch, so validate_jobid / validate_hostname are
- *      the boundary between a scheduler-supplied string and a command
- *      line. Their bounds and allowlists are checked here, along with the
- *      bounded command-output reader they share.
+ *   5. ras/slurm's "detect and report an allocation" capability, driven
+ *      through the framework rather than by calling into the component.
+ *      That is everything the component can do when jansson is absent --
+ *      every modify entry point declines without it -- and it is the half
+ *      that needs no scheduler to exercise. The modify surface belongs to
+ *      the multi-node harness in contrib/dockerswarm, which builds
+ *      --with-jansson deliberately.
  */
 
 #include "prte_config.h"
@@ -62,9 +64,6 @@
 
 #include "src/mca/ras/base/base.h"
 #include "src/mca/ras/ras.h"
-#if PRTE_TEST_HAVE_RAS_SLURM
-#    include "src/mca/ras/slurm/ras_slurm.h"
-#endif
 
 #define CHECK(label, cond)                                              \
     do {                                                                \
@@ -80,18 +79,17 @@
  * gated on the platform (and removable with --without-slurm) - referencing
  * those unconditionally makes `make check` fail to link on an ordinary
  * machine. Being *built* is not enough either: a component in the default
- * --enable-mca-dso list is a run-time loadable plugin and leaves nothing in
- * libprrte to reference, which is why the slurm checks below are also gated
- * on it being static (--enable-mca-static=ras-slurm). The gated components
- * are covered structurally by test_select(), which walks whatever the
- * framework actually built. */
+ * --enable-mca-dso list is a run-time loadable plugin, which puts nothing in
+ * libprrte to reference at all. The gated components are covered
+ * structurally by test_select(), which walks whatever the framework
+ * actually built, and ras/slurm is driven through that same public
+ * interface by test_slurm_allocation() below - no component symbol is
+ * named anywhere in this file. */
 extern prte_ras_base_module_t prte_ras_hosts_module;
 extern prte_ras_base_module_t prte_ras_pmix_module;
 extern prte_ras_base_module_t prte_ras_sim_module;
 extern prte_ras_base_module_t prte_ras_testrm_module;
 extern prte_ras_base_module_t prte_ras_bootstrap_module;
-/* prte_ras_slurm_module, the validators and the bounded output drain come
- * from ras_slurm.h, only when that component is built */
 
 /*
  * prte_init_util() stops short of building the global job/node/session
@@ -480,9 +478,9 @@ static int test_module_contract(void)
         {"simulator",  &prte_ras_sim_module,        true},
         {"testrm",     &prte_ras_testrm_module,     true},
         {"bootstrap",  &prte_ras_bootstrap_module,  true},
-#if PRTE_TEST_HAVE_RAS_SLURM
-        {"slurm",      &prte_ras_slurm_module,      true},
-#endif
+        /* ras/slurm is a plugin, so its module is not a symbol we can name
+         * here; test_slurm_allocation() checks its vtable on the module the
+         * component hands back from query */
         /* ras/pmix contributes nothing to initial discovery -- its
          * allocate is a deliberate TAKE_NEXT_OPTION stub -- but the slot
          * must still be filled so the driver has something to call */
@@ -495,16 +493,6 @@ static int test_module_contract(void)
             failures++;
         }
     }
-
-#if PRTE_TEST_HAVE_RAS_SLURM
-    /* only slurm implements the elastic completion hooks today; if another
-     * component grows them, the base cycles every module for both */
-    CHECK("contract: slurm shrink_complete", NULL != prte_ras_slurm_module.shrink_complete);
-    CHECK("contract: slurm release_allocation",
-          NULL != prte_ras_slurm_module.release_allocation);
-    CHECK("contract: slurm init", NULL != prte_ras_slurm_module.init);
-    CHECK("contract: slurm modify", NULL != prte_ras_slurm_module.modify);
-#endif
 
     /* the modify path is what serves PMIx_Allocation_request */
     CHECK("contract: hosts modify", NULL != prte_ras_hosts_module.modify);
@@ -609,109 +597,198 @@ static int test_flag_string(void)
     return failures;
 }
 
-#if PRTE_TEST_HAVE_RAS_SLURM
-/*
- * ras/slurm builds scancel/scontrol/sbatch command lines out of strings
- * that came from the scheduler or from a PMIx client, so these validators
- * are a security boundary, not a convenience.
- */
-static int test_slurm_validators(void)
+/* locate a component by name in whatever the framework opened, static or
+ * dlopened -- the same list prte_ras_base_select() walks */
+static pmix_mca_base_component_t *find_ras_component(const char *name)
 {
-    int failures = 0;
-    char toolong[PRTE_SLURM_JOB_ID_MAX_LEN + 8];
-    char longhost[PRTE_SLURM_HOSTNAME_MAX_LEN + 8];
+    pmix_mca_base_component_list_item_t *cli;
 
-    CHECK("jobid: plain", PRTE_SUCCESS == prte_ras_slurm_validate_jobid("12345"));
-    CHECK("jobid: zero ok", PRTE_SUCCESS == prte_ras_slurm_validate_jobid("0"));
-    CHECK("jobid: NULL", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(NULL));
-    CHECK("jobid: empty", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(""));
-    CHECK("jobid: non-digit", PRTE_SUCCESS != prte_ras_slurm_validate_jobid("12a45"));
-    CHECK("jobid: negative", PRTE_SUCCESS != prte_ras_slurm_validate_jobid("-1"));
-    /* the whole point: nothing that could reach a shell */
-    CHECK("jobid: shell metachar",
-          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("1;rm -rf /"));
-    CHECK("jobid: substitution",
-          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("$(id)"));
-    CHECK("jobid: trailing space",
-          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("123 "));
-
-    memset(toolong, '9', sizeof(toolong) - 1);
-    toolong[sizeof(toolong) - 1] = '\0';
-    CHECK("jobid: over length", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(toolong));
-
-    CHECK("host: plain", PRTE_SUCCESS == prte_ras_slurm_validate_hostname("node01"));
-    CHECK("host: fqdn",
-          PRTE_SUCCESS == prte_ras_slurm_validate_hostname("node01.example.com"));
-    CHECK("host: dashes", PRTE_SUCCESS == prte_ras_slurm_validate_hostname("nid-00-01"));
-    CHECK("host: NULL", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(NULL));
-    CHECK("host: empty", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(""));
-    CHECK("host: space", PRTE_SUCCESS != prte_ras_slurm_validate_hostname("node 01"));
-    CHECK("host: semicolon",
-          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("node01;reboot"));
-    CHECK("host: backtick",
-          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("`whoami`"));
-    CHECK("host: comma rejected (lists must be split first)",
-          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("n01,n02"));
-    CHECK("host: newline", PRTE_SUCCESS != prte_ras_slurm_validate_hostname("n01\n"));
-
-    memset(longhost, 'a', sizeof(longhost) - 1);
-    longhost[sizeof(longhost) - 1] = '\0';
-    CHECK("host: over length", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(longhost));
-
-    return failures;
+    PMIX_LIST_FOREACH(cli, &prte_ras_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t) {
+        if (NULL != cli->cli_component &&
+            0 == strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            return (pmix_mca_base_component_t *) cli->cli_component;
+        }
+    }
+    return NULL;
 }
 
 /*
- * The command-output drain is shared by scancel and scontrol and copies
- * scheduler error text into a fixed buffer -- an off-by-one here writes
- * past a stack array on the HNP.
+ * ras/slurm, exercised the way the base exercises it: query the component
+ * for a module, then drive that module's allocate().
+ *
+ * This is the whole of what the component can do without jansson --
+ * serve_extend_req, serve_release_req and serve_cancel_req each return
+ * PRTE_ERR_NOT_AVAILABLE when prte_ras_slurm_have_jansson() is false -- and
+ * it is the half that needs no live scheduler. Going through the vtable
+ * rather than calling in directly is not a workaround: it is the only way
+ * the DVM ever reaches this code, and it keeps the test working whether the
+ * component was linked statically or loaded as a plugin.
+ *
+ * The elastic modify surface is deliberately not here. It shells out to
+ * sbatch/scontrol and only means anything across multiple nodes, so it
+ * belongs to contrib/dockerswarm -- which is also the only automated build
+ * that configures --with-jansson and therefore compiles the JSON parser.
+ *
+ * The rejection cases below make the component log the refusals it is
+ * supposed to log, so a passing run of this test still prints SLURM error
+ * text. That output is the point, not a symptom.
  */
-static int test_slurm_drain_output(void)
+static int test_slurm_allocation(void)
 {
     int failures = 0;
-    char buf[32];
-    char guard[64];
-    FILE *fp;
-    int rc;
+    pmix_mca_base_component_t *comp;
+    pmix_mca_base_module_t *module;
+    prte_ras_base_module_t *mod;
+    prte_job_t *jdata;
+    pmix_list_t nodes;
+    prte_node_t *nd;
+    char *toolong;
+    /* SLURM_NODELIST is a compressed regex; "node[01-04]" must come back as
+     * four zero-padded names, and "4(x4)" as four slots on each of them */
+    static const char *expect[] = {"node01", "node02", "node03", "node04"};
+    size_t i;
+    int rc, pri;
 
-    fp = popen("printf 'hello world\\n'", "r");
-    CHECK("drain: popen", NULL != fp);
-    if (NULL == fp) {
+    comp = find_ras_component("slurm");
+    if (NULL == comp) {
+#if PRTE_TEST_HAVE_RAS_SLURM
+        fprintf(stderr,
+                "SKIP [slurm]: component was built but the framework does not "
+                "have it. It is a plugin, so a tree that has not been installed "
+                "-- or one built with --enable-testbuild-launchers, where its "
+                "JSON parser resolves to nothing -- has nothing to load.\n");
+#else
+        fprintf(stderr, "SKIP [slurm]: component not built on this platform\n");
+#endif
+        return 0;
+    }
+    CHECK("slurm: has a query function", NULL != comp->pmix_mca_query_component);
+    if (NULL == comp->pmix_mca_query_component) {
         return failures;
     }
-    rc = prte_ras_slurm_drain_cmd_output(fp, buf, sizeof(buf));
-    pclose(fp);
-    CHECK("drain: rc", PRTE_SUCCESS == rc);
-    CHECK("drain: captured", 0 == strcmp(buf, "hello world\n"));
 
-    /* more output than the buffer holds must truncate, stay
-     * NUL-terminated, and be marked with the "..." suffix */
-    fp = popen("printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\n'", "r");
-    CHECK("drain: popen 2", NULL != fp);
-    if (NULL != fp) {
-        memset(guard, 'X', sizeof(guard));
-        rc = prte_ras_slurm_drain_cmd_output(fp, guard, 16);
-        pclose(fp);
-        CHECK("drain: truncate rc", PRTE_SUCCESS == rc);
-        CHECK("drain: NUL terminated within bounds", 15 >= strlen(guard));
-        CHECK("drain: truncation marked", NULL != strstr(guard, "..."));
-        CHECK("drain: did not write past the buffer", 'X' == guard[16]);
+    /* "detect": no SLURM in the environment means the job is not ours */
+    unsetenv("SLURM_JOBID");
+    module = NULL;
+    pri = -1;
+    rc = comp->pmix_mca_query_component(&module, &pri);
+    CHECK("slurm query: no module without SLURM_JOBID", NULL == module);
+    CHECK("slurm query: declines without SLURM_JOBID", PRTE_SUCCESS != rc);
+
+    setenv("SLURM_JOBID", "12345", 1);
+    module = NULL;
+    pri = -1;
+    rc = comp->pmix_mca_query_component(&module, &pri);
+    CHECK("slurm query: rc", PRTE_SUCCESS == rc);
+    CHECK("slurm query: offers a module", NULL != module);
+    /* the framework guide documents this ordering: slurm sits below the
+     * nodefile-driven RMs and above the catch-all */
+    CHECK("slurm query: priority 50", 50 == pri);
+    if (NULL == module) {
+        return failures;
     }
 
-    /* a NULL output buffer means "drain and discard", not an error */
-    fp = popen("printf 'ignored\\n'", "r");
-    if (NULL != fp) {
-        rc = prte_ras_slurm_drain_cmd_output(fp, NULL, 0);
-        pclose(fp);
-        CHECK("drain: discard mode", PRTE_SUCCESS == rc);
+    mod = (prte_ras_base_module_t *) module;
+    /* the vtable contract, on the module the component actually hands out.
+     * slurm is the only component implementing the elastic completion hooks
+     * today; if another grows them, the base cycles every module for both. */
+    CHECK("slurm contract: allocate", NULL != mod->allocate);
+    CHECK("slurm contract: init", NULL != mod->init);
+    CHECK("slurm contract: modify", NULL != mod->modify);
+    CHECK("slurm contract: shrink_complete", NULL != mod->shrink_complete);
+    CHECK("slurm contract: release_allocation", NULL != mod->release_allocation);
+    if (NULL == mod->allocate) {
+        return failures;
+    }
+    /* init() builds the session stack that allocate() pushes onto. The
+     * framework does this at selection; nothing has selected slurm here
+     * because test_select() ran with SLURM_JOBID unset. */
+    if (NULL != mod->init) {
+        CHECK("slurm init: rc", PRTE_SUCCESS == mod->init());
     }
 
-    CHECK("drain: NULL stream rejected",
-          PRTE_SUCCESS != prte_ras_slurm_drain_cmd_output(NULL, buf, sizeof(buf)));
+    jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+
+    /* "report": the compressed nodelist expands into real nodes */
+    setenv("SLURM_NODELIST", "node[01-04]", 1);
+    setenv("SLURM_TASKS_PER_NODE", "4(x4)", 1);
+    unsetenv("SLURM_CPUS_PER_TASK");
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = mod->allocate(jdata, &nodes);
+    CHECK("slurm allocate: rc", PRTE_SUCCESS == rc);
+    CHECK("slurm allocate: node count", 4 == pmix_list_get_size(&nodes));
+    i = 0;
+    PMIX_LIST_FOREACH(nd, &nodes, prte_node_t) {
+        if (i < sizeof(expect) / sizeof(expect[0])) {
+            CHECK("slurm allocate: node name",
+                  NULL != nd->name && 0 == strcmp(expect[i], nd->name));
+            CHECK("slurm allocate: slots per node", 4 == nd->slots);
+            CHECK("slurm allocate: node is up", PRTE_NODE_STATE_UP == nd->state);
+        }
+        i++;
+    }
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* SLURM_NODELIST is per-job, not per-step, so a second step re-reads the
+     * same list. Returning SUCCESS here would insert the whole allocation a
+     * second time; the contract is PRTE_EXISTS with nothing added. */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = mod->allocate(jdata, &nodes);
+    CHECK("slurm allocate: re-discovery reports EXISTS", PRTE_EXISTS == rc);
+    CHECK("slurm allocate: re-discovery adds nothing", 0 == pmix_list_get_size(&nodes));
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* The jobid reaches scontrol/sbatch command lines, so it is a taint
+     * boundary: tag_node_allocation and assign_new_session both run it
+     * through validate_jobid, and allocate() must fail rather than carry a
+     * shell metacharacter forward. */
+    setenv("SLURM_JOBID", "1;rm -rf /", 1);
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = mod->allocate(jdata, &nodes);
+    CHECK("slurm allocate: rejects a jobid with a shell metacharacter",
+          PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    setenv("SLURM_JOBID", "$(id)", 1);
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = mod->allocate(jdata, &nodes);
+    CHECK("slurm allocate: rejects a jobid with a substitution", PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    setenv("SLURM_JOBID", "12a45", 1);
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = mod->allocate(jdata, &nodes);
+    CHECK("slurm allocate: rejects a non-numeric jobid", PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* check_taint bounds SLURM_NODELIST by ras_slurm_max_envar_length
+     * (default 32000) before anything tries to parse it */
+    toolong = malloc(64 * 1024);
+    CHECK("slurm allocate: test allocation", NULL != toolong);
+    if (NULL != toolong) {
+        memset(toolong, 'a', 64 * 1024 - 1);
+        toolong[64 * 1024 - 1] = '\0';
+        setenv("SLURM_JOBID", "12346", 1);
+        setenv("SLURM_NODELIST", toolong, 1);
+        PMIX_CONSTRUCT(&nodes, pmix_list_t);
+        rc = mod->allocate(jdata, &nodes);
+        CHECK("slurm allocate: rejects an over-length nodelist",
+              PRTE_ERR_BAD_PARAM == rc);
+        PMIX_LIST_DESTRUCT(&nodes);
+        free(toolong);
+    }
+
+    if (NULL != mod->finalize) {
+        mod->finalize();
+    }
+    unsetenv("SLURM_JOBID");
+    unsetenv("SLURM_NODELIST");
+    unsetenv("SLURM_TASKS_PER_NODE");
 
     return failures;
 }
-#endif /* PRTE_TEST_HAVE_RAS_SLURM */
+
 
 int main(void)
 {
@@ -736,10 +813,10 @@ int main(void)
     failures += test_preassigned_index();
     failures += test_hnp_dedup();
     failures += test_flag_string();
-#if PRTE_TEST_HAVE_RAS_SLURM
-    failures += test_slurm_validators();
-    failures += test_slurm_drain_output();
-#endif
+    /* after test_select(), which opens the framework and latches a
+     * selection made with no SLURM allocation in the environment -- so
+     * nothing has called slurm's init() before this does */
+    failures += test_slurm_allocation();
 
     prte_finalize();
 

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -57,6 +57,7 @@
 #include "src/runtime/runtime.h"
 #include "src/util/attr.h"
 #include "src/util/pmix_argv.h"
+#include "src/util/prte_bootstrap.h"
 #include "src/util/proc_info.h"
 
 #include "src/mca/ras/base/base.h"
@@ -242,6 +243,117 @@ static int test_node_insert(void)
     PMIX_DESTRUCT(&nodes);
     CHECK("empty: rc", PRTE_SUCCESS == rc);
     CHECK("empty: pool untouched", pool_count() == before);
+
+    return failures;
+}
+
+/*
+ * The bootstrap rank contract, on which both ras/bootstrap's pool layout
+ * and plm's daemon-vpid assignment depend.
+ *
+ * A bootstrapped daemon computes its OWN vpid from prte.conf, via
+ * prte_bootstrap_my_identity(), before it ever contacts the HNP - and
+ * prted_report_launch() then looks it up in daemons->procs by the rank it
+ * claims. So the HNP has to reach the same number independently, from the
+ * same authority. ras/bootstrap records it as the node's pool index and
+ * plm reads it back out as the vpid; what makes that round trip safe is
+ * that ranks over a well-formed DVMNodes list are exactly 1..N with no
+ * gaps, so the pool slots are contiguous and rank_of/host_of_rank are
+ * inverses.
+ *
+ * A host listed twice breaks precisely that property, which is why
+ * ras/bootstrap rejects it rather than letting a permanently unclaimable
+ * rank stall DVM formation.
+ */
+static int test_bootstrap_ranks(void)
+{
+    int failures = 0;
+    prte_bootstrap_config_t cfg;
+    pmix_rank_t rank;
+    const char *host;
+    int rc;
+
+    /* --- controller separate from the node list --- */
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.cluster = strdup("test");
+    cfg.ctrlhost = strdup("ctrl");
+    cfg.keep_fqdn = false;
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn01");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn02");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn03");
+
+    CHECK("bootranks: controller is rank 0",
+          PRTE_SUCCESS == prte_bootstrap_rank_of(&cfg, "ctrl", &rank) && 0 == rank);
+    /* contiguous 1..N is what lets the pool slot double as the rank */
+    rc = prte_bootstrap_rank_of(&cfg, "bn01", &rank);
+    CHECK("bootranks: first entry is rank 1", PRTE_SUCCESS == rc && 1 == rank);
+    rc = prte_bootstrap_rank_of(&cfg, "bn02", &rank);
+    CHECK("bootranks: second entry is rank 2", PRTE_SUCCESS == rc && 2 == rank);
+    rc = prte_bootstrap_rank_of(&cfg, "bn03", &rank);
+    CHECK("bootranks: third entry is rank 3", PRTE_SUCCESS == rc && 3 == rank);
+    CHECK("bootranks: a stranger is not a member",
+          PRTE_SUCCESS != prte_bootstrap_rank_of(&cfg, "bn99", &rank));
+    /* controller not in the list => N+1 daemons */
+    CHECK("bootranks: daemon count", 4 == prte_bootstrap_num_daemons(&cfg));
+
+    /* rank_of and host_of_rank must be inverses, or the HNP and the daemons
+     * disagree about who holds which vpid */
+    for (rank = 1; rank <= 3; rank++) {
+        pmix_rank_t back;
+
+        host = NULL;
+        rc = prte_bootstrap_host_of_rank(&cfg, rank, &host);
+        CHECK("bootranks: rank resolves to a host", PRTE_SUCCESS == rc && NULL != host);
+        if (PRTE_SUCCESS != rc || NULL == host) {
+            continue;
+        }
+        rc = prte_bootstrap_rank_of(&cfg, host, &back);
+        CHECK("bootranks: round trip", PRTE_SUCCESS == rc && back == rank);
+    }
+    prte_bootstrap_config_free(&cfg);
+
+    /* --- controller listed among the nodes: its entry consumes no rank --- */
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.cluster = strdup("test");
+    cfg.ctrlhost = strdup("bn02");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn01");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn02");   /* the controller, mid-list */
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn03");
+
+    rc = prte_bootstrap_rank_of(&cfg, "bn02", &rank);
+    CHECK("bootranks(ctrl-in-list): controller still rank 0",
+          PRTE_SUCCESS == rc && 0 == rank);
+    rc = prte_bootstrap_rank_of(&cfg, "bn01", &rank);
+    CHECK("bootranks(ctrl-in-list): rank 1", PRTE_SUCCESS == rc && 1 == rank);
+    /* the skipped controller entry must NOT leave a gap */
+    rc = prte_bootstrap_rank_of(&cfg, "bn03", &rank);
+    CHECK("bootranks(ctrl-in-list): still contiguous", PRTE_SUCCESS == rc && 2 == rank);
+    CHECK("bootranks(ctrl-in-list): daemon count", 3 == prte_bootstrap_num_daemons(&cfg));
+    prte_bootstrap_config_free(&cfg);
+
+    /* --- a duplicated host is what ras/bootstrap must reject --- */
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.cluster = strdup("test");
+    cfg.ctrlhost = strdup("ctrl");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn01");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn02");
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn01");   /* duplicate */
+    PMIx_Argv_append_nosize(&cfg.nodes, "bn03");
+
+    /* both occurrences resolve to the FIRST one's rank... */
+    rc = prte_bootstrap_rank_of(&cfg, "bn01", &rank);
+    CHECK("bootranks(dup): duplicate collapses to one rank",
+          PRTE_SUCCESS == rc && 1 == rank);
+    /* ...so the position it would have held is never handed to anybody, and
+     * the last entry's rank runs past the number of distinct hosts */
+    rc = prte_bootstrap_rank_of(&cfg, "bn03", &rank);
+    CHECK("bootranks(dup): later ranks are pushed out", PRTE_SUCCESS == rc && 4 == rank);
+    host = NULL;
+    rc = prte_bootstrap_host_of_rank(&cfg, 3, &host);
+    CHECK("bootranks(dup): rank 3 maps back to a host that is not rank 3",
+          PRTE_SUCCESS == rc && NULL != host &&
+          PRTE_SUCCESS == prte_bootstrap_rank_of(&cfg, host, &rank) && 3 != rank);
+    prte_bootstrap_config_free(&cfg);
 
     return failures;
 }
@@ -606,6 +718,7 @@ int main(void)
     failures += test_module_contract();
     failures += test_select();
     failures += test_node_insert();
+    failures += test_bootstrap_ranks();
     failures += test_preassigned_index();
     failures += test_hnp_dedup();
     failures += test_flag_string();

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -247,6 +247,67 @@ static int test_node_insert(void)
 }
 
 /*
+ * A component may pre-assign a node's pool slot by setting node->index
+ * before handing it over. ras/bootstrap depends on this: a bootstrapped
+ * daemon computes its own vpid from the config file, so the HNP has to
+ * land the node at the slot matching that canonical rank rather than at
+ * whatever slot the append order happens to produce.
+ */
+static int test_preassigned_index(void)
+{
+    int failures = 0;
+    pmix_list_t nodes;
+    prte_node_t *nd, *found;
+    int rc, slot;
+
+    /* pick a slot well clear of anything already in the pool */
+    slot = prte_node_pool->size + 16;
+
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = mknode(&nodes, "unittest-boot01", 1);
+    nd->index = slot;
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("preindex: rc", PRTE_SUCCESS == rc);
+
+    found = prte_node_match(NULL, "unittest-boot01");
+    CHECK("preindex: findable", NULL != found);
+    if (NULL != found) {
+        /* the whole point: the assignment survives the insert */
+        CHECK("preindex: landed at the requested slot", slot == found->index);
+        CHECK("preindex: pool agrees",
+              found == (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, slot));
+    }
+
+    /* a slot that is already occupied is a malformed request: fall back to
+     * an append rather than clobbering the node that is already there */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = mknode(&nodes, "unittest-boot02", 1);
+    nd->index = slot;                       /* same slot as boot01 */
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("preindex: collision rc", PRTE_SUCCESS == rc);
+    CHECK("preindex: occupant untouched",
+          found == (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, slot));
+    nd = prte_node_match(NULL, "unittest-boot02");
+    CHECK("preindex: collider still inserted", NULL != nd);
+    if (NULL != nd) {
+        CHECK("preindex: collider moved elsewhere", slot != nd->index);
+    }
+
+    /* the default (-1) still means "append to the lowest free slot" */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    mknode(&nodes, "unittest-boot03", 1);
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("preindex: default rc", PRTE_SUCCESS == rc);
+    nd = prte_node_match(NULL, "unittest-boot03");
+    CHECK("preindex: appended node indexed", NULL != nd && 0 < nd->index);
+
+    return failures;
+}
+
+/*
  * The HNP's node is pre-entered at pool index 0 before any component runs,
  * so an incoming entry for the local host must update that entry in place
  * rather than adding a second one -- otherwise the DVM would try to launch
@@ -545,6 +606,7 @@ int main(void)
     failures += test_module_contract();
     failures += test_select();
     failures += test_node_insert();
+    failures += test_preassigned_index();
     failures += test_hnp_dedup();
     failures += test_flag_string();
     failures += test_slurm_validators();

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -62,7 +62,9 @@
 
 #include "src/mca/ras/base/base.h"
 #include "src/mca/ras/ras.h"
-#include "src/mca/ras/slurm/ras_slurm.h"
+#if PRTE_TEST_HAVE_RAS_SLURM
+#    include "src/mca/ras/slurm/ras_slurm.h"
+#endif
 
 #define CHECK(label, cond)                                              \
     do {                                                                \
@@ -72,16 +74,20 @@
         }                                                               \
     } while (0)
 
-/* the statically-built components all export their module */
+/* Only the components with NO configure.m4 are guaranteed to be built, and
+ * therefore guaranteed to have symbols to link against. pbs, gridengine, lsf
+ * and flux are all gated on detecting their resource manager, and slurm is
+ * gated on the platform (and removable with --without-slurm) - referencing
+ * those unconditionally makes `make check` fail to link on an ordinary
+ * machine. The gated components are covered structurally by test_select(),
+ * which walks whatever the framework actually built. */
 extern prte_ras_base_module_t prte_ras_hosts_module;
 extern prte_ras_base_module_t prte_ras_pmix_module;
 extern prte_ras_base_module_t prte_ras_sim_module;
 extern prte_ras_base_module_t prte_ras_testrm_module;
 extern prte_ras_base_module_t prte_ras_bootstrap_module;
-extern prte_ras_base_module_t prte_ras_pbs_module;
-extern prte_ras_base_module_t prte_ras_gridengine_module;
-/* prte_ras_slurm_module, the validators and the bounded output drain all
- * come from ras_slurm.h above */
+/* prte_ras_slurm_module, the validators and the bounded output drain come
+ * from ras_slurm.h, only when that component is built */
 
 /*
  * prte_init_util() stops short of building the global job/node/session
@@ -470,9 +476,9 @@ static int test_module_contract(void)
         {"simulator",  &prte_ras_sim_module,        true},
         {"testrm",     &prte_ras_testrm_module,     true},
         {"bootstrap",  &prte_ras_bootstrap_module,  true},
-        {"pbs",        &prte_ras_pbs_module,        true},
-        {"gridengine", &prte_ras_gridengine_module, true},
+#if PRTE_TEST_HAVE_RAS_SLURM
         {"slurm",      &prte_ras_slurm_module,      true},
+#endif
         /* ras/pmix contributes nothing to initial discovery -- its
          * allocate is a deliberate TAKE_NEXT_OPTION stub -- but the slot
          * must still be filled so the driver has something to call */
@@ -486,17 +492,19 @@ static int test_module_contract(void)
         }
     }
 
+#if PRTE_TEST_HAVE_RAS_SLURM
     /* only slurm implements the elastic completion hooks today; if another
      * component grows them, the base cycles every module for both */
     CHECK("contract: slurm shrink_complete", NULL != prte_ras_slurm_module.shrink_complete);
     CHECK("contract: slurm release_allocation",
           NULL != prte_ras_slurm_module.release_allocation);
     CHECK("contract: slurm init", NULL != prte_ras_slurm_module.init);
+    CHECK("contract: slurm modify", NULL != prte_ras_slurm_module.modify);
+#endif
 
     /* the modify path is what serves PMIx_Allocation_request */
     CHECK("contract: hosts modify", NULL != prte_ras_hosts_module.modify);
     CHECK("contract: pmix modify", NULL != prte_ras_pmix_module.modify);
-    CHECK("contract: slurm modify", NULL != prte_ras_slurm_module.modify);
 
     return failures;
 }
@@ -597,6 +605,7 @@ static int test_flag_string(void)
     return failures;
 }
 
+#if PRTE_TEST_HAVE_RAS_SLURM
 /*
  * ras/slurm builds scancel/scontrol/sbatch command lines out of strings
  * that came from the scheduler or from a PMIx client, so these validators
@@ -698,6 +707,7 @@ static int test_slurm_drain_output(void)
 
     return failures;
 }
+#endif /* PRTE_TEST_HAVE_RAS_SLURM */
 
 int main(void)
 {
@@ -722,8 +732,10 @@ int main(void)
     failures += test_preassigned_index();
     failures += test_hnp_dedup();
     failures += test_flag_string();
+#if PRTE_TEST_HAVE_RAS_SLURM
     failures += test_slurm_validators();
     failures += test_slurm_drain_output();
+#endif
 
     prte_finalize();
 

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -1,0 +1,561 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the ras (Resource Allocation Subsystem) framework.
+ *
+ * Most of what ras *does* -- talking to SLURM/PBS/LSF/Flux, growing and
+ * shrinking a live DVM -- needs a real resource manager and a running set
+ * of daemons, so it is covered by the integration and dockerswarm
+ * harnesses. What can be pinned down in isolation is the machinery the
+ * whole framework funnels through, which is also where the accounting
+ * bugs hide:
+ *
+ *   1. prte_ras_base_node_insert. Every component's allocate() ends here:
+ *      it drains the caller's working list into the global prte_node_pool,
+ *      dedups against what is already there, normalizes FQDNs, honors
+ *      PRTE_NODE_ADD_SLOTS, and maintains prte_ras_base.total_slots_alloc.
+ *      The dedup/accounting path in particular is exercised on every
+ *      elastic re-grow of a node that was previously shrunk out, where a
+ *      double count silently inflates the DVM's idea of its own size.
+ *
+ *   2. The module contract. The driver walks selected_modules calling
+ *      mod->module->allocate, skipping NULL slots; a component that
+ *      forgets to fill in allocate contributes nothing and is invisible.
+ *      Check every statically-built component's vtable.
+ *
+ *   3. prte_ras_base_select. Unlike the usual single-winner MCA pattern,
+ *      ras keeps ALL modules that answer and stores them priority-sorted;
+ *      the driver depends on that ordering, and on `hosts` (priority 1)
+ *      always being present and last so the local-host fallback works.
+ *
+ *   4. prte_ras_base_flag_string, which renders the node flag bitmask for
+ *      --display-allocation.
+ *
+ *   5. The SLURM taint validators. ras/slurm shells out to
+ *      scancel/scontrol/sbatch, so validate_jobid / validate_hostname are
+ *      the boundary between a scheduler-supplied string and a command
+ *      line. Their bounds and allowlists are checked here, along with the
+ *      bounded command-output reader they share.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "constants.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/runtime.h"
+#include "src/util/attr.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/ras/base/base.h"
+#include "src/mca/ras/ras.h"
+#include "src/mca/ras/slurm/ras_slurm.h"
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/* the statically-built components all export their module */
+extern prte_ras_base_module_t prte_ras_hosts_module;
+extern prte_ras_base_module_t prte_ras_pmix_module;
+extern prte_ras_base_module_t prte_ras_sim_module;
+extern prte_ras_base_module_t prte_ras_testrm_module;
+extern prte_ras_base_module_t prte_ras_bootstrap_module;
+extern prte_ras_base_module_t prte_ras_pbs_module;
+extern prte_ras_base_module_t prte_ras_gridengine_module;
+/* prte_ras_slurm_module, the validators and the bounded output drain all
+ * come from ras_slurm.h above */
+
+/*
+ * prte_init_util() stops short of building the global job/node/session
+ * arrays -- that happens in prte_init(), which also wants a live ESS,
+ * session directories and a network stack. Stand up just the pieces
+ * node_insert touches, exactly as prte_init does.
+ */
+static int setup_globals(void)
+{
+    prte_job_t *djob;
+    prte_node_t *hnp;
+
+    prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_job_data, 8, INT_MAX, 8);
+    prte_node_pool = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_node_pool, 8, INT_MAX, 8);
+    prte_node_topologies = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_node_topologies, 8, INT_MAX, 8);
+    prte_sessions = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_sessions, 8, INT_MAX, 8);
+
+    /* the daemon job -- node_insert looks it up to test DO_NOT_LAUNCH */
+    djob = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(djob->nspace, "prte-unit-test-dvm");
+    PMIX_LOAD_PROCID(PRTE_PROC_MY_NAME, "prte-unit-test-dvm", 0);
+    prte_set_job_data_object(djob);
+
+    /* the HNP's own node always occupies pool index 0 */
+    hnp = PMIX_NEW(prte_node_t);
+    hnp->name = strdup("prte-unit-test-hnp");
+    hnp->state = PRTE_NODE_STATE_UP;
+    hnp->slots = 1;
+    hnp->index = pmix_pointer_array_add(prte_node_pool, hnp);
+
+    return (0 == hnp->index) ? PRTE_SUCCESS : PRTE_ERROR;
+}
+
+/* append a fresh node to a working list */
+static prte_node_t *mknode(pmix_list_t *list, const char *name, int slots)
+{
+    prte_node_t *nd = PMIX_NEW(prte_node_t);
+
+    nd->name = strdup(name);
+    nd->state = PRTE_NODE_STATE_UP;
+    nd->slots = slots;
+    nd->slots_max = 0;
+    nd->slots_inuse = 0;
+    pmix_list_append(list, &nd->super);
+    return nd;
+}
+
+/* how many non-NULL entries the pool holds */
+static int pool_count(void)
+{
+    int i, n = 0;
+
+    for (i = 0; i < prte_node_pool->size; i++) {
+        if (NULL != pmix_pointer_array_get_item(prte_node_pool, i)) {
+            n++;
+        }
+    }
+    return n;
+}
+
+static int test_node_insert(void)
+{
+    int failures = 0;
+    pmix_list_t nodes;
+    prte_node_t *nd, *found;
+    int rc, before;
+
+    /* --- a plain insert of two new nodes --- */
+    prte_ras_base.total_slots_alloc = 0;
+    before = pool_count();
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    mknode(&nodes, "unittest-n01", 4);
+    mknode(&nodes, "unittest-n02", 6);
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    CHECK("insert: rc", PRTE_SUCCESS == rc);
+    /* node_insert documents that it removes EVERY item from the list --
+     * callers destruct the list afterwards and would double-free if not */
+    CHECK("insert: list drained", pmix_list_is_empty(&nodes));
+    CHECK("insert: pool grew by 2", pool_count() == before + 2);
+    CHECK("insert: slots totalled", 10 == prte_ras_base.total_slots_alloc);
+    PMIX_DESTRUCT(&nodes);
+
+    found = prte_node_match(NULL, "unittest-n01");
+    CHECK("insert: n01 findable", NULL != found);
+    if (NULL != found) {
+        CHECK("insert: n01 slots", 4 == found->slots);
+        CHECK("insert: n01 indexed", 0 < found->index);
+    }
+
+    /* --- re-inserting a node the pool already holds ---
+     * This is the elastic re-grow case: a shrink removes the daemon but
+     * the pool entry survives, so the regrant arrives as a duplicate. The
+     * pool entry must be reused, its slots must NOT be counted a second
+     * time, and the incoming PRTE_NODE_STATE_ADDED marking must carry
+     * across or the DVM extension will skip the node entirely. */
+    before = pool_count();
+    prte_ras_base.total_slots_alloc = 0;
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = mknode(&nodes, "unittest-n01", 4);
+    nd->state = PRTE_NODE_STATE_ADDED;
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    CHECK("dedup: rc", PRTE_SUCCESS == rc);
+    CHECK("dedup: list drained", pmix_list_is_empty(&nodes));
+    CHECK("dedup: no duplicate entry", pool_count() == before);
+    CHECK("dedup: slots not double counted", 0 == prte_ras_base.total_slots_alloc);
+    PMIX_DESTRUCT(&nodes);
+
+    found = prte_node_match(NULL, "unittest-n01");
+    CHECK("dedup: still findable", NULL != found);
+    if (NULL != found) {
+        CHECK("dedup: ADDED carried across", PRTE_NODE_STATE_ADDED == found->state);
+        CHECK("dedup: slots unchanged", 4 == found->slots);
+    }
+
+    /* --- PRTE_NODE_ADD_SLOTS adjusts rather than replaces --- */
+    found = prte_node_match(NULL, "unittest-n02");
+    CHECK("addslots: n02 present", NULL != found);
+    if (NULL != found) {
+        found->slots_max = 8;
+        PMIX_CONSTRUCT(&nodes, pmix_list_t);
+        nd = mknode(&nodes, "unittest-n02", 3);
+        prte_set_attribute(&nd->attributes, PRTE_NODE_ADD_SLOTS, PRTE_ATTR_LOCAL,
+                           NULL, PMIX_BOOL);
+        rc = prte_ras_base_node_insert(&nodes, NULL);
+        PMIX_DESTRUCT(&nodes);
+        CHECK("addslots: rc", PRTE_SUCCESS == rc);
+        /* 6 + 3 = 9, clamped to slots_max of 8 */
+        CHECK("addslots: clamped to slots_max", 8 == found->slots);
+    }
+
+    /* --- FQDN normalization: short name kept, full name preserved --- */
+    before = pool_count();
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    mknode(&nodes, "unittest-n03.example.com", 2);
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("fqdn: rc", PRTE_SUCCESS == rc);
+    CHECK("fqdn: one node added", pool_count() == before + 1);
+    found = prte_node_match(NULL, "unittest-n03");
+    CHECK("fqdn: short name resolves", NULL != found);
+    if (NULL != found) {
+        CHECK("fqdn: name truncated", 0 == strcmp(found->name, "unittest-n03"));
+        CHECK("fqdn: rawname kept", NULL != found->rawname &&
+              0 == strcmp(found->rawname, "unittest-n03.example.com"));
+        /* both spellings must resolve, or a later --host using the FQDN
+         * would fabricate a second entry for the same machine */
+        CHECK("fqdn: long name resolves too",
+              found == prte_node_match(NULL, "unittest-n03.example.com"));
+    }
+
+    /* --- an empty list is a no-op, not an error --- */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    before = pool_count();
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("empty: rc", PRTE_SUCCESS == rc);
+    CHECK("empty: pool untouched", pool_count() == before);
+
+    return failures;
+}
+
+/*
+ * The HNP's node is pre-entered at pool index 0 before any component runs,
+ * so an incoming entry for the local host must update that entry in place
+ * rather than adding a second one -- otherwise the DVM would try to launch
+ * a daemon on itself.
+ */
+static int test_hnp_dedup(void)
+{
+    int failures = 0;
+    pmix_list_t nodes;
+    prte_node_t *hnp;
+    int before, rc;
+
+    hnp = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, 0);
+    CHECK("hnp: node at index 0", NULL != hnp);
+    if (NULL == hnp) {
+        return failures;
+    }
+
+    before = pool_count();
+    prte_ras_base.total_slots_alloc = 0;
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    mknode(&nodes, prte_process_info.nodename, 12);
+    rc = prte_ras_base_node_insert(&nodes, NULL);
+    PMIX_DESTRUCT(&nodes);
+    CHECK("hnp: rc", PRTE_SUCCESS == rc);
+    CHECK("hnp: no duplicate local node", pool_count() == before);
+    CHECK("hnp: slots adopted", 12 == hnp->slots);
+    CHECK("hnp: counted once", 12 == prte_ras_base.total_slots_alloc);
+    CHECK("hnp: marked allocated", prte_hnp_is_allocated);
+
+    return failures;
+}
+
+/*
+ * Every component fills in the same vtable and the driver dereferences the
+ * slots it uses without further checks beyond a NULL test on allocate.
+ */
+static int test_module_contract(void)
+{
+    int failures = 0;
+    size_t i;
+    struct {
+        const char *name;
+        prte_ras_base_module_t *mod;
+        bool needs_allocate;
+    } mods[] = {
+        {"hosts",      &prte_ras_hosts_module,      true},
+        {"simulator",  &prte_ras_sim_module,        true},
+        {"testrm",     &prte_ras_testrm_module,     true},
+        {"bootstrap",  &prte_ras_bootstrap_module,  true},
+        {"pbs",        &prte_ras_pbs_module,        true},
+        {"gridengine", &prte_ras_gridengine_module, true},
+        {"slurm",      &prte_ras_slurm_module,      true},
+        /* ras/pmix contributes nothing to initial discovery -- its
+         * allocate is a deliberate TAKE_NEXT_OPTION stub -- but the slot
+         * must still be filled so the driver has something to call */
+        {"pmix",       &prte_ras_pmix_module,       true},
+    };
+
+    for (i = 0; i < sizeof(mods) / sizeof(mods[0]); i++) {
+        if (mods[i].needs_allocate && NULL == mods[i].mod->allocate) {
+            fprintf(stderr, "FAIL [module contract]: %s has no allocate\n", mods[i].name);
+            failures++;
+        }
+    }
+
+    /* only slurm implements the elastic completion hooks today; if another
+     * component grows them, the base cycles every module for both */
+    CHECK("contract: slurm shrink_complete", NULL != prte_ras_slurm_module.shrink_complete);
+    CHECK("contract: slurm release_allocation",
+          NULL != prte_ras_slurm_module.release_allocation);
+    CHECK("contract: slurm init", NULL != prte_ras_slurm_module.init);
+
+    /* the modify path is what serves PMIx_Allocation_request */
+    CHECK("contract: hosts modify", NULL != prte_ras_hosts_module.modify);
+    CHECK("contract: pmix modify", NULL != prte_ras_pmix_module.modify);
+    CHECK("contract: slurm modify", NULL != prte_ras_slurm_module.modify);
+
+    return failures;
+}
+
+/*
+ * ras keeps every module that answers, priority-sorted -- it is not a
+ * single-winner selection. The driver walks that list in order, and the
+ * always-available `hosts` component must sort last so the RM components
+ * get first refusal and the local-host fallback still runs.
+ */
+static int test_select(void)
+{
+    int failures = 0;
+    prte_ras_base_selected_module_t *mod;
+    int last_pri = INT_MAX;
+    bool ordered = true, found_hosts = false;
+    const char *tail = NULL;
+    int rc;
+
+    /* keep a developer's own allocation out of the result */
+    unsetenv("SLURM_JOBID");
+    unsetenv("PBS_ENVIRONMENT");
+    unsetenv("PBS_JOBID");
+    unsetenv("COBALT_JOBID");
+    unsetenv("PE_HOSTFILE");
+    unsetenv("JOB_ID");
+    unsetenv("SGE_ROOT");
+
+    rc = pmix_mca_base_framework_open(&prte_ras_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    CHECK("select: framework opened", PMIX_SUCCESS == rc);
+    if (PMIX_SUCCESS != rc) {
+        return failures;
+    }
+
+    rc = prte_ras_base_select();
+    CHECK("select: rc", PRTE_SUCCESS == rc);
+    CHECK("select: something selected",
+          0 < pmix_list_get_size(&prte_ras_base.selected_modules));
+
+    PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules,
+                      prte_ras_base_selected_module_t) {
+        if (mod->pri > last_pri) {
+            ordered = false;
+        }
+        last_pri = mod->pri;
+        CHECK("select: module present", NULL != mod->module);
+        CHECK("select: component present", NULL != mod->component);
+        if (NULL != mod->component) {
+            tail = mod->component->pmix_mca_component_name;
+            if (0 == strcmp(tail, "hosts")) {
+                found_hosts = true;
+                CHECK("select: hosts is priority 1", 1 == mod->pri);
+            }
+        }
+    }
+    CHECK("select: descending priority order", ordered);
+    /* hosts is the unconditional catch-all: without it there is no
+     * --host/--hostfile handling and no local-host fallback */
+    CHECK("select: hosts selected", found_hosts);
+    CHECK("select: hosts sorts last", NULL != tail && 0 == strcmp(tail, "hosts"));
+
+    /* select() latches -- a second call must be a harmless no-op rather
+     * than appending every module a second time */
+    rc = prte_ras_base_select();
+    CHECK("select: idempotent rc", PRTE_SUCCESS == rc);
+
+    return failures;
+}
+
+static int test_flag_string(void)
+{
+    int failures = 0;
+    prte_node_t *nd;
+    char *s;
+
+    nd = PMIX_NEW(prte_node_t);
+
+    s = prte_ras_base_flag_string(nd);
+    CHECK("flags: none", NULL != s && NULL != strstr(s, "NONE"));
+    free(s);
+
+    PRTE_FLAG_SET(nd, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
+    s = prte_ras_base_flag_string(nd);
+    CHECK("flags: daemon launched", NULL != s && NULL != strstr(s, "DAEMON_LAUNCHED"));
+    free(s);
+
+    PRTE_FLAG_SET(nd, PRTE_NODE_FLAG_SLOTS_GIVEN);
+    PRTE_FLAG_SET(nd, PRTE_NODE_FLAG_OVERSUBSCRIBED);
+    s = prte_ras_base_flag_string(nd);
+    CHECK("flags: multiple rendered", NULL != s &&
+          NULL != strstr(s, "DAEMON_LAUNCHED") &&
+          NULL != strstr(s, "SLOTS_GIVEN") &&
+          NULL != strstr(s, "OVERSUBSCRIBED"));
+    free(s);
+
+    PMIX_RELEASE(nd);
+    return failures;
+}
+
+/*
+ * ras/slurm builds scancel/scontrol/sbatch command lines out of strings
+ * that came from the scheduler or from a PMIx client, so these validators
+ * are a security boundary, not a convenience.
+ */
+static int test_slurm_validators(void)
+{
+    int failures = 0;
+    char toolong[PRTE_SLURM_JOB_ID_MAX_LEN + 8];
+    char longhost[PRTE_SLURM_HOSTNAME_MAX_LEN + 8];
+
+    CHECK("jobid: plain", PRTE_SUCCESS == prte_ras_slurm_validate_jobid("12345"));
+    CHECK("jobid: zero ok", PRTE_SUCCESS == prte_ras_slurm_validate_jobid("0"));
+    CHECK("jobid: NULL", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(NULL));
+    CHECK("jobid: empty", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(""));
+    CHECK("jobid: non-digit", PRTE_SUCCESS != prte_ras_slurm_validate_jobid("12a45"));
+    CHECK("jobid: negative", PRTE_SUCCESS != prte_ras_slurm_validate_jobid("-1"));
+    /* the whole point: nothing that could reach a shell */
+    CHECK("jobid: shell metachar",
+          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("1;rm -rf /"));
+    CHECK("jobid: substitution",
+          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("$(id)"));
+    CHECK("jobid: trailing space",
+          PRTE_SUCCESS != prte_ras_slurm_validate_jobid("123 "));
+
+    memset(toolong, '9', sizeof(toolong) - 1);
+    toolong[sizeof(toolong) - 1] = '\0';
+    CHECK("jobid: over length", PRTE_SUCCESS != prte_ras_slurm_validate_jobid(toolong));
+
+    CHECK("host: plain", PRTE_SUCCESS == prte_ras_slurm_validate_hostname("node01"));
+    CHECK("host: fqdn",
+          PRTE_SUCCESS == prte_ras_slurm_validate_hostname("node01.example.com"));
+    CHECK("host: dashes", PRTE_SUCCESS == prte_ras_slurm_validate_hostname("nid-00-01"));
+    CHECK("host: NULL", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(NULL));
+    CHECK("host: empty", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(""));
+    CHECK("host: space", PRTE_SUCCESS != prte_ras_slurm_validate_hostname("node 01"));
+    CHECK("host: semicolon",
+          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("node01;reboot"));
+    CHECK("host: backtick",
+          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("`whoami`"));
+    CHECK("host: comma rejected (lists must be split first)",
+          PRTE_SUCCESS != prte_ras_slurm_validate_hostname("n01,n02"));
+    CHECK("host: newline", PRTE_SUCCESS != prte_ras_slurm_validate_hostname("n01\n"));
+
+    memset(longhost, 'a', sizeof(longhost) - 1);
+    longhost[sizeof(longhost) - 1] = '\0';
+    CHECK("host: over length", PRTE_SUCCESS != prte_ras_slurm_validate_hostname(longhost));
+
+    return failures;
+}
+
+/*
+ * The command-output drain is shared by scancel and scontrol and copies
+ * scheduler error text into a fixed buffer -- an off-by-one here writes
+ * past a stack array on the HNP.
+ */
+static int test_slurm_drain_output(void)
+{
+    int failures = 0;
+    char buf[32];
+    char guard[64];
+    FILE *fp;
+    int rc;
+
+    fp = popen("printf 'hello world\\n'", "r");
+    CHECK("drain: popen", NULL != fp);
+    if (NULL == fp) {
+        return failures;
+    }
+    rc = prte_ras_slurm_drain_cmd_output(fp, buf, sizeof(buf));
+    pclose(fp);
+    CHECK("drain: rc", PRTE_SUCCESS == rc);
+    CHECK("drain: captured", 0 == strcmp(buf, "hello world\n"));
+
+    /* more output than the buffer holds must truncate, stay
+     * NUL-terminated, and be marked with the "..." suffix */
+    fp = popen("printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\n'", "r");
+    CHECK("drain: popen 2", NULL != fp);
+    if (NULL != fp) {
+        memset(guard, 'X', sizeof(guard));
+        rc = prte_ras_slurm_drain_cmd_output(fp, guard, 16);
+        pclose(fp);
+        CHECK("drain: truncate rc", PRTE_SUCCESS == rc);
+        CHECK("drain: NUL terminated within bounds", 15 >= strlen(guard));
+        CHECK("drain: truncation marked", NULL != strstr(guard, "..."));
+        CHECK("drain: did not write past the buffer", 'X' == guard[16]);
+    }
+
+    /* a NULL output buffer means "drain and discard", not an error */
+    fp = popen("printf 'ignored\\n'", "r");
+    if (NULL != fp) {
+        rc = prte_ras_slurm_drain_cmd_output(fp, NULL, 0);
+        pclose(fp);
+        CHECK("drain: discard mode", PRTE_SUCCESS == rc);
+    }
+
+    CHECK("drain: NULL stream rejected",
+          PRTE_SUCCESS != prte_ras_slurm_drain_cmd_output(NULL, buf, sizeof(buf)));
+
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    rc = setup_globals();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "test globals setup failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_module_contract();
+    failures += test_select();
+    failures += test_node_insert();
+    failures += test_hnp_dedup();
+    failures += test_flag_string();
+    failures += test_slurm_validators();
+    failures += test_slurm_drain_output();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all ras unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d ras unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -79,8 +79,12 @@
  * and flux are all gated on detecting their resource manager, and slurm is
  * gated on the platform (and removable with --without-slurm) - referencing
  * those unconditionally makes `make check` fail to link on an ordinary
- * machine. The gated components are covered structurally by test_select(),
- * which walks whatever the framework actually built. */
+ * machine. Being *built* is not enough either: a component in the default
+ * --enable-mca-dso list is a run-time loadable plugin and leaves nothing in
+ * libprrte to reference, which is why the slurm checks below are also gated
+ * on it being static (--enable-mca-static=ras-slurm). The gated components
+ * are covered structurally by test_select(), which walks whatever the
+ * framework actually built. */
 extern prte_ras_base_module_t prte_ras_hosts_module;
 extern prte_ras_base_module_t prte_ras_pmix_module;
 extern prte_ras_base_module_t prte_ras_sim_module;


### PR DESCRIPTION
A deep review of `src/mca/ras`, plus the follow-on fixes it led to in `plm`
and the PMIx server. Ten commits, one logical change each.

The recurring theme: the paths that only run when something unusual happens —
a node rediscovered on an elastic re-grow, a malformed line in a scheduler's
node file, an error return from a library call — were the ones that had never
been exercised. Two whole components had never been *compiled*.

## The consequential ones

**Node-pool accounting (`prte_ras_base_node_insert`).** When the dedup scan
found the pool already held the incoming node, control fell through to the
common tail: the duplicate was leaked, its slots were counted into
`prte_ras_base.total_slots_alloc` a second time, and the multiplier copies
re-ran. This fires on **every elastic re-grow** — a shrink removes a node's
daemon but leaves its pool entry, so the regrant always arrives as a
duplicate. In a *managed* allocation that total is what the PMIx server
reports as `PMIX_UNIV_SIZE` / `PMIX_MAX_PROCS`, so the inflated count reaches
applications. (An unmanaged DVM recomputes it at launch, which is why a local
`prterun` never showed it.)

**The `ras/pmix` scheduler path was broken end to end.** The answer was
recorded in `req->status` while the handler tested `req->pstatus`, which
`prte_ras_base_modify` seeds with `PMIX_ERR_NOT_SUPPORTED` and stops updating
once a module takes ownership. A *granted* allocation was therefore never
applied and the requester was told its request was unsupported.

**Two thread-shift golden-rule violations.** `ras/pmix`'s `infocbfunc` and
`pmix_server.c`'s `send_alloc_resp` both recorded results on a
`prte_pmix_server_req_t` — and freed the array it was carrying — on the *PMIx*
progress thread. Both now capture into a caddy and do every mutation in the
shifted handler.

**Bootstrap DVM rank correspondence.** A bootstrapped daemon computes its own
vpid from `prte.conf` before it ever contacts the controller, and
`prted_report_launch` looks a reporting daemon up in `daemons->procs` *by the
rank it claims*. `ras/bootstrap` recorded that canonical rank as the node's
pool index — and `node_insert` silently overwrote it, while
`setup_virtual_machine` handed out sequential vpids. They agreed only because
`DVMNodes` happens to be listed in rank order. Both now derive from the config,
and `prte_bootstrap_parse` rejects a list naming a host twice, which would
leave a rank no daemon can ever claim.

## Crashes and UB in the parsers

These run on the HNP, so a NULL deref takes the DVM down.

- `ras/flux`: `json_t *root` was declared mid-function while **every** early
  `goto err` jumped over its initializer into a cleanup that decrefs it. Plus
  an `s?O` refcount leak, a `return` that leaked the broker handle and KVS
  future (with unreachable code after it), and success returned after a
  malformed `R_lite`.
- `ras/gridengine`: NULL deref on a blank `PE_HOSTFILE` line.
- `ras/pbs`: chopped the last character off every nodefile line whether or not
  it was a newline; a blank line became a node named `""`.
- `ras/simulator`: `slot_cnt[-1]` when the slots param is empty; a group-name
  prefix that accumulated (`nodeA, nodeB, nodeD, nodeG…`).
- `ras/hosts`: `isspace()` on a plain `char` (UB ≥ 0x80).
- `--display-topo` / `--display-cpus`: dereferenced `node->topology`
  unconditionally, but a node acquires one only when its daemon reports in.
- `prte_ras_base_allocate`: a failed notify released the state caddy and then
  fell through to release it again.

## Compiling what nobody compiles

`ras/flux` needs Flux *and* jansson; `ras/slurm` builds its ~1000-line
`scontrol --json` parser only when jansson is found — and jansson defaults to
`--with-jansson=no`. Neither is compiled by an ordinary developer build or CI
job. Both were broken in ways a compiler catches instantly: `ras/flux`
included `<flux/core.h>` ahead of `prte_config.h`, and passed an `int` index to
`json_array_foreach`, which compares against `size_t` and so fails the tree's
own `-Werror`.

`--enable-testbuild-launchers` now covers them via declaration-only stubs.

> **A tree configured that way must not be run** — the stubs are unimplemented
> and `ras/flux` builds statically, so its `query` segfaults during
> `prte_init`. Documented in `src/mca/ras/AGENTS.md` and the top-level
> configure table, including that `make install`ing such a tree poisons a later
> run of a good one.

## Testing

- **`test/unit/ras/test_ras.c`** (new, in `make check`): `node_insert` dedup /
  drain / slot accounting / `ADD_SLOTS` clamping / FQDN normalization / HNP
  dedup / pre-assigned pool slots, the module vtable contract, priority-ordered
  selection, `flag_string`, the bootstrap rank contract, and the SLURM taint
  validators + bounded output drain. Each new assertion was checked to fail
  when its fix is reverted.
- **dockerswarm**: 52 → 63 assertions. Grow/shrink/re-grow leaving exactly one
  daemon per node; `--add-hostfile` through `add_hosts → ras/pmix defer →
  ras/hosts` including `slots=+N`; and a **bootstrap DVM** across four nodes
  verifying each daemon's vpid against its `DVMNodes` position.
- The image now carries jansson, so the Slurm JSON parser is finally built
  there too.

## Also here

`build.sh` no longer distcleans blindly (it destroyed your in-tree build on
every run), and both out-of-tree builds now honor the `show_help` golden rule —
their build dirs persist, so an edited `help-*.txt` was never picked up.

## Caveats

- The SLURM/PBS/LSF/Flux discovery paths and the Slurm elastic modify surface
  need real resource managers; none of this has been near one. Slurm items
  I did **not** change for that reason are recorded on #2546.
- `ras/flux` is compile-verified only — never linked or run.
- The AGENTS.md guides under `src/mca/ras/` are updated with the ownership,
  NULL-safety, and lifetime rules the review had to reconstruct.