### PR TITLE
ras: make an allocation mean the same thing however it was obtained

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -41,6 +41,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `Dockerfile` | Base image: toolchain, a baked PMIx, SSH wiring, and a node entrypoint. It does **not** contain PRRTE. |
 | `docker-compose.yml` | The ten nodes `prte-node1`..`prte-node10`, each mounting the shared `prte-build` volume. |
 | `elastic.c` | The elastic test client (`elastic` in the install): issues a PMIx allocation request and waits for the phase-two completion event. |
+| `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §11. |
 
 ## 2. How it works
 
@@ -351,3 +352,81 @@ Network: bridge `dvm`. All nodes mount the shared `prte-build` volume read-only
 at `/opt/prte`, where `build.sh` installs PRRTE (`/opt/prte/prte`) and writes
 `/opt/prte/env.sh`. To add or remove nodes, copy or delete a service block in
 `docker-compose.yml` (and adjust the `seq 1 10` loops to match).
+
+## 11. Faking a SLURM environment (`ras/slurm`)
+
+`ras/slurm` is the only ras component with a full elastic **modify** surface,
+and everything past initial discovery is a shell-out: `sbatch` to grow,
+`scontrol show job <id> --json` to learn what SLURM granted, `scontrol update
+job <id> ReqNodeList=…` to shrink one in place, `scancel` to give one back.
+None of that runs on a developer machine, so it had no automated coverage at
+all — including the ~1000-line JSON parser, which this harness is also the
+**only** automated build that even compiles (jansson defaults to off; see
+`--with-jansson` in `build.sh`).
+
+[`fake-slurm.py`](fake-slurm.py) supplies the missing scheduler. `build.sh`
+installs it into the shared volume as
+`/opt/prte/fakeslurm/bin/{sbatch,scontrol,scancel}` (it dispatches on
+`argv[0]`), deliberately **not** into the install `bin/` that the node
+entrypoint puts on every node's default PATH — a test has to opt in by
+prepending that directory, so this cannot perturb anything else in the suite.
+
+It is not a SLURM emulator. It implements exactly the four command forms
+PRRTE issues, keeps its state under `/tmp/fake-slurm`, and hands out **real
+container hostnames** — so a grow driven through it launches real daemons on
+real nodes and a release really removes them.
+
+Driving it by hand:
+
+```sh
+RUN='docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 prte-node1 bash -lc'
+
+$RUN 'export PATH=/opt/prte/fakeslurm/bin:$PATH
+      fake-slurm init --jobid 1000 --base node1 --tasks 2 --pool node2,node3,node4
+      eval "$(fake-slurm env)"     # SLURM_JOBID, SLURM_NODELIST, SLURMD_NODENAME, ...
+      . /opt/prte/env.sh
+      nohup prte --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5 \
+            >/tmp/prte.out 2>&1 &
+      sleep 8
+      elastic extend 2             # PMIX_ALLOC_EXTEND: sbatch, poll, absorb
+      fake-slurm audit             # every command PRRTE issued
+      fake-slurm args 2001         # the sbatch argv it built
+      elastic shrink node3         # partial: scontrol update ReqNodeList=
+      elastic release-id 2001'     # whole job: scancel
+```
+
+Two things to know:
+
+- **The request shapes differ from a plain grow.** `elastic grow <nodes>` is
+  `PMIX_ALLOC_NEW` naming hosts, which the *base* serves. `ras/slurm`'s
+  `modify()` accepts only `PMIX_ALLOC_EXTEND`+`NUM_NODES`,
+  `PMIX_ALLOC_RELEASE`+(`NODE_LIST`|`NUM_NODES`|`ALLOC_ID`), and
+  `PMIX_ALLOC_REQ_CANCEL` — which nodes an extend lands on is the
+  scheduler's choice. Hence `elastic extend|release|release-id|cancel`.
+- **An extend emits no phase-two event.** Its nodes join the general pool
+  (the component deliberately leaves `node->session` NULL), and the directed
+  completion event is addressed to the requestor recorded on a *reservation*.
+  Phase one carries the real result, which is why `elastic extend` does not
+  wait for phase two. A **release** does go through a shrink campaign and
+  does emit `PMIX_DVM_IS_READY`.
+
+Fault injection, for the paths that only exist to handle a scheduler
+misbehaving (`fake-slurm set <key> <value>`):
+
+| key | effect |
+|-----|--------|
+| `pending_secs` | a new job sits in `PENDING` this long — lets a request be cancelled mid-poll |
+| `scancel_fail` | `scancel` exits non-zero with far more output than the 256-byte capture buffer holds |
+| `bad_json` | `scontrol show job --json` returns unparsable output with exit status 0 |
+
+The suite uses all three: a cancelled pending extend, a failing `scancel`
+(whose message must come back truncated and `...`-terminated, and must not
+take the HNP down), and malformed JSON. It also asserts a release naming a
+hostname with a shell metacharacter is refused before it can reach a command
+line.
+
+**Slot counts are asserted from `ras_base_verbose` output, not from the
+pool.** Outside a *managed* allocation the slot count a node was given is
+recomputed from its core count before mapping, so the pool cannot tell you
+whether the component parsed the allocation correctly. (`prte_managed_allocation`
+is presently never set for an RM allocation — see the note in `run-tests.sh`.)

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -425,8 +425,9 @@ take the HNP down), and malformed JSON. It also asserts a release naming a
 hostname with a shell metacharacter is refused before it can reach a command
 line.
 
-**Slot counts are asserted from `ras_base_verbose` output, not from the
-pool.** Outside a *managed* allocation the slot count a node was given is
-recomputed from its core count before mapping, so the pool cannot tell you
-whether the component parsed the allocation correctly. (`prte_managed_allocation`
-is presently never set for an RM allocation — see the note in `run-tests.sh`.)
+**Some slot counts are asserted from `ras_base_verbose` output, not from
+the pool.** The verbose line is what the component itself computed, so it
+separates a parser error from whatever the launch path later does with the
+number. The pool is asserted too, separately — a node whose count came
+from the scheduler must still carry that count at mapping time
+(`PRTE_NODE_FLAG_SLOTS_GIVEN`).

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -180,6 +180,20 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/elastic.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
 
+            # The fake SLURM control plane, installed under its own prefix --
+            # NOT into the install bin/, which the node entrypoint symlinks
+            # onto the default PATH of every node. ras/slurm gates on SLURM_JOBID,
+            # so a stray scontrol on PATH is harmless, but a test that has to
+            # opt in by prepending this directory is the one that cannot
+            # perturb any other test in the suite.
+            echo ">>>> fake SLURM stubs -> /opt/prte/fakeslurm/bin"
+            mkdir -p /opt/prte/fakeslurm/bin
+            install -m 0755 /prrte-src/contrib/dockerswarm/fake-slurm.py \
+                /opt/prte/fakeslurm/bin/fake-slurm
+            for t in sbatch scontrol scancel; do
+                ln -sf fake-slurm /opt/prte/fakeslurm/bin/$t
+            done
+
             # runtime env for login shells (node-entrypoint handles ld.so)
             printf "export PATH=/opt/prte/prte/bin:\$PATH\nexport LD_LIBRARY_PATH=/opt/prte/prte/lib:%s/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\n" \
                 "$PMIX_PREFIX" > /opt/prte/env.sh

--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -15,10 +15,30 @@
  * (success) or PMIX_ERR_DVM_MOD (failure) event so the two-phase completion
  * contract can be observed end to end.
  *
- *   elastic grow   <node[:slots],...>   # grow the DVM onto these nodes
- *   elastic shrink <node,...>           # shrink the DVM by these nodes
+ *   elastic grow       <node[:slots],...>  # PMIX_ALLOC_NEW     + NODE_LIST
+ *   elastic shrink     <node,...>          # PMIX_ALLOC_RELEASE + NODE_LIST
+ *   elastic extend     <num-nodes>         # PMIX_ALLOC_EXTEND  + NUM_NODES
+ *   elastic release    <num-nodes>         # PMIX_ALLOC_RELEASE + NUM_NODES
+ *   elastic release-id <alloc-id>          # PMIX_ALLOC_RELEASE + ALLOC_ID
+ *   elastic cancel     <req-id>            # PMIX_ALLOC_REQ_CANCEL
  *
- * (extend/release are accepted as aliases for grow/shrink.)
+ *   --req-id <id>   request id to send (default "elastic-test"); "cancel"
+ *                   names the request to cancel this way too
+ *   --wait          wait for the phase-two completion event
+ *   --no-wait       do not
+ *
+ * The last four forms exist for the resource managers that serve a size
+ * change by talking to a scheduler rather than by naming nodes -- ras/slurm
+ * is the one in tree, and NUM_NODES/ALLOC_ID/REQ_CANCEL are the only request
+ * shapes its modify() accepts.  Which nodes such a request lands on is the
+ * scheduler's choice, not the caller's.
+ *
+ * Phase two is waited for by default, but not for "extend" or "cancel".  The
+ * directed completion event is emitted to the requestor recorded on the
+ * *reservation* a grow created; an RM extend puts its new nodes in the
+ * general pool instead (ras/slurm deliberately leaves node->session NULL),
+ * so no such event is coming and waiting for one only burns the timeout.
+ * Phase one carries that path's real result.
  *
  * A grow may be followed by "-- <cmd> [args...]", in which case the tool
  * spawns that command INTO THE RESERVATION the grow just created, using the
@@ -100,6 +120,10 @@ static void alloc_cb(pmix_status_t status, pmix_info_t *info, size_t ninfo,
                 NULL != info[n].value.data.string) {
                 snprintf(alloc_id, sizeof(alloc_id), "%s",
                          info[n].value.data.string);
+                /* the info keys print as their PMIx attribute strings
+                 * ("pmix.alloc.id"), so name it once in a stable form a
+                 * caller can grep for */
+                fprintf(stderr, ">>> ALLOC_ID %s\n", alloc_id);
             }
         } else {
             fprintf(stderr, "      info[%zu] key=%s\n", n, info[n].key);
@@ -211,44 +235,87 @@ static int spawn_into_reservation(char **cmd) {
     return 0;
 }
 
+static void usage(const char *me) {
+    fprintf(stderr,
+            "usage: %s <op> <arg> [--req-id <id>] [--wait|--no-wait] [-- <cmd> ...]\n"
+            "  grow       <node[:slots],...>   PMIX_ALLOC_NEW     + NODE_LIST\n"
+            "  shrink     <node,...>           PMIX_ALLOC_RELEASE + NODE_LIST\n"
+            "  extend     <num-nodes>          PMIX_ALLOC_EXTEND  + NUM_NODES\n"
+            "  release    <num-nodes>          PMIX_ALLOC_RELEASE + NUM_NODES\n"
+            "  release-id <alloc-id>           PMIX_ALLOC_RELEASE + ALLOC_ID\n"
+            "  cancel     <req-id>             PMIX_ALLOC_REQ_CANCEL\n", me);
+}
+
 int main(int argc, char **argv) {
     pmix_status_t rc;
     pmix_info_t *info;
+    size_t ninfo = 2;
     pmix_alloc_directive_t directive;
     pmix_status_t codes[2];
     lock_t reglock;
     lock_t alloclock;
-    const char *op, *nodelist;
+    const char *op, *arg, *req_id = "elastic-test";
     char **spawn_cmd = NULL;
+    uint64_t num_nodes = 0;
+    bool wait_phase2 = true;
+    int wait_opt = -1;          /* an explicit --wait/--no-wait, if given */
     int rcexit = 0, i;
 
     if (argc < 3) {
-        fprintf(stderr,
-                "usage: %s <grow|shrink> <node1,node2,...> [-- <cmd> [args...]]\n",
-                argv[0]);
+        usage(argv[0]);
         return 1;
     }
     op = argv[1];
-    nodelist = argv[2];
-    /* anything after "--" is a command to run on the grown nodes */
+    arg = argv[2];
     for (i = 3; i < argc; i++) {
+        /* anything after "--" is a command to run on the grown nodes */
         if (0 == strcmp(argv[i], "--")) {
             if (i + 1 < argc) {
                 spawn_cmd = &argv[i + 1];
             }
             break;
         }
+        if (0 == strcmp(argv[i], "--req-id") && i + 1 < argc) {
+            req_id = argv[++i];
+        } else if (0 == strcmp(argv[i], "--wait")) {
+            wait_opt = 1;
+        } else if (0 == strcmp(argv[i], "--no-wait")) {
+            wait_opt = 0;
+        } else {
+            fprintf(stderr, "unknown option '%s'\n", argv[i]);
+            usage(argv[0]);
+            return 1;
+        }
     }
+
     /* A grow is a NEW reservation that names the nodes to add: PRRTE adds them
-     * to the pool and extends the DVM.  PMIX_ALLOC_EXTEND only adds to an
-     * already-existing reservation, so it is not the right trigger here. */
-    if (0 == strcmp(op, "grow") || 0 == strcmp(op, "extend")) {
+     * to the pool and extends the DVM.  PMIX_ALLOC_EXTEND asks the resource
+     * manager for more nodes instead, and names a count rather than hosts. */
+    if (0 == strcmp(op, "grow")) {
         directive = PMIX_ALLOC_NEW;
-    } else if (0 == strcmp(op, "shrink") || 0 == strcmp(op, "release")) {
+    } else if (0 == strcmp(op, "shrink")) {
         directive = PMIX_ALLOC_RELEASE;
+    } else if (0 == strcmp(op, "extend")) {
+        directive = PMIX_ALLOC_EXTEND;
+        num_nodes = strtoull(arg, NULL, 10);
+        wait_phase2 = false;    /* see the note at the top of this file */
+    } else if (0 == strcmp(op, "release")) {
+        directive = PMIX_ALLOC_RELEASE;
+        num_nodes = strtoull(arg, NULL, 10);
+    } else if (0 == strcmp(op, "release-id")) {
+        directive = PMIX_ALLOC_RELEASE;
+    } else if (0 == strcmp(op, "cancel")) {
+        directive = PMIX_ALLOC_REQ_CANCEL;
+        req_id = arg;
+        wait_phase2 = false;
     } else {
-        fprintf(stderr, "unknown op '%s' (want grow|shrink)\n", op);
+        fprintf(stderr, "unknown op '%s'\n", op);
+        usage(argv[0]);
         return 1;
+    }
+    /* an explicit --wait/--no-wait wins over the per-op default */
+    if (0 <= wait_opt) {
+        wait_phase2 = (1 == wait_opt);
     }
 
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
@@ -266,24 +333,48 @@ int main(int argc, char **argv) {
     lock_wait(&reglock);
     fprintf(stderr, "registered for PMIX_DVM_IS_READY / PMIX_ERR_DVM_MOD\n");
 
-    /* issue the size-change request naming the node list */
+    /* issue the size-change request.  Exactly one selector goes with the
+     * request id: the node list, the node count, or the allocation id -- the
+     * RM modules reject a request that carries more than one. */
     lock_init(&alloclock);
-    PMIX_INFO_CREATE(info, 2);
-    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, nodelist, PMIX_STRING);
-    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, "elastic-test", PMIX_STRING);
-    fprintf(stderr, "requesting %s of nodes [%s] ...\n", op, nodelist);
-    rc = PMIx_Allocation_request_nb(directive, info, 2, alloc_cb, &alloclock);
+    if (0 == strcmp(op, "cancel")) {
+        ninfo = 1;
+        PMIX_INFO_CREATE(info, ninfo);
+    } else {
+        PMIX_INFO_CREATE(info, ninfo);
+        if (PMIX_ALLOC_EXTEND == directive || 0 == strcmp(op, "release")) {
+            PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &num_nodes, PMIX_UINT64);
+        } else if (0 == strcmp(op, "release-id")) {
+            PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, arg, PMIX_STRING);
+        } else {
+            PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, arg, PMIX_STRING);
+        }
+    }
+    PMIX_INFO_LOAD(&info[ninfo - 1], PMIX_ALLOC_REQ_ID, req_id, PMIX_STRING);
+    fprintf(stderr, "requesting %s [%s] (req-id %s) ...\n", op, arg, req_id);
+    rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cb, &alloclock);
     if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
         fprintf(stderr, "PMIx_Allocation_request_nb failed immediately: %s\n",
                 PMIx_Error_string(rc));
+        rcexit = 1;
         goto done;
     }
     lock_wait(&alloclock);
-    PMIX_INFO_FREE(info, 2);
+    PMIX_INFO_FREE(info, ninfo);
 
-    fprintf(stderr, "waiting for phase-two completion event (60s) ...\n");
-    /* crude bounded wait so the tool can't hang forever in a test */
-    {
+    /* A phase one that failed is the end of it: nothing was started, so no
+     * completion event is coming and waiting would just burn the timeout. */
+    if (PMIX_SUCCESS != alloclock.status &&
+        PMIX_OPERATION_SUCCEEDED != alloclock.status &&
+        PMIX_OPERATION_IN_PROGRESS != alloclock.status) {
+        fprintf(stderr, ">>> REJECTED: %s\n", PMIx_Error_string(alloclock.status));
+        rcexit = 1;
+        wait_phase2 = false;
+    }
+
+    if (wait_phase2) {
+        fprintf(stderr, "waiting for phase-two completion event (60s) ...\n");
+        /* crude bounded wait so the tool can't hang forever in a test */
         struct timespec ts;
         clock_gettime(CLOCK_REALTIME, &ts);
         ts.tv_sec += 60;

--- a/contrib/dockerswarm/fake-slurm.py
+++ b/contrib/dockerswarm/fake-slurm.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+"""fake-slurm -- a stand-in SLURM control plane for the dockerswarm harness.
+
+``ras/slurm`` is the only ras component with a full elastic *modify* surface,
+and every bit of it talks to the scheduler by shelling out:
+
+    sbatch  --wrap=... --parsable --exclusive --nodes=N [propagated attrs]
+    scontrol show job <id> --json
+    scontrol update job <id> ReqNodeList=<survivors>
+    scancel <id>
+
+None of that can run on a developer's laptop, so the whole extend/release/
+cancel path -- including the ~1000-line ``scontrol --json`` parser, the
+``validate_hostname`` allowlist and ``prte_ras_slurm_drain_cmd_output`` -- had
+no automated coverage anywhere.  This script supplies the missing scheduler:
+it is installed into the swarm as ``sbatch``/``scontrol``/``scancel`` (it
+dispatches on argv[0]), keeps its state in a directory, and emits JSON in the
+shape ``ras_slurm_jansson.c`` expects.
+
+It is deliberately *not* a SLURM emulator.  It implements exactly the four
+command forms PRRTE issues, and it hands out real container hostnames, so a
+grow driven through it launches real daemons on real nodes.
+
+Housekeeping subcommands (run the script by its own name):
+
+    fake-slurm init --jobid 1000 --base node1 --pool node2,node3,...
+    fake-slurm env                     # export lines for the SLURM_* envars
+    fake-slurm set <key> <value>       # pending_secs|scancel_fail|bad_json|...
+    fake-slurm jobs                    # job ids, one per line
+    fake-slurm nodes <jobid>           # that job's nodes, comma separated
+    fake-slurm args <jobid>            # the sbatch argv that created it
+    fake-slurm pool                    # unallocated nodes
+    fake-slurm audit                   # every command this stub was given
+
+State lives in $FAKE_SLURM_STATE (default /tmp/fake-slurm).
+"""
+
+import json
+import os
+import shutil
+import sys
+import time
+
+STATE = os.environ.get("FAKE_SLURM_STATE", "/tmp/fake-slurm")
+JOBDIR = os.path.join(STATE, "jobs")
+CONFIG = os.path.join(STATE, "config.json")
+POOL = os.path.join(STATE, "pool")
+NEXTID = os.path.join(STATE, "nextid")
+AUDIT = os.path.join(STATE, "audit.log")
+
+DEFAULT_CONFIG = {
+    "jobid": "1000",
+    "base_nodes": [],
+    "tasks_per_node": 2,
+    # Per-node shape reported for an allocated node.  Two ALLOCATED cores and
+    # one UNALLOCATED one, against a much larger cpus.count, so the slot count
+    # PRRTE derives (allocated_cores * threads_per_core, capped by cpus.count)
+    # is 2 -- a number that can only come from counting core *statuses*.
+    "cpus_per_node": 8,
+    "allocated_cores": 2,
+    "idle_cores": 1,
+    # attributes of the "parent" job, i.e. the ones the extend path propagates
+    "account": "prrte-test",
+    "partition": "debug",
+    "qos": "normal",
+    "cwd": "/root",
+    "memory_per_cpu": None,          # unset: the sbatch arg must be omitted
+    "memory_per_node": 1024,
+    "time_limit": 60,
+    "threads_per_core": 1,
+    # fault injection
+    "pending_secs": 0,               # how long a new job sits in PENDING
+    "scancel_fail": 0,               # scancel exits non-zero, noisily
+    "bad_json": 0,                   # scontrol show job emits unparsable JSON
+}
+
+
+# --------------------------------------------------------------------------
+# state helpers
+# --------------------------------------------------------------------------
+
+def die(msg, rc=1):
+    """Report the way the real tools do: a line of text, a non-zero exit."""
+    sys.stdout.write(msg + "\n")
+    sys.exit(rc)
+
+
+def load_config():
+    try:
+        with open(CONFIG) as fp:
+            cfg = json.load(fp)
+    except (OSError, ValueError):
+        die("fake-slurm: no state in %s -- run 'fake-slurm init' first" % STATE)
+    merged = dict(DEFAULT_CONFIG)
+    merged.update(cfg)
+    return merged
+
+
+def save_config(cfg):
+    with open(CONFIG, "w") as fp:
+        json.dump(cfg, fp, indent=1)
+
+
+def job_path(jid):
+    return os.path.join(JOBDIR, "%s.json" % jid)
+
+
+def load_job(jid):
+    try:
+        with open(job_path(jid)) as fp:
+            return json.load(fp)
+    except (OSError, ValueError):
+        return None
+
+
+def save_job(job):
+    with open(job_path(job["job_id"]), "w") as fp:
+        json.dump(job, fp, indent=1)
+
+
+def all_jobs():
+    try:
+        names = sorted(os.listdir(JOBDIR))
+    except OSError:
+        return []
+    return [n[:-5] for n in names if n.endswith(".json")]
+
+
+def read_pool():
+    try:
+        with open(POOL) as fp:
+            return [ln.strip() for ln in fp if ln.strip()]
+    except OSError:
+        return []
+
+
+def write_pool(nodes):
+    with open(POOL, "w") as fp:
+        fp.write("".join(n + "\n" for n in nodes))
+
+
+def next_jobid():
+    try:
+        with open(NEXTID) as fp:
+            nid = int(fp.read().strip())
+    except (OSError, ValueError):
+        nid = 2001
+    with open(NEXTID, "w") as fp:
+        fp.write("%d\n" % (nid + 1))
+    return str(nid)
+
+
+def audit(argv):
+    try:
+        with open(AUDIT, "a") as fp:
+            fp.write("%d %s\n" % (time.time(), " ".join(argv)))
+    except OSError:
+        pass
+
+
+# --------------------------------------------------------------------------
+# JSON rendering -- the shape ras_slurm_jansson.c parses
+# --------------------------------------------------------------------------
+
+def numobj(value):
+    """A SLURM {set, infinite, number} triple.  None means "not set"."""
+    if value is None:
+        return {"set": False, "infinite": False, "number": 0}
+    if value == "infinite":
+        return {"set": True, "infinite": True, "number": 0}
+    return {"set": True, "infinite": False, "number": int(value)}
+
+
+def node_object(cfg, index, name):
+    cores = []
+    for k in range(int(cfg["allocated_cores"])):
+        cores.append({"index": k, "status": ["ALLOCATED"]})
+    for k in range(int(cfg["idle_cores"])):
+        cores.append({"index": int(cfg["allocated_cores"]) + k,
+                      "status": ["UNALLOCATED"]})
+    return {
+        "index": index,
+        "name": name,
+        "cpus": {"count": int(cfg["cpus_per_node"]), "used": 0},
+        "memory": {"allocated": 0, "used": 0},
+        "sockets": [{"index": 0, "cores": cores}],
+    }
+
+
+def render_job(cfg, job):
+    """Build the document `scontrol show job <id> --json` prints."""
+    if job.get("cancelled"):
+        states = ["CANCELLED"]
+    elif time.time() >= job.get("ready_at", 0):
+        states = ["RUNNING"]
+    else:
+        states = ["PENDING"]
+
+    alloc = [node_object(cfg, i, n) for i, n in enumerate(job["nodes"])]
+
+    jrec = {
+        "job_id": int(job["job_id"]),
+        "name": job.get("name", "prte-expander"),
+        "job_state": states,
+        "account": job.get("account"),
+        "partition": job.get("partition"),
+        "qos": job.get("qos"),
+        "current_working_directory": job.get("cwd"),
+        "memory_per_cpu": numobj(job.get("memory_per_cpu")),
+        "memory_per_node": numobj(job.get("memory_per_node")),
+        "time_limit": numobj(job.get("time_limit")),
+        "threads_per_core": numobj(job.get("threads_per_core")),
+        "job_resources": {
+            "nodes": {
+                "count": len(alloc),
+                "list": ",".join(job["nodes"]),
+                "allocation": alloc,
+            },
+        },
+    }
+    # real scontrol wraps the array in meta/errors/warnings; carrying them
+    # keeps the parser honest about ignoring what it was not asked for
+    return {
+        "meta": {"plugin": {"type": "openapi/slurmctld", "name": "fake-slurm"}},
+        "errors": [],
+        "warnings": [],
+        "jobs": [jrec],
+    }
+
+
+# --------------------------------------------------------------------------
+# sbatch
+# --------------------------------------------------------------------------
+
+def cmd_sbatch(args):
+    cfg = load_config()
+    audit(["sbatch"] + args)
+
+    nodes_req = None
+    job = {
+        "account": None, "partition": None, "qos": None, "cwd": None,
+        "memory_per_cpu": None, "memory_per_node": None,
+        "time_limit": None, "threads_per_core": 1,
+    }
+    for arg in args:
+        if arg.startswith("--nodes="):
+            try:
+                nodes_req = int(arg.split("=", 1)[1])
+            except ValueError:
+                die("sbatch: error: invalid node count '%s'" % arg)
+        elif arg.startswith("--account="):
+            job["account"] = arg.split("=", 1)[1]
+        elif arg.startswith("--partition="):
+            job["partition"] = arg.split("=", 1)[1]
+        elif arg.startswith("--qos="):
+            job["qos"] = arg.split("=", 1)[1]
+        elif arg.startswith("--chdir="):
+            job["cwd"] = arg.split("=", 1)[1]
+        elif arg.startswith("--mem-per-cpu="):
+            job["memory_per_cpu"] = arg.split("=", 1)[1]
+        elif arg.startswith("--mem="):
+            job["memory_per_node"] = arg.split("=", 1)[1]
+        elif arg.startswith("--time="):
+            job["time_limit"] = arg.split("=", 1)[1]
+        elif arg.startswith("--threads-per-core="):
+            job["threads_per_core"] = arg.split("=", 1)[1]
+
+    if nodes_req is None:
+        die("sbatch: error: --nodes was not requested")
+    if nodes_req < 1:
+        die("sbatch: error: refusing to allocate %d nodes" % nodes_req)
+
+    pool = read_pool()
+    if len(pool) < nodes_req:
+        die("sbatch: error: Node count specification invalid -- "
+            "only %d node(s) available" % len(pool))
+
+    job["job_id"] = next_jobid()
+    job["nodes"] = pool[:nodes_req]
+    job["ready_at"] = time.time() + float(cfg["pending_secs"])
+    job["cancelled"] = False
+    write_pool(pool[nodes_req:])
+    save_job(job)
+
+    with open(os.path.join(JOBDIR, "%s.args" % job["job_id"]), "w") as fp:
+        fp.write("".join(a + "\n" for a in args))
+
+    # --parsable output is "<jobid>[;<cluster>]"; PRRTE keeps the leading
+    # digits and stops at the separator, so print the cluster suffix too
+    sys.stdout.write("%s;swarm\n" % job["job_id"])
+    return 0
+
+
+# --------------------------------------------------------------------------
+# scontrol
+# --------------------------------------------------------------------------
+
+def scontrol_show_job(cfg, jid):
+    job = load_job(jid)
+    if job is None:
+        sys.stderr.write("slurm_load_jobs error: Invalid job id specified\n")
+        return 1
+    if int(cfg["bad_json"]):
+        # a truncated response: the command succeeds, the payload does not parse
+        sys.stdout.write('{"jobs": [ {"job_id": %s, ' % jid)
+        return 0
+    json.dump(render_job(cfg, job), sys.stdout, indent=1)
+    sys.stdout.write("\n")
+    return 0
+
+
+def scontrol_update_job(cfg, jid, settings):
+    job = load_job(jid)
+    if job is None:
+        sys.stdout.write("slurm_update error: Invalid job id specified\n")
+        return 1
+
+    survivors = None
+    for setting in settings:
+        if setting.startswith("ReqNodeList="):
+            value = setting.split("=", 1)[1]
+            survivors = [n for n in value.split(",") if n]
+    if survivors is None:
+        sys.stdout.write("slurm_update error: nothing to update\n")
+        return 1
+
+    unknown = [n for n in survivors if n not in job["nodes"]]
+    if unknown:
+        sys.stdout.write("slurm_update error: node(s) %s are not in job %s\n"
+                         % (",".join(unknown), jid))
+        return 1
+    if len(survivors) >= len(job["nodes"]):
+        sys.stdout.write("slurm_update error: job %s cannot grow this way\n" % jid)
+        return 1
+
+    released = [n for n in job["nodes"] if n not in survivors]
+    job["nodes"] = survivors
+    save_job(job)
+    write_pool(read_pool() + released)
+
+    # A real shrink leaves these behind in the caller's cwd for the user to
+    # run; PRRTE deletes them, so create them to give that cleanup something
+    # to do.
+    for suffix in ("sh", "csh"):
+        try:
+            with open("slurm_job_%s_resize.%s" % (jid, suffix), "w") as fp:
+                fp.write("# fake-slurm resize helper for job %s\n" % jid)
+        except OSError:
+            pass
+    return 0
+
+
+def cmd_scontrol(args):
+    cfg = load_config()
+    audit(["scontrol"] + args)
+
+    if len(args) >= 3 and args[0] == "show" and args[1] == "job":
+        return scontrol_show_job(cfg, args[2])
+    if len(args) >= 3 and args[0] == "update" and args[1] == "job":
+        return scontrol_update_job(cfg, args[2], args[3:])
+    sys.stdout.write("scontrol: error: unsupported command '%s'\n" % " ".join(args))
+    return 1
+
+
+# --------------------------------------------------------------------------
+# scancel
+# --------------------------------------------------------------------------
+
+def cmd_scancel(args):
+    cfg = load_config()
+    audit(["scancel"] + args)
+
+    if not args:
+        die("scancel: error: No job identification provided")
+    jid = args[0]
+
+    if int(cfg["scancel_fail"]):
+        # Deliberately long and multi-line: PRRTE captures this through
+        # prte_ras_slurm_drain_cmd_output() into a 256-byte buffer, so the
+        # message it reports must come back truncated and "..."-terminated.
+        for i in range(12):
+            sys.stdout.write("scancel: error: Kill job error on job id %s: "
+                             "Transport endpoint is not connected (line %d)\n"
+                             % (jid, i))
+        return 1
+
+    job = load_job(jid)
+    if job is None:
+        sys.stdout.write("scancel: error: Invalid job id %s\n" % jid)
+        return 1
+
+    write_pool(read_pool() + job["nodes"])
+    os.unlink(job_path(jid))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# housekeeping subcommands
+# --------------------------------------------------------------------------
+
+def cmd_init(args):
+    cfg = dict(DEFAULT_CONFIG)
+    pool = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--jobid":
+            cfg["jobid"] = args[i + 1]
+        elif args[i] == "--base":
+            cfg["base_nodes"] = [n for n in args[i + 1].split(",") if n]
+        elif args[i] == "--pool":
+            pool = [n for n in args[i + 1].split(",") if n]
+        elif args[i] == "--tasks":
+            cfg["tasks_per_node"] = int(args[i + 1])
+        else:
+            die("fake-slurm init: unknown option '%s'" % args[i])
+        i += 2
+
+    if not cfg["base_nodes"]:
+        die("fake-slurm init: --base is required")
+
+    shutil.rmtree(STATE, ignore_errors=True)
+    os.makedirs(JOBDIR)
+    write_pool(pool)
+    save_config(cfg)
+
+    # the job the DVM itself is running in: extend reads its attributes and
+    # propagates them onto the sbatch command line
+    save_job({
+        "job_id": cfg["jobid"],
+        "name": "prte-dvm",
+        "nodes": list(cfg["base_nodes"]),
+        "ready_at": 0,
+        "cancelled": False,
+        "account": cfg["account"],
+        "partition": cfg["partition"],
+        "qos": cfg["qos"],
+        "cwd": cfg["cwd"],
+        "memory_per_cpu": cfg["memory_per_cpu"],
+        "memory_per_node": cfg["memory_per_node"],
+        "time_limit": cfg["time_limit"],
+        "threads_per_core": cfg["threads_per_core"],
+    })
+    return 0
+
+
+def cmd_env(args):
+    """Shell to eval.  Every value is quoted: SLURM_TASKS_PER_NODE carries
+    the compressed "2(x4)" form, which is a syntax error unquoted."""
+    cfg = load_config()
+    nodes = cfg["base_nodes"]
+    def line(key, value):
+        print("export %s='%s'" % (key, value))
+    line("SLURM_JOBID", cfg["jobid"])
+    line("SLURM_JOB_ID", cfg["jobid"])
+    line("SLURM_NODELIST", ",".join(nodes))
+    line("SLURM_TASKS_PER_NODE",
+         "%d(x%d)" % (int(cfg["tasks_per_node"]), len(nodes)))
+    line("SLURM_JOB_CPUS_PER_NODE",
+         "%d(x%d)" % (int(cfg["cpus_per_node"]), len(nodes)))
+    line("SLURMD_NODENAME", args[0] if args else nodes[0])
+    return 0
+
+
+def cmd_set(args):
+    if len(args) < 2:
+        die("fake-slurm set: need <key> <value>")
+    cfg = load_config()
+    if args[0] not in DEFAULT_CONFIG:
+        die("fake-slurm set: unknown key '%s'" % args[0])
+    value = args[1]
+    if isinstance(DEFAULT_CONFIG[args[0]], int) and value.lstrip("-").isdigit():
+        value = int(value)
+    cfg[args[0]] = value
+    save_config(cfg)
+    return 0
+
+
+def cmd_jobs(args):
+    for jid in all_jobs():
+        print(jid)
+    return 0
+
+
+def cmd_nodes(args):
+    if not args:
+        die("fake-slurm nodes: need a job id")
+    job = load_job(args[0])
+    if job is None:
+        die("fake-slurm nodes: no such job %s" % args[0])
+    print(",".join(job["nodes"]))
+    return 0
+
+
+def cmd_args(args):
+    if not args:
+        die("fake-slurm args: need a job id")
+    try:
+        with open(os.path.join(JOBDIR, "%s.args" % args[0])) as fp:
+            sys.stdout.write(fp.read())
+    except OSError:
+        die("fake-slurm args: no sbatch record for job %s" % args[0])
+    return 0
+
+
+def cmd_pool(args):
+    for node in read_pool():
+        print(node)
+    return 0
+
+
+def cmd_audit(args):
+    try:
+        with open(AUDIT) as fp:
+            sys.stdout.write(fp.read())
+    except OSError:
+        pass
+    return 0
+
+
+HOUSEKEEPING = {
+    "init": cmd_init, "env": cmd_env, "set": cmd_set, "jobs": cmd_jobs,
+    "nodes": cmd_nodes, "args": cmd_args, "pool": cmd_pool, "audit": cmd_audit,
+}
+
+
+def main():
+    name = os.path.basename(sys.argv[0])
+    if name == "sbatch":
+        return cmd_sbatch(sys.argv[1:])
+    if name == "scontrol":
+        return cmd_scontrol(sys.argv[1:])
+    if name == "scancel":
+        return cmd_scancel(sys.argv[1:])
+
+    if len(sys.argv) < 2 or sys.argv[1] not in HOUSEKEEPING:
+        sys.stdout.write(__doc__)
+        return 2
+    return HOUSEKEEPING[sys.argv[1]](sys.argv[2:])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -212,7 +212,7 @@ test_slurm_alloc() {
     [ "$(echo "$out" | tr -d '\r')" = node3 ] \
         && ok "--host 3 resolved to node3 by launch id" \
         || bad "launch-id shorthand did not resolve: $out"
-    SL 'timeout 30 pterm' >/dev/null 2>&1
+    SL 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 
     banner "ras/slurm: an allocation that excludes the head node"
@@ -234,7 +234,7 @@ test_slurm_alloc() {
         echo "$out" | grep -q 'Missing requested host: node1' \
             && ok "--host naming the unallocated head node is refused" \
             || bad "the unallocated head node was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
-        SL 'timeout 30 pterm' >/dev/null 2>&1
+        SL 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "no DVM came up on an allocation excluding the head node"
     fi
@@ -285,7 +285,7 @@ test_slurm() {
     if [ -z "$jid" ]; then
         bad "extend did not report an allocation id: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
         printf '    HNP: %s\n' "$(SL 'tail -3 /tmp/prte.out' | tr '\n' ' ')"
-        SL 'timeout 30 pterm' >/dev/null 2>&1; cleanup_swarm; return
+        SL 'timeout -k 5 30 pterm' >/dev/null 2>&1; cleanup_swarm; return
     fi
     ok "extend accepted and reported PMIX_ALLOC_ID=$jid (RM=slurm)"
     nodes=$(FS "nodes $jid" | tr -d '\r')
@@ -471,7 +471,7 @@ test_slurm() {
         bad "could not submit the job for the scancel-failure case"
     fi
     FS 'set scancel_fail 0' >/dev/null
-    SL 'timeout 30 pterm' >/dev/null 2>&1
+    SL 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 
     banner "ras/slurm: propagate_* MCA params gate what reaches sbatch"
@@ -498,7 +498,7 @@ test_slurm() {
         else
             bad "extend failed under the propagate_* overrides: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
         fi
-        SL 'timeout 30 pterm' >/dev/null 2>&1
+        SL 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM with the propagate_* overrides"
     fi
@@ -617,7 +617,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             || bad "wildcard stdin reached $n/2 procs (rc=$rc): $(echo "$out" | tr '\n' ' ')"
 
         RUN 'rm -f /tmp/iof_stdin_in.txt /tmp/iof_stdin_out.txt /tmp/iof_stdin_err.txt' >/dev/null 2>&1
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM for the stdin tests"
     fi
@@ -762,7 +762,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         [ "$marker" = node4 ] \
             && ok "the grown node ran the job - it inherited from a survivor" \
             || bad "grown node never ran the job (marker='$marker')"
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the survivor-topology test"
     fi
@@ -795,7 +795,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             [ "$(echo "$out" | tr -d '\r')" = node3 ] \
                 && ok "--host by original address still matches (alias retained)" \
                 || bad "--host $ip3 no longer matches its node (alias lost): $(echo "$out" | tr '\n' ' ')"
-            RUN 'timeout 30 pterm' >/dev/null 2>&1
+            RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
         else
             bad "could not start a DVM allocated by IP address"
         fi
@@ -866,7 +866,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         out=$(RUN 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
         [ "$(echo "$out" | tr -d '\r')" = node1 ] && ok "DVM still responsive after the re-grow" \
                                                   || bad "DVM wedged after re-grow: $out"
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the re-grow test"
     fi
@@ -902,7 +902,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         echo "$out" | grep -q PMIX_DVM_IS_READY \
             && ok "a grow needing no new daemon still completes" \
             || bad "redundant grow never completed"
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the grow-scope test"
     fi
@@ -948,7 +948,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         [ "$(echo "$out" | tr -d '\r')" = node1 ] \
             && ok "DVM still responsive after the grow/shrink/re-grow cycle" \
             || bad "DVM wedged after the grow/shrink/re-grow cycle: $out"
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the pool-dedup test"
     fi
@@ -984,9 +984,43 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         echo "$alloc" | grep -qE '^[[:space:]]*node2:[[:space:]]+slots=4' \
             && ok "node2 slots adjusted 2 -> 4" \
             || bad "node2 slot adjustment not applied: $(echo "$alloc" | grep node2 | tr '\n' ' ')"
-        RUN 'timeout 30 pterm' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM for the add-hostfile test"
+    fi
+    cleanup_swarm
+
+    banner "dash-host: relative node syntax selects from the DVM"
+    # "+n<K>" names the K'th node of the allocation, "+e:N" names N nodes
+    # that are currently empty. Neither can say anything about how big a
+    # node is -- the colon in "+e:N" is a node count -- so a job that uses
+    # them gets the slots those nodes were discovered with.
+    #
+    # That is what makes these run at all. The available-slot computation
+    # matched the raw "+n1" text against each node name, matched nothing,
+    # and reported zero slots available, so the launch was refused for lack
+    # of resources even though the node list had been resolved correctly.
+    # It only ever "worked" with --map-by :OVERSUBSCRIBE, which skips the
+    # check.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --host node1:2,node2:2,node3:2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 30 prun --host +n1 -n 2 hostname' 2>&1)
+        n=$(echo "$out" | grep -c '^node2$')
+        [ "$n" = 2 ] && ok "+n1 resolved to the second node and used both its slots" \
+                     || bad "+n1 did not run 2 procs on node2: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        # ...and is still bounded by what that node actually has
+        out=$(RUN 'timeout 30 prun --host +n1 -n 3 hostname' 2>&1)
+        echo "$out" | grep -q 'not enough slots' \
+            && ok "+n1 is still held to the 2 slots the node was given" \
+            || bad "+n1 was not bounded by the node's slot count"
+        out=$(RUN 'timeout 30 prun --host +e:2 -n 2 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 2 ] && ok "+e:2 selected two empty nodes" \
+                     || bad "+e:2 did not spread over 2 empty nodes ($n): $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the relative-node-syntax test"
     fi
     cleanup_swarm
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -75,6 +75,24 @@ prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/nu
 # entry produces
 prted_procs() { docker exec "prte-node$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
 
+# --- fake-SLURM helpers -----------------------------------------------------
+# ras/slurm reaches its scheduler by shelling out to sbatch/scontrol/scancel,
+# so the harness supplies them: build.sh installs fake-slurm.py into the shared
+# volume under its own prefix, and everything in that phase runs with that
+# prefix FIRST on PATH and the SLURM_* envars exported.  Nothing outside these
+# helpers sees either, which is what keeps the rest of the suite unaffected.
+FS_BIN=/opt/prte/fakeslurm/bin
+# run on the head node inside a faked SLURM allocation
+SL() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+           prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+                                eval \"\$(fake-slurm env)\"; $*"; }
+# run a fake-slurm housekeeping command (no SLURM_* env needed)
+FS() { docker exec prte-node1 bash -lc "export PATH=$FS_BIN:\$PATH; fake-slurm $*"; }
+# "node2,node4" -> "2 4", for prted_count
+fs_idx() { echo "$1" | tr ',' '\n' | sed 's/^node//' | tr '\n' ' '; }
+# the sbatch argv that created a given fake job
+fs_args() { FS "args $1" 2>/dev/null; }
+
 # --- bootstrap-DVM helpers --------------------------------------------------
 # A bootstrapped DVM is configured by <sysconfdir>/prte.conf, which lives in the
 # install the swarm shares.  The node containers mount that volume READ-ONLY, so
@@ -105,6 +123,296 @@ bootstrap_start() {
             "prte-node$n" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
     done
     sleep 14
+}
+
+########################################################################
+# ras/slurm, against the fake scheduler (fake-slurm.py)
+########################################################################
+#
+# Everything ras/slurm does beyond reading SLURM_NODELIST is a shell-out --
+# sbatch to grow, "scontrol show job --json" to learn what it got, "scontrol
+# update job ReqNodeList=" to shrink one, scancel to give one back -- so none
+# of it can run on a developer machine and none of it had any coverage.  The
+# unit test covers the half that only reads the environment (query, allocate);
+# this covers the other half.  It is also the only place the ~1000-line JSON
+# parser is even COMPILED: jansson defaults to off, and this harness is the
+# one automated build that passes --with-jansson.
+#
+# The DVM runs in the foreground under "docker exec -d" rather than
+# --daemonize because several cases assert on what the HNP printed (a
+# scheduler error PRRTE captured and reported), and a daemonized HNP detaches
+# from stdio.
+test_slurm() {
+    local jid nodes idx out n sargs seg
+
+    banner "ras/slurm: faked SLURM allocation discovered at DVM startup"
+    cleanup_swarm
+    if ! FS 'init --jobid 1000 --base node1 --tasks 2 \
+                  --pool node2,node3,node4,node5,node6,node7,node8,node9' >/dev/null 2>&1; then
+        skp "fake SLURM stubs missing from the shared volume -- rerun ./build.sh"
+        return
+    fi
+    SL 'rm -f /tmp/prte.out /tmp/pwned' >/dev/null 2>&1
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+            eval \"\$(fake-slurm env)\"; cd /root &&
+            prte --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5 \
+                 >/tmp/prte.out 2>&1"
+    sleep 8
+    if ! SL 'pgrep -x prte >/dev/null'; then
+        bad "no DVM came up under the faked SLURM allocation: $(SL 'tail -5 /tmp/prte.out' | tr '\n' ' ')"
+        cleanup_swarm; return
+    fi
+    out=$(SL 'timeout 30 prun --display allocation -n 1 hostname' 2>&1)
+    echo "$out" | grep -qE '^[[:space:]]*node1:[[:space:]]+slots=' \
+        && ok "the DVM allocation came from SLURM_NODELIST" \
+        || bad "SLURM allocation not discovered: $(echo "$out" | tr '\n' ' ')"
+    # SLURM_NODELIST=node1 with SLURM_TASKS_PER_NODE="2(x1)": the compressed
+    # form has to expand to one node carrying two slots.  Assert that against
+    # what the component itself reports (ras_base_verbose), not against the
+    # pool.
+    #
+    # Why not the pool: a slot count is only treated as authoritative under
+    # prte_managed_allocation (or PRTE_NODE_FLAG_SLOTS_GIVEN); otherwise it is
+    # recomputed from the node's core count before mapping. And
+    # prte_managed_allocation is currently never set for an RM allocation --
+    # the base used to set it whenever a module returned nodes, and that was
+    # dropped when ras became multi-component ("Update ras framework to
+    # support multi-component operations"), leaving only ras/bootstrap to set
+    # it. So node1 shows up here with its container core count, not the 2
+    # slots SLURM handed out. That is a framework-level defect, not one this
+    # component can fix, so it is not what these cases assert.
+    SL 'grep -q "discover: adding node node1 (2 slots)" /tmp/prte.out' \
+        && ok "SLURM_TASKS_PER_NODE '2(x1)' expanded to node1 with 2 slots" \
+        || bad "nodelist/tasks-per-node expansion wrong: $(SL 'grep -m3 "adding node" /tmp/prte.out' | tr '\n' ' ')"
+
+    banner "ras/slurm: PMIX_ALLOC_EXTEND runs sbatch and grows the DVM"
+    # PMIX_ALLOC_EXTEND + PMIX_ALLOC_NUM_NODES is the only extend shape this
+    # component accepts: which nodes it gets back is the scheduler's choice,
+    # so the request names a count and the answer comes from the job JSON.
+    out=$(SL 'timeout 120 elastic extend 2' 2>&1)
+    jid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    if [ -z "$jid" ]; then
+        bad "extend did not report an allocation id: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        printf '    HNP: %s\n' "$(SL 'tail -3 /tmp/prte.out' | tr '\n' ' ')"
+        SL 'timeout 30 pterm' >/dev/null 2>&1; cleanup_swarm; return
+    fi
+    ok "extend accepted and reported PMIX_ALLOC_ID=$jid (RM=slurm)"
+    nodes=$(FS "nodes $jid" | tr -d '\r')
+    idx=$(fs_idx "$nodes")
+    sleep 10
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 2 ] \
+        && ok "daemons launched on the nodes SLURM granted ($nodes)" \
+        || bad "no daemons on the granted nodes ($nodes) -- the grow never reached them"
+    # The extend puts its nodes in the GENERAL pool (ras/slurm deliberately
+    # leaves node->session NULL), unlike a reservation-creating grow -- so a
+    # plain prun must be able to map onto them.
+    out=$(SL 'timeout 60 prun -n 3 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^node[0-9]+$')
+    [ "$n" = 3 ] && ok "a plain prun maps onto the extended allocation (3 nodes)" \
+                 || bad "prun did not reach the extended nodes ($n/3): $(echo "$out" | tr '\n' ' ')"
+    # Slots come from counting the cores whose status is ALLOCATED (2) times
+    # threads_per_core, capped by cpus.count -- the fake job deliberately
+    # reports an UNALLOCATED core as well and a much larger cpus.count, so
+    # only a parser that reads core statuses arrives at 2.
+    SL "grep -q 'add_modified_resources: discovered node ${nodes%%,*} with 2 slots' /tmp/prte.out" \
+        && ok "slots derived from ALLOCATED cores, capped by cpus.count" \
+        || bad "wrong slot count from the job JSON: $(SL 'grep -m3 discovered.node /tmp/prte.out' | tr '\n' ' ')"
+
+    banner "ras/slurm: the parent job's attributes are propagated onto sbatch"
+    sargs=$(fs_args "$jid")
+    for want in --parsable --exclusive --nodes=2 --account=prrte-test \
+                --partition=debug --qos=normal --chdir=/root --mem=1024 \
+                --time=60 --threads-per-core=1; do
+        echo "$sargs" | grep -qx -- "$want" \
+            && ok "sbatch carried $want" \
+            || bad "sbatch missing $want (got: $(echo "$sargs" | tr '\n' ' '))"
+    done
+    # memory_per_cpu is unset in the parent job, and an unset numeric object
+    # must be omitted rather than sent as a sentinel
+    echo "$sargs" | grep -q -- '--mem-per-cpu' \
+        && bad "sbatch sent --mem-per-cpu for an unset memory_per_cpu" \
+        || ok "an unset numeric field is omitted from the sbatch line"
+
+    banner "ras/slurm: releasing one node shrinks the SLURM job in place"
+    # Removing SOME of a job's nodes keeps the job and resizes it with
+    # "scontrol update job <id> ReqNodeList=<survivors>", then re-reads the
+    # JSON to detach the departed nodes from the session.
+    out=$(SL "timeout 120 elastic shrink ${nodes##*,}" 2>&1)
+    sleep 5
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "partial release completed (PMIX_DVM_IS_READY)" \
+        || bad "partial release never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $(fs_idx "${nodes##*,}"))" = 0 ] \
+        && ok "daemon gone from the released node (${nodes##*,})" \
+        || bad "daemon still running on the released node"
+    FS audit | grep -q "scontrol update job $jid ReqNodeList=${nodes%%,*}" \
+        && ok "job $jid resized to its survivors via scontrol update" \
+        || bad "no scontrol resize was issued: $(FS audit | tr '\n' ' ' | tail -c 200)"
+    [ "$(FS "nodes $jid" | tr -d '\r')" = "${nodes%%,*}" ] \
+        && ok "the SLURM job kept exactly its surviving node" \
+        || bad "job $jid node list wrong after resize: $(FS "nodes $jid")"
+    [ -z "$(SL 'find / -maxdepth 2 -name "slurm_job_*_resize.*" 2>/dev/null')" ] \
+        && ok "the resize helper scripts SLURM left behind were cleaned up" \
+        || bad "slurm_job_*_resize.* left behind after a shrink"
+
+    banner "ras/slurm: releasing a whole allocation scancels its SLURM job"
+    out=$(SL "timeout 120 elastic release-id $jid" 2>&1)
+    sleep 5
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "release by allocation id completed" \
+        || bad "release-id never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 0 ] && ok "both granted nodes left the DVM" \
+                                  || bad "a daemon survived the full release"
+    FS audit | grep -q "scancel $jid" && ok "scancel issued for job $jid" \
+                                      || bad "the SLURM job was never cancelled"
+    FS jobs | grep -qx "$jid" && bad "job $jid still exists after scancel" \
+                             || ok "job $jid is gone from the scheduler"
+    out=$(SL 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node1 ] \
+        && ok "DVM still responsive after the release" \
+        || bad "DVM wedged after the release: $out"
+
+    banner "ras/slurm: release by node COUNT picks the newest allocation"
+    # Re-extending reuses the pool entries the release left behind (daemon-less
+    # nodes PRRTE already knows), which is a different code path from the
+    # first-time grant above.
+    out=$(SL 'timeout 120 elastic extend 2' 2>&1)
+    jid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    nodes=$(FS "nodes $jid" | tr -d '\r'); idx=$(fs_idx "$nodes")
+    sleep 10
+    # shellcheck disable=SC2086
+    [ -n "$jid" ] && [ "$(prted_count $idx)" = 2 ] \
+        && ok "re-extend reused the released node objects ($nodes)" \
+        || bad "re-extend did not bring the nodes back ($nodes)"
+    out=$(SL 'timeout 120 elastic release 2' 2>&1)
+    sleep 5
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "release by count completed" \
+        || bad "release by count never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 0 ] && ok "the counted release emptied the newest allocation" \
+                                  || bad "a daemon survived the counted release"
+    FS audit | grep -q "scancel $jid" \
+        && ok "the whole SLURM job was cancelled rather than resized" \
+        || bad "count release did not scancel job $jid"
+    # the base allocation must survive: it holds the node PRRTE is running on
+    FS jobs | grep -qx 1000 && ok "the DVM's own SLURM job was left alone" \
+                            || bad "the release took out the base allocation"
+
+    banner "ras/slurm: a pending extend can be cancelled by request id"
+    # PMIX_ALLOC_REQ_CANCEL is served while the extend's poll loop is still
+    # waiting on a PENDING SLURM job: cancelling drops the pending record and
+    # scancels the job, and the next poll turns that into a failed request.
+    FS 'set pending_secs 45' >/dev/null
+    SL 'nohup timeout 120 elastic extend 1 --req-id slow-req \
+            >/tmp/extend.out 2>&1 & sleep 2' >/dev/null 2>&1
+    sleep 6
+    jid=$(FS jobs | grep -v '^1000$' | tail -1 | tr -d '\r')
+    if [ -n "$jid" ]; then
+        ok "extend submitted job $jid and is waiting for it to start"
+        SL 'timeout 60 elastic cancel slow-req' >/dev/null 2>&1
+        sleep 6
+        FS audit | grep -q "scancel $jid" \
+            && ok "the cancelled request scancelled its pending SLURM job" \
+            || bad "cancel did not reach the scheduler"
+        SL 'grep -q "REJECTED\|FAILURE" /tmp/extend.out' \
+            && ok "the waiting extend reported failure to its requester" \
+            || bad "the cancelled extend never answered: $(SL 'tr "\n" " " < /tmp/extend.out' | tail -c 200)"
+    else
+        bad "the pending extend never submitted a job"
+    fi
+    FS 'set pending_secs 0' >/dev/null
+    out=$(SL 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node1 ] \
+        && ok "DVM still responsive after the cancellation" \
+        || bad "DVM wedged after the cancellation: $out"
+
+    banner "ras/slurm: unparsable scheduler JSON fails the request, not the DVM"
+    # The HNP runs this parser, so a malformed scontrol response must come
+    # back as a refused request rather than a dead DVM.
+    FS 'set bad_json 1' >/dev/null
+    out=$(SL 'timeout 60 elastic extend 1' 2>&1)
+    FS 'set bad_json 0' >/dev/null
+    echo "$out" | grep -q 'REJECTED' \
+        && ok "an extend on unparsable JSON was refused" \
+        || bad "malformed scheduler JSON was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    SL 'pgrep -x prte >/dev/null' && ok "HNP survived the malformed JSON" \
+                                  || bad "HNP died parsing malformed JSON"
+
+    banner "ras/slurm: a node name that is not a hostname never reaches a shell"
+    # Every hostname bound for an scontrol/scancel command line goes through
+    # prte_ras_slurm_validate_hostname's allowlist first.  This one carries a
+    # command separator: it must be refused outright, and nothing may run.
+    out=$(SL "timeout 60 elastic shrink 'node9;touch /tmp/pwned'" 2>&1)
+    echo "$out" | grep -q 'REJECTED' \
+        && ok "a release naming a tainted hostname was refused" \
+        || bad "tainted hostname not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    SL 'test -e /tmp/pwned' \
+        && bad "the injected command RAN -- hostname validation is not holding" \
+        || ok "the injected command never ran"
+    SL 'pgrep -x prte >/dev/null' && ok "HNP survived the tainted request" \
+                                  || bad "HNP died on a tainted hostname"
+
+    banner "ras/slurm: a failing scancel is reported, truncated, and survived"
+    # prte_ras_slurm_drain_cmd_output() captures the scheduler's complaint
+    # into a fixed buffer and marks it "..." when it does not fit.  The fake
+    # scancel fails with far more output than that buffer holds.
+    FS 'set scancel_fail 1' >/dev/null
+    out=$(SL 'timeout 120 elastic extend 1' 2>&1)
+    jid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    sleep 8
+    if [ -n "$jid" ]; then
+        SL "timeout 120 elastic release-id $jid" >/dev/null 2>&1
+        sleep 5
+        seg=$(SL "awk '/failed to kill job/,0' /tmp/prte.out")
+        echo "$seg" | grep -q "failed to kill job $jid" \
+            && ok "the scancel failure was reported with the scheduler's text" \
+            || bad "a failing scancel went unreported"
+        { echo "$seg" | grep -q '\.\.\.' && ! echo "$seg" | grep -q '(line 11)'; } \
+            && ok "the oversized scheduler message was truncated with '...'" \
+            || bad "scheduler output was not truncated: $(echo "$seg" | tr '\n' ' ' | tail -c 200)"
+        SL 'pgrep -x prte >/dev/null' && ok "HNP survived a scancel failure" \
+                                      || bad "HNP died when scancel failed"
+    else
+        bad "could not submit the job for the scancel-failure case"
+    fi
+    FS 'set scancel_fail 0' >/dev/null
+    SL 'timeout 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+
+    banner "ras/slurm: propagate_* MCA params gate what reaches sbatch"
+    # Each propagated attribute has its own switch; turning two off must drop
+    # exactly those two arguments and leave the rest of the line intact.
+    FS 'init --jobid 1000 --base node1 --tasks 2 --pool node2,node3' >/dev/null
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+            eval \"\$(fake-slurm env)\"; cd /root &&
+            prte --prtemca prte_elastic_mode 1 --prtemca ras_slurm_propagate_qos 0 \
+                 --prtemca ras_slurm_propagate_time 0 >/tmp/prte.out 2>&1"
+    sleep 8
+    if SL 'pgrep -x prte >/dev/null'; then
+        out=$(SL 'timeout 120 elastic extend 1' 2>&1)
+        jid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+        sargs=$(fs_args "$jid")
+        if [ -n "$jid" ]; then
+            { ! echo "$sargs" | grep -q -- '--qos'; } && { ! echo "$sargs" | grep -q -- '--time'; } \
+                && ok "propagate_qos/propagate_time=0 dropped their sbatch args" \
+                || bad "a disabled attribute still reached sbatch: $(echo "$sargs" | tr '\n' ' ')"
+            echo "$sargs" | grep -qx -- '--account=prrte-test' \
+                && ok "the attributes still enabled were unaffected" \
+                || bad "disabling two attributes disturbed the rest of the line"
+        else
+            bad "extend failed under the propagate_* overrides: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        fi
+        SL 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM with the propagate_* overrides"
+    fi
+    cleanup_swarm
 }
 
 test_linux() {
@@ -591,6 +899,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         bad "could not start a DVM for the add-hostfile test"
     fi
     cleanup_swarm
+
+    test_slurm
 
     banner "bootstrap DVM: daemons come up on their own and agree on their ranks"
     # A bootstrapped DVM has no launcher: prted is started independently on

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -142,6 +142,105 @@ bootstrap_start() {
 # --daemonize because several cases assert on what the HNP printed (a
 # scheduler error PRRTE captured and reported), and a daemonized HNP detaches
 # from stdio.
+# Allocation semantics: what a scheduler allocation means to the DVM once
+# ras/slurm has read it. Distinct from test_slurm() below, which drives the
+# elastic modify surface -- these cases never grow or shrink anything, they
+# just ask whether an allocation PRRTE was handed is the allocation PRRTE
+# uses. A real scheduler is the only other way to ask, which is why none of
+# this was ever covered.
+#
+# start a DVM on node1 inside the current fake allocation.  $1 = extra args
+slurm_dvm_start() {
+    SL 'rm -f /tmp/prte.out' >/dev/null 2>&1
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+            eval \"\$(fake-slurm env)\"; cd /root &&
+            prte --prtemca ras_base_verbose 5 $* >/tmp/prte.out 2>&1"
+    sleep 8
+    SL 'pgrep -x prte >/dev/null'
+}
+
+test_slurm_alloc() {
+    local out n
+
+    banner "ras/slurm: a multi-node allocation forms the whole DVM"
+    # Nobody passes --host under a scheduler: the allocation IS the node
+    # list. A DVM that launches only where the user named launches nowhere.
+    cleanup_swarm
+    if ! FS 'init --jobid 1000 --base node1,node2,node3 --tasks 2 \
+                  --pool node4,node5' >/dev/null 2>&1; then
+        skp "fake SLURM stubs missing from the shared volume -- rerun ./build.sh"
+        return
+    fi
+    if ! slurm_dvm_start; then
+        bad "no DVM came up on the 3-node allocation: $(SL 'tail -5 /tmp/prte.out' | tr '\n' ' ')"
+        cleanup_swarm; return
+    fi
+    [ "$(prted_count 2 3)" = 2 ] \
+        && ok "daemons launched on every allocated node, with no --host given" \
+        || bad "the allocation did not form the DVM ($(prted_count 2 3)/2 daemons)"
+    # count DISTINCT nodes: three procs that all landed on node1 is exactly
+    # the failure being tested for, and would pass a line count
+    out=$(SL 'timeout 60 prun -n 3 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 3 ] && ok "a job maps across the whole allocation" \
+                 || bad "job did not spread over the allocation ($n/3 distinct): $(echo "$out" | tr '\n' ' ')"
+
+    banner "ras/slurm: the slot count SLURM gave is the slot count PRRTE uses"
+    # SLURM_TASKS_PER_NODE says 2. A node whose count came from the scheduler
+    # must not be re-sized from its core count -- that is what turns a
+    # 2-slot node into an 8-slot one and hides oversubscription.
+    out=$(SL 'timeout 30 prun --display allocation -n 1 hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^[[:space:]]*node[123]:[[:space:]]+slots=2[[:space:]]')
+    [ "$n" = 3 ] && ok "all three nodes kept slots=2 from SLURM_TASKS_PER_NODE" \
+                 || bad "slot counts were recomputed ($n/3 kept): $(echo "$out" | grep -E 'node[0-9]+:' | tr '\n' ' ')"
+
+    banner "ras/slurm: --host selects within the allocation, and only within it"
+    out=$(SL 'timeout 30 prun --host node2 -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node2 ] \
+        && ok "--host picks an allocated node" \
+        || bad "--host node2 did not run there: $out"
+    # a node outside the allocation must be refused, not silently dropped:
+    # --add-host is the sanctioned way to bring one in
+    out=$(SL 'timeout 30 prun --host node9 -n 1 hostname 2>&1 | tr -d "\0"')
+    echo "$out" | grep -q 'Missing requested host: node9' \
+        && ok "--host outside the allocation is refused, naming the host" \
+        || bad "--host node9 was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    # a bare integer is never a hostname: it names the launch id, so "3"
+    # has to resolve to node3
+    out=$(SL 'timeout 30 prun --host 3 -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node3 ] \
+        && ok "--host 3 resolved to node3 by launch id" \
+        || bad "launch-id shorthand did not resolve: $out"
+    SL 'timeout 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+
+    banner "ras/slurm: an allocation that excludes the head node"
+    # prte runs on node1, but SLURM allocated node2 and node3 only. The head
+    # node is in the pool (it always is) yet is not usable, so a job must map
+    # only onto the allocation and naming node1 must be an error rather than
+    # a quiet fall-back onto an unallocated machine.
+    FS 'init --jobid 1000 --base node2,node3 --tasks 2 --pool node4,node5' >/dev/null
+    if slurm_dvm_start; then
+        [ "$(prted_count 2 3)" = 2 ] \
+            && ok "daemons launched on the allocation, not on the head node" \
+            || bad "head-node-excluded allocation did not form ($(prted_count 2 3)/2)"
+        out=$(SL 'timeout 60 prun -n 2 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[23]$' | sort -u | wc -l | tr -d ' ')
+        { [ "$n" = 2 ] && ! echo "$out" | grep -qE '^node1$'; } \
+            && ok "the job ran only on allocated nodes" \
+            || bad "job leaked onto the unallocated head node: $(echo "$out" | tr '\n' ' ')"
+        out=$(SL 'timeout 30 prun --host node1 -n 1 hostname 2>&1 | tr -d "\0"')
+        echo "$out" | grep -q 'Missing requested host: node1' \
+            && ok "--host naming the unallocated head node is refused" \
+            || bad "the unallocated head node was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        SL 'timeout 30 pterm' >/dev/null 2>&1
+    else
+        bad "no DVM came up on an allocation excluding the head node"
+    fi
+    cleanup_swarm
+}
+
 test_slurm() {
     local jid nodes idx out n sargs seg
 
@@ -169,19 +268,10 @@ test_slurm() {
         || bad "SLURM allocation not discovered: $(echo "$out" | tr '\n' ' ')"
     # SLURM_NODELIST=node1 with SLURM_TASKS_PER_NODE="2(x1)": the compressed
     # form has to expand to one node carrying two slots.  Assert that against
-    # what the component itself reports (ras_base_verbose), not against the
-    # pool.
-    #
-    # Why not the pool: a slot count is only treated as authoritative under
-    # prte_managed_allocation (or PRTE_NODE_FLAG_SLOTS_GIVEN); otherwise it is
-    # recomputed from the node's core count before mapping. And
-    # prte_managed_allocation is currently never set for an RM allocation --
-    # the base used to set it whenever a module returned nodes, and that was
-    # dropped when ras became multi-component ("Update ras framework to
-    # support multi-component operations"), leaving only ras/bootstrap to set
-    # it. So node1 shows up here with its container core count, not the 2
-    # slots SLURM handed out. That is a framework-level defect, not one this
-    # component can fix, so it is not what these cases assert.
+    # what the component itself reports (ras_base_verbose) rather than the
+    # pool, so a parsing error here is not confused with anything the launch
+    # path does to the number afterwards -- test_slurm_alloc covers that end
+    # of it.
     SL 'grep -q "discover: adding node node1 (2 slots)" /tmp/prte.out' \
         && ok "SLURM_TASKS_PER_NODE '2(x1)' expanded to node1 with 2 slots" \
         || bad "nodelist/tasks-per-node expansion wrong: $(SL 'grep -m3 "adding node" /tmp/prte.out' | tr '\n' ' ')"
@@ -209,9 +299,9 @@ test_slurm() {
     # leaves node->session NULL), unlike a reservation-creating grow -- so a
     # plain prun must be able to map onto them.
     out=$(SL 'timeout 60 prun -n 3 --map-by node hostname' 2>&1)
-    n=$(echo "$out" | grep -cE '^node[0-9]+$')
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
     [ "$n" = 3 ] && ok "a plain prun maps onto the extended allocation (3 nodes)" \
-                 || bad "prun did not reach the extended nodes ($n/3): $(echo "$out" | tr '\n' ' ')"
+                 || bad "prun did not reach the extended nodes ($n/3 distinct): $(echo "$out" | tr '\n' ' ')"
     # Slots come from counting the cores whose status is ALLOCATED (2) times
     # threads_per_core, capped by cpus.count -- the fake job deliberately
     # reports an UNALLOCATED core as well and a much larger cpus.count, so
@@ -900,6 +990,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    test_slurm_alloc
     test_slurm
 
     banner "bootstrap DVM: daemons come up on their own and agree on their ranks"

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -183,7 +183,7 @@ spine of launch:
 | `prte_plm_base_setup_job_complete` | `INIT_COMPLETE` → `ALLOCATE`. |
 | `prte_plm_base_allocation_complete` | `ALLOCATION_COMPLETE` → `LAUNCH_DAEMONS` (the component's handler). Has a bootstrap-DVM special case that stands up the VM directly. |
 | `prte_plm_base_daemons_launched` | `DAEMONS_LAUNCHED` → **deliberately a no-op**; we wait for daemons to phone home rather than advancing. |
-| `prte_plm_base_daemons_reported` | `DAEMONS_REPORTED` → set node slots (unmanaged allocations), compute `total_slots_alloc`, then `VM_READY`. |
+| `prte_plm_base_daemons_reported` | `DAEMONS_REPORTED` → size any node whose slot count was not given (`PRTE_NODE_FLAG_SLOTS_GIVEN`), sum the job's session nodes into `total_slots_alloc`, then `VM_READY`. |
 | `prte_plm_base_vm_ready` | `VM_READY` → check topology limits, preposition files (`filem`), then `MAP`. |
 | `prte_plm_base_mapping_complete` | `MAP_COMPLETE` → `SYSTEM_PREP`. |
 | `prte_plm_base_complete_setup` | `SYSTEM_PREP` → `LAUNCH_APPS`. |

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -258,14 +258,18 @@ static void launch_daemons(int fd, short args, void *cbdata)
             PMIX_RELEASE(state);
             return;
         }
-        if (!prte_managed_allocation || prte_set_slots_override) {
+        /* This is the local-only module: there is no launcher, so the head
+         * node is the entire virtual machine and its slots are the whole of
+         * what this job can be given. Size it only if nobody gave us a count
+         * for it - and never report the size of an allocation whose other
+         * nodes we have no way to reach, which is what copying
+         * prte_ras_base.total_slots_alloc here used to do.
+         */
+        if (!PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN) || prte_set_slots_override) {
             // set the number of slots on our node
             prte_plm_base_set_slots(node);
-            state->jdata->total_slots_alloc = node->slots;
-        } else {
-            /* for managed allocations, the total slots allocated is fixed at time of allocation */
-            state->jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
         }
+        state->jdata->total_slots_alloc = node->slots;
 
         // check for topology limitations
         prte_rmaps_base.require_hwtcpus = !prte_hwloc_base_core_cpus(node->topology->topo);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -153,28 +153,30 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
         }
     }
 
-    /* if this is an unmanaged allocation, then set the default
-     * slots on each node as directed or using default
+    /* Size every node in this job's session, then total them.  A node whose
+     * count was GIVEN to us - by a resource manager, or by an explicit
+     * "slots=" - keeps it; only a node that arrived without one is sized
+     * here, from its topology or as prte_set_slots directs.  The total is
+     * therefore always the sum of the job's own nodes: summing a
+     * whole-allocation figure instead would be wrong for any job mapping
+     * onto a reservation rather than the default pool.
+     * prte_set_slots_override is the deliberate escape hatch - it re-sizes
+     * even the nodes whose counts were given.
      */
-    if (!prte_managed_allocation || prte_set_slots_override) {
-        caddy->jdata->total_slots_alloc = 0;
-        for (i = 0; i < caddy->jdata->session->nodes->size; i++) {
-            node = (prte_node_t *) pmix_pointer_array_get_item(caddy->jdata->session->nodes, i);
-            if (NULL == node) {
-                continue;
-            }
-            if (!PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
-                PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                     "%s plm:base:setting slots for node %s by %s",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name,
-                                     prte_set_slots));
-                prte_plm_base_set_slots(node);
-            }
-            caddy->jdata->total_slots_alloc += node->slots;
+    caddy->jdata->total_slots_alloc = 0;
+    for (i = 0; i < caddy->jdata->session->nodes->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(caddy->jdata->session->nodes, i);
+        if (NULL == node) {
+            continue;
         }
-    } else {
-        /* for managed allocations, the total slots allocated is fixed at time of allocation */
-        caddy->jdata->total_slots_alloc = prte_ras_base.total_slots_alloc;
+        if (!PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN) || prte_set_slots_override) {
+            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                                 "%s plm:base:setting slots for node %s by %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name,
+                                 prte_set_slots));
+            prte_plm_base_set_slots(node);
+        }
+        caddy->jdata->total_slots_alloc += node->slots;
     }
 
     /* progress the job */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2003,13 +2003,11 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     prte_job_map_t *map = NULL;
     int rc, i;
     prte_job_t *daemons;
-    pmix_list_t nodes, tnodes;
+    pmix_list_t nodes;
     pmix_list_item_t *item, *next;
     prte_app_context_t *app;
     bool one_filter = false;
     int num_nodes;
-    bool default_hostfile_used;
-    char *hosts = NULL;
     bool singleton = false;
     bool multi_sim = false;
     bool grow_request = false;
@@ -2284,157 +2282,25 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
      */
     map->num_new_daemons = 0;
 
-    /* if this is an unmanaged allocation, then we use
-     * the nodes that were specified for the union of
-     * all apps - there is no need to collect all
-     * available nodes and "filter" them
+    /* Construct the list of nodes this launch may use: everything in the
+     * node pool, filtered through the union of the app specs.  The pool is
+     * the allocation - whether a resource manager handed it to us or it was
+     * built from -host/-hostfile/the default hostfile at allocation time -
+     * so it is the authoritative node set, and the specs only narrow it.
+     *
+     * There used to be a second path here for an unmanaged allocation which
+     * built the VM from the app specs alone rather than from the pool. It
+     * could only ever shrink to nothing when there were no specs to read,
+     * which is precisely the case under a resource manager: nobody passes
+     * -host inside a SLURM allocation, so the DVM formed with the head node
+     * alone and every other allocated node sat unused. Everything that path
+     * consulted - a rank/seq file, -host, -hostfile, the default hostfile -
+     * is already read into the pool by ras/hosts at allocation time, so
+     * filtering the pool reaches the same set for those cases too.
+     *
+     * The grow and dynamic-spawn paths do not come through here: they
+     * select only the nodes their own request brought in.
      */
-    if (!prte_managed_allocation) {
-        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                             "%s setup:vm: working unmanaged allocation",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        default_hostfile_used = false;
-        PMIX_CONSTRUCT(&tnodes, pmix_list_t);
-        hosts = NULL;
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, (void **) &hosts, PMIX_STRING)) {
-            /* use the file, if provided */
-            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                 "%s using rank/seqfile %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                 hosts));
-            if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&tnodes, hosts))) {
-                PRTE_ERROR_LOG(rc);
-                free(hosts);
-                PMIX_LIST_DESTRUCT(&tnodes);
-                PMIX_LIST_DESTRUCT(&nodes);
-                return rc;
-            }
-            free(hosts);
-        } else {
-            for (i = 0; i < jdata->apps->size; i++) {
-                if (NULL
-                    == (app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i))) {
-                    continue;
-                }
-                /* if the app provided a dash-host, then use those nodes */
-                hosts = NULL;
-                if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void **) &hosts,
-                                       PMIX_STRING)) {
-                    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                         "%s using dash_host", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-                    if (PRTE_SUCCESS
-                        != (rc = prte_util_add_dash_host_nodes(&tnodes, hosts, false))) {
-                        PRTE_ERROR_LOG(rc);
-                        free(hosts);
-                        PMIX_LIST_DESTRUCT(&tnodes);
-                        PMIX_LIST_DESTRUCT(&nodes);
-                        return rc;
-                    }
-                    free(hosts);
-                } else if (prte_get_attribute(&app->attributes, PRTE_APP_HOSTFILE, (void **) &hosts,
-                                              PMIX_STRING)) {
-                    /* otherwise, if the app provided a hostfile, then use that */
-                    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                         "%s using hostfile %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                         hosts));
-                    if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&tnodes, hosts))) {
-                        PRTE_ERROR_LOG(rc);
-                        free(hosts);
-                        PMIX_LIST_DESTRUCT(&tnodes);
-                        PMIX_LIST_DESTRUCT(&nodes);
-                        return rc;
-                    }
-                    free(hosts);
-                } else if (NULL != prte_default_hostfile) {
-                    if (!default_hostfile_used) {
-                        /* fall back to the default hostfile, if provided */
-                        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                             "%s using default hostfile %s",
-                                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                             prte_default_hostfile));
-                        if (PRTE_SUCCESS
-                            != (rc = prte_util_add_hostfile_nodes(&tnodes,
-                                                                  prte_default_hostfile))) {
-                            PRTE_ERROR_LOG(rc);
-                            PMIX_LIST_DESTRUCT(&tnodes);
-                            PMIX_LIST_DESTRUCT(&nodes);
-                            return rc;
-                        }
-                        /* only include it once */
-                        default_hostfile_used = true;
-                    }
-                }
-            }
-        }
-
-        /* cycle thru the resulting list, finding the nodes on
-         * the node pool array while removing ourselves
-         * and all nodes that are down or otherwise unusable
-         */
-        while (NULL != (item = pmix_list_remove_first(&tnodes))) {
-            nptr = (prte_node_t *) item;
-            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output, "%s checking node %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), nptr->name));
-            for (i = 0; i < prte_node_pool->size; i++) {
-                node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
-                if (NULL == node) {
-                    continue;
-                }
-                if (!prte_nptr_match(node, nptr)) {
-                    continue;
-                }
-                /* have a match - now see if we want this node */
-                /* ignore nodes that are marked as do-not-use for this mapping */
-                if (PRTE_NODE_STATE_DO_NOT_USE == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
-                                         "NODE %s IS MARKED NO_USE", node->name));
-                    /* reset the state so it can be used another time */
-                    node->state = PRTE_NODE_STATE_UP;
-                    break;
-                }
-                if (PRTE_NODE_STATE_DOWN == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
-                                         "NODE %s IS MARKED DOWN", node->name));
-                    break;
-                }
-                if (PRTE_NODE_STATE_NOT_INCLUDED == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_plm_base_framework.framework_output,
-                                         "NODE %s IS MARKED NO_INCLUDE", node->name));
-                    break;
-                }
-                /* if this node is us, ignore it */
-                if (0 == node->index) {
-                    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                         "%s ignoring myself", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-                    break;
-                }
-                /* we want it - add it to list */
-                PMIX_RETAIN(node);
-                pmix_list_append(&nodes, &node->super);
-            }
-            PMIX_RELEASE(nptr);
-        }
-        PMIX_LIST_DESTRUCT(&tnodes);
-        /* if we didn't get anything, then we are the only node in the
-         * allocation - so there is nothing else to do as no other
-         * daemons are to be launched
-         */
-        if (0 == pmix_list_get_size(&nodes)) {
-            PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
-                                 "%s plm:base:setup_vm only HNP in allocation",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            PMIX_DESTRUCT(&nodes);
-            /* mark that the daemons have reported so we can proceed */
-            daemons->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
-            PRTE_FLAG_UNSET(daemons, PRTE_JOB_FLAG_UPDATED);
-            return PRTE_SUCCESS;
-        }
-        /* continue processing */
-        goto process;
-    }
-
-    /* construct a list of available nodes - the managed-allocation path
-     * falls into this; the grow and dynamic-spawn paths do not, as they
-     * select only the nodes their request brought in */
     for (i = 1; i < prte_node_pool->size; i++) {
         if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i))) {
             /* ignore nodes that are marked as do-not-use for this mapping */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -445,22 +445,26 @@ prototype here compiles and then mismatches the real library.
 | Layer | What it covers |
 |-------|----------------|
 | [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and `ras/slurm`'s detect-and-report half — query gating on `SLURM_JOBID` at priority 50, then `allocate()` expanding a compressed `SLURM_NODELIST` and refusing a tainted jobid or an over-length nodelist. That last part is driven **through the framework** (find the component, query it, call the module it returns) rather than by naming its symbols, because `ras-slurm` is a plugin and has none in `libprrte`; keep it that way. It skips with a printed reason when the component is not there to be found. |
-| [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), and `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust. |
+| [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust, and **`ras/slurm`'s whole modify surface** against a faked scheduler (below). |
 | Live RM | PBS/LSF/Flux discovery still needs a real scheduler; there is no substitute. |
 
-**`ras/slurm`'s `modify` surface has no automated coverage yet, and the
-unit test is not where it goes.** Extend, release and cancel shell out to
+**`ras/slurm`'s `modify` surface is covered in `contrib/dockerswarm`, not
+in the unit test.** Extend, release and cancel shell out to
 `sbatch`/`scontrol` and only mean anything across several nodes, and each
 of them returns `PRTE_ERR_NOT_AVAILABLE` outright unless jansson was
 found — so a `make check` build, which by default has no jansson, cannot
-reach a line of it. `contrib/dockerswarm` is the right home: it is
-multi-node, and its `build.sh` passes `--with-jansson` deliberately, so
-it is the only automated build anywhere that even compiles
-`ras_slurm_jansson.c`. What it still needs is a faked scheduler — the
-`SLURM_*` environment plus stub `scontrol`/`sbatch`/`scancel` on `PATH`
-returning canned JSON. `validate_hostname` and
-`prte_ras_slurm_drain_cmd_output` live on that path only, so they come
-along with it.
+reach a line of it. The harness is multi-node, and its `build.sh` passes
+`--with-jansson` deliberately, so it is the only automated build anywhere
+that even compiles `ras_slurm_jansson.c`. It supplies the scheduler with
+[`fake-slurm.py`](../../../contrib/dockerswarm/fake-slurm.py) — the
+`SLURM_*` environment plus `sbatch`/`scontrol`/`scancel` stubs on `PATH`
+that hand out real container hostnames, so an extend genuinely launches
+daemons and a release genuinely removes them. `validate_hostname`,
+`prte_ras_slurm_drain_cmd_output` and the JSON parser live on that path
+only and come along with it, as do the paths that exist purely to survive
+a misbehaving scheduler (a failing `scancel`, unparsable JSON, a request
+cancelled while its job is still `PENDING`). See
+[dockerswarm AGENTS.md §11](../../../contrib/dockerswarm/AGENTS.md).
 
 The unit test builds the global job/node/session arrays by hand (the
 real ones come from `prte_init()`, which wants a live ESS) — follow that

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -166,15 +166,19 @@ pre-empt everything.
 This state callback in `ras_base_allocate.c` is the heart of the
 framework. Its phases:
 
-1. **Reuse guard.** In an *unmanaged* allocation, the DVM's initial
-   (daemon-job) discovery is the fixed base allocation for the whole
-   session. If `prte_ras_base.allocation_established` is set and this is
-   **not** the DVM's own daemon job, the base *reuses* the existing pool
-   and jumps to display — re-running discovery would re-read the default
-   hostfile, overwrite established per-node slot counts, and clear
+1. **Reuse guard.** The DVM's initial (daemon-job) discovery is the
+   fixed base allocation for the whole session, whoever provided it. If
+   `prte_ras_base.allocation_established` is set and this is **not** the
+   DVM's own daemon job, the base *reuses* the existing pool and jumps to
+   display. Re-running discovery would re-read a hostfile, overwrite
+   established per-node slot counts and clear
    `PRTE_NODE_FLAG_SLOTS_GIVEN`, hiding genuine oversubscription from the
-   mapper. (The sanctioned way to grow an unmanaged allocation is
-   add-host/add-hostfile → `prte_ras_base_modify`.)
+   mapper — and re-reading an RM is no better, since a component that has
+   already recorded its allocation must spend a return code saying so
+   (`ras/slurm` answers `PRTE_EXISTS`) and one that does not would insert
+   it twice. (The sanctioned way to grow an allocation is
+   add-host/add-hostfile or an allocation request →
+   `prte_ras_base_modify`.)
 2. **Cycle modules.** Walk `selected_modules` in priority order calling
    `mod->module->allocate(jdata, &nodes)`, honoring the return protocol
    above.
@@ -226,18 +230,19 @@ input list.** Walk it carefully before touching allocation code:
   it there rather than appending to the lowest free slot (falling back
   to an append if the slot is occupied). `ras/bootstrap` is the only
   component that does this, and it needs it — see its guide.
-- **Managed = sacred slots.** Under `prte_managed_allocation` (or when a
-  node arrives with `PRTE_NODE_FLAG_SLOTS_GIVEN`), the base sets
-  `SLOTS_GIVEN` so downstream code treats the slot count as fixed and
-  never recomputes it from core count. This is also what makes
-  `total_slots_alloc` load-bearing: in a **managed** allocation
-  `plm_base_launch_support` copies `prte_ras_base.total_slots_alloc`
-  straight into `jdata->total_slots_alloc`, which the PMIx server hands
-  out as `PMIX_UNIV_SIZE` and `PMIX_MAX_PROCS`. A miscount here is
-  visible to applications. (In an *unmanaged* allocation the total is
-  recomputed from the pool at launch, which masks the error — so test
-  accounting changes against the managed path or a unit test, not a
-  local `prterun`.)
+- **`PRTE_NODE_FLAG_SLOTS_GIVEN` is the slot authority, and it is
+  per node.** The component that supplies a node says whether its count
+  is a given — every RM component sets the flag, the hostfile/dash-host
+  parsers set it for an explicit `slots=`/`:N`, and nobody sets it on
+  the bare local-host fallback. `node_insert` carries the flag into the
+  pool untouched; at launch `plm_base_launch_support` re-sizes only the
+  nodes that lack it (from the topology, as `prte_set_slots` directs)
+  and sums the job's session nodes into `jdata->total_slots_alloc`,
+  which the PMIx server hands out as `PMIX_UNIV_SIZE` and
+  `PMIX_MAX_PROCS`. A component that forgets the flag silently hands the
+  job its nodes' core counts instead of its allocation.
+  `prte_set_slots_override` is the deliberate escape hatch: it re-sizes
+  even the given ones.
 - **FQDN normalization.** `normalize_node()` truncates an FQDN to the
   short name, keeping the full name as `rawname` and an alias (unless
   `prte_keep_fqdn_hostnames` or the name is an IP). Sets
@@ -342,8 +347,8 @@ documented in each component's guide.
   is authoritative. `slots_max = 0` means "no max".
 - **Return `TAKE_NEXT_OPTION`, not an error, when the env is absent** —
   it is what lets `hosts` (and the local-node fallback) run.
-- **The reuse guard is load-bearing** for spawn/child jobs in unmanaged
-  allocations — don't bypass it.
+- **The reuse guard is load-bearing** for spawn/child jobs — don't
+  bypass it.
 - **The framework's `close` hook lives in `ras_base_frame.c`.**
   `prte_ras_base_close` is defined there and wired into the framework
   DECLARE; there is no separate close file. (An orphaned

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -360,26 +360,31 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
     /* construct a list to hold the results */
     PMIX_CONSTRUCT(&nodes, pmix_list_t);
 
-    /* In an unmanaged allocation, the nodes discovered for the DVM's
-     * initial (daemon-job) allocation constitute the fixed base allocation
-     * for the entire session - exactly as if a scheduler had provided them.
-     * Once that base has been established, a subsequent job (for example,
-     * the child of a PMIx_Spawn) must not re-run discovery: doing so re-reads
-     * the default hostfile and overwrites the established per-node slot counts
-     * while clearing PRTE_NODE_FLAG_SLOTS_GIVEN. That in turn lets the node be
-     * re-sized to its core count, which hides genuine oversubscription from
-     * the mapper and causes spawned processes to be bound on a node that is
-     * actually oversubscribed. The only sanctioned way to change an unmanaged
-     * allocation is an explicit add-host/add-hostfile request, which is
-     * handled separately (prte_ras_base_add_hosts -> prte_ras_base_modify)
-     * before we ever reach this point. So if the base allocation already
-     * exists and this is not the DVM's own daemon job, simply reuse it.
+    /* The nodes discovered for the DVM's initial (daemon-job) allocation
+     * constitute the fixed base allocation for the entire session, whoever
+     * provided them - a scheduler, a hostfile, or -host. Once that base has
+     * been established, a subsequent job (for example, the child of a
+     * PMIx_Spawn) must not re-run discovery. Re-reading a hostfile overwrites
+     * the established per-node slot counts while clearing
+     * PRTE_NODE_FLAG_SLOTS_GIVEN, which lets the node be re-sized to its core
+     * count - hiding genuine oversubscription from the mapper and binding
+     * spawned processes on a node that is actually oversubscribed. Re-reading
+     * a resource manager is no better: an RM component that has already
+     * recorded this allocation has to spend a return code saying so
+     * (ras/slurm answers PRTE_EXISTS to avoid double-inserting the whole
+     * node set), and one that does not would insert it twice.
+     *
+     * The only sanctioned way to change an established allocation is an
+     * explicit add-host/add-hostfile or allocation request, which is handled
+     * separately (prte_ras_base_add_hosts / prte_ras_base_modify) before we
+     * ever reach this point. So if the base allocation already exists and
+     * this is not the DVM's own daemon job, simply reuse it.
      *
      * The "established" test is deliberately independent of whether the HNP
      * node is part of the allocation (prte_ras_base.allocation_established is
      * set when the first allocation completes), so the protection holds even
      * for allocations that exclude the head node. */
-    if (!prte_managed_allocation && prte_ras_base.allocation_established &&
+    if (prte_ras_base.allocation_established &&
         0 != strcmp(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
                              "%s ras:base:allocate reusing established base allocation for job %s",

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1224,7 +1224,7 @@ static int ras_base_insert_node_string(char *ndstring, prte_session_t *dest)
 
     /* add these nodes to our node pool */
     PMIX_CONSTRUCT(&ndlist, pmix_list_t);
-    ret = prte_util_add_dash_host_nodes(&ndlist, ndstring, true);
+    ret = prte_util_add_dash_host_nodes(&ndlist, ndstring);
     if (PRTE_SUCCESS != ret) {
         PRTE_ERROR_LOG(ret);
         PMIX_LIST_DESTRUCT(&ndlist);

--- a/src/mca/ras/base/ras_base_node.c
+++ b/src/mca/ras/base/ras_base_node.c
@@ -183,10 +183,11 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 }
                 pmix_list_append(&hnp_node->attributes, &kv2->super);
             }
-            if (prte_managed_allocation || PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
-                /* the slots are always treated as sacred
-                 * in managed allocations
-                 */
+            /* the incoming node carries the authority for its own slot count:
+             * whoever supplied it says whether the number is a given (an RM
+             * allocation, an explicit "slots=" in a hostfile) or a placeholder
+             * to be computed from the node's topology later */
+            if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
                 PRTE_FLAG_SET(hnp_node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             } else {
                 PRTE_FLAG_UNSET(hnp_node, PRTE_NODE_FLAG_SLOTS_GIVEN);
@@ -267,12 +268,8 @@ int prte_ras_base_node_insert(pmix_list_t *nodes, prte_job_t *jdata)
                 PMIX_RELEASE(node);
                 continue;
             }
-            if (prte_managed_allocation) {
-                /* the slots are always treated as sacred
-                 * in managed allocations
-                 */
-                PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
-            }
+            /* PRTE_NODE_FLAG_SLOTS_GIVEN arrives already set by whoever
+             * supplied the node and is carried into the pool untouched */
             /* detect FQDN before normalizing, then normalize to short name */
             if (!pmix_net_isaddr(node->name) && NULL != strchr(node->name, '.')) {
                 prte_have_fqdn_allocation = true;

--- a/src/mca/ras/bootstrap/AGENTS.md
+++ b/src/mca/ras/bootstrap/AGENTS.md
@@ -29,9 +29,12 @@ Files:
 `allocate` reads the **same bootstrap config file the daemons read**
 (`prte_bootstrap_parse`, from `src/util/prte_bootstrap`). Because the
 `DVMNodes` list is a fixed, externally-defined node set — exactly like an
-RM allocation — it sets **`prte_managed_allocation = true`** so the VM
-setup treats the pool as authoritative (the construct path, not
-hostfile/dash-host filtering) and honors per-node slot counts as given.
+RM allocation — and it marks every node it supplies
+**`PRTE_NODE_FLAG_SLOTS_GIVEN`** so the per-node slot counts are honored
+as given rather than re-derived from each node's core count. (It used to
+also set a global `prte_managed_allocation` to keep VM setup from
+filtering the pool through hostfile/dash-host specs; that global is gone
+— the pool is now the authoritative node set for every allocation.)
 
 It then adds each `DVMNodes` entry to the caller's list at its canonical
 rank (`prte_bootstrap_rank_of`), **skipping rank 0** — the controller
@@ -70,6 +73,7 @@ node is already represented by the HNP at pool index 0. Each node is a
   is a bijection.
 - Skipping rank 0 avoids double-entering the controller (HNP) node;
   don't remove that guard.
-- Setting `prte_managed_allocation` is intentional and load-bearing for
-  the bootstrap construct path — see repo memory *Bootstrap DVM* entries.
+- Marking the nodes `PRTE_NODE_FLAG_SLOTS_GIVEN` is intentional: without
+  it the one slot per node this component assigns would be replaced by
+  the node's core count.
 </content>

--- a/src/mca/ras/bootstrap/ras_boot.c
+++ b/src/mca/ras/bootstrap/ras_boot.c
@@ -54,13 +54,6 @@ static int allocate(prte_job_t *jdata, pmix_list_t *ndlist)
         return rc;
     }
 
-    /* The DVMNodes list is a fixed, externally-defined set of nodes - exactly
-     * like a resource-manager allocation.  Mark the allocation managed so the
-     * virtual-machine setup treats the node pool as the authoritative node set
-     * (the construct path) rather than filtering it through a hostfile or
-     * dash-host list, and so the per-node slot counts are honored as given. */
-    prte_managed_allocation = true;
-
     /* add each DVMNodes entry to the pool at its canonical rank.  The
      * controller (rank 0) is already represented in the node pool by the HNP
      * itself, so skip that entry if it appears in the list. */

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -312,6 +312,8 @@ static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist)
         node->slots_inuse = 0;
         node->slots_max = 0;
         node->slots = hostinfo[i].nslots;
+        /* the count came from the Flux resource set - authoritative */
+        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
         PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
                              "%s ras:flux:allocate:discover: adding node %s (%d slots)",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name, hostinfo[i].nslots));

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -141,6 +141,8 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
             node->slots_inuse = 0;
             node->slots_max = 0;
             node->slots = (int) strtol(num, (char **) NULL, 10);
+            /* the count came from PE_HOSTFILE - authoritative */
+            PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             pmix_output(prte_mca_ras_gridengine_component.verbose,
                         "ras:gridengine: %s: PE_HOSTFILE shows slots=%d queue=%s arch=%s",
                         node->name, node->slots, queue, arch);

--- a/src/mca/ras/hosts/AGENTS.md
+++ b/src/mca/ras/hosts/AGENTS.md
@@ -38,7 +38,7 @@ one yields nodes; if all are empty it returns `PRTE_ERR_TAKE_NEXT_OPTION`
    (and `NO_OVERSUBSCRIBE` unless the user set a subscribe directive) —
    the rankfile *is* the allocation and the mapping.
 2. **Dash-host** (`PRTE_APP_DASH_HOST`), aggregated across all
-   app-contexts via `prte_util_add_dash_host_nodes(..., true)`.
+   app-contexts via `prte_util_add_dash_host_nodes()`.
 3. **Hostfile** (`PRTE_APP_HOSTFILE`), a comma-list per app parsed with
    `prte_util_add_hostfile_nodes`; the result is the UNION across apps.
 4. **Default hostfile** (`prte_default_hostfile`), if set.

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -101,7 +101,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
             PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
                                  "%s ras:base:allocate adding dash_hosts",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            rc = prte_util_add_dash_host_nodes(nodes, hosts, true);
+            rc = prte_util_add_dash_host_nodes(nodes, hosts);
             if (PRTE_SUCCESS != rc) {
                 free(hosts);
                 return rc;
@@ -414,7 +414,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
             }
             // comma-delimited list of hosts to add or delete
             PMIX_CONSTRUCT(&dhnodes, pmix_list_t);
-            rc = prte_util_add_dash_host_nodes(&dhnodes, req->info[n].value.data.string, true);
+            rc = prte_util_add_dash_host_nodes(&dhnodes, req->info[n].value.data.string);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_LIST_DESTRUCT(&dhnodes);

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -96,6 +96,9 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
         node->slots_inuse = 0;
         node->slots_max = 0;
         node->slots = 1;
+        /* lsb_getalloc returns one entry per allocated slot, so the count
+         * this loop arrives at is what LSF gave us - authoritative */
+        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
         node->state = PRTE_NODE_STATE_UP;
         pmix_list_append(nodes, &node->super);
 

--- a/src/mca/ras/pbs/ras_pbs_module.c
+++ b/src/mca/ras/pbs/ras_pbs_module.c
@@ -229,6 +229,8 @@ static int discover(pmix_list_t *nodelist, char *pbs_jobid)
             node->slots_inuse = 0;
             node->slots_max = 0;
             node->slots = ppn;
+            /* the count came from PBS_NODEFILE - authoritative */
+            PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             node->state = PRTE_NODE_STATE_UP;
             pmix_list_append(nodelist, &node->super);
         } else {

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -160,6 +160,10 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
             } else {
                 node->slots = strtol(slot_cnt[n], NULL, 10);
             }
+            /* a simulated allocation is still an allocation: the sizes it
+             * fabricates are the ones the test wants mapped against, so they
+             * must not be re-derived from the topology later */
+            PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
             if (NULL == max_slot_cnt || NULL == max_slot_cnt[n]) {
                 obj = hwloc_get_root_obj(t->topo);
                 node->slots_max = prte_hwloc_base_get_npus(t->topo, use_hwthread_cpus, available, obj);

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -137,7 +137,31 @@ coverage follows that seam.
 | Half | Covered by |
 |------|------------|
 | `query` + `allocate` (nodelist expansion, taint refusal, `PRTE_EXISTS` on re-discovery) | `test/unit/ras/test_ras.c` — no scheduler needed, since both read only the environment |
-| `modify` (extend/release/cancel, the JSON parser, `validate_hostname`, `drain_cmd_output`) | nothing yet. It shells out and is inherently multi-node, so it belongs in `contrib/dockerswarm` — the only automated build that configures `--with-jansson` — once that harness fakes a SLURM environment |
+| `modify` (extend/release/cancel, the JSON parser, `validate_hostname`, `drain_cmd_output`) | [`contrib/dockerswarm`](../../../../contrib/dockerswarm/) — it shells out and is inherently multi-node, and it is the only automated build that configures `--with-jansson`, so it is the only place `ras_slurm_jansson.c` is even compiled |
+
+The harness fakes the scheduler with
+[`fake-slurm.py`](../../../../contrib/dockerswarm/fake-slurm.py), installed
+into the swarm as `sbatch`/`scontrol`/`scancel` and handing out real
+container hostnames — so an extend really launches daemons and a release
+really removes them. Read
+[its AGENTS.md §11](../../../../contrib/dockerswarm/AGENTS.md) before adding
+a case. Two things that trip people up:
+
+- **The request shapes are not a plain grow.** `modify()` accepts only
+  `PMIX_ALLOC_EXTEND`+`NUM_NODES`, `PMIX_ALLOC_RELEASE` with one of
+  `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and `PMIX_ALLOC_REQ_CANCEL`. A
+  node-naming `PMIX_ALLOC_NEW` never reaches this component — the base
+  serves it.
+- **An extend emits no phase-two completion event.** Its nodes go into the
+  general pool (`node->session` stays NULL, by design — see above), and the
+  directed event is addressed to the requestor recorded on a *reservation*.
+  Phase one carries the result. A release does go through a shrink campaign,
+  so it does emit `PMIX_DVM_IS_READY`.
+
+Slot counts are asserted from `ras_base_verbose` output rather than from the
+node pool, because outside a managed allocation the count is recomputed from
+each node's core count before mapping — and `prte_managed_allocation` is
+currently never set for an RM allocation.
 
 ### Reference ownership across the session/tracker web
 

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -158,10 +158,10 @@ a case. Two things that trip people up:
   Phase one carries the result. A release does go through a shrink campaign,
   so it does emit `PMIX_DVM_IS_READY`.
 
-Slot counts are asserted from `ras_base_verbose` output rather than from the
-node pool, because outside a managed allocation the count is recomputed from
-each node's core count before mapping — and `prte_managed_allocation` is
-currently never set for an RM allocation.
+Some slot counts are asserted from `ras_base_verbose` output rather than
+from the node pool: the verbose line is what *this component* computed,
+so it isolates a parser error from anything the launch path does with the
+number afterwards.
 
 ### Reference ownership across the session/tracker web
 

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -113,6 +113,14 @@ degrade gracefully.
   validators; `check_taint` also bounds `SLURM_NODELIST` length.
 - **Guard JSON features behind `prte_ras_slurm_have_jansson()`** so the
   no-Jansson build path stays correct.
+- **Nodes an extend brings in must be `PRTE_NODE_STATE_ADDED`, not `UP`.**
+  A DVM grow launches daemons on the nodes in that state and only those
+  (`prte_plm_base_setup_virtual_machine`), so a node handed over as plain
+  `UP` — the state an *initial* discovery uses — lands in the pool with no
+  daemon and the extend adds resources the DVM cannot use. Both producers
+  here have to agree: `add_modified_resources` for newly granted nodes and
+  the reused-node branch of `extract_reused_nodes` for ones the pool
+  already knows.
 - **This component is a plugin** (`ras-slurm` is in the default
   `--enable-mca-dso` list), so nothing outside it — the ras unit test
   included — can name its symbols. `test/unit/ras` reaches it the way the

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -752,7 +752,17 @@ int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *
 
         prte_node_t *node = PMIX_NEW(prte_node_t);
 
-        node->state = PRTE_NODE_STATE_UP;
+        /* These nodes are being added to a DVM that is already running, so
+         * they must carry the mark the DVM extension selects on: a grow
+         * launches daemons on the nodes in PRTE_NODE_STATE_ADDED and only
+         * those (prte_plm_base_setup_virtual_machine). Handing them over as
+         * plain UP - the state an initial discovery uses - left every node
+         * Slurm granted us sitting in the pool with no daemon on it, so the
+         * extend added resources the DVM could never use. The other producers
+         * of a grow (ras/hosts, the no-scheduler insert path, and the
+         * reused-node branch of this component) all mark ADDED for exactly
+         * this reason. */
+        node->state = PRTE_NODE_STATE_ADDED;
         node->name = nodename_dyn;
         node->slots_inuse = 0;
         node->slots_max = 0;

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -767,6 +767,8 @@ int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *
         node->slots_inuse = 0;
         node->slots_max = 0;
         node->slots = slots;
+        /* derived from the allocation Slurm just granted - authoritative */
+        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
 
         pmix_list_append(node_list, &node->super);
 

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -322,7 +322,18 @@ static int prte_ras_slurm_exec_sbatch(char * const *argv, char *job_id)
                 pipe_draining = true;
             }
         }
-        
+
+        /* Already past the job ID: the rest of the output is of no interest,
+         * but it still has to be consumed so the child is not left writing
+         * into a full pipe. Reading it is NOT an error - falling through to
+         * the error branch here rejected every sbatch whose output carried
+         * more than one character after the job ID, which is exactly what
+         * "--parsable" produces on a cluster that reports one
+         * ("<jobid>;<cluster>"). */
+        else if(1 == r) {
+            continue;
+        }
+
         /* Nothing more to read */
         else if(0 == r) {
             pipe_drained = true;

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -536,6 +536,11 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         node->slots_inuse = 0;
         node->slots_max = 0;
         node->slots = slots[i];
+        /* This count came from the scheduler, so it is authoritative: mark it
+         * given or the launch path will discard it and re-derive the node's
+         * size from its core count, silently handing the job more slots than
+         * SLURM allocated and hiding real oversubscription from the mapper. */
+        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
         pmix_list_append(nodelist, &node->super);
     }
     free(slots);

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -134,15 +134,13 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                                      bool initial_map, bool silent, bool keepall)
 {
     pmix_list_item_t *item;
-    prte_node_t *node, *nd, *nptr, *next;
+    prte_node_t *node, *nd, *next;
     int32_t num_slots;
     int32_t i;
     int rc;
     prte_job_t *daemons;
     bool novm;
-    pmix_list_t nodes;
     char *hosts = NULL;
-    bool needhosts = false;
     prte_session_t **targets;
     size_t ntargets;
     prte_session_t *deftarget[1];
@@ -167,146 +165,21 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
     /* see if we have a vm or not */
     novm = prte_get_attribute(&daemons->attributes, PRTE_JOB_NO_VM, NULL, PMIX_BOOL);
 
-    /* if this is NOT a managed allocation, then we use the nodes
-     * that were specified for this app - there is no need to collect
-     * all available nodes and "filter" them.
+    /* Build the job's node set from the resources of the session(s) it may
+     * map onto, then narrow that set with whatever the app specified. The
+     * session resources are the allocation - a resource manager's, or one
+     * built from -host/-hostfile at allocation time - so they are the
+     * authoritative list, and -host/-hostfile can only select within it.
+     * prte_util_filter_dash_host_nodes rebuilds the list in the order the
+     * user named the hosts, so their ordering is preserved.
      *
-     * However, if it is a managed allocation AND the hostfile or the hostlist was
-     * provided, those take precedence, so process them and filter as we normally do.
+     * A second path used to run here for an unmanaged allocation, assembling
+     * the list from the app specs and looking each name up in the pool. It
+     * reached the same set by a longer route - nothing outside the pool could
+     * ever survive it either - but it bypassed the checks this one applies,
+     * notably that an unallocated head node is not usable just because
+     * someone named it.
      */
-    hosts = NULL;
-    if ((prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void **) &hosts, PMIX_STRING) ||
-         prte_get_attribute(&app->attributes, PRTE_APP_HOSTFILE, (void **) &hosts, PMIX_STRING)) &&
-         NULL != hosts) {
-        needhosts = true;
-        free(hosts);
-    }
-    if (!prte_managed_allocation ||
-        (prte_managed_allocation && needhosts)) {
-        PMIX_CONSTRUCT(&nodes, pmix_list_t);
-        /* if the app provided a dash-host, then use those nodes */
-        hosts = NULL;
-        if (prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, (void **) &hosts, PMIX_STRING) &&
-            NULL != hosts) {
-            PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
-                                 "%s using dash_host %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                 hosts));
-            if (PRTE_SUCCESS != (rc = prte_util_add_dash_host_nodes(&nodes, hosts, false))) {
-                PRTE_ERROR_LOG(rc);
-                free(hosts);
-                return rc;
-            }
-            free(hosts);
-        } else if (prte_get_attribute(&app->attributes, PRTE_APP_HOSTFILE, (void **) &hosts, PMIX_STRING) &&
-                   NULL != hosts) {
-            /* otherwise, if the app provided a hostfile, then use that */
-            PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
-                                 "%s using hostfile %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                 hosts));
-            if (PRTE_SUCCESS != (rc = prte_util_add_hostfile_nodes(&nodes, hosts))) {
-                free(hosts);
-                PRTE_ERROR_LOG(rc);
-                return rc;
-            }
-            free(hosts);
-        } else {
-            /* if nothing else was specified by the app, then use all known nodes, which
-             * will include ourselves
-             */
-            PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
-                                 "%s using known nodes", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            goto addknown;
-        }
-        /** if we still don't have anything */
-        if (0 == pmix_list_get_size(&nodes)) {
-            if (!silent) {
-                pmix_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
-                               true);
-            }
-            PMIX_DESTRUCT(&nodes);
-            return PRTE_ERR_SILENT;
-        }
-        /* find the nodes in the session and assemble them
-         * in list order as that is what the user specified. Note
-         * that the prte_node_t objects on the nodes list are not
-         * fully filled in - they only contain the user-provided
-         * name of the node as a temp object. Thus, we cannot just
-         * check to see if the node pointer matches that of a node
-         * in the session.
-         */
-        PMIX_LIST_FOREACH_SAFE(nptr, next, &nodes, prte_node_t)
-        {
-            for (i = 0; i < prte_node_pool->size; i++) {
-                node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
-                if (NULL == node) {
-                    continue;
-                }
-                /* ignore nodes that are not in the job's targeted session set */
-                if (!node_in_targets(node, targets, ntargets)) {
-                    continue;
-                }
-                /* ignore nodes that are non-usable */
-                if (PRTE_FLAG_TEST(node, PRTE_NODE_NON_USABLE)) {
-                    continue;
-                }
-                /* ignore nodes that are marked as do-not-use for this mapping */
-                if (PRTE_NODE_STATE_DO_NOT_USE == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
-                                         "NODE %s IS MARKED NO_USE", node->name));
-                    /* reset the state so it can be used another time */
-                    node->state = PRTE_NODE_STATE_UP;
-                    continue;
-                }
-                if (PRTE_NODE_STATE_DOWN == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
-                                         "NODE %s IS DOWN", node->name));
-                    continue;
-                }
-                if (PRTE_NODE_STATE_NOT_INCLUDED == node->state) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
-                                         "NODE %s IS MARKED NO_INCLUDE", node->name));
-                    /* not to be used */
-                    continue;
-                }
-                /* if this node wasn't included in the vm (e.g., by -host), ignore it,
-                 * unless we are mapping prior to launching the vm
-                 */
-                if (NULL == node->daemon && !novm) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
-                                         "NODE %s HAS NO DAEMON", node->name));
-                    continue;
-                }
-                if (!prte_nptr_match(node, nptr)) {
-                    PMIX_OUTPUT_VERBOSE((10, prte_rmaps_base_framework.framework_output,
-                                         "NODE %s DOESNT MATCH NODE %s", node->name, nptr->name));
-                    continue;
-                }
-                /* retain a copy for our use in case the item gets
-                 * destructed along the way
-                 */
-                PMIX_RETAIN(node);
-                if (initial_map) {
-                    /* if this is the first app_context we
-                     * are getting for an initial map of a job,
-                     * then mark all nodes as unmapped
-                     */
-                    PRTE_FLAG_UNSET(node, PRTE_NODE_FLAG_MAPPED);
-                }
-                /* the list is ordered as per user direction using -host
-                 * or the listing in -hostfile - preserve that ordering */
-                pmix_list_append(allocated_nodes, &node->super);
-                break;
-            }
-            /* remove the item from the list as we have allocated it */
-            pmix_list_remove_item(&nodes, (pmix_list_item_t *) nptr);
-            PMIX_RELEASE(nptr);
-        }
-        PMIX_DESTRUCT(&nodes);
-        /* now prune for usage and compute total slots */
-        goto complete;
-    }
-
-addknown:
     /* add everything in the node pool that can be used - add them
      * in daemon order, which may be different than the order in the
      * node pool. Since an empty list is passed into us, the list at
@@ -428,7 +301,6 @@ addknown:
                          "%s Retained %d nodes in list", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (int) pmix_list_get_size(allocated_nodes)));
 
-complete:
     /* if we are mapping debuggers, then they don't count against
      * the allocation */
     if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -148,7 +148,6 @@ char **prte_launch_environ = NULL;
 
 bool prte_hnp_is_allocated = false;
 bool prte_allocation_required = false;
-bool prte_managed_allocation = false;
 char *prte_set_slots = NULL;
 bool prte_set_slots_override = false;
 bool prte_nidmap_communicated = false;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -684,7 +684,6 @@ PRTE_EXPORT extern char **prte_launch_environ;
 
 PRTE_EXPORT extern bool prte_hnp_is_allocated;
 PRTE_EXPORT extern bool prte_allocation_required;
-PRTE_EXPORT extern bool prte_managed_allocation;
 PRTE_EXPORT extern char *prte_set_slots;
 PRTE_EXPORT extern bool prte_set_slots_override;
 PRTE_EXPORT extern bool prte_hnp_connected;

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -43,6 +43,47 @@
 
 #include "dash_host.h"
 
+/*
+ * Does this node answer to one -host token?
+ *
+ * A literal name match always wins. Failing that, a token made only of
+ * digits is a launch id rather than a hostname - no real host is called
+ * "15" - so it is compared against the number the node name ends in,
+ * which is what lets "--host 15" select "nid0015". Deciding this from the
+ * shape of the token rather than from the kind of allocation makes the
+ * shorthand available wherever such names are used, and costs nothing
+ * where they are not: a name ending in no digits simply does not match.
+ */
+static bool dash_host_match(prte_node_t *node, const char *token)
+{
+    size_t j, len;
+    char *end = NULL;
+    unsigned long id;
+
+    if (prte_quickmatch(node, (char *) token)) {
+        return true;
+    }
+    if (NULL == token || '\0' == token[0] || NULL == node->name) {
+        return false;
+    }
+    /* only a token that is entirely digits can be a launch id */
+    id = strtoul(token, &end, 10);
+    if (NULL == end || '\0' != *end) {
+        return false;
+    }
+    /* find where the node name's trailing run of digits begins */
+    len = strlen(node->name);
+    j = len;
+    while (0 < j && isdigit((unsigned char) node->name[j - 1])) {
+        --j;
+    }
+    if (j == len) {
+        /* the name does not end in a digit */
+        return false;
+    }
+    return id == strtoul(&node->name[j], NULL, 10);
+}
+
 int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
 {
     char **specs, *cptr;
@@ -60,7 +101,7 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
         } else {
             cptr = NULL;
         }
-        if (prte_quickmatch(node, specs[n])) {
+        if (dash_host_match(node, specs[n])) {
             if (NULL != cptr) {
                 if ('*' == *cptr || 0 == strcmp(cptr, "auto")) {
                     slots += node->slots - node->slots_inuse;
@@ -341,32 +382,13 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
         }
     }
 
-    if (prte_managed_allocation && !allocating) {
-        prte_node_t *node_from_pool = NULL;
-        PMIX_LIST_FOREACH(node, nodes, prte_node_t) {
-            needcheck = true;
-            for (i = 0; i < prte_node_pool->size; i++) {
-                node_from_pool = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
-                if (NULL == node_from_pool) {
-                    continue;
-                }
-                if (prte_nptr_match(node_from_pool, node)) {
-                    needcheck = false;
-                    if (node->slots < node_from_pool->slots) {
-                        node_from_pool->slots = node->slots;
-                    }
-                    break;
-                }
-            }
-            if (needcheck) {
-                // node in -host was not in allocation - this is not allowed
-                pmix_show_help("help-dash-host.txt", "not-all-mapped-alloc",
-                               true, node->name);
-                rc = PRTE_ERR_SILENT;
-                goto cleanup;
-            }
-        }
-    }
+    /* NOTE: there is deliberately no "is this host in the allocation?" check
+     * here. This routine only ever runs while the allocation is being BUILT
+     * (every caller passes allocating=true), so there is nothing yet to check
+     * against. Selecting nodes for a job goes through
+     * prte_util_filter_dash_host_nodes() instead, and that is where a name
+     * the allocation does not contain is reported and refused. */
+
     rc = PRTE_SUCCESS;
 
 cleanup:
@@ -514,14 +536,14 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
     pmix_list_item_t *item;
     pmix_list_item_t *next;
     int32_t i, j, len_mapped_node = 0;
-    int rc, test;
+    int rc;
     char **mapped_nodes = NULL;
     prte_node_t *node;
     int num_empty = 0;
     pmix_list_t keep;
     bool want_all_empty = false;
+    bool found_node;
     char *cptr;
-    size_t lst, lmn;
 
     /* if the incoming node list is empty, then there
      * is nothing to filter!
@@ -602,35 +624,21 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
             if (NULL != (cptr = strchr(mapped_nodes[i], ':'))) {
                 *cptr = '\0';
             }
+            found_node = false;
             /* we are looking for a specific node on the list. */
-            cptr = NULL;
-            lmn = strtoul(mapped_nodes[i], &cptr, 10);
             item = pmix_list_get_first(nodes);
             while (item != pmix_list_get_end(nodes)) {
                 next = pmix_list_get_next(item); /* save this position */
                 node = (prte_node_t *) item;
                 /* search -host list to see if this one is found */
-                if (prte_managed_allocation && (NULL == cptr || 0 == strlen(cptr))) {
-                    /* if we are only given a number, then we test the
-                     * value against the number in the node name. This allows support for
-                     * launch_id-based environments. For example, a hostname
-                     * of "nid0015" can be referenced by "--host 15" */
-                    for (j = strlen(node->name) - 1; 0 < j; j--) {
-                        if (!isdigit(node->name[j])) {
-                            j++;
-                            break;
-                        }
-                    }
-                    if (j >= (int) (strlen(node->name) - 1)) {
-                        test = 0;
-                    } else {
-                        lst = strtoul(&node->name[j], NULL, 10);
-                        test = (lmn == lst) ? 0 : 1;
-                    }
-                } else {
-                    test = (prte_quickmatch(node, mapped_nodes[i])) ? 0 : 1;
-                }
-                if (0 == test) {
+                /* dash_host_match() also accepts a bare launch id, so
+                 * "--host 15" selects "nid0015".  This used to be gated on
+                 * the allocation being a managed one, and to compare the
+                 * scan result against strlen-1 rather than strlen - which
+                 * declared a match for any node whose name ended in a
+                 * single digit, or in no digit at all, so "--host 15"
+                 * matched "node1" and even "node". */
+                if (dash_host_match(node, mapped_nodes[i])) {
                     if (remove) {
                         /* remove item from list */
                         pmix_list_remove_item(nodes, item);
@@ -640,9 +648,19 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
                         /* mark the node as found */
                         PRTE_FLAG_SET(node, PRTE_NODE_FLAG_MAPPED);
                     }
+                    found_node = true;
                     break;
                 }
                 item = next;
+            }
+            if (!found_node) {
+                /* Leave the entry in place: the loop below reports it by
+                 * name. Freeing every entry here regardless of whether it
+                 * matched left that report unreachable, so a -host naming
+                 * a node the job cannot have was silently dropped and the
+                 * user got a generic "no resources" complaint instead of
+                 * being told which host was the problem. */
+                continue;
             }
         }
         /* done with the mapped entry */

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -84,6 +84,39 @@ static bool dash_host_match(prte_node_t *node, const char *token)
     return id == strtoul(&node->name[j], NULL, 10);
 }
 
+/*
+ * Does this node answer to one relative-node token ("+n<K>" or "+e[:N]")?
+ *
+ * This deliberately carries no diagnostics: by the time slots are being
+ * computed the token has already been resolved against the node pool by
+ * prte_util_filter_dash_host_nodes(), and anything wrong with it was
+ * reported there - once, rather than once per node.
+ */
+static bool relative_token_matches(const char *token, prte_node_t *node)
+{
+    prte_node_t *nd;
+    int nodeidx;
+
+    if ('e' == token[1] || 'E' == token[1]) {
+        /* an empty node - which of them were actually taken was settled
+         * when the node list was filtered */
+        return (0 == node->num_procs);
+    }
+    if ('n' == token[1] || 'N' == token[1]) {
+        nodeidx = strtol(&token[2], NULL, 10);
+        if (0 > nodeidx || nodeidx > (int) prte_node_pool->size) {
+            return false;
+        }
+        /* the pool is offset by one when the HNP is not in the allocation */
+        if (!prte_hnp_is_allocated) {
+            nodeidx++;
+        }
+        nd = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
+        return (nd == node);
+    }
+    return false;
+}
+
 int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
 {
     char **specs, *cptr;
@@ -94,6 +127,21 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
 
     /* see if this node appears in the list */
     for (n = 0; NULL != specs[n]; n++) {
+        /* Relative syntax names nodes without saying anything about them,
+         * so it cannot carry a slot count of its own - the colon in
+         * "+e:N" is a node count, not a slot count. A node it designates
+         * therefore contributes the slots it was discovered to have, the
+         * same answer as for a job that named no hosts at all.
+         *
+         * Without this the token matched no node here, every node came out
+         * with zero available slots, and a "--host +n1" launch was refused
+         * for lack of resources even though the node list was correct. */
+        if ('+' == specs[n][0]) {
+            if (relative_token_matches(specs[n], node)) {
+                slots += node->slots - node->slots_inuse;
+            }
+            continue;
+        }
         /* check if the #slots was specified */
         if (NULL != (cptr = strchr(specs[n], ':'))) {
             *cptr = '\0';
@@ -117,15 +165,16 @@ int prte_util_dash_host_compute_slots(prte_node_t *node, char *hosts)
     return slots;
 }
 
-/* we can only enter this routine if no other allocation
- * was found, so we only need to know that finding any
- * relative node syntax should generate an immediate error
+/* Add the nodes named by a -host/--host specification to an allocation
+ * being built. Every caller is doing exactly that - selecting nodes for a
+ * job from an allocation that already exists goes through
+ * prte_util_filter_dash_host_nodes instead.
  */
-int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocating)
+int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts)
 {
     pmix_list_item_t *item;
     int32_t i, j, k;
-    int rc, nodeidx;
+    int rc;
     char **host_argv = NULL;
     char **mapped_nodes = NULL, **mini_map, *ndname;
     prte_node_t *node, *nd;
@@ -176,85 +225,16 @@ int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocati
     }
 
     for (i = 0; NULL != mapped_nodes[i]; ++i) {
-        /* if the specified node contains a relative node syntax,
-         * and we are allocating, then ignore it
+        /* A relative node specification selects from an allocation; it
+         * cannot contribute to one, since it says nothing about what any
+         * node is. This routine only ever runs while the allocation is
+         * being built, so ignore it here - prte_util_filter_dash_host_nodes
+         * resolves it when a job picks its nodes.
          */
         if ('+' == mapped_nodes[i][0]) {
-            if (!allocating) {
-                if ('e' == mapped_nodes[i][1] || 'E' == mapped_nodes[i][1]) {
-                    /* request for empty nodes - do they want
-                     * all of them?
-                     */
-                    if (NULL != (cptr = strchr(mapped_nodes[i], ':'))) {
-                        /* the colon indicates a specific # are requested */
-                        ++cptr;
-                        j = strtoul(cptr, NULL, 10);
-                    } else if ('\0' != mapped_nodes[0][2]) {
-                        j = strtoul(&mapped_nodes[0][2], NULL, 10);
-                    } else {
-                        /* add them all */
-                        j = prte_node_pool->size;
-                    }
-                    for (k = 0; 0 < j && k < prte_node_pool->size; k++) {
-                        if (NULL
-                            != (node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, k))) {
-                            if (0 == node->num_procs) {
-                                PMIx_Argv_append_nosize(&mini_map, node->name);
-                                --j;
-                            }
-                        }
-                    }
-                } else if ('n' == mapped_nodes[i][1] || 'N' == mapped_nodes[i][1]) {
-                    /* they want a specific relative node #, so
-                     * look it up on global pool
-                     */
-                    if ('\0' == mapped_nodes[i][2]) {
-                        /* they forgot to tell us the # */
-                        pmix_show_help("help-dash-host.txt",
-                                       "dash-host:invalid-relative-node-syntax", true,
-                                       mapped_nodes[i]);
-                        rc = PRTE_ERR_SILENT;
-                        goto cleanup;
-                    }
-                    nodeidx = strtol(&mapped_nodes[i][2], NULL, 10);
-                    if (nodeidx < 0 || nodeidx > (int) prte_node_pool->size) {
-                        /* this is an error */
-                        pmix_show_help("help-dash-host.txt",
-                                       "dash-host:relative-node-out-of-bounds", true, nodeidx,
-                                       mapped_nodes[i]);
-                        rc = PRTE_ERR_SILENT;
-                        goto cleanup;
-                    }
-                    /* if the HNP is not allocated, then we need to
-                     * adjust the index as the node pool is offset
-                     * by one
-                     */
-                    if (!prte_hnp_is_allocated) {
-                        nodeidx++;
-                    }
-                    /* see if that location is filled */
-                    node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
-                    if (NULL == node) {
-                        /* this is an error */
-                        pmix_show_help("help-dash-host.txt", "dash-host:relative-node-not-found",
-                                       true, nodeidx, mapped_nodes[i]);
-                        rc = PRTE_ERR_SILENT;
-                        goto cleanup;
-                    }
-                    /* add this node to the list */
-                    PMIx_Argv_append_nosize(&mini_map, node->name);
-                } else {
-                    /* invalid relative node syntax */
-                    pmix_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
-                                   true, mapped_nodes[i]);
-                    rc = PRTE_ERR_SILENT;
-                    goto cleanup;
-                }
-            }
-        } else {
-            /* just one node was given */
-            PMIx_Argv_append_nosize(&mini_map, mapped_nodes[i]);
+            continue;
         }
+        PMIx_Argv_append_nosize(&mini_map, mapped_nodes[i]);
     }
     if (NULL == mini_map) {
         rc = PRTE_SUCCESS;

--- a/src/util/dash_host/dash_host.h
+++ b/src/util/dash_host/dash_host.h
@@ -33,7 +33,7 @@
 
 BEGIN_C_DECLS
 
-PRTE_EXPORT int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool allocating);
+PRTE_EXPORT int prte_util_add_dash_host_nodes(pmix_list_t *nodes, char *hosts);
 
 PRTE_EXPORT int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remove);
 

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -59,18 +59,6 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         return rc;
     }
 
-    /* pack a flag indicating if we are in a managed allocation */
-    if (prte_managed_allocation) {
-        u8 = 1;
-    } else {
-        u8 = 0;
-    }
-    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &u8, 1, PMIX_UINT8);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
-
     /* Pack the size of the daemon vpid space, [0, span). This can be larger
      * than the number of live daemons packed below: a DVM shrink leaves a
      * permanent hole in the vpid space (the DVM never reuses a daemon vpid),
@@ -279,19 +267,6 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         prte_hnp_is_allocated = true;
     } else {
         prte_hnp_is_allocated = false;
-    }
-
-    /* unpack the flag indicating if we are in managed allocation */
-    cnt = 1;
-    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buf, &u8, &cnt, PMIX_UINT8);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        goto cleanup;
-    }
-    if (1 == u8) {
-        prte_managed_allocation = true;
-    } else {
-        prte_managed_allocation = false;
     }
 
     /* unpack the size of the daemon vpid space (may exceed the live daemon


### PR DESCRIPTION
Two related pieces of work: making `ras/slurm` testable at all, and then
fixing what that testing found. The second half is the important one.

## A resource-manager allocation was not forming the DVM

`prte_managed_allocation` has been set only by `ras/bootstrap` since ras
became multi-component (`9a3a027da0`) — the base used to set it whenever a
module returned nodes, and that assignment went away when the
hostfile/dash-host fallback moved into `ras/hosts`. So on every scheduler
PRRTE supports the flag has been false, and all ten of its read sites have
been taking their unmanaged branch.

Measured on a three-node SLURM allocation, with no `--host` given:

```
pool after allocation:   node1 slots=2, node2 slots=2, node3 slots=2
daemons after startup:   node1 only
prun -n 3 --map-by node: node1, node1, node1
```

`setup_virtual_machine`'s unmanaged branch builds the VM from the app's
`-host`/hostfile specs — and nobody passes `-host` inside an allocation, so
it found nothing and concluded the DVM was the head node alone. The slot
counts were separately recomputed from core count (node1: the 2 SLURM gave
it → 8), because `PRTE_NODE_FLAG_SLOTS_GIVEN` was never set for an RM node.

Rather than restore the global — which would have to guess which components
count as managed now that `ras/hosts` is one of them — each site is given a
local answer, and the global is deleted:

| site | now decided by |
|---|---|
| slot authority (4 sites) | `PRTE_NODE_FLAG_SLOTS_GIVEN`, set per node by whoever supplies it |
| the base-allocation reuse guard | `prte_ras_base.allocation_established` alone |
| VM construction, and mapping | the pool/session **is** the allocation; one path, narrowed by the app specs |
| dash-host (2 sites) | the shape of the token — a bare integer is a launch id |

Every RM component now marks its nodes `SLOTS_GIVEN`; the bare local-host
fallback deliberately still does not, so `prterun -np 4` continues to size
itself from the machine.

Two behaviors change for the user, both deliberate: a `--host` naming a node
outside the allocation is now refused by name instead of being silently
dropped (`--add-host` is how you add one), and that includes the head node
when the allocation excludes it.

## Defects found along the way

- `ras/slurm` handed extend-granted nodes over as `PRTE_NODE_STATE_UP`, but a
  grow launches only on `PRTE_NODE_STATE_ADDED` — so an extend added nodes the
  DVM never started a daemon on, and reported success.
- `exec_sbatch`'s read loop had no branch for a successful read once it had the
  job ID, so any `sbatch` output with more than one character past it failed the
  extend. That is exactly what `--parsable` produces where a cluster name is
  reported (`<jobid>;<cluster>`).
- `prte_util_dash_host_compute_slots` matched `-host` tokens literally, so a
  launch id or a relative token selected the right node and was then told that
  node had no slots. `prun --host +n1 -n 2` was refused for lack of resources
  unless you added `--map-by :OVERSUBSCRIBE`.
- The dash-host filter freed every token whether or not anything answered to
  it, leaving the "not included in the current allocation" report unreachable.
- The launch-id scan compared against `strlen-1`, so `--host 15` matched
  `node1` — and `node`.
- The plm base's local-only module (no launcher available, so the head node is
  the whole VM) reported the slot total of the entire allocation.
- Relative-node expansion existed twice; the copy in
  `prte_util_add_dash_host_nodes` was unreachable and had drifted from the live
  one in `parse_dash_host` (`+e2` vs `+e:2`). Deleted, along with the
  `allocating` parameter that had no other use.

## Making any of this testable

`ras/slurm` is the only ras component with a full elastic modify surface, and
all of it shells out to `sbatch`/`scontrol`/`scancel`, so none of it had
automated coverage — including the ~1000-line JSON parser, which this harness
is the only automated build that even compiles (jansson is off by default).

`contrib/dockerswarm/fake-slurm.py` supplies the scheduler: installed into the
shared volume as `sbatch`/`scontrol`/`scancel` under their own prefix (not on
any node's default PATH, so a test has to opt in), handing out real container
hostnames, so an extend launches real daemons and a release really removes
them. It injects faults too — a job that stays `PENDING`, a `scancel` that
fails with more output than the capture buffer holds, unparsable JSON.

That adds 58 cases: the modify surface (extend and the sbatch line it builds,
release by node list / allocation id / count, cancellation, and the
misbehaving-scheduler paths), what an allocation means to the DVM, and
relative node syntax. All of the allocation-semantics cases were written first
and failed.

## Verification

- `contrib/dockerswarm/run-tests.sh linux`: **121 passed, 0 failed, 0 skipped**
  (63 before this branch)
- `make check`: 10/10
- `make -C test/offline check-offline`: **1176 pass, 0 fail** — the regression
  net for the mapper change
- warning-free `--enable-debug` build

Happy to split this into two PRs (harness + `ras/slurm` fixes, then allocation
semantics) if you would rather review them separately; the second half's tests
live in the first, which is why they are together here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
