### PR TITLE
hostfile: make "+n#" mean the same thing as it does on the command line

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -234,6 +234,18 @@ test_slurm_alloc() {
         echo "$out" | grep -q 'Missing requested host: node1' \
             && ok "--host naming the unallocated head node is refused" \
             || bad "the unallocated head node was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        # "+n#" counts the ALLOCATION from zero, so with the head node left
+        # out of it, +n0 is the first node the job was actually given. A
+        # hostfile has to agree with --host about that: the head node still
+        # occupies pool slot 0, and the hostfile filter was the one relative
+        # -index implementation that did not skip it, so every index it
+        # resolved was one node adrift of the same index on the command line.
+        out=$(SL 'timeout 30 prun --host +n0 -n 1 hostname 2>&1 | tr -d "\0"' | grep -E '^node[0-9]+$' | head -1)
+        SL 'printf "+n0\n" > /tmp/relhosts.txt'
+        n=$(SL 'timeout 30 prun --hostfile /tmp/relhosts.txt -n 1 hostname 2>&1 | tr -d "\0"' | grep -E '^node[0-9]+$' | head -1)
+        { [ "$out" = node2 ] && [ "$n" = node2 ]; } \
+            && ok "+n0 is the allocation's first node for both --host and a hostfile" \
+            || bad "relative index disagrees across entry points (--host=$out hostfile=$n, want node2 for both)"
         SL 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "no DVM came up on an allocation excluding the head node"

--- a/docs/how-things-work/per-app-mapping.rst
+++ b/docs/how-things-work/per-app-mapping.rst
@@ -51,29 +51,45 @@ continue to apply at the job level.
    prun -n 3 app1 --map-by rankfile:file=/path/to/rfile : -n 2 app2
 
 Any ``--map-by`` qualifier that is valid at the job level is also valid per
-app, with the following exceptions (described in the next section).
+app.  A few of them describe the job rather than the app, and are handled as
+described in the next section.
 
 
-Job-Level-Only Directives
--------------------------
+Job-Level Directives Written On An App
+--------------------------------------
 
-Some directives are properties of the job as a whole and cannot be applied
-per app context:
+Some qualifiers are properties of the job as a whole.  They may still be
+written in a per-app ``--map-by`` string — indeed on a multi-app command line
+there is nowhere else to write them, since it takes two mapping directives to
+make the mapping per-app at all, and a lone directive belongs to the job.  So
+PRRTE takes such a qualifier off the app that carried it and applies it to the
+job.
+
+What cannot be honored is app contexts that answer the same question in
+opposite ways; that is refused, and the job aborts with
+``PRTE_JOB_STATE_MAP_FAILED``.  Apps that say nothing are silent, not
+dissenting: it is enough that the apps which do give the qualifier agree with
+each other, and with any job-level directive.
 
 ``OVERSUBSCRIBE`` / ``NOOVERSUBSCRIBE``
     Oversubscription governs whether the job as a whole may exceed node slot
     counts.  Because multiple app contexts share the same nodes, this decision
-    must be consistent across all apps.  Specifying ``OVERSUBSCRIBE`` or
-    ``NOOVERSUBSCRIBE`` in a per-app ``--map-by`` string is an error and will
-    cause the job to abort with ``PRTE_JOB_STATE_MAP_FAILED``.
+    has to be the same for all of them.
+
+    .. code-block:: sh
+
+       # legal: the qualifier is written once and applies to the whole job
+       prun -n 14 app1 --map-by slot:oversubscribe : -n 14 app2 --map-by node
+
+       # refused: the two apps ask for opposite things
+       prun -n 4 app1 --map-by core:oversubscribe : \
+            -n 4 app2 --map-by node:nooversubscribe
 
 ``INHERIT`` / ``NOINHERIT``
     These modifiers control whether a spawned child job copies its parent's
-    placement policies.  This is a job-level property.  If the PMIx spawn path
-    supplies ``INHERIT`` or ``NOINHERIT`` in per-app ``info[]`` arrays, PRRTE
-    will attempt to promote the directive to the job level.  If different app
-    contexts carry conflicting directives (one ``INHERIT`` and another
-    ``NOINHERIT``), the job will abort with ``PRTE_JOB_STATE_MAP_FAILED``.
+    placement policies.  This is a job-level property, promoted to the job in
+    the same way, whether it arrives on the command line or in a per-app
+    ``info[]`` array on the PMIx spawn path.
 
 ``--display-map`` / ``--display-devel-map``
     The job map is displayed once after all app contexts have been placed.

--- a/src/docs/prrte-rst-content/detail-hosts-cli.rst
+++ b/src/docs/prrte-rst-content/detail-hosts-cli.rst
@@ -45,3 +45,18 @@ For example:
 .. code::
 
    prterun --host node1:10,node2,node3:5 ...
+
+``--host`` *selects* from the hosts already available to the DVM
+|mdash| those a resource manager allocated, or those the DVM was
+started with. It does not add any. Naming a host that is not among
+them is an error, reported as:
+
+.. code::
+
+   At least one of the requested hosts is not included in the current
+   allocation.
+
+      Missing requested host: node9
+
+To bring a new host into a DVM that is already running, use
+``--add-host`` or ``--add-hostfile`` instead.

--- a/src/docs/prrte-rst-content/detail-hosts-relative-indexing.rst
+++ b/src/docs/prrte-rst-content/detail-hosts-relative-indexing.rst
@@ -34,14 +34,19 @@ specify the desired layout. In this case, a command line containing:
 
 .. code::
 
-   --host +n1,+n2 ./app1 : --host +n3,+n4 ./app2
+   --host +n0,+n1 ./app1 : --host +n2,+n3 ./app2
 
 would provide the desired pattern. The ``+`` syntax indicates that the
 information is being provided as a relative index into the existing
 allocation. Two methods of relative indexing are supported:
 
-* ``+n#``: A relative index into the allocation referencing the ``#``
-  node. PRRTE will substitute the ``#`` node in the allocation
+* ``+n#``: A relative index into the allocation, counted from zero
+  |mdash| ``+n0`` is the first node of the allocation, ``+n1`` the
+  second, and so on. PRRTE will substitute that node of the allocation.
+  Note that the index counts nodes the job was actually given: if the
+  node you launched from is not part of the allocation, it does not
+  occupy an index. An index past the end of the allocation is an
+  error.
 
 * ``+e[:#]``: A request for ``#`` empty nodes |mdash| i.e., PRRTE is
   to substitute this reference with nodes that have not yet been used
@@ -73,9 +78,9 @@ where the user has a hostfile containing:
 This may, for example, be a hostfile that describes a set of
 commonly-used resources that the user wishes to execute applications
 against. For this particular application, the user plans to map
-byslot, and wants the first two ranks to be on the second node of any
+byslot, and wants the first two ranks to be on the third node of any
 allocation, the next ranks to land on an empty node, have one rank
-specifically on ``dummy4``, the next rank to be on the second node of the
+specifically on ``dummy4``, the next rank to be on the third node of the
 allocation again, and finally any remaining ranks to be on whatever
 empty nodes are left. To accomplish this, the user provides a hostfile
 of:

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -139,6 +139,13 @@ PRTE_EXPORT int prte_rmaps_base_set_app_ranking_policy(prte_app_context_t *app,
 PRTE_EXPORT int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app,
                                                         char *spec);
 
+/* move the qualifiers that describe the whole job off the apps that carried
+ * them, holding the apps to agreeing about them. The agreed oversubscription
+ * directive is returned for the caller to apply once the job's mapping policy
+ * has been resolved */
+PRTE_EXPORT int prte_rmaps_base_hoist_job_directives(prte_job_t *jdata,
+                                                     prte_mapping_policy_t *oversubscribe);
+
 PRTE_EXPORT int prte_rmaps_base_set_default_ranking(prte_job_t *jdata,
                                                     prte_rmaps_options_t *options);
 PRTE_EXPORT int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec);

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -14,7 +14,7 @@
 # Copyright (c) 2011      Los Alamos National Security, LLC.
 #                         All rights reserved.
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
-# Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -280,6 +280,33 @@ requested ones:
 
 Please specify a mapping level that has more cpus, or else let us
 define a default mapping that will allow multiple cpus-per-proc.
+#
+[conflicting-directives]
+Two qualifiers that contradict each other were given in the same
+directive:
+
+  Qualifier:  %s
+  Qualifier:  %s
+
+Please give only one of them.
+#
+[conflicting-job-qualifiers]
+A qualifier that applies to the entire job was given more than once,
+with conflicting values:
+
+  Qualifier:       %s
+  Given by:        %s
+  Conflicts with:  %s
+
+Qualifiers such as OVERSUBSCRIBE and INHERIT describe the whole job -
+whether a node may hold more processes than it has slots, or whether
+this job takes on its parent's launch directives. Every application in
+the job therefore has to agree about them: it is fine to give such a
+qualifier on one application of several, and it will be applied to the
+job as a whole, but two applications cannot ask for opposite things.
+
+Please give the qualifier only once, or give it the same value
+everywhere.
 #
 [unrecognized-modifier]
 The mapping request contains an unrecognized qualifier:

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -189,9 +189,17 @@ PMIX_CLASS_INSTANCE(prte_rmaps_base_selected_module_t,
  *   app         a per-app policy       - recorded on the app context
  *
  * A qualifier whose effect necessarily spans the whole job (OVERSUBSCRIBE,
- * NOOVERSUBSCRIBE, INHERIT, NOINHERIT) cannot be attached to a single app,
- * and is refused at that level: one app cannot oversubscribe its nodes
- * while its siblings do not.
+ * NOOVERSUBSCRIBE, INHERIT, NOINHERIT) describes the job no matter which
+ * app's spec it was written in - one app cannot oversubscribe its nodes
+ * while its siblings do not. That is a reason to hoist it to the job, not a
+ * reason to refuse it, and refusing it left a multi-app command line with no
+ * way to ask for oversubscription at all: it takes two mapping directives to
+ * make the mapping per-app, and by then there is no job-level directive left
+ * to hang the qualifier on. So record it here wherever it was given and let
+ * prte_rmaps_base_hoist_job_directives() move the app-held copies onto the
+ * job once every app has been parsed. Only the case with no meaning - two
+ * apps asking for opposite things - is refused, and it is refused there,
+ * where the whole job is in view.
  *
  * Keeping this in one place is deliberate. It used to be written twice -
  * once here and once inline in prte_rmaps_base_set_app_mapping_policy() -
@@ -237,16 +245,6 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_GIVEN);
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_OVERSUB)) {
-            if (NULL != app) {
-                /* spans the whole job - cannot be attached to one app */
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
-                 * qualifier it does not recognize, and would report this one
-                 * a second time as a typo */
-                return PRTE_ERR_SILENT;
-            }
             if (nooversubscribe_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -259,16 +257,6 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             oversubscribe_given = true;
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOOVER)) {
-            if (NULL != app) {
-                /* spans the whole job - cannot be attached to one app */
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
-                 * qualifier it does not recognize, and would report this one
-                 * a second time as a typo */
-                return PRTE_ERR_SILENT;
-            }
             if (oversubscribe_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -311,16 +299,6 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             }
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_INHERIT)) {
-            if (NULL != app) {
-                /* spans the whole job - cannot be attached to one app */
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
-                 * qualifier it does not recognize, and would report this one
-                 * a second time as a typo */
-                return PRTE_ERR_SILENT;
-            }
             if (noinherit_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -331,22 +309,17 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             if (NULL == attrs) {
                 prte_rmaps_base.inherit = true;
             } else {
+                /* GLOBAL even on an app, where this is only held until the
+                 * hoist moves it to the job: a spawn request is packed and
+                 * sent to the HNP - possibly itself - so the job that gets
+                 * mapped is always an unpacked copy, and a LOCAL attribute
+                 * would not survive the trip to be hoisted at all */
                 prte_set_attribute(attrs, PRTE_JOB_INHERIT, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
             }
             inherit_given = true;
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOINHERIT)) {
-            if (NULL != app) {
-                /* spans the whole job - cannot be attached to one app */
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
-                 * qualifier it does not recognize, and would report this one
-                 * a second time as a typo */
-                return PRTE_ERR_SILENT;
-            }
             if (inherit_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -435,6 +408,115 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         }
     }
     PMIx_Argv_free(ck2);
+    return PRTE_SUCCESS;
+}
+
+/*
+ * Collect the job-level qualifiers that the apps' mapping specs carry, and
+ * move them onto the job.
+ *
+ * OVERSUBSCRIBE/NOOVERSUBSCRIBE and INHERIT/NOINHERIT answer a question about
+ * the job: whether a node may hold more processes than it has slots, and
+ * whether this job takes its parent's launch directives. One app of a job
+ * cannot answer either differently from its siblings, so wherever the user
+ * wrote the qualifier it is the job's. The one thing that cannot be honored
+ * is apps that answer it in opposite ways, and that is what is refused here -
+ * where every app is in view. Agreement is enough: apps that say nothing are
+ * silent, not dissenting, and a job-level directive is simply the first
+ * answer the apps have to agree with.
+ *
+ * An app's copy is removed once it has been hoisted, so an app whose spec
+ * held nothing else no longer drags the job onto the per-app dispatch path.
+ *
+ * The agreed oversubscription answer is returned rather than written to the
+ * job, because resolving the job's mapping policy assigns the whole policy
+ * word from a default or a parent and would overwrite it; the caller applies
+ * it once that has happened. INHERIT lives in the job's attributes, which
+ * nothing overwrites, so it is applied here.
+ */
+int prte_rmaps_base_hoist_job_directives(prte_job_t *jdata,
+                                         prte_mapping_policy_t *oversubscribe)
+{
+    prte_app_context_t *app;
+    prte_mapping_policy_t apppol, agreed = 0;
+    uint16_t u16;
+    uint16_t *u16ptr = &u16;
+    bool given = false, over = false, appover;
+    int i;
+
+    *oversubscribe = 0;
+
+    /* a job-level mapping directive, if one was given, is the first answer -
+     * read it now, before the mapping policy is resolved against a default */
+    if (NULL != jdata->map &&
+        (PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping))) {
+        given = true;
+        over = !(PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping));
+        agreed = PRTE_MAPPING_SUBSCRIBE_GIVEN;
+        if (!over) {
+            agreed |= PRTE_MAPPING_NO_OVERSUBSCRIBE;
+        }
+    }
+
+    for (i = 0; i < jdata->apps->size; i++) {
+        app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i);
+        if (NULL == app) {
+            continue;
+        }
+
+        /***   OVERSUBSCRIBE / NOOVERSUBSCRIBE   ***/
+        if (prte_get_attribute(&app->attributes, PRTE_APP_MAPBY, (void **) &u16ptr, PMIX_UINT16)) {
+            apppol = u16;
+            if (PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(apppol)) {
+                appover = !(PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(apppol));
+                if (given && over != appover) {
+                    pmix_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                                   true, appover ? "OVERSUBSCRIBE" : "NOOVERSUBSCRIBE",
+                                   app->app, over ? "OVERSUBSCRIBE" : "NOOVERSUBSCRIBE");
+                    return PRTE_ERR_SILENT;
+                }
+                given = true;
+                over = appover;
+                agreed = PRTE_MAPPING_SUBSCRIBE_GIVEN;
+                if (!over) {
+                    agreed |= PRTE_MAPPING_NO_OVERSUBSCRIBE;
+                }
+                /* the app no longer carries it */
+                PRTE_UNSET_MAPPING_DIRECTIVE(apppol, PRTE_MAPPING_SUBSCRIBE_GIVEN);
+                PRTE_UNSET_MAPPING_DIRECTIVE(apppol, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+                if (0 == apppol) {
+                    prte_remove_attribute(&app->attributes, PRTE_APP_MAPBY);
+                } else {
+                    prte_set_attribute(&app->attributes, PRTE_APP_MAPBY, PRTE_ATTR_GLOBAL,
+                                       &apppol, PMIX_UINT16);
+                }
+            }
+        }
+
+        /***   INHERIT / NOINHERIT   ***/
+        if (prte_get_attribute(&app->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
+            if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
+                pmix_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                               true, "INHERIT", app->app, "NOINHERIT");
+                return PRTE_ERR_SILENT;
+            }
+            prte_remove_attribute(&app->attributes, PRTE_JOB_INHERIT);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_INHERIT, PRTE_ATTR_GLOBAL,
+                               NULL, PMIX_BOOL);
+        }
+        if (prte_get_attribute(&app->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
+            if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
+                pmix_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                               true, "NOINHERIT", app->app, "INHERIT");
+                return PRTE_ERR_SILENT;
+            }
+            prte_remove_attribute(&app->attributes, PRTE_JOB_NOINHERIT);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, PRTE_ATTR_GLOBAL,
+                               NULL, PMIX_BOOL);
+        }
+    }
+
+    *oversubscribe = agreed;
     return PRTE_SUCCESS;
 }
 
@@ -911,8 +993,10 @@ int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec)
 }
 
 /* Per-app-context mapping policy parser.
- * Stores results in app->attributes rather than jdata->map.
- * Rejects job-level-only directives (OVERSUBSCRIBE, NOOVERSUBSCRIBE, INHERIT, NOINHERIT).
+ * Stores results in app->attributes rather than jdata->map. A qualifier that
+ * spans the whole job (OVERSUBSCRIBE, NOOVERSUBSCRIBE, INHERIT, NOINHERIT) is
+ * held on the app until prte_rmaps_base_hoist_job_directives() moves it onto
+ * the job, which is also where apps are held to agreeing about it.
  */
 int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec)
 {
@@ -952,9 +1036,9 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
             PMIX_ARGV_JOIN(cptr, &ck[1], ':');
         }
         /* Parse the qualifiers with the same code every other level uses.
-         * check_modifiers() refuses the ones that necessarily span the whole
-         * job, so a per-app spec still cannot carry OVERSUBSCRIBE,
-         * NOOVERSUBSCRIBE, INHERIT or NOINHERIT. */
+         * A qualifier that spans the whole job is recorded here and hoisted
+         * onto the job by prte_rmaps_base_hoist_job_directives() once every
+         * app has been seen. */
         rc = check_modifiers(cptr, NULL, app, &tmp);
         if (PRTE_SUCCESS != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
@@ -973,7 +1057,20 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         }
     }
 
+    /* a spec that opens with ':' names no policy - it is qualifiers only,
+     * which still have to be parsed. This mirrors the job-level parser; a
+     * per-app "--map-by :OVERSUBSCRIBE" used to be discarded in silence. */
     if (':' == inspec[0]) {
+        rc = check_modifiers(&inspec[1], NULL, app, &tmp);
+        if (PRTE_SUCCESS != rc) {
+            if (PRTE_ERR_BAD_PARAM == rc) {
+                pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier",
+                               true, inspec);
+                rc = PRTE_ERR_SILENT;
+            }
+            PMIx_Argv_free(ck);
+            return rc;
+        }
         PMIx_Argv_free(ck);
         goto setpolicy;
     }

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -177,11 +177,36 @@ PMIX_CLASS_INSTANCE(prte_rmaps_base_selected_module_t,
                     pmix_list_item_t,
                     NULL, NULL);
 
-static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *tmp)
+/*
+ * Parse the qualifiers of a mapping specification.
+ *
+ * One parser serves all three levels at which a mapping policy can be
+ * given, because the syntax is identical at each; only where the result
+ * is recorded differs, and whether a qualifier is allowed at all:
+ *
+ *   both NULL   the MCA default policy - recorded in prte_rmaps_base
+ *   jdata       a job-level policy     - recorded on the job
+ *   app         a per-app policy       - recorded on the app context
+ *
+ * A qualifier whose effect necessarily spans the whole job (OVERSUBSCRIBE,
+ * NOOVERSUBSCRIBE, INHERIT, NOINHERIT) cannot be attached to a single app,
+ * and is refused at that level: one app cannot oversubscribe its nodes
+ * while its siblings do not.
+ *
+ * Keeping this in one place is deliberate. It used to be written twice -
+ * once here and once inline in prte_rmaps_base_set_app_mapping_policy() -
+ * and the copies drifted, so "--map-by package:span" and ":ordered" were
+ * accepted for a job and silently rejected (a bare PRTE_ERR_BAD_PARAM, no
+ * message) for an app.
+ */
+static int check_modifiers(char *ck, prte_job_t *jdata,
+                           prte_app_context_t *app,
+                           prte_mapping_policy_t *tmp)
 {
     char **ck2, *ptr;
     int i;
     uint16_t u16;
+    pmix_list_t *attrs = NULL;
     bool inherit_given = false;
     bool noinherit_given = false;
     bool hwthread_cpus_given = false;
@@ -198,6 +223,13 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
         return PRTE_SUCCESS;
     }
 
+    /* where anything we record goes */
+    if (NULL != app) {
+        attrs = &app->attributes;
+    } else if (NULL != jdata) {
+        attrs = &jdata->attributes;
+    }
+
     ck2 = PMIx_Argv_split(ck, ':');
     for (i = 0; NULL != ck2[i]; i++) {
         if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_SPAN)) {
@@ -205,6 +237,16 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_GIVEN);
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_OVERSUB)) {
+            if (NULL != app) {
+                /* spans the whole job - cannot be attached to one app */
+                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                               "per-app mapping policy", ck2[i]);
+                PMIx_Argv_free(ck2);
+                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
+                 * qualifier it does not recognize, and would report this one
+                 * a second time as a typo */
+                return PRTE_ERR_SILENT;
+            }
             if (nooversubscribe_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -217,6 +259,16 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             oversubscribe_given = true;
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOOVER)) {
+            if (NULL != app) {
+                /* spans the whole job - cannot be attached to one app */
+                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                               "per-app mapping policy", ck2[i]);
+                PMIx_Argv_free(ck2);
+                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
+                 * qualifier it does not recognize, and would report this one
+                 * a second time as a typo */
+                return PRTE_ERR_SILENT;
+            }
             if (oversubscribe_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -232,9 +284,10 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_NO_USE_LOCAL);
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_ORDERED)) {
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                "mapping policy", ck2[i]);
+                PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             PRTE_SET_MAPPING_DIRECTIVE(*tmp, PRTE_MAPPING_ORDERED);
@@ -249,14 +302,25 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 prte_rmaps_base.default_pes = u16;
             } else {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, PRTE_ATTR_GLOBAL,
-                                   &u16, PMIX_UINT16);
+                prte_set_attribute(attrs,
+                                   (NULL != app) ? PRTE_APP_PES_PER_PROC : PRTE_JOB_PES_PER_PROC,
+                                   PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
             }
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_INHERIT)) {
+            if (NULL != app) {
+                /* spans the whole job - cannot be attached to one app */
+                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                               "per-app mapping policy", ck2[i]);
+                PMIx_Argv_free(ck2);
+                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
+                 * qualifier it does not recognize, and would report this one
+                 * a second time as a typo */
+                return PRTE_ERR_SILENT;
+            }
             if (noinherit_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -264,15 +328,25 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 prte_rmaps_base.inherit = true;
             } else {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_INHERIT, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(attrs, PRTE_JOB_INHERIT, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
             }
             inherit_given = true;
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOINHERIT)) {
+            if (NULL != app) {
+                /* spans the whole job - cannot be attached to one app */
+                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                               "per-app mapping policy", ck2[i]);
+                PMIx_Argv_free(ck2);
+                /* SILENT, not BAD_PARAM: the caller reserves BAD_PARAM for a
+                 * qualifier it does not recognize, and would report this one
+                 * a second time as a typo */
+                return PRTE_ERR_SILENT;
+            }
             if (inherit_given) {
                 /* conflicting directives */
                 pmix_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
@@ -280,10 +354,10 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 prte_rmaps_base.inherit = false;
             } else {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, PRTE_ATTR_GLOBAL,
+                prte_set_attribute(attrs, PRTE_JOB_NOINHERIT, PRTE_ATTR_GLOBAL,
                                    NULL, PMIX_BOOL);
             }
             noinherit_given = true;
@@ -295,11 +369,11 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 prte_rmaps_base.hwthread_cpus = true;
             } else {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL,
-                                   NULL, PMIX_BOOL);
+                prte_set_attribute(attrs, (NULL != app) ? PRTE_APP_HWT_CPUS : PRTE_JOB_HWT_CPUS,
+                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
             }
             hwthread_cpus_given = true;
 
@@ -314,17 +388,19 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
              * all; a core that holds a single hwthread is still a usable core
              * (matches the per-app path, which records corecpus as given) */
             if (!prte_rmaps_base.have_cores) {
-                if (NULL == jdata) {
+                if (NULL == attrs) {
                     prte_rmaps_base.hwthread_cpus = true;
                 } else {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, PRTE_ATTR_GLOBAL,
-                                       NULL, PMIX_BOOL);
+                    prte_set_attribute(attrs,
+                                       (NULL != app) ? PRTE_APP_HWT_CPUS : PRTE_JOB_HWT_CPUS,
+                                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                 }
             } else {
-                if (NULL == jdata) {
+                if (NULL == attrs) {
                     prte_rmaps_base.hwthread_cpus = false;
                 } else {
-                    prte_set_attribute(&jdata->attributes, PRTE_JOB_CORE_CPUS,
+                    prte_set_attribute(attrs,
+                                       (NULL != app) ? PRTE_APP_CORE_CPUS : PRTE_JOB_CORE_CPUS,
                                        PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                 }
             }
@@ -338,7 +414,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
-            if (NULL == jdata) {
+            if (NULL == attrs) {
                 if (NULL != prte_rmaps_base.file) {
                     // cannot specify it twice
                     pmix_show_help("help-prte-rmaps-base.txt", "multiply-defined", true, "mapping policy",
@@ -348,8 +424,8 @@ static int check_modifiers(char *ck, prte_job_t *jdata, prte_mapping_policy_t *t
                 }
                 prte_rmaps_base.file = strdup(&ck2[i][5]);
             } else {
-                prte_set_attribute(&jdata->attributes, PRTE_JOB_FILE, PRTE_ATTR_GLOBAL,
-                                   &ck2[i][5], PMIX_STRING);
+                prte_set_attribute(attrs, (NULL != app) ? PRTE_APP_MAP_FILE : PRTE_JOB_FILE,
+                                   PRTE_ATTR_GLOBAL, &ck2[i][5], PMIX_STRING);
             }
 
         } else {
@@ -523,7 +599,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                                 "%s rmaps:base policy %s modifiers %s provided",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ck[0], cptr);
         }
-        if (PRTE_SUCCESS != (rc = check_modifiers(cptr, jdata, &tmp)) &&
+        if (PRTE_SUCCESS != (rc = check_modifiers(cptr, jdata, NULL, &tmp)) &&
             PRTE_ERR_TAKE_NEXT_OPTION != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
@@ -546,7 +622,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
      * mapping policy for us to set, but we still
      * have to process the modifier */
     if (':' == inspec[0]) {
-        if (PRTE_SUCCESS != (rc = check_modifiers(&inspec[1], jdata, &tmp)) &&
+        if (PRTE_SUCCESS != (rc = check_modifiers(&inspec[1], jdata, NULL, &tmp)) &&
             PRTE_ERR_TAKE_NEXT_OPTION != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
                 pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
@@ -840,13 +916,12 @@ int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec)
  */
 int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec)
 {
-    char **ck, **range;
+    char **ck;
     char *ptr, *cptr, *val;
     prte_mapping_policy_t tmp;
-    int n;
+    int rc;
     bool ppr = false;
     uint16_t u16;
-    char *temp_token, *parm_delimiter;
 
     tmp = 0;
 
@@ -876,95 +951,21 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         } else {
             PMIX_ARGV_JOIN(cptr, &ck[1], ':');
         }
-        /* process modifiers, rejecting job-level-only ones */
-        char **ck2 = PMIx_Argv_split(cptr, ':');
-        for (int i = 0; NULL != ck2[i]; i++) {
-            if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_OVERSUB) ||
-                PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOOVER)) {
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                PMIx_Argv_free(ck);
-                free(cptr);
-                return PRTE_ERR_BAD_PARAM;
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_INHERIT) ||
-                       PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOINHERIT)) {
-                pmix_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
-                               "per-app mapping policy", ck2[i]);
-                PMIx_Argv_free(ck2);
-                PMIx_Argv_free(ck);
-                free(cptr);
-                return PRTE_ERR_BAD_PARAM;
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOLOCAL)) {
-                PRTE_SET_MAPPING_DIRECTIVE(tmp, PRTE_MAPPING_NO_USE_LOCAL);
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_PE)) {
-                u16 = (uint16_t)strtol(&ck2[i][3], &ptr, 10);
-                if ('\0' != *ptr) {
-                    pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                   "mapping policy", "PE", ck2[i]);
-                    PMIx_Argv_free(ck2);
-                    PMIx_Argv_free(ck);
-                    free(cptr);
-                    return PRTE_ERR_SILENT;
-                }
-                prte_set_attribute(&app->attributes, PRTE_APP_PES_PER_PROC,
-                                   PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_HWTCPUS)) {
-                prte_set_attribute(&app->attributes, PRTE_APP_HWT_CPUS,
-                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_CORECPUS)) {
-                prte_set_attribute(&app->attributes, PRTE_APP_CORE_CPUS,
-                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_QFILE)) {
-                if ('\0' == ck2[i][5]) {
-                    pmix_show_help("help-prte-rmaps-base.txt", "missing-value", true,
-                                   "mapping policy", "FILE", ck2[i]);
-                    PMIx_Argv_free(ck2);
-                    PMIx_Argv_free(ck);
-                    free(cptr);
-                    return PRTE_ERR_SILENT;
-                }
-                prte_set_attribute(&app->attributes, PRTE_APP_MAP_FILE,
-                                   PRTE_ATTR_GLOBAL, &ck2[i][5], PMIX_STRING);
-            } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_PELIST)) {
-                /* validate comma-delimited ranges */
-                temp_token = strtok(&ck2[i][8], ",");
-                while (NULL != temp_token) {
-                    range = PMIx_Argv_split(temp_token, '-');
-                    if (2 < PMIx_Argv_count(range)) {
-                        pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                       "mapping", "PE-LIST", ck2[i]);
-                        PMIx_Argv_free(range);
-                        PMIx_Argv_free(ck2);
-                        PMIx_Argv_free(ck);
-                        free(cptr);
-                        return PRTE_ERR_SILENT;
-                    }
-                    for (n = 0; NULL != range[n]; n++) {
-                        (void)strtol(range[n], &parm_delimiter, 10);
-                        if ('\0' != *parm_delimiter) {
-                            pmix_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
-                                           "mapping", "PE-LIST", &ck2[i][8]);
-                            PMIx_Argv_free(range);
-                            PMIx_Argv_free(ck2);
-                            PMIx_Argv_free(ck);
-                            free(cptr);
-                            return PRTE_ERR_SILENT;
-                        }
-                    }
-                    PMIx_Argv_free(range);
-                    temp_token = strtok(NULL, ",");
-                }
-                prte_set_attribute(&app->attributes, PRTE_APP_CPUSET,
-                                   PRTE_ATTR_GLOBAL, &ck2[i][8], PMIX_STRING);
-            } else {
-                PMIx_Argv_free(ck2);
-                PMIx_Argv_free(ck);
-                free(cptr);
-                return PRTE_ERR_BAD_PARAM;
+        /* Parse the qualifiers with the same code every other level uses.
+         * check_modifiers() refuses the ones that necessarily span the whole
+         * job, so a per-app spec still cannot carry OVERSUBSCRIBE,
+         * NOOVERSUBSCRIBE, INHERIT or NOINHERIT. */
+        rc = check_modifiers(cptr, NULL, app, &tmp);
+        if (PRTE_SUCCESS != rc) {
+            if (PRTE_ERR_BAD_PARAM == rc) {
+                pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier",
+                               true, cptr);
+                rc = PRTE_ERR_SILENT;
             }
+            PMIx_Argv_free(ck);
+            free(cptr);
+            return rc;
         }
-        PMIx_Argv_free(ck2);
         free(cptr);
         if (ppr) {
             PMIx_Argv_free(ck);

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -290,9 +290,13 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
      * reset to BIND_TO_NONE only if this app genuinely oversubscribes a node.
      * When the app changed neither, the job-level binding stands. */
     have_bind = prte_get_attribute(&app->attributes, PRTE_APP_BINDTO, (void **)&u16ptr, PMIX_UINT16);
+    opts->appbind = 0;
     if (have_bind) {
         opts->bind = PRTE_GET_BINDING_POLICY(u16);
         opts->overload = (0 != PRTE_BIND_OVERLOAD_ALLOWED(u16));
+        /* keep the whole word: the app asked for this binding, so its own
+         * directives - IF-SUPPORTED above all - describe it, not the job's */
+        opts->appbind = u16;
     } else if (have_map) {
         opts->bind = prte_rmaps_base_derive_binding(opts);
     }
@@ -305,15 +309,6 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
     return PRTE_SUCCESS;
 }
 
-/* Record the effective map/rank/bind policies for one app of a per-app
- * (MPMD) job so the map display can show a policy line per app. The bare
- * resolved policies in opts are overlaid onto snapshots of the job-level
- * policy values (captured before the per-app loop so a prior app's mapper
- * adjustments cannot bleed through), preserving the job-wide directive bits
- * - oversubscribe, if-supported, span, and so on. The binding policy in opts
- * reflects any reset to BIND_TO_NONE the mapper made for a genuinely
- * oversubscribed node. These are stored as job-local attributes and are never
- * packed or sent off-node. */
 /* return the per-node scratch cpusets a mapper computed into an options
  * struct. The mappers recycle these as they walk the node list, so the
  * final node's pair is still held when the map returns. */
@@ -334,6 +329,23 @@ static void free_cpusets(prte_rmaps_options_t *opts)
     free_target(opts);
 }
 
+/* Record the effective map/rank/bind policies for one app of a per-app
+ * (MPMD) job so the map display can show a policy line per app. The bare
+ * resolved policies in opts are overlaid onto snapshots of the job-level
+ * policy values (captured before the per-app loop so a prior app's mapper
+ * adjustments cannot bleed through), preserving the job-wide directive bits
+ * - oversubscribe, span, and so on. The binding policy in opts reflects any
+ * reset to BIND_TO_NONE the mapper made for a genuinely oversubscribed node.
+ *
+ * Binding is the exception to taking the job's directives: an app that gave
+ * its own --bind-to described that binding itself, so its own word supplies
+ * the directives. Otherwise an explicit "--bind-to numa" was reported as
+ * NUMA:IF-SUPPORTED - the job's binding is a derived default whenever the
+ * apps each gave their own, and a derived default is best-effort - telling
+ * the user their requirement was merely a preference.
+ *
+ * These are stored as job-local attributes and are never packed or sent
+ * off-node. */
 static void record_resolved_app_policy(prte_app_context_t *app,
                                        prte_mapping_policy_t jobmap,
                                        prte_ranking_policy_t jobrank,
@@ -342,7 +354,7 @@ static void record_resolved_app_policy(prte_app_context_t *app,
 {
     prte_mapping_policy_t emap = jobmap;
     prte_ranking_policy_t erank = jobrank;
-    prte_binding_policy_t ebind = jobbind;
+    prte_binding_policy_t ebind = (0 == opts->appbind) ? jobbind : opts->appbind;
 
     PRTE_SET_MAPPING_POLICY(emap, opts->map);
     if (opts->mapspan) {

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -403,6 +403,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     int slots, len;
     bool flag, *fptr;
     bool map_succeeded = false;
+    prte_mapping_policy_t job_oversub = 0;
 
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -441,6 +442,20 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         options.limit = u16;
         // reset any prior counters
         prte_hwloc_base_reset_counters();
+    }
+
+    /* an app's mapping spec may carry a qualifier that describes the whole
+     * job - take those off the apps now, while the job's own directives are
+     * still as the user gave them, and hold the apps to agreeing about them.
+     * The oversubscription answer is applied further down, once the job's
+     * mapping policy has been resolved (that resolution assigns the whole
+     * policy word and would otherwise overwrite it) */
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &job_oversub);
+    if (PRTE_SUCCESS != rc) {
+        // the error message has been printed
+        jdata->exit_code = rc;
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+        goto cleanup;
     }
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
@@ -733,6 +748,18 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     }
     if (NULL != nptr) {
         PMIX_PROC_RELEASE(nptr);
+    }
+
+    /* apply the oversubscription answer hoisted off the apps. It goes on
+     * before the parent's flag is considered below: the user saying so on
+     * this command line outranks whatever the parent job was given */
+    if (0 != job_oversub) {
+        if (PRTE_MAPPING_NO_OVERSUBSCRIBE & job_oversub) {
+            PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+        } else {
+            PRTE_UNSET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+        }
+        PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
     }
 
     /* we always inherit a parent's oversubscribe flag unless the job assigned it */

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,6 +109,11 @@ typedef struct {
 
     /* binding values */
     prte_binding_policy_t bind;
+    /* the full binding policy word of an app that gave its own --bind-to,
+     * directives and all; zero when the app gave none and the job's stand.
+     * Only the map display reads it - "bind" carries the bare policy the
+     * mappers use */
+    prte_binding_policy_t appbind;
     bool dobind;
     hwloc_obj_type_t hwb;
     uint16_t limit;

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -48,6 +48,15 @@ typedef struct {
     pmix_list_item_t super;
     pmix_app_t app;
     void *info;
+    /* The mapping/ranking/binding directives this app segment carried, held
+     * aside until the whole cmd line has been parsed. Only then is it known
+     * whether they are per-app at all: a directive given just once applies
+     * to the entire job however many apps there are, so it belongs in the
+     * job's spec, not in any app's. prte_parse_locals() decides and
+     * distributes them. */
+    char *mapby;
+    char *rankby;
+    char *bindto;
 } prte_pmix_app_t;
 PMIX_CLASS_DECLARATION(prte_pmix_app_t);
 

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -533,11 +533,17 @@ static void acon(prte_pmix_app_t *p)
 {
     PMIX_APP_CONSTRUCT(&p->app);
     PMIX_INFO_LIST_START(p->info);
+    p->mapby = NULL;
+    p->rankby = NULL;
+    p->bindto = NULL;
 }
 static void ades(prte_pmix_app_t *p)
 {
     PMIX_APP_DESTRUCT(&p->app);
     PMIX_INFO_LIST_RELEASE(p->info);
+    free(p->mapby);
+    free(p->rankby);
+    free(p->bindto);
 }
 PMIX_CLASS_INSTANCE(prte_pmix_app_t, pmix_list_item_t, acon, ades);
 

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1089,6 +1089,18 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     /* setup to capture job-level info */
     PMIX_INFO_LIST_START(jinfo);
 
+    /* Carry over the mapping/ranking/binding directives the app parser
+     * determined belong to the job rather than to any one app - a directive
+     * given once applies to the whole job, however many apps were given.
+     * The rest of the jobdata list (prefixes) is examined separately above. */
+    PMIX_LIST_FOREACH(iprteinfo, &jobdata, prte_info_item_t) {
+        if (PMIx_Check_key(iprteinfo->info.key, PMIX_MAPBY) ||
+            PMIx_Check_key(iprteinfo->info.key, PMIX_RANKBY) ||
+            PMIx_Check_key(iprteinfo->info.key, PMIX_BINDTO)) {
+            PMIX_INFO_LIST_XFER(ret, jinfo, &iprteinfo->info);
+        }
+    }
+
     /* see if we ourselves were spawned by someone */
     PMIX_LOAD_PROCID(&pname, myproc.nspace, PMIX_RANK_WILDCARD);
     ret = PMIx_Get(&pname, PMIX_PARENT_ID, NULL, 0, &val);

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -513,20 +513,22 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PREFIX, NULL, PMIX_STRING);
     }
 
-    // check for a mapping directive - we don't allow you to change the base
-    // mapper (e.g., from ppr to map-by core), but you could change the pe=N
-    // value or the ppr number itself
+    // Hold the mapping/ranking/binding directives on the app object rather
+    // than adding them to its spec. Whether they are per-app at all is not
+    // known until every segment has been parsed - one directive applies to
+    // the whole job, however many apps there are - so prte_parse_locals()
+    // makes that call once it has seen them all.
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_MAPBY);
     if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_MAPBY, opt->values[0], PMIX_STRING);
+        app->mapby = strdup(opt->values[0]);
     }
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_RANKBY);
     if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_RANKBY, opt->values[0], PMIX_STRING);
+        app->rankby = strdup(opt->values[0]);
     }
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_BINDTO);
     if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_BINDTO, opt->values[0], PMIX_STRING);
+        app->bindto = strdup(opt->values[0]);
     }
 
     *app_ptr = app;
@@ -541,6 +543,83 @@ cleanup:
     }
     PMIX_DESTRUCT(&results);
     return rc;
+}
+
+/*
+ * Hand out one class of directive (mapping, ranking or binding) once the
+ * whole cmd line has been parsed.
+ *
+ * A directive given only once applies to the entire job - even when several
+ * apps were given - because that is the only reading under which the apps
+ * can differ at all: they differ when the user says so more than once. So a
+ * lone directive goes to the job and is left out of every app's spec, which
+ * is also what lets it carry a qualifier that spans the job (OVERSUBSCRIBE
+ * and friends) - those are refused in an app's spec, and used to be refused
+ * even when the user had given exactly one directive for one app.
+ *
+ * Two or more, and each app keeps its own.
+ */
+static int distribute_directive(pmix_list_t *apps, pmix_list_t *jobdata,
+                                size_t offset, const char *key)
+{
+    prte_pmix_app_t *app;
+    prte_info_item_t *item;
+    char **held;
+    int count = 0, rc;
+
+    PMIX_LIST_FOREACH(app, apps, prte_pmix_app_t) {
+        held = (char **) ((char *) app + offset);
+        if (NULL != *held) {
+            ++count;
+        }
+    }
+    if (0 == count) {
+        return PRTE_SUCCESS;
+    }
+
+    if (1 < count) {
+        /* the user distinguished the apps - give each its own */
+        PMIX_LIST_FOREACH(app, apps, prte_pmix_app_t) {
+            held = (char **) ((char *) app + offset);
+            if (NULL != *held) {
+                PMIX_INFO_LIST_ADD(rc, app->info, key, *held, PMIX_STRING);
+                if (PMIX_SUCCESS != rc) {
+                    return prte_pmix_convert_status(rc);
+                }
+            }
+        }
+        return PRTE_SUCCESS;
+    }
+
+    /* exactly one - it belongs to the job */
+    if (NULL == jobdata) {
+        /* nowhere to put it - leave it with the app that carried it so the
+         * directive is not simply lost */
+        PMIX_LIST_FOREACH(app, apps, prte_pmix_app_t) {
+            held = (char **) ((char *) app + offset);
+            if (NULL != *held) {
+                PMIX_INFO_LIST_ADD(rc, app->info, key, *held, PMIX_STRING);
+                if (PMIX_SUCCESS != rc) {
+                    return prte_pmix_convert_status(rc);
+                }
+            }
+        }
+        return PRTE_SUCCESS;
+    }
+    PMIX_LIST_FOREACH(app, apps, prte_pmix_app_t) {
+        held = (char **) ((char *) app + offset);
+        if (NULL == *held) {
+            continue;
+        }
+        item = PMIX_NEW(prte_info_item_t);
+        if (NULL == item) {
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        PMIX_INFO_LOAD(&item->info, key, *held, PMIX_STRING);
+        pmix_list_append(jobdata, &item->super);
+        break;
+    }
+    return PRTE_SUCCESS;
 }
 
 int prte_parse_locals(prte_schizo_base_module_t *schizo,
@@ -609,6 +688,24 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
         PMIx_Argv_free(env);
     }
     PMIx_Argv_free(temp_argv);
+
+    /* every segment has now been seen, so it can be decided whether the
+     * mapping/ranking/binding directives are per-app or belong to the job */
+    rc = distribute_directive(jdata, jobdata,
+                              offsetof(prte_pmix_app_t, mapby), PMIX_MAPBY);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+    rc = distribute_directive(jdata, jobdata,
+                              offsetof(prte_pmix_app_t, rankby), PMIX_RANKBY);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+    rc = distribute_directive(jdata, jobdata,
+                              offsetof(prte_pmix_app_t, bindto), PMIX_BINDTO);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
 
     /* All done */
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -325,7 +325,8 @@ int prun_common(pmix_cli_result_t *results,
     int rc = 1;
     char *param, *ptr;
     prte_pmix_lock_t lock, rellock;
-    pmix_list_t apps;
+    pmix_list_t apps, jobdata;
+    prte_info_item_t *iprteinfo;
     prte_pmix_app_t *app;
     void *tinfo, *jinfo;
     pmix_info_t info, *iptr;
@@ -603,12 +604,19 @@ int prun_common(pmix_cli_result_t *results,
     /* they want to run an application, so let's parse
      * the cmd line to get it */
 
-    rc = prte_parse_locals(schizo, &apps, pargv, NULL, NULL, NULL);
+    PMIX_CONSTRUCT(&jobdata, pmix_list_t);
+    rc = prte_parse_locals(schizo, &apps, pargv, NULL, NULL, &jobdata);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        PMIX_LIST_DESTRUCT(&jobdata);
         PMIX_LIST_DESTRUCT(&apps);
         goto DONE;
     }
+    /* anything the parser determined to be job-level goes into the job spec */
+    PMIX_LIST_FOREACH(iprteinfo, &jobdata, prte_info_item_t) {
+        PMIX_INFO_LIST_XFER(ret, jinfo, &iprteinfo->info);
+    }
+    PMIX_LIST_DESTRUCT(&jobdata);
 
     /* bozo check */
     if (0 == pmix_list_get_size(&apps)) {
@@ -848,22 +856,12 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_STDIN_TGT, opt->values[0], PMIX_STRING);
     }
 
-    opt = pmix_cmd_line_get_param(results, PRTE_CLI_MAPBY);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MAPBY, opt->values[0], PMIX_STRING);
-    }
-
-    /* if the user specified a ranking policy, then set it */
-    opt = pmix_cmd_line_get_param(results, PRTE_CLI_RANKBY);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RANKBY, opt->values[0], PMIX_STRING);
-    }
-
-    /* if the user specified a binding policy, then set it */
-    opt = pmix_cmd_line_get_param(results, PRTE_CLI_BINDTO);
-    if (NULL != opt) {
-        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_BINDTO, opt->values[0], PMIX_STRING);
-    }
+    /* The mapping, ranking and binding directives are NOT taken from the
+     * global parse: it stops at the first app, so it cannot see a directive
+     * the user attached to a later one, and it cannot tell how many were
+     * given. prte_parse_locals() sees every segment and decides - a lone
+     * directive is the job's, several are the apps' - handing the job's back
+     * on the jobdata list, which is transferred into jinfo above. */
 
     /* check for an exec agent */
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_EXEC_AGENT);

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -710,6 +710,17 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
                  * look it up on global pool
                  */
                 nodeidx = strtol(&node_from_file->name[2], NULL, 10);
+                /* "+n#" indexes the ALLOCATION from zero. The head node
+                 * always occupies pool slot 0, so when it is not part of
+                 * the allocation the pool is offset by one and the index
+                 * has to be adjusted - otherwise "+n0" in a hostfile names
+                 * a node the job was never given, and every index is one
+                 * node adrift of the same index given to --host.
+                 * prte_util_get_ordered_host_list() and dash-host's
+                 * parse_dash_host() both make this adjustment. */
+                if (!prte_hnp_is_allocated) {
+                    nodeidx++;
+                }
                 node_from_pool = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
                 if (NULL == node_from_pool) {
                     /* this is an error */

--- a/test/offline/golden/test-topo/perapp.test-topo.jobqual.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.jobqual.map
@@ -1,0 +1,41 @@
+
+========================   JOB MAP   ========================
+Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
+    App 0: Mapping policy: BYSLOT:OVERSUBSCRIBE  Ranking policy: SLOT  Binding policy: NUMA:IF-SUPPORTED
+    App 1: Mapping policy: BYNODE:OVERSUBSCRIBE  Ranking policy: NODE  Binding policy: NONE:IF-SUPPORTED
+    Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
+
+
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 13
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 3 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 4 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 5 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 6 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 14 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 17 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 20 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 23 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 26 Bound: N/A
+
+Data for node: node1	Num slots: 8	Max slots: 0	Num procs: 11
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L0-43]
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 15 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 18 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 21 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 24 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 27 Bound: N/A
+
+Data for node: node2	Num slots: 8	Max slots: 0	Num procs: 4
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 16 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 19 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 22 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 25 Bound: N/A

--- a/test/offline/golden/test-topo2/perapp.test-topo2.jobqual.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.jobqual.map
@@ -1,0 +1,41 @@
+
+========================   JOB MAP   ========================
+Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
+    App 0: Mapping policy: BYSLOT:OVERSUBSCRIBE  Ranking policy: SLOT  Binding policy: NUMA:IF-SUPPORTED
+    App 1: Mapping policy: BYNODE:OVERSUBSCRIBE  Ranking policy: NODE  Binding policy: NONE:IF-SUPPORTED
+    Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
+
+
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 13
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 3 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 4 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 5 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 6 Bound: package[0][core:L6-11]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L6-11]
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 14 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 17 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 20 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 23 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 26 Bound: N/A
+
+Data for node: node1	Num slots: 8	Max slots: 0	Num procs: 11
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L0-5]
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 15 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 18 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 21 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 24 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 27 Bound: N/A
+
+Data for node: node2	Num slots: 8	Max slots: 0	Num procs: 4
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 16 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 19 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 22 Bound: N/A
+        Process jobid: prterun-JOBID@N App: 1 Process rank: 25 Bound: N/A

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -499,9 +499,8 @@ class Case:
     expect: str = "map"          # "map" | "reject"
     expect_banner: str = None    # substring expected on reject
     # value pinned for rmaps_default_mapping_policy; "" = the no-directive
-    # baseline. A case that needs the DVM default to permit oversubscription
-    # sets ":oversubscribe" here (OVERSUBSCRIBE cannot be given as a per-app
-    # --map-by qualifier, so it must come from the default policy).
+    # baseline. A case that wants oversubscription to come from the DVM
+    # default rather than from the command line sets ":oversubscribe" here.
     default_map_policy: str = ""
 
 
@@ -545,25 +544,20 @@ def negative_cases(topo):
         yield Case(cid, "negative", topo, "even", hostspec, pool, n=4,
                    expect="reject", expect_banner=banner, **kw)
 
-    # A qualifier whose effect spans the whole job cannot be attached to one
-    # app of several: one app cannot oversubscribe its nodes while its
-    # siblings do not.  It takes TWO directives to make this per-app at all -
-    # with only one on the cmd line the directive is the job's, however many
-    # apps there are, and "--map-by core:nooversubscribe" is then perfectly
-    # legal.  (It used to be refused, because a lone directive was copied
-    # into the app spec as well as the job's and then judged as if the user
-    # had attached it to that app.)
+    # A qualifier whose effect spans the whole job may be written in one app's
+    # spec - see perapp.jobqual below - but the apps have to agree about it.
+    # One app cannot oversubscribe its nodes while its siblings refuse to.
     yield Case("negative.%s.perappmod" % topo.name, "negative", topo, "even",
                hostspec, pool,
-               apps=[AppSpec(2, map_by="core"),
+               apps=[AppSpec(2, map_by="core:oversubscribe"),
                      AppSpec(2, map_by="node:nooversubscribe")],
-               expect="reject", expect_banner="not supported")
+               expect="reject", expect_banner="conflicting values")
 
 
 def group_cases(topo):
-    # oversubscribe: more procs than slots. OVERSUBSCRIBE cannot be a per-app
-    # --map-by qualifier, so this case permits it through the DVM default
-    # mapping policy instead (pinned per-case, keeping the harness hermetic).
+    # oversubscribe: more procs than slots, permitted through the DVM default
+    # mapping policy (pinned per-case, keeping the harness hermetic) rather
+    # than the command line - perapp.jobqual covers the command-line form.
     hostspec, pool = LAYOUTS["uneven"]   # 12 slots
     total = sum(s for _, s in pool)
     yield Case("group.%s.oversub" % topo.name, "oversubscribe", topo,
@@ -612,6 +606,19 @@ def perapp_cases(topo):
     yield Case("perapp.%s.rank.node-slot" % topo.name, "perapp", topo, "even",
                hostspec, pool,
                apps=[AppSpec(4, rank_by="node"), AppSpec(4, rank_by="slot")],
+               expect="map")
+
+    # A qualifier that describes the whole job, written in one app's spec.
+    # Two mapping directives are what makes the mapping per-app, and once the
+    # line is per-app there is no job-level directive left to hang
+    # OVERSUBSCRIBE on - so it has to be legal here, and it has to apply to
+    # the job: 28 procs onto 24 slots maps only if it did.  (It used to be
+    # refused outright, leaving a multi-app command line with no way to ask
+    # for oversubscription at all.)
+    yield Case("perapp.%s.jobqual" % topo.name, "perapp", topo, "even",
+               hostspec, pool,
+               apps=[AppSpec(14, map_by="slot:oversubscribe"),
+                     AppSpec(14, map_by="node")],
                expect="map")
 
     # three app contexts, three different object maps, default rank/bind each.

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -539,12 +539,25 @@ def negative_cases(topo):
         ("badmap", dict(map_by="bogus"), "Valid directives"),
         ("badrank", dict(rank_by="bogus"), "Valid directives"),
         ("rankcore", dict(rank_by="core"), "Valid directives"),
-        ("dfltmod", dict(map_by="core:nooversubscribe"), "not supported"),
     ]
     for name, kw, banner in bad:
         cid = "negative.%s.%s" % (topo.name, name)
         yield Case(cid, "negative", topo, "even", hostspec, pool, n=4,
                    expect="reject", expect_banner=banner, **kw)
+
+    # A qualifier whose effect spans the whole job cannot be attached to one
+    # app of several: one app cannot oversubscribe its nodes while its
+    # siblings do not.  It takes TWO directives to make this per-app at all -
+    # with only one on the cmd line the directive is the job's, however many
+    # apps there are, and "--map-by core:nooversubscribe" is then perfectly
+    # legal.  (It used to be refused, because a lone directive was copied
+    # into the app spec as well as the job's and then judged as if the user
+    # had attached it to that app.)
+    yield Case("negative.%s.perappmod" % topo.name, "negative", topo, "even",
+               hostspec, pool,
+               apps=[AppSpec(2, map_by="core"),
+                     AppSpec(2, map_by="node:nooversubscribe")],
+               expect="reject", expect_banner="not supported")
 
 
 def group_cases(topo):

--- a/test/unit/rmaps/Makefile.am
+++ b/test/unit/rmaps/Makefile.am
@@ -12,6 +12,7 @@ check_PROGRAMS = test_rmaps
 test_rmaps_SOURCES = \
     test_rmaps_main.c      \
     test_policy_parse.c    \
+    test_job_qualifiers.c  \
     test_resolve_options.c \
     test_dispatch.c        \
     test_round_robin.c     \

--- a/test/unit/rmaps/test_job_qualifiers.c
+++ b/test/unit/rmaps/test_job_qualifiers.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Tests prte_rmaps_base_hoist_job_directives(), the step that takes the
+ * qualifiers describing the whole job off the apps that carried them.
+ *
+ * A user with several apps on the command line has nowhere else to write
+ * OVERSUBSCRIBE: it takes two mapping directives to make the mapping per-app
+ * at all, and once the line is per-app there is no job-level directive left
+ * to hang the qualifier on.  So a per-app spec may carry it, and this is
+ * where it becomes the job's - and where the one thing that cannot be
+ * honored, two apps asking for opposite things, is refused.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/runtime/prte_globals.h"
+#include "src/mca/rmaps/base/base.h"
+#include "src/mca/rmaps/rmaps_types.h"
+#include "src/hwloc/hwloc-internal.h"
+#include "src/util/attr.h"
+
+int test_job_qualifiers(void);
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);          \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+/* a job of napps apps, each app's mapping spec taken from specs[] (NULL
+ * entries get no --map-by at all) */
+static prte_job_t *build_job(char **specs, int napps)
+{
+    prte_job_t *jdata;
+    prte_app_context_t *app;
+    int n;
+
+    jdata = PMIX_NEW(prte_job_t);
+    jdata->map = PMIX_NEW(prte_job_map_t);
+    for (n = 0; n < napps; n++) {
+        app = PMIX_NEW(prte_app_context_t);
+        app->app = strdup("hostname");
+        app->idx = pmix_pointer_array_add(jdata->apps, app);
+        jdata->num_apps++;
+        if (NULL != specs[n]) {
+            (void) prte_rmaps_base_set_app_mapping_policy(app, specs[n]);
+        }
+    }
+    return jdata;
+}
+
+static prte_app_context_t *appn(prte_job_t *jdata, int n)
+{
+    return (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, n);
+}
+
+int test_job_qualifiers(void)
+{
+    int failures = 0;
+    int rc;
+    prte_job_t *jdata;
+    prte_mapping_policy_t oversub;
+    uint16_t u16;
+    uint16_t *u16ptr = &u16;
+    char *specs[2];
+
+    /* === one app of two carries OVERSUBSCRIBE: it becomes the job's === */
+    specs[0] = "core";
+    specs[1] = "node:oversubscribe";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("oversub on one app: rc", PRTE_SUCCESS == rc);
+    CHECK("oversub on one app: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & oversub);
+    CHECK("oversub on one app: allowed", !(PRTE_MAPPING_NO_OVERSUBSCRIBE & oversub));
+    /* the app keeps its own mapping policy, and only that */
+    u16 = 0;
+    CHECK("oversub on one app: app keeps map-by",
+          prte_get_attribute(&appn(jdata, 1)->attributes, PRTE_APP_MAPBY,
+                             (void **) &u16ptr, PMIX_UINT16));
+    CHECK("oversub on one app: app policy intact",
+          PRTE_MAPPING_BYNODE == PRTE_GET_MAPPING_POLICY(u16));
+    CHECK("oversub on one app: app no longer carries it",
+          !(PRTE_MAPPING_SUBSCRIBE_GIVEN & u16));
+    PMIX_RELEASE(jdata);
+
+    /* === agreeing apps are fine, however many say it === */
+    specs[0] = "core:nooversubscribe";
+    specs[1] = "node:nooversubscribe";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("agreeing apps: rc", PRTE_SUCCESS == rc);
+    CHECK("agreeing apps: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & oversub);
+    CHECK("agreeing apps: denied", PRTE_MAPPING_NO_OVERSUBSCRIBE & oversub);
+    PMIX_RELEASE(jdata);
+
+    /* === opposite answers cannot both be honored === */
+    specs[0] = "core:oversubscribe";
+    specs[1] = "node:nooversubscribe";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("conflicting apps: refused", PRTE_ERR_SILENT == rc);
+    PMIX_RELEASE(jdata);
+
+    /* === an app must also agree with the job's own directive === */
+    specs[0] = NULL;
+    specs[1] = "node:oversubscribe";
+    jdata = build_job(specs, 2);
+    PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_NO_OVERSUBSCRIBE);
+    PRTE_SET_MAPPING_DIRECTIVE(jdata->map->mapping, PRTE_MAPPING_SUBSCRIBE_GIVEN);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("app vs job: refused", PRTE_ERR_SILENT == rc);
+    PMIX_RELEASE(jdata);
+
+    /* === a spec that was nothing but the qualifier leaves no per-app
+     * mapping behind, so the job is not dragged onto the per-app path === */
+    specs[0] = "core";
+    specs[1] = ":oversubscribe";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("qualifier-only spec: rc", PRTE_SUCCESS == rc);
+    CHECK("qualifier-only spec: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & oversub);
+    CHECK("qualifier-only spec: app has no map-by",
+          !prte_get_attribute(&appn(jdata, 1)->attributes, PRTE_APP_MAPBY,
+                              (void **) &u16ptr, PMIX_UINT16));
+    PMIX_RELEASE(jdata);
+
+    /* === INHERIT moves to the job === */
+    specs[0] = "core";
+    specs[1] = "node:inherit";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("inherit: rc", PRTE_SUCCESS == rc);
+    CHECK("inherit: on the job",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL));
+    CHECK("inherit: off the app",
+          !prte_get_attribute(&appn(jdata, 1)->attributes, PRTE_JOB_INHERIT,
+                              NULL, PMIX_BOOL));
+    PMIX_RELEASE(jdata);
+
+    /* === one app inheriting while another refuses to has no meaning === */
+    specs[0] = "core:inherit";
+    specs[1] = "node:noinherit";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("inherit vs noinherit: refused", PRTE_ERR_SILENT == rc);
+    PMIX_RELEASE(jdata);
+
+    /* === a job whose apps say nothing is left alone === */
+    specs[0] = "core";
+    specs[1] = "node";
+    jdata = build_job(specs, 2);
+    rc = prte_rmaps_base_hoist_job_directives(jdata, &oversub);
+    CHECK("silent apps: rc", PRTE_SUCCESS == rc);
+    CHECK("silent apps: nothing hoisted", 0 == oversub);
+    CHECK("silent apps: no inherit",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL));
+    PMIX_RELEASE(jdata);
+
+    return failures;
+}

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -129,28 +129,35 @@ int test_policy_parse(void)
     CHECK("mapby ppr:2:core: policy=PPR", PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(u16));
     PMIX_RELEASE(app);
 
+    /* --- rejected: the qualifiers that span the whole job ---
+     * These are refused in a per-app spec: one app cannot oversubscribe its
+     * nodes while its siblings do not.  PRTE_ERR_SILENT, not BAD_PARAM,
+     * because the parser has already told the user why - BAD_PARAM is
+     * reserved for a qualifier it does not recognize, and the caller turns
+     * that into a "check for a typo" message these must not attract.
+     */
     /* --- rejected: OVERSUBSCRIBE --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:oversubscribe");
-    CHECK("mapby OVERSUBSCRIBE: rejected", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("mapby OVERSUBSCRIBE: rejected", PRTE_ERR_SILENT == rc);
     PMIX_RELEASE(app);
 
     /* --- rejected: NOOVERSUBSCRIBE --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:nooversubscribe");
-    CHECK("mapby NOOVERSUBSCRIBE: rejected", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("mapby NOOVERSUBSCRIBE: rejected", PRTE_ERR_SILENT == rc);
     PMIX_RELEASE(app);
 
     /* --- rejected: INHERIT --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:inherit");
-    CHECK("mapby INHERIT: rejected", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("mapby INHERIT: rejected", PRTE_ERR_SILENT == rc);
     PMIX_RELEASE(app);
 
     /* --- rejected: NOINHERIT --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:noinherit");
-    CHECK("mapby NOINHERIT: rejected", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("mapby NOINHERIT: rejected", PRTE_ERR_SILENT == rc);
     PMIX_RELEASE(app);
 
     /* --- NULL spec is a no-op --- */

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,35 +129,68 @@ int test_policy_parse(void)
     CHECK("mapby ppr:2:core: policy=PPR", PRTE_MAPPING_PPR == PRTE_GET_MAPPING_POLICY(u16));
     PMIX_RELEASE(app);
 
-    /* --- rejected: the qualifiers that span the whole job ---
-     * These are refused in a per-app spec: one app cannot oversubscribe its
-     * nodes while its siblings do not.  PRTE_ERR_SILENT, not BAD_PARAM,
-     * because the parser has already told the user why - BAD_PARAM is
-     * reserved for a qualifier it does not recognize, and the caller turns
-     * that into a "check for a typo" message these must not attract.
+    /* --- the qualifiers that span the whole job ---
+     * These describe the job, not the app, but they are accepted in a per-app
+     * spec and recorded there: on a multi-app command line there is no other
+     * place to write them, since it takes two mapping directives to make the
+     * mapping per-app at all.  The hoist below is what moves them to the job
+     * and holds the apps to agreeing about them.
      */
-    /* --- rejected: OVERSUBSCRIBE --- */
+    /* --- OVERSUBSCRIBE --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:oversubscribe");
-    CHECK("mapby OVERSUBSCRIBE: rejected", PRTE_ERR_SILENT == rc);
+    CHECK("mapby OVERSUBSCRIBE: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby OVERSUBSCRIBE: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & u16);
+    CHECK("mapby OVERSUBSCRIBE: allowed", !(PRTE_MAPPING_NO_OVERSUBSCRIBE & u16));
     PMIX_RELEASE(app);
 
-    /* --- rejected: NOOVERSUBSCRIBE --- */
+    /* --- NOOVERSUBSCRIBE --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:nooversubscribe");
-    CHECK("mapby NOOVERSUBSCRIBE: rejected", PRTE_ERR_SILENT == rc);
+    CHECK("mapby NOOVERSUBSCRIBE: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby NOOVERSUBSCRIBE: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & u16);
+    CHECK("mapby NOOVERSUBSCRIBE: denied", PRTE_MAPPING_NO_OVERSUBSCRIBE & u16);
     PMIX_RELEASE(app);
 
-    /* --- rejected: INHERIT --- */
+    /* --- a spec that is nothing but a job-level qualifier.  It names no
+     * policy, so it used to be discarded without a word --- */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, ":oversubscribe");
+    CHECK("mapby :OVERSUBSCRIBE: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby :OVERSUBSCRIBE: given", PRTE_MAPPING_SUBSCRIBE_GIVEN & u16);
+    CHECK("mapby :OVERSUBSCRIBE: no policy", 0 == PRTE_GET_MAPPING_POLICY(u16));
+    PMIX_RELEASE(app);
+
+    /* --- INHERIT --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:inherit");
-    CHECK("mapby INHERIT: rejected", PRTE_ERR_SILENT == rc);
+    CHECK("mapby INHERIT: rc", PRTE_SUCCESS == rc);
+    CHECK("mapby INHERIT: flag", get_bool(&app->attributes, PRTE_JOB_INHERIT));
     PMIX_RELEASE(app);
 
-    /* --- rejected: NOINHERIT --- */
+    /* --- NOINHERIT --- */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "core:noinherit");
-    CHECK("mapby NOINHERIT: rejected", PRTE_ERR_SILENT == rc);
+    CHECK("mapby NOINHERIT: rc", PRTE_SUCCESS == rc);
+    CHECK("mapby NOINHERIT: flag", get_bool(&app->attributes, PRTE_JOB_NOINHERIT));
+    PMIX_RELEASE(app);
+
+    /* --- contradicting yourself within one spec is still refused.
+     * PRTE_ERR_SILENT, not BAD_PARAM, because the parser has already told the
+     * user why - BAD_PARAM is reserved for a qualifier it does not recognize,
+     * and the caller turns that into a "check for a typo" message this must
+     * not attract. --- */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "core:oversubscribe:nooversubscribe");
+    CHECK("mapby OVERSUB+NOOVERSUB: rejected", PRTE_ERR_SILENT == rc);
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "core:inherit:noinherit");
+    CHECK("mapby INHERIT+NOINHERIT: rejected", PRTE_ERR_SILENT == rc);
     PMIX_RELEASE(app);
 
     /* --- NULL spec is a no-op --- */

--- a/test/unit/rmaps/test_resolve_options.c
+++ b/test/unit/rmaps/test_resolve_options.c
@@ -144,6 +144,21 @@ int test_resolve_options(void)
     CHECK("bindovl: rc", PRTE_SUCCESS == prte_rmaps_base_resolve_app_options(NULL, app, &opts));
     CHECK("bindovl: bind masked", PRTE_BIND_TO_PACKAGE == opts.bind);  /* no overload bit in bind */
     CHECK("bindovl: overload flag", opts.overload);
+    /* the whole word is kept for the map display: an app that asked to bind
+     * describes that binding itself, so the display must not fall back on the
+     * job's binding directives and report the request as IF-SUPPORTED */
+    CHECK("bindovl: appbind kept", 0 != opts.appbind);
+    CHECK("bindovl: appbind not if-supported", !(PRTE_BIND_IF_SUPPORTED & opts.appbind));
+    CHECK("bindovl: appbind overload", 0 != PRTE_BIND_OVERLOAD_ALLOWED(opts.appbind));
+    PMIX_RELEASE(app);
+
+    /* === resolve: an app that gave only a map-by gets a *derived* binding,
+     *     which is best-effort - it must not claim the app asked for it === */
+    app = PMIX_NEW(prte_app_context_t);
+    prte_rmaps_base_set_app_mapping_policy(app, "package");
+    baseline(&opts);
+    CHECK("derivedbind: rc", PRTE_SUCCESS == prte_rmaps_base_resolve_app_options(NULL, app, &opts));
+    CHECK("derivedbind: no appbind", 0 == opts.appbind);
     PMIX_RELEASE(app);
 
     /* === resolve: pe=N and hwtcpus modifiers feed the cpu fields === */

--- a/test/unit/rmaps/test_rmaps_main.c
+++ b/test/unit/rmaps/test_rmaps_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2024-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -18,6 +18,7 @@
 #include "constants.h"
 
 extern int test_policy_parse(void);
+extern int test_job_qualifiers(void);
 extern int test_resolve_options(void);
 extern int test_dispatch(void);
 extern int test_round_robin(void);
@@ -81,6 +82,7 @@ int main(void)
     }
 
     failures += test_policy_parse();
+    failures += test_job_qualifiers();
     failures += test_resolve_options();
     failures += test_dispatch();
     failures += test_round_robin();


### PR DESCRIPTION
Follow-ups to #2560: one relative-node-indexing bug, and the documentation
that made it hard to see.

## `+n#` meant different nodes on the command line and in a hostfile

Relative node syntax counts the allocation from zero, so `+n0` is the first
node the job was given. The head node occupies node-pool slot 0 whether or not
it was allocated, so when it was not, the index has to skip it. `parse_dash_host()`
and `prte_util_get_ordered_host_list()` both do that; `prte_util_filter_hostfile_nodes()`
did not.

So with an allocation that excludes the head node — the only arrangement in
which they differ — `--host +n0` selected the allocation's first node while a
hostfile containing `+n0` selected the head node the job never had, and every
later index was one node adrift. The two forms are documented as
interchangeable.

Covered in `contrib/dockerswarm` by asking both entry points the same question
under a head-node-excluded allocation; the case fails without the fix.

## The relative-indexing page disagreed with itself

It also disagreed with the code and with the rankfile page it points at, which
says outright that `+n<X>` is "indexed from 0":

- The first example wants "the first two nodes" of `foo1..foo4` and writes
  `--host +n1,+n2`, which selects the second and third. Its `+n3,+n4` runs off
  the end and fails with `relative-node-not-found`.
- The hostfile example calls `+n2` "the second node" while its own expected
  results correctly name `dummy3`, the third.

Corrected, with the base of the index stated explicitly.

Finally, `detail-hosts-cli.rst` now records what `--host` does and does not do:
it selects among the hosts the DVM already has, and since #2560 naming anything
else is refused by name rather than silently dropped, so it points at
`--add-host`/`--add-hostfile` as the way to bring in a host that is not there.

## Verification

- `contrib/dockerswarm/run-tests.sh linux`: 122 passed, 0 failed, 0 skipped
- `make check` and `make -C test/offline check-offline` (1176 cases): pass on
  **both** Linux and native macOS
- docs build warning-free; both changes checked in the rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
