### PR TITLE
schizo review: repair the CLI translation defects, fix envar directive ordering, add output filename patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ test/unit/rml/Makefile
 test/unit/rml/test_rml
 test/unit/ras/Makefile
 test/unit/ras/test_ras
+test/unit/schizo/Makefile
+test/unit/schizo/test_schizo
 static-components.h
 static-components.h.new.extern
 static-components.h.new.struct

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,7 +456,12 @@ make check
 
 Add new unit tests here, under the framework they cover, and wire them
 into the appropriate `Makefile.am` `TESTS =` list so `make check` picks
-them up.
+them up.  A new directory also needs a line in
+[`config/prte_config_files.m4`](config/prte_config_files.m4) (which
+means re-running `./autogen.pl` — see "Modifying the configure / build
+system" above), a `SUBDIRS` entry in
+[`test/unit/Makefile.am`](test/unit/Makefile.am), and the resulting test
+binary added to `.gitignore`.
 
 **Offline mapper harness (`make check-offline`).**  Mapping, ranking, and
 binding behavior can be exercised without launching anything.

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -41,5 +41,6 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/plm/Makefile
         test/unit/rml/Makefile
         test/unit/ras/Makefile
+        test/unit/schizo/Makefile
     ])
 ])

--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -253,6 +253,22 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                          AC_MSG_WARN([accepts any unambiguous prefix of a qualifier's name.])
                          AC_MSG_ERROR([Please update PMIx and configure again])])
 
+    dnl The "pattern" qualifier on "--output file=NAME" hands the naming of
+    dnl the output files to the user.  Expanding the pattern is PMIx's job -
+    dnl PMIx owns the IOF sinks and is the only place that knows the rank and
+    dnl namespace at the moment a file is opened - so without those helpers
+    dnl PRRTE has nothing to hand the request to, and says so rather than
+    dnl accepting a qualifier it cannot honor.
+    AC_MSG_CHECKING([for PMIx output-file pattern support])
+    PRTE_CHECK_PMIX_CAP([IOF_FILE_PATTERN],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_iof_file_pattern=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_iof_file_pattern=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_IOF_FILE_PATTERN],
+                       [$prte_pmix_iof_file_pattern],
+                       [Whether PMIx can expand an output-file name pattern])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -278,6 +278,51 @@ with `--prtemca prte_rml_radix 2`, the daemon tree is 3–4 deep, so the
 routing/relay is broken the fence hangs to the 60s timeout instead of
 completing.
 
+**Personalities and CLI translation (`schizo`, `test_schizo`)**: schizo is
+a front-end framework, so most of it is covered by `test/unit/schizo`
+with no DVM at all. Three things are only observable across daemons, and
+those are what this phase asserts:
+
+- the **envar directives** (`-x`, `--set/prepend/append/unset-env`) are
+  applied by `odls`' `process_envars()` on the `prted` that forks the
+  process, not by the tool — so the probe runs on node2/node3 and prints
+  its own environment. They must take effect **in the order the user gave
+  them** (`--prepend-env FOO[:] x --set-env FOO=1` leaves `FOO=1`; the
+  reverse leaves `FOO=x:1`), and each exactly once — they used to be
+  applied twice, which duplicated every entry prepended onto `PATH`.
+- **`--output file=…`** is written per-daemon, and its `:`-delimited
+  qualifiers (`raw`, `copy`/`nocopy`) decide whether the output is *also*
+  copied back over the wire. Both qualifier orders must behave the same;
+  they did not when the qualifier run was split on the wrong delimiter.
+  The `pattern` qualifier is checked here too: its `%` conversions may
+  appear in the **directory** part of the name (`%h/rank-%R`), so each
+  daemon creates the directory its own expansion names — which is exactly
+  what one host cannot show.
+- a job's **personality is resolved again on every daemon** (`odls` calls
+  `detect_proxy` with the job's personality list), so a personality
+  nobody claims must be refused with a diagnostic — and, on a persistent
+  DVM, refused without taking the HNP down.
+
+### The install persists too, so a failed build is silently testable
+
+Same shape as the sticky-configure-args trap below, one level up. The
+install lives in the shared volume and outlives any one `build.sh` run, so
+a build that dies part-way — `configure` rejecting the baked PMIx because
+it predates a capability PRRTE now requires is the everyday case — leaves
+the **previous** install standing. `run-tests.sh`'s "tools on PATH" check
+passes, the whole suite runs, and every failure it reports is really
+"you are testing something else".
+
+`build.sh` now deletes `/opt/prte/.build-stamp` before it starts and
+rewrites it only after `make install` succeeds; `run-tests.sh`'s preflight
+prints the stamp and refuses to run without one. If you see
+`no build stamp in the volume`, re-run `build.sh` and **read its exit
+status** — a redirected `./build.sh > log 2>&1; echo rc=$?` reports the
+`echo`'s status if you are not careful, which is how this was missed.
+
+If your PMIx is the thing `configure` rejected, build PMIx from source in
+the same container: `PMIX_SRC=/path/to/openpmix ./build.sh`.
+
 ### The build dirs persist, so configure arguments are sticky
 
 The VPATH build dirs live in the shared volume and outlive any one run.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -175,6 +175,10 @@ build_linux() {
                 echo ">>>> PMIx: using baked $PMIX_PREFIX"
             fi
 
+            # invalidate the freshness stamp up front: from here until the
+            # build finishes, whatever is installed is NOT this source tree
+            rm -f /opt/prte/.build-stamp
+
             echo ">>>> PRRTE VPATH build -> /opt/prte/prte"
             mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
             # --with-jansson is deliberate: it is off by default, and without
@@ -220,6 +224,15 @@ build_linux() {
             # runtime env for login shells (node-entrypoint handles ld.so)
             printf "export PATH=/opt/prte/prte/bin:\$PATH\nexport LD_LIBRARY_PATH=/opt/prte/prte/lib:%s/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\n" \
                 "$PMIX_PREFIX" > /opt/prte/env.sh
+
+            # Written LAST, and only on success.  The install lives in a
+            # volume that outlives any one build, so a build that fails
+            # part-way -- configure rejecting the baked PMIx is the usual way
+            # -- leaves the PREVIOUS install standing, and run-tests.sh will
+            # happily exercise it and report on code that was never built.
+            # The stamp is what lets the suite say so.  It is removed first so
+            # a build that dies midway cannot leave a stale one behind.
+            date -u +%Y-%m-%dT%H:%M:%SZ > /opt/prte/.build-stamp
             echo ">>>> done: install in /opt/prte/prte"
         '
     echo ">>> Linux build complete."

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -824,6 +824,287 @@ test_rmaps() {
     cleanup_swarm
 }
 
+########################################################################
+# schizo: personalities and CLI translation, end to end
+########################################################################
+#
+# test/unit/schizo covers the parsers themselves - argv normalization, the
+# sanity checker, the output/display converters, and each personality's
+# deprecated-option table - with no DVM at all.  What only a live,
+# multi-node DVM can show is that the *result* of that translation survives
+# the trip to a remote daemon:
+#
+#   - the envar directives (-x, --set-env, --prepend-env, --append-env,
+#     --unset-env) are applied by prte_schizo_base_setup_fork() on the prted
+#     that forks the process, not by the tool.  The only place to see whether
+#     they were applied - and applied in the right order - is a REMOTE proc's
+#     own environment.
+#   - --output file=... is written by each daemon.  Its ':'-delimited
+#     qualifiers (raw, copy/nocopy) decide whether output is also copied back
+#     over the wire, so file-vs-stdout is a cross-daemon observation.
+#   - a job's personality is resolved again on every daemon (odls looks it up
+#     with detect_proxy from the job's personality list), so a personality
+#     the daemons cannot resolve is a launch-time failure, not a CLI one.
+#
+# The ompi personality gates root execution on OMPI_ALLOW_RUN_AS_ROOT rather
+# than the PRTE_* pair RUN() sets, so ompi cases carry their own.
+OMPIROOT='OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1'
+
+test_schizo() {
+    local out rc n f
+
+    banner "schizo: envar directives reach a REMOTE process"
+    # -x forwards a variable from the tool's environment; --set-env sets one
+    # outright; --unset-env removes one (and takes a trailing '*' as a
+    # prefix).  All of them are recorded as job/app attributes by the tool
+    # and only turned into environment on the daemon, so running the probe on
+    # node2/node3 - never the head node - is what proves they were applied
+    # there.  A remote daemon's environment is its OWN, not the submitting
+    # shell's, so a variable the probe expects to see has to be forwarded:
+    # that is what makes -x worth testing here and untestable locally.
+    out=$(RUN 'SZ_FWD=fwd-ok SZ_GONE=leftover SZ_ALSO=leftover prterun \
+                 --host node2:1,node3:1 -np 2 --map-by node \
+                 -x SZ_FWD \
+                 --set-env SZ_SET=set-ok \
+                 --unset-env "SZ_GO*" \
+                 bash -c "echo SZ \$(hostname) \$SZ_FWD \$SZ_SET \${SZ_GONE:-unset} \${SZ_ALSO:-unset}"' 2>&1); rc=$?
+    # SZ_ALSO is never forwarded, so it must read "unset" on the remote node -
+    # which is what makes SZ_FWD reading "fwd-ok" mean -x actually did it
+    n=$(echo "$out" | grep -cE '^SZ node[23] fwd-ok set-ok unset unset$')
+    [ "$rc" = 0 ] && [ "$n" = 2 ] \
+        && ok "-x / set / wildcard-unset applied on both remote nodes" \
+        || bad "envar directives wrong on a remote node (rc=$rc, matched=$n): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+
+    # PREPEND/APPEND edit an EXISTING value, so they need a variable the
+    # daemon really owns - PATH.  Two things are checked at once:
+    #
+    #   - the entry is added exactly ONCE.  These directives used to be
+    #     applied twice, by odls' process_envars() and again by the schizo
+    #     setup_fork hook.  SET and UNSET are idempotent so nothing showed,
+    #     but every entry a user prepended onto PATH or LD_LIBRARY_PATH was
+    #     duplicated.
+    #   - a differently-named variable that merely STARTS with the same
+    #     letters is left alone.  The match used to be a bare strncmp of the
+    #     name's length with no '=' anchor, so "PATH" also matched PATHOLOGY
+    #     - whichever the environment happened to list first.
+    out=$(RUN 'PATHOLOGY=untouched prterun --host node2:1 -np 1 \
+                 -x PATHOLOGY --prepend-env "PATH[:]" /SZDIR --append-env "PATH[:]" /SZEND \
+                 bash -c "echo SZP \$(echo \$PATH | tr : \\\\n | grep -c \"^/SZDIR\$\") \
+                          \$(echo \$PATH | tr : \\\\n | grep -c \"^/SZEND\$\") \$PATHOLOGY"' 2>&1)
+    echo "$out" | grep -qE '^SZP 1 1 untouched$' \
+        && ok "--prepend/append-env PATH each added their entry once, PATHOLOGY untouched" \
+        || bad "--prepend/append-env PATH misapplied: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    # A repeated --set-env must set BOTH variables.  pmix_cmd_line_parse
+    # stores one value per occurrence for --set-env (unlike --prepend-env,
+    # which stores a name and a value), so walking the value array two at a
+    # time skipped every other one - silently, since a variable that was
+    # never set just reads as empty in the app.
+    out=$(RUN 'prterun --host node2:1 -np 1 \
+                 --set-env SZ_A=a-ok --set-env SZ_B=b-ok \
+                 bash -c "echo SZ2 \${SZ_A:-missing} \${SZ_B:-missing}"' 2>&1)
+    echo "$out" | grep -q 'SZ2 a-ok b-ok' \
+        && ok "both --set-env directives reached the remote process" \
+        || bad "a repeated --set-env was dropped: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    banner "schizo: --merge-stderr-to-stdout is honored, not silently dropped"
+    # The deprecated spelling is in the prterun/prun option tables.  With no
+    # conversion behind it, it parsed cleanly and then did nothing at all -
+    # the user asked for merged output and got separate streams, with no
+    # error to say so.  Read stdout only: SZ-ERR appears there only if the
+    # merge really happened on the daemon that forked the process.
+    out=$(RUN 'prterun --host node2:1 -np 1 --merge-stderr-to-stdout \
+                 bash -c "echo SZ-OUT; echo SZ-ERR 1>&2" 2>/dev/null' )
+    echo "$out" | grep -q SZ-OUT && echo "$out" | grep -q SZ-ERR \
+        && ok "--merge-stderr-to-stdout merged a remote proc's stderr into stdout" \
+        || bad "--merge-stderr-to-stdout was ignored: $(echo "$out" | tr '\n' ' ')"
+    # the modern spelling must of course still work
+    out=$(RUN 'prterun --host node2:1 -np 1 --output merge-stderr-to-stdout \
+                 bash -c "echo SZ-OUT; echo SZ-ERR 1>&2" 2>/dev/null' )
+    echo "$out" | grep -q SZ-ERR \
+        && ok "--output merge-stderr-to-stdout still merges" \
+        || bad "--output merge-stderr-to-stdout stopped merging: $(echo "$out" | tr '\n' ' ')"
+
+    banner "schizo: envar directives take effect in the order they were given"
+    # SET replaces a value outright; PREPEND/APPEND edit the one already
+    # there.  Which of them the process ends up with therefore depends on the
+    # ORDER the user gave them in, and that order is theirs to choose - not a
+    # merge policy PRRTE gets to pick.  The attributes used to be assembled
+    # with prte_prepend_attribute(), which reversed the command line, so
+    # "-x FOO --prepend-env FOO[:] head" applied the -x SET last and threw
+    # the prepend away.
+    out=$(RUN 'prterun --host node2:1 -np 1 \
+                 --prepend-env "SZO[:]" x --set-env SZO=1 \
+                 bash -c "echo SZO1=\$SZO"' 2>&1)
+    echo "$out" | grep -q '^SZO1=1$' \
+        && ok "prepend then set: the later set wins, as asked" \
+        || bad "prepend-then-set gave the wrong value: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    out=$(RUN 'prterun --host node2:1 -np 1 \
+                 --set-env SZO=1 --prepend-env "SZO[:]" x \
+                 bash -c "echo SZO2=\$SZO"' 2>&1)
+    echo "$out" | grep -q '^SZO2=x:1$' \
+        && ok "set then prepend: the prepend edits the value the set left" \
+        || bad "set-then-prepend gave the wrong value: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    out=$(RUN 'SZO=middle prterun --host node2:1 -np 1 \
+                 -x SZO --prepend-env "SZO[:]" head --append-env "SZO[:]" tail \
+                 bash -c "echo SZO3=\$SZO"' 2>&1)
+    echo "$out" | grep -q '^SZO3=head:middle:tail$' \
+        && ok "-x then prepend then append wrap the forwarded value" \
+        || bad "-x with prepend/append gave the wrong value: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    banner "schizo: --output file=...:pattern names the files, not PRRTE"
+    # Without "pattern" the name is a stem PMIx annotates with the namespace
+    # and rank.  With it, the name is the user's own and its '%' conversions
+    # are expanded - including in the DIRECTORY part, which is why this is a
+    # multi-node case: each daemon creates the directory its own expansion
+    # names, and %h differs between them.
+    for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szpat' >/dev/null 2>&1; done
+    out=$(RUN 'prterun --host node2:1,node3:1 -np 2 --map-by node \
+                 --output "file=/tmp/szpat/%h/rank-%R:pattern" \
+                 bash -c "echo PAT-\$PMIX_RANK"' 2>&1)
+    f=0
+    for n in 2 3; do
+        ON "$n" 'cat /tmp/szpat/node'"$n"'/rank-*.out 2>/dev/null' | grep -q '^PAT-' && f=$((f+1))
+    done
+    [ "$f" = 2 ] \
+        && ok "each daemon expanded %h/%R and wrote under the directory it named" \
+        || bad "pattern expansion produced files on $f/2 nodes: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    # and the stream suffix is still appended, so stdout and stderr are split
+    for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szpat' >/dev/null 2>&1; done
+    RUN 'prterun --host node2:1 -np 1 --output "file=/tmp/szpat/r%r:pattern" \
+           bash -c "echo P-OUT; echo P-ERR 1>&2"' >/dev/null 2>&1
+    o=$(ON 2 'cat /tmp/szpat/r0.out 2>/dev/null')
+    e=$(ON 2 'cat /tmp/szpat/r0.err 2>/dev/null')
+    [ "$(echo "$o" | tr -d '\r')" = "P-OUT" ] && [ "$(echo "$e" | tr -d '\r')" = "P-ERR" ] \
+        && ok "the .out/.err suffix still splits the streams under a pattern" \
+        || bad "pattern streams wrong (out='$o' err='$e')"
+    # an unrecognized conversion is refused before anything is launched
+    out=$(RUN 'prterun --host node2:1 -np 1 --output "file=/tmp/szpat/%q:pattern" hostname' 2>&1)
+    echo "$out" | grep -q 'unrecognized conversion' \
+        && ok "a bad pattern conversion is reported, not launched with" \
+        || bad "a bad pattern conversion was accepted: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szpat' >/dev/null 2>&1; done
+
+    banner "schizo: every --output qualifier counts, whatever its position"
+    # Qualifiers are ':'-delimited and were split on ',' instead - which the
+    # directive split has already consumed - so the whole ':'-joined run was
+    # matched as ONE token.  Prefix matching then made the FIRST qualifier
+    # win and silently discarded the rest.  "copy" is the discriminator:
+    # nocopy is also the default, so only asking for copy can tell whether
+    # the qualifier was read at all.  Both orders must behave identically.
+    # Each rank's file is written by its own daemon, so this also checks the
+    # directive survived the wire.
+    for q in "copy:raw" "raw:copy"; do
+        for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szout' >/dev/null 2>&1; done
+        out=$(RUN "prterun --host node2:1,node3:1 -np 2 --map-by node \
+                     --output file=/tmp/szout/o:$q bash -c 'echo SZ-FILE-OK'" 2>/dev/null)
+        n=$(echo "$out" | grep -c SZ-FILE-OK)
+        [ "$n" = 2 ] \
+            && ok "--output file=...:$q copied output back to stdout as asked" \
+            || bad "--output file=...:$q lost the copy qualifier ($n/2 lines on stdout)"
+        f=0
+        for n in 2 3; do
+            ON "$n" 'grep -rl SZ-FILE-OK /tmp/szout 2>/dev/null | head -1' | grep -q . && f=$((f+1))
+        done
+        [ "$f" = 2 ] && ok "--output file=...:$q wrote a file on each daemon" \
+                     || bad "--output file=...:$q produced files on $f/2 nodes"
+    done
+    # and nocopy really does keep it off stdout
+    for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szout' >/dev/null 2>&1; done
+    out=$(RUN "prterun --host node2:1 -np 1 \
+                 --output file=/tmp/szout/o:raw:nocopy bash -c 'echo SZ-FILE-OK'" 2>/dev/null)
+    [ -z "$(echo "$out" | grep SZ-FILE-OK)" ] \
+        && ok "--output file=...:raw:nocopy kept output off stdout" \
+        || bad "--output file=...:raw:nocopy leaked output to stdout"
+    for n in 1 2 3; do ON "$n" 'rm -rf /tmp/szout' >/dev/null 2>&1; done
+
+    banner "schizo: --personality is honored in both spellings"
+    # normalize_argv() is what finds the personality, before any option table
+    # exists to parse with.  It only understood "--personality ompi" and not
+    # the "--personality=ompi" form getopt_long equally accepts, so the "="
+    # form silently fell back to the default (prte) personality - and then
+    # rejected every ompi-only option as unrecognized.  --display-comm is
+    # defined ONLY by the ompi personality, so it is the discriminator.
+    for form in "--personality ompi" "--personality=ompi"; do
+        out=$(RUN "$OMPIROOT prterun $form --host node2:1,node3:1 -np 2 --map-by node \
+                     --display-comm hostname" 2>&1); rc=$?
+        n=$(echo "$out" | grep -cE '^node[23]$')
+        [ "$rc" = 0 ] && [ "$n" = 2 ] \
+            && ok "\"$form\" selected the ompi personality and launched" \
+            || bad "\"$form\" did not select ompi (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    done
+    # the same for a renamed option given with '=' - the tables carry the
+    # un-hyphenated key, so "--map-by=node" only reaches them if normalize
+    # rewrote it
+    out=$(RUN 'prterun --host node2:1,node3:1 -np 2 --map-by=node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[23]$')
+    [ "$rc" = 0 ] && [ "$n" = 2 ] \
+        && ok "--map-by=node (the '=' spelling) was normalized and honored" \
+        || bad "--map-by=node was rejected (rc=$rc, procs=$n): $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    banner "schizo: a bare '--map-by ppr' is refused, not a crash"
+    # The socket->package rewrite reaches for the resource field of a ppr
+    # pattern.  Under the ompi personality it did so with strrchr(), which
+    # returns NULL for a pattern with no ':' at all - and the result was
+    # advanced past and dereferenced, killing the tool at address 0x1 before
+    # it ever reached the mapper.  prte had been fixed; ompi had not.
+    out=$(RUN 'prterun --host node2:1 -np 1 --map-by ppr hostname' 2>&1)
+    echo "$out" | grep -qiE 'signal|Segmentation' \
+        && bad "prterun (prte) crashed on a bare --map-by ppr" \
+        || ok "prterun (prte) refused a bare --map-by ppr without crashing"
+    out=$(RUN "$OMPIROOT prterun --personality ompi --host node2:1 -np 1 --map-by ppr hostname" 2>&1)
+    echo "$out" | grep -qiE 'signal|Segmentation' \
+        && bad "prterun --personality ompi crashed on a bare --map-by ppr" \
+        || ok "prterun --personality ompi refused a bare --map-by ppr without crashing"
+
+    banner "schizo: an option that takes one value may not be repeated"
+    # pmix_cmd_line_parse appends every occurrence of an option to the SAME
+    # instance, and every consumer reads values[0] - so "-np 2 -np 3" ran
+    # silently with 2 procs.  The guard that was meant to catch that had its
+    # comparison inverted and never fired.
+    out=$(RUN 'prterun --host node2:2 -np 2 -np 3 hostname' 2>&1)
+    echo "$out" | grep -q 'too many instances' \
+        && ok "a repeated --np is reported instead of silently taking the first" \
+        || bad "a repeated --np was accepted: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    banner "schizo: a personality nobody claims falls back to the native one"
+    # No component claims an unrecognized personality, so every bid is zero.
+    # The election used to award the job to whichever component carried the
+    # highest static priority, silently reading the command line in the OMPI
+    # dialect - a different option table and a different MCA translation than
+    # the user asked for.  It must land on the catch-all instead.
+    #
+    # Falling back rather than refusing is deliberate and load-bearing: Open
+    # MPI starts a singleton's DVM with "--prtemca schizo prte", so only the
+    # native component is loaded, and then spawns with
+    # PMIX_PERSONALITY="ompi5".  Refusing that fails every MPI_Comm_spawn from
+    # a singleton.  --display-comm is defined ONLY by the ompi personality, so
+    # it is what tells the two apart.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --host node1:1,node2:1,node3:1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 30 prun --personality no-such-personality --display-comm -np 1 hostname' 2>&1)
+        echo "$out" | grep -q 'unrecognized option' \
+            && ok "an unknown --personality reads the command line as prte, not ompi" \
+            || bad "an unknown --personality did not fall back to prte: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        out=$(RUN 'timeout 30 prun --personality no-such-personality --host node2:1 -np 1 hostname' 2>&1)
+        echo "$out" | grep -qE '^node2$' \
+            && ok "and a prte-valid command line still runs under it" \
+            || bad "the fallback personality could not run a job: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        RUN 'pgrep -x prte >/dev/null' \
+            && ok "the persistent DVM survived both" \
+            || bad "the DVM died on an unknown --personality"
+        out=$(RUN 'timeout 30 prun --host node2:1,node3:1 -np 2 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -cE '^node[23]$')
+        [ "$n" = 2 ] && ok "the DVM still launches jobs afterwards" \
+                     || bad "the DVM could not launch afterwards ($n/2)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the unknown-personality test"
+    fi
+    cleanup_swarm
+}
+
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
         echo "swarm not up -- run: docker compose up -d" >&2; exit 2
@@ -841,6 +1122,21 @@ test_linux() {
         ok "prterun/prte/prun/pterm/elastic on PATH"
     else
         bad "tools missing -- did ./build.sh run?"; return
+    fi
+    # The install lives in a volume that outlives any one build, so "the tools
+    # are on PATH" says nothing about WHICH source they were built from. A
+    # build.sh run that dies part-way -- configure rejecting the baked PMIx is
+    # the usual way -- leaves the previous install standing, and without this
+    # check the whole suite runs against code the author never built, reporting
+    # failures that are really "you are testing something else".
+    stamp=$(RUN 'cat /opt/prte/.build-stamp 2>/dev/null' | tr -d '\r')
+    if [ -n "$stamp" ]; then
+        ok "install built $stamp"
+    else
+        bad "no build stamp in the volume -- the last ./build.sh did not complete."
+        echo "     Re-run ./build.sh and check its exit status; the install now" >&2
+        echo "     present is from an earlier build and would be tested instead." >&2
+        return
     fi
 
     banner "prterun (non-elastic, one-shot) -- local"
@@ -1352,6 +1648,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     cleanup_swarm
 
     test_rmaps
+
+    test_schizo
 
     test_slurm_alloc
     test_slurm

--- a/src/docs/prrte-rst-content/cli-output.rst
+++ b/src/docs/prrte-rst-content/cli-output.rst
@@ -50,6 +50,38 @@ Supported values include:
   ``filename.rank.`` The provided name will be converted to an absolute
   path
 
-Supported qualifiers include ``NOCOPY`` (do not copy the output to the
-stdout/err streams), and ``RAW`` (do not buffer the output into complete
-lines, but instead output it as it is received).
+Supported qualifiers include ``COPY`` (also send a copy of the output to
+the stdout/err streams), ``NOCOPY`` (do not copy the output to the
+stdout/err streams |mdash| the default), ``RAW`` (do not buffer the output
+into complete lines, but instead output it as it is received), and
+``PATTERN``.
+
+``PATTERN`` is used with the ``FILE`` directive. It says that the name you
+gave is a pattern you compose yourself, rather than a stem to be annotated
+with the namespace and rank. These conversions are expanded in it:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Conversion
+     - Expands to
+   * - ``%n``
+     - the job's namespace
+   * - ``%r``
+     - the process's rank
+   * - ``%R``
+     - the rank, zero-padded to the width of the job's largest rank
+   * - ``%h``
+     - the hostname of the node the process ran on
+   * - ``%%``
+     - a literal ``%`` character
+
+The stream suffix (``.out`` or ``.err``) is still appended, so stdout and
+stderr can never land on the same file. A pattern containing no ``%`` at
+all is therefore simply a fixed name shared by every process in the job.
+
+For example, ``--output file=run/%h/rank-%R:pattern`` writes each
+process's stdout to ``run/<hostname>/rank-<rank>.out``.
+
+Any conversion other than those listed above is an error, reported when
+the command line is parsed.

--- a/src/docs/prrte-rst-content/deprecated-display-devel-allocation.rst
+++ b/src/docs/prrte-rst-content/deprecated-display-devel-allocation.rst
@@ -18,4 +18,6 @@ allocation being used by this job.
 .. admonition:: Deprecated
    :class: warning
 
-   This option is deprecated.  Please use ``--display alloc-devel``.
+   This option is deprecated.  Please use ``--display allocation``.
+   There is no longer a separate developer-detail allocation display;
+   ``allocation`` is the only allocation directive ``--display`` accepts.

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -250,6 +250,38 @@ to `prte_event_base`.
   attributes trumping job attributes), calls the schizo's `setup_fork`,
   links prepositioned files (`prte_filem`), checks the executable, and
   applies resource limits.
+
+  **`process_envars` owns the envar directives — all of them.** It runs
+  for every personality whatever that personality's `setup_fork` does,
+  which is why the schizo hook deliberately does not repeat them: applying
+  `PREPEND`/`APPEND` twice is not a no-op (it duplicates every entry a
+  user prepends onto `PATH`), and `prte_schizo_base_setup_fork` used to do
+  exactly that. The schizo hook is left with the PMIx prefix only.
+
+  **Order is the contract.** The list is walked front to back, and that
+  order is the order the user's directives take effect in: `SET` replaces
+  a value outright while `PREPEND`/`APPEND` edit the one already there, so
+  `--prepend-env FOO[:] x --set-env FOO=1` leaves `FOO=1` and the reverse
+  order leaves `FOO=x:1`. Neither is a merge policy we get to choose — the
+  user said what to do and in what sequence. What builds the list in that
+  sequence is `prte_append_attribute()` in `pmix_server_dyn.c`; the
+  `prte_prepend_attribute()` calls in `construct_child_list` are the
+  deliberate exception, putting the values `PMIx_server_setup_application`
+  returned in FRONT so the user's own directives, which arrive on the job
+  already, are applied afterwards and win. That block is walked in reverse
+  for the same reason: prepending a block one entry at a time reverses it.
+
+  Two shapes to keep in mind when editing it:
+  - **`UNSET` is a `PMIX_STRING`, not a `pmix_envar_t`** — it names a
+    variable and carries no value. It has to be handled *before* the
+    `PMIX_ENVAR != attr->data.type` filter that guards the rest of the
+    loop, or `--unset-env` silently does nothing. A trailing `*` makes the
+    name a prefix.
+  - **Match an environment entry's name up to and including the `=`.** A
+    bare `strncmp` of the name's length matches any variable that merely
+    starts with it, so prepending onto `PATH` would edit `PATHEXT`
+    instead — whichever the environment happens to list first. That is
+    what `envar_value()` is for.
 - For each **local child of that app** in `INIT`/`RESTART` state: registers
   the `waitpid` callback (`prte_wait_cb` → `prte_odls_base_default_wait_local_proc`),
   sets `PRTE_PROC_FLAG_ALIVE`, allocates a **`prte_odls_spawn_caddy_t`**,

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -793,33 +793,43 @@ next:
             goto REPORT_ERROR;
         }
         PMIX_DATA_BUFFER_DESTRUCT(&pbuf);
-        /* add any cache'd values to the front of the job attributes  */
-        for (m = 0; m < ninfo; m++) {
-            if (0 == strcmp(info[m].key, PMIX_SET_ENVAR)) {
-                envt.envar = info[m].value.data.envar.envar;
-                envt.value = info[m].value.data.envar.value;
-                envt.separator = info[m].value.data.envar.separator;
+        /* Add any cache'd values to the FRONT of the job attributes: these
+         * come from PMIx_server_setup_application, and the user's own
+         * directives - which arrive on the job already - have to be applied
+         * after them so the user's wins.
+         *
+         * Walk the array in REVERSE to do it. Prepending a block one entry
+         * at a time reverses that block, and these are envar directives:
+         * PREPEND/APPEND edit an existing value, so the order they are
+         * applied in is the value the process ends up with. */
+        for (m = ninfo; m > 0; m--) {
+            size_t idx = m - 1;
+            pmix_info_t *iptr = &info[idx];
+            if (0 == strcmp(iptr->key, PMIX_SET_ENVAR)) {
+                envt.envar = iptr->value.data.envar.envar;
+                envt.value = iptr->value.data.envar.value;
+                envt.separator = iptr->value.data.envar.separator;
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envt, PMIX_ENVAR);
-            } else if (0 == strcmp(info[m].key, PMIX_ADD_ENVAR)) {
-                envt.envar = info[m].value.data.envar.envar;
-                envt.value = info[m].value.data.envar.value;
-                envt.separator = info[m].value.data.envar.separator;
+            } else if (0 == strcmp(iptr->key, PMIX_ADD_ENVAR)) {
+                envt.envar = iptr->value.data.envar.envar;
+                envt.value = iptr->value.data.envar.value;
+                envt.separator = iptr->value.data.envar.separator;
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envt, PMIX_ENVAR);
-            } else if (0 == strcmp(info[m].key, PMIX_UNSET_ENVAR)) {
+            } else if (0 == strcmp(iptr->key, PMIX_UNSET_ENVAR)) {
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR, PRTE_ATTR_GLOBAL,
-                                       info[m].value.data.string, PMIX_STRING);
-            } else if (0 == strcmp(info[m].key, PMIX_PREPEND_ENVAR)) {
-                envt.envar = info[m].value.data.envar.envar;
-                envt.value = info[m].value.data.envar.value;
-                envt.separator = info[m].value.data.envar.separator;
+                                       iptr->value.data.string, PMIX_STRING);
+            } else if (0 == strcmp(iptr->key, PMIX_PREPEND_ENVAR)) {
+                envt.envar = iptr->value.data.envar.envar;
+                envt.value = iptr->value.data.envar.value;
+                envt.separator = iptr->value.data.envar.separator;
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envt, PMIX_ENVAR);
-            } else if (0 == strcmp(info[m].key, PMIX_APPEND_ENVAR)) {
-                envt.envar = info[m].value.data.envar.envar;
-                envt.value = info[m].value.data.envar.value;
-                envt.separator = info[m].value.data.envar.separator;
+            } else if (0 == strcmp(iptr->key, PMIX_APPEND_ENVAR)) {
+                envt.envar = iptr->value.data.envar.envar;
+                envt.value = iptr->value.data.envar.value;
+                envt.separator = iptr->value.data.envar.separator;
                 prte_prepend_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR, PRTE_ATTR_GLOBAL,
                                        &envt, PMIX_ENVAR);
             }
@@ -1273,17 +1283,81 @@ errorout:
     PMIX_RELEASE(cd);
 }
 
+/*
+ * If this "NAME=value" environment entry is for exactly this variable,
+ * return its value; otherwise NULL.
+ *
+ * The name has to be matched up to - and including - the '='.  A bare
+ * strncmp() of the name's length matches any variable that merely STARTS
+ * with it, so "--prepend-env PATH[:] /foo" would edit PATHEXT (or
+ * PATH_SEPARATOR, or the user's own PATHOLOGY) instead of, or as well as,
+ * PATH - whichever the environment happened to list first.
+ */
+static char *envar_value(char *entry, const char *name)
+{
+    size_t len = strlen(name);
+
+    if (0 != strncmp(entry, name, len) || '=' != entry[len]) {
+        return NULL;
+    }
+    return entry + len + 1;
+}
+
+/*
+ * Remove a variable from the app's environment.  A trailing '*' makes the
+ * name a prefix: every variable that starts with it goes.
+ */
+static void unset_envar(const char *name, prte_app_context_t *app)
+{
+    char *ptr, *tmp, *p2;
+    size_t n;
+
+    if (NULL == name) {
+        return;
+    }
+    if (NULL == strchr(name, '*')) {
+        pmix_unsetenv((char *) name, &app->env);
+        return;
+    }
+    ptr = strdup(name);
+    ptr[strlen(ptr) - 1] = '\0'; // trim off the '*'
+    for (n = 0; NULL != app->env[n]; n++) {
+        if (0 == strncmp(app->env[n], ptr, strlen(ptr))) {
+            // find the '=' sign
+            tmp = strdup(app->env[n]);
+            p2 = strchr(tmp, '=');
+            if (NULL != p2) {
+                *p2 = '\0';
+                pmix_unsetenv(tmp, &app->env);
+            }
+            free(tmp);
+            /* the entry we just removed shifted the array down, so re-check
+             * this index rather than stepping past the new occupant */
+            --n;
+        }
+    }
+    free(ptr);
+}
+
 static void process_envars(prte_job_t *jdata,
                            prte_app_context_t *app)
 {
     prte_attribute_t *attr;
     pmix_value_t *val;
     pmix_envar_t *envar;
-    char *ptr, *tmp, *p2;
+    char *ptr, *tmp;
     size_t n;
     bool found;
 
     PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t) {
+        /* UNSET names a variable, so it is carried as a STRING, not as a
+         * pmix_envar_t - it has to be handled BEFORE the PMIX_ENVAR type
+         * filter below, and read out of data.string.  Filtered out first
+         * (and read as an envar), --unset-env quietly did nothing. */
+        if (attr->key == PRTE_JOB_UNSET_ENVAR) {
+            unset_envar(attr->data.data.string, app);
+            continue;
+        }
         if (PMIX_ENVAR != attr->data.type) {
             continue;
         }
@@ -1295,35 +1369,14 @@ static void process_envars(prte_job_t *jdata,
         } else if (attr->key == PRTE_JOB_ADD_ENVAR) {
             PMIx_Setenv(envar->envar, envar->value, true, &app->env);
 
-        } else if (attr->key == PRTE_JOB_UNSET_ENVAR) {
-            // need to support the wildcard here
-            if (NULL != strchr(envar->envar, '*')) {
-                ptr = strdup(envar->envar);
-                ptr[strlen(ptr)-1] = '\0';  // trim off the '*'
-                for (n=0; NULL != app->env[n]; n++) {
-                    if (0 == strncmp(app->env[n], ptr, strlen(ptr))) {
-                        // find the '=' sign
-                        tmp = strdup(app->env[n]);
-                        p2 = strchr(tmp, '=');
-                        *p2 = '\0';
-                        pmix_unsetenv(tmp, &app->env);
-                        free(tmp);
-                    }
-                }
-                free(ptr);
-            } else {
-                pmix_unsetenv(envar->envar, &app->env);
-            }
-
         } else if (attr->key == PRTE_JOB_PREPEND_ENVAR) {
             // see if this envar exists
             ptr = NULL;
             found = false;
             for (n=0; NULL != app->env[n]; n++) {
-                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
-                    // find the value - this is a copied env, so we can modify
-                    ptr = strchr(app->env[n], '=');
-                    ++ptr; // step over the '='
+                ptr = envar_value(app->env[n], envar->envar);
+                if (NULL != ptr) {
+                    // this is a copied env, so we can modify it
                     pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, envar->value, envar->separator, ptr);
                     free(app->env[n]);
                     app->env[n] = tmp;
@@ -1341,10 +1394,9 @@ static void process_envars(prte_job_t *jdata,
             ptr = NULL;
             found = false;
             for (n=0; NULL != app->env[n]; n++) {
-                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
-                    // find the value - this is a copied env, so we can modify
-                    ptr = strchr(app->env[n], '=');
-                    ++ptr; // step over the '='
+                ptr = envar_value(app->env[n], envar->envar);
+                if (NULL != ptr) {
+                    // this is a copied env, so we can modify it
                     pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, ptr, envar->separator, envar->value);
                     free(app->env[n]);
                     app->env[n] = tmp;
@@ -1361,6 +1413,11 @@ static void process_envars(prte_job_t *jdata,
 
     // app trumps job, so do it after the job
     PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t) {
+        /* see the note on UNSET in the job loop above */
+        if (attr->key == PRTE_APP_UNSET_ENVAR) {
+            unset_envar(attr->data.data.string, app);
+            continue;
+        }
         if (PMIX_ENVAR != attr->data.type) {
             continue;
         }
@@ -1372,18 +1429,14 @@ static void process_envars(prte_job_t *jdata,
         } else if (attr->key == PRTE_APP_ADD_ENVAR) {
             PMIx_Setenv(envar->envar, envar->value, true, &app->env);
 
-        } else if (attr->key == PRTE_APP_UNSET_ENVAR) {
-            pmix_unsetenv(envar->envar, &app->env);
-
         } else if (attr->key == PRTE_APP_PREPEND_ENVAR) {
             // see if this envar exists
             ptr = NULL;
             found = false;
             for (n=0; NULL != app->env[n]; n++) {
-                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
-                    // find the value - this is a copied env, so we can modify
-                    ptr = strchr(app->env[n], '=');
-                    ++ptr; // step over the '='
+                ptr = envar_value(app->env[n], envar->envar);
+                if (NULL != ptr) {
+                    // this is a copied env, so we can modify it
                     pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, envar->value, envar->separator, ptr);
                     free(app->env[n]);
                     app->env[n] = tmp;
@@ -1401,10 +1454,9 @@ static void process_envars(prte_job_t *jdata,
             ptr = NULL;
             found = false;
             for (n=0; NULL != app->env[n]; n++) {
-                if (0 == strncmp(app->env[n], envar->envar, strlen(envar->envar))) {
-                    // find the value - this is a copied env, so we can modify
-                    ptr = strchr(app->env[n], '=');
-                    ++ptr; // step over the '='
+                ptr = envar_value(app->env[n], envar->envar);
+                if (NULL != ptr) {
+                    // this is a copied env, so we can modify it
                     pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, ptr, envar->separator, envar->value);
                     free(app->env[n]);
                     app->env[n] = tmp;

--- a/src/mca/schizo/AGENTS.md
+++ b/src/mca/schizo/AGENTS.md
@@ -249,11 +249,30 @@ table.
      `nocopy`, while `file=X:nocopy:raw` did the reverse. Order must not
      matter.
 
-  Known gap: the `pattern` qualifier is inert end to end - it is absent
-  from `prte_schizo_base_sanity`'s `outquals[]`, so the CLI rejects it
-  before `parse_output` runs, and nothing in PRRTE consumes
-  `PMIX_IOF_FILE_PATTERN` either.
+  The `pattern` qualifier is the one directive whose *meaning* lives
+  outside PRRTE. `--output file=NAME:pattern` says NAME is the user's own
+  name rather than a stem PMIx annotates with the namespace and rank, and
+  PMIx is what expands it — it owns the IOF sinks and is the only place
+  that knows the rank at the moment a file is opened. So the chain has
+  four links, and all four have to be present or the qualifier is silently
+  inert:
 
+  1. `prte_schizo_base_sanity`'s `outquals[]` must list `pattern`, or the
+     CLI rejects it before `parse_output` sees it;
+  2. `parse_output` emits `PMIX_IOF_FILE_PATTERN` **alongside the
+     filename** (it means nothing without one, so a `pattern` with no
+     `file=` is refused), having first checked the pattern's conversions
+     with `pmix_iof_check_pattern()` — asking PMIx keeps the CLI's idea of
+     a valid pattern and the expander's identical;
+  3. `pmix_server_dyn.c` turns the key into `PRTE_JOB_OUTPUT_FILE_PATTERN`
+     on the job;
+  4. `pmix_server_register_fns.c` puts it back on the wire in the nspace
+     registration, which is what `pmix_iof_check_flags` reads into the
+     namespace's `iof_flags`.
+
+  The whole thing is gated on `PRTE_PMIX_IOF_FILE_PATTERN`
+  (`PMIX_CAP_IOF_FILE_PATTERN`); built against a PMIx without it, the
+  qualifier is refused with a diagnostic rather than accepted and ignored.
 - **`prte_schizo_base_expose(param, prefix)`** — split a `key=value`
   string and `setenv` it as `<prefix>key=value` (used by `parse_cli` to
   push `--prtemca`/`--pmixmca` values into the environment).

--- a/src/mca/schizo/AGENTS.md
+++ b/src/mca/schizo/AGENTS.md
@@ -313,6 +313,20 @@ table.
   personality's `setup_fork` does. If you are adding envar handling, add
   it there, not here.
 
+  **The envar directives take effect in the order the user gave them**, and
+  that is a contract, not an accident. `SET` replaces a value outright
+  while `PREPEND`/`APPEND` edit the one already there, so
+  `--prepend-env FOO[:] x --set-env FOO=1` must leave `FOO=1` and the
+  reverse order must leave `FOO=x:1`. Both are what the user asked for.
+  Three places have to agree for that to hold: `prte_app_parse.c` walks
+  `results->instances` **in list order** (which is the order the options
+  first appeared) rather than looking each key up in a fixed sequence;
+  `pmix_server_dyn.c` uses `prte_append_attribute()`, not
+  `prte_prepend_attribute()`, so the attribute list keeps that order; and
+  `process_envars()` walks the list front to back. The one case this
+  cannot reproduce is an option type repeated after another has
+  intervened — every occurrence is grouped onto that option's single
+  instance, so it applies at the position of its first appearance.
 - **`prte_schizo_base_getline` / `_strip_quotes` / `_root_error_msg`** —
   small shared utilities. The first two are fed **user data** (MCA
   param/tune files, `--prtemca` values), so they must not assume it is

--- a/src/mca/schizo/AGENTS.md
+++ b/src/mca/schizo/AGENTS.md
@@ -31,9 +31,10 @@ distinct places:
   `check_sanity`, `parse_env`, and `job_info` hooks to turn the command
   line into a spawn request.
 - **In the daemons / HNP**, where a much thinner slice is used:
-  `setup_fork` injects personality-specific envars into each local
-  process's environment just before `fork`/`exec` (called from
-  `odls/base`), and the `set_default_mapping`/`ranking`/`binding`/`rto`
+  `setup_fork` injects personality-specific environment into each local
+  process just before `fork`/`exec` (called from `odls/base`, right after
+  that framework's own `process_envars()` has applied the generic envar
+  directives), and the `set_default_mapping`/`ranking`/`binding`/`rto`
   hooks let a personality override PRRTE's default placement policy from
   inside the rmaps and state machinery.
 
@@ -92,7 +93,7 @@ each component calls from its own `parse_cli`.
 | `set_default_binding` | `(prte_job_t *, prte_rmaps_options_t *)` | Override default `--bind-to`. Both `NULL` today. |
 | `set_default_rto` | `(prte_job_t *, prte_rmaps_options_t *)` | Set default runtime options for a job. Both delegate to `prte_state_base_set_runtime_options`. |
 | `setup_app` | `(prte_pmix_app_t *app)` | Rewrite an app before launch (e.g. relative→absolute path, prepend `java`). Both currently `NULL`. |
-| `setup_fork` | `(prte_job_t *, prte_app_context_t *)` | Inject job/app envar attributes into `app->env` just before fork. Both use `prte_schizo_base_setup_fork` (shared base impl). |
+| `setup_fork` | `(prte_job_t *, prte_app_context_t *)` | Inject personality-specific environment into `app->env` just before fork. Both use `prte_schizo_base_setup_fork` (shared base impl), which sets `PRTE_LAUNCHED` and applies the PMIx prefix. The generic envar directives are **not** applied here — `odls`' `process_envars()` owns those (see below). |
 | `job_info` | `(pmix_cli_result_t *, void *jobinfo)` | Add personality-specific job info to a spawn request. Both currently no-ops. |
 | `check_sanity` | `(pmix_cli_result_t *cmd_line)` | Validate directives/qualifiers and flag conflicts. Both use `prte_schizo_base_sanity`. |
 | `finalize` | `(void)` | Cleanup. Both `NULL`. |
@@ -136,10 +137,8 @@ But the static priority is **not** how a personality is chosen. That
 happens per-invocation in `prte_schizo_base_detect_proxy()`
 (`schizo_base_stubs.c`), which walks `active_modules`, calls each
 module's `detect_proxy(cmdpath)`, and returns the module with the
-**strictly highest** returned confidence (ties keep the first/higher
-static-priority module, since the test is `pri < p`). Each component's
-`detect_proxy` decides its own confidence from three signals, in
-override order:
+highest returned confidence. Each component's `detect_proxy` decides its
+own confidence from three signals, in override order:
 
 1. **Explicit `--personality` list** (passed in as `cmdpath`): if it
    names the component, that component bids (prte bids its static
@@ -150,6 +149,32 @@ override order:
 3. **Default**: prte falls back to its static priority (`5`) — it is the
    catch-all; ompi bids `0` (it never claims an invocation it wasn't
    explicitly asked for).
+
+**A bid of `0` means "not me", so the bar is a strictly positive bid,
+not merely the highest one** — and when nothing clears that bar,
+`detect_proxy` falls back to the **default** personality (whatever a
+query with no hint at all returns), not to whichever component happens
+to sort first. Seeded at `-1`, an all-zero field was won by the
+highest-static-priority component, so a personality nobody claims read
+the command line in the **ompi** dialect: a different option table and
+a different MCA translation than the user asked for. Landing on the
+catch-all instead is the fix; the falling back itself was never the
+problem.
+
+That distinction is load-bearing, not cosmetic. **Open MPI starts a
+singleton's DVM with `--prtemca schizo prte`** — so only the native
+component is even loaded — **and then spawns with
+`PMIX_PERSONALITY="ompi5"`.** Nothing claims that name in that DVM.
+Refusing it fails every `MPI_Comm_spawn` from a singleton, which is
+exactly what a first attempt at this did. Do not "tighten" the fallback
+into an error.
+
+`detect_proxy` still returns `NULL` when there is no default either
+(no modules at all), so callers that resolve a personality out of a
+**spawn request** rather than a command line (`pmix_server_dyn.c`,
+`pmix_server_session.c`) null-check and reject the request: every later
+use of `jdata->schizo` is an unchecked dereference, and on a persistent
+DVM that is the whole DVM, not one job.
 
 So absent any personality hint, **prte always wins** as the default
 personality, and ompi only takes over when the user (or the
@@ -186,6 +211,19 @@ table.
   `binders[]`/… tables via `prte_schizo_base_check_directives`; enforces
   per-option value-count limits (`check_ndirs`); and flags the map-by
   PE / bind-to conflict.
+
+  `check_ndirs` is worth understanding before touching it.
+  `pmix_cmd_line_parse` appends **every occurrence** of an option to the
+  *same* `pmix_cli_item_t`'s value array, and every consumer of the keys
+  in `limits[]` (`--path`, `--wdir`, `--pset`, `--np`, `--keepalive`)
+  reads `values[0]`. So a repeated option is not "last wins" or "first
+  wins" by design — the later values are simply discarded. `check_ndirs`
+  is what refuses it, and the check is `1 < count` (a count of *zero* is
+  not "too many"; it means a flag-style option with no value at all).
+  This is safe for MPMD because `prte_parse_locals()` splits the command
+  line at each `:` and calls `parse_cli`/`check_sanity` on one app
+  segment at a time, so a per-app `--np` is a single value in its own
+  result set.
 - **`prte_schizo_base_check_directives` / `_check_qualifiers`** — the
   reusable directive validators, including the special-cased
   `--map-by ppr:N:resource` pattern check.
@@ -194,6 +232,28 @@ table.
   (`PMIX_DISPLAY_MAP`, `PMIX_IOF_TAG_OUTPUT`, `PMIX_IOF_OUTPUT_TO_FILE`,
   …) on the job-info object. These are where the human-facing directive
   strings become PMIx keys.
+
+  Two shape rules govern both, and both have been got wrong before —
+  each time silently, because an unrecognized directive here is simply
+  not emitted and the job runs without it:
+
+  1. **Iterate over every value.** `opt->values` is an array (each
+     repetition of `--output`/`--display` appends one), so the loop body
+     must split `values[n]`, not `values[0]`.
+  2. **Directives are `,`-delimited; qualifiers are `:`-delimited.**
+     After the `,` split, the text following the first `:` in a token is
+     a `:`-joined run of qualifiers and must be split on `:` again.
+     Splitting it on `,` yields one token that still contains the
+     colons, and `PMIX_CHECK_CLI_OPTION` prefix-matches it against the
+     first qualifier only — so `file=X:raw:nocopy` kept `raw` and lost
+     `nocopy`, while `file=X:nocopy:raw` did the reverse. Order must not
+     matter.
+
+  Known gap: the `pattern` qualifier is inert end to end - it is absent
+  from `prte_schizo_base_sanity`'s `outquals[]`, so the CLI rejects it
+  before `parse_output` runs, and nothing in PRRTE consumes
+  `PMIX_IOF_FILE_PATTERN` either.
+
 - **`prte_schizo_base_expose(param, prefix)`** — split a `key=value`
   string and `setenv` it as `<prefix>key=value` (used by `parse_cli` to
   push `--prtemca`/`--pmixmca` values into the environment).
@@ -211,6 +271,17 @@ table.
   are renamed unconditionally on every occurrence because MPMD lines may
   repeat them per app-context; detecting an illegal duplicate is the
   MPMD parser's job.
+
+  This runs on the raw argv **before any option table exists**, so it
+  has to reproduce what `getopt_long` will later accept: both
+  `--opt value` **and** `--opt=value`. Handling only the first form
+  leaves the `=` spelling to be rejected downstream as an unrecognized
+  option (for the renamed options) or — worse — silently ignored (for
+  `--personality`, which then falls back to the default personality and
+  rejects every option only the requested personality defines). The
+  renames are driven by the `normalized_opts[]` table; add both forms at
+  once by adding a row, and note the `=` match is anchored (`argv[i][len]
+  == '='`) so `--map-by-something` is not mistaken for `--map-by`.
 - **`prte_schizo_base_parse_prte` / `_parse_pmix`** — shared scanners
   that pull `--prtemca`/`--mca` (and `--pmixmca`/`--gpmixmca`/`--gmca`)
   triples out of an argv, map generic `--mca fw ...` to the right
@@ -226,13 +297,30 @@ table.
   `display`, `output`, `tune`, `rtos`), handle the leading-`:` qualifier
   form, and optionally emit the "deprecated-converted" warning.
 - **`prte_schizo_base_setup_fork(jdata, app)`** — the shared `setup_fork`
-  impl. Sets `PRTE_LAUNCHED=1`, then walks job-level then app-level
-  attributes and applies every envar directive (`SET`/`ADD`/`UNSET`/
-  `PREPEND`/`APPEND_ENVAR`, `PRTE_APP_PMIX_PREFIX`) into `app->env` **in
-  order** (app-level overrides job-level), and applies a default
-  `PMIX_PREFIX`/`LD_LIBRARY_PATH` if none was set on the app.
+  impl. Sets `PRTE_LAUNCHED=1` and applies the **PMIx prefix**: the app's
+  own `PRTE_APP_PMIX_PREFIX` (plus the matching `LD_LIBRARY_PATH` entry),
+  or the DVM-wide default from the daemon job's `PRTE_JOB_PMIX_PREFIX` if
+  the app named none.
+
+  It does **not** apply the generic envar directives
+  (`SET`/`ADD`/`UNSET`/`PREPEND`/`APPEND_ENVAR`). `odls`'
+  `process_envars()` applies all of those to `app->env` in the statement
+  immediately before it calls this hook, and doing it a second time is
+  not a no-op: `PREPEND`/`APPEND` **edit** the existing value, so applying
+  them twice yields `head:head:middle` and duplicates every entry a user
+  prepends onto `PATH` or `LD_LIBRARY_PATH`. `process_envars()` owns them
+  because it runs for every personality regardless of what that
+  personality's `setup_fork` does. If you are adding envar handling, add
+  it there, not here.
+
 - **`prte_schizo_base_getline` / `_strip_quotes` / `_root_error_msg`** —
-  small shared utilities.
+  small shared utilities. The first two are fed **user data** (MCA
+  param/tune files, `--prtemca` values), so they must not assume it is
+  well formed: `getline` only strips a trailing newline if there is one
+  (a file whose last line has none would otherwise lose a character),
+  and `strip_quotes` only inspects a last character if the string has
+  one (`""` used to index `pout[-1]`, writing in front of the
+  allocation).
 
 ### `schizo_base_select.c`
 
@@ -253,6 +341,22 @@ priority-insert, dump the final priority list at verbosity > 4).
   directive/qualifier form via `prte_schizo_base_add_directive/
   _add_qualifier`, and warns exactly once (gated by the component's
   `warn_deprecations` MCA param and one-shot `warned` flag).
+- **Every deprecated entry in an option table needs a conversion.** An
+  option that a table defines but `convert_deprecated_cli` has no branch
+  for parses perfectly and is then **silently discarded** — the user
+  asks for something and gets nothing, with no error. That is how
+  `--merge-stderr-to-stdout` and `--display-devel-allocation` came to be
+  no-ops under the prte personality while `--merge-stderr-to-stdout`
+  worked under ompi. When adding a deprecated spelling, add the table
+  entry, the conversion, and the mirror in the *other* personality, in
+  one change; when reviewing, diff the set of literal option strings in
+  the tables against the set of `strcmp(option, "...")` branches in the
+  converter. (Some converter branches have no table entry — those are
+  merely dead, not harmful.)
+- **A conversion's `report` argument is the component's `warn`, never a
+  literal `true`.** Hard-coding it makes that one option scold users who
+  have deliberately turned deprecation warnings off — which, for ompi,
+  is the default.
 - **Help text is embedded, not read at runtime.** These `help-*.txt`
   files feed the generated `show_help` content. Per the GOLDEN RULE in
   the top-level guide, after editing any `help-*.txt` you must
@@ -282,6 +386,37 @@ list**. `detect_proxy` logs at verbosity ≥ 2 which personality is
 bidding on the invocation and with what confidence. The
 `schizo_base_test_proxy_launch` MCA param exists to exercise the
 proxy-launch path in testing.
+
+---
+
+## Testing
+
+**Unit tests: [`test/unit/schizo/`](../../../test/unit/schizo/)**, wired
+into `make check`. They need no DVM: they build `pmix_cli_result_t`
+objects by hand (exactly as `pmix_cmd_line_parse` would — one instance
+per key, every occurrence appended to that instance's value array) and
+run the base helpers and each personality's `parse_cli` over them.
+
+| File | Covers |
+|------|--------|
+| `test_normalize.c` | `normalize_argv` (both option spellings, personality capture), `strip_quotes`, `getline`, `expose` |
+| `test_directives.c` | `add_directive`/`add_qualifier` merging rules, `check_directives`/`check_qualifiers` incl. the `ppr:N:resource` pattern |
+| `test_sanity.c` | `prte_schizo_base_sanity`: duplicates, `check_ndirs`, synonyms, bad directives, the PE/bind-to conflict |
+| `test_output.c` | `parse_output`/`parse_display` — asserts on the resulting `PMIX_INFO` array, which is the only way to see a directive that was silently dropped |
+| `test_personality.c` | `detect_proxy` election (incl. an unknown personality returning NULL) and both personalities' deprecated-option conversions |
+
+Reach a personality through the framework (`schizo_test_module()`), not
+by naming its module symbol — the module belongs to its component, which
+may be a DSO and is not visible outside `libprrte` in any case.
+
+**Multi-node: `test_schizo()` in
+[`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/).**
+What the unit tests cannot show is that the *result* of a translation
+survives the trip to a remote daemon — the envar directives are applied
+by `setup_fork` on the prted that forks the process, `--output file=…`
+is written per-daemon, and a job's personality is resolved again on
+every daemon by `odls`. Those cases, plus "an unknown personality must
+be refused without taking a persistent DVM down", live there.
 
 ---
 

--- a/src/mca/schizo/base/help-schizo-output.txt
+++ b/src/mca/schizo/base/help-schizo-output.txt
@@ -60,8 +60,54 @@ Supported qualifiers include:
 * "RAW" - do not buffer the output into complete lines, but instead output
   it as it is received.
 
+* "PATTERN" - when combined with the "FILE" option, the given name is a
+  pattern you compose yourself instead of being annotated with the namespace
+  and rank. These conversions are expanded in it:
+
+    %%n  the job's namespace
+    %%r  the process's rank
+    %%R  the rank, zero-padded to the width of the job's largest rank
+    %%h  the hostname of the node the process ran on
+    %%%%  a literal "%%" character
+
+  The stream suffix (".out" or ".err") is still appended, so stdout and
+  stderr can never land on the same file. A pattern containing no "%%" at all
+  is therefore simply a fixed name shared by every process in the job.
+
 Note that directives and qualifiers are case-insensitive.
 #
 [copy-nocopy]
 Both the "copy" and "nocopy" qualifiers were given. This is a contradictory
 set of directives. Please correct the input and try again.
+#
+[bad-pattern]
+The output filename pattern contains an unrecognized conversion:
+
+  Pattern:     %s
+  Conversion:  %s
+
+Supported conversions are:
+
+  %%n  the job's namespace
+  %%r  the process's rank
+  %%R  the rank, zero-padded to the width of the job's largest rank
+  %%h  the hostname of the node the process ran on
+  %%%%  a literal "%%" character
+
+Please correct the pattern and try again.
+#
+[pattern-needs-file]
+The "pattern" qualifier was given to the "output" directive, but no
+"file=<name>" directive was given for it to qualify. "pattern" says how to
+name the output FILES, so it has no meaning on its own.
+
+Please add a "file=<name>" directive, or drop the "pattern" qualifier.
+#
+[pattern-unsupported]
+The "pattern" qualifier was given to the "output" directive, but the PMIx
+library this PRRTE was built against cannot expand an output filename
+pattern - PMIx opens the output files, so it is what has to do the
+expansion.
+
+Please rebuild PRRTE against a PMIx that provides the
+PMIX_CAP_IOF_FILE_PATTERN capability, or drop the "pattern" qualifier.

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -29,6 +29,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/runtime/prte_globals.h"
 
+#include "src/common/pmix_iof.h"
 #include "src/mca/schizo/base/base.h"
 /*
  * The following file was created by configure.  It contains extern
@@ -473,6 +474,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_COPY,
         PRTE_CLI_NOCOPY,
         PRTE_CLI_RAW,
+        PRTE_CLI_PATTERN,
         NULL
     };
 
@@ -776,6 +778,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
     pmix_status_t ret = PRTE_SUCCESS;
     bool fileonly = true;
     bool copyqualgiven = false;
+    bool patternqualgiven = false;
 
     for (n=0; NULL != opt->values[n]; n++) {
         /* every value on this option is a directive list of its own - the
@@ -819,11 +822,19 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                         copyqualgiven = true;
 
                     } else if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_PATTERN)) {
-                        PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
-                        if (PMIX_SUCCESS != ret) {
-                            PMIX_ERROR_LOG(ret);
-                            goto cleanup;
-                        }
+#if PRTE_PMIX_IOF_FILE_PATTERN
+                        /* only record it here - the key is emitted with the
+                         * filename it qualifies, since it means nothing
+                         * without one */
+                        patternqualgiven = true;
+#else
+                        /* expanding the pattern is PMIx's job, and this one
+                         * cannot do it - say so rather than accept a
+                         * qualifier that would be silently ignored */
+                        pmix_show_help("help-schizo-output.txt", "pattern-unsupported", true);
+                        ret = PRTE_ERR_SILENT;
+                        goto cleanup;
+#endif
 
                     } else if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_RAW)) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
@@ -954,10 +965,37 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 } else {
                     outfile = strdup(ptr);
                 }
+#if PRTE_PMIX_IOF_FILE_PATTERN
+                if (patternqualgiven) {
+                    /* the name is a pattern the user composed, so check its
+                     * conversions now - while they are still looking at the
+                     * command line they typed.  PMIx owns the expansion, so
+                     * it owns the definition of what is valid; asking it
+                     * here is what keeps the two answers the same. */
+                    char *badconv = NULL;
+                    ret = pmix_iof_check_pattern(outfile, &badconv);
+                    if (PMIX_SUCCESS != ret) {
+                        pmix_show_help("help-schizo-output.txt", "bad-pattern", true,
+                                       ptr, (NULL == badconv) ? "(none)" : badconv);
+                        if (NULL != badconv) {
+                            free(badconv);
+                        }
+                        ret = PRTE_ERR_SILENT;
+                        goto cleanup;
+                    }
+                }
+#endif
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     goto cleanup;
+                }
+                if (patternqualgiven) {
+                    PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
+                    if (PMIX_SUCCESS != ret) {
+                        PMIX_ERROR_LOG(ret);
+                        goto cleanup;
+                    }
                 }
                 if (copyqualgiven) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, &fileonly, PMIX_BOOL);
@@ -970,6 +1008,14 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
         }
         PMIx_Argv_free(targv);
         targv = NULL;
+    }
+    if (patternqualgiven && NULL == outfile) {
+        /* "pattern" says how to name an output FILE.  Given without one it
+         * has nothing to qualify, and silently ignoring it would leave the
+         * user believing they had asked for something */
+        pmix_show_help("help-schizo-output.txt", "pattern-needs-file", true);
+        ret = PRTE_ERR_SILENT;
+        goto cleanup;
     }
     ret = PRTE_SUCCESS;
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -155,6 +155,12 @@ void prte_schizo_base_expose(char *param, char *prefix)
     char *value, *pm;
 
     value = strchr(param, '=');
+    if (NULL == value) {
+        /* pmix_cmd_line_parse always hands us "name=value" for an MCA option,
+         * so this cannot happen from the CLI path - but the function is
+         * exported, and a bare name has nothing to expose */
+        return;
+    }
     *value = '\0';
     ++value;
     pmix_asprintf(&pm, "%s%s", prefix, param);
@@ -348,6 +354,15 @@ static char *limits[] = {
     NULL
 };
 
+/* The options in limits[] carry exactly one value apiece.  Repeating one on
+ * a command line does not override the earlier value - pmix_cmd_line_parse
+ * appends every occurrence to the same instance's value array, and every
+ * consumer of these keys reads values[0] - so the second and subsequent
+ * values are silently discarded.  Reject that rather than guess which one
+ * the user meant.  MPMD is not affected: prte_parse_locals() splits the
+ * command line at each ':' and parses/sanity-checks one app segment at a
+ * time, so a per-app --np/--wdir/--path is a single value in its own
+ * result set. */
 static int check_ndirs(pmix_cli_item_t *opt)
 {
     int n, count;
@@ -356,10 +371,11 @@ static int check_ndirs(pmix_cli_item_t *opt)
     for (n=0; NULL != limits[n]; n++) {
         if (0 == strcmp(opt->key, limits[n])) {
             count = PMIx_Argv_count(opt->values);
-            if (1 > count) {
+            if (1 < count) {
                 param = PMIx_Argv_join(opt->values, ' ');
                 pmix_show_help("help-schizo-base.txt", "too-many-instances", true,
                                param, opt->key, count, 1);
+                free(param);
                 return PRTE_ERR_SILENT;
             }
         }
@@ -667,10 +683,12 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     } else {
                         pmix_show_help("help-prte-rmaps-base.txt", "unrecognized-qualifier", true,
                                        "display", cptr, "PARSEABLE,PARSABLE");
+                        PMIx_Argv_free(quals);
                         PMIx_Argv_free(targv);
                         return PRTE_ERR_FATAL;
                     }
                 }
+                PMIx_Argv_free(quals);
             }
 
             if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_ALLOC)) {
@@ -753,22 +771,31 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
 {
     char *outdir=NULL;
     char *outfile=NULL;
-    char **targv, *ptr, *cptr, **options;
+    char **targv = NULL, *ptr, *cptr, **options = NULL;
     int m, n, idx;
-    pmix_status_t ret;
+    pmix_status_t ret = PRTE_SUCCESS;
     bool fileonly = true;
     bool copyqualgiven = false;
 
     for (n=0; NULL != opt->values[n]; n++) {
-        targv = PMIx_Argv_split(opt->values[0], ',');
+        /* every value on this option is a directive list of its own - the
+         * user may repeat "--output" as well as comma-delimit within one
+         * instance, and both spellings have to be honored */
+        targv = PMIx_Argv_split(opt->values[n], ',');
         for (idx = 0; NULL != targv[idx]; idx++) {
             /* check for qualifiers */
             cptr = strchr(targv[idx], ':');
             if (NULL != cptr) {
                 *cptr = '\0';
                 ++cptr;
-                /* could be multiple qualifiers, so separate them */
-                options = PMIx_Argv_split(cptr, ',');
+                /* could be multiple qualifiers, and a qualifier is separated
+                 * from the directive - and from its fellows - by a ':'.  The
+                 * ',' that separates directives has already been consumed
+                 * above, so splitting on ',' here would hand the whole
+                 * ':'-joined run to the matcher as one token; that token
+                 * prefix-matches only its FIRST qualifier, and every
+                 * qualifier after it is silently dropped */
+                options = PMIx_Argv_split(cptr, ':');
                 for (m=0; NULL != options[m]; m++) {
 
                     if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_NOCOPY)) {
@@ -776,9 +803,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                             // cannot give both copy and nocopy
                             pmix_show_help("help-schizo-output.txt", "copy-nocopy", true, cptr);
                             ret = PRTE_ERR_SILENT;
-                            PMIx_Argv_free(options);
-                            PMIx_Argv_free(targv);
-                            return ret;
+                            goto cleanup;
                         }
                         fileonly = true;
                         copyqualgiven = true;
@@ -788,9 +813,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                             // cannot give both copy and nocopy
                             pmix_show_help("help-schizo-output.txt", "copy-nocopy", true, cptr);
                             ret = PRTE_ERR_SILENT;
-                            PMIx_Argv_free(options);
-                            PMIx_Argv_free(targv);
-                            return ret;
+                            goto cleanup;
                         }
                         fileonly = false;
                         copyqualgiven = true;
@@ -799,22 +822,19 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_PATTERN, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIx_Argv_free(targv);
-                            PMIx_Argv_free(options);
-                            return ret;
+                            goto cleanup;
                         }
 
                     } else if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_RAW)) {
                         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_RAW, NULL, PMIX_BOOL);
                         if (PMIX_SUCCESS != ret) {
                             PMIX_ERROR_LOG(ret);
-                            PMIx_Argv_free(targv);
-                            PMIx_Argv_free(options);
-                            return ret;
+                            goto cleanup;
                         }
                     }
                 }
                 PMIx_Argv_free(options);
+                options = NULL;
             }
             if (0 == strlen(targv[idx])) {
                 // only qualifiers were given
@@ -829,56 +849,49 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_TAG_DET)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_DETAILED_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_TAG_FULL)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TAG_FULLNAME_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_RANK)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_RANK_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_TIMESTAMP)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_TIMESTAMP_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_XML)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_XML_OUTPUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_MERGE_ERROUT)) {
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_MERGE_STDERR_STDOUT, NULL, PMIX_BOOL);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_DIR)) {
@@ -886,14 +899,13 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "directory", "directory");
-                    PMIx_Argv_free(targv);
-                    return PRTE_ERR_FATAL;
+                    ret = PRTE_ERR_FATAL;
+                    goto cleanup;
                 }
                 if (NULL != outfile) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, ptr);
-                    PMIx_Argv_free(targv);
-                    free(outfile);
-                    return PRTE_ERR_FATAL;
+                    ret = PRTE_ERR_FATAL;
+                    goto cleanup;
                 }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
@@ -902,8 +914,8 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        PMIx_Argv_free(targv);
-                        return PRTE_ERR_FATAL;
+                        ret = PRTE_ERR_FATAL;
+                        goto cleanup;
                     }
                     outdir = pmix_os_path(false, cwd, ptr, NULL);
                 } else {
@@ -912,8 +924,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_DIRECTORY, outdir, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_FILE)) {
@@ -921,13 +932,13 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     pmix_show_help("help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "filename", "filename");
-                    PMIx_Argv_free(targv);
-                    return PRTE_ERR_FATAL;
+                    ret = PRTE_ERR_FATAL;
+                    goto cleanup;
                 }
                 if (NULL != outdir) {
                     pmix_show_help("help-prted.txt", "both-file-and-dir-set", true, ptr, outdir);
-                    PMIx_Argv_free(targv);
-                    return PRTE_ERR_FATAL;
+                    ret = PRTE_ERR_FATAL;
+                    goto cleanup;
                 }
                 /* If the given filename isn't an absolute path, then
                  * convert it to one so the name will be relative to
@@ -936,8 +947,8 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 if (!pmix_path_is_absolute(ptr)) {
                     char cwd[PRTE_PATH_MAX];
                     if (NULL == getcwd(cwd, sizeof(cwd))) {
-                        PMIx_Argv_free(targv);
-                        return PRTE_ERR_FATAL;
+                        ret = PRTE_ERR_FATAL;
+                        goto cleanup;
                     }
                     outfile = pmix_os_path(false, cwd, ptr, NULL);
                 } else {
@@ -946,21 +957,25 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                 PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_OUTPUT_TO_FILE, outfile, PMIX_STRING);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
-                    PMIx_Argv_free(targv);
-                    return ret;
+                    goto cleanup;
                 }
                 if (copyqualgiven) {
                     PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_IOF_FILE_ONLY, &fileonly, PMIX_BOOL);
                     if (PMIX_SUCCESS != ret) {
                         PMIX_ERROR_LOG(ret);
-                        PMIx_Argv_free(targv);
-                        return ret;
+                        goto cleanup;
                     }
                 }
             }
         }
         PMIx_Argv_free(targv);
+        targv = NULL;
     }
+    ret = PRTE_SUCCESS;
+
+cleanup:
+    PMIx_Argv_free(options);
+    PMIx_Argv_free(targv);
     if (NULL != outdir) {
         free(outdir);
     }
@@ -968,7 +983,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
         free(outfile);
     }
 
-    return PRTE_SUCCESS;
+    return ret;
 }
 
 PMIX_CLASS_INSTANCE(prte_schizo_base_active_module_t,

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -572,84 +572,27 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
     char *param, *p2, *saveptr, *p, *defprefix;
     int i;
     prte_job_t *daemons;
+    /* the job is part of the hook's contract, but the only prefix this
+     * function consults is the app's own and the DVM-wide default carried
+     * on the daemon job */
+    PRTE_HIDE_UNUSED_PARAMS(jdata);
 
     /* flag that we started this job */
     PMIx_Setenv("PRTE_LAUNCHED", "1", true, &app->env);
 
-    /* now process any envar attributes - we begin with the job-level
-     * ones as the app-specific ones can override them. We have to
-     * process them in the order they were given to ensure we wind
-     * up in the desired final state */
-    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t)
-    {
-        if (PRTE_JOB_SET_ENVAR == attr->key) {
-            PMIx_Setenv(attr->data.data.envar.envar,
-                               attr->data.data.envar.value,
-                               true, &app->env);
-        } else if (PRTE_JOB_ADD_ENVAR == attr->key) {
-            PMIx_Setenv(attr->data.data.envar.envar,
-                               attr->data.data.envar.value,
-                               false, &app->env);
-        } else if (PRTE_JOB_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-        } else if (PRTE_JOB_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIx_Setenv(attr->data.data.envar.envar,
-                                   attr->data.data.envar.value,
-                                   true, &app->env);
-            }
-        } else if (PRTE_JOB_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIx_Setenv(attr->data.data.envar.envar,
-                                   attr->data.data.envar.value,
-                                   true, &app->env);
-            }
-        }
-    }
+    /* NOTE: the generic envar directives (SET/ADD/UNSET/PREPEND/APPEND, at
+     * both job and app level) are NOT applied here.  odls' process_envars()
+     * applies all of them to app->env immediately before calling this hook,
+     * and applying them a second time is not a no-op: PREPEND and APPEND
+     * edit the existing value, so doing it twice yields "head:head:middle"
+     * and duplicates every entry a user prepends onto PATH or
+     * LD_LIBRARY_PATH.  process_envars() is also the more complete of the
+     * two (it supports the '*' wildcard on UNSET) and it runs for every
+     * personality, whatever that personality's setup_fork does - which is
+     * why it, and not this hook, owns those directives.
+     *
+     * What remains here is what only this hook does: the PMIx prefix. */
 
-    /* now do the same thing for any app-level attributes */
     PMIX_LIST_FOREACH(attr, &app->attributes, prte_attribute_t)
     {
         if (PRTE_APP_PMIX_PREFIX == attr->key) {
@@ -694,75 +637,6 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
                 free(p2);
                 free(param);
             }
-
-        } else if (PRTE_APP_SET_ENVAR == attr->key) {
-            PMIx_Setenv(attr->data.data.envar.envar,
-                               attr->data.data.envar.value,
-                               true, &app->env);
-
-        } else if (PRTE_APP_ADD_ENVAR == attr->key) {
-            PMIx_Setenv(attr->data.data.envar.envar,
-                               attr->data.data.envar.value,
-                               false, &app->env);
-
-        } else if (PRTE_APP_UNSET_ENVAR == attr->key) {
-            pmix_unsetenv(attr->data.data.string, &app->env);
-
-        } else if (PRTE_APP_PREPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", attr->data.data.envar.value,
-                                  attr->data.data.envar.separator, param);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIx_Setenv(attr->data.data.envar.envar,
-                                   attr->data.data.envar.value,
-                                   true, &app->env);
-            }
-
-        } else if (PRTE_APP_APPEND_ENVAR == attr->key) {
-            /* see if the envar already exists */
-            exists = false;
-            for (i = 0; NULL != app->env[i]; i++) {
-                saveptr = strchr(app->env[i], '='); // cannot be NULL
-                *saveptr = '\0';
-                if (0 == strcmp(app->env[i], attr->data.data.envar.envar)) {
-                    /* we have the var - prepend it */
-                    param = saveptr;
-                    ++param; // move past where the '=' sign was
-                    pmix_asprintf(&p2, "%s%c%s", param, attr->data.data.envar.separator,
-                                  attr->data.data.envar.value);
-                    *saveptr = '='; // restore the current envar setting
-                    PMIx_Setenv(attr->data.data.envar.envar, p2, true, &app->env);
-                    free(p2);
-                    exists = true;
-                    break;
-                } else {
-                    *saveptr = '='; // restore the current envar setting
-                }
-            }
-            if (!exists) {
-                /* just insert it */
-                PMIx_Setenv(attr->data.data.envar.envar,
-                                   attr->data.data.envar.value,
-                                   true, &app->env);
-            }
         }
     }
 
@@ -770,7 +644,8 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
      * of a default one */
     if (!prefix_defined) {
         daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        if (prte_get_attribute(&daemons->attributes, PRTE_JOB_PMIX_PREFIX, (void **)&defprefix, PMIX_STRING)) {
+        if (NULL != daemons &&
+            prte_get_attribute(&daemons->attributes, PRTE_JOB_PMIX_PREFIX, (void **)&defprefix, PMIX_STRING)) {
             PMIx_Setenv("PMIX_PREFIX",
                                defprefix,
                                true, &app->env);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -36,8 +36,16 @@ prte_schizo_base_module_t *prte_schizo_base_detect_proxy(char *cmdpath)
 {
     prte_schizo_base_active_module_t *mod;
     prte_schizo_base_module_t *md = NULL;
-    int pri = -1, p;
+    int pri = 0, p;
 
+    /* A confidence of zero means "this is not me" - every component returns
+     * it for a personality list that does not name it.  So the bar for being
+     * selected is a STRICTLY POSITIVE bid, not merely the highest one.  Seeded
+     * at -1, the first component queried won a field of all-zero bids, which
+     * made a personality nobody claims select whichever component happens to
+     * carry the highest static priority - so a typo in "--personality" ran the
+     * command line in the ompi dialect, complete with its own option table and
+     * MCA translation, rather than the native one. */
     PMIX_LIST_FOREACH(mod, &prte_schizo_base.active_modules, prte_schizo_base_active_module_t)
     {
         if (NULL != mod->module->detect_proxy) {
@@ -48,13 +56,41 @@ prte_schizo_base_module_t *prte_schizo_base_detect_proxy(char *cmdpath)
             }
         }
     }
+
+    /* Nobody claimed it.  Fall back to the DEFAULT personality - which is
+     * what a component tells us it would be when asked with no hint at all -
+     * rather than refusing outright.  A name we do not recognize is not
+     * necessarily a mistake: Open MPI starts a singleton's DVM with
+     * "--prtemca schizo prte", so only the native component is even loaded,
+     * and then spawns with PMIX_PERSONALITY="ompi5".  Refusing that fails
+     * every MPI_Comm_spawn from a singleton.  The catch-all is the right
+     * answer there, and remains the right answer for a typo - what was wrong
+     * before was landing on some *other* personality's dialect, not the
+     * falling back itself. */
+    if (NULL == md && NULL != cmdpath) {
+        md = prte_schizo_base_detect_proxy(NULL);
+    }
     return md;
 }
 
+/* the deprecated hyphenated spelling of each option whose canonical key is
+ * un-hyphenated, paired with the key the option tables actually carry */
+static struct {
+    const char *deprecated;
+    const char *canonical;
+} normalized_opts[] = {
+    {.deprecated = "--map-by",          .canonical = "--mapby"},
+    {.deprecated = "--rank-by",         .canonical = "--rankby"},
+    {.deprecated = "--bind-to",         .canonical = "--bindto"},
+    {.deprecated = "--runtime-options", .canonical = "--rtos"},
+    {.deprecated = NULL,                .canonical = NULL}
+};
+
 char *prte_schizo_base_normalize_argv(char **argv)
 {
-    char *personality = NULL;
-    int i;
+    char *personality = NULL, *value, *tmp;
+    size_t len;
+    int i, n;
 
     /* Normalize the deprecated hyphenated option spellings to their canonical
      * forms and capture any personality specification.  --rank-by and --bind-to
@@ -63,22 +99,37 @@ char *prte_schizo_base_normalize_argv(char **argv)
      * renamed unconditionally on every occurrence.  Detecting an erroneous
      * duplicate (e.g. two job-level --rank-by with no intervening MPMD
      * separator) is the schizo MPMD parser's responsibility, since it has the
-     * app-context boundaries that this flat argv scan lacks. */
+     * app-context boundaries that this flat argv scan lacks.
+     *
+     * Both spellings getopt_long accepts have to be handled here - "--opt value"
+     * AND "--opt=value".  Only recognizing the space-separated form leaves the
+     * "=" form to be rejected later as an unrecognized option (for the renamed
+     * options) or, worse, silently ignored (for --personality, which would then
+     * drop the invocation onto the default personality). */
     for (i = 0; NULL != argv[i]; i++) {
         if (0 == strcmp(argv[i], "--personality")) {
             personality = argv[i + 1];
-        } else if (0 == strcmp(argv[i], "--map-by")) {
-            free(argv[i]);
-            argv[i] = strdup("--mapby");
-        } else if (0 == strcmp(argv[i], "--rank-by")) {
-            free(argv[i]);
-            argv[i] = strdup("--rankby");
-        } else if (0 == strcmp(argv[i], "--bind-to")) {
-            free(argv[i]);
-            argv[i] = strdup("--bindto");
-        } else if (0 == strcmp(argv[i], "--runtime-options")) {
-            free(argv[i]);
-            argv[i] = strdup("--rtos");
+            continue;
+        }
+        if (0 == strncmp(argv[i], "--personality=", strlen("--personality="))) {
+            value = argv[i] + strlen("--personality=");
+            personality = ('\0' == value[0]) ? NULL : value;
+            continue;
+        }
+        for (n = 0; NULL != normalized_opts[n].deprecated; n++) {
+            len = strlen(normalized_opts[n].deprecated);
+            if (0 == strcmp(argv[i], normalized_opts[n].deprecated)) {
+                free(argv[i]);
+                argv[i] = strdup(normalized_opts[n].canonical);
+                break;
+            }
+            if (0 == strncmp(argv[i], normalized_opts[n].deprecated, len) &&
+                '=' == argv[i][len]) {
+                pmix_asprintf(&tmp, "%s%s", normalized_opts[n].canonical, &argv[i][len]);
+                free(argv[i]);
+                argv[i] = tmp;
+                break;
+            }
         }
     }
     return personality;
@@ -140,6 +191,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
             fprintf(stderr, "%s\n", ptr);
+            free(ptr);
             return PRTE_ERR_SILENT;
         } else {
             // does this contain only a qualifier?
@@ -157,6 +209,7 @@ int prte_schizo_base_add_directive(pmix_cli_result_t *results,
                                                 true, target, tmp, deprecated, directive);
                     free(tmp);
                     fprintf(stderr, "%s\n", ptr);
+                    free(ptr);
                     return PRTE_ERR_SILENT;
                 }
                 // does the value contain a qualifier?
@@ -218,6 +271,7 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
             ptr = pmix_show_help_string("help-schizo-base.txt", "too-many-values",
                                         true, target);
             fprintf(stderr, "%s\n", ptr);
+            free(ptr);
             return PRTE_ERR_SILENT;
         } else {
             // append with a colon delimiter
@@ -250,12 +304,21 @@ int prte_schizo_base_add_qualifier(pmix_cli_result_t *results,
 char *prte_schizo_base_getline(FILE *fp)
 {
     char *ret, *buff;
+    size_t len;
     char input[2048];
 
     memset(input, 0, 2048);
     ret = fgets(input, 2048, fp);
     if (NULL != ret) {
-        input[strlen(input) - 1] = '\0'; /* remove newline */
+        /* strip the newline - but only if there IS one.  The last line of a
+         * file that does not end in a newline has none, and blindly chopping
+         * its final character silently corrupts that line (an MCA param file
+         * saved without a trailing newline would lose a character off its
+         * last parameter) */
+        len = strlen(input);
+        if (0 < len && '\n' == input[len - 1]) {
+            input[len - 1] = '\0';
+        }
         buff = strdup(input);
         return buff;
     }
@@ -266,6 +329,7 @@ char *prte_schizo_base_getline(FILE *fp)
 char *prte_schizo_base_strip_quotes(char *p)
 {
     char *pout;
+    size_t len;
 
     /* strip any quotes around the args */
     if ('\"' == p[0]) {
@@ -273,8 +337,11 @@ char *prte_schizo_base_strip_quotes(char *p)
     } else {
         pout = strdup(p);
     }
-    if ('\"' == pout[strlen(pout) - 1]) {
-        pout[strlen(pout) - 1] = '\0';
+    /* an empty string has no trailing character to inspect - reading (and
+     * writing) pout[-1] here walks off the front of the allocation */
+    len = strlen(pout);
+    if (0 < len && '\"' == pout[len - 1]) {
+        pout[len - 1] = '\0';
     }
     return pout;
 }

--- a/src/mca/schizo/ompi/AGENTS.md
+++ b/src/mca/schizo/ompi/AGENTS.md
@@ -78,11 +78,31 @@ keys as prte.
    identity.
 3. Then runs `pmix_cmd_line_parse` against `ompioptions`/
    `help-schizo-ompi.txt` and `convert_deprecated_cli`.
+4. **Restores the tail from the original argv**, so the app's own
+   arguments are passed on as the user wrote them rather than as the
+   dash correction rewrote them. The tail is the trailing run of the
+   command line, so its start is `argc - tailc` — not "the first token
+   equal to `tail[0]`", which lands on an option's *value* whenever that
+   value happens to equal the executable's name
+   (`mpirun --wdir /tmp/app … /tmp/app`) and splices the options back
+   into the app's argv.
 
 `convert_deprecated_cli` is the ompi analogue of prte's — the same
 `add_directive`/`add_qualifier` machinery — but gated by ompi's
 `warn_deprecations`, which defaults to **false** (Open MPI users are not
-warned about the legacy spellings they've always used).
+warned about the legacy spellings they've always used). Pass that
+`warn` variable as each conversion's `report` argument; hard-coding
+`true` (as `--rankfile` used to) makes one option scold users who have
+warnings switched off, which here is everybody by default.
+
+The `--map-by` socket→package rewrite has the same shape rule as prte's,
+and this is where it bit: the `ppr` resource is the **third**
+`:`-delimited field of `ppr:N:resource[:qualifier…]`, so the value must
+be split and field `[2]` inspected. Using `strrchr()` finds the last
+`:` — the resource only when nothing follows it — and returns NULL for a
+bare `--map-by ppr`, where `++p2` then dereferenced address `0x1` and
+killed the tool outright. prte was fixed for this and ompi was not; it
+is the canonical example of why the parity rule below matters.
 
 ---
 
@@ -104,6 +124,12 @@ counterpart in prte.
   the user's explicit PRRTE/PMIx envars keep precedence). It returns
   `100` — hence detecting the ompi personality also carries a definitive
   confidence.
+
+  Splitting an `OMPI_MCA_name=value` environment entry uses **`strchr`,
+  the first `=`** — that is the one separating name from value. Using
+  `strrchr` splits at the last one instead, so any value that itself
+  contains an `=` (`mca_base_env_list="FOO=1;BAR=2"` is the everyday
+  case) gets translated under a mangled name with a truncated value.
 - **`check_prte_overlap` / `check_pmix_overlap`** encode the specific
   OMPI-name → PRRTE/PMIx-name equivalences (framework renames like OMPI
   `oob`/`if`/`dl`/`reachable`/`hwloc` mapping onto their PRRTE/PMIx
@@ -156,7 +182,25 @@ counterpart in prte.
 
 - **Keep parity with `prte`.** A new placement/output/runtime option
   usually must land in *both* personalities. The two tables drifting is a
-  classic "works with `prun`, not `mpirun`" bug.
+  classic "works with `prun`, not `mpirun`" bug — and a **fix** to a
+  shared conversion has to be mirrored just as carefully as a feature:
+  the bare-`ppr` NULL dereference above was repaired in prte and left
+  live in ompi for exactly that reason. When you touch
+  `convert_deprecated_cli` in either component, diff the two:
+
+  ```sh
+  cd src/mca/schizo
+  for f in prte/schizo_prte.c ompi/schizo_ompi.c; do
+      grep -o 'strcmp(option, "[^"]*")' $f | sed 's/.*"\(.*\)"/\1/' | sort -u > /tmp/$(basename $f).conv
+  done
+  diff /tmp/schizo_prte.c.conv /tmp/schizo_ompi.c.conv
+  ```
+
+  Differences are allowed (`with-ft` and `stream-buffering` are
+  ompi-only, by design) but each one should be a decision, not a drift.
+  Also check the option **tables** the same way: an entry with no
+  conversion behind it is an option that parses and is then silently
+  discarded.
 - **The framework-prefix list is load-bearing.** `ompi_frameworks[]`
   decides what counts as an "Open MPI MCA param" and thus what gets
   forwarded to the app env vs. translated for PRRTE/PMIx. Adding an OMPI

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -227,6 +227,7 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE("output-filename", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("merge-stderr-to-stdout", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("display-devel-map", PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE("display-devel-allocation", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("display-topo", PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE("report-bindings", PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE("display-map", PMIX_ARG_NONE),
@@ -392,11 +393,15 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         char *corrected_args = NULL;
         int tail_pos = 0;
 
-        // Find the position of the tail.
-        for(n = 0; NULL != pargv[n]; n++) {
-            if(0 == strcmp(results->tail[0], pargv[n])) break;
+        /* The tail is the trailing run of pargv, so its position is fixed by
+         * the counts.  Searching for the first token equal to tail[0] finds
+         * an OPTION'S VALUE instead whenever the executable's name was also
+         * given as one (--wdir /tmp/app ... /tmp/app), which would count
+         * corrected options as being "after" the executable. */
+        tail_pos = PMIx_Argv_count(pargv) - PMIx_Argv_count(results->tail);
+        if (0 > tail_pos) {
+            tail_pos = 0;
         }
-        tail_pos = n;
 
         for(n = 0; n < cur_caught_pos; n++) {
             // Add all offending arguments before the user executable (tail).
@@ -469,15 +474,20 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
     // check for the --stream-buffering option
 
     if (NULL != results->tail) {
-        /* search for the leader of the tail */
-        for (n=0; NULL != argv[n]; n++) {
-            if (0 == strcmp(results->tail[0], argv[n])) {
-                /* this starts the tail - replace the rest of the
-                 * tail with the original argv */
-                PMIx_Argv_free(results->tail);
-                results->tail = PMIx_Argv_copy(&argv[n]);
-                break;
-            }
+        /* Restore the tail from the ORIGINAL argv, so the app's own
+         * arguments are handed on exactly as the user wrote them rather
+         * than as the single-dash correction rewrote them.
+         *
+         * The tail is the trailing run of the command line and argv has the
+         * same length as the pargv it was parsed from, so its start is
+         * argc - tailc.  Searching for the first token equal to tail[0]
+         * instead lands on an option's VALUE whenever that value happens to
+         * equal the executable name ("--wdir /tmp/app ... /tmp/app"), which
+         * would splice the options back into the app's argv. */
+        n = PMIx_Argv_count(argv) - PMIx_Argv_count(results->tail);
+        if (0 < n && NULL != argv[n] && 0 == strcmp(results->tail[0], argv[n])) {
+            PMIx_Argv_free(results->tail);
+            results->tail = PMIx_Argv_copy(&argv[n]);
         }
     }
 
@@ -488,6 +498,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                   bool silent)
 {
     char *option, *p1, *p2, *tmp, *tmp2, *output;
+    char **ppr;
     int rc = PRTE_SUCCESS;
     pmix_cli_item_t *opt, *nxt, *opt2;
     bool warn;
@@ -662,7 +673,11 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         /* --rankfile X -> map-by rankfile:file=X */
         else if (0 == strcmp(option, "rankfile")) {
             pmix_asprintf(&p2, "%s:%s%s", PRTE_CLI_RANKFILE, PRTE_CLI_QFILE, opt->values[0]);
-            rc = prte_schizo_base_add_directive(results, option, PRTE_CLI_MAPBY, p2, true);
+            /* pass "warn", not an unconditional "true" - this personality
+             * defaults warn_deprecations to false, and hard-coding the report
+             * made --rankfile the one legacy option that scolded Open MPI
+             * users no matter how they had configured the warning */
+            rc = prte_schizo_base_add_directive(results, option, PRTE_CLI_MAPBY, p2, warn);
             free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
@@ -712,10 +727,19 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
-        /* --display-devel-map  -> --display allocation-devel */
+        /* --display-devel-map  -> --display map-devel */
         else if (0 == strcmp(option, "display-devel-map")) {
             rc = prte_schizo_base_add_directive(results, option,
                                                 PRTE_CLI_DISPLAY, PRTE_CLI_MAPDEV,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+        /* --display-devel-allocation  ->  --display allocation.  There is no
+         * separate developer allocation display any more, so it folds onto
+         * the one allocation directive parse_display knows. */
+        else if (0 == strcmp(option, "display-devel-allocation")) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_DISPLAY, PRTE_CLI_ALLOC,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
@@ -830,15 +854,21 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 free(p1);
                 free(opt->values[0]);
                 opt->values[0] = tmp;
-            } else if (0 == strncasecmp(opt->values[0], "ppr", strlen("ppr"))) {
+            } else if (0 == strncasecmp(opt->values[0], PRTE_CLI_PPR, strlen(PRTE_CLI_PPR))) {
                 // see if they specified "socket" as the resource
-                p1 = strdup(opt->values[0]);
-                p2 = strrchr(p1, ':');
-                ++p2;
-                if (0 == strncasecmp(p2, "socket", strlen("socket")) ||
-                    0 == strncasecmp(p2, "skt", strlen("skt"))) {
-                    *p2 = '\0';
-                    pmix_asprintf(&p2, "%spackage", p1);
+                /* the pattern is "ppr:N:resource[:qualifier...]", so the
+                 * resource is the THIRD field.  Reaching for it with strrchr()
+                 * finds the last ':' instead, which is the resource only when
+                 * no qualifiers follow it - and returns NULL for a bare
+                 * "--map-by ppr", where advancing past it dereferenced address
+                 * 0x1 and killed the tool outright */
+                ppr = PMIx_Argv_split(opt->values[0], ':');
+                if (3 <= PMIx_Argv_count(ppr) &&
+                    (0 == strncasecmp(ppr[2], "socket", strlen("socket")) ||
+                     0 == strncasecmp(ppr[2], "skt", strlen("skt")))) {
+                    free(ppr[2]);
+                    ppr[2] = strdup(PRTE_CLI_PACKAGE);
+                    p2 = PMIx_Argv_join(ppr, ':');
                     if (warn) {
                         pmix_asprintf(&tmp, "%s %s", option, opt->values[0]);
                         pmix_asprintf(&tmp2, "%s %s", option, p2);
@@ -854,7 +884,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                     free(opt->values[0]);
                     opt->values[0] = p2;
                 }
-                free(p1);
+                PMIx_Argv_free(ppr);
             }
         }
         /* --rank-by socket ->  --rank-by package */
@@ -1894,7 +1924,17 @@ static int translate_params(void)
     for (n=0; NULL != environ[n]; n++) {
         if (0 == strncmp(environ[n], "OMPI_MCA_", len)) {
             e2 = strdup(environ[n]);
-            evar = strrchr(e2, '=');
+            /* split at the FIRST '=' - that is the one separating the
+             * variable's name from its value.  strrchr() splits at the last
+             * one instead, so any OMPI_MCA_ value that itself contains an
+             * '=' (mca_base_env_list="FOO=1;BAR=2" is the common one) is
+             * translated under a mangled name with a truncated value */
+            evar = strchr(e2, '=');
+            if (NULL == evar) {
+                /* environ entries always carry one, but do not trust it */
+                free(e2);
+                continue;
+            }
             *evar = '\0';
             ++evar;
             if (check_prte_overlap(&e2[len], evar)) {

--- a/src/mca/schizo/prte/AGENTS.md
+++ b/src/mca/schizo/prte/AGENTS.md
@@ -27,6 +27,12 @@ This "always bids at least 5, never 0 by default" behavior is what makes
 `prte` the default. `ompi` bids 0 unless explicitly selected, so an
 un-hinted `prun`/`prte`/`prterun` is a prte-personality invocation.
 
+A bid of 0 means "not me", and the base requires a strictly positive bid
+to select anything — so when a `--personality` list names neither
+personality, both bid 0, `detect_proxy` returns NULL, and the tool reports
+`no-proxy`. Keep that property when editing this component's bids: a
+personality nobody claims must be an error, not a silent fallback.
+
 ---
 
 ## Files
@@ -106,6 +112,11 @@ instance with `PMIX_CLI_REMOVE_DEPRECATED`. Examples:
 
 - `--n` → `--np` (silent, no warning).
 - `--nolocal` → `--map-by :NOLOCAL` (qualifier).
+- `--merge-stderr-to-stdout` → `--output merge-stderr-to-stdout`.
+- `--display-devel-allocation` → `--display allocation` (there is no
+  separate developer-detail allocation display; `allocation` is the only
+  allocation directive `parse_display` knows, so the docs' old advice to
+  use `--display alloc-devel` named a directive that does not exist).
 - and the rest of the classic ORTE-era options mapped onto the current
   `--map-by`/`--rank-by`/`--bind-to`/`--output`/`--display` directive
   vocabulary.
@@ -113,11 +124,30 @@ instance with `PMIX_CLI_REMOVE_DEPRECATED`. Examples:
 Because prte defaults `warn_deprecations = true`, native-tool users get a
 warning for each converted option — the opposite of `ompi` (see below).
 
+Two of the rewrites are narrower than they look, and both were once
+wider by mistake:
+
+- **`--rank-by` only renames `socket`→`package`.** It used to rewrite
+  every object spelling (`numa`, `core`, `l1/l2/l3cache`, `hwthread`) to
+  `package` as well. That is not a rename — those are distinct objects,
+  and none of them is a ranking directive PRRTE supports either way (the
+  rankers are `slot`, `node`, `fill`, `span`). The rewrite never made
+  them work; it only made the sanity checker's error name `package`, an
+  option the user never typed. Leave a value alone unless you are
+  genuinely renaming it.
+- **The `ppr` resource is the THIRD `:`-delimited field.** The pattern
+  is `ppr:N:resource[:qualifier…]`, so the socket→package rewrite splits
+  the value and inspects field `[2]`. Reaching for it with `strrchr()`
+  finds the *last* `:` instead, which is the resource only when no
+  qualifier follows — and returns NULL for a bare `--map-by ppr`, where
+  advancing past it dereferences address `0x1`.
+
 ## Other hooks
 
 - **`parse_env`** — effectively a no-op (logs and returns
-  `PRTE_SUCCESS`). The native personality forwards no special envars; app
-  environment handling happens through attributes in `setup_fork`.
+  `PRTE_SUCCESS`). The native personality forwards no special envars; the
+  user's envar directives become job/app attributes and are applied on the
+  daemon by `odls`' `process_envars()`.
 - **`allow_run_as_root`** — honors `--allow-run-as-root`, or the pair
   `PRTE_ALLOW_RUN_AS_ROOT` + `PRTE_ALLOW_RUN_AS_ROOT_CONFIRM` both set to
   `1`; otherwise calls `prte_schizo_base_root_error_msg()` (which
@@ -156,6 +186,21 @@ warning for each converted option — the opposite of `ompi` (see below).
 - **Use canonical un-hyphenated `PRTE_CLI_*` keys**, and if you add a
   deprecated spelling, wire its conversion in `convert_deprecated_cli`
   rather than adding a second table entry.
+- **A table entry with no conversion is a silently-ignored option.** It
+  parses, it is never read by anyone, and the user gets no error — which
+  is exactly how `--merge-stderr-to-stdout` and
+  `--display-devel-allocation` sat dead in `prterunoptions`/
+  `prunoptions`. Cross-check the two lists when you touch either:
+
+  ```sh
+  cd src/mca/schizo/prte
+  grep -o 'PMIX_OPTION_DEFINE("[^"]*"' schizo_prte.c | sed 's/.*"\(.*\)"/\1/' | sort -u
+  grep -o 'strcmp(option, "[^"]*")' schizo_prte.c | sed 's/.*"\(.*\)"/\1/' | sort -u
+  ```
+
+  A table entry missing from the second list is a live bug; a converter
+  branch missing from the first is merely dead code (prte carries a few:
+  `amca`, `am`, `bind-to-socket`).
 - **Mirror in `ompi` when it's a shared concept.** Placement, output,
   and runtime-option changes usually need the ompi table/handler updated
   too, or the two personalities drift.

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -537,6 +537,14 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
         shorts = pinfoshorts;
         helpfile = "help-prte-info.txt";
         sdprefix = "prte";
+    } else {
+        /* every PRRTE tool sets prte_tool_actual to one of the six names
+         * above, so this is unreachable today - but handing
+         * pmix_cmd_line_parse a NULL option table is a crash, not a
+         * diagnosable error, so refuse rather than continue */
+        pmix_show_help("help-schizo-base.txt", "no-proxy", true,
+                       prte_tool_basename, prte_tool_actual);
+        return PRTE_ERR_NOT_FOUND;
     }
     pmix_tool_msg = "Report bugs to: https://github.com/openpmix/prrte";
     pmix_tool_org = "PRRTE";
@@ -592,6 +600,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                                   bool silent)
 {
     char *option, *p1, *p2, *tmp, *tmp2, *output;
+    char **ppr;
     int rc = PRTE_SUCCESS;
     pmix_cli_item_t *opt, *nxt;
     bool warn;
@@ -822,10 +831,37 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
 
-        /* --display-devel-map  -> --display allocation-devel */
+        /* --display-devel-map  -> --display map-devel */
         else if (0 == strcmp(option, "display-devel-map")) {
             rc = prte_schizo_base_add_directive(results, option,
                                                 PRTE_CLI_DISPLAY, PRTE_CLI_MAPDEV,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --display-devel-allocation  ->  --display allocation
+         *
+         * There is no separate "developer" allocation display any more -
+         * PRTE_CLI_ALLOC is the only allocation directive parse_display
+         * knows - so the deprecated option folds onto it.  Without this
+         * branch the option is accepted by the tables and then silently
+         * discarded, which asks for a display and gets none. */
+        else if (0 == strcmp(option, "display-devel-allocation")) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_DISPLAY, PRTE_CLI_ALLOC,
+                                                warn);
+            PMIX_CLI_REMOVE_DEPRECATED(results, opt);
+        }
+
+        /* --merge-stderr-to-stdout  ->  --output merge-stderr-to-stdout
+         *
+         * The option is in the prterun/prun tables; with no conversion here
+         * it parsed cleanly and then did nothing at all, so stderr stayed
+         * separate no matter what the user asked for.  The ompi personality
+         * has always converted it - this is the missing mirror. */
+        else if (0 == strcmp(option, "merge-stderr-to-stdout")) {
+            rc = prte_schizo_base_add_directive(results, option,
+                                                PRTE_CLI_OUTPUT, PRTE_CLI_MERGE_ERROUT,
                                                 warn);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
@@ -955,21 +991,20 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                 free(p1);
                 free(opt->values[0]);
                 opt->values[0] = tmp;
-            } else if (0 == strncasecmp(opt->values[0], "ppr", strlen("ppr"))) {
+            } else if (0 == strncasecmp(opt->values[0], PRTE_CLI_PPR, strlen(PRTE_CLI_PPR))) {
                 // see if they specified "socket" as the resource
-                p1 = strdup(opt->values[0]);
-                p2 = strrchr(p1, ':');
-                /* a bare "ppr" with no ":resource" qualifier has nothing to
-                 * inspect - strrchr returns NULL, so guard against advancing
-                 * past it (which would dereference address 0x1 and crash) */
-                if (NULL != p2) {
-                    ++p2;
-                }
-                if (NULL != p2 &&
-                    (0 == strncasecmp(p2, "socket", strlen("socket")) ||
-                     0 == strncasecmp(p2, "skt", strlen("skt")))) {
-                    *p2 = '\0';
-                    pmix_asprintf(&p2, "%spackage", p1);
+                /* the pattern is "ppr:N:resource[:qualifier...]", so the
+                 * resource is the THIRD field.  Reaching for it with strrchr()
+                 * finds the last ':' instead, which is the resource only when
+                 * no qualifiers follow it - and returns NULL for a bare "ppr",
+                 * where advancing past it dereferences address 0x1 */
+                ppr = PMIx_Argv_split(opt->values[0], ':');
+                if (3 <= PMIx_Argv_count(ppr) &&
+                    (0 == strncasecmp(ppr[2], "socket", strlen("socket")) ||
+                     0 == strncasecmp(ppr[2], "skt", strlen("skt")))) {
+                    free(ppr[2]);
+                    ppr[2] = strdup(PRTE_CLI_PACKAGE);
+                    p2 = PMIx_Argv_join(ppr, ':');
                     if (warn) {
                         pmix_asprintf(&tmp, "%s %s", option, opt->values[0]);
                         pmix_asprintf(&tmp2, "%s %s", option, p2);
@@ -985,21 +1020,23 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                     free(opt->values[0]);
                     opt->values[0] = p2;
                 }
-                free(p1);
+                PMIx_Argv_free(ppr);
             }
         }
 
-        /* --rank-by */
+        /* --rank-by socket  ->  --rank-by package
+         *
+         * ONLY "socket" is renamed here.  This used to rewrite every
+         * object-level spelling (numa, core, l1/l2/l3cache, hwthread) to
+         * "package" as well, which is not a rename - those are distinct
+         * objects, and none of them is a ranking directive PRRTE supports
+         * (the rankers are slot, node, fill and span).  The rewrite did not
+         * make them work; it only made the error message name "package", an
+         * option the user never typed.  Leaving them alone lets the sanity
+         * checker report what was actually given. */
         else if (0 == strcmp(option, PRTE_CLI_RANKBY)) {
-            /* check the value of the option for object-level directives - show help
-             * for ranking if given */
-            if (0 == strncasecmp(opt->values[0], "socket", strlen("socket")) ||
-                0 == strncasecmp(opt->values[0], "l1cache", strlen("l1cache"))  ||
-                0 == strncasecmp(opt->values[0], "l2cache", strlen("l2cache")) ||
-                0 == strncasecmp(opt->values[0], "l3cache", strlen("l3cache")) ||
-                0 == strncasecmp(opt->values[0], "numa", strlen("numa")) ||
-                0 == strncasecmp(opt->values[0], "hwthread", strlen("hwthread")) ||
-                0 == strncasecmp(opt->values[0], "core", strlen("core"))) {
+            /* check the value of the option for "socket" */
+            if (0 == strncasecmp(opt->values[0], "socket", strlen("socket"))) {
                 p1 = strdup(opt->values[0]); // save the original option
                 /* replace "socket" with "package" */
                 if (NULL == (p2 = strchr(opt->values[0], ':'))) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1008,6 +1008,21 @@ static void interim(int sd, short args, void *cbdata)
         /* use the default */
         jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(NULL);
     }
+    if (NULL == jdata->schizo) {
+        /* the requestor named a personality no component claims. Every later
+         * use of jdata->schizo (starting with set_default_rto just below) is
+         * an unchecked dereference, so reject the request here - a bad
+         * personality string in a spawn request must not take down the DVM */
+        char *prsn = (NULL == jdata->personality)
+                     ? NULL : PMIx_Argv_join(jdata->personality, ',');
+        pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
+                       (NULL == prsn) ? "NULL" : prsn);
+        if (NULL != prsn) {
+            free(prsn);
+        }
+        rc = PRTE_ERR_NOT_FOUND;
+        goto complete;
+    }
 
     /* transfer the apps across */
     for (n = 0; n < cd->napps; n++) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -596,6 +596,14 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, PRTE_ATTR_GLOBAL,
                                &flag, PMIX_BOOL);
 
+        } else if (PMIX_CHECK_KEY(info, PMIX_IOF_FILE_PATTERN)) {
+            /* the output filename is the requestor's to compose - carry the
+             * flag through to the nspace registration, which is what puts it
+             * in front of the PMIx IOF that opens the file */
+            flag = PMIX_INFO_TRUE(info);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_FILE_PATTERN, PRTE_ATTR_GLOBAL,
+                               &flag, PMIX_BOOL);
+
             /***   MERGE STDERR TO STDOUT   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_IOF_MERGE_STDERR_STDOUT) ||
                    PMIX_CHECK_KEY(info, PMIX_MERGE_STDERR_STDOUT)) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -899,62 +899,62 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
                 if (0 == app->idx) {
-                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 } else {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&app->attributes, PRTE_APP_SET_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 }
             } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
                 if (0 == app->idx) {
-                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 } else {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&app->attributes, PRTE_APP_ADD_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 }
             } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
                 if (0 == app->idx) {
-                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           info->value.data.string, PMIX_STRING);
+                    prte_append_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          info->value.data.string, PMIX_STRING);
                 } else {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           info->value.data.string, PMIX_STRING);
+                    prte_append_attribute(&app->attributes, PRTE_APP_UNSET_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          info->value.data.string, PMIX_STRING);
                 }
             } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
                 if (0 == app->idx) {
-                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 } else {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&app->attributes, PRTE_APP_PREPEND_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 }
             } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
                 envar.envar = info->value.data.envar.envar;
                 envar.value = info->value.data.envar.value;
                 envar.separator = info->value.data.envar.separator;
                 if (0 == app->idx) {
-                    prte_prepend_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 } else {
-                    prte_prepend_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
-                                           PRTE_ATTR_GLOBAL,
-                                           &envar, PMIX_ENVAR);
+                    prte_append_attribute(&app->attributes, PRTE_APP_APPEND_ENVAR,
+                                          PRTE_ATTR_GLOBAL,
+                                          &envar, PMIX_ENVAR);
                 }
 
             } else if (PMIX_CHECK_KEY(info, PMIX_PSET_NAME)) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -553,6 +553,11 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_NOCOPY, (void**)&fptr, PMIX_BOOL)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_OUTPUT_NOCOPY, &flag, PMIX_BOOL);
     }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_FILE_PATTERN, (void**)&fptr, PMIX_BOOL)) {
+        /* PMIx expands the pattern when it opens the sink, so the flag has to
+         * reach the nspace it will read the filename from */
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_FILE_PATTERN, &flag, PMIX_BOOL);
+    }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MERGE_STDERR_STDOUT, (void**)&fptr, PMIX_BOOL)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_MERGE_STDERR_STDOUT, &flag, PMIX_BOOL);
     }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -16,6 +16,7 @@
 #include "src/mca/ras/base/base.h"
 #include "src/mca/rmaps/rmaps.h"
 #include "src/mca/schizo/base/base.h"
+#include "src/util/pmix_show_help.h"
 
 /* Process the session control directive from the scheduler */
 static int process_directive(prte_pmix_server_req_t *req)
@@ -226,10 +227,22 @@ static int process_directive(prte_pmix_server_req_t *req)
         if (NULL == personality) {
             /* use the default */
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(NULL);
-        } else {
+        } else if (NULL == jdata->personality) {
+            /* only resolve it once - the info scan above may already have
+             * done so, and repeating the split leaks the first argv and
+             * caches the same job info twice */
             jdata->personality = PMIx_Argv_split(personality->value.data.string, ',');
             jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
             pmix_server_cache_job_info(jdata, personality);
+        }
+        if (NULL == jdata->schizo) {
+            /* no component claims the requested personality - refuse the
+             * request instead of leaving the job with a NULL personality
+             * for someone downstream to dereference */
+            pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
+                           (NULL == personality) ? "NULL" : personality->value.data.string);
+            rc = PMIX_ERR_NOT_FOUND;
+            goto ANSWER;
         }
     }
 

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -344,126 +344,124 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         goto cleanup;
     }
 
-    // check for any envar directives
-    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_FWD_ENVAR);
-    if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n++) {
-            param = strdup(opt->values[n]);
-            /* if there is an '=' in it, then they are setting a value */
-            if (NULL != (value = strchr(param, '='))) {
-                *value = '\0';
-                ++value;
-                envt.envar = param;
-                envt.value = strdup(value);
-                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                PMIX_ENVAR_DESTRUCT(&envt);
-            } else {
-                // have to support the wildcard here
-                if (NULL != (ptr = strchr(param, '*'))) {
-                    *ptr = '\0';
-                    for (i=0; NULL != environ[i]; i++) {
-                        if (0 == strncmp(environ[i], param, strlen(param))) {
-                            // this is a var to fwd
-                            // extract the name and value
-                            ptr = strdup(environ[i]);
-                            value = strchr(ptr, '=');
-                            *value = '\0';
-                            ++value;
-                            envt.envar = ptr;
+    /* Check for any envar directives.
+     *
+     * These are applied to the process environment IN THE ORDER GIVEN. That
+     * matters: SET replaces a value outright while PREPEND/APPEND edit the
+     * one already there, so "--prepend-env FOO[:] x --set-env FOO=1" leaves
+     * FOO=1 and "--set-env FOO=1 --prepend-env FOO[:] x" leaves FOO=x:1.
+     * Both are what the user asked for; neither is a merge policy we get to
+     * choose.
+     *
+     * So walk results->instances in list order rather than looking each key
+     * up in a fixed sequence - pmix_cmd_line_parse appends instances in the
+     * order their options were first seen, which IS command-line order.
+     * (Repeating one option type after another has intervened is the one
+     * case this cannot reproduce: every occurrence of an option is grouped
+     * onto that option's single instance, so it is applied at the position
+     * of its FIRST appearance.)
+     */
+    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
+        if (0 == strcmp(opt->key, PRTE_CLI_FWD_ENVAR)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                param = strdup(opt->values[n]);
+                /* if there is an '=' in it, then they are setting a value */
+                if (NULL != (value = strchr(param, '='))) {
+                    *value = '\0';
+                    ++value;
+                    envt.envar = param;
+                    envt.value = strdup(value);
+                    PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                    PMIX_ENVAR_DESTRUCT(&envt);
+                } else {
+                    // have to support the wildcard here
+                    if (NULL != (ptr = strchr(param, '*'))) {
+                        *ptr = '\0';
+                        for (i=0; NULL != environ[i]; i++) {
+                            if (0 == strncmp(environ[i], param, strlen(param))) {
+                                // this is a var to fwd
+                                // extract the name and value
+                                ptr = strdup(environ[i]);
+                                value = strchr(ptr, '=');
+                                *value = '\0';
+                                ++value;
+                                envt.envar = ptr;
+                                envt.value = strdup(value);
+                                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                                PMIX_ENVAR_DESTRUCT(&envt);
+                            }
+                        }
+                        free(param);
+                    } else {
+                        // given a unique name
+                        value = getenv(param);
+                        if (NULL == value) {
+                            pmix_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
+                            free(param);
+                        } else {
+                            envt.envar = param;
                             envt.value = strdup(value);
                             PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
                             PMIX_ENVAR_DESTRUCT(&envt);
                         }
                     }
-                    free(param);
-                } else {
-                    // given a unique name
-                    value = getenv(param);
-                    if (NULL == value) {
-                        pmix_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
-                        free(param);
-                    } else {
-                        envt.envar = param;
-                        envt.value = strdup(value);
-                        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                        PMIX_ENVAR_DESTRUCT(&envt);
-                    }
                 }
             }
-        }
-    }
 
-    opt = pmix_cmd_line_get_param(&results, PMIX_CLI_PREPEND_ENVAR);
-    if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n+=2) {
-            param = strdup(opt->values[n]);
-            // find the [] enclosing the separator
-            i = strlen(param);
-            if (']' != param[i-1] || '[' != param[i-3]) {
-                pmix_show_help("help-prun.txt", "malformed-envar", true,
-                               "prepend", app->app.cmd, param);
-                rc = PRTE_ERR_SILENT;
-                free(param);
-                goto cleanup;
+        } else if (0 == strcmp(opt->key, PMIX_CLI_PREPEND_ENVAR) ||
+                   0 == strcmp(opt->key, PMIX_CLI_APPEND_ENVAR)) {
+            /* these two store the variable's name and the value as SEPARATE
+             * entries, so they are read two at a time */
+            bool prepend = (0 == strcmp(opt->key, PMIX_CLI_PREPEND_ENVAR));
+            for (n=0; NULL != opt->values[n] && NULL != opt->values[n+1]; n+=2) {
+                param = strdup(opt->values[n]);
+                // find the [] enclosing the separator
+                i = strlen(param);
+                if (3 > i || ']' != param[i-1] || '[' != param[i-3]) {
+                    pmix_show_help("help-prun.txt", "malformed-envar", true,
+                                   prepend ? "prepend" : "append", app->app.cmd, param);
+                    rc = PRTE_ERR_SILENT;
+                    free(param);
+                    goto cleanup;
+                }
+                param[i-3] = '\0';
+                envt.envar = param;
+                envt.value = strdup(opt->values[n+1]);
+                envt.separator = param[i-2];
+                PMIX_INFO_LIST_ADD(rc, app->info,
+                                   prepend ? PMIX_PREPEND_ENVAR : PMIX_APPEND_ENVAR,
+                                   &envt, PMIX_ENVAR);
+                PMIX_ENVAR_DESTRUCT(&envt);
             }
-            param[i-3] = '\0';
-            envt.envar = param;
-            envt.value = strdup(opt->values[n+1]);
-            envt.separator = param[i-2];
-            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PREPEND_ENVAR, &envt, PMIX_ENVAR);
-            PMIX_ENVAR_DESTRUCT(&envt);
-        }
-    }
 
-    opt = pmix_cmd_line_get_param(&results, PMIX_CLI_APPEND_ENVAR);
-    if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n+=2) {
-            param = strdup(opt->values[n]);
-            // find the [] enclosing the separator
-            i = strlen(param);
-            if (']' != param[i-1] || '[' != param[i-3]) {
-                pmix_show_help("help-prun.txt", "malformed-envar", true,
-                               "append", app->app.cmd, param);
-                rc = PRTE_ERR_SILENT;
-                free(param);
-                goto cleanup;
+        } else if (0 == strcmp(opt->key, PMIX_CLI_SET_ENVAR)) {
+            /* --set-env stores ONE value per occurrence ("NAME=value"),
+             * unlike --prepend-env/--append-env above.  Striding by two here
+             * skipped every other --set-env on the command line, silently. */
+            for (n=0; NULL != opt->values[n]; n++) {
+                param = strdup(opt->values[n]);
+                // find the '=' separating name from value
+                tval = strchr(param, '=');
+                if (NULL == tval) {
+                    pmix_show_help("help-prun.txt", "malformed-envar", true,
+                                   "set", app->app.cmd, param);
+                    rc = PRTE_ERR_SILENT;
+                    free(param);
+                    goto cleanup;
+                }
+                *tval = '\0';
+                ++tval;
+                PMIX_ENVAR_CONSTRUCT(&envt);
+                envt.envar = param;
+                envt.value = strdup(tval);
+                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                PMIX_ENVAR_DESTRUCT(&envt);
             }
-            param[i-3] = '\0';
-            envt.envar = param;
-            envt.value = strdup(opt->values[n+1]);
-            envt.separator = param[i-2];
-            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_APPEND_ENVAR, &envt, PMIX_ENVAR);
-            PMIX_ENVAR_DESTRUCT(&envt);
-        }
-    }
 
-    opt = pmix_cmd_line_get_param(&results, PMIX_CLI_SET_ENVAR);
-    if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n+=2) {
-            param = strdup(opt->values[n]);
-            // find the '=' separating name from value
-            tval = strchr(param, '=');
-            if (NULL == tval) {
-                pmix_show_help("help-prun.txt", "malformed-envar", true,
-                               "set", app->app.cmd, param);
-                rc = PRTE_ERR_SILENT;
-                free(param);
-                goto cleanup;
+        } else if (0 == strcmp(opt->key, PMIX_CLI_UNSET_ENVAR)) {
+            for (n=0; NULL != opt->values[n]; n++) {
+                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_UNSET_ENVAR, opt->values[n], PMIX_STRING);
             }
-            *tval = '\0';
-            ++tval;
-            PMIX_ENVAR_CONSTRUCT(&envt);
-            envt.envar = param;
-            envt.value = strdup(tval);
-            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-            PMIX_ENVAR_DESTRUCT(&envt);
-        }
-    }
-
-    opt = pmix_cmd_line_get_param(&results, PMIX_CLI_UNSET_ENVAR);
-    if (NULL != opt) {
-        for (n=0; NULL != opt->values[n]; n++) {
-            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_UNSET_ENVAR, opt->values[n], PMIX_STRING);
         }
     }
 

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -575,6 +575,9 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
         case PRTE_JOB_SPAWN_TARGET:
             return "SPAWN_TARGET";
 
+        case PRTE_JOB_OUTPUT_FILE_PATTERN:
+            return "JOB-OUTPUT-FILE-PATTERN";
+
         case PRTE_PROC_NOBARRIER:
             return "PROC-NOBARRIER";
         case PRTE_PROC_PRIOR_NODE:

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -170,6 +170,23 @@ int prte_prepend_attribute(pmix_list_t *attributes, prte_attribute_key_t key, bo
     return PRTE_SUCCESS;
 }
 
+int prte_append_attribute(pmix_list_t *attributes, prte_attribute_key_t key, bool local,
+                          void *data, pmix_data_type_t type)
+{
+    prte_attribute_t *kv;
+    int rc;
+
+    kv = PMIX_NEW(prte_attribute_t);
+    kv->key = key;
+    kv->local = local;
+    if (PRTE_SUCCESS != (rc = prte_attr_load(kv, data, type))) {
+        PMIX_RELEASE(kv);
+        return rc;
+    }
+    pmix_list_append(attributes, &kv->super);
+    return PRTE_SUCCESS;
+}
+
 void prte_remove_attribute(pmix_list_t *attributes, prte_attribute_key_t key)
 {
     prte_attribute_t *kv;

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -264,6 +264,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_DO_NOT_SPAWN               (PRTE_JOB_START_KEY + 123) // bool - do not spawn app procs
 #define PRTE_JOB_SPAWN_TARGET               (PRTE_JOB_START_KEY + 124) // char* - comma-delimited list of PMIX_ALLOC_ID strings naming the
                                                                        // allocations (sessions) this job may map onto; empty token = default session
+#define PRTE_JOB_OUTPUT_FILE_PATTERN        (PRTE_JOB_START_KEY + 125) // bool - treat PRTE_JOB_OUTPUT_TO_FILE as a name pattern the user
+                                                                       // controls instead of annotating it with nspace and rank
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -348,8 +348,20 @@ PRTE_EXPORT void prte_remove_attribute(pmix_list_t *attributes, prte_attribute_k
 PRTE_EXPORT prte_attribute_t *prte_fetch_attribute(pmix_list_t *attributes, prte_attribute_t *prev,
                                                    prte_attribute_key_t key);
 
+/* Add an attribute to the front of a list, keeping any prior entry with the
+ * same key - use for the multi-valued attributes (the envar directives) when
+ * the new entry must be applied BEFORE the ones already there.  Note that
+ * prepending a block of entries one at a time reverses that block: walk the
+ * source in reverse if its internal order matters. */
 PRTE_EXPORT int prte_prepend_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
                                        bool local, void *data, pmix_data_type_t type);
+
+/* Add an attribute to the end of a list, keeping any prior entry with the
+ * same key.  This is what preserves the order a set of multi-valued
+ * attributes was generated in - which, for the envar directives, is the
+ * order the user gave them on the command line. */
+PRTE_EXPORT int prte_append_attribute(pmix_list_t *attributes, prte_attribute_key_t key,
+                                      bool local, void *data, pmix_data_type_t type);
 
 PRTE_EXPORT int prte_attr_load(prte_attribute_t *kv, void *data, pmix_data_type_t type);
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml ras
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml ras schizo

--- a/test/unit/odls/test_odls.c
+++ b/test/unit/odls/test_odls.c
@@ -56,6 +56,8 @@
 #include "src/hwloc/hwloc-internal.h"
 #include "src/runtime/runtime.h"
 #include "src/util/pmix_argv.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/attr.h"
 #include "src/util/proc_info.h"
 
 #include "src/mca/odls/odls.h"
@@ -306,6 +308,65 @@ static int test_classes(void)
     return failures;
 }
 
+/*
+ * The envar directives (SET/ADD/UNSET/PREPEND/APPEND) are multi-valued job
+ * and app attributes, and process_envars() applies them to the process
+ * environment by walking that list FRONT TO BACK.  The order of the list is
+ * therefore the order the user's directives take effect in, and the user's
+ * command line is what decides it: "--prepend-env FOO[:] x --set-env FOO=1"
+ * must leave FOO=1, while the reverse order must leave FOO=x:1.
+ *
+ * That makes the append-vs-prepend distinction a behavioral contract, not a
+ * style choice: prte_append_attribute() is what preserves generation order,
+ * and prte_prepend_attribute() is what puts an entry in FRONT of everything
+ * already there (used for the values PMIx_server_setup_application hands
+ * back, which must be applied before - and hence be overridable by - the
+ * user's own).  Assert both, since a swap in either direction is silent.
+ */
+static int test_attribute_order(void)
+{
+    int failures = 0;
+    pmix_list_t attrs;
+    prte_attribute_t *attr;
+    pmix_envar_t envt;
+    int n;
+    const char *names[] = {"FIRST", "SECOND", "THIRD"};
+
+    PMIX_CONSTRUCT(&attrs, pmix_list_t);
+
+    /* appending preserves the order the entries were generated in */
+    for (n = 0; n < 3; n++) {
+        PMIX_ENVAR_CONSTRUCT(&envt);
+        envt.envar = (char *) names[n];
+        envt.value = (char *) "v";
+        envt.separator = ':';
+        prte_append_attribute(&attrs, PRTE_JOB_SET_ENVAR, PRTE_ATTR_GLOBAL,
+                              &envt, PMIX_ENVAR);
+    }
+    n = 0;
+    PMIX_LIST_FOREACH(attr, &attrs, prte_attribute_t) {
+        CHECK("append keeps generation order",
+              n < 3 && 0 == strcmp(attr->data.data.envar.envar, names[n]));
+        ++n;
+    }
+    CHECK("append added every entry", 3 == n);
+
+    /* prepending puts the new entry in front of all of them */
+    PMIX_ENVAR_CONSTRUCT(&envt);
+    envt.envar = (char *) "SETUP";
+    envt.value = (char *) "v";
+    envt.separator = ':';
+    prte_prepend_attribute(&attrs, PRTE_JOB_SET_ENVAR, PRTE_ATTR_GLOBAL,
+                           &envt, PMIX_ENVAR);
+    attr = (prte_attribute_t *) pmix_list_get_first(&attrs);
+    CHECK("prepend lands in front",
+          NULL != attr && 0 == strcmp(attr->data.data.envar.envar, "SETUP"));
+    CHECK("prepend kept the rest", 4 == pmix_list_get_size(&attrs));
+
+    PMIX_LIST_DESTRUCT(&attrs);
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -330,6 +391,7 @@ int main(void)
     failures += test_daemon_cmd_uniqueness();
     failures += test_child_err_enum();
     failures += test_classes();
+    failures += test_attribute_order();
 
     (void) pmix_mca_base_framework_close(&prte_odls_base_framework);
     prte_finalize();

--- a/test/unit/schizo/Makefile.am
+++ b/test/unit/schizo/Makefile.am
@@ -1,0 +1,32 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_schizo
+
+test_schizo_SOURCES = \
+    test_schizo_main.c  \
+    test_helpers.c      \
+    test_normalize.c    \
+    test_directives.c   \
+    test_sanity.c       \
+    test_output.c       \
+    test_personality.c
+
+noinst_HEADERS = test_schizo.h
+
+test_schizo_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_schizo
+
+# Run against the components in this build tree, not just an installed one:
+# the personality tests reach prte/ompi through the framework, which in a
+# --enable-mca-dso build has nothing to open without this.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/schizo/test_directives.c
+++ b/test/unit/schizo/test_directives.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * The option->directive plumbing every deprecated-option conversion goes
+ * through (add_directive / add_qualifier) and the directive validators the
+ * sanity checker is built on (check_directives / check_qualifiers).
+ */
+
+#include "test_schizo.h"
+
+static char *first_value(pmix_cli_result_t *results, const char *key)
+{
+    pmix_cli_item_t *opt;
+
+    opt = pmix_cmd_line_get_param(results, key);
+    if (NULL == opt || NULL == opt->values) {
+        return NULL;
+    }
+    return opt->values[0];
+}
+
+int test_directives(void)
+{
+    int failures = 0, rc;
+    pmix_cli_result_t results;
+    char *v;
+
+    char *mappers[] = {
+        PRTE_CLI_SLOT, PRTE_CLI_NODE, PRTE_CLI_PPR, PRTE_CLI_PACKAGE, NULL
+    };
+    char *mapquals[] = {
+        PRTE_CLI_PE, PRTE_CLI_SPAN, PRTE_CLI_OVERSUB, PRTE_CLI_NOLOCAL, NULL
+    };
+
+    /*** a directive lands on an option that did not exist yet ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    rc = prte_schizo_base_add_directive(&results, "bynode", PRTE_CLI_MAPBY,
+                                        PRTE_CLI_NODE, false);
+    CHECK("add_directive:new-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_MAPBY);
+    CHECK("add_directive:new-value", NULL != v && 0 == strcmp(v, PRTE_CLI_NODE));
+    PMIX_DESTRUCT(&results);
+
+    /*** a qualifier on an option that did not exist yet keeps its ':' ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    rc = prte_schizo_base_add_qualifier(&results, "nolocal", PRTE_CLI_MAPBY,
+                                        PRTE_CLI_NOLOCAL, false);
+    CHECK("add_qualifier:new-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_MAPBY);
+    CHECK("add_qualifier:new-value", NULL != v && 0 == strcmp(v, ":nolocal"));
+
+    /*** and a directive added afterwards is PREPENDED to that qualifier ***/
+    rc = prte_schizo_base_add_directive(&results, "bynode", PRTE_CLI_MAPBY,
+                                        PRTE_CLI_NODE, false);
+    CHECK("add_directive:prepend-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_MAPBY);
+    CHECK("add_directive:prepend-value", NULL != v && 0 == strcmp(v, "node:nolocal"));
+    PMIX_DESTRUCT(&results);
+
+    /*** a second qualifier is appended with a ':' ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "node", NULL);
+    rc = prte_schizo_base_add_qualifier(&results, "nolocal", PRTE_CLI_MAPBY,
+                                        PRTE_CLI_NOLOCAL, false);
+    CHECK("add_qualifier:append-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_MAPBY);
+    CHECK("add_qualifier:append-value", NULL != v && 0 == strcmp(v, "node:nolocal"));
+    PMIX_DESTRUCT(&results);
+
+    /*** --map-by takes ONE directive: a second is an error, not a merge ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "node", NULL);
+    fprintf(stderr, "--- expected error output follows (map-by, two directives) ---\n");
+    rc = prte_schizo_base_add_directive(&results, "bycore", PRTE_CLI_MAPBY,
+                                        PRTE_CLI_CORE, false);
+    CHECK("add_directive:single-value-option", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** --runtime-options does take several, comma-joined ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_RTOS, PRTE_CLI_NOLAUNCH, NULL);
+    rc = prte_schizo_base_add_directive(&results, "stop-in-init", PRTE_CLI_RTOS,
+                                        PRTE_CLI_STOP_IN_INIT, false);
+    CHECK("add_directive:multi-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_RTOS);
+    CHECK("add_directive:multi-value",
+          NULL != v && 0 == strcmp(v, "donotlaunch,stop-in-init"));
+    PMIX_DESTRUCT(&results);
+
+    /*** ...and a multi-directive option keeps its qualifier at the end ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_OUTPUT, "tag:raw", NULL);
+    rc = prte_schizo_base_add_directive(&results, "timestamp-output",
+                                        PRTE_CLI_OUTPUT, PRTE_CLI_TIMESTAMP,
+                                        false);
+    CHECK("add_directive:multi-qual-rc", PRTE_SUCCESS == rc);
+    v = first_value(&results, PRTE_CLI_OUTPUT);
+    CHECK("add_directive:multi-qual-value",
+          NULL != v && 0 == strcmp(v, "tag,timestamp:raw"));
+    PMIX_DESTRUCT(&results);
+
+    /*** check_directives: plain directives ***/
+    CHECK("check_directives:valid",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, "node"));
+    CHECK("check_directives:abbreviated",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, "pack"));
+    fprintf(stderr, "--- expected error output follows (unrecognized directive) ---\n");
+    CHECK("check_directives:invalid",
+          !prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, "bogus"));
+
+    /*** check_directives: qualifier-only form ***/
+    CHECK("check_directives:qual-only",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, ":span"));
+    fprintf(stderr, "--- expected error output follows (unrecognized qualifier) ---\n");
+    CHECK("check_directives:qual-only-bad",
+          !prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals, ":bogus"));
+
+    /*** check_directives: the ppr:N:resource special case ***/
+    CHECK("check_directives:ppr-ok",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                            "ppr:2:node"));
+    CHECK("check_directives:ppr-plus-qual",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                            "ppr:2:node:span"));
+    fprintf(stderr, "--- expected error output follows (bad ppr patterns) ---\n");
+    CHECK("check_directives:ppr-short",
+          !prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                             "ppr:2"));
+    CHECK("check_directives:ppr-not-a-number",
+          !prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                             "ppr:x:node"));
+    CHECK("check_directives:ppr-bad-resource",
+          !prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                             "ppr:2:bogus"));
+
+    /* A BARE "ppr" carries no pattern to check, so this validator passes it
+     * through - rmaps is what refuses it later.  Recorded here because it is
+     * exactly the string that reaches the personalities' socket->package
+     * rewrite, where it used to be dereferenced past its end (see
+     * test_personality). */
+    CHECK("check_directives:ppr-bare-passes-through",
+          prte_schizo_base_check_directives(PRTE_CLI_MAPBY, mappers, mapquals,
+                                            "ppr"));
+
+    /*** check_qualifiers directly ***/
+    CHECK("check_qualifiers:valid",
+          prte_schizo_base_check_qualifiers(PRTE_CLI_MAPBY, mapquals, "span"));
+    CHECK("check_qualifiers:with-value",
+          prte_schizo_base_check_qualifiers(PRTE_CLI_MAPBY, mapquals, "pe=2"));
+    fprintf(stderr, "--- expected error output follows (bad qualifier) ---\n");
+    CHECK("check_qualifiers:invalid",
+          !prte_schizo_base_check_qualifiers(PRTE_CLI_MAPBY, mapquals, "bogus"));
+
+    return failures;
+}

--- a/test/unit/schizo/test_helpers.c
+++ b/test/unit/schizo/test_helpers.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <stdarg.h>
+
+#include "test_schizo.h"
+
+/*
+ * Build a pmix_cli_item_t the way pmix_cmd_line_parse would: one instance
+ * per option key, with every occurrence of that option appended to the same
+ * value array.  Reproducing that shape by hand is what lets the sanity
+ * checker and the output/display parsers be exercised without running a
+ * tool.
+ */
+void schizo_test_add(pmix_cli_result_t *results, const char *key, ...)
+{
+    pmix_cli_item_t *opt;
+    va_list ap;
+    const char *val;
+
+    opt = PMIX_NEW(pmix_cli_item_t);
+    opt->key = strdup(key);
+
+    va_start(ap, key);
+    while (NULL != (val = va_arg(ap, const char *))) {
+        PMIx_Argv_append_nosize(&opt->values, val);
+    }
+    va_end(ap);
+
+    pmix_list_append(&results->instances, &opt->super);
+}
+
+/*
+ * Reach a personality through the framework rather than naming its module
+ * symbol: the module belongs to its component, which may be a DSO and in
+ * any case is not visible outside libprrte in a hidden-visibility build.
+ * Returns NULL when the component was not built, so a caller can skip.
+ */
+prte_schizo_base_module_t *schizo_test_module(const char *name)
+{
+    prte_schizo_base_active_module_t *mod;
+
+    PMIX_LIST_FOREACH(mod, &prte_schizo_base.active_modules,
+                      prte_schizo_base_active_module_t)
+    {
+        if (NULL != mod->module->name &&
+            0 == strcmp(name, mod->module->name)) {
+            return mod->module;
+        }
+    }
+    return NULL;
+}

--- a/test/unit/schizo/test_normalize.c
+++ b/test/unit/schizo/test_normalize.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * The shared argv/string helpers in schizo/base: normalize_argv (deprecated
+ * option spellings and the personality hint), strip_quotes, getline, and
+ * expose.  All of these run before anything else in a tool's main(), on the
+ * raw argv, so a mistake here is a mistake every tool inherits.
+ */
+
+#include "test_schizo.h"
+
+#include <stdarg.h>
+#include <unistd.h>
+
+#include "src/util/pmix_environ.h"
+
+static char **mkargv(const char *first, ...)
+{
+    char **argv = NULL;
+    va_list ap;
+    const char *p;
+
+    PMIx_Argv_append_nosize(&argv, first);
+    va_start(ap, first);
+    while (NULL != (p = va_arg(ap, const char *))) {
+        PMIx_Argv_append_nosize(&argv, p);
+    }
+    va_end(ap);
+    return argv;
+}
+
+int test_normalize(void)
+{
+    int failures = 0;
+    char **argv;
+    char *personality, *p;
+    char *tmpname;
+    FILE *fp;
+
+    /*** the space-separated spellings ***/
+    argv = mkargv("prterun", "--map-by", "node", "--rank-by", "slot",
+                  "--bind-to", "core", "--runtime-options", "donotlaunch",
+                  "--personality", "ompi", "hostname", NULL);
+    personality = prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:mapby", 0 == strcmp(argv[1], "--mapby"));
+    CHECK("normalize:rankby", 0 == strcmp(argv[3], "--rankby"));
+    CHECK("normalize:bindto", 0 == strcmp(argv[5], "--bindto"));
+    CHECK("normalize:rtos", 0 == strcmp(argv[7], "--rtos"));
+    CHECK("normalize:personality",
+          NULL != personality && 0 == strcmp(personality, "ompi"));
+    /* values must be left strictly alone */
+    CHECK("normalize:value-untouched", 0 == strcmp(argv[2], "node"));
+    PMIx_Argv_free(argv);
+
+    /*** the "--opt=value" spellings getopt_long equally accepts ***/
+    argv = mkargv("prterun", "--map-by=node", "--rank-by=slot",
+                  "--bind-to=core", "--runtime-options=donotlaunch",
+                  "--personality=ompi", "hostname", NULL);
+    personality = prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:eq-mapby", 0 == strcmp(argv[1], "--mapby=node"));
+    CHECK("normalize:eq-rankby", 0 == strcmp(argv[2], "--rankby=slot"));
+    CHECK("normalize:eq-bindto", 0 == strcmp(argv[3], "--bindto=core"));
+    CHECK("normalize:eq-rtos", 0 == strcmp(argv[4], "--rtos=donotlaunch"));
+    CHECK("normalize:eq-personality",
+          NULL != personality && 0 == strcmp(personality, "ompi"));
+    PMIx_Argv_free(argv);
+
+    /*** a bare "--personality=" carries no name ***/
+    argv = mkargv("prterun", "--personality=", "hostname", NULL);
+    personality = prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:eq-personality-empty", NULL == personality);
+    PMIx_Argv_free(argv);
+
+    /*** the canonical spellings, and unrelated options, are left alone ***/
+    argv = mkargv("prterun", "--mapby", "node", "--map-by-hand",
+                  "--host", "node1", "hostname", NULL);
+    personality = prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:canonical-kept", 0 == strcmp(argv[1], "--mapby"));
+    CHECK("normalize:no-prefix-match", 0 == strcmp(argv[3], "--map-by-hand"));
+    CHECK("normalize:unrelated-kept", 0 == strcmp(argv[4], "--host"));
+    CHECK("normalize:no-personality", NULL == personality);
+    PMIx_Argv_free(argv);
+
+    /*** --personality as the last token has no value to take ***/
+    argv = mkargv("prterun", "--personality", NULL);
+    personality = prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:trailing-personality", NULL == personality);
+    PMIx_Argv_free(argv);
+
+    /*** every occurrence is renamed - MPMD lines repeat them ***/
+    argv = mkargv("prterun", "--map-by", "node", ":", "--map-by", "slot", NULL);
+    (void) prte_schizo_base_normalize_argv(argv);
+    CHECK("normalize:repeat-1", 0 == strcmp(argv[1], "--mapby"));
+    CHECK("normalize:repeat-2", 0 == strcmp(argv[4], "--mapby"));
+    PMIx_Argv_free(argv);
+
+    /*** strip_quotes ***/
+    p = prte_schizo_base_strip_quotes("\"quoted\"");
+    CHECK("strip:both", 0 == strcmp(p, "quoted"));
+    free(p);
+    p = prte_schizo_base_strip_quotes("bare");
+    CHECK("strip:none", 0 == strcmp(p, "bare"));
+    free(p);
+    /* an empty string has no last character to inspect - this used to read
+     * and write one byte in front of the allocation */
+    p = prte_schizo_base_strip_quotes("");
+    CHECK("strip:empty", 0 == strcmp(p, ""));
+    free(p);
+    /* and a lone quote leaves an empty string behind */
+    p = prte_schizo_base_strip_quotes("\"");
+    CHECK("strip:lone-quote", 0 == strcmp(p, ""));
+    free(p);
+
+    /*** getline: a file whose last line has no newline keeps its last
+     *** character (an MCA param file saved without a trailing newline) ***/
+    pmix_asprintf(&tmpname, "prte_schizo_getline_%lu.txt",
+                  (unsigned long) getpid());
+    fp = fopen(tmpname, "w+");
+    if (NULL == fp) {
+        fprintf(stderr, "FAIL [getline]: cannot create %s\n", tmpname);
+        failures++;
+    } else {
+        fputs("first=1\nlast=2", fp);
+        rewind(fp);
+        p = prte_schizo_base_getline(fp);
+        CHECK("getline:first", NULL != p && 0 == strcmp(p, "first=1"));
+        if (NULL != p) {
+            free(p);
+        }
+        p = prte_schizo_base_getline(fp);
+        CHECK("getline:last-no-newline", NULL != p && 0 == strcmp(p, "last=2"));
+        if (NULL != p) {
+            free(p);
+        }
+        p = prte_schizo_base_getline(fp);
+        CHECK("getline:eof", NULL == p);
+        fclose(fp);
+        unlink(tmpname);
+    }
+    free(tmpname);
+
+    /*** expose: split at the '=' and push into the environment under the
+     *** given prefix, leaving the caller's string as it found it ***/
+    {
+        char param[] = "schizo_test_var=a=b";
+        prte_schizo_base_expose(param, "PRTE_MCA_");
+        p = getenv("PRTE_MCA_schizo_test_var");
+        CHECK("expose:value", NULL != p && 0 == strcmp(p, "a=b"));
+        CHECK("expose:restored", 0 == strcmp(param, "schizo_test_var=a=b"));
+        unsetenv("PRTE_MCA_schizo_test_var");
+    }
+    {
+        /* nothing to expose, and nothing to dereference */
+        char param[] = "schizo_test_novalue";
+        prte_schizo_base_expose(param, "PRTE_MCA_");
+        CHECK("expose:no-equals",
+              NULL == getenv("PRTE_MCA_schizo_test_novalue"));
+    }
+
+    return failures;
+}

--- a/test/unit/schizo/test_output.c
+++ b/test/unit/schizo/test_output.c
@@ -17,6 +17,7 @@
 
 #include "test_schizo.h"
 
+#include "src/common/pmix_iof.h"
 #include "src/pmix/pmix-internal.h"
 
 /* Run a parser over an option value set and hand back the info array it
@@ -220,6 +221,73 @@ int test_output(void)
     rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals5,
                     &iptr, &ninfo);
     CHECK("display:bad-qual", PRTE_SUCCESS != rc);
+
+#if PRTE_PMIX_IOF_FILE_PATTERN
+    /*** the "pattern" qualifier hands the naming of the output files to the
+     *** user.  It only means anything alongside a "file=" directive, and the
+     *** conversions in it are checked here - while the user is still looking
+     *** at the command line they typed - rather than at the moment a daemon
+     *** fails to open a file. ***/
+    {
+        char *pvals1[] = {"file=/tmp/prte-schizo-test-%h/rank-%R:pattern", NULL};
+        char *pvals2[] = {"file=/tmp/prte-schizo-test-%q:pattern", NULL};
+        char *pvals3[] = {"tag:pattern", NULL};
+        char *pvals4[] = {"file=/tmp/prte-schizo-test:pattern:copy", NULL};
+
+        rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, pvals1,
+                        &iptr, &ninfo);
+        CHECK("output:pattern-rc", PRTE_SUCCESS == rc);
+        CHECK("output:pattern-file", has_key(iptr, ninfo, PMIX_IOF_OUTPUT_TO_FILE));
+        CHECK("output:pattern-key", has_key(iptr, ninfo, PMIX_IOF_FILE_PATTERN));
+        PMIX_INFO_FREE(iptr, ninfo);
+
+        /* an unrecognized conversion is refused up front */
+        fprintf(stderr, "--- expected error output follows (bad pattern) ---\n");
+        rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, pvals2,
+                        &iptr, &ninfo);
+        CHECK("output:pattern-bad-conversion", PRTE_SUCCESS != rc);
+
+        /* ...and so is a pattern with nothing to name */
+        fprintf(stderr, "--- expected error output follows (pattern, no file) ---\n");
+        rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, pvals3,
+                        &iptr, &ninfo);
+        CHECK("output:pattern-needs-file", PRTE_SUCCESS != rc);
+
+        /* pattern composes with the other qualifiers */
+        rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, pvals4,
+                        &iptr, &ninfo);
+        CHECK("output:pattern-with-copy-rc", PRTE_SUCCESS == rc);
+        CHECK("output:pattern-with-copy-key", has_key(iptr, ninfo, PMIX_IOF_FILE_PATTERN));
+        val = key_is_true(iptr, ninfo, PMIX_IOF_FILE_ONLY, &found);
+        CHECK("output:pattern-with-copy-present", found);
+        CHECK("output:pattern-with-copy-false", !val);
+        PMIX_INFO_FREE(iptr, ninfo);
+    }
+
+    /*** the conversions PMIx accepts are the conversions we advertise ***/
+    {
+        char *bad = NULL;
+        CHECK("pattern:all-conversions",
+              PMIX_SUCCESS == pmix_iof_check_pattern("%n/%r/%R/%h/%%", &bad));
+        CHECK("pattern:no-conversions",
+              PMIX_SUCCESS == pmix_iof_check_pattern("plain-name", &bad));
+        CHECK("pattern:unknown-conversion",
+              PMIX_SUCCESS != pmix_iof_check_pattern("out-%q", &bad));
+        CHECK("pattern:names-the-offender",
+              NULL != bad && 0 == strcmp(bad, "%q"));
+        if (NULL != bad) {
+            free(bad);
+            bad = NULL;
+        }
+        /* a trailing '%' has no conversion character at all - report it
+         * rather than read past the end of the string */
+        CHECK("pattern:trailing-percent",
+              PMIX_SUCCESS != pmix_iof_check_pattern("out-%", &bad));
+        if (NULL != bad) {
+            free(bad);
+        }
+    }
+#endif
 
     return failures;
 }

--- a/test/unit/schizo/test_output.c
+++ b/test/unit/schizo/test_output.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * prte_schizo_base_parse_output() and _parse_display() - where the
+ * human-facing "--output"/"--display" directive strings become the PMIx
+ * keys carried on the spawn request.  A directive that silently fails to
+ * produce its key is invisible: the job runs, just not the way it was asked
+ * to, so these are checked by inspecting the resulting info array.
+ */
+
+#include "test_schizo.h"
+
+#include "src/pmix/pmix-internal.h"
+
+/* Run a parser over an option value set and hand back the info array it
+ * produced.  Returns the parser's rc; the returned array is only valid on
+ * PRTE_SUCCESS and must be released by the caller. */
+static int run_parser(int (*parser)(pmix_cli_item_t *, void *),
+                      const char *key, char **values,
+                      pmix_info_t **iptr, size_t *ninfo)
+{
+    pmix_cli_item_t opt;
+    pmix_data_array_t darray;
+    void *jinfo;
+    int rc;
+    pmix_status_t ret;
+    int n;
+
+    *iptr = NULL;
+    *ninfo = 0;
+
+    PMIX_CONSTRUCT(&opt, pmix_cli_item_t);
+    opt.key = strdup(key);
+    for (n = 0; NULL != values[n]; n++) {
+        PMIx_Argv_append_nosize(&opt.values, values[n]);
+    }
+
+    PMIX_INFO_LIST_START(jinfo);
+    rc = parser(&opt, jinfo);
+    if (PRTE_SUCCESS == rc) {
+        PMIX_INFO_LIST_CONVERT(ret, jinfo, &darray);
+        if (PMIX_SUCCESS == ret) {
+            *iptr = (pmix_info_t *) darray.array;
+            *ninfo = darray.size;
+        } else if (PMIX_ERR_EMPTY != ret) {
+            rc = prte_pmix_convert_status(ret);
+        }
+    }
+    PMIX_INFO_LIST_RELEASE(jinfo);
+    PMIX_DESTRUCT(&opt);
+    return rc;
+}
+
+static bool has_key(pmix_info_t *iptr, size_t ninfo, const char *key)
+{
+    size_t n;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&iptr[n], key)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool key_is_true(pmix_info_t *iptr, size_t ninfo, const char *key,
+                        bool *found)
+{
+    size_t n;
+
+    *found = false;
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&iptr[n], key)) {
+            *found = true;
+            return PMIX_INFO_TRUE(&iptr[n]);
+        }
+    }
+    return false;
+}
+
+static char *key_string(pmix_info_t *iptr, size_t ninfo, const char *key)
+{
+    size_t n;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&iptr[n], key)) {
+            return iptr[n].value.data.string;
+        }
+    }
+    return NULL;
+}
+
+int test_output(void)
+{
+    int failures = 0, rc;
+    pmix_info_t *iptr;
+    size_t ninfo;
+    bool found, val;
+    char *vals1[] = {"tag,timestamp", NULL};
+    char *vals2[] = {"tag", "timestamp", NULL};
+    char *vals3[] = {"file=/tmp/prte-schizo-test:raw:nocopy", NULL};
+    char *vals4[] = {"file=/tmp/prte-schizo-test:raw:copy", NULL};
+    char *vals5[] = {"file=/tmp/prte-schizo-test:copy:nocopy", NULL};
+    char *vals6[] = {"dir=/tmp/prte-schizo-testdir", NULL};
+    char *vals7[] = {"file=/tmp/a", "dir=/tmp/b", NULL};
+    char *dvals1[] = {"map,bind", NULL};
+    char *dvals2[] = {"map", "bind", NULL};
+    char *dvals3[] = {"map:parseable", NULL};
+    char *dvals4[] = {"topo=node1;node2", NULL};
+    char *dvals5[] = {"map:bogus", NULL};
+
+    /*** comma-delimited directives in ONE value ***/
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals1,
+                    &iptr, &ninfo);
+    CHECK("output:comma-rc", PRTE_SUCCESS == rc);
+    CHECK("output:comma-tag", has_key(iptr, ninfo, PMIX_IOF_TAG_OUTPUT));
+    CHECK("output:comma-timestamp",
+          has_key(iptr, ninfo, PMIX_IOF_TIMESTAMP_OUTPUT));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** the SAME directives given as two instances of --output.  Repeating
+     *** an option appends to one instance's value array, and the parser used
+     *** to re-read values[0] on every pass - so "timestamp" was dropped and
+     *** "tag" applied twice. ***/
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals2,
+                    &iptr, &ninfo);
+    CHECK("output:multi-instance-rc", PRTE_SUCCESS == rc);
+    CHECK("output:multi-instance-tag", has_key(iptr, ninfo, PMIX_IOF_TAG_OUTPUT));
+    CHECK("output:multi-instance-timestamp",
+          has_key(iptr, ninfo, PMIX_IOF_TIMESTAMP_OUTPUT));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** qualifiers are ':'-delimited, and EVERY one of them counts.  They
+     *** used to be split on ',' - which the directive split had already
+     *** consumed - so only the first qualifier in the run was ever seen and
+     *** "raw:nocopy" quietly lost its nocopy. ***/
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals3,
+                    &iptr, &ninfo);
+    CHECK("output:qual-rc", PRTE_SUCCESS == rc);
+    CHECK("output:qual-file", has_key(iptr, ninfo, PMIX_IOF_OUTPUT_TO_FILE));
+    CHECK("output:qual-raw", has_key(iptr, ninfo, PMIX_IOF_OUTPUT_RAW));
+    val = key_is_true(iptr, ninfo, PMIX_IOF_FILE_ONLY, &found);
+    CHECK("output:qual-nocopy-present", found);
+    CHECK("output:qual-nocopy-true", val);
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** the same, with "copy" second ***/
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals4,
+                    &iptr, &ninfo);
+    CHECK("output:copy-rc", PRTE_SUCCESS == rc);
+    CHECK("output:copy-raw", has_key(iptr, ninfo, PMIX_IOF_OUTPUT_RAW));
+    val = key_is_true(iptr, ninfo, PMIX_IOF_FILE_ONLY, &found);
+    CHECK("output:copy-present", found);
+    CHECK("output:copy-false", !val);
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** copy and nocopy together are contradictory ***/
+    fprintf(stderr, "--- expected error output follows (copy + nocopy) ---\n");
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals5,
+                    &iptr, &ninfo);
+    CHECK("output:copy-nocopy", PRTE_SUCCESS != rc);
+
+    /*** a relative directory is made absolute ***/
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals6,
+                    &iptr, &ninfo);
+    CHECK("output:dir-rc", PRTE_SUCCESS == rc);
+    CHECK("output:dir-key",
+          NULL != key_string(iptr, ninfo, PMIX_IOF_OUTPUT_TO_DIRECTORY));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** file and directory at once is refused ***/
+    fprintf(stderr, "--- expected error output follows (file + dir) ---\n");
+    rc = run_parser(prte_schizo_base_parse_output, PRTE_CLI_OUTPUT, vals7,
+                    &iptr, &ninfo);
+    CHECK("output:file-and-dir", PRTE_SUCCESS != rc);
+
+    /*** display: comma-delimited, and repeated ***/
+    rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals1,
+                    &iptr, &ninfo);
+    CHECK("display:comma-rc", PRTE_SUCCESS == rc);
+    CHECK("display:comma-map", has_key(iptr, ninfo, PMIX_DISPLAY_MAP));
+    CHECK("display:comma-bind", has_key(iptr, ninfo, PMIX_REPORT_BINDINGS));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals2,
+                    &iptr, &ninfo);
+    CHECK("display:multi-rc", PRTE_SUCCESS == rc);
+    CHECK("display:multi-map", has_key(iptr, ninfo, PMIX_DISPLAY_MAP));
+    CHECK("display:multi-bind", has_key(iptr, ninfo, PMIX_REPORT_BINDINGS));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** display qualifiers ***/
+    rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals3,
+                    &iptr, &ninfo);
+    CHECK("display:qual-rc", PRTE_SUCCESS == rc);
+    CHECK("display:qual-map", has_key(iptr, ninfo, PMIX_DISPLAY_MAP));
+    CHECK("display:qual-parseable",
+          has_key(iptr, ninfo, PMIX_DISPLAY_PARSEABLE_OUTPUT));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** "topo=<nodes>" carries its value through ***/
+    rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals4,
+                    &iptr, &ninfo);
+    CHECK("display:topo-rc", PRTE_SUCCESS == rc);
+    CHECK("display:topo-value",
+          NULL != key_string(iptr, ninfo, PMIX_DISPLAY_TOPOLOGY) &&
+          0 == strcmp(key_string(iptr, ninfo, PMIX_DISPLAY_TOPOLOGY),
+                      "node1;node2"));
+    PMIX_INFO_FREE(iptr, ninfo);
+
+    /*** an unknown display qualifier is an error ***/
+    fprintf(stderr, "--- expected error output follows (bad display qualifier) ---\n");
+    rc = run_parser(prte_schizo_base_parse_display, PRTE_CLI_DISPLAY, dvals5,
+                    &iptr, &ninfo);
+    CHECK("display:bad-qual", PRTE_SUCCESS != rc);
+
+    return failures;
+}

--- a/test/unit/schizo/test_personality.c
+++ b/test/unit/schizo/test_personality.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Personality election (detect_proxy) and the per-personality command line
+ * translation (parse_cli + convert_deprecated_cli).  These decide which
+ * dialect a command line is read in and what the deprecated spellings turn
+ * into, so a defect here changes what a job does without changing what the
+ * user typed.
+ */
+
+#include "test_schizo.h"
+
+#include <stdarg.h>
+
+#include "src/runtime/prte_globals.h"
+#include "src/util/proc_info.h"
+
+/* Parse a command line with the given module and return the value of one
+ * option key, or NULL if the option is absent.  The returned string belongs
+ * to the caller. */
+static char *parse_and_get(prte_schizo_base_module_t *mod, const char *key,
+                           int *rcp, const char *first, ...)
+{
+    pmix_cli_result_t results;
+    pmix_cli_item_t *opt;
+    char **argv = NULL;
+    char *value = NULL;
+    va_list ap;
+    const char *p;
+
+    PMIx_Argv_append_nosize(&argv, first);
+    va_start(ap, first);
+    while (NULL != (p = va_arg(ap, const char *))) {
+        PMIx_Argv_append_nosize(&argv, p);
+    }
+    va_end(ap);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    *rcp = mod->parse_cli(argv, &results, PMIX_CLI_SILENT);
+    if (PRTE_SUCCESS == *rcp) {
+        opt = pmix_cmd_line_get_param(&results, key);
+        if (NULL != opt && NULL != opt->values && NULL != opt->values[0]) {
+            value = strdup(opt->values[0]);
+        }
+    }
+    PMIX_DESTRUCT(&results);
+    PMIx_Argv_free(argv);
+    return value;
+}
+
+static int test_prte_personality(prte_schizo_base_module_t *mod)
+{
+    int failures = 0, rc;
+    char *v;
+
+    /* --merge-stderr-to-stdout is in the prterun/prun tables; with no
+     * conversion behind it the option parsed cleanly and then did nothing */
+    v = parse_and_get(mod, PRTE_CLI_OUTPUT, &rc, "prterun",
+                      "--merge-stderr-to-stdout", "hostname", NULL);
+    CHECK("prte:merge-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:merge-value",
+          NULL != v && 0 == strcmp(v, PRTE_CLI_MERGE_ERROUT));
+    free(v);
+
+    /* likewise --display-devel-allocation, which folds onto --display
+     * allocation (there is no separate developer allocation display) */
+    v = parse_and_get(mod, PRTE_CLI_DISPLAY, &rc, "prterun",
+                      "--display-devel-allocation", "hostname", NULL);
+    CHECK("prte:devel-alloc-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:devel-alloc-value",
+          NULL != v && 0 == strcmp(v, PRTE_CLI_ALLOC));
+    free(v);
+
+    /* the classic ORTE-era spellings still land on the modern directives */
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--npernode", "2", "hostname", NULL);
+    CHECK("prte:npernode-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:npernode-value", NULL != v && 0 == strcmp(v, "ppr:2:node"));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--pernode", "hostname", NULL);
+    CHECK("prte:pernode-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:pernode-value", NULL != v && 0 == strcmp(v, "ppr:1:node"));
+    free(v);
+
+    /* socket is the old name for package */
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--mapby", "socket:pe=2", "hostname", NULL);
+    CHECK("prte:socket-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:socket-value", NULL != v && 0 == strcmp(v, "package:pe=2"));
+    free(v);
+
+    /* ...including as the RESOURCE of a ppr pattern.  The resource is the
+     * third ':'-delimited field; looking for it with strrchr() found the
+     * last field instead, so a trailing qualifier hid it */
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--mapby", "ppr:2:socket", "hostname", NULL);
+    CHECK("prte:ppr-socket-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:ppr-socket-value", NULL != v && 0 == strcmp(v, "ppr:2:package"));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--mapby", "ppr:2:socket:pe=2", "hostname", NULL);
+    CHECK("prte:ppr-socket-qual-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:ppr-socket-qual-value",
+          NULL != v && 0 == strcmp(v, "ppr:2:package:pe=2"));
+    free(v);
+
+    /* a BARE "ppr" has no resource field at all - this used to be reached
+     * for anyway and dereferenced past the end of the string */
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "prterun",
+                      "--mapby", "ppr", "hostname", NULL);
+    CHECK("prte:ppr-bare-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:ppr-bare-value", NULL != v && 0 == strcmp(v, "ppr"));
+    free(v);
+
+    /* --rank-by objects other than "socket" are NOT renamed.  Rewriting
+     * numa/core/l1cache/... to "package" was never a rename - none of them
+     * is a valid ranker either way, and the rewrite only made the error
+     * message name an option the user never typed */
+    v = parse_and_get(mod, PRTE_CLI_RANKBY, &rc, "prterun",
+                      "--rankby", "numa", "hostname", NULL);
+    CHECK("prte:rankby-numa-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:rankby-numa-value", NULL != v && 0 == strcmp(v, "numa"));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_RANKBY, &rc, "prterun",
+                      "--rankby", "core", "hostname", NULL);
+    CHECK("prte:rankby-core-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:rankby-core-value", NULL != v && 0 == strcmp(v, "core"));
+    free(v);
+
+    /* "socket" IS renamed, since that one really is package's old name */
+    v = parse_and_get(mod, PRTE_CLI_RANKBY, &rc, "prterun",
+                      "--rankby", "socket", "hostname", NULL);
+    CHECK("prte:rankby-socket-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:rankby-socket-value", NULL != v && 0 == strcmp(v, "package"));
+    free(v);
+
+    /* --bind-to socket likewise */
+    v = parse_and_get(mod, PRTE_CLI_BINDTO, &rc, "prterun",
+                      "--bindto", "socket", "hostname", NULL);
+    CHECK("prte:bindto-socket-rc", PRTE_SUCCESS == rc);
+    CHECK("prte:bindto-socket-value", NULL != v && 0 == strcmp(v, "package"));
+    free(v);
+
+    return failures;
+}
+
+static int test_ompi_personality(prte_schizo_base_module_t *mod)
+{
+    int failures = 0, rc;
+    char *v;
+
+    /* the crash this personality carried until the prte-side fix was
+     * mirrored here: a bare "ppr" has no ':' for strrchr() to find, and the
+     * result was advanced past and dereferenced */
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "mpirun",
+                      "--mapby", "ppr", "hostname", NULL);
+    CHECK("ompi:ppr-bare-rc", PRTE_SUCCESS == rc);
+    CHECK("ompi:ppr-bare-value", NULL != v && 0 == strcmp(v, "ppr"));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "mpirun",
+                      "--mapby", "ppr:2:socket:pe=2", "hostname", NULL);
+    CHECK("ompi:ppr-socket-qual-rc", PRTE_SUCCESS == rc);
+    CHECK("ompi:ppr-socket-qual-value",
+          NULL != v && 0 == strcmp(v, "ppr:2:package:pe=2"));
+    free(v);
+
+    /* the shared deprecations must give the same answer as prte's */
+    v = parse_and_get(mod, PRTE_CLI_OUTPUT, &rc, "mpirun",
+                      "--merge-stderr-to-stdout", "hostname", NULL);
+    CHECK("ompi:merge-rc", PRTE_SUCCESS == rc);
+    CHECK("ompi:merge-value",
+          NULL != v && 0 == strcmp(v, PRTE_CLI_MERGE_ERROUT));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_DISPLAY, &rc, "mpirun",
+                      "--display-devel-allocation", "hostname", NULL);
+    CHECK("ompi:devel-alloc-rc", PRTE_SUCCESS == rc);
+    CHECK("ompi:devel-alloc-value",
+          NULL != v && 0 == strcmp(v, PRTE_CLI_ALLOC));
+    free(v);
+
+    v = parse_and_get(mod, PRTE_CLI_MAPBY, &rc, "mpirun",
+                      "--npernode", "2", "hostname", NULL);
+    CHECK("ompi:npernode-rc", PRTE_SUCCESS == rc);
+    CHECK("ompi:npernode-value", NULL != v && 0 == strcmp(v, "ppr:2:node"));
+    free(v);
+
+    return failures;
+}
+
+int test_personality(void)
+{
+    int failures = 0;
+    prte_schizo_base_module_t *mod, *prte_mod, *ompi_mod;
+
+    /* the environment can name a personality; make sure it is not doing so
+     * behind these checks */
+    unsetenv("PRTE_MCA_schizo_proxy");
+    unsetenv("PRTE_MCA_personality");
+
+    prte_mod = schizo_test_module("prte");
+    CHECK("personality:prte-present", NULL != prte_mod);
+    ompi_mod = schizo_test_module("ompi");
+
+    /*** with no hint at all, prte is the fallback ***/
+    mod = prte_schizo_base_detect_proxy(NULL);
+    CHECK("detect:default-is-prte",
+          NULL != mod && 0 == strcmp(mod->name, "prte"));
+
+    /*** an explicit request is honored ***/
+    mod = prte_schizo_base_detect_proxy("prte");
+    CHECK("detect:explicit-prte",
+          NULL != mod && 0 == strcmp(mod->name, "prte"));
+
+    if (NULL != ompi_mod) {
+        mod = prte_schizo_base_detect_proxy("ompi");
+        CHECK("detect:explicit-ompi",
+              NULL != mod && 0 == strcmp(mod->name, "ompi"));
+    }
+
+    /*** A personality nobody claims falls back to the DEFAULT one - never to
+     *** whichever component carries the highest static priority.  That
+     *** distinction is the whole point: landing on some other personality's
+     *** dialect changes which options are legal and how MCA params are
+     *** translated, while landing on the catch-all is what Open MPI relies on
+     *** (it starts a singleton's DVM with only the native component loaded,
+     *** then spawns with PMIX_PERSONALITY="ompi5" - refusing that fails every
+     *** MPI_Comm_spawn from a singleton). ***/
+    mod = prte_schizo_base_detect_proxy("no-such-personality");
+    CHECK("detect:unknown-falls-back-to-default",
+          NULL != mod && 0 == strcmp(mod->name, "prte"));
+    mod = prte_schizo_base_detect_proxy("ompi5");
+    CHECK("detect:unclaimed-suffix-is-not-ompi",
+          NULL != mod && NULL != ompi_mod
+              ? 0 == strcmp(mod->name, "ompi")   /* ompi claims it by substring */
+              : (NULL != mod && 0 == strcmp(mod->name, "prte")));
+
+    /*** the per-personality translations ***/
+    if (NULL != prte_mod) {
+        prte_tool_actual = "prterun";
+        failures += test_prte_personality(prte_mod);
+    }
+    if (NULL != ompi_mod) {
+        failures += test_ompi_personality(ompi_mod);
+    } else {
+        fprintf(stdout, "SKIP schizo/ompi checks - component not built\n");
+    }
+
+    return failures;
+}

--- a/test/unit/schizo/test_sanity.c
+++ b/test/unit/schizo/test_sanity.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * prte_schizo_base_sanity() - the shared check_sanity implementation both
+ * personalities install.  It runs once per app context (prte_parse_locals
+ * splits an MPMD line at each ':' and calls it on each segment), so every
+ * expectation below is about ONE app's option set.
+ */
+
+#include "test_schizo.h"
+
+int test_sanity(void)
+{
+    int failures = 0, rc;
+    pmix_cli_result_t results;
+    pmix_cli_item_t *opt;
+
+    /*** a well-formed set passes ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "node:span", NULL);
+    schizo_test_add(&results, PRTE_CLI_RANKBY, "slot", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "core:overload-allowed", NULL);
+    schizo_test_add(&results, PRTE_CLI_OUTPUT, "tag,timestamp", NULL);
+    schizo_test_add(&results, PRTE_CLI_DISPLAY, "map:parseable", NULL);
+    schizo_test_add(&results, PRTE_CLI_RTOS, "donotlaunch,stop-in-init", NULL);
+    schizo_test_add(&results, PRTE_CLI_NP, "4", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:clean", PRTE_SUCCESS == rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** repeating a single-value placement option is rejected ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "node", "core", NULL);
+    fprintf(stderr, "--- expected error output follows (two --map-by) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:dup-mapby", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_RANKBY, "slot", "node", NULL);
+    fprintf(stderr, "--- expected error output follows (two --rank-by) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:dup-rankby", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** and so is repeating an option that carries exactly one value.
+     *** pmix_cmd_line_parse appends every occurrence to the SAME instance,
+     *** and every consumer reads values[0], so "-n 2 -n 3" used to run
+     *** silently with 2 procs rather than being reported. ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_NP, "2", "3", NULL);
+    fprintf(stderr, "--- expected error output follows (two --np) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:dup-np", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_WDIR, "/tmp/a", "/tmp/b", NULL);
+    fprintf(stderr, "--- expected error output follows (two --wdir) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:dup-wdir", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    /* one value apiece is of course fine */
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_NP, "2", NULL);
+    schizo_test_add(&results, PRTE_CLI_WDIR, "/tmp/a", NULL);
+    schizo_test_add(&results, PRTE_CLI_PSET, "myset", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:single-values", PRTE_SUCCESS == rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** synonyms are expanded onto their canonical key ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MACHINEFILE, "/tmp/hosts", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:machinefile-rc", PRTE_SUCCESS == rc);
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_HOSTFILE);
+    CHECK("sanity:machinefile-synonym",
+          NULL != opt && NULL != opt->values &&
+          0 == strcmp(opt->values[0], "/tmp/hosts"));
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_WD, "/tmp/here", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:wd-rc", PRTE_SUCCESS == rc);
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_WDIR);
+    CHECK("sanity:wd-synonym",
+          NULL != opt && NULL != opt->values &&
+          0 == strcmp(opt->values[0], "/tmp/here"));
+    PMIX_DESTRUCT(&results);
+
+    /*** bad directives are caught ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "bogus", NULL);
+    fprintf(stderr, "--- expected error output follows (bad map-by) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:bad-mapby", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_RTOS, "donotlaunch,bogus", NULL);
+    fprintf(stderr, "--- expected error output follows (bad runtime option) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:bad-rtos", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** a PE=n mapping already dictates the binding: only core/hwt agree ***/
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "slot:pe=2", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "package", NULL);
+    fprintf(stderr, "--- expected error output follows (pe/bind conflict) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:pe-bind-conflict", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "slot:pe=2", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "core", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:pe-bind-core-ok", PRTE_SUCCESS == rc);
+    PMIX_DESTRUCT(&results);
+
+    return failures;
+}

--- a/test/unit/schizo/test_schizo.h
+++ b/test/unit/schizo/test_schizo.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PRTE_TEST_SCHIZO_H
+#define PRTE_TEST_SCHIZO_H
+
+#include "prte_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/mca/schizo/base/base.h"
+#include "src/mca/schizo/schizo.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/prte_cmd_line.h"
+
+#define CHECK(label, cond)                                          \
+    do {                                                            \
+        if (!(cond)) {                                              \
+            fprintf(stderr, "FAIL [%s]: %s\n", (label), #cond);     \
+            failures++;                                             \
+        }                                                           \
+    } while (0)
+
+/* the individual test entry points */
+extern int test_normalize(void);
+extern int test_directives(void);
+extern int test_sanity(void);
+extern int test_output(void);
+extern int test_personality(void);
+
+/* shared helpers (test_helpers.c) */
+
+/* Append an option instance to a result set.  Pass the values in order,
+ * terminated by NULL; pass no values at all for a boolean-style option. */
+extern void schizo_test_add(pmix_cli_result_t *results, const char *key, ...);
+
+/* Look up the module a personality name resolves to, or NULL if that
+ * component was not built into this tree. */
+extern prte_schizo_base_module_t *schizo_test_module(const char *name);
+
+#endif /* PRTE_TEST_SCHIZO_H */

--- a/test/unit/schizo/test_schizo_main.c
+++ b/test/unit/schizo/test_schizo_main.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "test_schizo.h"
+
+#include "src/runtime/runtime.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/proc_info.h"
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    /* the schizo modules read prte_tool_actual to pick a per-tool option
+     * table, and prte_tool_basename for their error text - a tool sets both
+     * in main() long before schizo is opened */
+    prte_tool_actual = "prterun";
+    prte_tool_basename = "prterun";
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* the personality tests take their modules from the framework, so it
+     * has to be open and selected before they run */
+    rc = pmix_mca_base_framework_open(&prte_schizo_base_framework,
+                                      PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "schizo framework open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+    rc = prte_schizo_base_select();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "schizo select failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+
+    failures += test_normalize();
+    failures += test_directives();
+    failures += test_sanity();
+    failures += test_output();
+    failures += test_personality();
+
+    (void) pmix_mca_base_framework_close(&prte_schizo_base_framework);
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all schizo unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d schizo unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
A deep review of `src/mca/schizo`, plus the two things it turned up that
needed a decision rather than a fix. Four commits, each standing on its own.

> **Depends on openpmix/openpmix#4036** — the output-filename pattern is
> expanded by PMIx, and the commit that adds it is gated behind the capability
> flag that PR introduces. The other three commits are independent of it.

## 1. `schizo: repair the command-line translation defects`

One crash and a family of options PRRTE accepted and then quietly did nothing
with. Every one is silent — the job runs, just not the way the user asked.

**The crash.** The `ompi` personality's socket→package rewrite reaches for the
resource field of `ppr:N:resource` with `strrchr()`, which returns NULL for a
bare `--map-by ppr`; the result was advanced past and dereferenced.
`mpirun --map-by ppr ...` died at address `0x1` before reaching the mapper. The
identical bug had already been fixed in `prte` and was never mirrored.

**Silently ignored.**

| Option | What happened |
|---|---|
| `--merge-stderr-to-stdout` | in the prterun/prun tables with no conversion behind it — parsed, then discarded. Works under `ompi`, which does convert it. |
| `--display-devel-allocation` | same; and the docs named `--display alloc-devel` as its replacement, a directive that does not exist. |
| `--output file=X:raw:copy` | qualifiers were split on `,` instead of `:`, so only the first of a `:`-joined run was honored. `copy:raw` worked; `raw:copy` dropped the copy. |
| `--output tag --output timestamp` | `parse_output` re-split `values[0]` every pass — tag applied twice, timestamp dropped. |
| `-np 2 -np 3` | the "one value only" guard had its comparison inverted; ran silently with 2. |
| `--map-by=node`, `--personality=ompi` | `normalize_argv` only understood `--opt value`, not the `=` spelling getopt_long equally accepts. |

**Personality election.** A bid of 0 means "not me", but the comparison was
seeded at `-1`, so an all-zero field was won by whichever component came
first — a typo in `--personality` silently ran the command line in a dialect
the user never asked for. Now requires a strictly positive bid, and the two
spawn-path callers that never null-checked reject the request instead.

Also: `--rank-by numa|core|l1cache|…` no longer rewritten to `package` (they
are distinct objects, none is a valid ranker either way, and the rewrite only
made the error name an option the user never typed); ompi's `--rankfile`
warned unconditionally despite `warn_deprecations=false`; `translate_params`
split `OMPI_MCA_name=value` at the *last* `=`; ompi's tail restoration matched
the first token equal to `tail[0]`, which lands on an option's value when it
equals the executable's name; plus leaks, and `strip_quotes("")` writing in
front of its allocation.

New `test/unit/schizo` (5 files, in `make check`) covers the parsers with no
DVM, asserting on the resulting `PMIX_INFO` array — the only way to see a
directive that was silently dropped.

## 2. `Apply each envar directive once, in the order the user gave it`

`-x`, `--set-env`, `--prepend-env`, `--append-env`, `--unset-env` were applied
**twice**, in the **wrong order**, and one of them **not at all**.

- *Twice*: `odls`' `process_envars()` and the schizo `setup_fork` hook — called
  in the very next statement — both walked the same attributes. SET/UNSET are
  idempotent so nothing showed, but PREPEND/APPEND edit the existing value, so
  every entry prepended onto `PATH` landed twice. `process_envars()` now owns
  them outright.
- *Not at all*: UNSET is a `PMIX_STRING`, and `process_envars()` filtered on
  `PMIX_ENVAR` before looking at the key. It appeared to work only because of
  the duplicate.
- *Wrong order*: these are order-sensitive by definition. Per @rhc54's ruling —
  "if they say prepend, then prepend it. if they later say set it, then set it
  at that point … User beware." — the order is now the user's:

  ```
  --prepend-env "FOO[:]" x --set-env FOO=1   ->  FOO=1
  --set-env FOO=1 --prepend-env "FOO[:]" x   ->  FOO=x:1
  ```

  Three things had to agree: `prte_app_parse` walks `results->instances` in
  list order; `xfer_app` appends rather than prepends (new
  `prte_append_attribute()`); and the prepends that remain — folding in what
  `PMIx_server_setup_application` returned, which must land in *front* — now
  walk their block in reverse, since prepending one entry at a time reverses it.

One case this cannot reproduce, because `pmix_cli_result_t` groups every
occurrence of an option onto a single instance: **openpmix/openpmix#4037**.

Also: `--set-env` was read with a stride of two (right for `--prepend-env`,
wrong here), skipping every other one; and `process_envars` matched env names
with a bare `strncmp`, so prepending onto `PATH` could edit `PATHEXT`.

## 3. `Let the user compose the names of the output files`

`--output file=NAME:pattern` makes NAME the user's own rather than a stem
annotated with the namespace and rank:

| | |
|---|---|
| `%n` | namespace |
| `%r` | rank |
| `%R` | rank, zero-padded to the width of the job's largest rank |
| `%h` | hostname of the node the process ran on |
| `%%` | a literal `%` |

```
--output file=run/%h/rank-%R:pattern   ->  run/<hostname>/rank-<rank>.out
```

The qualifier already existed and did nothing: sanity's `outquals[]` did not
list it, so the CLI rejected it first, and nothing consumed the key either.
All four links of the chain are now present, and the whole thing is gated on
the PMIx capability — built against a PMIx without it, the qualifier is refused
with a diagnostic rather than accepted and ignored. A bad conversion is
reported when the command line is parsed, by asking PMIx, so the CLI's idea of
a valid pattern and the expander's are the same one.

## 4. `dockerswarm: cover the schizo paths only a real DVM can show`

The envar directives (applied by the daemon that forks the process), the
per-daemon `--output file=…` including a pattern whose conversions appear in
the *directory* part, and a personality no component claims being refused
without taking a persistent DVM down.

Plus a fix for a way the harness could lie: the install outlives any one
`build.sh`, so a build that died part-way left the *previous* install standing
and the whole suite ran against code that was never built. `build.sh` now
writes a stamp only on success and `run-tests.sh` refuses to run without one.

## Testing

- `make check` — 11/11 suites (two new: `test/unit/schizo`, and an
  attribute-order contract in `test/unit/odls`)
- `make -C test/offline check-offline` — 1180 pass / 0 fail
- `contrib/dockerswarm/run-tests.sh linux` — **168 pass / 0 fail**, 24 of them
  schizo
- docs build clean; `--enable-debug` build warning-free

Every defect above was reproduced against a built tree before being fixed, and
the fix confirmed the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
