### PR TITLE
Deep review of src/prted: memory safety, two hangs, job-scoped signalling, and an unblocked command path

### DIFF
--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -39,6 +39,7 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/odls/Makefile
         test/unit/iof/Makefile
         test/unit/plm/Makefile
+        test/unit/prted/Makefile
         test/unit/rml/Makefile
         test/unit/ras/Makefile
         test/unit/schizo/Makefile

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -325,6 +325,38 @@ those are what this phase asserts:
   nobody claims must be refused with a diagnostic — and, on a persistent
   DVM, refused without taking the HNP down.
 
+**The daemon body and the PMIx server host module (`src/prted`,
+`test_prted`)**: `src/prted` is where the DVM actually lives, and almost
+none of it means anything on one node. This phase asserts the three things
+that need a second daemon, plus two cheap startup-hardening cases:
+
+- a **cross-job job-level query** — a client asks for another job's
+  `PMIX_JOB_SIZE` from a node that hosts none of that job's procs. The
+  probe is `jobinfo`, a bare PMIx client that `build.sh` compiles the same
+  way it compiles `elastic`. Note the honest scope comment in the test: the
+  local PMIx server may satisfy this from its own cache without upcalling
+  into `dmodex_req`, so treat it as coverage of the query working across
+  nodes rather than as a guaranteed reproducer for the request-tracker
+  mix-up it was written for.
+- **job-scoped signal delivery**. `PRTE_DAEMON_SIGNAL_LOCAL_PROCS` carries
+  the target job's nspace, and the daemon used to ignore it and signal
+  every local child — so in a persistent DVM running two jobs, signalling
+  one killed both. It takes two jobs whose procs land on the *same* daemon,
+  which means a persistent DVM and more than one node. This case does catch
+  the regression: against the unfixed daemon both jobs die.
+- a **malformed `--singleton`** and a **`--prefix /`**. Both are startup
+  paths that used to fault (the first inside PMIx, the second by
+  overrunning a two-byte heap allocation), and both are one line to check
+  once a swarm is up.
+
+Two harness notes if you extend this phase. A live `prun` holds its own
+`pmix.*` rendezvous file, so any case that leaves one running in the
+background must point every later tool at the DVM explicitly — the helpers
+`prted_dvm_start`/`PRUN`/`PRUN_BG` do that with `--report-uri` and
+`--dvm-uri`. And `cleanup_swarm` reaps daemons and tools but not the
+application processes they left behind, so a case that counts procs on a
+node should clear strays first.
+
 ### The install persists too, so a failed build is silently testable
 
 Same shape as the sticky-configure-args trap below, one level up. The

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -234,6 +234,17 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/elastic.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
 
+            # jobinfo: a bare PMIx client used to drive the direct-modex
+            # paths in the daemon.  A job-level (wildcard) Get of data
+            # belonging to ANOTHER job is answered by the daemon itself, and
+            # is only reachable when the asking client sits on a daemon that
+            # hosts none of the procs of the target job -- i.e. never on one
+            # node.  (No apostrophes here: see the note further down.)
+            echo ">>>> jobinfo (direct-modex) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/jobinfo \
+                /prrte-src/contrib/dockerswarm/jobinfo.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
+
             # examples/dynamic.c is the PMIx_Spawn example shipped in this
             # tree: rank 0 spawns "client" from its cwd as a CHILD JOB.  It
             # is the only way this harness can produce a parent/child job

--- a/contrib/dockerswarm/jobinfo.c
+++ b/contrib/dockerswarm/jobinfo.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * jobinfo -- a minimal PMIx client for exercising the daemon's direct-modex
+ * paths (src/prted/pmix/pmix_server_fence.c) across nodes.
+ *
+ *   jobinfo publish <seconds>
+ *       Print "NSPACE <ns>" and stay alive.  Used as the *target* job: run it
+ *       pinned to one node so that every other daemon in the DVM knows about
+ *       the job but hosts none of its processes.
+ *
+ *   jobinfo fetch <nspace> [seconds]
+ *       PMIx_Get(<nspace>, PMIX_RANK_WILDCARD, PMIX_JOB_SIZE) -- a request for
+ *       another job's JOB-LEVEL data.  Print "JOBSIZE <n>" on success.
+ *
+ *   jobinfo fetchkey <nspace> <rank> <key> [seconds]
+ *       PMIx_Get of a specific remote rank's key, with PMIX_REQUIRED_KEY so
+ *       the hosting daemon waits for the key rather than answering "no".
+ *       Used to *park* a request in the local daemon's request array for the
+ *       duration; see the swarm test for why that matters.
+ *
+ * Why this exists: a wildcard (job-level) direct-modex is answered locally --
+ * the daemon already has the job data, it just has to register the nspace with
+ * its PMIx server.  Before it gets there it checks whether some other request
+ * for the same target is already in flight, and that check used to compare
+ * against the wrong field of the request tracker.  Because an unset target is
+ * {"", PMIX_RANK_INVALID}, and PMIx treats an empty nspace as matching
+ * anything and PMIX_RANK_WILDCARD as matching anything, a wildcard request
+ * "matched" the first unrelated entry in the array, was parked as
+ * already-requested, and was never answered.  Reproducing that needs two
+ * clients of the SAME daemon and a job whose procs live somewhere else --
+ * i.e. a real multi-node DVM.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+static int do_publish(int seconds)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    /* the harness scrapes this line to learn the nspace it has to ask about */
+    printf("NSPACE %s\n", myproc.nspace);
+    fflush(stdout);
+
+    sleep(seconds);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+static int do_fetch(const char *nspace, int seconds)
+{
+    pmix_status_t rc;
+    pmix_proc_t target;
+    pmix_value_t *val = NULL;
+    pmix_info_t info;
+    uint32_t jobsize = 0;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* rank=WILDCARD means "the job-level data for this job" */
+    PMIX_LOAD_PROCID(&target, nspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&info, PMIX_TIMEOUT, &seconds, PMIX_INT);
+
+    rc = PMIx_Get(&target, PMIX_JOB_SIZE, &info, 1, &val);
+    PMIX_INFO_DESTRUCT(&info);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        fprintf(stderr, "ERROR PMIx_Get(JOB_SIZE of %s): %s\n",
+                nspace, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    PMIx_Value_get_number(val, (void *) &jobsize, PMIX_UINT32);
+    PMIX_VALUE_RELEASE(val);
+
+    printf("JOBSIZE %u\n", jobsize);
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+static int do_fetchkey(const char *nspace, unsigned int rank, const char *key, int seconds)
+{
+    pmix_status_t rc;
+    pmix_proc_t target;
+    pmix_value_t *val = NULL;
+    pmix_info_t info[2];
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    PMIX_LOAD_PROCID(&target, nspace, (pmix_rank_t) rank);
+    /* REQUIRED_KEY makes the hosting daemon hold the request until the key
+     * shows up, which is what keeps a tracker parked in OUR daemon's request
+     * array for the duration */
+    PMIX_INFO_LOAD(&info[0], PMIX_REQUIRED_KEY, key, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_TIMEOUT, &seconds, PMIX_INT);
+
+    printf("FETCHKEY-STARTED\n");
+    fflush(stdout);
+
+    rc = PMIx_Get(&target, key, info, 2, &val);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+    /* we fully expect this to end in a timeout or not-found - the point was
+     * to occupy a request slot, not to get an answer */
+    printf("FETCHKEY-DONE %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (2 > argc) {
+        fprintf(stderr, "usage: %s publish <secs> | fetch <nspace> [secs] |"
+                        " fetchkey <nspace> <rank> <key> [secs]\n", argv[0]);
+        return 2;
+    }
+
+    if (0 == strcmp(argv[1], "publish")) {
+        return do_publish((3 > argc) ? 120 : atoi(argv[2]));
+    }
+    if (0 == strcmp(argv[1], "fetch")) {
+        if (3 > argc) {
+            fprintf(stderr, "fetch needs an nspace\n");
+            return 2;
+        }
+        return do_fetch(argv[2], (4 > argc) ? 20 : atoi(argv[3]));
+    }
+    if (0 == strcmp(argv[1], "fetchkey")) {
+        if (5 > argc) {
+            fprintf(stderr, "fetchkey needs <nspace> <rank> <key>\n");
+            return 2;
+        }
+        return do_fetchkey(argv[2], (unsigned int) strtoul(argv[3], NULL, 10),
+                           argv[4], (6 > argc) ? 60 : atoi(argv[5]));
+    }
+
+    fprintf(stderr, "unknown mode: %s\n", argv[1]);
+    return 2;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1351,6 +1351,193 @@ test_state() {
     cleanup_swarm
 }
 
+########################################################################
+# src/prted -- the daemon body and the PMIx server host module
+########################################################################
+#
+# Everything interesting in src/prted needs more than one daemon.  A single
+# node hides the whole point of the code: the command dispatcher only has one
+# recipient, every client is a client of the HNP, and a job-level Get is
+# always answered out of the local cache.  These are the cases that only exist
+# across nodes.
+#
+# NOTE on DVM discovery: several cases here leave a prun running in the
+# background, and a live prun holds its own pmix.* rendezvous file.  A later
+# prun that searches $TMPDIR then finds more than one server and refuses to
+# guess ("multiple possible servers ... connection handles have been read from
+# files named pmix.*").  So every case that starts a persistent DVM reports its
+# URI to a file and every prun is pointed at it explicitly.
+PRTED_URI=/tmp/prted-test.uri
+# start a persistent DVM on node1 with the given --host spec, reporting its URI
+prted_dvm_start() {
+    RUN "rm -f $PRTED_URI" >/dev/null 2>&1
+    RUN "timeout -k 5 60 prte --daemonize --report-uri $PRTED_URI --host $1" >/dev/null 2>&1
+    sleep 4
+    RUN "test -s $PRTED_URI"
+}
+# run a tool against that DVM, from the head node ($@ = argv after "prun")
+PRUN() { RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI $*"; }
+# ...and in the background, with its output captured on node1
+PRUN_BG() {
+    local outf=$1; shift
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        prte-node1 bash -lc ". /opt/prte/env.sh;
+            prun --dvm-uri file:$PRTED_URI $* > $outf 2>&1"
+}
+test_prted() {
+    local out rc ns n bpid
+
+    banner "prted: a job-level Get of ANOTHER job is answered by the daemon"
+    # A client asks for the JOB-LEVEL data of a DIFFERENT job, from a node
+    # that hosts none of that job's procs.  This is the cross-job job-level
+    # query path, and it only exists with more than one daemon.
+    #
+    # SCOPE, honestly: depending on what the daemon has already registered
+    # with its PMIx server, this may be answered out of the PMIx cache
+    # without ever upcalling into dmodex_req.  So treat these two cases as
+    # COVERAGE of the query working end to end across nodes -- they are not
+    # a guaranteed reproducer for the tproc/target mix-up in the dmodex
+    # in-flight check (that one is established by inspection: req->target is
+    # only ever assigned on the monitor and tool-connect paths, so on a
+    # dmodex it is {"", PMIX_RANK_INVALID}, which PMIx matches against any
+    # nspace and against PMIX_RANK_WILDCARD).  If you find a way to force
+    # the upcall, tighten these.
+    cleanup_swarm
+    if ! RUN 'command -v jobinfo >/dev/null'; then
+        skp "jobinfo client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the direct-modex tests"
+    else
+        # target job: 2 procs, pinned to node2, alive for the duration
+        PRUN_BG /tmp/ji-pub.out '--host node2:2 -n 2 jobinfo publish 90'
+        sleep 8
+        ns=$(RUN 'grep -m1 "^NSPACE " /tmp/ji-pub.out' 2>/dev/null | awk '{print $2}' | tr -d '\r')
+        if [ -z "$ns" ]; then
+            bad "target job never reported its nspace: $(RUN 'cat /tmp/ji-pub.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "target job is up on node2 (nspace $ns)"
+            # the asking client runs on node3, whose daemon holds no procs of $ns
+            out=$(PRUN "--host node3:1 -n 1 jobinfo fetch $ns 20" 2>&1)
+            n=$(echo "$out" | grep -m1 '^JOBSIZE ' | awk '{print $2}' | tr -d '\r')
+            [ "$n" = 2 ] \
+                && ok "wildcard direct-modex from a daemon hosting no procs returned JOB_SIZE=2" \
+                || bad "wildcard direct-modex did not answer (got '$n'): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            banner "prted: ...and still answers with another request already parked"
+            # THE regression case.  Before answering, dmodex_req scans the
+            # daemon's request array for an in-flight request for the same
+            # target.  It compared against req->target, which only the monitor
+            # and tool-connect paths ever set -- so for every dmodex it is
+            # {"", PMIX_RANK_INVALID}.  PMIx treats an empty nspace as matching
+            # anything and PMIX_RANK_WILDCARD as matching anything, so a
+            # wildcard request "matched" whatever unrelated entry happened to
+            # be in the array, was filed as already-requested, and was never
+            # answered.  The client hangs until its timeout.
+            #
+            # So: park an unrelated request in a daemon first (a Get of a
+            # specific remote rank with PMIX_REQUIRED_KEY, which the hosting
+            # daemon holds waiting for a key that never arrives), then ask the
+            # wildcard question through the SAME daemon.
+            #
+            # This has to be a DIFFERENT node from the case above.  Answering a
+            # wildcard request registers the nspace with that daemon's PMIx
+            # server, so a second Get on node3 would be served straight out of
+            # the PMIx cache and never reach the host at all -- the case would
+            # pass without exercising anything.  node4 has not seen $ns yet.
+            PRUN_BG /tmp/ji-park.out "--host node4:1 -n 1 jobinfo fetchkey $ns 0 prte.test.never 60"
+            sleep 10
+            if RUN 'grep -q FETCHKEY-STARTED /tmp/ji-park.out' && \
+               ! RUN 'grep -q FETCHKEY-DONE /tmp/ji-park.out'; then
+                ok "an unrelated request is parked in node4's daemon"
+            else
+                skp "could not park a request in node4's daemon; the next case is weaker"
+            fi
+            out=$(PRUN "--host node4:1 -n 1 jobinfo fetch $ns 20" 2>&1)
+            n=$(echo "$out" | grep -m1 '^JOBSIZE ' | awk '{print $2}' | tr -d '\r')
+            [ "$n" = 2 ] \
+                && ok "wildcard direct-modex still answered with a request parked" \
+                || bad "wildcard direct-modex was swallowed by the in-flight check: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "prted: a signal reaches the job it was sent to, and no other"
+    # PRTE_DAEMON_SIGNAL_LOCAL_PROCS carries the target job's nspace.  The
+    # daemon used to unpack it and then hand NULL to the ODLS, which means
+    # "every local child" -- so in a persistent DVM running more than one job,
+    # signalling one job killed them all.  One node cannot show this: it needs
+    # two jobs whose procs land on the same daemon, and a persistent DVM to
+    # hold them both.
+    # cleanup_swarm reaps daemons and tools but not the application procs
+    # they left behind, and this case counts procs on node2 - a stray sleep
+    # from an earlier run would make the precondition check nonsense
+    for n in 1 2; do docker exec "prte-node$n" sh -c 'pkill -9 -x sleep 2>/dev/null; true'; done
+    if ! prted_dvm_start 'node1:4,node2:4'; then
+        bad "could not start a DVM for the job-scoped signal test"
+    else
+        # SIGUSR1 is in the default forwarded-signal set (ess_base_frame.c),
+        # so no --forward-signals is needed -- and prun would reject it: the
+        # option is only in the prte/prterun tables.
+        PRUN_BG /tmp/jobA.out '--host node2:1 -n 1 sleep 120'
+        PRUN_BG /tmp/jobB.out '--host node2:1 -n 1 sleep 120'
+        sleep 10
+        n=$(ON 2 'pgrep -c -x sleep' 2>/dev/null | tr -d ' \r')
+        if [ "$n" = 2 ]; then
+            ok "two jobs are running, both with procs on node2"
+            # signal ONLY job A's launcher; prun relays it as a job-scoped
+            # PMIX_JOB_CTRL_SIGNAL for its own nspace
+            # match the launcher by executable name: "pgrep -f sleep 120"
+            # would also match the shell this very command runs in
+            bpid=$(RUN 'pgrep -x prun | head -1' 2>/dev/null | tr -d ' \r')
+            RUN "kill -USR1 $bpid" >/dev/null 2>&1
+            sleep 10
+            n=$(ON 2 'pgrep -c -x sleep' 2>/dev/null | tr -d ' \r')
+            [ "$n" = 1 ] \
+                && ok "the signalled job died and the other one did not" \
+                || bad "signal was not job-scoped ($n of 2 procs left on node2; expected 1)"
+            n=$(RUN 'pgrep -c -x prun' 2>/dev/null | tr -d ' \r')
+            [ "$n" = 1 ] \
+                && ok "the unsignalled launcher is still waiting on its job" \
+                || bad "$n launchers left after signalling one job; expected 1"
+        else
+            bad "could not get two concurrent jobs running on node2 (saw $n procs)"
+        fi
+        RUN 'pkill -f "sleep 120"' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "prted: a malformed --singleton is refused, not a crash"
+    # The value is handed straight down to PMIx_server_init as PMIX_SINGLETON,
+    # which faults on anything that is not "<nspace>.<rank>", so prte has to
+    # reject it BEFORE prte_init.  A crash here is a segfault at startup.
+    out=$(RUN 'timeout -k 5 30 prte --singleton notanid' 2>&1)
+    echo "$out" | grep -q 'malformed singleton identifier' \
+        && ok "a malformed --singleton is reported and refused" \
+        || bad "malformed --singleton was not cleanly refused: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    echo "$out" | grep -qi 'signal: segmentation' \
+        && bad "malformed --singleton still crashes" \
+        || ok "...and does not crash"
+    cleanup_swarm
+
+    banner "prted: a root path prefix does not corrupt the heap"
+    # The four --prefix normalizers used strncpy(param, PRTE_PATH_SEP,
+    # sizeof(param) - 1) on a char*, so sizeof gave the size of the POINTER
+    # and strncpy NUL-padded eight bytes into a two-byte allocation.
+    # "--prefix /" is that two-byte allocation.  The job has to actually RUN:
+    # a corrupted heap shows up as a crash or a hang later in startup, and
+    # "no output" would otherwise look like a pass.
+    out=$(RUN 'timeout -k 5 60 prterun --prefix / --host node1:1 -n 1 hostname' 2>&1)
+    echo "$out" | grep -qE '^node1$' \
+        && ok "--prefix / still launched the job" \
+        || bad "--prefix / broke the launch: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    echo "$out" | grep -qi 'signal: segmentation\|corrupt\|malloc' \
+        && bad "--prefix / corrupted the heap: $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+        || ok "...and did not corrupt the heap"
+    cleanup_swarm
+}
+
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
         echo "swarm not up -- run: docker compose up -d" >&2; exit 2
@@ -1898,6 +2085,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_schizo
 
     test_state
+
+    test_prted
 
     test_slurm_alloc
     test_slurm

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -426,10 +426,10 @@ specification and try again.
 #
 [redefining-policy]
 
-Conflicting directives for binding policy are causing the policy to be
+Conflicting directives for %s policy are causing the policy to be
 redefined:
 
-   New policy:   %s
+   New policy:    %s
    Prior policy:  %s
 
 Please check that only one policy is defined.

--- a/src/mca/schizo/prte/help-prte.txt
+++ b/src/mca/schizo/prte/help-prte.txt
@@ -418,3 +418,15 @@ Output a brief periodic report on DVM startup progress
 [rtos]
 
 #include#help-schizo-rtos.txt#rtos
+
+#
+[bad-singleton]
+%s was given a malformed singleton identifier:
+
+  Identifier: %s
+
+The value of the "--singleton" option must have the form
+
+  <namespace>.<rank>
+
+for example, "myapp.0". Please correct the identifier and try again.

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -1,0 +1,316 @@
+# AGENTS.md — `src/prted` (the daemon body and the tool front ends)
+
+Orientation for AI agents and human contributors working in
+`src/prted/`. This is a map, not the rulebook: the authoritative project
+guidance lives in the top-level [`AGENTS.md`](../../AGENTS.md) and under
+[`docs/`](../../docs/). When this file and those disagree, **the docs
+win** — and please fix this file.
+
+---
+
+## What lives here, and what does not
+
+`src/prted/` is not an MCA framework. It is the **body of the running
+system**: the code that every PRRTE process actually executes, as opposed
+to the pluggable policy that the frameworks under `src/mca/` supply.
+
+The name is historical and misleading in one important way: this
+directory holds far more than the `prted` daemon. Everything here is
+compiled into `libprrte`, and the thin `main()` wrappers under
+`src/tools/` call into it.
+
+| File | Runs in | Purpose |
+|------|---------|---------|
+| `prte.c` | `prte`, `prterun` | The HNP/DVM-master body. Command line → PRRTE init → DVM startup → (optionally) spawn one job → event loop. ~1700 lines, and the single longest function in the tree. |
+| `prted_comm.c` | every daemon incl. the HNP | The `PRTE_RML_TAG_DAEMON` command dispatcher: one `switch` over `prte_daemon_cmd_flag_t`. This is how the HNP tells daemons to launch, signal, kill, shrink, halt. |
+| `prte_app_parse.c` | `prte`, `prterun`, `prun` | Turns an application command line (with `:`-separated app contexts) into a list of `prte_pmix_app_t`. |
+| `prun_common.c` | `prun`, and `prterun --dvm` | The tool-side body: attach to a DVM as a PMIx tool, spawn, forward I/O and signals, wait for termination. |
+| `prted.h` | — | The handful of symbols the tools need from here. |
+| `pmix/` | every daemon | The PMIx **server host module** — the ~10k lines that answer PMIx's upcalls. It has its own [`AGENTS.md`](pmix/AGENTS.md); read it before touching anything in there. |
+
+Not here: `src/tools/prted/prted.c` is the daemon's `main()` and its
+startup/rollup logic. `src/runtime/` holds the globals
+(`prte_job_t`, `prte_node_t`, `prte_proc_t`) that all of this code
+manipulates.
+
+---
+
+## Who executes what
+
+This is the first thing to get straight, because the same file often runs
+in three different roles with different rules:
+
+```
+        prte / prterun                prted (per node)          prun (tool)
+        ────────────────              ────────────────          ───────────
+ body:  prte.c                        src/tools/prted/prted.c   prun_common.c
+        prted_comm.c (as a daemon)    prted_comm.c              (no daemon cmds)
+        prted/pmix/*   (as HNP)       prted/pmix/*  (as prted)  —
+```
+
+- **The HNP is also a daemon.** `prte.c` registers
+  `prte_daemon_recv` for `PRTE_RML_TAG_DAEMON` just as `prted` does,
+  because "send this to all daemons" includes the HNP. Any new daemon
+  command must therefore behave sensibly at the HNP too — several
+  existing cases branch on `PRTE_PROC_IS_MASTER` for exactly this reason.
+- **`prterun` is `prte` wearing a different hat.** `prte()` detects that
+  it is being run as a proxy (`prte_schizo_base_detect_proxy`), and, if
+  `--dvm` was given, hands straight off to `prun_common()` and never
+  starts a DVM at all. Otherwise it starts a one-shot DVM, spawns the
+  job, and exits when it completes (`prte_persistent == false`).
+- **`prun` never runs any of this except `prun_common.c` and
+  `prte_app_parse.c`.** It is a PMIx tool; it has no PRRTE runtime.
+
+---
+
+## The thread rule — this is where it bites hardest
+
+`src/prted` sits directly on the boundary between the PMIx progress
+thread and the PRRTE progress thread, so the top-level golden rule
+("thread-shift every PMIx callback and server-module upcall") is not
+abstract advice here: it is the single most common source of bugs in this
+directory. Read that section of the top-level
+[`AGENTS.md`](../../AGENTS.md) before writing anything that takes a
+callback.
+
+Two concrete consequences specific to this directory:
+
+**The daemon's event base is driven by its main thread.** Both
+`src/tools/prted/prted.c` and `prte.c` run
+
+```c
+while (prte_event_base_active) {
+    prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+}
+```
+
+so every RML receive callback — including `prte_daemon_recv` — executes
+*on the thread that drives the event base*. That means:
+
+- A `prte_pmix_shifted_wakeup()` posted from the PMIx thread can only be
+  processed by that same thread. Code here that blocks waiting for such a
+  wakeup must use the loop-driving idiom, never `PRTE_PMIX_WAIT_THREAD`:
+
+  ```c
+  while (prte_event_base_active && lock.active) {
+      prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+  }
+  ```
+
+  `prte.c` does this in five places and says so in comments at each; copy
+  that pattern rather than inventing a new one.
+
+- **No daemon command blocks the loop.** `prted_comm.c` contains no
+  `PRTE_PMIX_WAIT_THREAD` at all, and should not acquire one. The three
+  commands that have to wait on PMIx — `HALT_VM`, `SHRINK` and
+  `DVM_CLEANUP_JOB` — are written as continuations instead: the command
+  issues the PMIx call and returns, PMIx's completion callback captures
+  and thread-shifts (`_daemon_cont_cbfunc`), and the work that would have
+  followed a wait runs in `_daemon_continue()` on the progress thread.
+  A `prte_daemon_caddy_t` carries the state across.
+
+  This is not stylistic. Blocking there froze the daemon's entire event
+  loop — no RML traffic, no timers, no other command — and, worse, meant
+  that anything PMIx needed *from us* to finish the call could never run.
+  The `prte.notify.donotloop` marker on those notifications exists
+  precisely because one such deadlock was found the hard way.
+
+  Two things to keep right when adding to this pattern: the info array
+  must be heap-allocated and owned by the caddy (PMIx needs it valid
+  after `prte_daemon_recv` has returned, so a stack array is a
+  use-after-free), and a PMIx call that returns anything other than
+  `PMIX_SUCCESS` will *not* invoke the callback — run the continuation
+  directly in that case, since you are already on the right thread.
+
+**`prun_common.c` is the exception.** `prun` is a tool: its main thread
+does not drive a PRRTE event base, so the classic
+`PRTE_PMIX_WAIT_THREAD` / `PRTE_PMIX_WAKEUP_THREAD` pair is correct there
+and is used throughout. Do not "fix" it to match `prte.c`.
+
+---
+
+## `prte.c` — the HNP body
+
+One enormous function, `prte()`, in roughly this order. Knowing the order
+matters because a surprising amount of the code depends on *when* it runs
+relative to `prte_init()`.
+
+1. **Pre-init.** Save a pristine environment for launched procs (all
+   `PMIX_`/`PRTE_` vars stripped), pre-scan argv for MCA params, open the
+   event base, install signal handlers, open and select `schizo`.
+2. **Personality & proxy detection.** `detect_proxy` picks the schizo
+   module. If it returns NULL we cannot continue — every later use of
+   `jdata->schizo` is an unchecked dereference.
+3. **Command-line parse** through the selected schizo, then the standalone
+   options (`--daemonize`, `--report-uri`, `--singleton`, `--prefix`,
+   `--report-pid`, `--keepalive`, …).
+4. **Proxy hand-off.** `--dvm` + proxy ⇒ `prun_common()` and `exit()`.
+5. **`prte_init(PRTE_PROC_MASTER)`.** After this the daemon job object,
+   the node pool, and the PMIx server all exist. **Anything that must
+   reject bad user input before PMIx sees it has to happen above this
+   line** — `--singleton` is the cautionary tale: the value is handed
+   straight to `PMIx_server_init` as `PMIX_SINGLETON`, so a malformed one
+   faults inside the PMIx library long before PRRTE's own
+   `prep_singleton()` would look at it.
+6. **DVM startup.** `PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOCATE)`,
+   then loop the event base until `prte_dvm_ready`.
+7. **Spawn (non-persistent only).** Build `pmix_app_t`s from the parsed
+   apps, `PMIx_Spawn_nb`, push stdin.
+8. **`proceed:`** — loop the event base until something clears
+   `prte_event_base_active`, then `prte_finalize()` and `exit()`.
+
+### Things in `prte.c` that are easy to get wrong
+
+- **`goto DONE` is the only exit.** It runs `prte_finalize()`. An early
+  `return` after `prte_init()` leaks the session directory.
+- **The `--prefix` normalizers.** There are four textually identical
+  copies (PRRTE prefix from the command line, from `PRTE_PREFIX`, PMIx
+  prefix from the command line, from `PMIX_PREFIX`). They now all call
+  `prte_strip_trailing_pathsep()`. Do not re-inline the loop: the version
+  that was inlined four times used `sizeof(param)` on a `char *` and
+  overran the heap for any prefix shorter than a pointer.
+- **The signal handlers are not async-signal-safe.**
+  `abort_signal_callback()` is installed with `signal()` and, on the third
+  ctrl-c, calls `prte_job_session_dir_finalize()` and
+  `PMIx_server_finalize()`. That is a known wart on a
+  we-are-dying-anyway path; do not add to it. The first ctrl-c correctly
+  does nothing but `write()` to `term_pipe`, which wakes `clean_abort`
+  inside the event loop.
+- **`prte_event_reinit()` after `--daemonize`.** The event base is opened
+  before the fork and some backends (kqueue on macOS) do not survive it.
+- **`prep_singleton()` builds a job by hand.** It fabricates a
+  `prte_job_t`/`prte_app_context_t`/`prte_proc_t` and registers the
+  nspace, so a singleton can `PMIx_Init` against this DVM. It is the only
+  place outside the mappers that constructs a job map.
+
+---
+
+## `prted_comm.c` — the daemon command dispatcher
+
+`prte_daemon_recv()` is a single `switch` over the command byte. Adding a
+command means: a new `PRTE_DAEMON_*` value in
+[`src/mca/plm/plm_types.h`](../mca/plm/plm_types.h) (unique offset — see
+the top-level AGENTS.md rule on hand-assigned codes), a `case` here, and
+a string in `get_prted_comm_cmd_str()`.
+
+| Command | Effect |
+|---------|--------|
+| `KILL_LOCAL_PROCS` | Kill the named procs, or all of them if the list is empty. |
+| `SIGNAL_LOCAL_PROCS` | Deliver a signal to the named **job**'s local procs. |
+| `ADD_LOCAL_PROCS` / `DVM_ADD_PROCS` | Hand the launch message to `odls.launch_local_procs`. |
+| `ABORT_PROCS_CALLED` | An app called `PMIx_Abort`; terminate the listed procs (deduplicated against everything already ordered to die). |
+| `DEFINE_PSET` | Register a process set with the local PMIx server. |
+| `EXIT_CMD` | Orderly shutdown once our children and routing children are gone. |
+| `HALT_VM_CMD` | Abnormal shutdown; notify attached tools, then terminate. |
+| `SHRINK_CMD` | We are being removed from the DVM (see below). |
+| `DVM_CLEANUP_JOB_CMD` | A job finished; deregister its nspace and clear pending server ops. |
+| `GET_STACK_TRACES` | Run `gstack` on each local proc of a job and ship the output to the HNP. |
+
+Rules that this switch has broken before and will break again:
+
+- **Every `case` owns its allocations.** The `switch` has one shared
+  `CLEANUP:` label that does nothing but `return`. There is no common
+  teardown, so a `goto CLEANUP` from the middle of a case leaks whatever
+  that case had allocated — buffers, `PMIx_Proc_create` arrays, unpacked
+  strings. Free explicitly before jumping.
+- **`PMIX_NEW` objects need `PMIX_RELEASE`, not `free()`.** A
+  `prte_proc_t` built to carry a name still has a destructor.
+- **`break` inside a `for` inside a `case` leaves the loop, not the
+  switch.** The `GET_STACK_TRACES` case relies on this deliberately;
+  read carefully before adding one.
+- **Do not block.** See the thread rule above — a command that must wait
+  on PMIx is written as a continuation, not as a wait on a lock.
+- **Do not assume the daemon job object exists.** `prte_get_job_data_object`
+  can return NULL during teardown.
+
+### The shrink path is subtler than it looks
+
+A daemon told to leave the DVM must **not** exit immediately in elastic
+mode: the master completes the shrink campaign from the broadcast's
+collective ACK, so leaving before our subtree's ACK propagates means the
+completion handler never fires. `PRTE_DAEMON_SHRINK_CMD` therefore sets
+`prte_dvm_leaving` and arms a bounded (2 s) departure timer, with
+`prte_rml_route_lost()` providing an earlier exit if the lifeline
+actually drops. The legacy (non-elastic) path exits at once because
+nothing is tracking completion. The long comment above
+`prte_shrink_depart_ev` is the authoritative explanation.
+
+---
+
+## `prte_app_parse.c` and `prun_common.c`
+
+`prte_parse_locals()` splits the command line on `:` into app contexts
+and produces `prte_pmix_app_t` list entries plus two out-params
+(`hostfiles`, `hosts`) and a `jobdata` list of directives that belong to
+the **job** rather than to any one app. That last list is why
+`--map-by` given once applies to the whole job however many apps there
+are — `prte.c` and `prun_common.c` both walk `jobdata` looking for
+`PMIX_MAPBY`/`RANKBY`/`BINDTO` and the two prefix keys.
+
+`prun_common()` is the tool body: `PMIx_tool_init` (with whatever DVM
+search directive the user gave), register event handlers for job
+termination and debugger events, `PMIx_Spawn_nb`, push stdin, wait, then
+report the job's exit status. Signal forwarding is done with
+`PMIx_Job_control(PMIX_JOB_CTRL_SIGNAL)` against the spawned nspace,
+which is what eventually arrives at `prted_comm.c`'s
+`SIGNAL_LOCAL_PROCS`.
+
+---
+
+## Testing
+
+**Unit — `test/unit/prted/` (`make check`).** Everything in here that can
+be exercised without a DVM: the `--prefix` normalizer, the `--singleton`
+identifier parser, `prte_pmix_xfer_job_info()`'s directive handling
+(including its conflict rejection and its cache-the-unknown default),
+`prte_pmix_xfer_app()`'s translation and — importantly — its ownership
+contract with the caller's job object, and the job-info cache. Extend it
+whenever you add a decision that does not need a live runtime.
+
+**Offline mapper harness.** Not relevant here unless you touch how job
+directives reach the mapper — but if you change `prte_pmix_xfer_job_info`,
+run `make -C test/offline check-offline`, since that is the function that
+turns a spawn request into a mapping policy.
+
+**Live smoke test.** For anything touching the command dispatcher, DVM
+startup, or teardown:
+
+```sh
+prte --daemonize && prun -n 4 hostname && pterm
+```
+
+**Multi-node — `contrib/dockerswarm/`.** Most of what is interesting in
+this directory only exists across nodes: a daemon that hosts none of a
+job's procs, a tool connecting through a non-master daemon, a signal that
+must reach one job and not another, a shrink that has to ACK before it
+departs. `run-tests.sh`'s `test_prted()` covers these; see
+[`contrib/dockerswarm/AGENTS.md`](../../contrib/dockerswarm/AGENTS.md).
+
+---
+
+## Debugging
+
+```sh
+prte --prtemca state_base_verbose 5 ...        # job/DVM state transitions
+prte --prtemca plm_base_verbose 5 ...          # daemon launch
+prte --prtemca pmix_server_verbose 5 ...       # every PMIx upcall and reply
+prte --debug-daemons ...                       # the pmix_output() traces in prted_comm.c
+prte --debug-daemons-file ...                  # ...to a file, per daemon
+```
+
+`prte_debug_daemons_flag` guards the plain-language traces in
+`prted_comm.c`; `prte_pmix_server_globals.output` (verbosity ≥2) guards
+the ones under `pmix/`.
+
+---
+
+## Where to go next
+
+- [`pmix/AGENTS.md`](pmix/AGENTS.md) — the PMIx server host module. Two
+  thirds of the code in this directory lives there.
+- [`../mca/state/AGENTS.md`](../mca/state/AGENTS.md) — what
+  `PRTE_ACTIVATE_JOB_STATE` actually does.
+- [`../mca/plm/AGENTS.md`](../mca/plm/AGENTS.md) — the other end of the
+  daemon command channel.
+- [`../mca/odls/AGENTS.md`](../mca/odls/AGENTS.md) — what
+  `ADD_LOCAL_PROCS` and `KILL_LOCAL_PROCS` hand off to.

--- a/src/prted/CLAUDE.md
+++ b/src/prted/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -1,0 +1,323 @@
+# AGENTS.md — `src/prted/pmix` (the PMIx server host module)
+
+Orientation for AI agents and human contributors working in
+`src/prted/pmix/`. This is a map, not the rulebook: the authoritative
+project guidance lives in the top-level [`AGENTS.md`](../../../AGENTS.md)
+and under [`docs/`](../../../docs/). When this file and those disagree,
+**the docs win** — and please fix this file. Read
+[`../AGENTS.md`](../AGENTS.md) first for how this code fits into the
+daemon.
+
+---
+
+## What this is
+
+Every PRRTE daemon — the HNP and every `prted` — embeds a PMIx server.
+Application processes and tools connect to it and issue PMIx calls. For
+anything the PMIx library cannot answer out of its own cache, it calls
+*up* into the host, and **this directory is that host**. The whole
+directory is one implementation of `pmix_server_module_t`.
+
+```
+   app / tool                 PMIx server library            PRRTE
+   ──────────                 ───────────────────            ─────
+   PMIx_Spawn()      ──►      spawn upcall          ──►  pmix_server_spawn_fn()
+                                                              │ thread-shift
+                                                              ▼
+                                                         interim() → PLM
+   PMIx_Get(remote)  ──►      direct_modex upcall    ──►  pmix_server_dmodex_req_fn()
+   PMIx_Fence()      ──►      fence_nb upcall        ──►  pmix_server_fencenb_fn() → grpcomm
+   PMIx_Notify_event ──►      notify_event upcall    ──►  pmix_server_notify_event() → xcast
+```
+
+The module table is at the top of `pmix_server.c`. Each entry is an
+upcall; each file below implements a related group of them.
+
+| File | Upcalls / role |
+|------|----------------|
+| `pmix_server.c` | Init/finalize, MCA params, the module table, the request trackers, direct-modex RML plumbing (`dmdx_recv`/`dmdx_resp`), logging relay, the scheduler relay (`pmix_server_sched`). The biggest file. |
+| `pmix_server_internal.h` | `prte_pmix_server_req_t` (the universal request tracker), `prte_pmix_server_op_caddy_t`, the globals struct, and the thread-shift macros. **Read this first.** |
+| `pmix_server_register_fns.c` | Turning a `prte_job_t` into the info arrays PMIx needs (`PMIx_server_register_nspace`, `register_client`, tool registration). |
+| `pmix_server_dyn.c` | `spawn` — plus `prte_pmix_xfer_job_info()`/`prte_pmix_xfer_app()`, the translators from PMIx directives to PRRTE job/app attributes. Also `connect`/`disconnect`. |
+| `pmix_server_queries.c` | `query` — namespaces, proc tables, psets, groups, allocations. |
+| `pmix_server_gen.c` | `abort`, `client_finalized`, `client_connected2`, `tool_connected`, `iof_pull`, `push_stdin`, `log`. |
+| `pmix_server_fence.c` | `fence_nb` and `direct_modex`. |
+| `pmix_server_pub.c` | `publish`/`lookup`/`unpublish` (relayed to the data server). |
+| `pmix_server_notify.c` | `notify_event` (up), and the RML receive that fans a peer's event out to local clients (down). |
+| `pmix_server_group.c` | `group` — a thin pass-through to grpcomm. |
+| `pmix_server_job_ctrl.c` | `job_control` — kill/terminate/signal/define-pset, as daemon commands. |
+| `pmix_server_monitor.c` | `monitor` — heartbeat/file monitoring, fanned out to all daemons and collected. |
+| `pmix_server_alloc*.c`, `pmix_server_session.c` | `allocate` and `session_control`, relayed to the DVM master and on to a scheduler. |
+
+---
+
+## THE rule for this directory
+
+> **Every function in here that PMIx calls executes on the PMIx progress
+> thread. It must capture its arguments and post an event to
+> `prte_event_base`, and do nothing else.**
+
+This is the top-level golden rule, and this directory is where it
+applies to essentially every function. A `prte_job_t`, a `prte_node_t`, a
+`prte_pmix_server_req_t`, `prte_pmix_server_globals.local_reqs` — all of
+these belong to the PRRTE progress thread. Touching them from a PMIx
+callback is a data race, and freeing something from one is worse.
+
+The canonical shape (from `pmix_server_job_ctrl.c`):
+
+```c
+pmix_status_t pmix_server_job_ctrl_fn(const pmix_proc_t *requestor, ...)
+{
+    prte_pmix_server_op_caddy_t *cd;
+
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    memcpy(&cd->proc, requestor, sizeof(pmix_proc_t));
+    cd->procs = (pmix_proc_t *) targets;      /* borrowed, see below */
+    cd->nprocs = ntargets;
+    cd->infocbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _job_ctrl, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    return PMIX_SUCCESS;
+}
+```
+
+Three things about that:
+
+- **Arrays are borrowed, not copied.** PMIx keeps the `info`/`procs`/`apps`
+  arrays alive until the host invokes the completion callback. That is
+  why the caddy stores pointers. It is also why the shifted handler must
+  not return without eventually calling `cbfunc`.
+- **`PMIX_POST_OBJECT` / `PMIX_ACQUIRE_OBJECT` bracket the hand-off.**
+  They are the memory barriers that make the caddy's contents visible to
+  the other thread. Every shifted handler starts with `PMIX_ACQUIRE_OBJECT`.
+- **The same rule applies in the other direction.** A callback *PMIx*
+  invokes on us to deliver a result — `send_alloc_resp`, the session
+  `infocbfunc`, `modex_resp` — also runs on the PMIx thread and must
+  capture into its own caddy rather than writing the request. Both of
+  those use a dedicated response caddy (`prte_alloc_resp_caddy_t`,
+  `prte_sessctrl_resp_caddy_t`, `prte_dmdx_resp_caddy_t`) that holds a
+  reference on the request so it cannot be reclaimed underneath the
+  shift. Copy that pattern; do not write the request from the PMIx
+  thread "just this once".
+
+The daemon-command side follows the same discipline: `prted_comm.c`'s
+`HALT_VM`/`SHRINK`/`DVM_CLEANUP_JOB` cases issue their PMIx call and
+return, and pick up in `_daemon_continue()` once PMIx is done. Nothing on
+a running daemon's command path blocks its own event loop waiting on
+PMIx.
+
+The two `PRTE_PMIX_WAIT_THREAD` calls left in this directory are both in
+`pmix_server_init()`, which runs inside `prte_init()` — before the event
+loop exists. There is no loop to park there, so blocking is correct. Any
+*new* one outside that function is almost certainly a bug.
+
+The narrow exception is a callback that PMIx guarantees to invoke
+synchronously on our own thread — `prte_pmix_server_register_nspace`'s
+completion when we called it from a shifted handler. Those are marked
+with a comment saying so at each site.
+
+---
+
+## `prte_pmix_server_req_t` — the universal tracker
+
+Almost every asynchronous operation in this directory is tracked by one
+of these (`pmix_server_internal.h`). It is deliberately a union of every
+field any operation might need, which makes it flexible and makes
+ownership bugs easy. The parts that matter:
+
+| Field | Meaning |
+|-------|---------|
+| `tproc` | The **target** of the operation — for a dmodex, the proc whose data was asked for. |
+| `target` | Only the monitor and tool-connection paths set this. It is `{"", PMIX_RANK_INVALID}` everywhere else. |
+| `proxy` | The peer daemon on the other end of a relayed request. |
+| `local_index` | Our index into `prte_pmix_server_globals.local_reqs`. Sent on the wire; the peer echoes it back so we can find the request again. |
+| `remote_index` | *Their* index, to echo back to them. |
+| `copy` / `dircopy` / `moncopy` | Does the destructor own `info` / `directives` / `monitor`? Set it when you allocate into those fields, or the array leaks. |
+| `event_active` / `cycle_active` | Is `ev` / `cycle` armed as a timer? |
+| `inprogress` | Someone else (host or PMIx library) currently holds this request; do not release it. |
+
+**`tproc` versus `target` is a live trap.** `PMIx_Check_nspace()` treats
+an *empty* nspace as matching anything, and `PMIx_Check_rank()` treats
+`PMIX_RANK_WILDCARD` as matching anything. So
+`PMIX_CHECK_PROCID(&r->target, &something_wildcard)` returns **true** for
+every request that never set `target` — which is all of them outside
+monitor/tool-connect. The dmodex de-duplication loop in
+`pmix_server_fence.c` had exactly this bug: a `PMIX_RANK_WILDCARD`
+job-level fetch matched the first unrelated entry in the array, got
+parked as "already requested", and was never answered. Compare `tproc`
+against `tproc`.
+
+**Two request arrays, two meanings.** `local_reqs` holds requests *we*
+originated and are waiting on; `remote_reqs` holds requests *a peer*
+asked us to service. `prte_pmix_server_clear()` sweeps only
+`remote_reqs`, because the local ones belong to callbacks that will still
+fire.
+
+---
+
+## The relay pattern
+
+Anything a non-master daemon cannot answer itself is packed and sent to
+the DVM master over an RML tag, and the answer comes back on a partner
+tag. All of them follow the same shape, and all of them carry the
+requester's index so the reply can find its way home:
+
+| Operation | Request tag | Response tag |
+|-----------|-------------|--------------|
+| direct modex | `PRTE_RML_TAG_DIRECT_MODEX` | `..._DIRECT_MODEX_RESP` |
+| spawn | `PRTE_RML_TAG_PLM` | `..._LAUNCH_RESP` |
+| tool connection | `PRTE_RML_TAG_PLM` | `..._TCONN_RESP` |
+| allocate / session ctrl | `PRTE_RML_TAG_SCHED` | `..._SCHED_RESP` |
+| monitor | `..._MONITOR_REQUEST` | `..._MONITOR_RESP` |
+| log | `PRTE_RML_TAG_LOGGING` | `..._LOGGING_RESP` |
+
+When adding to a relay, remember that the index arriving on the wire is
+untrusted input. `pmix_pointer_array_get_item()` bounds-checks and
+returns NULL, so check for NULL — but do not then `return` without
+completing the request, because the requester is still waiting.
+
+**A collecting relay must complete on *every* path.** `monitor`
+fans out to all daemons and counts responses (`ndaemons` vs `nreported`).
+It increments `nreported` as soon as a response arrives, so a response
+that then fails to unpack must still fall through to the "have all
+daemons reported?" check. Returning early there means that if the *last*
+daemon's response is malformed, the request never completes and the
+client hangs forever.
+
+---
+
+## Info-array expansion
+
+Several relays add an entry (usually `PMIX_REQUESTOR`) to an info array
+before passing it on. The idiom is three steps and all three are
+required:
+
+```c
+PMIX_INFO_CREATE(xfer, ninfo + 1);          /* 1. allocate one extra    */
+for (n = 0; n < ninfo; n++) {
+    PMIX_INFO_XFER(&xfer[n], &info[n]);
+}
+PMIX_INFO_LOAD(&xfer[ninfo], PMIX_REQUESTOR, &proc, PMIX_PROC);
+++ninfo;                                     /* 2. count the new entry  */
+req->copy = true;                            /* 3. record who frees it  */
+```
+
+Skipping (2) is the classic failure: the added entry is never sent
+downstream (defeating the point of adding it) and the destructor frees
+one element short. Worse, if the "empty" case sets `ninfo = 1` *and*
+allocates one element, the `PMIX_INFO_LOAD` writes past the end of the
+array. `pmix_server_sched()` in `pmix_server.c` shipped that
+out-of-bounds write; `pass_request()` in `pmix_server_session.c` has
+always had it right and is the model.
+
+---
+
+## Directive translation (`pmix_server_dyn.c`)
+
+`prte_pmix_xfer_job_info()` and `prte_pmix_xfer_app()` are the two
+biggest `if`/`else if` chains in the tree: they map PMIx spawn directives
+onto PRRTE job and app attributes. Notes for extending them:
+
+- **Both return PRRTE codes**, not PMIx status. Their callers convert.
+- **The final `else` is not an error.** An unrecognized job-level key is
+  cached via `pmix_server_cache_job_info()` for delivery at nspace
+  registration, so that an attribute PRRTE knows nothing about still
+  reaches the application. Keep that fallback.
+- **A conflicting policy is an error, never an overwrite.** `PMIX_MAPBY`
+  and `PMIX_PPR` are two spellings of the same thing, so giving both is
+  refused; likewise a second `RANKBY`/`BINDTO`.
+- **`prte_pmix_xfer_app()` does not own `jdata`.** Its caller constructed
+  the job and will dispose of it on an error return; releasing it here
+  hands the caller a dangling pointer. (It used to do this on a `getcwd`
+  failure.)
+- **A directive the mapper must read has to be `PRTE_ATTR_GLOBAL`.** The
+  mapper sees an unpacked *copy* of the job, and only global attributes
+  survive the pack. This is why every `prte_set_attribute` in these
+  functions passes `PRTE_ATTR_GLOBAL`.
+- **Watch for shadowed branches.** The chain is long enough that a key
+  handled early makes a later `else if` on the same key dead code —
+  `PMIX_TIMEOUT` was matched by the `SPAWN_TIMEOUT` branch and its own
+  branch was unreachable.
+
+---
+
+## Locally-originated notifications
+
+The top-level `AGENTS.md` has the full rule; the short version, because
+it is enforced here:
+
+- Any event **we** originate with `PMIx_Notify_event` must carry
+  `PMIX_INFO_LOAD(&info[i], "prte.notify.donotloop", NULL, PMIX_BOOL)`.
+- `pmix_server_notify_event()` checks for that marker **first** and
+  returns `PMIX_OPERATION_SUCCEEDED` synchronously without
+  thread-shifting. Without it, a *blocking* `PMIx_Notify_event` issued
+  from the progress thread deadlocks against its own deferred upcall.
+- It also breaks the xcast echo: `pmix_server_notify()` (the RML receive)
+  broadcasts to every daemon including the originator, and the originator
+  must update its group registry but must not re-notify its own clients.
+
+---
+
+## Conventions specific to this directory
+
+- **PMIx status vs. PRRTE status.** Functions reachable from an upcall
+  must return `pmix_status_t`; functions in the PRRTE half return `int`
+  PRRTE codes. They are *different numbering schemes* that happen to
+  agree on 0. Convert with `prte_pmix_convert_rc()` /
+  `prte_pmix_convert_status()` at the boundary, and log with
+  `PMIX_ERROR_LOG` or `PRTE_ERROR_LOG` to match. Mixing them silently
+  reports the wrong error to the application.
+- **A helper must not answer for its caller.** `process_directive()` in
+  `pmix_server_session.c` used to invoke `req->infocbfunc` itself on an
+  error and then return to a caller that also invokes it — a double
+  callback and a double release. If the caller has a `callback:` tail,
+  the helper returns a status and nothing else.
+- **Widths on the wire.** Pack what the receiver unpacks. Handing PMIx
+  the address of a `size_t` with `PMIX_INT32` reads the wrong four bytes
+  on a big-endian machine.
+- **Verbose output is free.** Everything here is behind
+  `pmix_output_verbose(N, prte_pmix_server_globals.output, ...)`; add
+  traces liberally at level 2.
+- Standard PRRTE rules apply: `prte_config.h` first, braces everywhere,
+  constant-on-the-left comparisons, `PMIX_NEW`/`PMIX_RELEASE` for class
+  objects, no new compiler warnings.
+
+---
+
+## Testing
+
+**Unit — `test/unit/prted/`.** The directive translators
+(`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`) and the job-info cache
+are pure data transforms and are covered there. Most of the rest of this
+directory needs a live PMIx server and at least one peer daemon.
+
+**Live smoke test.** `prte --daemonize && prun -n 4 hostname && pterm`
+exercises register_nspace, register_client, fence, and the spawn path on
+one node.
+
+**Multi-node — `contrib/dockerswarm/`, `test_prted()`.** The things that
+only exist with more than one daemon:
+
+- a **wildcard direct modex** — `PMIx_Get` of job-level data on a daemon
+  that hosts none of that job's procs, which is the path the `tproc`/
+  `target` bug hung;
+- a **tool connecting through a non-master daemon**, which exercises the
+  `TCONN` relay rather than the HNP's local shortcut;
+- **job-scoped signal delivery** in a DVM running more than one job.
+
+---
+
+## Debugging
+
+```sh
+prte --prtemca pmix_server_verbose 5 ...   # every upcall, relay and reply
+prte --prtemca grpcomm_base_verbose 5 ...  # what fence/group hand off to
+prte --prtemca state_base_verbose 5 ...    # the states these upcalls activate
+```
+
+If a client is hung in a PMIx call, the first question is always "which
+request array is it sitting in, and what was supposed to take it out?" —
+verbosity 2 prints the local/remote index of every request as it is
+created and retired.

--- a/src/prted/pmix/CLAUDE.md
+++ b/src/prted/pmix/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -987,6 +987,9 @@ int pmix_server_init(void)
     /* if we were launched by a debugger, then we need to have
      * notification of our termination sent */
     if (PRTE_PROC_IS_MASTER && NULL != getenv("PMIX_LAUNCHER_PAUSE_FOR_TOOL")) {
+        /* must be an explicit "true" - `flag` at this point still holds
+         * whatever an unrelated earlier directive left in it */
+        flag = true;
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_EVENT_SILENT_TERMINATION, &flag, PMIX_BOOL);
         if (PMIX_SUCCESS != prc) {
             PMIX_INFO_LIST_RELEASE(ilist);
@@ -1065,7 +1068,7 @@ int pmix_server_init(void)
 
     /* register our hostname so everyone agrees on it */
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_HOSTNAME, prte_process_info.nodename, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_SUCCESS != prc) {
         PMIX_INFO_LIST_RELEASE(ilist);
         rc = prte_pmix_convert_status(prc);
         return rc;
@@ -1076,7 +1079,7 @@ int pmix_server_init(void)
         tmp = PMIx_Argv_join(prte_process_info.aliases, ',');
         PMIX_INFO_LIST_ADD(prc, ilist, PMIX_HOSTNAME_ALIASES, tmp, PMIX_STRING);
         free(tmp);
-        if (PMIX_SUCCESS != rc) {
+        if (PMIX_SUCCESS != prc) {
             PMIX_INFO_LIST_RELEASE(ilist);
             rc = prte_pmix_convert_status(prc);
             return rc;
@@ -1095,7 +1098,9 @@ int pmix_server_init(void)
     ninfo = darray.size;
     prc = PMIx_server_register_resources(info, ninfo, NULL, NULL);
     PMIX_INFO_FREE(info, ninfo);
-    rc = prte_pmix_convert_status(prc);
+    if (PMIX_SUCCESS != prc) {
+        return prte_pmix_convert_status(prc);
+    }
 
     /* register the "lost-connection" event handler */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
@@ -1108,7 +1113,9 @@ int pmix_server_init(void)
     prc = lock.status;
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(info, ninfo);
-    rc = prte_pmix_convert_status(prc);
+    if (PMIX_SUCCESS != prc) {
+        return prte_pmix_convert_status(prc);
+    }
 
 #if defined(PMIX_ALLOC_TIMEOUT_WARNING)
     /* register the allocation-timeout-warning relay handler */
@@ -1646,13 +1653,17 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         tv.tv_sec = 2;
         prte_event_evtimer_add(&req->cycle, &tv);
 
-        /* if they asked for a timeout, then set that too */
+        /* if they asked for a timeout, then set that too - arm it on the
+         * request's own event, NOT on the retry cycle: adding to the cycle
+         * would re-arm the 2-second retry with the timeout interval and
+         * leave the timeout itself unarmed, so the request would never
+         * time out */
         if (0 < timeout) {
             prte_event_evtimer_set(prte_event_base, &req->ev, timeout_cbfunc, req);
             req->event_active = true;
             PMIX_POST_OBJECT(req);
             tv.tv_sec = timeout;
-            prte_event_evtimer_add(&req->cycle, &tv);
+            prte_event_evtimer_add(&req->ev, &tv);
         }
         return;
     }
@@ -2294,21 +2305,25 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
             goto reply;
     }
 
-    // need to add the requestor's ID to the info array, so expand it
+    /* Need to add the requestor's ID to the info array, so allocate one
+     * extra slot for it.  Note that ninfo must then be advanced to cover
+     * that slot: it is both the count we hand downstream (the requestor
+     * entry is the whole point of the expansion) and the count the request
+     * destructor frees with. */
     if (0 < ninfo) {
         PMIX_INFO_CREATE(info, ninfo+1);
         cnt = ninfo;
         rc = PMIx_Data_unpack(NULL, buffer, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_INFO_FREE(info, ninfo);
+            PMIX_INFO_FREE(info, ninfo+1);
             goto reply;
         }
     } else {
-        ninfo = 1;
         PMIX_INFO_CREATE(info, 1);
     }
     PMIX_INFO_LOAD(&info[ninfo], PMIX_REQUESTOR, &source, PMIX_PROC);
+    ++ninfo;
 
     if (PRTE_PMIX_ALLOC_REQ == cmd) {
         req = PMIX_NEW(prte_pmix_server_req_t);

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -58,6 +58,7 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
         goto ANSWER;
     }
 
+    cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &req->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
@@ -67,6 +68,9 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
 
     if (0 < req->ninfo) {
         PMIX_INFO_CREATE(req->info, req->ninfo);
+        /* the request now owns this array - without this its destructor
+         * leaves the whole unpacked result behind */
+        req->copy = true;
 
         cnt = req->ninfo;
         rc = PMIx_Data_unpack(NULL, buffer, req->info, &cnt, PMIX_INFO);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -703,10 +703,6 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT,
                                PRTE_ATTR_GLOBAL, &rc, PMIX_INT);
 
-        } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
-            prte_set_attribute(&jdata->attributes, PRTE_SPAWN_TIMEOUT, PRTE_ATTR_GLOBAL,
-                               &info->value.data.integer, PMIX_INT);
-
         } else if (PMIX_CHECK_KEY(info, PMIX_JOB_TIMEOUT)) {
             if (PMIX_STRING == info->value.type) {
                 rc = PMIX_CONVERT_TIME(info->value.data.string);
@@ -823,7 +819,10 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                     /* get the cwd */
                     if (PRTE_SUCCESS != (rc = pmix_getcwd(cwd, sizeof(cwd)))) {
                         pmix_show_help("help-prted.txt", "cwd", true, "spawn", rc);
-                        PMIX_RELEASE(jdata);
+                        /* jdata belongs to our caller - it constructed it and
+                         * will dispose of it on our error return.  Releasing
+                         * it here would leave the caller with a dangling
+                         * pointer it goes on to use and release again */
                         return rc;
                     }
                     /* construct the absolute path */
@@ -856,7 +855,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 ck = PMIx_Argv_split(info->value.data.string, ':');
                 if (3 > PMIx_Argv_count(ck)) {
                     PMIx_Argv_free(ck);
-                    return PMIX_ERR_BAD_PARAM;
+                    return PRTE_ERR_BAD_PARAM;
                 }
                 if (0 == strcasecmp(ck[0], "ppr")) {
                     ppn =  strtoul(ck[1], NULL, 10);
@@ -1084,7 +1083,14 @@ static void interim(int sd, short args, void *cbdata)
     return;
 
 complete:
-    if (NULL != cd->spcbfunc) {
+    if (NULL == cd->spcbfunc) {
+        /* nobody to answer - discard the partially-built job rather than
+         * leaking it */
+        PMIX_RELEASE(jdata);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    {
         pmix_status_t prc;
         pmix_nspace_t nspace;
         PMIX_LOAD_NSPACE(nspace, NULL);

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -96,7 +96,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
     pmix_value_t *pval;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    PMIX_ACQUIRE_OBJECT(rq);
+    PMIX_ACQUIRE_OBJECT(req);
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s DMODX REQ FOR %s:%u",
@@ -142,13 +142,21 @@ static void dmodex_req(int sd, short args, void *cbdata)
     }
 
     /* has anyone already requested data for this target? If so,
-     * then the data is already on its way */
+     * then the data is already on its way.
+     *
+     * Compare against the other request's tproc - the proc whose data was
+     * asked for.  It must NOT be compared against r->target, which only the
+     * monitor and tool-connection paths ever set and which is therefore
+     * {"", PMIX_RANK_INVALID} for every dmodex request: PMIx_Check_nspace
+     * treats an empty nspace as matching anything, so a request for
+     * PMIX_RANK_WILDCARD (the job-level data fetch below) would "match" the
+     * first entry in the array, get parked here, and never be answered. */
     for (rnum = 0; rnum < prte_pmix_server_globals.local_reqs.size; rnum++) {
         r = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, rnum);
         if (NULL == r) {
             continue;
         }
-        if (PMIX_CHECK_PROCID(&r->target, &req->tproc)) {
+        if (PMIX_CHECK_PROCID(&r->tproc, &req->tproc)) {
             /* save the request in the array until the
              * data is returned */
             req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -392,9 +392,10 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, room, NULL);
 
     if (NULL == req) {
-        /* we are hosed */
+        /* we are hosed - note that the jobid has not been unpacked yet,
+         * so it must not be reported here */
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        pmix_output(0, "UNABLE TO RETRIEVE SPWN_REQ FOR JOB %s [room=%d]", jobid, room);
+        pmix_output(0, "UNABLE TO RETRIEVE TOOL CONNECTION REQ [room=%d]", room);
         return;
     }
 
@@ -404,6 +405,7 @@ void pmix_server_tconn_return(int status, pmix_proc_t *sender,
         rc = PMIx_Data_unpack(NULL, buffer, &jobid, &cnt, PMIX_PROC_NSPACE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(req);
             return;
         }
         PMIX_LOAD_NSPACE(req->target.nspace, jobid);

--- a/src/prted/pmix/pmix_server_job_ctrl.c
+++ b/src/prted/pmix/pmix_server_job_ctrl.c
@@ -66,7 +66,7 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                                       size_t ntargets, const pmix_info_t directives[], size_t ndirs)
 {
     int rc, j;
-    int32_t signum;
+    int32_t signum, ntgts;
     size_t m, n;
     prte_proc_t *proc;
     pmix_nspace_t jobid;
@@ -204,8 +204,12 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                 PMIX_DATA_BUFFER_RELEASE(cmd);
                 return rc;
             }
-            // pack the #targets
-            rc = PMIx_Data_pack(NULL, cmd, &ntargets, 1, PMIX_INT32);
+            /* pack the #targets - the receiver unpacks an int32, so
+             * narrow it here rather than handing PMIx the address of a
+             * size_t and letting it read the wrong half on a big-endian
+             * machine */
+            ntgts = (int32_t) ntargets;
+            rc = PMIx_Data_pack(NULL, cmd, &ntgts, 1, PMIX_INT32);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(cmd);

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -478,13 +478,19 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     // record that another daemon reported
     ++req->nreported;
 
+    /* Note that every failure below records the error on the request and
+     * then falls through to the completion check.  Returning early would
+     * leave nreported already incremented for this daemon, so a malformed
+     * response from the LAST daemon to report would mean the request never
+     * completes and the requestor hangs forever. */
+
     // unpack the returned status
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &rstatus, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         req->pstatus = rc;
-        return;
+        goto complete;
     }
     req->pstatus = rstatus;
 
@@ -495,7 +501,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             req->pstatus = rc;
-            return;
+            goto complete;
         }
         if (0 < ninfo) {
             PMIX_INFO_CREATE(info, ninfo);
@@ -503,9 +509,9 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
             rc = PMIx_Data_unpack(NULL, buffer, info, &cnt, PMIX_INFO);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                PMIx_Info_free(info, ninfo);
+                PMIX_INFO_FREE(info, ninfo);
                 req->pstatus = rc;
-                return;
+                goto complete;
             }
         }
         // add these to the collected results
@@ -526,12 +532,16 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
                 ++m;
             }
             PMIX_INFO_FREE(req->info, req->ninfo);
+            /* PMIX_INFO_XFER deep-copies, so the array we just unpacked
+             * still owns its entries - release them */
+            PMIX_INFO_FREE(info, ninfo);
             req->info = results;
             req->ninfo = sz;
         }
         req->copy = true;
     }
 
+complete:
     // if all daemons have reported, then we are complete
     if (req->ndaemons == req->nreported) {
         if (NULL != req->infocbfunc) {

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -18,8 +18,15 @@
 #include "src/mca/schizo/base/base.h"
 #include "src/util/pmix_show_help.h"
 
-/* Process the session control directive from the scheduler */
-static int process_directive(prte_pmix_server_req_t *req)
+/* Process the session control directive from the scheduler.
+ *
+ * Returns a pmix_status_t - NOT a PRRTE return code.  The caller
+ * (pass_request) hands the result straight to req->infocbfunc, which is a
+ * PMIx callback, so every exit from here must already be in PMIx's numbering.
+ * This function must also never invoke that callback itself: pass_request
+ * falls through to its "callback:" tail on return, so answering here too
+ * would deliver the response twice and release the request twice. */
+static pmix_status_t process_directive(prte_pmix_server_req_t *req)
 {
     char *user_refid = NULL, *alloc_refid = NULL;
     pmix_info_t *personality = NULL, *iptr;
@@ -31,7 +38,7 @@ static int process_directive(prte_pmix_server_req_t *req)
     pmix_app_t *apps;
     size_t napps;
     size_t n, i;
-    int j;
+    int j, prc;
     pmix_status_t rc;
     bool terminate = false;
     bool pause = false;
@@ -51,21 +58,19 @@ static int process_directive(prte_pmix_server_req_t *req)
             if (NULL != session) {
                 // this is an error - cannot instantiate a preexisting
                 // session
-                rc = PMIX_ERR_BAD_PARAM;
-                goto ANSWER;
+                return PMIX_ERR_BAD_PARAM;
             }
             /* create a new session object */
             session = PMIX_NEW(prte_session_t);
             if (NULL == session) {
-                rc = PRTE_ERR_OUT_OF_RESOURCE;
-                PRTE_ERROR_LOG(rc);
-                goto ANSWER;
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                return PMIX_ERR_NOMEM;
             }
             session->session_id = req->sessionID;
-            rc = prte_set_session_object(session);
-            if (PRTE_SUCCESS != rc) {
+            prc = prte_set_session_object(session);
+            if (PRTE_SUCCESS != prc) {
                 PMIX_RELEASE(session);
-                goto ANSWER;
+                return prte_pmix_convert_rc(prc);
             }
             // if a job has already been described, add it here
             if (NULL != jdata) {
@@ -92,11 +97,10 @@ static int process_directive(prte_pmix_server_req_t *req)
             // transfer the job description across
             iptr = (pmix_info_t*)req->info[n].value.data.darray->array;
             i = req->info[n].value.data.darray->size;
-            rc = prte_pmix_xfer_job_info(jdata, iptr, i);
-            if (PRTE_SUCCESS != rc) {
-                PRTE_ERROR_LOG(rc);
-                rc = prte_pmix_convert_rc(rc);
-                goto ANSWER;
+            prc = prte_pmix_xfer_job_info(jdata, iptr, i);
+            if (PRTE_SUCCESS != prc) {
+                PRTE_ERROR_LOG(prc);
+                return prte_pmix_convert_rc(prc);
             }
 
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_APP)) {
@@ -112,11 +116,10 @@ static int process_directive(prte_pmix_server_req_t *req)
             apps = (pmix_app_t*)req->info[n].value.data.darray->array;
             napps = req->info[n].value.data.darray->size;
             for (i=0; i < napps; i++) {
-                rc = prte_pmix_xfer_app(jdata, &apps[n]);
-                if (PRTE_SUCCESS != rc) {
-                    PRTE_ERROR_LOG(rc);
-                    rc = prte_pmix_convert_rc(rc);
-                    goto ANSWER;
+                prc = prte_pmix_xfer_app(jdata, &apps[i]);
+                if (PRTE_SUCCESS != prc) {
+                    PRTE_ERROR_LOG(prc);
+                    return prte_pmix_convert_rc(prc);
                 }
             }
 
@@ -137,8 +140,7 @@ static int process_directive(prte_pmix_server_req_t *req)
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_NODES) ||
                    PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_IMAGE)) {
             // we don't support these directives
-            rc = PMIX_ERR_NOT_SUPPORTED;
-            goto ANSWER;
+            return PMIX_ERR_NOT_SUPPORTED;
 
         } else if(PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_ID)) {
             if (NULL != session) {
@@ -159,8 +161,7 @@ static int process_directive(prte_pmix_server_req_t *req)
 
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_NUM_CPU_LIST)) {
             // we don't support this directive
-            rc = PMIX_ERR_NOT_SUPPORTED;
-            goto ANSWER;
+            return PMIX_ERR_NOT_SUPPORTED;
 
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PAUSE)) {
             pause = PMIX_INFO_TRUE(&req->info[n]);
@@ -181,7 +182,7 @@ static int process_directive(prte_pmix_server_req_t *req)
             signal = true;
             PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, sigvalue, int);
             if (PMIX_SUCCESS != rc) {
-                return PRTE_ERR_BAD_PARAM;
+                return PMIX_ERR_BAD_PARAM;
             }
 
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_EXTEND)) {
@@ -190,7 +191,7 @@ static int process_directive(prte_pmix_server_req_t *req)
         } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_TIMEOUT)) {
             PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, tval, int);
             if (PMIX_SUCCESS != rc) {
-                return PRTE_ERR_BAD_PARAM;
+                return PMIX_ERR_BAD_PARAM;
             }
         }
     }  // for loop
@@ -201,14 +202,14 @@ static int process_directive(prte_pmix_server_req_t *req)
         session = prte_get_session_object(req->sessionID);
         if (NULL == session) {
             // we don't know about it
-            return PRTE_ERR_NOT_FOUND;
+            return PMIX_ERR_NOT_FOUND;
         }
         // TODO: execute the specified operation on this session
         if (terminate || pause || resume || restore || preempt ||
             signal || extend || 0 < tval || 0 < sigvalue) {
-            return PRTE_ERR_NOT_SUPPORTED;
+            return PMIX_ERR_NOT_SUPPORTED;
         }
-        return PRTE_SUCCESS;
+        return PMIX_SUCCESS;
     }
 
     // continue working on a new instantiation
@@ -241,8 +242,7 @@ static int process_directive(prte_pmix_server_req_t *req)
              * for someone downstream to dereference */
             pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
                            (NULL == personality) ? "NULL" : personality->value.data.string);
-            rc = PMIX_ERR_NOT_FOUND;
-            goto ANSWER;
+            return PMIX_ERR_NOT_FOUND;
         }
     }
 
@@ -267,16 +267,7 @@ static int process_directive(prte_pmix_server_req_t *req)
             }
         }
     }
-    return PRTE_SUCCESS;
-
-// only come here upon error
-ANSWER:
-    if (NULL != req->infocbfunc) {
-        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);
-    } else {
-        PMIX_RELEASE(req);
-    }
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 /* Callbacks to process a session control answer from the scheduler
@@ -290,13 +281,75 @@ static void passthru(int sd, short args, void *cbdata)
     if (NULL != req->infocbfunc) {
         // call the requestor's callback with the returned info
         req->infocbfunc(req->status, req->info, req->ninfo, req->cbdata, req->rlcbfunc, req->rlcbdata);
-    } else {
-        // let them cleanup
+    } else if (NULL != req->rlcbfunc) {
+        // no one to answer, but the result array still has to go back
         req->rlcbfunc(req->rlcbdata);
     }
     // cleanup our request
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
+}
+
+/* Caddy carrying a session-control result from the PMIx progress thread over
+ * to the PRRTE progress thread - the same shape, and for the same reason, as
+ * prte_alloc_resp_caddy_t in pmix_server.c.  A prte_pmix_server_req_t is a
+ * PRRTE object owned by the PRRTE progress thread, so the PMIx-thread callback
+ * must only capture the result; recording it on the request - and above all
+ * freeing the array the request was carrying - has to happen in the shifted
+ * handler. */
+typedef struct {
+    pmix_object_t super;
+    prte_event_t ev;
+    prte_pmix_server_req_t *req;
+    pmix_status_t status;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_release_cbfunc_t rel;
+    void *relcbdata;
+} prte_sessctrl_resp_caddy_t;
+static void srcon(prte_sessctrl_resp_caddy_t *p)
+{
+    p->req = NULL;
+    p->status = PMIX_SUCCESS;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->rel = NULL;
+    p->relcbdata = NULL;
+}
+static void srdes(prte_sessctrl_resp_caddy_t *p)
+{
+    if (NULL != p->req) {
+        PMIX_RELEASE(p->req);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_sessctrl_resp_caddy_t, pmix_object_t, srcon, srdes);
+
+/* record the result on the request and answer - runs on the PRRTE
+ * progress thread */
+static void _sessctrl_resp(int sd, short args, void *cbdata)
+{
+    prte_sessctrl_resp_caddy_t *cd = (prte_sessctrl_resp_caddy_t*)cbdata;
+    prte_pmix_server_req_t *req = cd->req;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* now safe to touch the request. Beware that a caller may hand the
+     * request's OWN info array back as the result - do not free it in
+     * that case */
+    req->status = cd->status;
+    if (req->copy && NULL != req->info && cd->info != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+        req->copy = false;
+    }
+    req->info = cd->info;
+    req->ninfo = cd->ninfo;
+    req->rlcbfunc = cd->rel;
+    req->rlcbdata = cd->relcbdata;
+
+    passthru(0, 0, req);
+    /* passthru released the request's array-slot reference; drop ours */
+    PMIX_RELEASE(cd);
 }
 
 static void infocbfunc(pmix_status_t status,
@@ -305,22 +358,20 @@ static void infocbfunc(pmix_status_t status,
                        pmix_release_cbfunc_t rel, void *relcbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
+    prte_sessctrl_resp_caddy_t *cd;
 
-    // need to pass this into our progress thread for processing
-    // since we touch the global request array
-    req->status = status;
-    if (req->copy && NULL != req->info) {
-        PMIX_INFO_FREE(req->info, req->ninfo);
-        req->copy = false;
-    }
-    req->info = info;
-    req->ninfo = ninfo;
-    req->rlcbfunc = rel;
-    req->rlcbdata = relcbdata;
+    /* GOLDEN RULE: this can be invoked on the PMIx progress thread, so
+     * capture the result and post it - touch no PRRTE state here */
+    cd = PMIX_NEW(prte_sessctrl_resp_caddy_t);
+    PMIX_RETAIN(req);
+    cd->req = req;
+    cd->status = status;
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->rel = rel;
+    cd->relcbdata = relcbdata;
 
-    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, passthru, req);
-    PMIX_POST_OBJECT(req);
-    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, _sessctrl_resp);
 }
 
 static void pass_request(int sd, short args, void *cbdata)

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -244,6 +244,82 @@ static void shutdown_callback(int fd, short flags, void *arg)
     exit(PRTE_ERROR_DEFAULT_EXIT_CODE);
 }
 
+
+/* Strip any trailing path separators from an in-place prefix string.  A value
+ * consisting solely of separators normalizes to a single separator.
+ *
+ * NOTE: this must not be done with strncpy(param, PRTE_PATH_SEP,
+ * sizeof(param) - 1) at the call site, as the code here once did four times
+ * over: `param` is a char*, so sizeof yields the size of the *pointer*, and
+ * strncpy then NUL-pads out to that many bytes - overrunning the heap for any
+ * prefix shorter than a pointer.  "--prefix /" (a two-byte allocation) was
+ * enough to corrupt the heap.  The loop below also has to guard len before
+ * indexing param[len - 1]; an empty prefix string used to read off the front
+ * of the allocation.
+ */
+void prte_strip_trailing_pathsep(char *param)
+{
+    size_t len;
+
+    if (NULL == param) {
+        return;
+    }
+    len = strlen(param);
+    if (0 == len) {
+        /* nothing to strip - and no room to write a separator into */
+        return;
+    }
+    while (0 < len && 0 == strcmp(PRTE_PATH_SEP, &param[len - 1])) {
+        param[len - 1] = '\0';
+        --len;
+    }
+    if (0 == len) {
+        /* it was nothing but separators, so the prefix is a single
+         * separator.  The original string held at least one character,
+         * so the buffer has room for this. */
+        param[0] = PRTE_PATH_SEP[0];
+        param[1] = '\0';
+    }
+}
+
+/* Split a singleton identifier of the form "<nspace>.<rank>" into its parts.
+ * Returns PRTE_SUCCESS and fills nspace/rank on success.  The value arrives
+ * straight off the command line, so a missing "." must be reported rather
+ * than dereferenced - strrchr returns NULL and "prte --singleton foo" used
+ * to segfault on the spot.
+ */
+int prte_parse_singleton_id(const char *name, pmix_nspace_t nspace, pmix_rank_t *rank)
+{
+    char *ptr, *p1, *end;
+    unsigned long rk;
+
+    if (NULL == name || NULL == rank) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    ptr = strdup(name);
+    if (NULL == ptr) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    p1 = strrchr(ptr, '.');
+    if (NULL == p1 || p1 == ptr || '\0' == p1[1]) {
+        /* no rank suffix, or an empty nspace/rank */
+        free(ptr);
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *p1 = '\0';
+    ++p1;
+    errno = 0;
+    rk = strtoul(p1, &end, 10);
+    if (0 != errno || NULL == end || '\0' != *end) {
+        free(ptr);
+        return PRTE_ERR_BAD_PARAM;
+    }
+    PMIX_LOAD_NSPACE(nspace, ptr);
+    free(ptr);
+    *rank = (pmix_rank_t) rk;
+    return PRTE_SUCCESS;
+}
+
 PRTE_EXPORT int prte(int argc, char *argv[])
 {
     int rc = 1, i;
@@ -253,7 +329,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     prte_pmix_app_t *app;
     pmix_info_t *iptr, *iptr2, info;
     pmix_status_t ret;
-    size_t n, ninfo, param_len;
+    size_t n, ninfo;
     pmix_app_t *papps;
     size_t napps;
     mylock_t mylock;
@@ -662,10 +738,21 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         setenv("PRTE_MCA_prte_launch_agent", opt->values[0], true); // cmd line overrides all
     }
 
-    /* if we are supporting a singleton, cache its ID
-     * so it can get picked up and registered by server init */
+    /* If we are supporting a singleton, cache its ID so it can get picked
+     * up and registered by server init.  Validate it here, before prte_init:
+     * the value is handed straight down to PMIx_server_init as
+     * PMIX_SINGLETON, and a value that is not "<nspace>.<rank>" faults
+     * inside the PMIx library long before PRRTE's own prep_singleton would
+     * ever see it. */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_SINGLETON);
     if (NULL != opt) {
+        pmix_nspace_t sgltn;
+        pmix_rank_t sgrank;
+        if (PRTE_SUCCESS != prte_parse_singleton_id(opt->values[0], sgltn, &sgrank)) {
+            pmix_show_help("help-prte.txt", "bad-singleton", true,
+                           prte_tool_basename, opt->values[0]);
+            return 1;
+        }
         prte_pmix_server_globals.singleton = strdup(opt->values[0]);
     }
 
@@ -841,36 +928,14 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             param = strdup(prte_install_dirs.prefix);
         }
         /* "Parse" the param, aka remove superfluous path_sep. */
-        param_len = strlen(param);
-        while (0 == strcmp(PRTE_PATH_SEP, &(param[param_len - 1]))) {
-            param[param_len - 1] = '\0';
-            param_len--;
-            if (0 == param_len) {
-                /* We get here if we removed all PATH_SEP's and end up
-                   with an empty string.  In this case, the prefix is
-                   just a single PATH_SEP. */
-                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
-                break;
-            }
-        }
+        prte_strip_trailing_pathsep(param);
     } else if (NULL != (cptr = getenv("PRTE_PREFIX"))) {
         /* need to cover the case where "want prefix by default" is not
          * given, but PRTE_PREFIX was added to the environment prior
          * to actually invoking prte */
         param = strdup(cptr);
         /* "Parse" the param, aka remove superfluous path_sep. */
-        param_len = strlen(param);
-        while (0 == strcmp(PRTE_PATH_SEP, &(param[param_len - 1]))) {
-            param[param_len - 1] = '\0';
-            param_len--;
-            if (0 == param_len) {
-                /* We get here if we removed all PATH_SEP's and end up
-                   with an empty string.  In this case, the prefix is
-                   just a single PATH_SEP. */
-                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
-                break;
-            }
-        }
+        prte_strip_trailing_pathsep(param);
     } else {
         /* Check if called with fully-qualified path to prte.
            (Note: Put this second so can override with --prefix (above). */
@@ -946,33 +1011,11 @@ PRTE_EXPORT int prte(int argc, char *argv[])
      * cmd line above, so we can just use that result */
     if (NULL != param) {
         /* "Parse" the param, aka remove superfluous path_sep. */
-        param_len = strlen(param);
-        while (0 == strcmp(PRTE_PATH_SEP, &(param[param_len - 1]))) {
-            param[param_len - 1] = '\0';
-            param_len--;
-            if (0 == param_len) {
-                /* We get here if we removed all PATH_SEP's and end up
-                   with an empty string.  In this case, the prefix is
-                   just a single PATH_SEP. */
-                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
-                break;
-            }
-        }
+        prte_strip_trailing_pathsep(param);
     } else if (NULL != (cptr = getenv("PMIX_PREFIX"))) {
         param = strdup(cptr);
         /* "Parse" the param, aka remove superfluous path_sep. */
-        param_len = strlen(param);
-        while (0 == strcmp(PRTE_PATH_SEP, &(param[param_len - 1]))) {
-            param[param_len - 1] = '\0';
-            param_len--;
-            if (0 == param_len) {
-                /* We get here if we removed all PATH_SEP's and end up
-                   with an empty string.  In this case, the prefix is
-                   just a single PATH_SEP. */
-                strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1);
-                break;
-            }
-        }
+        prte_strip_trailing_pathsep(param);
     }
     if (NULL != param) {
         // add the directive to the daemon job object
@@ -1539,7 +1582,7 @@ static void abort_signal_callback(int fd)
 
 static int prep_singleton(const char *name)
 {
-    char *ptr, *p1;
+    pmix_nspace_t nspace;
     prte_job_t *jdata;
     prte_node_t *node;
     prte_proc_t *proc;
@@ -1549,14 +1592,13 @@ static int prep_singleton(const char *name)
     char cwd[PRTE_PATH_MAX];
     prte_pmix_lock_t lock;
 
-    ptr = strdup(name);
-    p1 = strrchr(ptr, '.');
-    *p1 = '\0';
-    ++p1;
-    rank = strtoul(p1, NULL, 10);
+    rc = prte_parse_singleton_id(name, nspace, &rank);
+    if (PRTE_SUCCESS != rc) {
+        pmix_show_help("help-prte.txt", "bad-singleton", true, prte_tool_basename, name);
+        return rc;
+    }
     jdata = PMIX_NEW(prte_job_t);
-    PMIX_LOAD_NSPACE(jdata->nspace, ptr);
-    free(ptr);
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
     jdata->session = prte_default_session;
     rc = prte_set_job_data_object(jdata);
     if (PRTE_SUCCESS != rc) {
@@ -1569,8 +1611,6 @@ static int prep_singleton(const char *name)
     app->app = strdup(jdata->nspace);
     app->num_procs = 1;
     PMIx_Argv_append_nosize(&app->argv, app->app);
-    pmix_getcwd(cwd, sizeof(cwd));
-    app->cwd = strdup(cwd);
     pmix_pointer_array_set_item(jdata->apps, 0, app);
     jdata->num_apps = 1;
 
@@ -1584,6 +1624,11 @@ static int prep_singleton(const char *name)
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         return PRTE_ERR_NOT_FOUND;
     }
+    if (PRTE_SUCCESS != pmix_getcwd(cwd, sizeof(cwd))) {
+        cwd[0] = '\0';
+    }
+    free(app->cwd);
+    app->cwd = strdup(cwd);
     PMIX_RETAIN(node);
     pmix_pointer_array_add(jdata->map->nodes, node);
     ++(jdata->map->num_nodes);

--- a/src/prted/prted.h
+++ b/src/prted/prted.h
@@ -57,6 +57,16 @@ PRTE_EXPORT int prun_common(pmix_cli_result_t *cli,
 PRTE_EXPORT int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
                                            prte_schizo_base_module_t *schizo,
                                            pmix_list_t *apps);
+
+/* Normalize a prefix string in place, removing any trailing path
+ * separators.  A value consisting solely of separators becomes a single
+ * separator; an empty string is left alone. */
+PRTE_EXPORT void prte_strip_trailing_pathsep(char *param);
+
+/* Split a singleton identifier of the form "<nspace>.<rank>" into its
+ * parts.  Returns PRTE_ERR_BAD_PARAM if the value is not of that form. */
+PRTE_EXPORT int prte_parse_singleton_id(const char *name, pmix_nspace_t nspace,
+                                        pmix_rank_t *rank);
 END_C_DECLS
 
 #endif /* PRTED_H */

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -83,15 +83,82 @@
  */
 static const char *get_prted_comm_cmd_str(int command);
 
-static void _notify_release(pmix_status_t status, void *cbdata)
-{
-    prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(status);
-
-    PRTE_PMIX_WAKEUP_THREAD(lk);
-}
-
 static pmix_pointer_array_t *procs_prev_ordered_to_terminate = NULL;
+
+/*
+ * Continuations for the three daemon commands that cannot finish until PMIx
+ * has finished something for us.
+ *
+ * These used to be written as "issue the PMIx call, then block on a
+ * prte_pmix_lock_t until its completion callback wakes us up".  That works,
+ * but prte_daemon_recv runs on the thread that DRIVES prte_event_base - both
+ * prted and the HNP sit in a while (prte_event_base_active) prte_event_loop()
+ * loop, and an RML receive callback is dispatched from inside it.  Blocking
+ * there parks the daemon's entire event loop for the duration: no RML traffic
+ * is serviced, no timer fires, no other daemon command runs, and - the reason
+ * this is a correctness problem and not just a latency one - anything PMIx
+ * needs from us in order to complete the call can never run.  That is a
+ * deadlock waiting for a PMIx implementation detail to change underneath us;
+ * the "prte.notify.donotloop" marker on the notifications below is precisely
+ * a workaround for one instance of it.
+ *
+ * So none of them block.  The PMIx completion callback obeys the golden rule
+ * - capture and post, touch nothing - and everything that used to follow the
+ * wait now runs here, on the progress thread, out of the caddy.
+ *
+ * One consequence to keep in mind when editing these: the info array's
+ * lifetime is now ours.  PMIx needs it to stay valid until the callback
+ * fires, which happens after prte_daemon_recv has returned, so it must be
+ * heap-allocated and carried on the caddy rather than left on the stack.
+ */
+typedef enum {
+    PRTE_DAEMON_CONT_HALT_VM,
+    PRTE_DAEMON_CONT_SHRINK,
+    PRTE_DAEMON_CONT_CLEANUP_JOB
+} prte_daemon_cont_t;
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    prte_daemon_cont_t what;
+    pmix_nspace_t job;      /* CLEANUP_JOB only */
+    pmix_info_t *info;      /* the notification array, ours to free */
+    size_t ninfo;
+} prte_daemon_caddy_t;
+
+static void dcdcon(prte_daemon_caddy_t *p)
+{
+    p->what = PRTE_DAEMON_CONT_HALT_VM;
+    PMIX_LOAD_NSPACE(p->job, NULL);
+    p->info = NULL;
+    p->ninfo = 0;
+}
+static void dcddes(prte_daemon_caddy_t *p)
+{
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_daemon_caddy_t, pmix_object_t, dcdcon, dcddes);
+
+/* is there anything local left to wait for before we can exit? */
+static bool nothing_left_locally(void)
+{
+    prte_proc_t *proct;
+    int i;
+
+    if (0 != prte_rml_base.n_children) {
+        return false;
+    }
+    for (i = 0; i < prte_local_children->size; i++) {
+        proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+        if (NULL != proct && PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_ALIVE)) {
+            /* at least one is still alive */
+            return false;
+        }
+    }
+    return true;
+}
 
 /* A daemon named as a target of a DVM shrink does not exit the instant it
  * receives PRTE_DAEMON_SHRINK_CMD: it must stay alive long enough for its
@@ -112,6 +179,100 @@ static void prte_shrink_depart(int sd, short args, void *cbdata)
      * force a local termination exactly as the comm-failure path would */
     prte_abnormal_term_ordered = true;
     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+}
+
+/* runs on the PRRTE progress thread once PMIx has completed the call the
+ * command issued - see the note above prte_daemon_caddy_t */
+static void _daemon_continue(int sd, short args, void *cbdata)
+{
+    prte_daemon_caddy_t *cd = (prte_daemon_caddy_t *) cbdata;
+    pmix_proc_t pname;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    switch (cd->what) {
+
+    case PRTE_DAEMON_CONT_HALT_VM:
+        // ensure daemons know we were ordered to terminate
+        prte_prteds_term_ordered = true;
+        if (PRTE_PROC_IS_MASTER && !nothing_left_locally()) {
+            /* something is still alive under us - the state machine will
+             * bring us down when it goes away */
+            break;
+        }
+        if (prte_debug_daemons_flag && PRTE_PROC_IS_MASTER) {
+            pmix_output(0, "%s prted_cmd: all routes and children gone - exiting",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+        }
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+        break;
+
+    case PRTE_DAEMON_CONT_SHRINK:
+        // mark abnormal exit status
+        PRTE_UPDATE_EXIT_STATUS(-1);
+        if (prte_elastic_mode) {
+            /* Elastic shrink: the master completes the campaign from the
+             * broadcast's completion, so we must NOT exit until our
+             * subtree's ACK of this broadcast has reached it.  Record that
+             * we are leaving - which also lets the lifeline-loss path treat
+             * a dropped connection as a cue to depart rather than recover -
+             * and arm a bounded departure timer; we exit when it fires or,
+             * if sooner, when our lifeline drops (prte_rml_route_lost
+             * departs early once prte_dvm_leaving is set).  Because the
+             * shrink command reached us through our own lifeline, setting
+             * this here can never race ahead of a genuine fault. */
+            prte_dvm_leaving = true;
+            prte_event_evtimer_set(prte_event_base, &prte_shrink_depart_ev,
+                                   prte_shrink_depart, NULL);
+            prte_event_evtimer_add(&prte_shrink_depart_ev, &prte_shrink_depart_tv);
+        } else {
+            /* legacy fire-and-forget shrink (no completion tracking): do a
+             * clean immediate exit, exactly as before.  The HNP detects our
+             * departure via the normal daemon-loss (comm-failure) path. */
+            prte_abnormal_term_ordered = true;
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+        }
+        break;
+
+    case PRTE_DAEMON_CONT_CLEANUP_JOB:
+        /* the nspace is deregistered - now clear any server ops still
+         * holding a reference to it */
+        PMIX_LOAD_PROCID(&pname, cd->job, PMIX_RANK_WILDCARD);
+        prte_pmix_server_clear(&pname);
+        break;
+    }
+
+    PMIX_RELEASE(cd);
+}
+
+/* PMIx invokes this on ITS progress thread: capture and post, nothing else */
+static void _daemon_cont_cbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_daemon_caddy_t *cd = (prte_daemon_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(status);
+
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, _daemon_continue);
+}
+
+/* Build the "job end" courtesy notification we send to any tools attached to
+ * us before we go away.  Returns a caddy owning the info array; the caller
+ * hands that array to PMIx and the caddy outlives the call. */
+static prte_daemon_caddy_t *notify_job_end(prte_daemon_cont_t what)
+{
+    prte_daemon_caddy_t *cd;
+
+    cd = PMIX_NEW(prte_daemon_caddy_t);
+    cd->what = what;
+    cd->ninfo = 4;
+    PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    PMIX_INFO_LOAD(&cd->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&cd->info[1], PMIX_EVENT_AFFECTED_PROC,
+                   &prte_process_info.myproc, PMIX_PROC);
+    /* keep delivery local: do not loop back through our own server upcall */
+    PMIX_INFO_LOAD(&cd->info[2], "prte.notify.donotloop", NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&cd->info[3], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
+    return cd;
 }
 
 void prte_daemon_recv(int status, pmix_proc_t *sender,
@@ -137,12 +298,10 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
     FILE *fp;
     char gscmd[256], path[1035], *pathptr;
     char string[256], *string_ptr = string;
-    prte_pmix_lock_t lk;
-    pmix_proc_t pname;
     pmix_byte_object_t pbo;
     char *tmp;
-    pmix_info_t info[4];
     pmix_rank_t *ranks;
+    prte_daemon_caddy_t *cd;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     /* unpack the command */
@@ -493,37 +652,20 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         /* kill the local procs */
         prte_odls.kill_local_procs(NULL);
         /* any tools attached to us will have done so via PMIx, so
-         * let's provide them with a friendly "job end" notification */
-        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &prte_process_info.myproc, PMIX_PROC);
-        PMIX_INFO_LOAD(&info[2], "prte.notify.donotloop", NULL, PMIX_BOOL);
-        PMIX_INFO_LOAD(&info[3], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
-        PRTE_PMIX_CONSTRUCT_LOCK(&lk);
+         * let's provide them with a friendly "job end" notification.  We do
+         * NOT wait for it here - see the note above prte_daemon_caddy_t; the
+         * teardown that used to follow the wait now runs in the continuation */
+        cd = notify_job_end(PRTE_DAEMON_CONT_HALT_VM);
         ret = PMIx_Notify_event(PMIX_EVENT_JOB_END, &prte_process_info.myproc,
-                                PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
-        PRTE_PMIX_WAIT_THREAD(&lk);
-        PRTE_PMIX_DESTRUCT_LOCK(&lk);
-        // ensure daemons know we were ordered to terminate
-        prte_prteds_term_ordered = true;
-        if (PRTE_PROC_IS_MASTER) {
-            /* if all my routes and local children are gone, then terminate ourselves */
-            if (0 == prte_rml_base.n_children) {
-                for (i = 0; i < prte_local_children->size; i++) {
-                    proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
-                    if (NULL != proct && PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_ALIVE)) {
-                        /* at least one is still alive */
-                        return;
-                    }
-                }
-                /* call our appropriate exit procedure */
-                if (prte_debug_daemons_flag) {
-                    pmix_output(0, "%s prted_cmd: all routes and children gone - exiting",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-                }
-                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+                                PMIX_RANGE_SESSION, cd->info, cd->ninfo,
+                                _daemon_cont_cbfunc, cd);
+        if (PMIX_SUCCESS != ret) {
+            /* the callback will not fire - we are already on the progress
+             * thread, so just run the continuation directly */
+            if (PMIX_OPERATION_SUCCEEDED != ret) {
+                PMIX_ERROR_LOG(ret);
             }
-        } else {
-            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+            _daemon_continue(0, 0, cd);
         }
         return;
 
@@ -553,40 +695,27 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         // see if we are one of them
         for (i=0; i < num_procs; i++) {
             if (ranks[i] == PRTE_PROC_MY_NAME->rank) {
+                if (prte_dvm_leaving) {
+                    /* we are already on our way out - a repeat of the
+                     * broadcast must not re-arm the departure timer */
+                    break;
+                }
                 /* any tools attached to us will have done so via PMIx, so
-                 * let's provide them with a friendly "job end" notification */
-                PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
-                PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &prte_process_info.myproc, PMIX_PROC);
-                PMIX_INFO_LOAD(&info[2], "prte.notify.donotloop", NULL, PMIX_BOOL);
-                PMIX_INFO_LOAD(&info[3], PMIX_EVENT_DO_NOT_CACHE, NULL, PMIX_BOOL);
-                PRTE_PMIX_CONSTRUCT_LOCK(&lk);
+                 * let's provide them with a friendly "job end" notification.
+                 * We do NOT wait for it here - see the note above
+                 * prte_daemon_caddy_t; the departure that used to follow the
+                 * wait now runs in the continuation */
+                cd = notify_job_end(PRTE_DAEMON_CONT_SHRINK);
                 ret = PMIx_Notify_event(PMIX_EVENT_JOB_END, &prte_process_info.myproc,
-                                        PMIX_RANGE_SESSION, info, 4, _notify_release, &lk);
-                PRTE_PMIX_WAIT_THREAD(&lk);
-                PRTE_PMIX_DESTRUCT_LOCK(&lk);
-                // mark abnormal exit status
-                PRTE_UPDATE_EXIT_STATUS(-1);
-                if (prte_elastic_mode) {
-                    /* Elastic shrink: the master completes the campaign from the
-                     * broadcast's completion, so we must NOT exit until our
-                     * subtree's ACK of this broadcast has reached it.  Record that
-                     * we are leaving — which also lets the lifeline-loss path treat
-                     * a dropped connection as a cue to depart rather than recover —
-                     * and arm a bounded departure timer; we exit when it fires or,
-                     * if sooner, when our lifeline drops (prte_rml_route_lost
-                     * departs early once prte_dvm_leaving is set).  Because the
-                     * shrink command reached us through our own lifeline, setting
-                     * this here can never race ahead of a genuine fault. */
-                    prte_dvm_leaving = true;
-                    prte_event_evtimer_set(prte_event_base, &prte_shrink_depart_ev,
-                                           prte_shrink_depart, NULL);
-                    prte_event_evtimer_add(&prte_shrink_depart_ev, &prte_shrink_depart_tv);
-                } else {
-                    /* legacy fire-and-forget shrink (no completion tracking): do a
-                     * clean immediate exit, exactly as before.  The HNP detects our
-                     * departure via the normal daemon-loss (comm-failure) path. */
-                    prte_abnormal_term_ordered = true;
-                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+                                        PMIX_RANGE_SESSION, cd->info, cd->ninfo,
+                                        _daemon_cont_cbfunc, cd);
+                if (PMIX_SUCCESS != ret) {
+                    /* the callback will not fire - we are already on the
+                     * progress thread, so just run the continuation */
+                    if (PMIX_OPERATION_SUCCEEDED != ret) {
+                        PMIX_ERROR_LOG(ret);
+                    }
+                    _daemon_continue(0, 0, cd);
                 }
                 break;
             }
@@ -617,14 +746,16 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             PRTE_ERROR_LOG(ret);
         }
 
-        PRTE_PMIX_CONSTRUCT_LOCK(&lk);
-        PMIx_server_deregister_nspace(job, _notify_release, &lk);
-        PRTE_PMIX_WAIT_THREAD(&lk);
-        PRTE_PMIX_DESTRUCT_LOCK(&lk);
-
-        /* cleanup any pending server ops */
-        PMIX_LOAD_PROCID(&pname, job, PMIX_RANK_WILDCARD);
-        prte_pmix_server_clear(&pname);
+        /* Deregister the nspace and, once that completes, clear any pending
+         * server ops that still reference it.  Deliberately not waited on
+         * here - see the note above prte_daemon_caddy_t.  This one matters
+         * most of the three: a job ending is a routine event on a busy
+         * persistent DVM, so parking the daemon's whole event loop on it
+         * stalls every other job the daemon is running. */
+        cd = PMIX_NEW(prte_daemon_caddy_t);
+        cd->what = PRTE_DAEMON_CONT_CLEANUP_JOB;
+        PMIX_LOAD_NSPACE(cd->job, job);
+        PMIx_server_deregister_nspace(job, _daemon_cont_cbfunc, cd);
 
         break;
 

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -192,7 +192,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             if (PRTE_SUCCESS != (ret = prte_odls.kill_local_procs(NULL))) {
                 PRTE_ERROR_LOG(ret);
             }
-            break;
         } else {
             /* kill the procs */
             if (PRTE_SUCCESS != (ret = prte_odls.kill_local_procs(&procarray))) {
@@ -200,11 +199,13 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             }
         }
 
-        /* cleanup */
+        /* cleanup - these are PMIX_NEW'd class objects, so they must be
+         * released, not free()d: free() skips the destructor and leaks
+         * everything the proc object owns */
     KILL_PROC_CLEANUP:
         for (i = 0; i < procarray.size; i++) {
             if (NULL != (proct = (prte_proc_t *) pmix_pointer_array_get_item(&procarray, i))) {
-                free(proct);
+                PMIX_RELEASE(proct);
             }
         }
         PMIX_DESTRUCT(&procarray);
@@ -250,9 +251,28 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), signal);
         }
 
-        /* signal them */
-        if (PRTE_SUCCESS != (ret = prte_odls.signal_local_procs(NULL, signal))) {
-            PRTE_ERROR_LOG(ret);
+        /* Signal them.  The command names a target job, so honor it:
+         * handing NULL to the ODLS means "every local child", which in a
+         * persistent DVM hosting several jobs would deliver the signal to
+         * jobs that were never named.  An empty nspace means "all jobs",
+         * which is what the job-control path packs when it is given no
+         * targets at all. */
+        if (0 == strlen(job)) {
+            if (PRTE_SUCCESS != (ret = prte_odls.signal_local_procs(NULL, signal))) {
+                PRTE_ERROR_LOG(ret);
+            }
+        } else {
+            for (i = 0; i < prte_local_children->size; i++) {
+                proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+                if (NULL == proct ||
+                    !PMIX_CHECK_NSPACE(proct->name.nspace, job)) {
+                    continue;
+                }
+                ret = prte_odls.signal_local_procs(&proct->name, signal);
+                if (PRTE_SUCCESS != ret) {
+                    PRTE_ERROR_LOG(ret);
+                }
+            }
         }
         break;
 
@@ -306,7 +326,8 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             ret = PMIx_Data_unpack(NULL, buffer, &(cur_proc->name), &n, PMIX_PROC);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
-                goto CLEANUP;
+                PMIX_RELEASE(cur_proc);
+                goto ABORT_PROC_CLEANUP;
             }
 
             /* See if duplicate */
@@ -335,7 +356,11 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 PMIX_RETAIN(cur_proc);
                 pmix_pointer_array_add(procs_prev_ordered_to_terminate, (void *) cur_proc);
                 num_new_procs++;
+            } else {
+                /* nobody took a reference to it */
+                PMIX_RELEASE(cur_proc);
             }
+            cur_proc = NULL;
         }
 
         /*
@@ -353,7 +378,17 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                                  "terminating from request (%2d / %2d).",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_new_procs, num_procs));
         }
-
+    ABORT_PROC_CLEANUP:
+        /* terminate_procs copies what it needs, so release our tracking
+         * array and the references it holds */
+        for (p = 0; p < procs_to_kill->size; ++p) {
+            cur_proc = (prte_proc_t *) pmix_pointer_array_get_item(procs_to_kill, p);
+            if (NULL != cur_proc) {
+                PMIX_RELEASE(cur_proc);
+            }
+        }
+        PMIX_RELEASE(procs_to_kill);
+        procs_to_kill = NULL;
         break;
 
         /****    DEFINE PSET    ****/
@@ -369,20 +404,24 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         n = 1;
         ret = PMIx_Data_unpack(NULL, buffer, &num_procs, &n, PMIX_INT32);
         if (PMIX_SUCCESS != ret) {
-            PRTE_ERROR_LOG(ret);
+            PMIX_ERROR_LOG(ret);
+            free(cmd_str);
             goto CLEANUP;
         }
         // create space for them
         pptr = PMIx_Proc_create(num_procs);
         if (NULL == pptr) {
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            free(cmd_str);
             goto CLEANUP;
         }
         // unpack the targets
         n = num_procs;
         ret = PMIx_Data_unpack(NULL, buffer, pptr, &n, PMIX_PROC);
         if (PMIX_SUCCESS != ret) {
-            PRTE_ERROR_LOG(ret);
+            PMIX_ERROR_LOG(ret);
+            free(cmd_str);
+            PMIx_Proc_free(pptr, num_procs);
             goto CLEANUP;
         }
         // define the pset
@@ -401,7 +440,8 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             pmix_output(0, "%s prted_cmd: received exit cmd", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         }
         jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+        if (NULL != jdata &&
+            prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
             return;
         }
@@ -445,7 +485,8 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         prte_abnormal_term_ordered = true;
 
         jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
+        if (NULL != jdata &&
+            prte_get_attribute(&jdata->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL)) {
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
             return;
         }
@@ -597,6 +638,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         ret = PMIx_Data_unpack(NULL, buffer, &job, &n, PMIX_PROC_NSPACE);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(answer);
             goto CLEANUP;
         }
 
@@ -615,6 +657,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             if (NULL != gstack_exec) {
                 free(gstack_exec);
             }
+            PMIX_DATA_BUFFER_RELEASE(answer);
             break;
         }
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm rml ras schizo state
+SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm prted rml ras schizo state

--- a/test/unit/prted/.gitignore
+++ b/test/unit/prted/.gitignore
@@ -1,0 +1,1 @@
+test_prted

--- a/test/unit/prted/Makefile.am
+++ b/test/unit/prted/Makefile.am
@@ -1,0 +1,24 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_prted
+
+test_prted_SOURCES = \
+    test_prted.c
+
+test_prted_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_prted
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find
+# and the framework-dependent cases fail to resolve a mapper.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for src/prted -- the daemon/HNP body and the PMIx server
+ * upcalls that sit under it.
+ *
+ * Most of src/prted only makes sense with a live DVM: the command dispatcher
+ * needs peers to talk to, the spawn path needs a PLM, and the dmodex machinery
+ * needs a second daemon that actually holds the data.  Those belong to the
+ * integration and dockerswarm harnesses.  What is testable here in isolation
+ * is the pure decision-making that the daemon does *before* it touches the
+ * network -- and that is exactly where this review found defects:
+ *
+ *  - prte_strip_trailing_pathsep(), the --prefix/--pmix-prefix normalizer.
+ *    Four copies of this loop used "strncpy(param, PRTE_PATH_SEP,
+ *    sizeof(param) - 1)" on a char*, so sizeof gave the size of the pointer
+ *    and strncpy NUL-padded eight bytes into whatever the prefix had been
+ *    allocated as.  "--prefix /" is a two-byte allocation.  The loop also
+ *    indexed param[len-1] before checking len, so an empty prefix read off
+ *    the front of the allocation.
+ *
+ *  - prte_parse_singleton_id(), the "--singleton <nspace>.<rank>" splitter.
+ *    It did strrchr(ptr, '.') and dereferenced the result unconditionally,
+ *    so any value without a '.' was a null dereference.  The value is also
+ *    handed down to PMIx_server_init as PMIX_SINGLETON, which faults on a
+ *    malformed value, so it has to be rejected at the CLI.
+ *
+ *  - prte_pmix_xfer_job_info(), the spawn-directive translator.  This is the
+ *    one substantial piece of src/prted that runs on plain data structures,
+ *    so its policy handling (map-by/rank-by/bind-to conflict rejection, the
+ *    boolean directives, the "cache anything unrecognized" default) is
+ *    pinned down here rather than being exercised only through a spawn.
+ *
+ *  - prte_pmix_xfer_app(), which must not release the job object its caller
+ *    owns on an error return -- it used to PMIX_RELEASE(jdata) on a getcwd
+ *    failure, leaving the caller with a dangling pointer.
+ *
+ * The tests run without a DVM: prte_init_util() plus the rmaps/schizo/state
+ * frameworks is enough for the translation paths.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "constants.h"
+#include "src/event/event-internal.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/pmix/pmix-internal.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/mca/rmaps/base/base.h"
+#include "src/mca/rmaps/rmaps_types.h"
+#include "src/mca/schizo/base/base.h"
+#include "src/mca/state/base/base.h"
+#include "src/prted/prted.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/*
+ * --prefix normalization.
+ *
+ * Every case here is run on a heap allocation of exactly strlen+1 bytes, so
+ * that any write past the end of the string is a genuine heap overflow that
+ * a debug allocator or ASAN will catch -- which is the whole point: the bug
+ * this replaces was silent on a large stack buffer and fatal on a short heap
+ * one.
+ */
+static int check_strip(const char *in, const char *expected, int *failures)
+{
+    char *buf = strdup(in);
+    int bad = 0;
+
+    prte_strip_trailing_pathsep(buf);
+    if (0 != strcmp(buf, expected)) {
+        fprintf(stderr, "FAIL [strip]: \"%s\" -> \"%s\", expected \"%s\"\n",
+                in, buf, expected);
+        ++(*failures);
+        bad = 1;
+    }
+    free(buf);
+    return bad;
+}
+
+static int test_prefix_normalization(void)
+{
+    int failures = 0;
+
+    /* the ordinary cases */
+    check_strip("/opt/prrte", "/opt/prrte", &failures);
+    check_strip("/opt/prrte/", "/opt/prrte", &failures);
+    check_strip("/opt/prrte///", "/opt/prrte", &failures);
+    check_strip("relative/path/", "relative/path", &failures);
+
+    /* nothing but separators normalizes to a single separator.  "/" is the
+     * two-byte allocation that the old strncpy(..., sizeof(char*) - 1)
+     * overran */
+    check_strip(PRTE_PATH_SEP, PRTE_PATH_SEP, &failures);
+    check_strip(PRTE_PATH_SEP PRTE_PATH_SEP, PRTE_PATH_SEP, &failures);
+    check_strip(PRTE_PATH_SEP PRTE_PATH_SEP PRTE_PATH_SEP, PRTE_PATH_SEP, &failures);
+
+    /* an empty prefix has no separator to strip and, critically, no room to
+     * write one into - the old loop indexed param[-1] here */
+    check_strip("", "", &failures);
+
+    /* must tolerate a NULL rather than faulting */
+    prte_strip_trailing_pathsep(NULL);
+
+    return failures;
+}
+
+/*
+ * --singleton <nspace>.<rank> parsing.
+ */
+static int test_singleton_id(void)
+{
+    int failures = 0;
+    pmix_nspace_t nspace;
+    pmix_rank_t rank;
+
+    /* the normal form */
+    memset(nspace, 0, sizeof(nspace));
+    rank = PMIX_RANK_INVALID;
+    CHECK("singleton/ok", PRTE_SUCCESS == prte_parse_singleton_id("myapp.0", nspace, &rank));
+    CHECK("singleton/ok-nspace", 0 == strcmp(nspace, "myapp"));
+    CHECK("singleton/ok-rank", 0 == rank);
+
+    /* a namespace may itself contain dots - the LAST one is the separator */
+    memset(nspace, 0, sizeof(nspace));
+    rank = PMIX_RANK_INVALID;
+    CHECK("singleton/dotted",
+          PRTE_SUCCESS == prte_parse_singleton_id("my.app.name.17", nspace, &rank));
+    CHECK("singleton/dotted-nspace", 0 == strcmp(nspace, "my.app.name"));
+    CHECK("singleton/dotted-rank", 17 == rank);
+
+    /* no separator at all - this is the value that used to dereference the
+     * NULL returned by strrchr */
+    CHECK("singleton/no-dot",
+          PRTE_SUCCESS != prte_parse_singleton_id("foo", nspace, &rank));
+
+    /* empty rank, empty nspace, non-numeric rank, trailing garbage */
+    CHECK("singleton/empty-rank",
+          PRTE_SUCCESS != prte_parse_singleton_id("myapp.", nspace, &rank));
+    CHECK("singleton/empty-nspace",
+          PRTE_SUCCESS != prte_parse_singleton_id(".0", nspace, &rank));
+    CHECK("singleton/non-numeric",
+          PRTE_SUCCESS != prte_parse_singleton_id("myapp.abc", nspace, &rank));
+    CHECK("singleton/trailing",
+          PRTE_SUCCESS != prte_parse_singleton_id("myapp.0x", nspace, &rank));
+
+    /* degenerate inputs */
+    CHECK("singleton/null-name",
+          PRTE_SUCCESS != prte_parse_singleton_id(NULL, nspace, &rank));
+    CHECK("singleton/null-rank",
+          PRTE_SUCCESS != prte_parse_singleton_id("myapp.0", nspace, NULL));
+    CHECK("singleton/empty",
+          PRTE_SUCCESS != prte_parse_singleton_id("", nspace, &rank));
+
+    return failures;
+}
+
+static prte_job_t *fresh_job(void)
+{
+    prte_job_t *jdata = PMIX_NEW(prte_job_t);
+    jdata->map = PMIX_NEW(prte_job_map_t);
+    return jdata;
+}
+
+/*
+ * prte_pmix_xfer_job_info() -- the spawn directive translator.
+ */
+static int test_xfer_job_info(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    pmix_info_t info[3];
+    char *str;
+    uint32_t u32, *u32ptr;
+
+    /* a boolean directive lands as a job attribute */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+    CHECK("xfer/bool-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    CHECK("xfer/bool-set",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_COMPLETION, NULL, PMIX_BOOL));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* a string directive is copied, not aliased */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_CPU_LIST, "0-3", PMIX_STRING);
+    CHECK("xfer/str-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    str = NULL;
+    CHECK("xfer/str-set",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_CPUSET, (void **) &str, PMIX_STRING));
+    CHECK("xfer/str-value", NULL != str && 0 == strcmp(str, "0-3"));
+    if (NULL != str) {
+        free(str);
+    }
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* a numeric directive that goes through PMIX_VALUE_GET_NUMBER.  Note
+     * the get-side convention: prte_get_attribute hands back a freshly
+     * allocated value through a pointer-to-pointer, it does not fill a
+     * caller-supplied scalar */
+    jdata = fresh_job();
+    u32 = 42;
+    PMIX_INFO_LOAD(&info[0], PMIX_SESSION_ID, &u32, PMIX_UINT32);
+    CHECK("xfer/u32-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    u32 = 0;
+    u32ptr = &u32;   /* unload copies into caller-supplied storage for scalars */
+    CHECK("xfer/u32-set",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID, (void **) &u32ptr,
+                             PMIX_UINT32));
+    CHECK("xfer/u32-value", 42 == u32);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* map-by is accepted and records the policy on the map */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "node", PMIX_STRING);
+    CHECK("xfer/mapby-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    CHECK("xfer/mapby-set", PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* ...and a second, conflicting mapping policy is refused rather than
+     * silently overwriting the first.  PPR and MAPBY are two spellings of
+     * the same policy, so giving both must be an error */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "node", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_PPR, "2:node", PMIX_STRING);
+    CHECK("xfer/conflict", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 2));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_RELEASE(jdata);
+
+    /* a bad policy string is rejected, not accepted-and-ignored */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "notapolicy", PMIX_STRING);
+    CHECK("xfer/bad-mapby", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* an unrecognized key is not an error - it is cached for delivery to
+     * the job at nspace registration */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], "prte.test.unknown.key", "value", PMIX_STRING);
+    CHECK("xfer/unknown-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    CHECK("xfer/unknown-cached",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, NULL, PMIX_POINTER));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* an empty directive array is a no-op, not a fault */
+    jdata = fresh_job();
+    CHECK("xfer/empty", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, NULL, 0));
+    PMIX_RELEASE(jdata);
+
+    return failures;
+}
+
+/*
+ * prte_pmix_xfer_app() -- app translation, and the ownership contract that
+ * goes with it.
+ */
+static int test_xfer_app(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    prte_app_context_t *app;
+    pmix_app_t papp;
+
+    /* the ordinary case: cmd, argv and maxprocs come across */
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    papp.cmd = strdup("/bin/hostname");
+    PMIx_Argv_append_nosize(&papp.argv, "hostname");
+    papp.maxprocs = 3;
+    CHECK("app/rc", PRTE_SUCCESS == prte_pmix_xfer_app(jdata, &papp));
+    CHECK("app/count", 1 == jdata->num_apps);
+    app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 0);
+    CHECK("app/present", NULL != app);
+    if (NULL != app) {
+        CHECK("app/cmd", NULL != app->app && 0 == strcmp(app->app, "/bin/hostname"));
+        CHECK("app/argv", NULL != app->argv && 0 == strcmp(app->argv[0], "hostname"));
+        CHECK("app/nprocs", 3 == app->num_procs);
+        CHECK("app/idx", 0 == app->idx);
+        /* the app must point back at the job it was added to */
+        CHECK("app/backptr", (struct prte_job_t *) jdata == app->job);
+    }
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    /* with no cmd, argv[0] becomes the executable */
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    PMIx_Argv_append_nosize(&papp.argv, "uptime");
+    papp.maxprocs = 1;
+    CHECK("app/argv0-rc", PRTE_SUCCESS == prte_pmix_xfer_app(jdata, &papp));
+    app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 0);
+    CHECK("app/argv0", NULL != app && NULL != app->app && 0 == strcmp(app->app, "uptime"));
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    /* neither cmd nor argv is a bad-param error */
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    CHECK("app/no-cmd", PRTE_SUCCESS != prte_pmix_xfer_app(jdata, &papp));
+    /* ...and, critically, the caller's job object must still be alive and
+     * usable.  This used to PMIX_RELEASE(jdata) on an error path, handing
+     * the caller back a dangling pointer it went on to use and release
+     * again.  Touching jdata here is the assertion. */
+    CHECK("app/job-alive", NULL != jdata->map);
+    jdata->num_procs = 7;
+    CHECK("app/job-usable", 7 == jdata->num_procs);
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    /* two apps land at successive indices, and num_apps tracks them */
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    papp.cmd = strdup("a");
+    papp.maxprocs = 1;
+    CHECK("app/multi-1", PRTE_SUCCESS == prte_pmix_xfer_app(jdata, &papp));
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_APP_CONSTRUCT(&papp);
+    papp.cmd = strdup("b");
+    papp.maxprocs = 2;
+    CHECK("app/multi-2", PRTE_SUCCESS == prte_pmix_xfer_app(jdata, &papp));
+    CHECK("app/multi-count", 2 == jdata->num_apps);
+    app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 1);
+    CHECK("app/multi-idx", NULL != app && 1 == app->idx);
+    CHECK("app/multi-cmd", NULL != app && 0 == strcmp(app->app, "b"));
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    return failures;
+}
+
+/*
+ * pmix_server_cache_job_info() -- the "I don't recognize this key, hold it
+ * for nspace registration" path that prte_pmix_xfer_job_info falls back to.
+ * It creates the cache list lazily on first use and appends thereafter; a
+ * regression that recreated the list would silently drop every earlier key.
+ */
+static int test_job_info_cache(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    pmix_info_t info;
+    pmix_list_t *cache = NULL;
+
+    jdata = fresh_job();
+    CHECK("cache/absent",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, NULL, PMIX_POINTER));
+
+    PMIX_INFO_LOAD(&info, "prte.test.first", "1", PMIX_STRING);
+    pmix_server_cache_job_info(jdata, &info);
+    PMIX_INFO_DESTRUCT(&info);
+
+    PMIX_INFO_LOAD(&info, "prte.test.second", "2", PMIX_STRING);
+    pmix_server_cache_job_info(jdata, &info);
+    PMIX_INFO_DESTRUCT(&info);
+
+    CHECK("cache/present",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, (void **) &cache,
+                             PMIX_POINTER));
+    /* the cache is a borrowed pointer - the job owns the list */
+    CHECK("cache/both-kept", NULL != cache && 2 == pmix_list_get_size(cache));
+
+    PMIX_RELEASE(jdata);
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+    rc = prte_event_base_open();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_event_base_open failed: %d\n", rc);
+        prte_finalize();
+        return 1;
+    }
+    /* the directive translator reaches into the rmaps base to parse
+     * map-by/rank-by/bind-to, and into the state base for runtime options */
+    rc = pmix_mca_base_framework_open(&prte_rmaps_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "rmaps framework open failed: %d\n", rc);
+        prte_event_base_close();
+        prte_finalize();
+        return 1;
+    }
+    rc = pmix_mca_base_framework_open(&prte_state_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "state framework open failed: %d\n", rc);
+        (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
+        prte_event_base_close();
+        prte_finalize();
+        return 1;
+    }
+
+    failures += test_prefix_normalization();
+    failures += test_singleton_id();
+    failures += test_xfer_job_info();
+    failures += test_xfer_app();
+    failures += test_job_info_cache();
+
+    (void) pmix_mca_base_framework_close(&prte_state_base_framework);
+    (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
+    prte_event_base_close();
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all prted unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d prted unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

`src/prted` is the body of the running system — the HNP, the daemon command
dispatcher, the tool front ends, and the PMIx server host module that answers
every upcall PMIx makes. It is about fifteen thousand lines, it had no
orientation guide, and it had no unit coverage at all. This is a deep review of
all of it.

The review found memory-safety defects reachable from ordinary use, two ways
for a client to hang forever, a signal delivery bug that hits every job on a
persistent DVM, and a blocking construct on the daemon's command path that
stops the daemon dead while it waits.

## What is here

Eight commits, each standing on its own.

**Memory safety.** The scheduler relay wrote one element past the end of the
info array it had just allocated, reachable from a relayed
`PMIx_Allocate_request` on a daemon that is not the DVM master. The `--prefix`
normalizer — four copies of the same loop — ended in
`strncpy(param, PRTE_PATH_SEP, sizeof(param) - 1)` on a `char *`, so `sizeof`
gave the size of the pointer and the call NUL-padded eight bytes into whatever
the prefix had been allocated as; `--prefix /` is a two-byte allocation. A
session-control directive naming applications transferred the wrong
application, indexing the array with the enclosing loop's counter and reading
out of bounds when that counter exceeded the application count.
`prte_pmix_xfer_app()` released the job object its caller owns on an error
return. `process_directive()` answered the requestor and then returned to a
caller that answers again, delivering the response twice and releasing the
request twice.

**Hangs.** A monitoring response that failed to unpack returned after the
reporting count had been incremented, so a malformed response from the last
daemon meant the request never completed. A direct modex arriving before its
job was known armed its timeout on the retry timer rather than on its own
event, so it never timed out. The in-flight check in `dmodex_req()` compared
`req->target`, a field only the monitor and tool-connection paths ever set —
so on a direct modex it is `{"", PMIX_RANK_INVALID}`, which PMIx matches
against any namespace and against `PMIX_RANK_WILDCARD`.

**Signal scoping.** `PRTE_DAEMON_SIGNAL_LOCAL_PROCS` carries the target job's
namespace. The daemon unpacked it and then passed `NULL` to the ODLS, which
means every local child, so on a persistent DVM signalling one job signalled
all of them.

**The blocking command path.** Three daemon commands waited on a
`prte_pmix_lock_t` for PMIx to finish. `prte_daemon_recv` is dispatched from
inside the loop that drives `prte_event_base`, so this stopped the daemon
entirely — no RML traffic, no timers, no other command — and meant anything
PMIx needed *from us* to complete could never run. The
`prte.notify.donotloop` marker these notifications carry exists because one
such deadlock was already found this way. All three are now continuations.
`prted_comm.c` contains no `PRTE_PMIX_WAIT_THREAD` at all.

Plus assorted smaller things: leaks on the dispatcher's error exits, `free()`
on reference-counted objects, unchecked job-object dereferences, a `size_t`
packed as an `int32`, two status variables tested or discarded wrongly in
`pmix_server_init`, an unreachable spawn-directive branch, and a help message
whose four callers all passed one more argument than it took.

## Tests

`test/unit/prted` is new and wired into `make check`. It covers what the
daemon decides before it touches the network: the prefix normalizer (on heap
allocations of exactly the string length, so an overflow is a real one), the
singleton identifier parser, `prte_pmix_xfer_job_info()`'s directive and
conflict handling, and `prte_pmix_xfer_app()`'s ownership contract.

`contrib/dockerswarm` gains a `test_prted` phase for what needs a second
daemon, and a small PMIx probe client to drive it.

Verified: warning-free `--enable-debug` build; all 13 unit suites pass; a
persistent DVM running sequential jobs plus `pterm`, and one-shot `prterun`;
and the full 207-case swarm suite passes with no failures, including all eight
elastic grow/shrink cases, which are what exercise the reworked shrink
continuation.

## On test strength, honestly

The job-scoped signal case is a genuine regression test: reverting that fix and
rebuilding makes it fail, with both jobs dying instead of one.

The two direct-modex cases are **not**. I could not get them to fail against
the unfixed code, because the local PMIx server answers the job-level query
from its own cache without upcalling into `dmodex_req`. They are coverage of
the query working across nodes, and the test says so in a comment. The fix
itself rests on inspection rather than on a reproducer: `req->target` is
assigned in exactly two places, neither of them a direct modex.

## Documentation

`src/prted/AGENTS.md` and `src/prted/pmix/AGENTS.md` (with the usual
`CLAUDE.md` symlinks), written in the shape the framework guides use. Both lead
with what actually causes bugs — which process runs what and why a command may
not block for the daemon body; the capture-and-post rule, the `target`/`tproc`
distinction, the relay shape and the info-array expansion idiom for the host
module — and both record the defects found here.

## Found but not fixed

Two things are filed rather than addressed, as neither is in this subsystem:

- #2568 — a tool attached to a non-master daemon never receives
  `PMIX_EVENT_JOB_END`, so `prun` hangs after its job completes. Clean
  reproducer in the issue.
- #2569 — `prun` documents `--forward-signals` and implements it, but the
  option is missing from `prunoptions[]`, so the parser rejects it.

Also noted in the guide rather than changed: `prte.c`'s POSIX signal handlers
call functions that are not async-signal-safe. That is a last-resort
third-ctrl-C path and changing it is a separate piece of work.
