### PR TITLE
Require a PMIx that provides the CLI qualifier value helper

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -22,7 +22,7 @@ release=0
 # PRRTE required dependency versions.
 # List in x.y.z format.
 
-pmix_min_version=6.1.1
+pmix_min_version=7.0.0
 hwloc_min_version=2.1.0
 pmix_max_version=1000.0.0
 hwloc_min_version=1.11.0

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -244,13 +244,14 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
 
     AC_MSG_CHECKING([for PMIx command-line qualifier value support])
     PRTE_CHECK_PMIX_CAP([CLI_QUAL_VALUE],
-                        [AC_MSG_RESULT([yes])
-                         prte_pmix_have_cli_qual_value=1],
+                        [AC_MSG_RESULT([yes])],
                         [AC_MSG_RESULT([no])
-                         prte_pmix_have_cli_qual_value=0])
-    AC_DEFINE_UNQUOTED([PRTE_PMIX_HAVE_CLI_QUAL_VALUE],
-                       [$prte_pmix_have_cli_qual_value],
-                       [Whether PMIx provides pmix_cli_qualifier_value()])
+                         AC_MSG_WARN([PRRTE requires pmix_cli_qualifier_value(), which this])
+                         AC_MSG_WARN([PMIx does not provide. It reads the value of a command])
+                         AC_MSG_WARN([line qualifier - the text after its '=' - which cannot])
+                         AC_MSG_WARN([be done correctly outside PMIx, as the option matcher])
+                         AC_MSG_WARN([accepts any unambiguous prefix of a qualifier's name.])
+                         AC_MSG_ERROR([Please update PMIx and configure again])])
 
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -264,25 +264,10 @@ BEGIN_C_DECLS
  * and the caller therefore cannot know how long the name it matched was.
  * Never index past the qualifier's full spelling to reach its value.
  *
- * Older PMIx installations do not have it.  PRRTE still supports building
- * against those, so supply it here when the installed PMIx does not.
+ * There is deliberately no local fallback for a PMIx that lacks it.  A
+ * second implementation of a rule this easy to get wrong is a second thing
+ * to keep right; configure refuses such a PMIx instead.
  */
-#if !PRTE_PMIX_HAVE_CLI_QUAL_VALUE
-static inline char *prte_cli_qualifier_value_compat(char *qual)
-{
-    char *ptr;
-
-    if (NULL == qual) {
-        return NULL;
-    }
-    ptr = strchr(qual, '=');
-    if (NULL == ptr || '\0' == *(ptr + 1)) {
-        return NULL;
-    }
-    return ptr + 1;
-}
-#    define pmix_cli_qualifier_value(q) prte_cli_qualifier_value_compat(q)
-#endif
 
 END_C_DECLS
 


### PR DESCRIPTION
Follow-up to #2564, which landed `pmix_cli_qualifier_value()` usage behind a
capability check with a local fallback for older PMIx.

The fallback was a mistake: two implementations of one rule, needing parallel
attention and free to drift the moment either changed — which is exactly how
this class of bug arose in the first place. So drop it, and let configure
refuse a PMIx that cannot support PRRTE rather than quietly working around it.

The helper arrived in PMIx v7.0.0 (openpmix/openpmix#4035), so that becomes
PRRTE's minimum.

## What a user sees now

A PMIx below the minimum fails the version check:

```
checking version at or above v7.0.0... no
configure: WARNING: PRRTE requires PMIx v0x00070000 or above.
configure: error: Please select a supported version and configure again
```

A v7.0.0 that predates the helper fails the capability check, which says what
is missing and why it is not something PRRTE can paper over:

```
checking for PMIx command-line qualifier value support... no
configure: WARNING: PRRTE requires pmix_cli_qualifier_value(), which this
configure: WARNING: PMIx does not provide. It reads the value of a command
configure: WARNING: line qualifier - the text after its '=' - which cannot
configure: WARNING: be done correctly outside PMIx, as the option matcher
configure: WARNING: accepts any unambiguous prefix of a qualifier's name.
configure: error: Please update PMIx and configure again
```

## Testing

Both messages above are actual output, from configuring against PMIx v6.1.1
and against a v7.0.0 build predating the merge. Against current PMIx master
both checks pass and the suites are green: `make check` 10/10, the offline
mapping harness 1180/0, and the ten-node container suite 142/0. The
abbreviated qualifier forms (`P=2`, `L=1`, `F=path`) and the empty-value
rejection were re-checked by hand now that only the PMIx implementation is
reachable.

Note this raises the bar for anyone building PRRTE master: PMIx must be at
master (or a v7.0.0 that includes #4035). The container harness needs
`PMIX_SRC` pointed at such a checkout — its baked PMIx predates it and is now
correctly refused.
