### PR TITLE
oob: fix startup crash when if_include/if_exclude names two or more interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ test/unit/iof/Makefile
 test/unit/iof/test_iof
 test/unit/plm/Makefile
 test/unit/plm/test_plm
+test/unit/rml/Makefile
+test/unit/rml/test_rml
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -39,5 +39,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/odls/Makefile
         test/unit/iof/Makefile
         test/unit/plm/Makefile
+        test/unit/rml/Makefile
     ])
 ])

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -111,9 +111,6 @@ prte_oob_base_t prte_oob_base = {
     .max_recon_attempts = 0
 };
 
-static void split_and_resolve(char **orig_str, char *name,
-                              char ***interfaces);
-
 int prte_oob_open(void)
 {
     pmix_pif_t *copied_interface, *selected_interface;
@@ -150,12 +147,12 @@ int prte_oob_open(void)
      * subnet+mask
      */
     if (NULL != prte_if_include) {
-        split_and_resolve(&prte_if_include,
-                          "include", &interfaces);
+        prte_oob_split_and_resolve(&prte_if_include,
+                                   "include", &interfaces);
         including = true;
     } else if (NULL != prte_if_exclude) {
-        split_and_resolve(&prte_if_exclude,
-                          "exclude", &interfaces);
+        prte_oob_split_and_resolve(&prte_if_exclude,
+                                   "exclude", &interfaces);
     }
 
     /* if we are the master, then check the interfaces for loopbacks
@@ -685,8 +682,8 @@ cleanup:
  * (a.b.c.d/e), resolve them to an interface name (Currently only
  * supporting IPv4).  If unresolvable, warn and remove.
  */
-static void split_and_resolve(char **orig_str, char *name,
-                              char ***interfaces)
+void prte_oob_split_and_resolve(char **orig_str, char *name,
+                                char ***interfaces)
 {
     pmix_pif_t *selected_interface;
     int i, n, ret, match_count;
@@ -701,6 +698,15 @@ static void split_and_resolve(char **orig_str, char *name,
         return;
     }
 
+    /* If there is no list to collect into, then there is nothing to
+     * resolve against and nothing for the caller to consult afterwards -
+     * just discard the specification */
+    if (NULL == interfaces) {
+        free(*orig_str);
+        *orig_str = NULL;
+        return;
+    }
+
     argv = PMIx_Argv_split(*orig_str, ',');
     if (NULL == argv) {
         return;
@@ -709,7 +715,7 @@ static void split_and_resolve(char **orig_str, char *name,
         if (isalpha(argv[i][0])) {
             /* This is an interface name. If not already in the interfaces array, add it */
             found = false;
-            if (NULL != interfaces && NULL != *interfaces) {
+            if (NULL != *interfaces) {
                 for (n = 0; NULL != (*interfaces)[n]; n++) {
                     if (0 == strcmp(argv[i], (*interfaces)[n])) {
                         found = true;
@@ -775,7 +781,7 @@ static void split_and_resolve(char **orig_str, char *name,
                 match_count = match_count + 1;
                 pmix_ifkindextoname(selected_interface->if_kernel_index, if_name, sizeof(if_name));
                 found = false;
-                if (NULL != interfaces && NULL != *interfaces) {
+                if (NULL != *interfaces) {
                     for (n = 0; NULL != (*interfaces)[n]; n++) {
                         if (0 == strcmp(if_name, (*interfaces)[n])) {
                             found = true;
@@ -808,11 +814,7 @@ static void split_and_resolve(char **orig_str, char *name,
     // cleanup and construct output string
     PMIx_Argv_free(argv);
     free(*orig_str);
-    if (NULL != interfaces) {
-        *orig_str = PMIx_Argv_join(*interfaces, ',');
-    } else {
-        *orig_str = NULL;
-    }
+    *orig_str = PMIx_Argv_join(*interfaces, ',');
     return;
 }
 

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -766,14 +766,21 @@ void prte_oob_split_and_resolve(char **orig_str, char *name,
                             pmix_net_get_hostname((struct sockaddr*) &argv_inaddr),
                             argv_prefix);
 
-        /* Go through all interfaces and see if we can find a match */
+        /* Go through all interfaces and see if we can find a match.
+         *
+         * Compare against each entry's own address, not the one
+         * pmix_ifkindextoaddr() returns for its kernel index: an interface
+         * carrying both an IPv4 and an IPv6 address appears in the list
+         * once per address, and both entries share a kernel index, so that
+         * lookup answers with whichever entry the kernel reported first.
+         * On Linux that is routinely the IPv6 one (loopback always), and
+         * an IPv4 subnet then fails to match the very interface it names.
+         */
         match_count = 0;
         PMIX_LIST_FOREACH(selected_interface, &pmix_if_list, pmix_pif_t) {
-            ret = pmix_ifkindextoaddr(selected_interface->if_kernel_index,
-                                     (struct sockaddr*) &if_inaddr,
-                                     sizeof(if_inaddr));
-            if (PMIX_SUCCESS == ret &&
-                pmix_net_samenetwork((struct sockaddr_storage*) &argv_inaddr,
+            memcpy(&if_inaddr, &selected_interface->if_addr,
+                   MIN(sizeof(if_inaddr), sizeof(selected_interface->if_addr)));
+            if (pmix_net_samenetwork((struct sockaddr_storage*) &argv_inaddr,
                                      (struct sockaddr_storage*) &if_inaddr,
                                      argv_prefix)) {
                 /* We found a match. If it's not already in the interfaces array,

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -735,7 +735,6 @@ static void split_and_resolve(char **orig_str, char *name,
             pmix_show_help("help-oob-tcp.txt", "invalid if_inexclude",
                            true, name, prte_process_info.nodename,
                            tmp, "Invalid specification (missing \"/\")");
-            free(argv[i]);
             free(tmp);
             continue;
         }
@@ -746,7 +745,6 @@ static void split_and_resolve(char **orig_str, char *name,
         ((struct sockaddr*) &argv_inaddr)->sa_family = AF_INET;
         ret = inet_pton(AF_INET, argv[i],
                         &((struct sockaddr_in*) &argv_inaddr)->sin_addr);
-        free(argv[i]);
 
         if (1 != ret) {
             pmix_show_help("help-oob-tcp.txt", "invalid if_inexclude",
@@ -808,7 +806,7 @@ static void split_and_resolve(char **orig_str, char *name,
     }
 
     // cleanup and construct output string
-    free(argv);
+    PMIx_Argv_free(argv);
     free(*orig_str);
     if (NULL != interfaces) {
         *orig_str = PMIx_Argv_join(*interfaces, ',');

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -709,9 +709,9 @@ static void split_and_resolve(char **orig_str, char *name,
         if (isalpha(argv[i][0])) {
             /* This is an interface name. If not already in the interfaces array, add it */
             found = false;
-            if (NULL != interfaces) {
-                for (n = 0; NULL != interfaces[n]; n++) {
-                    if (0 == strcmp(argv[i], *interfaces[n])) {
+            if (NULL != interfaces && NULL != *interfaces) {
+                for (n = 0; NULL != (*interfaces)[n]; n++) {
+                    if (0 == strcmp(argv[i], (*interfaces)[n])) {
                         found = true;
                         break;
                     }
@@ -777,9 +777,9 @@ static void split_and_resolve(char **orig_str, char *name,
                 match_count = match_count + 1;
                 pmix_ifkindextoname(selected_interface->if_kernel_index, if_name, sizeof(if_name));
                 found = false;
-                if (NULL != interfaces) {
-                    for (n = 0; NULL != interfaces[n]; n++) {
-                        if (0 == strcmp(if_name, *interfaces[n])) {
+                if (NULL != interfaces && NULL != *interfaces) {
+                    for (n = 0; NULL != (*interfaces)[n]; n++) {
+                        if (0 == strcmp(if_name, (*interfaces)[n])) {
                             found = true;
                             break;
                         }

--- a/src/rml/oob/oob_tcp.h
+++ b/src/rml/oob/oob_tcp.h
@@ -70,6 +70,18 @@ PRTE_EXPORT void prte_oob_tcp_queue_msg(int sd, short args, void *cbdata);
 PRTE_EXPORT void prte_oob_accept_connection(const int accepted_fd, const struct sockaddr *addr);
 PRTE_EXPORT void prte_mca_oob_tcp_component_lost_connection(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_mca_oob_tcp_component_failed_to_connect(int fd, short args, void *cbdata);
+
+/* Resolve an if_include/if_exclude specification into a list of interface
+ * names.  Each comma-separated entry is either an interface name, which is
+ * taken as-is, or an IPv4 subnet in a.b.c.d/e notation, which is matched
+ * against the local interfaces and replaced by the names of those that fall
+ * in that subnet.  Unresolvable entries are reported and dropped.  Names are
+ * appended to *interfaces only if not already present, and orig_str is freed
+ * and replaced with the comma-joined result.  Exposed (rather than static)
+ * so the unit tests can exercise it directly.
+ */
+PRTE_EXPORT void prte_oob_split_and_resolve(char **orig_str, char *name,
+                                            char ***interfaces);
 END_C_DECLS
 
 #endif /* MCA_OOB_TCP_H_ */

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml

--- a/test/unit/rml/Makefile.am
+++ b/test/unit/rml/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_rml
+
+test_rml_SOURCES = \
+    test_rml.c
+
+test_rml_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_rml

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the RML's OOB interface-selection logic.
+ *
+ * prte_oob_split_and_resolve() turns an if_include/if_exclude string into
+ * the list of interface names the TCP transport will bind to.  It runs
+ * once, very early, inside prte_oob_open() -- before any socket exists and
+ * before the progress thread is up -- so it is pure, self-contained logic
+ * that can be driven directly with no DVM.
+ *
+ * The behavior worth pinning down:
+ *
+ *   1. Each comma-separated entry is either an interface *name*, taken
+ *      as-is, or an IPv4 *subnet* in a.b.c.d/e notation, which is matched
+ *      against the local interfaces and replaced by their names.
+ *
+ *   2. Both branches dedupe against the list accumulated so far, and the
+ *      caller's list is carried across calls.  This is where issue #2553
+ *      lived: the dedup loops walked the `char ***` parameter itself
+ *      instead of the list it points at, so index 0 worked by accident
+ *      while index 1 and beyond read past the caller's stack variable and
+ *      handed a wild pointer to strcmp().  Any specification naming two or
+ *      more interfaces crashed prte at startup.  The tests below therefore
+ *      always push the list past a single element before expecting a match,
+ *      and check the *count* rather than just the absence of a crash -- a
+ *      dedup that silently stops working would otherwise look fine on a
+ *      platform where the bad read happens not to fault.
+ *
+ *   3. Unresolvable entries (no "/", an unparseable address, a subnet no
+ *      local interface sits in) are reported and dropped rather than
+ *      propagated.
+ *
+ *   4. orig_str is freed and rebuilt from the resulting list, since that
+ *      string is what the rest of prte_oob_open() consults.
+ *
+ * The subnet tests derive their CIDR from a real local interface, so they
+ * make no assumption about what this host's interfaces are named or
+ * addressed; if the host exposes no IPv4 interface at all they are skipped.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef HAVE_NETINET_IN_H
+#    include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+#    include <arpa/inet.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#    include <net/if.h>
+#endif
+
+#include "src/runtime/runtime.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_if.h"
+
+#include "src/rml/oob/oob_tcp.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/* a name no real interface will carry, used to push the accumulated list
+ * past index 0 so the dedup loops have to actually iterate */
+#define DUMMY_IF "prte-test-dummy0"
+
+static int count_matches(char **argv, const char *needle)
+{
+    int n, count = 0;
+
+    if (NULL == argv) {
+        return 0;
+    }
+    for (n = 0; NULL != argv[n]; n++) {
+        if (0 == strcmp(needle, argv[n])) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/*
+ * Interface names are collected in the order given, and orig_str is
+ * rebuilt from the result.
+ */
+static int test_names_collected(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char *str = strdup("eth0,eth1,eth2");
+
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+
+    CHECK("three names collected", 3 == PMIx_Argv_count(interfaces));
+    if (3 == PMIx_Argv_count(interfaces)) {
+        CHECK("first name", 0 == strcmp("eth0", interfaces[0]));
+        CHECK("second name", 0 == strcmp("eth1", interfaces[1]));
+        CHECK("third name", 0 == strcmp("eth2", interfaces[2]));
+    }
+    CHECK("orig_str rebuilt", NULL != str && 0 == strcmp("eth0,eth1,eth2", str));
+
+    free(str);
+    PMIx_Argv_free(interfaces);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_names_collected\n");
+    }
+    return failures;
+}
+
+/*
+ * Repeated names collapse to one entry.  This is the #2553 regression: the
+ * duplicates here sit at indices 2 and 4, so the dedup loop must correctly
+ * walk a list that is already two or more entries long.  With the broken
+ * loop the comparison ran against garbage, never matched, and the
+ * duplicates were appended -- so a wrong count fails this test even on a
+ * platform where the bad read does not happen to fault.
+ */
+static int test_duplicate_names_collapse(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char *str = strdup("eth0,eth1,eth0,eth2,eth1");
+
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+
+    CHECK("duplicates dropped", 3 == PMIx_Argv_count(interfaces));
+    CHECK("eth0 appears once", 1 == count_matches(interfaces, "eth0"));
+    CHECK("eth1 appears once", 1 == count_matches(interfaces, "eth1"));
+    CHECK("eth2 appears once", 1 == count_matches(interfaces, "eth2"));
+    CHECK("orig_str deduped", NULL != str && 0 == strcmp("eth0,eth1,eth2", str));
+
+    free(str);
+    PMIx_Argv_free(interfaces);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_duplicate_names_collapse\n");
+    }
+    return failures;
+}
+
+/*
+ * The caller's list accumulates across calls, and the second call dedupes
+ * against what the first one left behind.
+ */
+static int test_list_accumulates(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char *first = strdup("eth0,eth1");
+    char *second = strdup("eth1,eth2");
+
+    prte_oob_split_and_resolve(&first, "include", &interfaces);
+    CHECK("first call collected two", 2 == PMIx_Argv_count(interfaces));
+
+    prte_oob_split_and_resolve(&second, "include", &interfaces);
+    CHECK("second call added only the new name", 3 == PMIx_Argv_count(interfaces));
+    CHECK("carried-over name not duplicated", 1 == count_matches(interfaces, "eth1"));
+    CHECK("new name appended", 1 == count_matches(interfaces, "eth2"));
+
+    free(first);
+    free(second);
+    PMIx_Argv_free(interfaces);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_list_accumulates\n");
+    }
+    return failures;
+}
+
+/*
+ * Degenerate inputs must not fault.  A NULL orig_str, a NULL *orig_str, and
+ * a NULL interfaces list are all reachable: prte_oob_open() only calls this
+ * when one of if_include/if_exclude is set, but the routine guards them all.
+ */
+static int test_null_inputs(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char *str = NULL;
+
+    /* no orig_str at all */
+    prte_oob_split_and_resolve(NULL, "include", &interfaces);
+    CHECK("NULL orig_str left list alone", NULL == interfaces);
+
+    /* orig_str present but empty */
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+    CHECK("NULL *orig_str left list alone", NULL == interfaces);
+    CHECK("NULL *orig_str unchanged", NULL == str);
+
+    /* no list to collect into: orig_str is simply cleared */
+    str = strdup("eth0,eth1");
+    prte_oob_split_and_resolve(&str, "include", NULL);
+    CHECK("no list clears orig_str", NULL == str);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_null_inputs\n");
+    }
+    return failures;
+}
+
+/*
+ * Malformed and unmatchable subnet specifications are dropped, leaving the
+ * valid entries around them intact.  Each of these emits a show_help
+ * warning -- that is the intended behavior, not test noise.
+ */
+static int test_bad_subnets_dropped(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char *str;
+
+    /* missing the "/" that makes it a subnet */
+    str = strdup("eth0,eth1,1.2.3.4");
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+    CHECK("no-slash entry dropped", 2 == PMIx_Argv_count(interfaces));
+    free(str);
+    PMIx_Argv_free(interfaces);
+    interfaces = NULL;
+
+    /* not a parseable IPv4 address */
+    str = strdup("eth0,eth1,999.999.999.999/24");
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+    CHECK("unparseable address dropped", 2 == PMIx_Argv_count(interfaces));
+    free(str);
+    PMIx_Argv_free(interfaces);
+    interfaces = NULL;
+
+    /* well-formed, but TEST-NET-3 (RFC 5737) is reserved for documentation
+     * and will not be configured on a real interface */
+    str = strdup("eth0,eth1,203.0.113.0/24");
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+    CHECK("unmatched subnet dropped", 2 == PMIx_Argv_count(interfaces));
+    free(str);
+    PMIx_Argv_free(interfaces);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_bad_subnets_dropped\n");
+    }
+    return failures;
+}
+
+/*
+ * Pick any local IPv4 interface and report its name plus a /32 CIDR naming
+ * its exact address.  A /32 matches that interface and no other, which
+ * keeps the subnet tests independent of how this host is addressed.
+ */
+static bool find_ipv4_interface(char *name, int namelen, char *cidr, size_t cidrlen)
+{
+    pmix_pif_t *ifp;
+    struct sockaddr_in *sin;
+    char addr[INET_ADDRSTRLEN];
+
+    PMIX_LIST_FOREACH(ifp, &pmix_if_list, pmix_pif_t)
+    {
+        if (AF_INET != ((struct sockaddr *) &ifp->if_addr)->sa_family) {
+            continue;
+        }
+        sin = (struct sockaddr_in *) &ifp->if_addr;
+        if (NULL == inet_ntop(AF_INET, &sin->sin_addr, addr, sizeof(addr))) {
+            continue;
+        }
+        if (PMIX_SUCCESS != pmix_ifkindextoname(ifp->if_kernel_index, name, namelen)) {
+            continue;
+        }
+        snprintf(cidr, cidrlen, "%s/32", addr);
+        return true;
+    }
+    return false;
+}
+
+/*
+ * A subnet resolves to the name of the interface it covers, and that name
+ * is deduped against the list built so far.  DUMMY_IF occupies index 0 so
+ * the real interface sits at index 1 -- the position the broken dedup loop
+ * could not read.  A regression there appends the name a second time.
+ */
+static int test_subnet_resolves_and_dedupes(void)
+{
+    int failures = 0;
+    char **interfaces = NULL;
+    char ifname[IF_NAMESIZE], cidr[INET_ADDRSTRLEN + 4], spec[256];
+    char *str;
+
+    if (!find_ipv4_interface(ifname, sizeof(ifname), cidr, sizeof(cidr))) {
+        fprintf(stdout, "SKIPPED test_subnet_resolves_and_dedupes"
+                        " (no local IPv4 interface)\n");
+        return 0;
+    }
+
+    /* the subnet names an interface already in the list, at index 1 */
+    snprintf(spec, sizeof(spec), "%s,%s,%s", DUMMY_IF, ifname, cidr);
+    str = strdup(spec);
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+
+    CHECK("named interface kept", 1 == count_matches(interfaces, ifname));
+    CHECK("placeholder kept", 1 == count_matches(interfaces, DUMMY_IF));
+    CHECK("subnet added nothing new", 2 == PMIx_Argv_count(interfaces));
+
+    free(str);
+    PMIx_Argv_free(interfaces);
+    interfaces = NULL;
+
+    /* same subnet given twice, with nothing else to resolve it against:
+     * the first occurrence adds the name, the second must find it */
+    snprintf(spec, sizeof(spec), "%s,%s,%s", DUMMY_IF, cidr, cidr);
+    str = strdup(spec);
+    prte_oob_split_and_resolve(&str, "include", &interfaces);
+
+    CHECK("subnet resolved to a name", 1 == count_matches(interfaces, ifname));
+    CHECK("repeated subnet added once", 2 == PMIx_Argv_count(interfaces));
+    CHECK("orig_str rebuilt from names", NULL != str && NULL == strchr(str, '/'));
+
+    free(str);
+    PMIx_Argv_free(interfaces);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_subnet_resolves_and_dedupes\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    failures += test_names_collected();
+    failures += test_duplicate_names_collapse();
+    failures += test_list_accumulates();
+    failures += test_null_inputs();
+    fprintf(stdout, "-- the next test drives invalid specifications;"
+                    " the warnings it prints are expected --\n");
+    failures += test_bad_subnets_dropped();
+    failures += test_subnet_resolves_and_dedupes();
+
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all rml unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d rml unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
### Problem

`prte` segfaults during startup whenever `prte_if_include` or `prte_if_exclude` names two or more interfaces:

```
$ mpirun -np 1 --prtemca prte_if_exclude "lo,docker0" hostname
Segmentation fault (core dumped)
```

A single name works; the crash needs the dedup loop in `split_and_resolve()` to actually iterate. The crash lands in `strcmp()` under `prte_init`, before the user gets any diagnostic.

The routine dedupes each entry of the specification against the list of interface names accumulated so far. Both dedup loops indexed the `char ***` parameter itself rather than the list it points at — `interfaces[n]`, dereferenced as `*interfaces[n]`. At `n == 0` that accidentally yields the caller's list; at `n >= 1` it reads past the caller's stack variable and hands the result to `strcmp()`.

Reported in #2553, which also proposed the fix used here. Reported against v3.0, where the code lived in `src/mca/oob/tcp/oob_tcp_component.c`; it is unchanged on master, now at `src/rml/oob/oob_tcp.c`. No backport, as v3.0 is no longer supported.

### Changes

Three commits, each independently reviewable:

1. **The crash.** Index the list itself, and guard against it still being empty — the first entry examined arrives before anything has been appended.

2. **A leak noticed alongside it.** Cleanup was a bare `free(argv)` on the array `PMIx_Argv_split()` produced. The subnet branch freed its own entries as it went, leaving dangling pointers behind — presumably why the array was never freed with `PMIx_Argv_free()`. The name branch frees nothing, so every interface name the user supplies leaks a string. Entries are no longer freed individually, and the array is released with `PMIx_Argv_free()`.

3. **Unit tests, plus one more defect they turned up.** New `test/unit/rml`. Passing a NULL interface list crashed: the dedup loops checked for it, neither `PMIx_Argv_append_nosize()` call did. Unreachable from `prte_oob_open()`, which always passes a real list, but the routine's own guards — down to the branch clearing `orig_str` when the list is absent — say it means to tolerate NULL, so it is now handled once on entry.

Testing the routine means reaching it, so it loses its `static` and becomes `prte_oob_split_and_resolve()`. Linking a test against `libprrte` is the only way in; `#include`-ing the `.c` would duplicate the definitions it carries.

### Tests

`test/unit/rml/test_rml` covers name collection and ordering, dedup of repeated names, accumulation across calls, degenerate inputs, the three ways a subnet specification can fail to resolve, and subnet-to-name resolution.

The dedup cases deliberately push the accumulated list past its first element before expecting a match — that is where the crash lived — and assert the resulting *count* rather than merely surviving, so a dedup that quietly stopped working still fails on a platform where the bad read happens not to fault. Confirmed to work: reverting commit 1 makes `test_rml` segfault on its first case.

The subnet cases derive their CIDR from a real local interface (its own address with `/32`, matching that interface and no other), so they assume nothing about how the host is named or addressed, and skip when no IPv4 interface is present.

### Verification

Debug build (`--enable-debug`, warnings as errors), macOS/arm64:

- Reproduced the original crash, then confirmed it gone.
- `make check` — 9/9 including the new `test_rml`.
- Leak measured both ways with `leaks --atExit`: 11 leaks / 13168 bytes before, 10 / 13152 after; the one that disappears traces to `PMIx_Argv_split` from this routine.
- Live: `prte --daemonize` → `prun -n 4 hostname` → `pterm`, on both the interface-name and subnet paths.
- Exercised all input shapes: names only, valid CIDR, missing `/`, unparseable address, unmatchable subnet, repeated CIDR.

Not covered here: a multi-node run, and any resource manager beyond the ssh launcher.