### PR TITLE
Review the RML: routing tree, OOB transport, and reliable messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ test/unit/plm/Makefile
 test/unit/plm/test_plm
 test/unit/rml/Makefile
 test/unit/rml/test_rml
+test/unit/rml/test_rml_routing
 test/unit/ras/Makefile
 test/unit/ras/test_ras
 test/unit/schizo/Makefile

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1538,6 +1538,194 @@ test_prted() {
     cleanup_swarm
 }
 
+########################################################################
+# src/rml -- routing tree, relay, and the TCP transport
+########################################################################
+#
+# The RML is the one subsystem a single host cannot exercise at all: with one
+# daemon every send is a send-to-self, nothing is ever routed, and no byte
+# ever crosses a socket.  The unit tests (test/unit/rml) cover the tree math,
+# the incarnation guard, the purge, and URI parsing, all of which are pure
+# computation.  What is left -- and what lives here -- is everything that
+# needs a real tree of real daemons:
+#
+#   * a message being RELAYED by an intermediate daemon, which is a distinct
+#     code path from either sending or receiving one (oob_tcp_sendrecv.c
+#     rebuilds a prte_rml_send_t and re-enters the send path)
+#   * the tree actually being a tree -- with the default radix of 64 and ten
+#     nodes every daemon is a direct child of the HNP, so nothing is ever
+#     relayed. Forcing a small radix is the only way to get interior nodes.
+#   * a payload larger than one socket write, which is what drives the
+#     partial-writev / partial-read bookkeeping
+#   * interface selection actually binding and connecting, not just parsing
+#   * a daemon dying under a live DVM, which is what prte_rml_route_lost and
+#     the peer teardown exist for
+test_rml() {
+    local out rc n c
+
+    banner "rml: a small radix builds an interior tree and messages get relayed"
+    # radix 2 over 7 nodes gives the HNP two children and four grandchildren,
+    # so every launch command for a leaf is relayed by an interior daemon and
+    # every line of output travels back the same way.  If the relay path is
+    # broken this hangs or loses procs rather than returning 7 hostnames.
+    cleanup_swarm
+    out=$(RUN 'timeout -k 5 90 prterun --prtemca rml_base_radix 2 \
+                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
+                  -np 7 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-7]$')
+    [ "$rc" = 0 ] && [ "$n" = 7 ] \
+        && ok "radix 2: 7 procs across 7 nodes through a relayed tree" \
+        || bad "radix 2 relay failed (rc=$rc, lines=$n): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    c=$(prted_count 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after the radix-2 run" \
+                 || bad "$c stray prted after the radix-2 run"
+
+    banner "rml: every daemon computes the same tree the HNP does"
+    # Each daemon derives its own placement from the radix math alone -- there
+    # is no tree broadcast -- so a disagreement is silent until a message goes
+    # somewhere nobody is listening.  routed_base_verbose makes each daemon
+    # print the parent and children it arrived at; with radix 2 over 7 nodes
+    # the HNP must report exactly two children, and somebody other than the
+    # HNP must report children of its own (i.e. the tree really has an
+    # interior).  --leave-session-attached is what gets daemon stderr back.
+    cleanup_swarm
+    out=$(RUN 'timeout -k 5 90 prterun --prtemca rml_base_radix 2 \
+                  --prtemca routed_base_verbose 1 --leave-session-attached \
+                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
+                  -np 7 --map-by node hostname' 2>&1)
+    if echo "$out" | grep -q 'num_children'; then
+        # the HNP's own line (rank 0): two children at radix 2
+        echo "$out" | grep -E '@0,0\]: parent .* num_children 2' >/dev/null \
+            && ok "the HNP computed two children at radix 2" \
+            || bad "the HNP did not report 2 children: $(echo "$out" | grep num_children | tr '\n' ' ' | tail -c 300)"
+        # at least one NON-root daemon reporting children => a real interior
+        n=$(echo "$out" | grep 'num_children' | grep -vE '@0,0\]:' | grep -cvE 'num_children 0')
+        [ "$n" -ge 1 ] \
+            && ok "at least one interior daemon has children of its own ($n)" \
+            || bad "no interior daemon reported children -- the tree is flat"
+    else
+        skp "daemons did not report their tree (no routed verbose output captured)"
+    fi
+    cleanup_swarm
+
+    banner "rml: a payload larger than one socket write survives the relay"
+    # IOF output travels the same tree as everything else, so a proc on a leaf
+    # emitting a few MB forces the partial-writev/partial-read bookkeeping in
+    # oob_tcp_sendrecv.c on both the leaf's daemon and every relaying hop.  A
+    # byte-count check catches truncation, which a "did it run" check cannot.
+    out=$(RUN 'timeout -k 5 120 prterun --prtemca rml_base_radix 2 \
+                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
+                  -np 7 --map-by node \
+                  sh -c "head -c 500000 /dev/zero | tr \"\\0\" \"x\""' 2>&1)
+    n=$(echo "$out" | tr -cd 'x' | wc -c | tr -d ' ')
+    [ "$n" = 3500000 ] \
+        && ok "3.5 MB of output relayed back intact" \
+        || bad "large payload was truncated or lost (got $n bytes of 3500000)"
+    cleanup_swarm
+
+    banner "rml: the max-message-size guard rejects an oversized message"
+    # prte_max_msg_size bounds what a receiving daemon will malloc for an
+    # incoming message -- the length comes off the wire, so without the check
+    # a peer dictates the allocation.  IOF output is chunked well below any
+    # cap, so the launch message is the one that can be made arbitrarily
+    # large: it carries the job's environment, and a 1.5 MB envar against a
+    # 1 MB cap is certain to trip it on the receiving daemon.
+    # The cap is driven to 0 rather than 1 MB, and that is deliberate.  Two
+    # things defeat the obvious probe of "send something bigger than the cap":
+    # a single argv/envp string is capped at MAX_ARG_STRLEN (128 KB) so a lone
+    # multi-megabyte variable cannot even be exec'd, and PMIx compresses the
+    # launch buffer, so a payload of repeated bytes shrinks to nothing on the
+    # wire and sails under any cap.  A cap of 0 makes the check unambiguous:
+    # every message is over it, so the guard must fire, name both sizes, and
+    # tear the connection down instead of trusting the length off the wire.
+    out=$(RUN 'timeout -k 5 60 prterun --prtemca prte_max_msg_size 0 \
+                  --host node2:1 -np 1 hostname' 2>&1)
+    echo "$out" | grep -q 'too large' \
+        && ok "the size guard refused a message over the cap" \
+        || bad "a message past prte_max_msg_size was accepted: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    echo "$out" | grep -qE 'Limit: *0' \
+        && ok "...and reported the limit it enforced" \
+        || bad "the size guard did not report its limit"
+    # ...and the same job under the default cap must still run, so the guard
+    # cannot have been "refuse everything"
+    out=$(RUN 'timeout -k 5 60 prterun --host node2:1 -np 1 hostname' 2>&1)
+    echo "$out" | grep -qE '^node2$' \
+        && ok "the same job runs under the default size limit" \
+        || bad "the default size limit broke the launch: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    cleanup_swarm
+
+    banner "rml/oob: interface selection actually binds and connects"
+    # The unit test proves prte_oob_split_and_resolve parses a specification;
+    # only a real DVM proves the interface it picked is the one the sockets
+    # end up on.  eth0 is what the compose network gives every container.
+    out=$(RUN 'timeout -k 5 60 prterun --prtemca prte_if_include eth0 \
+                  --host node1:1,node2:1,node3:1 -np 3 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-3]$')
+    [ "$rc" = 0 ] && [ "$n" = 3 ] \
+        && ok "if_include eth0 formed a working DVM" \
+        || bad "if_include eth0 broke the DVM (rc=$rc, lines=$n): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+    # Excluding the only usable interface leaves the OOB with no address to
+    # advertise.  prte_rml_open used to ignore what prte_oob_open returned,
+    # walk on to get_addr() -- which answers NULL -- and strdup() it, so the
+    # user got a SIGSEGV where a diagnostic belonged.  Assert on the
+    # diagnostic, not merely on "it did not hang": a crash also does not hang.
+    out=$(RUN 'timeout -k 5 60 prterun --prtemca prte_if_exclude eth0 \
+                  --host node1:1,node2:1 -np 2 --map-by node hostname' 2>&1); rc=$?
+    [ "$rc" != 124 ] \
+        && ok "excluding every usable interface failed instead of hanging (rc=$rc)" \
+        || bad "excluding every usable interface hung the launch"
+    echo "$out" | grep -qi 'no usable network interfaces' \
+        && ok "...and said why" \
+        || bad "no diagnostic for an empty interface list: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    echo "$out" | grep -qi 'signal: segmentation\|Segmentation fault' \
+        && bad "an empty interface list crashed the daemon" \
+        || ok "...without crashing"
+    cleanup_swarm
+
+    banner "rml: losing a daemon under a live DVM is detected, not hung on"
+    # Killing an interior daemon drops its sockets; the peers' recv handlers
+    # see the close, run prte_oob_tcp_peer_close (which must complete every
+    # queued send as a failure rather than leak it) and call
+    # prte_rml_route_lost.  The observable is that the DVM notices and the
+    # job ends -- a leaked send or a missed teardown shows up as a hang.
+    cleanup_swarm
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1'; then
+        PRUN_BG /tmp/rml-longrun.out '--host node7:1 -n 1 sleep 120'
+        sleep 6
+        # the whole case is meaningless if the job never got going: a prun
+        # that already exited makes the wait loop below fall through at once
+        # and report a pass it did not earn
+        if ! RUN 'pgrep -x prun' >/dev/null 2>&1; then
+            bad "the long-running job never started: $(RUN 'cat /tmp/rml-longrun.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        elif ! ON 7 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node7 has no daemon to kill -- the job did not land where expected"
+        else
+            ok "a job is running on node7 with its daemon up"
+            # kill the daemon hosting the live proc: its peers' recv handlers
+            # see the socket close, run prte_oob_tcp_peer_close (which must
+            # complete every queued send as a failure) and call route_lost
+            ON 7 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 45 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            [ "$n" -lt 45 ] \
+                && ok "the DVM noticed the lost daemon and released the job (${n}s)" \
+                || bad "prun never returned after its daemon died -- route_lost did not fire"
+            # the HNP itself must survive: losing a leaf is not fatal to the DVM
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "the HNP survived losing a daemon" \
+                || bad "the HNP died along with the lost daemon"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the lost-daemon test"
+    fi
+    cleanup_swarm
+}
+
 test_linux() {
     if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
         echo "swarm not up -- run: docker compose up -d" >&2; exit 2
@@ -1689,7 +1877,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     # directly to the HNP, so a wrong routing/child list shows up as a launch
     # that hangs at DAEMONS_LAUNCHED rather than a wrong answer.
     cleanup_swarm
-    out=$(RUN 'prterun --prtemca prte_rml_radix 2 \
+    out=$(RUN 'prterun --prtemca rml_base_radix 2 \
                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1 \
                  -np 8 --map-by node hostname' 2>&1); rc=$?
     n=$(echo "$out" | grep -cE '^node[1-8]$')
@@ -2088,6 +2276,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
 
     test_prted
 
+    test_rml
+
     test_slurm_alloc
     test_slurm
 
@@ -2153,7 +2343,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
 
     banner "elastic DVM: radix-2 deep tree grow + shrink (multi-hop relay)"
-    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --prtemca prte_rml_radix 2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --prtemca rml_base_radix 2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
     out=$(RUN 'elastic grow node2:2,node3:2,node4:2,node5:2,node6:2,node7:2,node8:2,node9:2' 2>&1)
     echo "$out" | grep -q PMIX_DVM_IS_READY \
         && ok "radix-2 grow onto 8 nodes completed (relay fence succeeded)" \

--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -144,8 +144,11 @@ Routing: the radix tree
 
 Daemons are numbered ``0 .. N-1`` (rank 0 is the HNP) and arranged in a radix
 tree.  The radix (fan-out) defaults to 64 and is set with
-``--prtemca prte_rml_radix``.  The tree keeps the number of hops between any two
-daemons small while bounding each daemon's connection count.
+``--prtemca rml_base_radix`` (``--prtemca routed_radix`` is a deprecated
+synonym).  The minimum is 2 — the tree arithmetic divides by ``radix - 1``, so
+a smaller value is not a degenerate tree but a division by zero, and a value
+below 2 is clamped with a warning.  The tree keeps the number of hops between
+any two daemons small while bounding each daemon's connection count.
 
 ``prte_rml_get_route(target)`` (``routed_radix.c``) returns the rank of the next
 hop:

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -91,13 +91,72 @@ routed on toward its destination.
 ## Routing in one paragraph
 
 Daemons are ranks `0..N-1` (rank 0 is the HNP) arranged in a radix tree
-(default radix 64; `--prtemca prte_rml_radix`). `prte_rml_get_route(target)`
-returns: `target` if it is me; my parent (lifeline) if `target` is outside my
-subtree; otherwise the child whose subtree contains `target`. After a daemon
-fault, `prte_rml_repair_routing_tree` recomputes ancestors, children, and
-possible self-promotion, packages the delta into a
-`prte_rml_recovery_status_t`, and notifies the RML, grpcomm, filem, and relm
-fault handlers.
+(default radix 64; `--prtemca rml_base_radix`, with `routed_radix` as a
+deprecated synonym — note it is **not** `prte_rml_radix`, which is silently
+ignored). `prte_rml_get_route(target)` returns: `target` if it is me; my parent
+(lifeline) if `target` is outside my subtree; otherwise the child whose subtree
+contains `target`. After a daemon fault, `prte_rml_repair_routing_tree`
+recomputes ancestors, children, and possible self-promotion, packages the delta
+into a `prte_rml_recovery_status_t`, and notifies the RML, grpcomm, filem, and
+relm fault handlers.
+
+### The tree layout, precisely
+
+`radix.h` is the whole of the math, and it is worth writing down because the
+layout is **not** the contiguous one you might assume. Rank 0 is the root at
+depth 0. A node of rank `r` at depth `d` has
+
+```
+width W = radix^d          count = 1 + radix + ... + radix^d
+```
+
+its children are `r+W, r+2W, ..., r+(radix)W`, and its subtree is every rank
+`>= r` congruent to `r` modulo `W`. So at radix 2 the tree is
+`0 -> {1,2}`, `1 -> {3,5}`, `2 -> {4,6}` — siblings are *strided*, not adjacent.
+`radix_subtree_contains` is exactly that congruence test, which is why it is a
+single modulo rather than a walk.
+
+Two traversal helpers matter for fault recovery, and both are easy to misread:
+
+- `radix_to_next` walks the tree **depth-first, right-first**, and
+  `radix_to_next_living` keeps walking until it lands on a rank that is not in
+  `failed_dmns`. That is how `update_ancestors` finds a dead ancestor's
+  inheritor and how `update_descendants` replaces a dead child. If this walk
+  ever ends early, live daemons silently vanish from the repaired tree — there
+  is no other signal.
+- Ranks are dense in `[0, n_dmns)`. Any candidate rank equal to `n_dmns` is one
+  past the end, not the last one. This bit once: the walk stepped in from a
+  node's rightmost child slot while testing `> n_dmns`, so a node whose
+  rightmost slot landed exactly on `n_dmns` — rank 0 with the default radix 64
+  in a **64-daemon DVM**, for instance — stopped on a rank that does not exist.
+
+`test/unit/rml/test_rml_routing.c` pins both properties over a matrix of radices
+and DVM sizes: every rank has exactly one parent, and the depth-first walk from
+the root visits every rank exactly once.
+
+### Radix values below 2 are not valid
+
+The math divides by `radix - 1` and takes a logarithm to base `radix`, so a
+radix of 1 (or 0) is a division by zero the moment a second daemon exists, not
+a degenerate-but-workable tree. `prte_rml_register` is the single point where a
+user value enters, and it clamps there with a warning. Do not "support" radix 1
+by special-casing the math.
+
+### Recomputing the tree is not the same as repairing it
+
+`prte_rml_compute_routing_tree` runs at open **and again on every DVM grow**,
+and `prte_rml_revive_routing_tree` shares its helper (`build_tree_from_base`).
+Both rebuild from the fault-free radix positions and then route around whatever
+is currently failed. Two consequences to keep in mind when editing that helper:
+
+- It must **fully overwrite** the children array, not just write as many slots
+  as there are children. `resize_ranks` fills only the slots it newly creates
+  and is a no-op when the array is already `radix` long, so a partially-written
+  array keeps the previous computation's children in its tail.
+- It is the only place a returned (revived) rank can reappear.
+  `prte_rml_update_ancestors` only ever walks a dead ancestor *forward* to its
+  inheritor, so it can shorten an ancestor list but never grow one — rebuilding
+  from base is what makes a revival possible at all.
 
 ## Elastic DVM and launcher-less bootstrap
 
@@ -155,6 +214,40 @@ connection path.
   forever, preserving the original behavior. The HNP is never subject to
   `connect_max_time`.
 
+## Who owns what — the memory rules
+
+Nearly every defect this code has had is an ownership mistake, so the rules are
+worth stating rather than re-deriving:
+
+- **A send is completed, not released.** `PRTE_RML_SEND_COMPLETE(msg)` is the
+  only correct way to finish a `prte_rml_send_t`: it clears the buffer pointer,
+  fires the caller's callback with it, and then releases the send. A bare
+  `PMIX_RELEASE(msg)` frees the buffer *without* telling the caller — fine for
+  the default callback, silently wrong for anything that tracks completion (all
+  of RELM). Every failure path in `prte_oob_base_send_nb` and
+  `prte_oob_tcp_peer_close` must complete, not release.
+- **The receive side owns its payload until someone takes it.** A
+  `prte_oob_tcp_recv_t` frees `data` in its destructor. The two paths that hand
+  the payload on — local delivery via `PMIx_Data_load`, and the relay — set
+  `data = NULL` first. Anything else (a message dropped as a stale incarnation,
+  a partial recv abandoned when the peer closed) is freed by the destructor.
+- **A `prte_rml_recv_t` owns its buffer object even when it is empty.** The
+  recv callback may unload the payload; the (now empty) `pmix_data_buffer_t`
+  itself is still ours.
+- **A stack `prte_rml_recovery_status_t` still needs destructing.** Its
+  constructor heap-copies the current ancestor and child arrays, so *every*
+  path out of `repair_routing_tree` — including the "no new information, just
+  return" one, which is the common case under duplicate failure notices — has
+  to `PMIX_DESTRUCT` it.
+- **`PMIX_RELEASE` on a `pmix_list_t` does not touch its items.** Use
+  `PMIX_LIST_RELEASE`/`PMIX_LIST_DESTRUCT` for a list whose items you built.
+- **`prte_reachable_t` is a refcounted object**, not a plain struct — dispose
+  of it with `PMIX_RELEASE`. `free()`ing it leaks the single block backing the
+  whole weight matrix.
+- **Compare `pmix_proc_t` nspaces with `PMIx_Check_nspace`.** `nspace` is a
+  `char[]`; `a.nspace != b.nspace` compiles fine and compares two array
+  *addresses*, which is always true.
+
 ## Gotchas before you edit
 
 - **Single progress thread.** All RML/OOB state is owned by the progress
@@ -163,7 +256,10 @@ connection path.
   state off that thread, and never block on it.
 - **The wire header is not an ABI.** `prte_oob_tcp_hdr_t` is exchanged only
   among daemons of the *same* DVM, which all run the same build. You may change
-  its layout, but every daemon must agree — there is no versioning.
+  its layout, but every daemon must agree — there is no versioning. It *is*
+  byte-order converted, though, so keep `MCA_OOB_TCP_HDR_HTON`/`_NTOH` covering
+  every multi-byte field you add, and zero a header before filling it — the
+  whole struct goes on the wire, padding included.
 - **One transport, one router.** Do not reintroduce component/module
   abstraction to "make it pluggable" unless there is a real second
   implementation; that abstraction is exactly what was removed.
@@ -171,5 +267,43 @@ connection path.
   bitmap that is *not* reset by `compute_routing_tree`; resetting it reopens the
   #2491 grow bug. `pmix_bitmap` auto-expands as ranks are set, so it needs no
   resizing when the DVM grows.
+- **A tag nobody receives is a leak, not a no-op.** An arriving message with no
+  matching posted recv is parked on `unmatched_msgs` *forever*. That is correct
+  for a message whose recv is merely late, and wrong for a message that is only
+  ever consumed inline — `PRTE_RML_TAG_WARMUP_CONNECTION` is the one such tag,
+  and `prte_rml_base_process_msg` must dispose of it on every path rather than
+  fall through to the matching loop.
+- **`prte_oob_open` can fail for reasons a user causes** — an if_include or
+  if_exclude that leaves no interface, a static port range nothing can bind.
+  Check its return: the next thing `prte_rml_open` does is build a contact URI,
+  and with no interface there is none to build.
 - **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
   tree warning-free.
+
+## Testing
+
+There are two layers, and the split is dictated by what needs a live DVM.
+
+**Unit tests — `test/unit/rml/`, run by `make check`.**
+
+| Binary | Covers |
+|--------|--------|
+| `test_rml` | `prte_oob_split_and_resolve`: turning an if_include/if_exclude string into the interface list the transport binds to. Pure parsing, no socket. |
+| `test_rml_routing` | The radix math (`radix.h`), the routing tree (`compute_routing_tree`, `get_route`, `get_subtree_index`, `get_num_contributors`), the dead/absent-rank restoration across a recompute, the boot-epoch incarnation guard, `prte_rml_purge`, and `prte_rml_parse_uris`. |
+
+`test_rml_routing` stands `prte_rml_base` up by hand rather than calling
+`prte_rml_open` (which would also start listeners), so adding a case is just a
+matter of setting `radix`/`num_daemons`/`PRTE_PROC_MY_NAME->rank` and calling
+`prte_rml_compute_routing_tree`. What it deliberately does **not** cover is
+`repair_routing_tree` and `revive_routing_tree`: both end by calling the
+grpcomm, filem, and relm fault handlers and by emitting notices over the RML,
+none of which exist in a unit-test process.
+
+**Multi-node — `contrib/dockerswarm`, the `test_rml` phase.** Everything the
+unit tests cannot reach, because it needs real daemons on real sockets: a
+message actually being *relayed* by an intermediate daemon (which needs a small
+radix — at the default 64 a ten-node DVM is flat and nothing is ever relayed),
+every daemon independently agreeing on the tree shape, a payload big enough to
+drive the partial-write/partial-read bookkeeping, the max-message-size guard,
+interface selection actually binding and connecting, and a daemon dying under a
+live DVM so `prte_rml_route_lost` and the peer teardown run for real.

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -63,11 +63,36 @@ relaying is just "send again from here."
 ## The wire header
 
 Every message carries a `prte_oob_tcp_hdr_t` (`oob_tcp_hdr.h`): `origin`, final
-`dst`, `tag`, a sequence number, payload length, and a message `type`
-(`IDENT`/`PROBE` for the handshake, `USER` for a normal message). It is
-exchanged **only** among daemons of the same DVM, which all run the same build,
-so it is **not** a stable ABI — you may change its layout, but every daemon must
-agree; there is no versioning.
+`dst`, `tag`, a sequence number, payload length, the origin's boot `epoch`, and
+a message `type` (`IDENT`/`PROBE` for the handshake, `USER` for a normal
+message). It is exchanged **only** among daemons of the same DVM, which all run
+the same build, so it is **not** a stable ABI — you may change its layout, but
+every daemon must agree; there is no versioning.
+
+Two rules that are not obvious from the struct:
+
+- **Every multi-byte field is byte-order converted**, by
+  `MCA_OOB_TCP_HDR_HTON`/`_NTOH`. Add a field, extend both macros — a field
+  that is quietly not converted works perfectly until two daemons differ in
+  endianness.
+- **The whole struct goes on the wire, padding included.** The handshake builds
+  its header on the stack, so zero it before filling it in; leaving a field (or
+  the padding) undefined ships uninitialized bytes and trips every memory
+  checker.
+
+## Message-size bound
+
+`prte_max_msg_size` (MBytes, default 100) bounds what a *receiving* daemon will
+`malloc` for an incoming message. This matters more than a tuning knob usually
+does: the length comes straight off the wire, so without the check a peer
+dictates the allocation. It is enforced in two places — the normal recv path in
+`oob_tcp_sendrecv.c` and the handshake in `oob_tcp_connection.c` — and both
+respond by refusing the message and closing the connection with the
+`msg-too-big` help text.
+
+Note when trying to *test* this: PMIx compresses the launch buffer, so a large
+payload of repeated bytes shrinks to nothing on the wire and sails under any
+cap. Driving the cap to `0` is the unambiguous probe.
 
 ## Connection retry and backoff
 
@@ -108,5 +133,39 @@ In a launcher-less (bootstrapped) DVM daemons boot independently, so:
   thread, and never block on it.
 - **The header is not an ABI.** See above; do not add versioning, but do keep
   every daemon in a build in sync.
+- **Finish a send, never just free it.** A `prte_rml_send_t` that is abandoned
+  — no route, no peer, the connection torn down — must go through
+  `PRTE_RML_SEND_COMPLETE` so the caller's callback runs with a status.
+  `PMIX_RELEASE` frees the buffer and tells nobody, which is invisible for the
+  default callback and a lost message for RELM.
+- **The recv object owns its payload.** `prte_oob_tcp_recv_t`'s destructor
+  frees `data`; the paths that hand the payload on (`PMIx_Data_load` for local
+  delivery, the relay) null the pointer first. Add a third path and it has to
+  do the same, or free it.
+- **`prte_oob_base_send_nb` runs on a *hop*, and the hop can be
+  `PMIX_RANK_INVALID`** when the target sits behind a hole the tree cannot
+  reach past. Handle that before it reaches the peer lookup.
+- **Don't tear down a peer over one bad address.** `set_addr` parses a URI that
+  may name several addresses, and the peer object it is filling in may be an
+  existing one with a live socket and queued sends. A malformed address is a
+  reason to skip that address, not to remove the peer from `prte_oob_base.peers`.
+- **`prte_reachable.reachable()` returns a refcounted object**, and the
+  `pmix_list_t` of remote interfaces you build for it holds objects the list
+  destructor will not touch. `PMIX_RELEASE` the former, `PMIX_LIST_RELEASE` the
+  latter.
+- **`prte_oob_open` has real failure modes.** No usable interface (an
+  if_include/if_exclude that leaves nothing) and no bindable port both return an
+  error with a `show_help` explaining it. Callers must not walk on.
 - **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
   tree warning-free.
+
+## Testing
+
+`prte_oob_split_and_resolve` — the interface-selection parser — is covered by
+`test/unit/rml/test_rml`, which runs under `make check` with no DVM. Everything
+else in this directory needs sockets between real daemons and lives in the
+`test_rml` phase of `contrib/dockerswarm/run-tests.sh`: relaying through an
+intermediate hop (which needs `--prtemca rml_base_radix 2`, since a ten-node
+DVM at the default radix 64 is flat), a payload large enough to force partial
+writes and reads, the message-size guard, interface include/exclude actually
+binding, and the teardown path when a daemon dies under a live DVM.

--- a/src/rml/oob/help-oob-tcp.txt
+++ b/src/rml/oob/help-oob-tcp.txt
@@ -123,3 +123,16 @@ A message being sent between two PRRTE daemons is too large:
 Please increase the size limit via the "prte_max_msg_size" MCA
 parameter, or if you believe the message to be inappropriately
 large, report the problem to a PRRTE developer.
+#
+[no-interfaces]
+No usable network interfaces were found on this host, so no TCP
+sockets can be opened for out-of-band communication between PRRTE
+daemons.
+
+  Local host: %s
+
+This is most often caused by an interface include or exclude list
+that leaves nothing behind.  Interfaces that are down, that are not
+IPv4 (or IPv6, where enabled), and that appear to be virtual are
+also skipped.  Please check the "prte_if_include" and
+"prte_if_exclude" MCA parameters and retry.

--- a/src/rml/oob/oob_base_stubs.c
+++ b/src/rml/oob/oob_base_stubs.c
@@ -77,6 +77,21 @@ void prte_oob_base_send_nb(int fd, short args, void *cbdata)
     /* do we have a route to this peer (could be direct)? */
     PMIX_LOAD_NSPACE(hop.nspace, PRTE_PROC_MY_NAME->nspace);
     hop.rank = prte_rml_get_route(msg->dst.rank);
+    if (PMIX_RANK_INVALID == hop.rank && PRTE_PROC_MY_HNP->rank != msg->dst.rank) {
+        /* The routing tree has no next hop toward this target - it sits behind
+         * a hole we cannot get any closer to.  Report that to the sender rather
+         * than dragging an invalid rank through the lookup below.  A message
+         * for the HNP is the exception: it is allowed to fall through to the
+         * direct-to-HNP attempt just below, which is the last resort when our
+         * whole ancestor chain has died. */
+        pmix_output_verbose(4, prte_oob_base.output,
+                            "%s oob:base:send no route to %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            PRTE_NAME_PRINT(&msg->dst));
+        msg->status = PRTE_ERR_NO_PATH_TO_TARGET;
+        PRTE_RML_SEND_COMPLETE(msg);
+        return;
+    }
     /* do we know this hop? */
     if (NULL == (peer = prte_oob_tcp_peer_lookup(&hop))) {
         /* if this message is going to the HNP, send it direct */
@@ -91,6 +106,10 @@ void prte_oob_base_send_nb(int fd, short args, void *cbdata)
         PRTE_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PROC_URI, &hop, (char **) &uri, PMIX_STRING);
         if (PRTE_SUCCESS == rc && NULL != uri) {
             peer = process_uri(uri);
+            /* process_uri only reads (and temporarily splits) the string - the
+             * copy the modex handed us is ours to release */
+            free(uri);
+            uri = NULL;
             if (NULL == peer) {
                 /* that is just plain wrong */
                 pmix_output_verbose(5, prte_oob_base.output,
@@ -98,13 +117,17 @@ void prte_oob_base_send_nb(int fd, short args, void *cbdata)
                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                     PRTE_NAME_PRINT(&msg->dst));
 
-                if (prte_prteds_term_ordered || prte_finalizing || prte_abnormal_term_ordered) {
-                    /* just ignore the problem */
-                    PMIX_RELEASE(msg);
-                    return;
+                /* Complete the send, do not merely release it: the callback is
+                 * how the originator learns the message died. Releasing frees
+                 * the buffer and tells nobody - invisible for the default
+                 * callback, a silently lost message for anything that tracks
+                 * completion (all of RELM). */
+                if (!prte_prteds_term_ordered && !prte_finalizing
+                    && !prte_abnormal_term_ordered) {
+                    PRTE_ACTIVATE_PROC_STATE(&hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
                 }
-                PRTE_ACTIVATE_PROC_STATE(&hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
-                PMIX_RELEASE(msg);
+                msg->status = PRTE_ERR_ADDRESSEE_UNKNOWN;
+                PRTE_RML_SEND_COMPLETE(msg);
                 return;
             }
         } else if (prte_bootstrap_setup) {
@@ -121,15 +144,15 @@ void prte_oob_base_send_nb(int fd, short args, void *cbdata)
             }
         }
         if (NULL == peer) {
-            // unable to send it
-             if (prte_prteds_term_ordered || prte_finalizing || prte_abnormal_term_ordered) {
-                /* just ignore the problem */
-                PMIX_RELEASE(msg);
-                return;
+            // unable to send it - as above, complete rather than release so
+            // the originator's callback runs with a status
+            if (!prte_prteds_term_ordered && !prte_finalizing
+                && !prte_abnormal_term_ordered) {
+                PMIX_ERROR_LOG(rc);
+                PRTE_ACTIVATE_PROC_STATE(&hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
             }
-            PMIX_ERROR_LOG(rc);
-            PRTE_ACTIVATE_PROC_STATE(&hop, PRTE_PROC_STATE_UNABLE_TO_SEND_MSG);
-            PMIX_RELEASE(msg);
+            msg->status = PRTE_ERR_ADDRESSEE_UNKNOWN;
+            PRTE_RML_SEND_COMPLETE(msg);
             return;
        }
    }
@@ -365,6 +388,7 @@ static void set_addr(pmix_proc_t *peer, char **uris)
         ports = strrchr(tcpuri, ':');
         if (NULL == ports) {
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            PMIx_Argv_free(masks);
             free(tcpuri);
             continue;
         }
@@ -438,11 +462,13 @@ static void set_addr(pmix_proc_t *peer, char **uris)
             if (PRTE_SUCCESS
                 != (rc = parse_uri(af_family, host, ports,
                                    (struct sockaddr_storage *) &(maddr->addr)))) {
+                /* one unparseable address is not a reason to tear down the
+                 * peer: it may well be an established one with a live socket
+                 * and queued sends, and the remaining addresses in this URI may
+                 * be perfectly usable. Drop just this address and carry on. */
                 PRTE_ERROR_LOG(rc);
                 PMIX_RELEASE(maddr);
-                pmix_list_remove_item(&prte_oob_base.peers, &pr->super);
-                PMIX_RELEASE(pr);
-                return;
+                continue;
             }
             maddr->if_mask = if_mask;
 
@@ -453,6 +479,7 @@ static void set_addr(pmix_proc_t *peer, char **uris)
             pmix_list_append(&pr->addrs, &maddr->super);
         }
         PMIx_Argv_free(addrs);
+        PMIx_Argv_free(masks);
         free(tcpuri);
     }
 }

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -263,6 +263,7 @@ int prte_oob_open(void)
         }
         copied_interface = PMIX_NEW(pmix_pif_t);
         if (NULL == copied_interface) {
+            PMIx_Argv_free(interfaces);
             return PRTE_ERR_OUT_OF_RESOURCE;
         }
         pmix_string_copy(copied_interface->if_name, selected_interface->if_name, PMIX_IF_NAMESIZE);
@@ -295,11 +296,17 @@ int prte_oob_open(void)
         && 0 == PMIx_Argv_count(prte_oob_base.ipv6conns)
 #endif
     ) {
+        /* say so: this is reachable straight from user input (an if_include or
+         * if_exclude that leaves nothing), and the caller can only turn the
+         * bare error code into an abort */
+        pmix_show_help("help-oob-tcp.txt", "no-interfaces", true,
+                       prte_process_info.nodename);
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
     // start the listeners
     if (PRTE_SUCCESS != (rc = prte_oob_tcp_start_listening())) {
+        pmix_show_help("help-oob-tcp.txt", "no-listeners", true);
         PRTE_ERROR_LOG(rc);
     }
     return rc;
@@ -324,6 +331,29 @@ void prte_oob_close(void)
 
     PMIX_LIST_DESTRUCT(&prte_oob_base.local_ifs);
     PMIX_LIST_DESTRUCT(&prte_oob_base.peers);
+    /* the listener objects and the parsed port ranges are ours too - this tree
+     * is kept valgrind-clean, so tear down everything prte_oob_open and
+     * prte_oob_register built */
+    PMIX_LIST_DESTRUCT(&prte_oob_base.listeners);
+
+    if (NULL != prte_oob_base.tcp_static_ports) {
+        PMIx_Argv_free(prte_oob_base.tcp_static_ports);
+        prte_oob_base.tcp_static_ports = NULL;
+    }
+    if (NULL != prte_oob_base.tcp_dyn_ports) {
+        PMIx_Argv_free(prte_oob_base.tcp_dyn_ports);
+        prte_oob_base.tcp_dyn_ports = NULL;
+    }
+#if PRTE_ENABLE_IPV6
+    if (NULL != prte_oob_base.tcp6_static_ports) {
+        PMIx_Argv_free(prte_oob_base.tcp6_static_ports);
+        prte_oob_base.tcp6_static_ports = NULL;
+    }
+    if (NULL != prte_oob_base.tcp6_dyn_ports) {
+        PMIx_Argv_free(prte_oob_base.tcp6_dyn_ports);
+        prte_oob_base.tcp6_dyn_ports = NULL;
+    }
+#endif
 
     if (NULL != prte_oob_base.ipv4conns) {
         PMIx_Argv_free(prte_oob_base.ipv4conns);

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -164,6 +164,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         pmix_output(0, "%s CANNOT CREATE SOCKET, OUT OF MEMORY",
                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
+        PMIX_RELEASE(op);
         return;
     }
 
@@ -503,7 +504,9 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         }
         /* close the socket */
         CLOSE_THE_SOCKET(peer->sd);
-        goto out;
+        /* "cleanup", not "out": the caddy is ours to release on this path too,
+         * and only the connect-in-progress return above hands it off */
+        goto cleanup;
     } else {
         pmix_output(0,
                     "%s prte_tcp_peer_try_connect: "
@@ -520,10 +523,15 @@ cleanup:
     PMIX_RELEASE(op);
 out:
     if (NULL != results) {
-        free(results);
+        /* a reference-counted object whose destructor frees the single block
+         * backing the whole weight matrix - free()ing the object itself leaks
+         * that block on every connection attempt */
+        PMIX_RELEASE(results);
     }
     if (NULL != remote_list) {
-        PMIX_RELEASE(remote_list);
+        /* the list destructor does not touch the items, and every pmix_pif_t
+         * on this list was allocated above just for this call */
+        PMIX_LIST_RELEASE(remote_list);
     }
 }
 
@@ -541,12 +549,15 @@ static int tcp_peer_send_connect_ack(prte_oob_tcp_peer_t *peer)
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s SEND CONNECT ACK", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
-    /* load the header */
+    /* load the header. Zero it first: the whole struct goes on the wire, so
+     * every field - including the epoch and any padding - has to be defined */
+    memset(&hdr, 0, sizeof(hdr));
     hdr.origin = *PRTE_PROC_MY_NAME;
     hdr.dst = peer->name;
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
+    hdr.epoch = prte_rml_boot_epoch;
 
     /* payload size */
     sdsize = sizeof(ack_flag) + strlen(prte_version_string) + 1;
@@ -595,12 +606,14 @@ static int tcp_peer_send_connect_nack(int sd, pmix_proc_t *name)
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s SEND CONNECT NACK", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
-    /* load the header */
+    /* load the header - see the note in tcp_peer_send_connect_ack */
+    memset(&hdr, 0, sizeof(hdr));
     hdr.origin = *PRTE_PROC_MY_NAME;
     hdr.dst = *name;
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
+    hdr.epoch = prte_rml_boot_epoch;
 
     /* payload size */
     sdsize = sizeof(ack_flag);
@@ -1139,7 +1152,8 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
     close(peer->sd);
     peer->sd = -1;
 
-    /* clean up any partial send/recv data */
+    /* clean up any partial send/recv data - the recv object's destructor
+     * disposes of whatever payload had already been read into it */
     if (NULL != peer->recv_msg) {
         PMIX_RELEASE(peer->recv_msg);
         peer->recv_msg = NULL;

--- a/src/rml/oob/oob_tcp_hdr.h
+++ b/src/rml/oob/oob_tcp_hdr.h
@@ -67,21 +67,27 @@ typedef struct {
 /**
  * Convert the message header to host byte order
  */
-#define MCA_OOB_TCP_HDR_NTOH(h)                 \
-    (h)->origin.rank = ntohl((h)->origin.rank); \
-    (h)->dst.rank = ntohl((h)->dst.rank);       \
-    (h)->tag = PRTE_RML_TAG_NTOH((h)->tag);     \
-    (h)->nbytes = ntohl((h)->nbytes);           \
-    (h)->epoch = prte_ntoh64((h)->epoch);
+#define MCA_OOB_TCP_HDR_NTOH(h)                     \
+    do {                                            \
+        (h)->origin.rank = ntohl((h)->origin.rank); \
+        (h)->dst.rank = ntohl((h)->dst.rank);       \
+        (h)->tag = PRTE_RML_TAG_NTOH((h)->tag);     \
+        (h)->seq_num = ntohl((h)->seq_num);         \
+        (h)->nbytes = ntohl((h)->nbytes);           \
+        (h)->epoch = prte_ntoh64((h)->epoch);       \
+    } while (0)
 
 /**
  * Convert the message header to network byte order
  */
-#define MCA_OOB_TCP_HDR_HTON(h)                 \
-    (h)->origin.rank = htonl((h)->origin.rank); \
-    (h)->dst.rank = htonl((h)->dst.rank);       \
-    (h)->tag = PRTE_RML_TAG_HTON((h)->tag);     \
-    (h)->nbytes = htonl((h)->nbytes);           \
-    (h)->epoch = prte_hton64((h)->epoch);
+#define MCA_OOB_TCP_HDR_HTON(h)                     \
+    do {                                            \
+        (h)->origin.rank = htonl((h)->origin.rank); \
+        (h)->dst.rank = htonl((h)->dst.rank);       \
+        (h)->tag = PRTE_RML_TAG_HTON((h)->tag);     \
+        (h)->seq_num = htonl((h)->seq_num);         \
+        (h)->nbytes = htonl((h)->nbytes);           \
+        (h)->epoch = prte_hton64((h)->epoch);       \
+    } while (0)
 
 #endif /* _MCA_OOB_TCP_HDR_H_ */

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -534,6 +534,8 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     PRTE_RML_POST_MESSAGE(&peer->recv_msg->hdr.origin, peer->recv_msg->hdr.tag,
                                           peer->recv_msg->hdr.seq_num, peer->recv_msg->data,
                                           peer->recv_msg->hdr.nbytes);
+                    /* PMIx_Data_load took ownership of the payload */
+                    peer->recv_msg->data = NULL;
                     PMIX_RELEASE(peer->recv_msg);
                 } else {
                     /* not for us - we are an intermediate hop. Re-enter the
@@ -620,7 +622,19 @@ static void rcv_cons(prte_oob_tcp_recv_t *ptr)
 {
     memset(&ptr->hdr, 0, sizeof(prte_oob_tcp_hdr_t));
     ptr->hdr_recvd = false;
+    ptr->data = NULL;
     ptr->rdptr = NULL;
     ptr->rdbytes = 0;
 }
-PMIX_CLASS_INSTANCE(prte_oob_tcp_recv_t, pmix_list_item_t, rcv_cons, NULL);
+/* the payload buffer belongs to the recv object until somebody takes it: the
+ * two paths that hand it on (deliver locally, relay onward) clear the pointer
+ * first, so anything still here - a message dropped as a stale incarnation, or
+ * a partial recv abandoned when the peer was closed - is ours to free
+ */
+static void rcv_des(prte_oob_tcp_recv_t *ptr)
+{
+    if (NULL != ptr->data) {
+        free(ptr->data);
+    }
+}
+PMIX_CLASS_INSTANCE(prte_oob_tcp_recv_t, pmix_list_item_t, rcv_cons, rcv_des);

--- a/src/rml/radix.h
+++ b/src/rml/radix.h
@@ -282,9 +282,16 @@ static void radix_to_next(radix_node_t* node){
     if(node->rank >= prte_rml_base.n_dmns){
         node->rank = PMIX_RANK_INVALID;
     } else if(node->rank+node->width < prte_rml_base.n_dmns){
-        // Node has at least one child
+        // Node has at least one child. Walk in from the rightmost child slot
+        // until we land on a rank that actually exists: valid ranks are
+        // [0, n_dmns), so a child equal to n_dmns is one past the end and must
+        // keep stepping left. Testing "> n_dmns" instead left the traversal
+        // sitting on the non-existent rank n_dmns whenever a node's rightmost
+        // child slot fell exactly on the boundary (e.g. rank 0 with the default
+        // radix 64 in a 64-daemon DVM), which made radix_to_next_living give up
+        // and silently drop every rank in that subtree from the repaired tree.
         pmix_rank_t child = node->rank + node->width*prte_rml_base.radix;
-        while(child > prte_rml_base.n_dmns) child -= node->width;
+        while(child >= prte_rml_base.n_dmns) child -= node->width;
         radix_incr_depth(node);
         node->rank = child;
     } else {

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -74,5 +74,31 @@ new neighbors so in-flight messages resume over the repaired tree.
   evicted; cached data is dropped by timer (`relm_base_cache_ms`) or when the
   cache exceeds `relm_base_cache_max_count`. Don't assume `msg->data.bytes` is
   non-NULL.
+- **Every lookup helper can answer NULL.** `prte_relm_find_rank`,
+  `find_msg`, `get_rank`, `get_msg`, `find_prev_msg`, `get_prev_msg` all return
+  NULL for a bad signature, an out-of-range rank, or a hash-table failure. They
+  are usually called where a predecessor "must" exist — which is exactly the
+  assumption a fault breaks. Check.
+- **The hash tables hold references, not copies.** Removing a
+  `prte_relm_rank_t` from `prte_relm_sm->ranks` (or a `prte_relm_msg_t` from
+  `rank->msgs`) drops only the table's entry; the object came from `PMIX_NEW`
+  and still has to be `PMIX_RELEASE`d, along with everything hanging off it.
+  The purge in `base/link_updates.c` is where this matters most.
+- **`prte_relm_close` may run without `prte_relm_open`.** `prte_rml_open` has
+  error returns before it reaches RELM, and `prte_rml_close` runs regardless —
+  so the module can still be the zeroed initializer. Guard before calling
+  through it.
 - **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
   tree warning-free.
+
+## Testing
+
+RELM has no unit test, and the reason is structural rather than an oversight:
+every entry point either thread-shifts onto `prte_event_base` or is reached
+from the RML's fault handler, and the state machine's whole purpose is what
+happens across *several* daemons when one of them dies. Coverage therefore
+lives in `contrib/dockerswarm` — the `test_rml` phase drives the relay and
+lost-daemon paths RELM sits on, and the elastic grow/shrink phases exercise the
+link-update exchange after a tree change. If you add a unit test here, the
+tractable pieces are the pure ones: the pack/unpack helpers in `util.c` and the
+UID/GUID identity and ordering logic in `types.h`/`state_machine.c`.

--- a/src/rml/relm/base/AGENTS.md
+++ b/src/rml/relm/base/AGENTS.md
@@ -52,5 +52,19 @@ For the protocol itself see
   recovery messages will be silently dropped.
 - **Never persist ephemeral states.** `CACHED`/`EVICTED`/`NEW`/`ACKACKED` are
   transitions, not stored states (see `../AGENTS.md`).
+- **The purge frees objects, not just table entries.** `purge()` drops a failed
+  rank from `prte_relm_sm->ranks` and drops individual messages from
+  `rank->msgs`. Both tables hold `PMIX_NEW`ed objects, and removing the entry
+  releases nothing — the rank (and every message still hanging off it) has to
+  be `PMIX_RELEASE`d explicitly. The per-message half of the routine already
+  does this; the per-rank half is the one that is easy to get wrong, because
+  the leak is silent and grows with every fault.
+- **The link bitmaps are indexed by link slot, not by rank.** `link_i_to_r` /
+  `link_r_to_i` map between the two: slots `0..radix-1` are the children (in
+  `prte_rml_base.children` order) and slot `radix` is the lifeline. A slot past
+  the current child count is `PMIX_RANK_INVALID`, which the fault handler
+  treats as "nothing to exchange" — that is also what keeps it from indexing
+  `status->prev_children` past its end, since `repair_routing_tree` only
+  guarantees `prev_children` is at least as long as the *current* child array.
 - **Warnings are errors.** Debug builds enable `--enable-devel-check`; keep the
   tree warning-free.

--- a/src/rml/relm/base/link_updates.c
+++ b/src/rml/relm/base/link_updates.c
@@ -224,9 +224,13 @@ static size_t purge_rank(
 
 static void purge(const prte_rml_recovery_status_t* status){
     for(size_t i = 0; i < status->failed_ranks.size; i++){
-        pmix_hash_table_remove_value_uint32(
-            &prte_relm_sm->ranks, ((pmix_rank_t*)status->failed_ranks.array)[i]
-        );
+        pmix_rank_t failed = ((pmix_rank_t*)status->failed_ranks.array)[i];
+        /* removing the table entry only drops the reference the table held -
+         * the rank object (and every message still hanging off it) came from
+         * PMIX_NEW and has to be released as well */
+        prte_relm_rank_t* rank = prte_relm_find_rank(failed);
+        pmix_hash_table_remove_value_uint32(&prte_relm_sm->ranks, failed);
+        if(NULL != rank) PMIX_RELEASE(rank);
     }
 
     pmix_rank_t* empty = malloc(

--- a/src/rml/relm/relm.c
+++ b/src/rml/relm/relm.c
@@ -24,6 +24,11 @@ void prte_relm_open(void){
 }
 
 void prte_relm_close(void){
-    prte_relm.finalize();
+    /* prte_rml_open() can fail before it ever reaches prte_relm_open(), and
+     * prte_rml_close() runs regardless - so the module may still be the zeroed
+     * initializer */
+    if (NULL != prte_relm.finalize) {
+        prte_relm.finalize();
+    }
     prte_relm = (prte_relm_module_t) {0};
 }

--- a/src/rml/relm/state_machine.c
+++ b/src/rml/relm/state_machine.c
@@ -104,7 +104,9 @@ prte_relm_msg_t* prte_relm_get_msg(prte_relm_signature_t* sig){
     );
     if(PMIX_SUCCESS != ret){
         PMIX_ERROR_LOG(ret);
-        PMIX_RELEASE(rank);
+        /* the message never made it into the table, so it is the object that
+         * has to go - the rank is still live and still holds its other msgs */
+        PMIX_RELEASE(msg);
         return NULL;
     }
     return msg;
@@ -191,7 +193,7 @@ int prte_relm_start_msg(
     if(NULL == buf){
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
         return PRTE_ERR_BAD_PARAM;
-    } else if(dst > prte_rml_base.n_dmns){
+    } else if(dst >= prte_rml_base.n_dmns){
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
         return PRTE_ERR_BAD_PARAM;
     } else if(!prte_rml_is_node_up(dst)){
@@ -405,7 +407,14 @@ void prte_relm_message_handler(pmix_rank_t src, pmix_data_buffer_t* buf){
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         return;
     } else if(msg->prev_uid <= PRTE_RELM_UID_MAX){
-        prte_relm_get_prev_msg(msg)->next_uid = msg->uid;
+        prte_relm_msg_t* prev = prte_relm_get_prev_msg(msg);
+        if(NULL == prev){
+            /* get_msg returns NULL on a bad signature or a table failure */
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+            return;
+        }
+        prev->next_uid = msg->uid;
     }
 
     prte_relm_state_t state = prte_relm_unpack_state(buf);

--- a/src/rml/relm/util.c
+++ b/src/rml/relm/util.c
@@ -61,8 +61,14 @@ void prte_relm_post(prte_relm_msg_t* msg){
 }
 
 bool prte_relm_prev_is_posted(prte_relm_msg_t* msg){
-    return PRTE_RELM_UID_NONE == msg->prev_uid
-        || PRTE_RELM_STATE_ACKED == prte_relm_get_prev_msg(msg)->state;
+    if(PRTE_RELM_UID_NONE == msg->prev_uid){
+        return true;
+    }
+    /* get_prev_msg answers NULL for a bad/absent predecessor; treat that as
+     * "not posted yet" so the caller keeps the message PENDING rather than
+     * dereferencing nothing */
+    prte_relm_msg_t* prev = prte_relm_get_prev_msg(msg);
+    return NULL != prev && PRTE_RELM_STATE_ACKED == prev->state;
 }
 
 #define RELM_STATE_CASE(s) case PRTE_RELM_STATE_ ## s: return #s

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -160,11 +160,20 @@ void prte_rml_register(void)
     }
 
     ret = pmix_mca_base_var_register("prte", "rml", "base", "radix",
-                                     "Radix to be used for routing tree",
+                                     "Radix to be used for routing tree (minimum 2)",
                                      PMIX_MCA_BASE_VAR_TYPE_INT,
                                      &prte_rml_base.radix);
     pmix_mca_base_var_register_synonym(ret, "prte", "routed", "radix", NULL,
                                        PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    /* The radix-tree math divides by (radix - 1) and takes a logarithm to base
+     * radix, so anything below 2 is not a degenerate tree - it is a division by
+     * zero the moment a second daemon exists. This is the only place a user
+     * value enters, so clamp it here rather than defending every call site. */
+    if (2 > prte_rml_base.radix) {
+        pmix_output(0, "PRRTE: routing tree radix %d is invalid (minimum is 2)"
+                       " - using 2", prte_rml_base.radix);
+        prte_rml_base.radix = 2;
+    }
 
     prte_oob_register();
 
@@ -200,6 +209,11 @@ void prte_rml_close(void)
     PMIx_Data_array_destruct(&prte_rml_base.children);
     if (0 <= prte_rml_base.rml_output) {
         pmix_output_close(prte_rml_base.rml_output);
+        prte_rml_base.rml_output = -1;
+    }
+    if (0 <= prte_rml_base.routed_output) {
+        pmix_output_close(prte_rml_base.routed_output);
+        prte_rml_base.routed_output = -1;
     }
 }
 
@@ -255,15 +269,31 @@ int prte_rml_open(void)
 
     prte_rml_base.lifeline = PRTE_PROC_MY_PARENT->rank;
 
-    prte_oob_open();
+    /* Bring up the transport. This fails for real reasons a user can cause -
+     * an if_include/if_exclude that leaves no usable interface, or a static
+     * port range nothing could bind - and every one of them leaves us with no
+     * address to advertise. Ignoring the return meant walking on to
+     * get_addr(), which answers NULL, and then strdup()ing it: a segfault
+     * where the user should have gotten "no interfaces available". */
+    ret = prte_oob_open();
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        return ret;
+    }
 
     /* store our URI for later */
     prte_oob_base_get_addr(&uri);
+    if (NULL == uri) {
+        /* the listeners came up but produced no advertisable address */
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_AVAILABLE);
+        return PRTE_ERR_NOT_AVAILABLE;
+    }
     PMIX_VALUE_LOAD(&val, uri, PMIX_STRING);
     ret = PMIx_Store_internal(PRTE_PROC_MY_NAME, PMIX_PROC_URI, &val);
     if (PMIX_SUCCESS != ret) {
         PRTE_ERROR_LOG(PRTE_ERROR);
         PMIX_VALUE_DESTRUCT(&val);
+        free(uri);
         return PRTE_ERROR;
     }
     PMIX_VALUE_DESTRUCT(&val);

--- a/src/rml/rml_base_msg_handlers.c
+++ b/src/rml/rml_base_msg_handlers.c
@@ -164,7 +164,11 @@ void prte_rml_base_process_msg(int fd, short flags, void *cbdata)
         (5, prte_rml_base.rml_output, "%s message received from %s for tag %d",
          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&msg->sender), msg->tag));
 
-    /* if this message is just to warmup the connection, then drop it */
+    /* a warmup message exists only to establish the connection - nobody ever
+     * posts a recv for it, so it must be consumed here rather than falling
+     * through to the matching loop, which would park it in unmatched_msgs
+     * forever. If the node map has not been communicated yet, answer it with
+     * one first. Either way the message dies here. */
     if (PRTE_RML_TAG_WARMUP_CONNECTION == msg->tag) {
         if (!prte_nidmap_communicated) {
             pmix_data_buffer_t *buffer;
@@ -175,6 +179,7 @@ void prte_rml_base_process_msg(int fd, short flags, void *cbdata)
             if (PRTE_SUCCESS != (rc = prte_util_nidmap_create(prte_node_pool, buffer))) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buffer);
+                PMIX_RELEASE(msg);
                 return;
             }
 
@@ -183,11 +188,10 @@ void prte_rml_base_process_msg(int fd, short flags, void *cbdata)
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(buffer);
-                return;
             }
-            PMIX_RELEASE(msg);
-            return;
         }
+        PMIX_RELEASE(msg);
+        return;
     }
 
     /* see if we have a waiting recv for this message */

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -79,6 +79,8 @@ void prte_rml_recv_failures_notice(
     }
 
     prte_rml_repair_routing_tree(&failed_ranks, global);
+    /* repair takes a copy of what it needs, so the unpacked array is ours */
+    PMIx_Data_array_destruct(&failed_ranks);
 }
 
 void prte_rml_recv_adoption_notice(
@@ -115,7 +117,10 @@ void prte_rml_recv_adoption_notice(
         different = ((pmix_rank_t*)report.array)[i] !=
             ((pmix_rank_t*)prte_rml_base.ancestors.array)[i];
     }
-    if(!different) return;
+    if(!different){
+        PMIx_Data_array_destruct(&report);
+        return;
+    }
 
     if(report.size > prte_rml_base.ancestors.size){
         // This should never happen -- it implies there is some extra failure
@@ -160,7 +165,10 @@ void prte_rml_recv_adoption_notice(
     while(ancestors.size > report.size){
         pmix_rank_t ancestor = ((pmix_rank_t*)ancestors.array)[report.size];
 
-        if(infer_i <= inferred.size) resize_ranks(&inferred, (infer_i+1)*1.5);
+        // grow only when the next slot is past the end - "<=" also fired while
+        // the array still had room and shrank it back under the entries we had
+        // already recorded
+        if(infer_i >= inferred.size) resize_ranks(&inferred, (infer_i+1)*1.5);
         ((pmix_rank_t*)inferred.array)[infer_i++] = ancestor;
 
         pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, ancestor);
@@ -261,6 +269,7 @@ static void send_failures_notice(const prte_rml_recovery_status_t* status){
     if(PMIX_SUCCESS != ret){
         PMIX_ERROR_LOG(ret);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+        PMIX_DATA_BUFFER_RELEASE(msg);
         return;
     }
 
@@ -299,6 +308,8 @@ static void send_failures_notice(const prte_rml_recovery_status_t* status){
                 ((pmix_rank_t*)arr.array)[idx++] = rank;
             }
         }
+        PMIX_DESTRUCT(&ones);
+        PMIX_DESTRUCT(&local_only);
     } else {
         // Parent is unchanged, just report current failures in my subtree
         resize_ranks(&arr, status->failed_ranks.size);

--- a/src/rml/rml_purge.c
+++ b/src/rml/rml_purge.c
@@ -33,7 +33,10 @@ void prte_rml_purge(pmix_proc_t* peer){
     PMIX_LIST_FOREACH_SAFE(
         msg, next_msg, &prte_rml_base.unmatched_msgs, prte_rml_recv_t
     ) {
-        if(msg->sender.nspace != peer->nspace) continue;
+        // as above: compare the nspace strings, not the addresses of the two
+        // char arrays - "!=" on those is a pointer comparison that is always
+        // true, so no held message was ever purged
+        if(!PMIx_Check_nspace(msg->sender.nspace, peer->nspace)) continue;
         if(msg->sender.rank   != peer->rank  ) continue;
 
         pmix_list_remove_item(&prte_rml_base.unmatched_msgs, &msg->super);

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -85,6 +85,7 @@ pmix_rank_t prte_rml_get_route(pmix_rank_t target){
         for(size_t i = 0; i < prte_rml_base.ancestors.size; i++){
             if(ancestors[i] == target){
                 ret = PRTE_PROC_MY_PARENT->rank;
+                break;
             }
         }
     }
@@ -275,7 +276,13 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
     shrink_ranks(&status.failed_ranks);
 
     //If no new information, just return
-    if(status.failed_ranks.size == 0) return;
+    if(status.failed_ranks.size == 0){
+        // the status carries heap copies of the previous ancestor/child arrays,
+        // so even the do-nothing path has to destruct it - a duplicate failure
+        // notice is the common case, not a rare one
+        PMIX_DESTRUCT(&status);
+        return;
+    }
 
     if(!global){
         // Skip this work for global, since it will have already been done
@@ -583,9 +590,18 @@ static void build_tree_from_base(void){
     resize_ranks(&prte_rml_base.children, prte_rml_base.radix);
     pmix_rank_t* children = (pmix_rank_t*) prte_rml_base.children.array;
     radix_node_t child;
-    int child_index = 0;
+    size_t child_index = 0;
     RADIX_CHILD_FOREACH(prte_rml_base.cur_node, child){
         children[child_index++] = child.rank;
+    }
+    // Clear the tail. resize_ranks only fills with INVALID the slots it newly
+    // creates, and it is a no-op when the array is already radix long - so
+    // without this any slot the walk above did not reach keeps whatever child
+    // the *previous* computation put there. A recompute (which is what a DVM
+    // grow, and a revival, both do) would then keep routing to children this
+    // daemon no longer has.
+    for(; child_index < prte_rml_base.children.size; child_index++){
+        children[child_index] = PMIX_RANK_INVALID;
     }
     shrink_ranks(&prte_rml_base.children);
     prte_rml_base.n_children = prte_rml_base.children.size;
@@ -636,11 +652,13 @@ void prte_rml_compute_routing_tree(void){
         0, "%s: parent %s num_children %d", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
         PRTE_VPID_PRINT(PRTE_PROC_MY_PARENT->rank), prte_rml_base.n_children
     );
+    // the daemon job may not be registered yet the first time we compute the
+    // tree, so this debug-only lookup has to tolerate its absence
     prte_job_t* dmns = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
     for(size_t i = 0; i < prte_rml_base.children.size; i++){
         pmix_rank_t child_rank = ((pmix_rank_t*) prte_rml_base.children.array)[i];
 
-        prte_proc_t* d =
+        prte_proc_t* d = (NULL == dmns || NULL == dmns->procs) ? NULL :
             (prte_proc_t*) pmix_pointer_array_get_item(dmns->procs, child_rank);
         bool has_name = NULL!=d && NULL!=d->node && NULL!=d->node->name;
         char* node_name = has_name ? d->node->name : "";

--- a/test/unit/rml/Makefile.am
+++ b/test/unit/rml/Makefile.am
@@ -7,14 +7,19 @@ AM_CPPFLAGS = \
     -I$(top_srcdir)/include \
     -I$(top_srcdir)
 
-check_PROGRAMS = test_rml
+check_PROGRAMS = test_rml test_rml_routing
 
 test_rml_SOURCES = \
     test_rml.c
 
 test_rml_LDADD = $(top_builddir)/src/libprrte.la
 
-TESTS = test_rml
+test_rml_routing_SOURCES = \
+    test_rml_routing.c
+
+test_rml_routing_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_rml test_rml_routing
 
 # Run against the components in this build tree, not just an installed
 # one: without this a --enable-mca-dso build has no components to find

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -1,0 +1,650 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for the RML's routing tree, incarnation guard, message purge,
+ * and contact-URI parsing.
+ *
+ * All of this is pure computation over `prte_rml_base` plus a handful of
+ * process-info globals: no socket, no progress thread, no DVM.  The tests
+ * therefore stand `prte_rml_base` up by hand -- exactly the fields
+ * prte_rml_open() would set -- rather than calling prte_rml_open(), which
+ * would also open listeners and the OOB.
+ *
+ * What is deliberately NOT covered here: prte_rml_repair_routing_tree() and
+ * prte_rml_revive_routing_tree().  Both end by calling into the grpcomm,
+ * filem, and relm fault handlers and by emitting adoption/failure notices
+ * over the RML, none of which exist in a unit-test process.  Their effect on
+ * the *tree* is reachable another way, and is tested here: a departed rank is
+ * recorded in dead_dmns/absent_dmns, and prte_rml_compute_routing_tree()
+ * restores those marks and rebuilds around them -- which is precisely the
+ * property #2491 was about.  End-to-end fault recovery belongs to the
+ * container harness (contrib/dockerswarm).
+ *
+ * The radix layout under test: rank 0 is the root at depth 0.  A node of rank
+ * r at depth d has width W = radix^d and count = 1 + radix + ... + radix^d;
+ * its children are r+W, r+2W, ..., r+(radix)W, and its subtree is every rank
+ * >= r congruent to r modulo W.  Ranks are dense in [0, n_dmns).
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "src/class/pmix_bitmap.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/runtime.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/proc_info.h"
+
+#include "src/rml/radix.h"
+#include "src/rml/rml.h"
+#include "src/rml/rml_contact.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/*
+ * Stand up prte_rml_base as a DVM of ndmns daemons with the given radix,
+ * from the point of view of rank myrank, and compute the routing tree.
+ * Any rank marked in dead_dmns/absent_dmns beforehand stays marked.
+ */
+static void build_dvm(int radix, pmix_rank_t ndmns, pmix_rank_t myrank)
+{
+    prte_rml_base.radix = radix;
+    prte_process_info.num_daemons = ndmns;
+    PRTE_PROC_MY_NAME->rank = myrank;
+    prte_rml_compute_routing_tree();
+}
+
+/* construct the four failure bitmaps the way prte_rml_open() does */
+static void bitmaps_construct(void)
+{
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&prte_rml_base.global_failed_dmns, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&prte_rml_base.dead_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.dead_dmns, 64);
+    PMIX_CONSTRUCT(&prte_rml_base.absent_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.absent_dmns, 64);
+}
+
+static void bitmaps_destruct(void)
+{
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.global_failed_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.absent_dmns);
+}
+
+/* forget every failure mark between cases */
+static void bitmaps_reset(void)
+{
+    bitmaps_destruct();
+    bitmaps_construct();
+}
+
+/*
+ * Every rank except the root is the child of exactly one node, radix_parent()
+ * inverts radix_child(), and a node's subtree is exactly the set of ranks its
+ * children's subtrees cover plus itself.
+ */
+static int check_shape(int radix, pmix_rank_t ndmns)
+{
+    int failures = 0;
+    pmix_rank_t r, c;
+    unsigned char *seen = calloc(ndmns, 1);
+    radix_node_t node, child;
+    char label[128];
+
+    build_dvm(radix, ndmns, 0);
+
+    for (r = 0; r < ndmns; r++) {
+        node = radix_node(r);
+        snprintf(label, sizeof(label), "radix %d/%u: rank %u is its own node",
+                 radix, ndmns, r);
+        CHECK(label, node.rank == r);
+        CHECK(label, radix_subtree_contains(&node, r));
+
+        RADIX_CHILD_FOREACH(node, child)
+        {
+            c = child.rank;
+            snprintf(label, sizeof(label), "radix %d/%u: child %u of %u",
+                     radix, ndmns, c, r);
+            CHECK(label, c < ndmns);
+            if (c >= ndmns) {
+                continue;
+            }
+            /* nobody else already claimed it */
+            CHECK(label, 0 == seen[c]);
+            seen[c] = 1;
+            /* the inverse holds */
+            CHECK(label, radix_parent(&child).rank == r);
+            /* and it is in this node's subtree, at this child index */
+            CHECK(label, radix_subtree_contains(&node, c));
+            CHECK(label, radix_subtree_index(&node, c) < (pmix_rank_t) radix);
+        }
+    }
+
+    snprintf(label, sizeof(label), "radix %d/%u: root has no parent", radix, ndmns);
+    CHECK(label, 0 == seen[0]);
+    for (r = 1; r < ndmns; r++) {
+        snprintf(label, sizeof(label), "radix %d/%u: rank %u has a parent",
+                 radix, ndmns, r);
+        CHECK(label, 1 == seen[r]);
+    }
+
+    free(seen);
+    return failures;
+}
+
+static int test_radix_shape(void)
+{
+    int failures = 0;
+    static const int radices[] = {2, 3, 4, 8, 64};
+    static const pmix_rank_t sizes[] = {1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17,
+                                        63, 64, 65, 100, 128, 129};
+    size_t i, j;
+
+    for (i = 0; i < sizeof(radices) / sizeof(radices[0]); i++) {
+        for (j = 0; j < sizeof(sizes) / sizeof(sizes[0]); j++) {
+            failures += check_shape(radices[i], sizes[j]);
+        }
+    }
+    bitmaps_reset();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_radix_shape\n");
+    }
+    return failures;
+}
+
+/*
+ * radix_to_next() walks the whole tree depth-first, so from the root it must
+ * reach every rank in [0, n_dmns) exactly once before reporting INVALID.
+ *
+ * This is the regression for the boundary bug: the walk stepped in from a
+ * node's rightmost child slot while the candidate was "> n_dmns" rather than
+ * ">= n_dmns", so whenever a node's rightmost slot landed exactly on n_dmns
+ * the walk stopped on the non-existent rank n_dmns.  radix_to_next_living()
+ * then gave up, and every rank below that node vanished from the repaired
+ * tree -- update_ancestors and the child replacement in update_descendants
+ * both rely on this walk to find a dead node's inheritor.  With the default
+ * radix of 64 that is the *entire* DVM at exactly 64 daemons: rank 0's
+ * rightmost child slot is 0 + 1*64 = 64.
+ */
+static int check_traversal(int radix, pmix_rank_t ndmns)
+{
+    int failures = 0;
+    unsigned char *seen = calloc(ndmns, 1);
+    pmix_rank_t visited = 0;
+    radix_node_t node;
+    char label[128];
+
+    build_dvm(radix, ndmns, 0);
+
+    node = radix_node(0);
+    while (PMIX_RANK_INVALID != node.rank) {
+        snprintf(label, sizeof(label), "radix %d/%u: walk stays in range (at %u)",
+                 radix, ndmns, node.rank);
+        CHECK(label, node.rank < ndmns);
+        if (node.rank >= ndmns) {
+            break;
+        }
+        CHECK(label, 0 == seen[node.rank]);
+        seen[node.rank] = 1;
+        visited++;
+        /* a tree of n_dmns ranks cannot take more than n_dmns steps */
+        if (visited > ndmns) {
+            break;
+        }
+        radix_to_next(&node);
+    }
+
+    snprintf(label, sizeof(label), "radix %d/%u: walk visited every rank", radix, ndmns);
+    CHECK(label, visited == ndmns);
+
+    free(seen);
+    return failures;
+}
+
+static int test_radix_traversal(void)
+{
+    int failures = 0;
+    static const int radices[] = {2, 3, 4, 8, 64};
+    static const pmix_rank_t sizes[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 13, 15,
+                                        16, 17, 63, 64, 65, 72, 100, 128, 129};
+    size_t i, j;
+
+    for (i = 0; i < sizeof(radices) / sizeof(radices[0]); i++) {
+        for (j = 0; j < sizeof(sizes) / sizeof(sizes[0]); j++) {
+            failures += check_traversal(radices[i], sizes[j]);
+        }
+    }
+    bitmaps_reset();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_radix_traversal\n");
+    }
+    return failures;
+}
+
+/*
+ * The tree a daemon computes for itself: its ancestor chain ends at its
+ * parent, its children are the radix children that exist, and get_route
+ * answers "me" for me, "my parent" for anything outside my subtree, and the
+ * right child for anything inside it.
+ */
+static int test_routing_tree(void)
+{
+    int failures = 0;
+    pmix_rank_t r, target, hop;
+    size_t i;
+
+    /* radix 2, 7 daemons: 0 -> {1,2}, 1 -> {3,5}, 2 -> {4,6} */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    CHECK("root has no ancestors", 0 == prte_rml_base.ancestors.size);
+    CHECK("root has no lifeline", PMIX_RANK_INVALID == prte_rml_base.lifeline);
+    CHECK("root has two children", 2 == prte_rml_base.n_children);
+    CHECK("root routes to self", 0 == prte_rml_get_route(0));
+    CHECK("root routes 1 via 1", 1 == prte_rml_get_route(1));
+    CHECK("root routes 3 via 1", 1 == prte_rml_get_route(3));
+    CHECK("root routes 5 via 1", 1 == prte_rml_get_route(5));
+    CHECK("root routes 2 via 2", 2 == prte_rml_get_route(2));
+    CHECK("root routes 4 via 2", 2 == prte_rml_get_route(4));
+    CHECK("root routes 6 via 2", 2 == prte_rml_get_route(6));
+
+    build_dvm(2, 7, 1);
+    CHECK("rank 1 has one ancestor", 1 == prte_rml_base.ancestors.size);
+    CHECK("rank 1's parent is the root", 0 == prte_rml_base.lifeline);
+    CHECK("rank 1 has two children", 2 == prte_rml_base.n_children);
+    CHECK("rank 1 routes 3 down", 3 == prte_rml_get_route(3));
+    CHECK("rank 1 routes 5 down", 5 == prte_rml_get_route(5));
+    CHECK("rank 1 routes 2 up", 0 == prte_rml_get_route(2));
+    CHECK("rank 1 routes 4 up", 0 == prte_rml_get_route(4));
+    CHECK("rank 1 routes the root up", 0 == prte_rml_get_route(0));
+
+    build_dvm(2, 7, 3);
+    CHECK("rank 3 has two ancestors", 2 == prte_rml_base.ancestors.size);
+    CHECK("rank 3's ancestors are 0 then 1",
+          0 == ((pmix_rank_t *) prte_rml_base.ancestors.array)[0]
+              && 1 == ((pmix_rank_t *) prte_rml_base.ancestors.array)[1]);
+    CHECK("rank 3's parent is 1", 1 == prte_rml_base.lifeline);
+    CHECK("rank 3 is a leaf", 0 == prte_rml_base.n_children);
+    for (target = 0; target < 7; target++) {
+        if (3 == target) {
+            continue;
+        }
+        CHECK("a leaf routes everything through its parent",
+              1 == prte_rml_get_route(target));
+    }
+
+    /* every daemon in a larger DVM agrees on who its parent is, and every
+     * rank is reachable from every rank in at most a few hops */
+    bitmaps_reset();
+    for (r = 0; r < 40; r++) {
+        build_dvm(4, 40, r);
+        for (i = 0; i < prte_rml_base.children.size; i++) {
+            pmix_rank_t c = ((pmix_rank_t *) prte_rml_base.children.array)[i];
+            if (PMIX_RANK_INVALID == c) {
+                continue;
+            }
+            CHECK("a child is in range", c < 40);
+            CHECK("a child routes directly", c == prte_rml_get_route(c));
+        }
+        for (target = 0; target < 40; target++) {
+            hop = prte_rml_get_route(target);
+            CHECK("every target has a next hop", PMIX_RANK_INVALID != hop);
+            CHECK("the next hop is in range", hop < 40);
+        }
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_routing_tree\n");
+    }
+    return failures;
+}
+
+/*
+ * Recomputing the tree -- which is what a DVM grow does -- must not resurrect
+ * a rank that has permanently departed.  prte_rml_repair_routing_tree()
+ * records departures in dead_dmns (a launched/elastic DVM) or absent_dmns (a
+ * bootstrapped one whose node may reboot); both survive the recompute and are
+ * restored into the freshly-wiped failed set.  Without that the rebuilt tree
+ * routes to a dead vpid and wireup on the grow breaks (#2491).
+ */
+static int test_departed_ranks_survive_recompute(void)
+{
+    int failures = 0;
+    pmix_rank_t hop;
+
+    /* radix 2, 7 daemons, we are the root; rank 1 has departed */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    CHECK("rank 1 starts out up", prte_rml_is_node_up(1));
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 1);
+
+    /* the grow: more daemons, tree recomputed from scratch */
+    build_dvm(2, 9, 0);
+    CHECK("a dead rank is restored into the failed set",
+          pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 1));
+    CHECK("a dead rank is not up", !prte_rml_is_node_up(1));
+    CHECK("no child of the root is the dead rank",
+          1 != ((pmix_rank_t *) prte_rml_base.children.array)[0]);
+    hop = prte_rml_get_route(3);
+    CHECK("traffic for the dead rank's subtree does not go through it", 1 != hop);
+    CHECK("traffic for the dead rank's subtree still has a hop",
+          PMIX_RANK_INVALID != hop);
+
+    /* absent (bootstrap) ranks are restored the same way... */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    pmix_bitmap_set_bit(&prte_rml_base.absent_dmns, 2);
+    build_dvm(2, 9, 0);
+    CHECK("an absent rank is restored into the failed set",
+          pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 2));
+    CHECK("an absent rank is not up", !prte_rml_is_node_up(2));
+
+    /* ...but unlike dead ranks they can be cleared, and the next recompute
+     * then has the rank back in the tree */
+    pmix_bitmap_clear_bit(&prte_rml_base.absent_dmns, 2);
+    build_dvm(2, 9, 0);
+    CHECK("a cleared absent rank is live again", prte_rml_is_node_up(2));
+    CHECK("a cleared absent rank is routable", 2 == prte_rml_get_route(2));
+
+    bitmaps_reset();
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_departed_ranks_survive_recompute\n");
+    }
+    return failures;
+}
+
+/*
+ * get_num_contributors counts how many of my child subtrees a set of daemons
+ * falls into -- what a collective uses to know how many reports to expect.
+ * Failed ranks contribute nothing.
+ */
+static int test_num_contributors(void)
+{
+    int failures = 0;
+    pmix_rank_t set[4];
+
+    /* radix 2, 7 daemons, we are the root: children 1 and 2 */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+
+    set[0] = 3;
+    CHECK("one rank in one subtree", 1 == prte_rml_get_num_contributors(set, 1));
+    set[1] = 5; /* also under child 1 */
+    CHECK("two ranks in the same subtree", 1 == prte_rml_get_num_contributors(set, 2));
+    set[2] = 4; /* under child 2 */
+    CHECK("a second subtree counts once more", 2 == prte_rml_get_num_contributors(set, 3));
+    set[3] = 6; /* also under child 2 */
+    CHECK("still two subtrees", 2 == prte_rml_get_num_contributors(set, 4));
+
+    /* a failed rank drops out of the count */
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 4);
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 6);
+    CHECK("failed ranks do not contribute", 1 == prte_rml_get_num_contributors(set, 4));
+
+    bitmaps_reset();
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_num_contributors\n");
+    }
+    return failures;
+}
+
+/*
+ * The incarnation guard.  A bootstrap daemon that reboots into the same rank
+ * comes back with a strictly greater boot epoch, so traffic stamped with an
+ * older epoch for that rank is from the stale incarnation and is dropped.
+ */
+static int test_epoch_guard(void)
+{
+    int failures = 0;
+
+    CHECK("an unstamped message is always accepted", prte_rml_epoch_ok(3, 0));
+    CHECK("an unknown rank starts at epoch 0", 0 == prte_rml_get_epoch(3));
+
+    /* first sighting is learned, not judged */
+    CHECK("the first epoch seen is accepted", prte_rml_epoch_ok(3, 1000));
+    CHECK("...and recorded", 1000 == prte_rml_get_epoch(3));
+
+    CHECK("the same epoch is still accepted", prte_rml_epoch_ok(3, 1000));
+    CHECK("an older epoch is rejected", !prte_rml_epoch_ok(3, 999));
+    CHECK("a rejection does not disturb the record", 1000 == prte_rml_get_epoch(3));
+
+    /* a newer epoch passes but does not advance the table on its own -- only
+     * the arbitrated revival is allowed to do that */
+    CHECK("a newer epoch is accepted", prte_rml_epoch_ok(3, 2000));
+    CHECK("...without advancing the record", 1000 == prte_rml_get_epoch(3));
+    prte_rml_record_epoch(3, 2000);
+    CHECK("recording advances it", 2000 == prte_rml_get_epoch(3));
+    CHECK("the previously-current epoch is now stale", !prte_rml_epoch_ok(3, 1000));
+
+    /* recording epoch 0 means "unknown" and must not erase what we know */
+    prte_rml_record_epoch(3, 0);
+    CHECK("recording 0 is ignored", 2000 == prte_rml_get_epoch(3));
+
+    /* ranks are independent, and the table grows on demand */
+    CHECK("an unrelated rank is unaffected", 0 == prte_rml_get_epoch(4));
+    CHECK("a far rank can be recorded", (prte_rml_record_epoch(400, 77), true));
+    CHECK("...and read back", 77 == prte_rml_get_epoch(400));
+    CHECK("a far rank rejects a stale epoch", !prte_rml_epoch_ok(400, 76));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_epoch_guard\n");
+    }
+    return failures;
+}
+
+/* count how many entries a list holds */
+static size_t list_len(pmix_list_t *l)
+{
+    return pmix_list_get_size(l);
+}
+
+/*
+ * prte_rml_purge drops the posted recvs and the held (unmatched) messages
+ * belonging to a departed peer, and leaves everyone else's alone.  The
+ * held-message half is the regression: it compared the two pmix_proc_t
+ * nspace *arrays* with "!=", which is a comparison of their addresses and so
+ * was always true -- every held message survived a purge, and a message from
+ * a dead daemon stayed on the list for the life of the DVM.
+ */
+static int test_purge(void)
+{
+    int failures = 0;
+    prte_rml_posted_recv_t *post;
+    prte_rml_recv_t *msg;
+    pmix_proc_t gone;
+
+    PMIX_CONSTRUCT(&prte_rml_base.posted_recvs, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_rml_base.unmatched_msgs, pmix_list_t);
+
+    PMIX_LOAD_PROCID(&gone, PRTE_PROC_MY_NAME->nspace, 7);
+
+    /* two recvs for the departing peer, one for a survivor, one wildcard */
+    post = PMIX_NEW(prte_rml_posted_recv_t);
+    PMIX_LOAD_PROCID(&post->peer, PRTE_PROC_MY_NAME->nspace, 7);
+    post->tag = PRTE_RML_TAG_DAEMON;
+    pmix_list_append(&prte_rml_base.posted_recvs, &post->super);
+
+    post = PMIX_NEW(prte_rml_posted_recv_t);
+    PMIX_LOAD_PROCID(&post->peer, PRTE_PROC_MY_NAME->nspace, 7);
+    post->tag = PRTE_RML_TAG_PLM;
+    pmix_list_append(&prte_rml_base.posted_recvs, &post->super);
+
+    post = PMIX_NEW(prte_rml_posted_recv_t);
+    PMIX_LOAD_PROCID(&post->peer, PRTE_PROC_MY_NAME->nspace, 8);
+    post->tag = PRTE_RML_TAG_DAEMON;
+    pmix_list_append(&prte_rml_base.posted_recvs, &post->super);
+
+    post = PMIX_NEW(prte_rml_posted_recv_t);
+    PMIX_XFER_PROCID(&post->peer, PRTE_NAME_WILDCARD);
+    post->tag = PRTE_RML_TAG_DAEMON;
+    pmix_list_append(&prte_rml_base.posted_recvs, &post->super);
+
+    /* two held messages from the departing peer, one from a survivor */
+    msg = PMIX_NEW(prte_rml_recv_t);
+    PMIX_LOAD_PROCID(&msg->sender, PRTE_PROC_MY_NAME->nspace, 7);
+    msg->tag = PRTE_RML_TAG_DAEMON;
+    pmix_list_append(&prte_rml_base.unmatched_msgs, &msg->super);
+
+    msg = PMIX_NEW(prte_rml_recv_t);
+    PMIX_LOAD_PROCID(&msg->sender, PRTE_PROC_MY_NAME->nspace, 7);
+    msg->tag = PRTE_RML_TAG_PLM;
+    pmix_list_append(&prte_rml_base.unmatched_msgs, &msg->super);
+
+    msg = PMIX_NEW(prte_rml_recv_t);
+    PMIX_LOAD_PROCID(&msg->sender, PRTE_PROC_MY_NAME->nspace, 8);
+    msg->tag = PRTE_RML_TAG_DAEMON;
+    pmix_list_append(&prte_rml_base.unmatched_msgs, &msg->super);
+
+    CHECK("four recvs posted", 4 == list_len(&prte_rml_base.posted_recvs));
+    CHECK("three messages held", 3 == list_len(&prte_rml_base.unmatched_msgs));
+
+    prte_rml_purge(&gone);
+
+    CHECK("the departed peer's recvs are gone",
+          2 == list_len(&prte_rml_base.posted_recvs));
+    CHECK("the departed peer's held messages are gone",
+          1 == list_len(&prte_rml_base.unmatched_msgs));
+
+    PMIX_LIST_FOREACH(post, &prte_rml_base.posted_recvs, prte_rml_posted_recv_t)
+    {
+        CHECK("no surviving recv names the departed peer", 7 != post->peer.rank);
+    }
+    PMIX_LIST_FOREACH(msg, &prte_rml_base.unmatched_msgs, prte_rml_recv_t)
+    {
+        CHECK("no surviving message is from the departed peer", 7 != msg->sender.rank);
+    }
+
+    /* purging a peer with nothing outstanding changes nothing */
+    PMIX_LOAD_PROCID(&gone, PRTE_PROC_MY_NAME->nspace, 9);
+    prte_rml_purge(&gone);
+    CHECK("purging an unrelated peer left the recvs",
+          2 == list_len(&prte_rml_base.posted_recvs));
+    CHECK("purging an unrelated peer left the messages",
+          1 == list_len(&prte_rml_base.unmatched_msgs));
+
+    PMIX_LIST_DESTRUCT(&prte_rml_base.posted_recvs);
+    PMIX_LIST_DESTRUCT(&prte_rml_base.unmatched_msgs);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_purge\n");
+    }
+    return failures;
+}
+
+/*
+ * prte_rml_parse_uris splits a contact URI -- "<name>;<addr>;<addr>..." --
+ * into the peer's process name and the list of addresses.  This is what turns
+ * the HNP URI a daemon was handed on its command line into something the OOB
+ * can connect to, so a malformed one has to be rejected rather than half
+ * parsed.
+ */
+static int test_parse_uris(void)
+{
+    int failures = 0;
+    pmix_proc_t peer;
+    char **uris = NULL;
+    int rc;
+
+    rc = prte_rml_parse_uris("prterun-node-1234@0.1;tcp://10.0.0.1:1024:24",
+                             &peer, &uris);
+    CHECK("a well-formed uri parses", PRTE_SUCCESS == rc);
+    if (PRTE_SUCCESS == rc) {
+        CHECK("the rank is recovered", 1 == peer.rank);
+        CHECK("one address recovered", 1 == PMIx_Argv_count(uris));
+        CHECK("the address is intact",
+              NULL != uris && 0 == strcmp("tcp://10.0.0.1:1024:24", uris[0]));
+        PMIx_Argv_free(uris);
+        uris = NULL;
+    }
+
+    /* several addresses */
+    rc = prte_rml_parse_uris("prterun-node-1234@0.2;tcp://10.0.0.1:1024:24;"
+                             "tcp://192.168.1.1:1025:16",
+                             &peer, &uris);
+    CHECK("a multi-address uri parses", PRTE_SUCCESS == rc);
+    if (PRTE_SUCCESS == rc) {
+        CHECK("the rank is recovered", 2 == peer.rank);
+        CHECK("both addresses recovered", 2 == PMIx_Argv_count(uris));
+        PMIx_Argv_free(uris);
+        uris = NULL;
+    }
+
+    /* the caller may not want the addresses at all -- rml_open() does this
+     * just to learn the HNP's name */
+    rc = prte_rml_parse_uris("prterun-node-1234@0.3;tcp://10.0.0.1:1024:24",
+                             &peer, NULL);
+    CHECK("a NULL address list is allowed", PRTE_SUCCESS == rc);
+    CHECK("...and the name still comes back", 3 == peer.rank);
+
+    /* no separator at all: there is no address section, so this is not a
+     * contact uri */
+    fprintf(stdout, "-- the next case drives a malformed uri;"
+                    " the error it prints is expected --\n");
+    rc = prte_rml_parse_uris("prterun-node-1234@0.4", &peer, &uris);
+    CHECK("a uri with no address section is rejected", PRTE_SUCCESS != rc);
+    CHECK("...and produces no address list", NULL == uris);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_parse_uris\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, "prte-rml-unit-test");
+    bitmaps_construct();
+
+    failures += test_radix_shape();
+    failures += test_radix_traversal();
+    failures += test_routing_tree();
+    failures += test_departed_ranks_survive_recompute();
+    failures += test_num_contributors();
+    failures += test_epoch_guard();
+    failures += test_purge();
+    failures += test_parse_uris();
+
+    bitmaps_destruct();
+    PMIx_Data_array_destruct(&prte_rml_base.ancestors);
+    PMIx_Data_array_destruct(&prte_rml_base.children);
+    if (NULL != prte_rml_base.peer_epochs) {
+        free(prte_rml_base.peer_epochs);
+        prte_rml_base.peer_epochs = NULL;
+        prte_rml_base.peer_epochs_size = 0;
+    }
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all rml routing unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d rml routing unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
A deep review of `src/rml` — the RML API and message matching, the radix
routing tree, the OOB TCP transport, and RELM — plus the coverage that
would have caught what it found, and the documentation updates that
record it.

## The problems

**A daemon can disappear from the repaired routing tree.** The depth-first
walk in `radix_to_next()` steps in from a node's rightmost child slot until
it lands on a rank that exists, and it tested that candidate with
`> n_dmns`. Ranks are dense in `[0, n_dmns)`, so a candidate equal to
`n_dmns` is one past the end and must keep stepping left. Testing "greater
than" left the walk sitting on a rank that does not exist whenever a node's
rightmost slot fell exactly on the boundary. `radix_to_next_living()` then
gave up — and since that walk is how `update_ancestors` finds a dead
ancestor's inheritor and how `update_descendants` replaces a dead child,
every rank below that node silently vanished from the tree. With the
default radix of 64 this is the entire DVM at exactly 64 daemons: rank 0's
rightmost child slot is `0 + 1*64 = 64`.

**A recompute could keep children the daemon no longer has.**
`build_tree_from_base()` sizes the child array to the radix and then writes
one entry per child it finds, but `resize_ranks()` fills only the slots it
newly creates and is a no-op when the array is already that long. Any slot
the walk did not reach kept whatever the *previous* computation put there.
That routine runs again on every DVM grow and on every revival.

**No usable interface was a segfault, not a diagnostic.** `prte_rml_open()`
ignored what `prte_oob_open()` returned. That routine fails for reasons a
user can reach directly — an `if_include`/`if_exclude` that leaves nothing,
a static port range nothing can bind — and each leaves the process with no
address to advertise. Walking on meant calling `prte_oob_base_get_addr()`,
which answers NULL, and then `strdup()`ing it. `--prtemca prte_if_exclude
eth0` on a host whose only interface is eth0 crashed.

**A departed peer's held messages were never purged.** `prte_rml_purge()`
compared the two `pmix_proc_t` nspaces with `msg->sender.nspace !=
peer->nspace`. Those are `char` arrays, so that is a comparison of their
addresses — always true. The loop skipped every message it looked at, and a
message from a dead daemon stayed on `unmatched_msgs` for the life of the
DVM. A related unbounded-growth path: `PRTE_RML_TAG_WARMUP_CONNECTION` is
consumed inline and nobody ever posts a receive for it, but its handler
returned early only on the branch that answers with a node map — so once
the map had been communicated, warmup messages fell through to the matching
loop and were parked forever.

**An abandoned send was released rather than completed.**
`PRTE_RML_SEND_COMPLETE` hands the buffer to the originator's callback with
a status; `PMIX_RELEASE` frees it and tells nobody. For the default
callback the two look alike, which is how three failure paths in
`prte_oob_base_send_nb` had drifted onto the second — but anything that
tracks completion, which is all of RELM, simply loses the message.

**RELM dereferenced and released the wrong things.** Every lookup helper in
the state machine can answer NULL, and two callers assumed a predecessor
message must exist — precisely the assumption a fault breaks.
`prte_relm_get_msg` released the *rank* when it failed to insert a message
into that rank's table, freeing a live object still holding its other
messages and leaking the one just created. The fault purge removed a failed
rank from the table without releasing it, leaking the rank and every
message hanging off it, once per fault. And `prte_relm_close()` called
through the module unconditionally, though `prte_rml_open()` has error
returns before it ever reaches `prte_relm_open()`.

**Leaks on paths taken every time a peer is contacted**: the contact URI
fetched from the modex; the interface masks `set_addr` splits; the
`prte_reachable_t`, which was `free()`d though it is a refcounted object
whose destructor frees the single block backing the whole weight matrix;
the remote-interface list, `PMIX_RELEASE`d though that does not touch the
items on it; the connect caddy on the simultaneous-connection race path;
the payload of any received message that gets dropped; and the stack
recovery status on `repair_routing_tree`'s "no new information" exit, which
is the common case under duplicate failure notices.

**Wire hygiene**: the handshake built its header on the stack without
zeroing it, so the epoch field and the struct padding went out undefined,
and `seq_num` was the one multi-byte header field neither byte-order macro
converted.

**A radix below 2 is a division by zero**, not a degenerate tree — the
arithmetic divides by `radix - 1`. Clamped where the user value enters.

## Coverage

`test/unit/rml/test_rml_routing.c` (new, wired into `make check`) stands
`prte_rml_base` up by hand and covers the radix layout and the depth-first
walk over a matrix of radices and DVM sizes — including the sizes where a
node's rightmost child slot lands exactly on `n_dmns` — plus the tree each
daemon computes for itself, dead/absent survival across a recompute
(#2491), `get_num_contributors`, the boot-epoch incarnation guard, both
halves of the purge, and URI parsing. Each fix above was confirmed by
reverting it and watching a test fail.

`repair_routing_tree`/`revive_routing_tree` are deliberately not unit
tested: both end by calling the grpcomm, filem and relm fault handlers and
by emitting notices over the RML, none of which exist in a unit-test
process.

A `test_rml` phase in `contrib/dockerswarm/run-tests.sh` covers what needs
real daemons on real sockets: a message relayed by an intermediate daemon
(which needs a small radix to exist at all — at the default 64 a ten-node
DVM is flat), every daemon independently agreeing on the tree shape, 3.5 MB
of output relayed back intact, the max-message-size guard, interface
selection actually binding and connecting, and a daemon killed under a live
DVM so the peer teardown and `prte_rml_route_lost` run for real.

Two existing swarm cases passed `--prtemca prte_rml_radix 2` and so were
never running at radix 2 at all: the parameter is `rml_base_radix`, and an
unrecognized `--prtemca` name is passed through to the environment without
complaint. Corrected here, along with the same error in
`docs/how-things-work/rml/index.rst`.

## Documentation

The four `AGENTS.md` files under `src/rml` gain the actual radix layout
(strided, not contiguous — siblings are not adjacent ranks), the traversal
helpers fault recovery depends on, why a radix below 2 cannot work, what a
recompute must do that a repair need not, the ownership rules nearly every
defect here turned on, and where each subsystem's coverage lives.

## Testing

- warning-free `--enable-debug` build
- `make check`: 14/14
- `make -C test/offline check-offline`: 1180/1180
- live DVM smoke (default radix and radix 2)
- sphinx docs build clean
- full `contrib/dockerswarm` suite: **222 passed, 0 failed, 0 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
