### PR TITLE
test/unit: reach components through the framework, not their symbols

### DIFF
--- a/test/unit/errmgr/test_errmgr.c
+++ b/test/unit/errmgr/test_errmgr.c
@@ -28,6 +28,8 @@
 #include <stdio.h>
 
 #include "constants.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/errmgr/base/base.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 
@@ -51,9 +53,46 @@
  *  - the default module leaves init/finalize NULL (it only logs);
  *  - each real role module wires up both init and finalize.
  */
+/*
+ * Ask the framework for the module a component hands *this* process.
+ *
+ * Naming the component's module symbol assumes it was linked into
+ * libprrte; with --enable-mca-dso the component is a separate DSO and the
+ * symbol is not there to link against.  Each errmgr component also gates
+ * its query on the process type, so the caller says which type it is
+ * asking as.
+ */
+static prte_errmgr_base_module_t *errmgr_module(const char *name, prte_proc_type_t as)
+{
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_module_t *mod = NULL;
+    prte_proc_type_t save;
+    int pri = 0;
+
+    PMIX_LIST_FOREACH(cli, &prte_errmgr_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 != strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            continue;
+        }
+        if (NULL == cli->cli_component->pmix_mca_query_component) {
+            return NULL;
+        }
+        save = prte_process_info.proc_type;
+        prte_process_info.proc_type = as;
+        if (PRTE_SUCCESS != cli->cli_component->pmix_mca_query_component(&mod, &pri)) {
+            mod = NULL;
+        }
+        prte_process_info.proc_type = save;
+        return (prte_errmgr_base_module_t *) mod;
+    }
+    return NULL;
+}
+
 static int test_errmgr_modules(void)
 {
     int failures = 0;
+    prte_errmgr_base_module_t *dvm, *prted;
 
     /* the log-only fallback: logfn set, no state-machine wiring */
     CHECK("default logfn", NULL != prte_errmgr_default_fns.logfn);
@@ -64,15 +103,25 @@ static int test_errmgr_modules(void)
      * whether a component has been selected yet */
     CHECK("live logfn", NULL != prte_errmgr.logfn);
 
-    /* the HNP component */
-    CHECK("dvm logfn", NULL != prte_errmgr_dvm_module.logfn);
-    CHECK("dvm init", NULL != prte_errmgr_dvm_module.init);
-    CHECK("dvm finalize", NULL != prte_errmgr_dvm_module.finalize);
+    /* the HNP component, asked as the master it serves */
+    dvm = errmgr_module("dvm", PRTE_PROC_MASTER);
+    if (NULL == dvm) {
+        fprintf(stdout, "  (skipping dvm module checks: component absent)\n");
+    } else {
+        CHECK("dvm logfn", NULL != dvm->logfn);
+        CHECK("dvm init", NULL != dvm->init);
+        CHECK("dvm finalize", NULL != dvm->finalize);
+    }
 
-    /* the daemon component */
-    CHECK("prted logfn", NULL != prte_errmgr_prted_module.logfn);
-    CHECK("prted init", NULL != prte_errmgr_prted_module.init);
-    CHECK("prted finalize", NULL != prte_errmgr_prted_module.finalize);
+    /* the daemon component, asked as the daemon it serves */
+    prted = errmgr_module("prted", PRTE_PROC_DAEMON);
+    if (NULL == prted) {
+        fprintf(stdout, "  (skipping prted module checks: component absent)\n");
+    } else {
+        CHECK("prted logfn", NULL != prted->logfn);
+        CHECK("prted init", NULL != prted->init);
+        CHECK("prted finalize", NULL != prted->finalize);
+    }
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_errmgr_modules\n");
@@ -114,6 +163,16 @@ int main(void)
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
         fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* the module checks ask the framework for their subject */
+    rc = pmix_mca_base_framework_open(&prte_errmgr_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "errmgr framework open failed: %d\n", rc);
+        (void) pmix_mca_base_framework_close(&prte_errmgr_base_framework);
+    prte_finalize();
         return 1;
     }
 

--- a/test/unit/grpcomm/Makefile.am
+++ b/test/unit/grpcomm/Makefile.am
@@ -14,4 +14,14 @@ test_grpcomm_SOURCES = \
 
 test_grpcomm_LDADD = $(top_builddir)/src/libprrte.la
 
+# A few cases reach at grpcomm/direct's own symbols - its module entry
+# points and the classes it defines.  Those are linkable only when the
+# component is compiled into libprrte; built as a DSO it is a separate
+# object the test never links against.  Compile them in only then.
+if !MCA_BUILD_prte_grpcomm_direct_DSO
+test_grpcomm_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_GRPCOMM_DIRECT=1
+else
+test_grpcomm_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_GRPCOMM_DIRECT=0
+endif
+
 TESTS = test_grpcomm

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -48,6 +48,7 @@
 #include <stdint.h>
 
 #include "constants.h"
+#include "src/mca/base/pmix_base.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 
@@ -69,10 +70,63 @@
  * tree calls.  init/finalize/fault_handler are file-static in the
  * component, so we can only assert they are wired, not their identity.
  */
+/*
+ * Ask the framework for a component by name, and for the module that
+ * component hands *this* process.
+ *
+ * These are two different questions.  A component is present whenever the
+ * framework opened it; whether it yields a module is up to its query,
+ * which is free to decline - iof/prted, for one, answers only a daemon.
+ * Naming the component's module symbol instead would assume it was linked
+ * into libprrte, which is false with --enable-mca-dso: there the component
+ * is a separate DSO and the symbol is not there to link against.
+ */
+static bool grpcomm_component_present(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+
+    PMIX_LIST_FOREACH(cli, &prte_grpcomm_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 == strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static prte_grpcomm_base_module_t *grpcomm_module(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_module_t *mod = NULL;
+    int pri = 0;
+
+    PMIX_LIST_FOREACH(cli, &prte_grpcomm_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 != strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            continue;
+        }
+        if (NULL == cli->cli_component->pmix_mca_query_component) {
+            return NULL;
+        }
+        if (PRTE_SUCCESS != cli->cli_component->pmix_mca_query_component(&mod, &pri)) {
+            return NULL;
+        }
+        return (prte_grpcomm_base_module_t *) mod;
+    }
+    return NULL;
+}
+
 static int test_module_contract(void)
 {
     int failures = 0;
-    prte_grpcomm_base_module_t *m = &prte_grpcomm_direct_module;
+    prte_grpcomm_base_module_t *m = grpcomm_module("direct");
+
+    if (NULL == m) {
+        fprintf(stdout, "SKIPPED test_module_contract (grpcomm/direct absent)\n");
+        return 0;
+    }
 
     CHECK("init set", NULL != m->init);
     CHECK("finalize set", NULL != m->finalize);
@@ -82,11 +136,15 @@ static int test_module_contract(void)
     CHECK("fence set", NULL != m->fence);
     CHECK("group set", NULL != m->group);
 
-    /* the public entry points must be exactly what the module advertises */
+    /* The identity of each entry point can only be checked where the
+     * component's own symbols are linkable - see PRTE_TEST_GRPCOMM_DIRECT
+     * in this directory's Makefile.am. */
+#if PRTE_TEST_GRPCOMM_DIRECT
     CHECK("xcast identity", m->xcast == prte_grpcomm_direct_xcast);
     CHECK("xcast_nb identity", m->xcast_nb == prte_grpcomm_direct_xcast_nb);
     CHECK("fence identity", m->fence == prte_grpcomm_direct_fence);
     CHECK("group identity", m->group == prte_grpcomm_direct_group);
+#endif
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_module_contract\n");
@@ -101,9 +159,14 @@ static int test_module_contract(void)
 static int test_component_identity(void)
 {
     int failures = 0;
-    prte_grpcomm_base_component_t *c = &prte_mca_grpcomm_direct_component.super;
-
-    CHECK("component name", 0 == strcmp(c->pmix_mca_component_name, "direct"));
+    /* the framework must have opened a component by this name - asking it
+     * for one is the assertion */
+    if (!grpcomm_component_present("direct")) {
+        fprintf(stdout, "SKIPPED test_component_identity"
+                        " (grpcomm/direct not loadable from the build tree)\n");
+        return 0;
+    }
+    CHECK("component present", grpcomm_component_present("direct"));
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_component_identity\n");
@@ -138,6 +201,12 @@ static int test_classes(void)
 {
     int failures = 0;
 
+    /* Everything from here to the group caddy constructs a class the
+     * component defines.  Those classes are reachable only where the
+     * component's symbols are linkable - not from a DSO build, and not
+     * once the library hides its internals - so they are compiled in
+     * only when this directory's Makefile.am says so. */
+#if PRTE_TEST_GRPCOMM_DIRECT
     /* fence signature: empty proc set */
     prte_grpcomm_direct_fence_signature_t *fsig =
         PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
@@ -211,6 +280,8 @@ static int test_classes(void)
     CHECK("fence caddy cbfunc NULL", NULL == fcd->cbfunc);
     PMIX_RELEASE(fcd);
 
+#endif
+
     /* group caddy (lives in the framework header): NONE op, empty */
     prte_pmix_grp_caddy_t *gcd = PMIX_NEW(prte_pmix_grp_caddy_t);
     CHECK("grp caddy op NONE", PMIX_GROUP_NONE == gcd->op);
@@ -239,11 +310,22 @@ int main(void)
         return 1;
     }
 
+    /* the module and component tests ask the framework for their subject,
+     * so it has to be open before they run */
+    rc = pmix_mca_base_framework_open(&prte_grpcomm_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "grpcomm framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
     failures += test_module_contract();
     failures += test_component_identity();
     failures += test_base_context_id();
     failures += test_classes();
 
+    (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     prte_finalize();
 
     if (0 == failures) {

--- a/test/unit/iof/test_iof.c
+++ b/test/unit/iof/test_iof.c
@@ -53,6 +53,7 @@
 
 #include "prte_config.h"
 #include "constants.h"
+#include "src/mca/base/pmix_base.h"
 
 #include <fcntl.h>
 #include <stdio.h>
@@ -136,11 +137,73 @@ static int test_tag_model(void)
  * slot must be wired in both, since the base and its callers only NULL-check
  * the optional entry points.
  */
+/*
+ * Ask the framework for a component by name, and for the module that
+ * component hands *this* process.
+ *
+ * These are two different questions.  A component is present whenever the
+ * framework opened it; whether it yields a module is up to its query,
+ * which is free to decline - iof/prted, for one, answers only a daemon.
+ * Naming the component's module symbol instead would assume it was linked
+ * into libprrte, which is false with --enable-mca-dso: there the component
+ * is a separate DSO and the symbol is not there to link against.
+ */
+static bool iof_component_present(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+
+    PMIX_LIST_FOREACH(cli, &prte_iof_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 == strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static prte_iof_base_module_t *iof_module(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_module_t *mod = NULL;
+    int pri = 0;
+
+    PMIX_LIST_FOREACH(cli, &prte_iof_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 != strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            continue;
+        }
+        if (NULL == cli->cli_component->pmix_mca_query_component) {
+            return NULL;
+        }
+        if (PRTE_SUCCESS != cli->cli_component->pmix_mca_query_component(&mod, &pri)) {
+            return NULL;
+        }
+        return (prte_iof_base_module_t *) mod;
+    }
+    return NULL;
+}
+
 static int test_module_contract(void)
 {
     int failures = 0;
-    prte_iof_base_module_t *hnp = &prte_iof_hnp_module;
-    prte_iof_base_module_t *prted = &prte_iof_prted_module;
+    prte_iof_base_module_t *hnp, *prted;
+    prte_proc_type_t save;
+
+    hnp = iof_module("hnp");
+    /* iof/prted hands its module only to a daemon, and this test is not
+     * one, so ask the question it answers rather than skipping its half of
+     * the contract */
+    save = prte_process_info.proc_type;
+    prte_process_info.proc_type = PRTE_PROC_DAEMON;
+    prted = iof_module("prted");
+    prte_process_info.proc_type = save;
+
+    if (NULL == hnp || NULL == prted) {
+        fprintf(stdout, "SKIPPED test_module_contract (iof/hnp or iof/prted absent)\n");
+        return 0;
+    }
 
     /* the HNP hub wires all seven slots */
     CHECK("hnp init set", NULL != hnp->init);
@@ -173,10 +236,15 @@ static int test_component_identity(void)
 {
     int failures = 0;
 
-    CHECK("hnp component name",
-          0 == strcmp(prte_mca_iof_hnp_component.super.pmix_mca_component_name, "hnp"));
-    CHECK("prted component name",
-          0 == strcmp(prte_mca_iof_prted_component.super.pmix_mca_component_name, "prted"));
+    /* the framework must have opened a component under each name -
+     * finding one is the assertion */
+    if (!iof_component_present("hnp") || !iof_component_present("prted")) {
+        fprintf(stdout, "SKIPPED test_component_identity"
+                        " (iof components not loadable from the build tree)\n");
+        return 0;
+    }
+    CHECK("hnp component present", iof_component_present("hnp"));
+    CHECK("prted component present", iof_component_present("prted"));
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_component_identity\n");
@@ -444,6 +512,15 @@ int main(void)
     }
 
     failures += test_tag_model();
+    /* the module tests ask the framework for their subject, so it has to
+     * be open before they run */
+    rc = pmix_mca_base_framework_open(&prte_iof_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "iof framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
     failures += test_module_contract();
     failures += test_component_identity();
     failures += test_classes();
@@ -451,6 +528,7 @@ int main(void)
     failures += test_write_output_chunking();
     failures += test_fd_always_ready();
 
+    (void) pmix_mca_base_framework_close(&prte_iof_base_framework);
     prte_finalize();
 
     if (0 == failures) {

--- a/test/unit/odls/test_odls.c
+++ b/test/unit/odls/test_odls.c
@@ -52,6 +52,7 @@
 #include <stdint.h>
 
 #include "constants.h"
+#include "src/mca/base/pmix_base.h"
 #include "src/hwloc/hwloc-internal.h"
 #include "src/runtime/runtime.h"
 #include "src/util/pmix_argv.h"
@@ -77,10 +78,63 @@
  * get_add_procs_data, however, is documented to be the base function used
  * verbatim, so we pin that.
  */
+/*
+ * Ask the framework for a component by name, and for the module that
+ * component hands *this* process.
+ *
+ * These are two different questions.  A component is present whenever the
+ * framework opened it; whether it yields a module is up to its query,
+ * which is free to decline - iof/prted, for one, answers only a daemon.
+ * Naming the component's module symbol instead would assume it was linked
+ * into libprrte, which is false with --enable-mca-dso: there the component
+ * is a separate DSO and the symbol is not there to link against.
+ */
+static bool odls_component_present(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+
+    PMIX_LIST_FOREACH(cli, &prte_odls_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 == strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static prte_odls_base_module_t *odls_module(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_module_t *mod = NULL;
+    int pri = 0;
+
+    PMIX_LIST_FOREACH(cli, &prte_odls_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 != strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            continue;
+        }
+        if (NULL == cli->cli_component->pmix_mca_query_component) {
+            return NULL;
+        }
+        if (PRTE_SUCCESS != cli->cli_component->pmix_mca_query_component(&mod, &pri)) {
+            return NULL;
+        }
+        return (prte_odls_base_module_t *) mod;
+    }
+    return NULL;
+}
+
 static int test_module_contract(void)
 {
     int failures = 0;
-    prte_odls_base_module_t *m = &prte_odls_pdefault_module;
+    prte_odls_base_module_t *m = odls_module("pdefault");
+
+    if (NULL == m) {
+        fprintf(stdout, "SKIPPED test_module_contract (odls/pdefault absent)\n");
+        return 0;
+    }
 
     CHECK("get_add_procs_data set", NULL != m->get_add_procs_data);
     CHECK("launch_local_procs set", NULL != m->launch_local_procs);
@@ -106,9 +160,14 @@ static int test_module_contract(void)
 static int test_component_identity(void)
 {
     int failures = 0;
-    prte_odls_base_component_t *c = &prte_mca_odls_pdefault_component;
-
-    CHECK("component name", 0 == strcmp(c->pmix_mca_component_name, "pdefault"));
+    /* the framework must have opened a component by this name - asking it
+     * for one is the assertion */
+    if (!odls_component_present("pdefault")) {
+        fprintf(stdout, "SKIPPED test_component_identity"
+                        " (odls/pdefault not loadable from the build tree)\n");
+        return 0;
+    }
+    CHECK("component present", odls_component_present("pdefault"));
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_component_identity\n");
@@ -257,12 +316,22 @@ int main(void)
         return 1;
     }
 
+    /* the module tests ask the framework for their subject, so it has to
+     * be open before they run */
+    rc = pmix_mca_base_framework_open(&prte_odls_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "odls framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
     failures += test_module_contract();
     failures += test_component_identity();
     failures += test_daemon_cmd_uniqueness();
     failures += test_child_err_enum();
     failures += test_classes();
 
+    (void) pmix_mca_base_framework_close(&prte_odls_base_framework);
     prte_finalize();
 
     if (0 == failures) {

--- a/test/unit/plm/test_plm.c
+++ b/test/unit/plm/test_plm.c
@@ -55,6 +55,7 @@
 #include <string.h>
 
 #include "constants.h"
+#include "src/mca/base/pmix_base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
 #include "src/util/pmix_argv.h"
@@ -243,6 +244,40 @@ static int test_state_code_uniqueness(void)
  * remote_spawn is genuinely optional (ssh alone implements the tree
  * fan-out) and finalize is optional for the default module.
  */
+/*
+ * Ask the framework for a component by name, and for the module that
+ * component hands *this* process.
+ *
+ * These are two different questions.  A component is present whenever the
+ * framework opened it; whether it yields a module is up to its query,
+ * which is free to decline - iof/prted, for one, answers only a daemon.
+ * Naming the component's module symbol instead would assume it was linked
+ * into libprrte, which is false with --enable-mca-dso: there the component
+ * is a separate DSO and the symbol is not there to link against.
+ */
+static prte_plm_base_module_t *plm_module(const char *name)
+{
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_module_t *mod = NULL;
+    int pri = 0;
+
+    PMIX_LIST_FOREACH(cli, &prte_plm_base_framework.framework_components,
+                      pmix_mca_base_component_list_item_t)
+    {
+        if (0 != strcmp(name, cli->cli_component->pmix_mca_component_name)) {
+            continue;
+        }
+        if (NULL == cli->cli_component->pmix_mca_query_component) {
+            return NULL;
+        }
+        if (PRTE_SUCCESS != cli->cli_component->pmix_mca_query_component(&mod, &pri)) {
+            return NULL;
+        }
+        return (prte_plm_base_module_t *) mod;
+    }
+    return NULL;
+}
+
 static int test_module_contract(void)
 {
     int failures = 0;
@@ -264,20 +299,26 @@ static int test_module_contract(void)
     CHECK("default signal_job identity",
           prte_plm_base_prted_signal_local_procs == prte_plm.signal_job);
 
-    /* ssh: the always-available fallback and the only tree-spawner */
-    CHECK("ssh init set", NULL != prte_plm_ssh_module.init);
-    CHECK("ssh set_hnp_name set", NULL != prte_plm_ssh_module.set_hnp_name);
-    CHECK("ssh spawn set", NULL != prte_plm_ssh_module.spawn);
-    CHECK("ssh remote_spawn set", NULL != prte_plm_ssh_module.remote_spawn);
-    CHECK("ssh terminate_job set", NULL != prte_plm_ssh_module.terminate_job);
-    CHECK("ssh terminate_orteds set", NULL != prte_plm_ssh_module.terminate_orteds);
-    CHECK("ssh terminate_procs set", NULL != prte_plm_ssh_module.terminate_procs);
-    CHECK("ssh signal_job set", NULL != prte_plm_ssh_module.signal_job);
-    CHECK("ssh finalize set", NULL != prte_plm_ssh_module.finalize);
+    /* ssh: the always-available fallback and the only tree-spawner.  Its
+     * query is environment-sensitive (it declines when an indicated launch
+     * agent is missing), so a NULL module here is an answer, not a fault. */
+    prte_plm_base_module_t *ssh = plm_module("ssh");
+    if (NULL == ssh) {
+        fprintf(stdout, "  (skipping ssh module checks: component declined)\n");
+        goto ssh_done;
+    }
+    CHECK("ssh init set", NULL != ssh->init);
+    CHECK("ssh set_hnp_name set", NULL != ssh->set_hnp_name);
+    CHECK("ssh spawn set", NULL != ssh->spawn);
+    CHECK("ssh remote_spawn set", NULL != ssh->remote_spawn);
+    CHECK("ssh terminate_job set", NULL != ssh->terminate_job);
+    CHECK("ssh terminate_orteds set", NULL != ssh->terminate_orteds);
+    CHECK("ssh terminate_procs set", NULL != ssh->terminate_procs);
+    CHECK("ssh signal_job set", NULL != ssh->signal_job);
+    CHECK("ssh finalize set", NULL != ssh->finalize);
     CHECK("ssh set_hnp_name identity",
-          prte_plm_base_set_hnp_name == prte_plm_ssh_module.set_hnp_name);
-    CHECK("ssh component name",
-          0 == strcmp(prte_mca_plm_ssh_component.super.pmix_mca_component_name, "ssh"));
+          prte_plm_base_set_hnp_name == ssh->set_hnp_name);
+ssh_done:
 
     /* the base defaults every component inherits */
     CHECK("nodes assigned at launch defaults true",
@@ -552,6 +593,15 @@ int main(void)
         return 1;
     }
 
+    /* the module tests ask the framework for their subject, so it has to
+     * be open before they run */
+    rc = pmix_mca_base_framework_open(&prte_plm_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "plm framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
     failures += test_state_code_uniqueness();
     failures += test_module_contract();
     failures += test_wrap_args();
@@ -559,6 +609,7 @@ int main(void)
     failures += test_append_basic_args();
     failures += test_naming();
 
+    (void) pmix_mca_base_framework_close(&prte_plm_base_framework);
     prte_finalize();
 
     if (0 == failures) {

--- a/test/unit/rmaps/test_ppr.c
+++ b/test/unit/rmaps/test_ppr.c
@@ -22,7 +22,7 @@
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 
-extern prte_rmaps_base_module_t prte_rmaps_ppr_module;
+extern prte_rmaps_base_module_t *test_rmaps_module(const char *name);
 
 int test_ppr(void);
 
@@ -37,9 +37,16 @@ int test_ppr(void);
 int test_ppr(void)
 {
     int failures = 0;
+    prte_rmaps_base_module_t *mod;
     prte_job_t *jdata;
     prte_rmaps_options_t opts;
     int rc;
+
+    mod = test_rmaps_module("ppr");
+    if (NULL == mod) {
+        fprintf(stdout, "  SKIP test_ppr (component not built)\n");
+        return 0;
+    }
 
     /* not a ppr job (and no PRTE_JOB_PPR set) -> defer */
     jdata = PMIX_NEW(prte_job_t);
@@ -47,7 +54,7 @@ int test_ppr(void)
     PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_BYSLOT);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_ppr_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("ppr defers non-ppr policy", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 
@@ -58,7 +65,7 @@ int test_ppr(void)
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_RESTART);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_ppr_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("ppr defers restart", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 

--- a/test/unit/rmaps/test_rank_file.c
+++ b/test/unit/rmaps/test_rank_file.c
@@ -23,7 +23,7 @@
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 
-extern prte_rmaps_base_module_t prte_rmaps_rank_file_module;
+extern prte_rmaps_base_module_t *test_rmaps_module(const char *name);
 
 int test_rank_file(void);
 
@@ -38,9 +38,16 @@ int test_rank_file(void);
 int test_rank_file(void)
 {
     int failures = 0;
+    prte_rmaps_base_module_t *mod;
     prte_job_t *jdata;
     prte_rmaps_options_t opts;
     int rc;
+
+    mod = test_rmaps_module("rank_file");
+    if (NULL == mod) {
+        fprintf(stdout, "  SKIP test_rank_file (component not built)\n");
+        return 0;
+    }
 
     /* not a rankfile (BYUSER) job -> defer */
     jdata = PMIX_NEW(prte_job_t);
@@ -48,7 +55,7 @@ int test_rank_file(void)
     PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_BYSLOT);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_rank_file_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("rf defers non-byuser policy", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 
@@ -59,7 +66,7 @@ int test_rank_file(void)
     jdata->map->req_mapper = strdup("round_robin");
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_rank_file_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("rf defers other req_mapper", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 

--- a/test/unit/rmaps/test_rmaps_main.c
+++ b/test/unit/rmaps/test_rmaps_main.c
@@ -10,7 +10,9 @@
 #include "prte_config.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
+#include "src/mca/rmaps/base/base.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 #include "constants.h"
@@ -23,6 +25,35 @@ extern int test_ppr(void);
 extern int test_seq(void);
 extern int test_rank_file(void);
 
+/* shared with the mapper tests in this directory */
+prte_rmaps_base_module_t *test_rmaps_module(const char *name);
+
+/*
+ * Hand a mapper test its subject.
+ *
+ * The tests used to name the component's module symbol directly, which
+ * asks two things of the build that are not actually true: that the
+ * symbol is visible outside libprrte (it is not, once the library is
+ * compiled with -fvisibility=hidden - it belongs to the component, not
+ * to the framework), and that the component was built at all.  Ask the
+ * framework instead, which is how the mapper is reached in production,
+ * and let a caller skip when its component is absent.
+ */
+prte_rmaps_base_module_t *test_rmaps_module(const char *name)
+{
+    prte_rmaps_base_selected_module_t *mod;
+
+    PMIX_LIST_FOREACH(mod, &prte_rmaps_base.selected_modules,
+                      prte_rmaps_base_selected_module_t)
+    {
+        if (NULL != mod->component &&
+            0 == strcmp(name, mod->component->pmix_mca_component_name)) {
+            return mod->module;
+        }
+    }
+    return NULL;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -30,6 +61,22 @@ int main(void)
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
         fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* the mapper tests take their module from the framework, so it has to
+     * be open and selected before they run */
+    rc = pmix_mca_base_framework_open(&prte_rmaps_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "rmaps framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+    rc = prte_rmaps_base_select();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "rmaps select failed: %d\n", rc);
+        prte_finalize();
         return 1;
     }
 
@@ -41,6 +88,7 @@ int main(void)
     failures += test_seq();
     failures += test_rank_file();
 
+    (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
     prte_finalize();
 
     if (0 == failures) {

--- a/test/unit/rmaps/test_round_robin.c
+++ b/test/unit/rmaps/test_round_robin.c
@@ -24,7 +24,7 @@
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 
-extern prte_rmaps_base_module_t prte_rmaps_round_robin_module;
+extern prte_rmaps_base_module_t *test_rmaps_module(const char *name);
 
 int test_round_robin(void);
 
@@ -39,9 +39,16 @@ int test_round_robin(void);
 int test_round_robin(void)
 {
     int failures = 0;
+    prte_rmaps_base_module_t *mod;
     prte_job_t *jdata;
     prte_rmaps_options_t opts;
     int rc;
+
+    mod = test_rmaps_module("round_robin");
+    if (NULL == mod) {
+        fprintf(stdout, "  SKIP test_round_robin (component not built)\n");
+        return 0;
+    }
 
     /* a policy this component does not handle -> defer to the next mapper */
     jdata = PMIX_NEW(prte_job_t);
@@ -49,7 +56,7 @@ int test_round_robin(void)
     PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_SEQ);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_round_robin_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("rr defers non-rr policy", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 
@@ -60,7 +67,7 @@ int test_round_robin(void)
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_RESTART);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_round_robin_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("rr defers restart", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 

--- a/test/unit/rmaps/test_seq.c
+++ b/test/unit/rmaps/test_seq.c
@@ -23,7 +23,7 @@
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 
-extern prte_rmaps_base_module_t prte_rmaps_seq_module;
+extern prte_rmaps_base_module_t *test_rmaps_module(const char *name);
 
 int test_seq(void);
 
@@ -38,9 +38,16 @@ int test_seq(void);
 int test_seq(void)
 {
     int failures = 0;
+    prte_rmaps_base_module_t *mod;
     prte_job_t *jdata;
     prte_rmaps_options_t opts;
     int rc;
+
+    mod = test_rmaps_module("seq");
+    if (NULL == mod) {
+        fprintf(stdout, "  SKIP test_seq (component not built)\n");
+        return 0;
+    }
 
     /* not a seq job -> defer */
     jdata = PMIX_NEW(prte_job_t);
@@ -48,7 +55,7 @@ int test_seq(void)
     PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_BYSLOT);
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_seq_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("seq defers non-seq policy", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 
@@ -59,7 +66,7 @@ int test_seq(void)
     jdata->map->req_mapper = strdup("round_robin");
     memset(&opts, 0, sizeof(opts));
     opts.app_idx = -1;
-    rc = prte_rmaps_seq_module.map_job(jdata, &opts);
+    rc = mod->map_job(jdata, &opts);
     CHECK("seq defers other req_mapper", PRTE_ERR_TAKE_NEXT_OPTION == rc);
     PMIX_RELEASE(jdata);
 


### PR DESCRIPTION
### Problem

Six of the nine unit tests name a component's module symbol directly — `prte_rmaps_round_robin_module`, `prte_plm_ssh_module`, `prte_iof_hnp_module`, and so on — and several also name its classes and internal functions. That only works because the default build links every component into `libprrte`.

Configure with `--enable-mca-dso` and the component is a separate DSO instead. The symbol is not there to link against, and the tests do not build:

```
--enable-mca-dso + make check → 21 unresolved symbols across 6 test binaries
only test_ess, test_filem and test_rml link
```

So that configuration has had no unit-test coverage at all, and never has. This is on master today with no other changes.

### Change

Ask the framework, which is how a module is reached in production. Each test walks its framework's component list for the name it wants and calls that component's `query()`, exactly as the framework's own `select` does; the rmaps tests take their mapper from `prte_rmaps_base.selected_modules`. Nothing is resolved at link time, so it works whether the component was compiled into the library or dlopened from a DSO.

Two distinctions had to be drawn to keep that honest:

- **Present ≠ available.** `iof/prted` and `errmgr/prted` hand out their module only to a daemon. The vtable tests now ask as the process type the component serves; the identity checks ask the separate question of whether the framework opened a component of that name.
- **Absent ≠ broken.** A component this build did not produce is a skip, naming what was missing — not a failure.

The cases that genuinely reach inside `grpcomm/direct` (its own classes, and the identity of its entry points) cannot be expressed through any framework interface, so they are compiled in only when that component is part of `libprrte`, keyed off the existing `MCA_BUILD_prte_grpcomm_direct_DSO` conditional. They still run in full in a default build.

### Testing

Linux, both configurations:

| | default build | `--enable-mca-dso` |
|---|---|---|
| before | 9/9 pass | **6 of 9 fail to link** |
| after | 9/9 pass | 9/9 pass |

### Known gap, deliberately not closed here

A DSO build still cannot exercise the components themselves: the tests run from the build tree and MCA has no path to the component libraries there. PMIx hands its tests `PMIX_COMPONENT_LIBRARY_PATHS` for exactly this; PRRTE has the same `config/mca_library_paths.txt` but no substitution using it. Adding that is build-system work rather than a test fix, so it is left for a follow-up — but those cases now announce the skip rather than passing in silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)