### PR TITLE
runtime: let PRTE_MCA_mca_base_component_path name extra component dirs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1026,6 +1026,25 @@ AC_SUBST(prteincludedir)
 
 prte_want_prd=0
 
+# Where "make check" can find components that have been built but not
+# installed.  Unit tests run from the build tree, and the only component
+# directory PRRTE knows about is the installed one, so a --enable-mca-dso
+# build otherwise finds no components at all and the tests can only skip.
+# config/mca_library_paths.txt is written by autogen.pl and lists every
+# component directory relative to the top of the tree.
+prte_comp_build_path=
+if test -f "$srcdir/config/mca_library_paths.txt"; then
+    for prte_cpath in `tr ':' ' ' < "$srcdir/config/mca_library_paths.txt"`; do
+        if test -z "$prte_comp_build_path"; then
+            prte_comp_build_path="$ac_pwd/$prte_cpath/.libs"
+        else
+            prte_comp_build_path="$prte_comp_build_path:$ac_pwd/$prte_cpath/.libs"
+        fi
+    done
+fi
+PRTE_COMPONENT_BUILD_PATH=$prte_comp_build_path
+AC_SUBST(PRTE_COMPONENT_BUILD_PATH)
+
 prte_show_subtitle "Final output"
 
 AC_CONFIG_FILES([

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -166,6 +166,7 @@ int prte_init_minimum(void)
 {
     int ret, n;
     char *path = NULL;
+    char *extra;
     char *evar, **prefixes;
     const char *rvers;
     char token[100];
@@ -258,9 +259,22 @@ int prte_init_minimum(void)
         return ret;
     }
 
-    /* initialize the MCA infrastructure */
+    /* initialize the MCA infrastructure.  PRTE_MCA_mca_base_component_path
+     * names additional directories to search, mirroring what PMIx offers
+     * for its own components: the installed location is the only one we
+     * would otherwise look in, which leaves no way to run against
+     * components that have been built but not installed - a build tree,
+     * for one, which is where "make check" runs. */
+    extra = getenv("PRTE_MCA_mca_base_component_path");
     if (check_exist(prte_install_dirs.pmixlibdir)) {
-        pmix_asprintf(&path, "prte@%s", prte_install_dirs.pmixlibdir);
+        if (NULL == extra) {
+            pmix_asprintf(&path, "prte@%s", prte_install_dirs.pmixlibdir);
+        } else {
+            pmix_asprintf(&path, "prte@%s%c%s", extra, PMIX_ENV_SEP,
+                          prte_install_dirs.pmixlibdir);
+        }
+    } else if (NULL != extra) {
+        pmix_asprintf(&path, "prte@%s", extra);
     }
     ret = pmix_init_util(NULL, 0, path);
     if (NULL != path) {

--- a/test/unit/errmgr/Makefile.am
+++ b/test/unit/errmgr/Makefile.am
@@ -15,3 +15,10 @@ test_errmgr_SOURCES = \
 test_errmgr_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_errmgr
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/ess/Makefile.am
+++ b/test/unit/ess/Makefile.am
@@ -15,3 +15,10 @@ test_ess_SOURCES = \
 test_ess_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_ess
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/filem/Makefile.am
+++ b/test/unit/filem/Makefile.am
@@ -15,3 +15,10 @@ test_filem_SOURCES = \
 test_filem_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_filem
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/grpcomm/Makefile.am
+++ b/test/unit/grpcomm/Makefile.am
@@ -25,3 +25,10 @@ test_grpcomm_CPPFLAGS = $(AM_CPPFLAGS) -DPRTE_TEST_GRPCOMM_DIRECT=0
 endif
 
 TESTS = test_grpcomm
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/iof/Makefile.am
+++ b/test/unit/iof/Makefile.am
@@ -15,3 +15,10 @@ test_iof_SOURCES = \
 test_iof_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_iof
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/odls/Makefile.am
+++ b/test/unit/odls/Makefile.am
@@ -15,3 +15,10 @@ test_odls_SOURCES = \
 test_odls_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_odls
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/plm/Makefile.am
+++ b/test/unit/plm/Makefile.am
@@ -15,3 +15,10 @@ test_plm_SOURCES = \
 test_plm_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_plm
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/ras/Makefile.am
+++ b/test/unit/ras/Makefile.am
@@ -27,3 +27,10 @@ endif
 test_ras_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_ras
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/rmaps/Makefile.am
+++ b/test/unit/rmaps/Makefile.am
@@ -26,3 +26,10 @@ test_rmaps_LDADD = $(top_builddir)/src/libprrte.la
 # (see the "Testing" section, "Offline mapper harness", in AGENTS.md).
 
 TESTS = test_rmaps
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/rml/Makefile.am
+++ b/test/unit/rml/Makefile.am
@@ -15,3 +15,10 @@ test_rml_SOURCES = \
 test_rml_LDADD = $(top_builddir)/src/libprrte.la
 
 TESTS = test_rml
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and every component-dependent case skips.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;


### PR DESCRIPTION
> **Stacked on #2556** — it contains that PR's commit as well. Review/merge #2556 first.

### Problem

PRRTE tells the MCA base about exactly one place to find its components — `"prte@"` followed by the installed library directory, and only when that directory already exists:

```c
if (check_exist(prte_install_dirs.pmixlibdir)) {
    pmix_asprintf(&path, "prte@%s", prte_install_dirs.pmixlibdir);
}
ret = pmix_init_util(NULL, 0, path);
```

So there is no way to run against components that have been **built but not installed**. PMIx has offered `component_path` for its own components all along; PRRTE never offered the equivalent. Note the paths are project-scoped (`project@dirs`, split on `;`), so `PMIX_MCA_mca_base_component_path` cannot help — its entries land in the `pmix@` scope and PRRTE's frameworks never look there.

The sharp edge is `make check`. Unit tests run from the build tree, so with `--enable-mca-dso` every component is a DSO that MCA cannot find: no framework opens anything, and every component-dependent case can only skip. After #2556 the tests at least *say* they are skipping — but they were passing while covering nothing.

### Change

Honor `PRTE_MCA_mca_base_component_path`, prepended to the installed location so an explicit request wins over whatever happens to be installed.

For the tests, `configure` turns the component directory list `autogen.pl` already writes into `config/mca_library_paths.txt` into absolute `.libs` paths under the build tree, and each test directory hands it over via `AM_TESTS_ENVIRONMENT`. **No test source changes.**

### Testing

Linux, `--enable-debug` (warnings are errors), both configurations:

| | default build | `--enable-mca-dso` |
|---|---|---|
| before | 9/9, components covered | 9/9, **every component case skipped** |
| after | 9/9, components covered | 9/9, components covered |

The DSO run now reports **no skips at all**, and the per-case logs confirm the work is really happening rather than the message having changed:

```
rmaps:   PASS test_round_robin / test_ppr / test_seq / test_rank_file
grpcomm: PASSED test_module_contract / test_component_identity
iof:     PASSED test_module_contract / test_component_identity
```

The user-facing half stands on its own: trying a component out of a build tree, or from a directory alongside an installation, is now expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)