### PR TITLE
Deep review of src/runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ test/Makefile
 test/unit/Makefile
 test/unit/rmaps/Makefile
 test/unit/rmaps/test_rmaps
+test/unit/runtime/Makefile
+test/unit/runtime/test_runtime
 test/unit/errmgr/Makefile
 test/unit/errmgr/test_errmgr
 test/unit/ess/Makefile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,10 @@ The three central data structures — `prte_job_t`, `prte_node_t`, and
 `prte_proc_t` — are defined in `src/runtime/prte_globals.h` and carry
 all runtime state for a running job.  Code throughout the tree reaches
 for these; understand them before touching launch, mapping, or error
-handling paths.
+handling paths.  [`src/runtime/AGENTS.md`](src/runtime/AGENTS.md) covers
+the object model, who owns whom (several of those references are
+deliberately *borrowed*, not counted), the three-stage init, and the
+global registries.
 
 ---
 

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -32,6 +32,7 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/offline/Makefile
         test/unit/Makefile
         test/unit/rmaps/Makefile
+        test/unit/runtime/Makefile
         test/unit/errmgr/Makefile
         test/unit/ess/Makefile
         test/unit/filem/Makefile

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -42,6 +42,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `docker-compose.yml` | The ten nodes `prte-node1`..`prte-node10`, each mounting the shared `prte-build` volume. |
 | `elastic.c` | The elastic test client (`elastic` in the install): issues a PMIx allocation request and waits for the phase-two completion event. |
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
+| `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
 ## 2. How it works
@@ -607,3 +608,104 @@ separates a parser error from whatever the launch path later does with the
 number. The pool is asserted too, separately — a node whose count came
 from the scheduler must still carry that count at mapping time
 (`PRTE_NODE_FLAG_SLOTS_GIVEN`).
+
+## 13. The data server (`dataserver`, `test_runtime`)
+
+Most of [`src/runtime`](../../src/runtime/AGENTS.md) needs no DVM and is
+covered by `test/unit/runtime`. Two things are not, and they are what the
+`test_runtime` phase asserts.
+
+**The publish/lookup data server is a single store on the HNP** that every
+client reaches over the RML through its own daemon. That shape is what makes
+it a multi-node subject:
+
+- **`PMIX_RANGE_LOCAL` compares the publisher's proxy against the
+  requestor's proxy** — the daemons that relayed the two requests. On one
+  node those are the same object no matter what the code does, so the check
+  cannot be wrong there. (It was: neither object's constructor initialized
+  `proxy`, and `PMIX_NEW` does not zero its allocation.)
+- **A `PMIX_WAIT` lookup parks in the store** until a later publish
+  satisfies it. The publish arrives from one daemon and the reply goes back
+  out through another, so the parked request has to carry the requestor's
+  proxy and room number across the gap. That path also has to *dispose of*
+  the answer buffer it was handed and will never send.
+- **A partial lookup** (two keys, one published) has to return the half it
+  found alongside `PMIX_ERR_PARTIAL_SUCCESS`. It used to return the status
+  and drop both the values and the buffer holding them.
+
+The probe is `dataserver`, compiled by `build.sh` the same way as `elastic`
+and `jobinfo`:
+
+```sh
+dataserver publish <key> <value> [session|namespace|local|proc-local|global] [secs]
+dataserver lookup <key> [secs]           # no wait
+dataserver lookupwait <key> [secs]       # PMIX_WAIT -- parks in the store
+dataserver lookup2 <key1> <key2> [secs]  # the partial-success shape
+dataserver unpublish <key> [secs]        # publish, confirm, unpublish, confirm gone
+```
+
+`publish` and `lookupwait` stay alive for their `secs` argument and print a
+marker line (`PUBLISHED`, `WAITING`) as soon as they reach that state, so a
+test runs them with `PRUN_BG` and greps the capture file rather than
+sleeping blind.
+
+**The second thing** is that the object destructors — and the ownership
+rules in `src/runtime/AGENTS.md` they encode — only run for real at
+teardown. `prte_session_t` had been registered against the wrong parent
+class, and the symptom (an assert inside `pmix_list_item_destruct` reading
+the middle of the session's own data) fires only when a session is actually
+*released*. So the phase ends by running jobs and then taking the DVM down,
+asserting `pterm` succeeds, that nothing on the way out looks like an assert
+or a fault, and that no daemon survived.
+
+Note that the harness image builds a debug PMIx. That matters here: the
+class-hierarchy check that catches this is `#if PMIX_ENABLE_DEBUG` only, so
+against a release PMIx the same bug is silent memory corruption instead.
+
+## 14. A remote app gets an EMPTY environment, and that hides a stale PMIx
+
+Two related traps, same root cause, and the second one is genuinely nasty.
+
+**The root cause.** An application launched onto a node other than node1
+does *not* inherit the head node's login environment. Concretely, for a
+proc on node4:
+
+```
+$ prun --host node4:1,node1:1 -n 2 --map-by node sh -c 'echo $(hostname) LDLP=$LD_LIBRARY_PATH'
+node4 LDLP=
+node1 LDLP=/opt/prte/prte/lib:/opt/prte/pmix/lib:...
+```
+
+`-x LD_LIBRARY_PATH` does not change that. node1 works only because its
+apps inherit from the HNP, which *was* started from a shell that sourced
+`env.sh`.
+
+**Trap 1 — PATH.** The node entrypoint symlinks the install's `bin` into
+`/usr/local/bin` when the **container** starts, so anything added by a later
+`build.sh` is not on a remote app's PATH. A bare name then fails with
+`PMIX_ERR_JOB_FAILED_TO_LAUNCH` and *no diagnostic*. Use an absolute path
+for helpers in new cases (`DS=/opt/prte/prte/bin/dataserver`); the older
+`jobinfo`/`elastic` cases work only because the entrypoint happened to link
+them.
+
+**Trap 2 — the wrong libpmix, silently.** `/usr/local/lib/libpmix.so.2` is
+the PMIx baked into the *image*. With no `LD_LIBRARY_PATH`, that is what a
+remote app loads — same soname, same version string, different code — so
+every PMIx-linking helper on nodes 2-10 was running the image's PMIx rather
+than the one `PMIX_SRC=... ./build.sh` had just built. Nothing announces
+this. A change spanning both code bases passes on node1 and quietly tests
+the wrong library everywhere else; that is exactly how the partial-lookup
+case (§13) looked broken after it had been fixed.
+
+`build.sh` now links every helper with `-Wl,-rpath,$PMIX_PREFIX/lib` so the
+binary finds the right PMIx regardless of environment. **Any new helper must
+carry that too.** To check one:
+
+```sh
+docker exec prte-node4 sh -c 'ldd /opt/prte/prte/bin/<helper> | grep pmix'
+# must say /opt/prte/pmix/lib, NOT /usr/local/lib
+```
+
+The daemons themselves are fine — `prted` is launched with the right
+environment and loads the volume's PMIx on every node. It is only the
+application processes they fork that lose it.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -229,10 +229,19 @@ build_linux() {
             make -j"$jobs"
             make install
 
+            # NOTE the -Wl,-rpath on every helper below.  An application
+            # launched onto a NON-head node gets an EMPTY LD_LIBRARY_PATH --
+            # the head node inherits the login shell that sourced env.sh, the
+            # others do not -- so without an rpath these binaries load the
+            # PMIx baked into the image (/usr/local/lib) instead of the one
+            # this script just built.  That is silent: same soname, same
+            # version, different code.  Anything testing a PMIx change would
+            # pass on node1 and quietly test the wrong library everywhere
+            # else.
             echo ">>>> elastic test client"
             gcc -O0 -g -o /opt/prte/prte/bin/elastic \
                 /prrte-src/contrib/dockerswarm/elastic.c \
-                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
             # jobinfo: a bare PMIx client used to drive the direct-modex
             # paths in the daemon.  A job-level (wildcard) Get of data
@@ -243,7 +252,18 @@ build_linux() {
             echo ">>>> jobinfo (direct-modex) test client"
             gcc -O0 -g -o /opt/prte/prte/bin/jobinfo \
                 /prrte-src/contrib/dockerswarm/jobinfo.c \
-                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
+            # dataserver: a bare PMIx client for the publish/lookup service
+            # in src/runtime/data_server.  The store is a single array on
+            # the HNP and every client reaches it through its own daemon, so
+            # the publisher proxy vs requestor proxy distinction that
+            # PMIX_RANGE_LOCAL turns on only exists across nodes.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> dataserver (publish/lookup) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/dataserver \
+                /prrte-src/contrib/dockerswarm/dataserver.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
             # examples/dynamic.c is the PMIx_Spawn example shipped in this
             # tree: rank 0 spawns "client" from its cwd as a CHILD JOB.  It
@@ -256,7 +276,7 @@ build_linux() {
             echo ">>>> dynamic (PMIx_Spawn) test client"
             gcc -O0 -g -o /opt/prte/prte/bin/dynamic \
                 /prrte-src/examples/dynamic.c -I/prrte-src/examples \
-                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -lpmix
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
             # The fake SLURM control plane, installed under its own prefix --
             # NOT into the install bin/, which the node entrypoint symlinks

--- a/contrib/dockerswarm/dataserver.c
+++ b/contrib/dockerswarm/dataserver.c
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * dataserver -- a minimal PMIx client for exercising PRRTE's publish/lookup
+ * data server (src/runtime/data_server/) across nodes.
+ *
+ *   dataserver publish <key> <value> [range] [seconds]
+ *       PMIx_Publish the key, print "PUBLISHED <key>", then stay alive for
+ *       <seconds> (the data lives as long as the publisher does, and a
+ *       lookup has to find it while it is there).
+ *
+ *   dataserver lookup <key> [seconds] [range]
+ *       PMIx_Lookup with no wait.  Prints one "FOUND <key> <value>" line per
+ *       key returned, then "STATUS <status>".
+ *
+ *   dataserver lookupwait <key> [seconds] [range]
+ *       PMIx_Lookup with PMIX_WAIT, which parks the request in the data
+ *       server until somebody publishes the key.  Prints "WAITING" first so
+ *       the harness can tell it got that far.
+ *
+ *   dataserver lookup2 <key1> <key2> [seconds]
+ *       Look both keys up in one call.  With only one of them published
+ *       this is the PARTIAL_SUCCESS path.
+ *
+ * The lookup range matters and defaults to whatever PMIx picks.  A
+ * PMIX_RANGE_LOCAL publish is routed by the daemon to its OWN data server
+ * instance rather than to the HNP (see pmix_server_pub.c), so it is only
+ * reachable by a lookup carrying the same range.
+ *
+ *   dataserver unpublish <key> [seconds]
+ *       Publish, then unpublish, then look up - all from one process, since
+ *       only the publisher may unpublish its own data.  Prints
+ *       "UNPUBLISHED" and then the lookup outcome.
+ *
+ * <range> is one of session (default), namespace, local, proc-local, global.
+ *
+ * Why this exists: the store is a SINGLE array on the HNP, and every client
+ * reaches it over the RML through its own daemon.  So the publisher's
+ * "proxy" (the daemon that relayed its request) and the requestor's proxy
+ * are only different objects when the two processes are on different nodes -
+ * which is exactly what PMIX_RANGE_LOCAL discriminates on, and what a
+ * single-host run can never distinguish.  Same for the parked-request path:
+ * the publish that satisfies a waiting lookup arrives from one daemon and
+ * the reply goes back out through another.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+static pmix_data_range_t parse_range(const char *s)
+{
+    if (NULL == s) {
+        return PMIX_RANGE_SESSION;
+    }
+    if (0 == strcmp(s, "namespace")) {
+        return PMIX_RANGE_NAMESPACE;
+    }
+    if (0 == strcmp(s, "local")) {
+        return PMIX_RANGE_LOCAL;
+    }
+    if (0 == strcmp(s, "proc-local")) {
+        return PMIX_RANGE_PROC_LOCAL;
+    }
+    if (0 == strcmp(s, "global")) {
+        return PMIX_RANGE_GLOBAL;
+    }
+    return PMIX_RANGE_SESSION;
+}
+
+static int do_publish(const char *key, const char *value,
+                      const char *rangestr, int seconds)
+{
+    pmix_status_t rc;
+    pmix_info_t info[2];
+    pmix_data_range_t range = parse_range(rangestr);
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    printf("NSPACE %s\n", myproc.nspace);
+    fflush(stdout);
+
+    PMIX_INFO_LOAD(&info[0], key, value, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+
+    rc = PMIx_Publish(info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Publish(%s): %s\n", key, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    printf("PUBLISHED %s\n", key);
+    fflush(stdout);
+
+    sleep(seconds);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+/* Look up 1..2 keys and report what came back. Returns 0 if the lookup
+ * itself succeeded (fully or partially). */
+static int lookup_keys(char **keys, size_t nkeys, int seconds, bool wait,
+                       const char *rangestr)
+{
+    pmix_status_t rc;
+    pmix_pdata_t *pdata;
+    pmix_info_t info[3];
+    pmix_data_range_t range;
+    size_t n, ninfo = 1;
+
+    PMIX_PDATA_CREATE(pdata, nkeys);
+    for (n = 0; n < nkeys; n++) {
+        PMIX_LOAD_KEY(pdata[n].key, keys[n]);
+    }
+
+    PMIX_INFO_LOAD(&info[0], PMIX_TIMEOUT, &seconds, PMIX_INT);
+    if (wait) {
+        PMIX_INFO_LOAD(&info[ninfo++], PMIX_WAIT, NULL, PMIX_BOOL);
+        printf("WAITING\n");
+        fflush(stdout);
+    }
+    if (NULL != rangestr) {
+        range = parse_range(rangestr);
+        PMIX_INFO_LOAD(&info[ninfo++], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    }
+
+    rc = PMIx_Lookup(pdata, nkeys, info, ninfo);
+
+    for (n = 0; n < ninfo; n++) {
+        PMIX_INFO_DESTRUCT(&info[n]);
+    }
+
+    for (n = 0; n < nkeys; n++) {
+        if (0 == strlen(pdata[n].key) || PMIX_UNDEF == pdata[n].value.type) {
+            continue;
+        }
+        printf("FOUND %s %s (from %s:%u)\n", pdata[n].key,
+               (PMIX_STRING == pdata[n].value.type && NULL != pdata[n].value.data.string)
+                   ? pdata[n].value.data.string : "<non-string>",
+               pdata[n].proc.nspace, (unsigned) pdata[n].proc.rank);
+    }
+    printf("STATUS %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+
+    PMIX_PDATA_FREE(pdata, nkeys);
+    /* A partial result is a legitimate outcome we are deliberately probing,
+     * not a failure of this process.  Exiting non-zero would make PRRTE tear
+     * the job down and bury the FOUND lines under an abort banner. */
+    return (PMIX_SUCCESS == rc || PMIX_ERR_PARTIAL_SUCCESS == rc
+            || PMIX_ERR_NOT_FOUND == rc) ? 0 : 1;
+}
+
+static int do_lookup(char **keys, size_t nkeys, int seconds, bool wait,
+                     const char *rangestr)
+{
+    pmix_status_t rc;
+    int ret;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    ret = lookup_keys(keys, nkeys, seconds, wait, rangestr);
+    PMIx_Finalize(NULL, 0);
+    return ret;
+}
+
+static int do_unpublish(const char *key, int seconds)
+{
+    pmix_status_t rc;
+    pmix_info_t info;
+    /* PMIx_Unpublish takes a NULL-terminated key array */
+    char *keys[2] = {NULL, NULL};
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    PMIX_INFO_LOAD(&info, key, "unpublish-me", PMIX_STRING);
+    rc = PMIx_Publish(&info, 1);
+    PMIX_INFO_DESTRUCT(&info);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Publish: %s\n", PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    printf("PUBLISHED %s\n", key);
+    fflush(stdout);
+
+    /* confirm it is really there before we take it away, so a later
+     * NOTFOUND cannot be blamed on the publish */
+    keys[0] = (char *) key;
+    (void) lookup_keys(keys, 1, seconds, false, NULL);
+
+    keys[0] = (char *) key;
+    keys[1] = NULL;
+    rc = PMIx_Unpublish(keys, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Unpublish: %s\n", PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    printf("UNPUBLISHED %s\n", key);
+    fflush(stdout);
+
+    keys[0] = (char *) key;
+    (void) lookup_keys(keys, 1, seconds, false, NULL);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    char *keys[2];
+
+    if (2 > argc) {
+        fprintf(stderr,
+                "usage: %s publish <key> <value> [range] [secs]\n"
+                "       %s lookup <key> [secs] [range]\n"
+                "       %s lookupwait <key> [secs] [range]\n"
+                "       %s lookup2 <key1> <key2> [secs]\n"
+                "       %s unpublish <key> [secs]\n",
+                argv[0], argv[0], argv[0], argv[0], argv[0]);
+        return 2;
+    }
+
+    if (0 == strcmp(argv[1], "publish")) {
+        if (4 > argc) {
+            fprintf(stderr, "publish needs <key> <value>\n");
+            return 2;
+        }
+        return do_publish(argv[2], argv[3], (5 > argc) ? NULL : argv[4],
+                          (6 > argc) ? 120 : atoi(argv[5]));
+    }
+    if (0 == strcmp(argv[1], "lookup") || 0 == strcmp(argv[1], "lookupwait")) {
+        if (3 > argc) {
+            fprintf(stderr, "%s needs a key\n", argv[1]);
+            return 2;
+        }
+        keys[0] = argv[2];
+        return do_lookup(keys, 1, (4 > argc) ? 20 : atoi(argv[3]),
+                         (0 == strcmp(argv[1], "lookupwait")),
+                         (5 > argc) ? NULL : argv[4]);
+    }
+    if (0 == strcmp(argv[1], "lookup2")) {
+        if (4 > argc) {
+            fprintf(stderr, "lookup2 needs two keys\n");
+            return 2;
+        }
+        keys[0] = argv[2];
+        keys[1] = argv[3];
+        return do_lookup(keys, 2, (5 > argc) ? 20 : atoi(argv[4]), false, NULL);
+    }
+    if (0 == strcmp(argv[1], "unpublish")) {
+        if (3 > argc) {
+            fprintf(stderr, "unpublish needs a key\n");
+            return 2;
+        }
+        return do_unpublish(argv[2], (4 > argc) ? 20 : atoi(argv[3]));
+    }
+
+    fprintf(stderr, "unknown mode: %s\n", argv[1]);
+    return 2;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1384,6 +1384,219 @@ PRUN_BG() {
         prte-node1 bash -lc ". /opt/prte/env.sh;
             prun --dvm-uri file:$PRTED_URI $* > $outf 2>&1"
 }
+########################################################################
+# src/runtime -- the object model, the global registries, and the
+# publish/lookup data server.  Most of src/runtime is covered without a DVM
+# by test/unit/runtime; what lands here is what only exists between real
+# daemons.
+########################################################################
+# Absolute path, deliberately.  The node entrypoint symlinks the install bin
+# into /usr/local/bin when the CONTAINER starts, and an app launched into the
+# DVM inherits the daemon PATH -- which does not contain the install bindir.
+# So a helper added since the containers came up is not on the app PATH, and a
+# bare name fails with PMIX_ERR_JOB_FAILED_TO_LAUNCH and no diagnostic.
+DS=/opt/prte/prte/bin/dataserver
+
+test_runtime() {
+    local out n rc
+
+    banner "runtime/data_server: publish on one node, look it up from another"
+    # The store is a SINGLE pointer array living on the HNP.  Every client
+    # reaches it over the RML through its own daemon, so a publish on node2
+    # and a lookup on node3 is the only shape that exercises the real path:
+    # PMIx -> prted -> RML(PRTE_RML_TAG_DATA_SERVER) -> HNP -> ds_publish,
+    # and the reply back out through a DIFFERENT daemon.  On one node the
+    # whole thing collapses into the local PMIx server.
+    cleanup_swarm
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the data-server tests"
+    else
+        PRUN_BG /tmp/ds-pub.out "--host node2:1 -n 1 $DS publish prte.test.k1 hello session 90"
+        sleep 8
+        if ! RUN 'grep -q "^PUBLISHED prte.test.k1" /tmp/ds-pub.out'; then
+            bad "publisher never published: $(RUN 'cat /tmp/ds-pub.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "a proc on node2 published into the HNP store"
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.k1 20" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.k1 hello' \
+                && ok "a proc on node3 looked it up and got the value back" \
+                || bad "cross-node lookup failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            # ...and the answer names the publisher, which is the "data owner"
+            # field ds_publish packs ahead of every returned value
+            echo "$out" | grep -q 'from .*:0)' \
+                && ok "...and the reply carried the publisher's identity" \
+                || bad "the reply did not name the data owner: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            banner "runtime/data_server: a key nobody published is NOT_FOUND, not a hang"
+            # A miss travels the same path and has to come back as a status.
+            # ds_lookup used to have exits that returned without sending
+            # anything AND without releasing the answer buffer.
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.nosuchkey 15" 2>&1)
+            echo "$out" | grep -qE 'STATUS .*(NOT.FOUND|NOT_FOUND)' \
+                && ok "a missing key came back as not-found" \
+                || bad "a missing key did not report not-found: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            banner "runtime/data_server: a partial lookup is reported as partial"
+            # Two keys, one published.  ds_lookup used to set
+            # PMIX_ERR_PARTIAL_SUCCESS and then fall straight through to
+            # "return rc" without sending anything, so the caller relayed a
+            # bare error, the values that HAD been found were dropped, and
+            # the buffer holding them leaked.  It now packs the status and
+            # the payload and sends them like any other answer.
+            #
+            # It takes BOTH halves of the round trip to be right, which is
+            # why this asserts on the value and not just the status.  The
+            # PMIx client used to discard the payload too - answering the
+            # lookup callback with (ret, NULL, 0) for any status that was not
+            # PMIX_SUCCESS, even though the layer immediately above it
+            # explicitly handles PMIX_ERR_PARTIAL_SUCCESS as data-carrying -
+            # so a correct server still produced an empty answer.  Needs a
+            # PMIx built from source (PMIX_SRC=... ./build.sh).
+            out=$(PRUN "--host node4:1 -n 1 $DS lookup2 prte.test.k1 prte.test.absent 15" 2>&1)
+            echo "$out" | grep -q 'STATUS PMIX_ERR_PARTIAL_SUCCESS' \
+                && ok "a half-satisfiable lookup came back as PARTIAL_SUCCESS" \
+                || bad "a partial lookup did not report itself as partial: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            echo "$out" | grep -q '^FOUND prte.test.k1 hello' \
+                && ok "...carrying the key that did exist, not an empty answer" \
+                || bad "a partial lookup lost the data it found: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            echo "$out" | grep -q '^FOUND prte.test.absent' \
+                && bad "a key nobody published was reported as found" \
+                || ok "...and the absent key was not invented"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "runtime/data_server: a waiting lookup is satisfied by a later publish"
+    # PMIX_WAIT parks the request on prte_data_store.pending until somebody
+    # publishes the key.  The publish arrives from one daemon and the reply
+    # goes back out through another, so the parked request has to carry the
+    # requestor's proxy and room number across the gap.  The park side also
+    # has to dispose of the answer buffer it was handed but will never send
+    # -- otherwise every waiting lookup leaks one on the HNP.
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the waiting-lookup test"
+    else
+        PRUN_BG /tmp/ds-wait.out "--host node3:1 -n 1 $DS lookupwait prte.test.later 60"
+        sleep 8
+        if ! RUN 'grep -q "^WAITING" /tmp/ds-wait.out'; then
+            skp "the waiting lookup never started; the next case is weaker"
+        else
+            ok "a lookup on node3 is parked waiting for a key"
+            # nothing may have been answered yet
+            RUN 'grep -q "^FOUND" /tmp/ds-wait.out' \
+                && bad "the parked lookup answered before anything was published" \
+                || ok "...and it has not been answered yet"
+        fi
+        PRUN_BG /tmp/ds-late.out "--host node2:1 -n 1 $DS publish prte.test.later worldwide session 40"
+        sleep 12
+        RUN 'grep -q "^FOUND prte.test.later worldwide" /tmp/ds-wait.out' \
+            && ok "the publish from node2 satisfied the lookup parked from node3" \
+            || bad "a parked lookup was never satisfied: $(RUN 'cat /tmp/ds-wait.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        # a fully-resolved parked request must report SUCCESS, not
+        # PARTIAL_SUCCESS: ds_publish derived that by counting req->keys,
+        # which by then holds only the keys still UNresolved (i.e. none), so
+        # a complete answer was reported as partial
+        RUN 'grep -qE "^STATUS SUCCESS|^STATUS .*(PMIX_SUCCESS)" /tmp/ds-wait.out' \
+            && ok "...and reported it as a complete, not partial, result" \
+            || bad "a fully satisfied lookup was reported as partial: $(RUN 'grep "^STATUS" /tmp/ds-wait.out' 2>&1 | tr -d '\r')"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "runtime/data_server: unpublish removes the data"
+    # Only the publisher may unpublish its own keys, so this runs in one
+    # process: publish, confirm, unpublish, confirm gone.
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2'; then
+        bad "could not start a DVM for the unpublish test"
+    else
+        out=$(PRUN "--host node2:1 -n 1 $DS unpublish prte.test.gone 15" 2>&1)
+        echo "$out" | grep -q '^FOUND prte.test.gone' \
+            && ok "the key was there before the unpublish" \
+            || bad "the key was never findable: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        echo "$out" | grep -q '^UNPUBLISHED prte.test.gone' \
+            && ok "unpublish was accepted" \
+            || bad "unpublish was refused: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        n=$(echo "$out" | grep -c '^FOUND prte.test.gone')
+        [ "$n" = 1 ] \
+            && ok "...and the key was gone afterwards" \
+            || bad "the key survived the unpublish (FOUND $n times)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "runtime/data_server: PMIX_RANGE_LOCAL data does not leave its node"
+    # A LOCAL-range publish is not sent to the HNP at all: the daemon routes
+    # it to its OWN data server instance (pmix_server_pub.c picks
+    # target = PRTE_PROC_MY_NAME for that range), so the item lives in the
+    # store of the daemon that relayed it.  A lookup has to carry the same
+    # range to be routed to the same place.
+    #
+    # That is the property worth asserting across nodes, and one host cannot
+    # show it: with a single daemon "the local store" and "the HNP store"
+    # are the same object, so LOCAL data confined to a node and LOCAL data
+    # leaking everywhere look identical.  (The proxy comparison in
+    # prte_data_server_check_range that backs this up - and that was reading
+    # an uninitialized field - is covered directly in test/unit/runtime.)
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2'; then
+        bad "could not start a DVM for the range test"
+    else
+        PRUN_BG /tmp/ds-loc.out "--host node2:1 -n 1 $DS publish prte.test.loc mine local 60"
+        sleep 8
+        if ! RUN 'grep -q "^PUBLISHED prte.test.loc" /tmp/ds-loc.out'; then
+            bad "the LOCAL-range publish never happened: $(RUN 'cat /tmp/ds-loc.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "a LOCAL-range key was published from node2"
+            # a peer behind the SAME daemon may see it
+            out=$(PRUN "--host node2:1 -n 1 $DS lookup prte.test.loc 15 local" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.loc mine' \
+                && ok "a peer on the same node can see it" \
+                || bad "a LOCAL-range key was hidden from its own node: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            # ...and the same LOCAL-range lookup from another node reaches
+            # THAT node's daemon, which has never seen the key
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.loc 15 local" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.loc' \
+                && bad "a LOCAL-range key leaked to another node" \
+                || ok "a client on another node cannot see it, as LOCAL range requires"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "runtime: a DVM tears down cleanly with jobs and sessions built"
+    # The object destructors -- and the ownership rules they encode -- only
+    # run for real at teardown.  prte_session_t was registered against the
+    # wrong parent class, and the destructor that exposed it (an assert
+    # inside pmix_list_item_destruct reading the middle of the session's own
+    # data) fires only when a session is actually RELEASED.  Run some jobs,
+    # then take the DVM down and check it went quietly.
+    if ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the teardown test"
+    else
+        PRUN '--host node2:1,node3:1 -n 2 --map-by node hostname' >/dev/null 2>&1
+        PRUN '--host node4:2 -n 2 hostname' >/dev/null 2>&1
+        out=$(RUN 'timeout -k 5 30 pterm' 2>&1); rc=$?
+        [ "$rc" = 0 ] \
+            && ok "the DVM shut down cleanly after running jobs" \
+            || bad "pterm failed (rc=$rc): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        echo "$out" | grep -qiE 'assert|signal|segmentation|abort' \
+            && bad "teardown produced a crash diagnostic: $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+            || ok "...with no assert or fault on the way out"
+        n=$(prted_count 1 2 3 4)
+        [ "$n" = 0 ] && ok "no daemons survived the teardown" \
+                     || bad "$n daemons still running after pterm"
+    fi
+    cleanup_swarm
+}
+
 test_prted() {
     local out rc ns n bpid
 
@@ -2275,6 +2488,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_state
 
     test_prted
+
+    test_runtime
 
     test_rml
 

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -1,0 +1,276 @@
+# AGENTS.md — `src/runtime`
+
+Orientation for AI agents and human contributors working in `src/runtime/`.
+This is a map, not the rulebook: the authoritative project guidance lives in
+the top-level [`AGENTS.md`](../../AGENTS.md) and under [`docs/`](../../docs/).
+When this file and those disagree, **the docs win** — and please fix this
+file.
+
+---
+
+## What lives here
+
+`src/runtime` is the foundation the rest of PRRTE is built on. It is not a
+framework and has no components: it is the process lifecycle, the global
+state, and the object model. Practically everything else in the tree
+includes [`prte_globals.h`](prte_globals.h).
+
+Five separable things share the directory:
+
+| Area | Files | What it is |
+|------|-------|------------|
+| **Object model & globals** | `prte_globals.[ch]` | The three central data structures (`prte_job_t`, `prte_node_t`, `prte_proc_t`), plus `prte_session_t`, `prte_app_context_t`, `prte_topology_t`, the launch-fence campaign objects — their class instances, and the global registries (`prte_job_data`, `prte_node_pool`, `prte_sessions`, ...) with the lookup functions over them. |
+| **Lifecycle** | `prte_init.c`, `prte_finalize.c`, `prte_quit.[ch]`, `prte_locks.[ch]` | The three-stage startup (`prte_init_minimum` → `prte_init_util` → `prte_init`), teardown, the "stop looping the event base" path, and the one-shot mutexes that keep re-entrant shutdown from bouncing. |
+| **MCA parameters** | `prte_mca_params.c` | `prte_register_params()` — every `prte_*` MCA variable, registered once. |
+| **Threads & timers** | `prte_progress_threads.[ch]`, `prte_wait.[ch]` | Named progress threads (event base + engine thread + refcount), the SIGCHLD/waitpid plumbing, and the `PRTE_DETECT_TIMEOUT`/`PRTE_TIMER_EVENT` macros. |
+| **Sub-directories** | [`data_server/`](data_server/AGENTS.md), [`data_type_support/`](data_type_support/AGENTS.md) | The PMIx publish/lookup service, and the pack/unpack/copy/print functions for the objects above. Each has its own AGENTS.md. |
+
+---
+
+## The three-stage init, and why it is three
+
+Tools do not all need the same amount of runtime, and some of them need a
+*part* of it before they can decide what else to do. Hence:
+
+```
+prte_init_minimum()   PMIx version check, installdirs, MCA var system,
+                      prte_register_params(), MCA param files preloaded.
+                      No event base, no frameworks, no globals.
+        │
+        ▼
+prte_init_util(flags) + malloc/output init, hostname, stack handlers,
+                      system limits, prtebacktrace.  Records proc_type.
+        │
+        ▼
+prte_init(argc,argv,flags)
+                      + event base, locks, proc_info, hwloc, the global
+                        arrays, prte_default_session, schizo + ess
+                        selection, prte_ess.init(), the cache and the
+                        launch-fence arrays.
+```
+
+Each stage is idempotent behind its own `static bool` (`min_initialized`,
+`util_initialized`, `prte_initialized`). `prte_register_params()` has its
+own `passed_thru` guard because `mpirun` reaches it twice.
+
+**Consequences for anything you add here:**
+
+- Something registered in `prte_register_params()` is available to *tools*
+  that never call `prte_init()`. Something set up in `prte_init()` is not.
+- MCA variables read their environment exactly once, on first registration.
+  That is why the bootstrap daemon has to publish the DVM-wide parameters it
+  reads out of `prte.conf` (`prte_ess_base_bootstrap_params()`) *before*
+  `prte_register_params()` runs, and why that call sits where it does.
+- The global arrays (`prte_job_data`, `prte_node_pool`, `prte_sessions`,
+  `prte_node_topologies`) are **NULL** until `prte_init()`. Any function
+  reachable from a tool or a parser has to tolerate that.
+
+---
+
+## The object model
+
+### Class hierarchy — get the declared parent right
+
+Every object here is a PMIx reference-counted object. The parent named in
+`PMIX_CLASS_INSTANCE` **must be the type actually embedded as the struct's
+first member**. The class system runs the whole ancestor chain's
+constructors and destructors, so naming a wider parent than the struct
+embeds makes those run over the object's own leading fields.
+
+`prte_session_t` embeds `pmix_object_t` and was registered against
+`pmix_list_item_t`. The constructor damage was invisible (`session_con` runs
+afterwards and rewrites the same bytes), but `pmix_list_item_destruct`
+asserts that the item is not still on a list, and under a debug PMIx it read
+that "refcount" out of the middle of the session's own data and aborted the
+process. It survived for as long as it did only because
+`prte_default_session` — the one session that always exists — is never
+released.
+
+Current parents: `prte_job_t`, `prte_node_t`, `prte_proc_t`,
+`prte_attribute_t`, and the two campaign objects are `pmix_list_item_t`
+(they really do go on lists); `prte_app_context_t`, `prte_job_map_t`,
+`prte_topology_t`, `prte_timer_t`, and `prte_session_t` are `pmix_object_t`.
+
+### Who owns whom
+
+This is the part that bites. The rules, and the reason for each:
+
+| Reference | Counted? | Why |
+|-----------|----------|-----|
+| `job->procs[]`, `job->apps[]` | yes | the job owns them |
+| `node->procs[]`, `node->daemon` | yes | the node owns them |
+| `proc->node` | **no** — borrowed | retaining it would close a cycle with `node->procs`/`node->daemon`; neither side could ever reach zero, so nothing would be freed. `prte_node_destruct` clears the backpointer on every proc it knows about, so a proc that outlives its node points at NULL rather than at freed memory. |
+| `node->session` | **no** — borrowed | same reason, against `session->nodes`. `prte_ras_base_release_allocation` clears it when a reservation is torn down. |
+| `session->nodes[]` | yes | a reservation withholds its nodes |
+| `session->jobs[]` | **no** — borrowed | a job's lifetime is governed by the global job pool, not by the session it ran in |
+| `session->children[]`, `session->owner_job` | yes | |
+| `job->target_sessions[]` | **no** — borrowed | owned via `prte_set_session_object`; the destructor frees only the array |
+| `node->topology` | yes | a topology outlives any one node pointing at it |
+| `map->nodes[]` | yes | `prte_job_map_destruct` releases every node it holds — so anything that *puts* a node in a map must retain it |
+
+`prte_job_destruct` also has to reach into the job's attributes and release
+the pointers hiding in them (`PRTE_JOB_TIMEOUT_EVENT`,
+`PRTE_SPAWN_TIMEOUT_EVENT`, `PRTE_JOB_ABORTED_PROC`, `PRTE_JOB_INFO_CACHE`):
+an attribute holding `PMIX_POINTER` is invisible to the generic attribute
+teardown.
+
+### The global registries
+
+`prte_job_data` and `prte_sessions` are **slot maps, not append-only logs**:
+`prte_set_job_data_object` / `prte_set_session_object` scan for the first
+free slot and reuse it, and the destructors NULL their own slot out. Two
+things follow — a destroyed object silently vacates its index, and the index
+you were handed can be handed to somebody else later.
+
+The lookups are linear scans over the whole array. That is fine at DVM
+scale, but do not put one inside a per-proc loop on a launch path.
+
+---
+
+## Sessions (reservations)
+
+A `prte_session_t` is an allocation. `prte_default_session` is the general,
+unreserved pool; it is special-cased everywhere:
+
+- its `nodes` array **is** `prte_node_pool` (`prte_init` releases the array
+  the constructor made and substitutes the global one);
+- it is owned by everyone — `prte_session_is_owned_by` and
+  `prte_session_add_owner` both short-circuit on it;
+- `prte_ras_base_release_allocation` returns immediately for it.
+
+`prte_session_is_owned_by` is the ownership gate for spawning into a
+reservation. Note the trap it stepped in: **`PMIX_CHECK_NSPACE` answers
+"true" when either side is an empty nspace** — that is its wildcard rule.
+`prte_pmix_server_globals.scheduler.nspace` is empty until a scheduler
+connects, so testing it unguarded declared every namespace to be the
+scheduler on every DVM running without one, and the whole check collapsed
+into an unconditional yes. Guard any such comparison with
+`PMIX_NSPACE_INVALID` first.
+
+---
+
+## Progress threads
+
+`prte_progress_thread_init(name)` is refcounted by name and returns an
+existing base for a name already in use. Each tracker owns an event base, a
+`pmix_thread_t`, and a persistent long-timeout event that exists purely so
+the base is never empty (an empty base makes `prte_event_loop` return
+immediately and the engine spin).
+
+`prte_progress_thread_pause(NULL)` means "pause them all" and is what
+`prte_finalize` uses. With a name, `pause`/`resume`/`finalize` all report
+`PRTE_ERR_NOT_FOUND` for a name that does not exist — the header has always
+said so.
+
+`prte_progress_thread_parse_cpus()` expands the `prte_progress_thread_cpus`
+specification. It is deliberately outside the `HAVE_PTHREAD_SETAFFINITY_NP`
+guard its only caller sits behind, so it can be tested on a platform without
+`pthread_setaffinity_np`; ranges are **inclusive** of their upper bound.
+
+---
+
+## Gotchas before you edit
+
+- **`prte_config.h` first.** Every `.c` file in the tree, no exceptions.
+- **Logical macros are `#if`, not `#ifdef`.** `configure` emits things like
+  `PRTE_PICKY_COMPILERS` and `PRTE_WANT_HOME_CONFIG_FILES` with
+  `AC_DEFINE_UNQUOTED` as `0` or `1`, so they are *always defined* and
+  `#ifdef` never excludes anything. `prte_finalize`'s entire teardown sat
+  behind `#ifdef PRTE_PICKY_COMPILERS` and had therefore always run — and
+  "correcting" it to `#if` would have silently deleted the teardown from
+  every normal build. If you find one of these, work out which behavior is
+  the intended one before changing the spelling.
+- **The `#else` arms get compiled somewhere.** `--disable-per-user-config-files`
+  turns `PRTE_WANT_HOME_CONFIG_FILES` off, and that arm had been calling a
+  function that does not exist. If you add a variant arm, build it.
+- **`PMIX_NEW` does not zero the allocation.** Anything a destructor
+  `free()`s, or any field a comparison reads, has to be set by the
+  constructor. The campaign objects and the data-server objects both learned
+  this the hard way.
+- **A pointer array's `size` is not the caller's to set.** Copy through
+  `pmix_pointer_array_set_item` and let the array grow itself; blitting the
+  bookkeeping across and then writing `addr[i]` directly overruns whatever
+  the destination constructor allocated (`PRTE_GLOBAL_ARRAY_BLOCK_SIZE`
+  entries).
+- **`strtoul`'s end pointer is never NULL.** It points at the first
+  unconsumed character, so a "did it stop at a delimiter" test has to look
+  at `*end`, not at `end`.
+- **Attributes are `prte_attribute_t`, not `prte_value_t`.** They look
+  similar enough to walk with the wrong type and still compile; the value
+  then comes from the wrong offset and the key is dropped entirely.
+- **Only `PRTE_ATTR_GLOBAL` attributes go on the wire.** That asymmetry is
+  load-bearing — the mapper works on an unpacked *copy* of the job, so an
+  attribute it must read has to be GLOBAL. See
+  [`data_type_support/AGENTS.md`](data_type_support/AGENTS.md).
+- **Everything runs on the PRRTE progress thread.** Nothing in this
+  directory may be touched from a PMIx callback without a thread-shift; see
+  the golden rule in the top-level `AGENTS.md`.
+- **Warnings are errors.** Debug builds enable `--enable-devel-check`.
+
+---
+
+## Session teardown at finalize
+
+`prte_finalize` releases the sessions, and the node pool goes with them.
+Three constraints fix the order, and all three have to hold:
+
+1. **Sessions before the pool.** A reservation holds a *counted* reference
+   on each of its nodes, so it has to give those back while the nodes are
+   still alive.
+2. **The default session last.** Its node array *is* `prte_node_pool`, so
+   releasing it performs the pool teardown — every other session must
+   already have let go by then. `prte_finalize` keeps a fallback loop for
+   the case where there is no default session at all (a process that failed
+   partway through `prte_init`).
+3. **Before the `ras` framework closes.** `session_des` calls
+   `prte_ras_base_release_allocation`, which walks
+   `prte_ras_base.selected_modules`. Today nothing closes that framework —
+   neither `ess/hnp`'s `rte_finalize` nor `ess/base`'s `prted_finalize` — so
+   the list is still valid at finalize. **If you ever add that close, this
+   block has to move ahead of it**, or the walk runs over a destructed list.
+
+Reaching `release_allocation` here is deliberate, not collateral: it only
+cancels an allocation PRRTE itself created dynamically and still tracks, so
+a DVM that exits still holding a sub-allocation gives it back, while a
+user's own resource-manager allocation is left alone.
+
+`session->children` needs no separate walk. Nothing in the tree ever
+populates that array — which also means `prte_sessions_related()` can only
+ever report identity, and its parent/child branch is unreachable today.
+
+## Known gaps
+
+- **`prte_job_copy` and `prte_proc_copy` have no callers.** They are
+  `PMIX_RETAIN` + assign, i.e. aliases rather than copies, which is a
+  surprising thing for a function named `copy` to be. `prte_app_copy` and
+  `prte_map_copy` have no callers either but are real deep copies.
+
+---
+
+## Testing
+
+**Unit tests — `test/unit/runtime/test_runtime.c`, run by `make check`.**
+Covers what needs no DVM, which is most of this directory: the job/session
+registries (including slot reuse and duplicate rejection), session ownership,
+proc lookups, node matching and its aliases, the copy functions (including a
+map with more nodes than one array block, and the refcount arithmetic when
+both maps are released), the pack/unpack round trips for job/app/proc/node/map
+and the GLOBAL-vs-LOCAL attribute split, object lifetimes and the borrowed
+backpointer contract, the exit-status macros, the data server's range checks
+and object construction, and the progress-thread cpu parser and lifecycle.
+
+It builds the global arrays by hand (`prte_init_util` does not) and calls
+`PMIx_server_init` because `PMIx_Data_pack` refuses to run until PMIx is up.
+
+**Multi-node — `contrib/dockerswarm`, the `test_runtime` phase.** The data
+server is a genuinely distributed service — the store lives on the HNP and
+every participant reaches it over the RML — so publish/lookup/unpublish
+across nodes, the range and userid access checks between real processes, and
+the `PMIX_WAIT` path where a lookup parks until a later publish satisfies it
+all need real daemons. So does DVM teardown, which is where the object
+destructors actually run.
+
+**What is not covered anywhere:** the `prte_init`/`prte_finalize` sequence
+itself beyond the smoke test, and the `#else` arm of
+`PRTE_WANT_HOME_CONFIG_FILES` (nothing in CI configures with
+`--disable-per-user-config-files`).

--- a/src/runtime/CLAUDE.md
+++ b/src/runtime/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -1,0 +1,165 @@
+# AGENTS.md — `src/runtime/data_server`
+
+Orientation for AI agents and human contributors. Read
+[`../AGENTS.md`](../AGENTS.md) first for the runtime's object model and
+ownership rules, and the top-level [`AGENTS.md`](../../../AGENTS.md) for the
+project rules. When this file and the docs disagree, **the docs win**.
+
+---
+
+## What this is
+
+The data server backs PMIx's publish/lookup/unpublish service — the
+key/value rendezvous MPI applications use for `MPI_Publish_name` and
+friends. It is a **single store on one process** (normally the HNP) that
+every other participant reaches over the RML.
+
+```
+app proc ──PMIx──▶ its prted ──RML(PRTE_RML_TAG_DATA_SERVER)──▶ HNP
+                                                                 │
+                                                       prte_data_server()
+                                                                 │
+                          ┌──────────────┬──────────────┬────────┴─────┐
+                     ds_publish     ds_lookup     ds_unpublish     ds_purge
+                                                                 │
+app proc ◀─PMIx── its prted ◀──RML(PRTE_RML_TAG_DATA_CLIENT)─────┘
+```
+
+| File | Role |
+|------|------|
+| `prte_data_server.h` | The public surface: init/finalize, the RML receive callback, and the four command codes. |
+| `ds.h` | The internal objects — `prte_data_object_t` (one published item), `prte_data_req_t` (one parked lookup), `prte_ds_info_t`, and the `prte_data_store` singleton. |
+| `ds_main.c` | `prte_data_server()` — the RML receive that unpacks the room number and command and dispatches; `prte_data_server_check_range()`; all the class instances. |
+| `ds_publish.c` | Store an item, then satisfy any parked lookups it answers. |
+| `ds_lookup.c` | Answer from the store, or park the request if the caller asked to wait. |
+| `ds_unpublish.c` | Remove the caller's own items by key. |
+| `ds_purge.c` | Remove everything a (departing) process owns. |
+
+State is `prte_data_store`: a `pmix_pointer_array_t` of published objects
+plus a `pmix_list_t` of parked requests. There is no locking — everything
+runs on the PRRTE progress thread, inside the RML receive.
+
+---
+
+## The answer-buffer contract
+
+This is the single easiest thing to get wrong here, so it is written down.
+
+`prte_data_server()` creates `answer`, packs the room number and the command
+into it, and hands it to a sub-handler. From that point:
+
+> **Returning `PMIX_SUCCESS` means the handler has disposed of `answer`** —
+> sent it, or released it. **Returning anything else means the handler left
+> it alone**, and `prte_data_server()` packs the error into it and sends it.
+
+Both halves matter. `prte_ds_lookup`'s wait path returns without sending
+anything (the request is parked until a publish satisfies it); it therefore
+has to *release* the buffer, or every waiting lookup leaks one. And a
+handler that has already sent the buffer must not return an error, or the
+caller sends a freed buffer.
+
+The room number leads every reply because it is how the requesting PMIx
+client matches an answer to its outstanding request. A reply that omits it,
+or that carries a status without the payload the status implies, wedges the
+client rather than failing it.
+
+A related trap, seen in three of these files: `PMIx_Data_pack(NULL, buf,
+&rc, 1, PMIX_STATUS)` assigned back to `rc` packs the right value but then
+discards it, so the error being reported is replaced by the pack's own
+status. Keep the two in separate variables.
+
+---
+
+## Ranges — the access-control rules
+
+`prte_data_server_check_range()` decides whether a requestor may see a
+published item. It is the only access control here, so it is worth reading
+before changing:
+
+| `data->range` | Admits |
+|---------------|--------|
+| `SESSION`, `GLOBAL`, `UNDEF` | anyone |
+| `NAMESPACE` | any rank of the publisher's namespace |
+| `LOCAL` | requestors behind the same daemon (`req->proxy` vs `data->proxy`) |
+| `PROC_LOCAL` | the publishing process itself |
+| `RM` | our own (the host server's) namespace |
+| `CUSTOM` | **nobody** — the accessor list is not implemented |
+
+`CUSTOM` denying is deliberate, not an oversight in the tests: the function
+falls through to `return PMIX_ERROR`, which is the safe direction for an
+unimplemented rule.
+
+Separately from the range, both publish and lookup compare `uid` — data is
+only visible to the user that posted it. That check is in the callers, not
+in `check_range`.
+
+`data->proxy` and `req->proxy` are what the `LOCAL` rule compares, and
+`PMIX_NEW` does not zero its allocation, so both constructors have to
+`PMIX_PROC_CONSTRUCT` them. They did not, and the `LOCAL` check was reading
+uninitialized memory.
+
+---
+
+## Persistence and parked requests
+
+`PMIX_PERSIST_FIRST_READ` removes an item from `data->info` as soon as it is
+returned. Both `ds_lookup` (returning from the store) and `ds_publish`
+(satisfying a parked request) implement it, and both then have to notice
+that an object whose `info` list is now empty must leave the store.
+
+A lookup carrying `PMIX_WAIT` that cannot be fully satisfied is parked on
+`prte_data_store.pending` with **only the keys it is still missing**. When a
+later publish resolves the rest, `complete_resolved` is what says the
+request is finished — do not re-derive it by counting `req->keys`, because
+that array has already been swapped for the unresolved remainder.
+
+`ds_purge` drops both the departing process's published items *and* any
+lookup it left parked; a request that outlives its requestor would otherwise
+have a later publish trying to reply to a process that no longer exists.
+
+---
+
+## Gotchas before you edit
+
+- **The answer-buffer contract above.** Every new exit path has to say which
+  side of it you are on.
+- **`PMIX_RELEASE(req)` while `req` is still on `pending` leaves a freed
+  item on the list.** Remove it first.
+- **Success paths free too.** `ds_publish` unpacks a `pmix_info_t` array,
+  copies what it keeps into the data object, and has to `PMIX_INFO_FREE` the
+  array — that was happening only on the unpack-failure path, so a
+  successful publish leaked.
+- **A stack `PMIX_CONSTRUCT`ed object needs `PMIX_DESTRUCT` on *every*
+  return.** `ds_lookup` and `ds_unpublish` both build a `prte_data_req_t` on
+  the stack to carry the requestor into `check_range`.
+- **No locking, and none is wanted.** Everything here runs inside the RML
+  receive on the progress thread.
+- **`prte_data_store.output` is `-1` until a verbosity is registered**, so
+  `pmix_output_verbose` on it is a no-op. That is fine — do not "fix" it by
+  reaching for `pmix_output(0, ...)`.
+
+---
+
+## Testing
+
+**Unit — `test/unit/runtime/test_runtime.c`.** `prte_data_server_check_range`
+against every range value in both directions, and the object constructors'
+initialization contract. Neither needs the RML.
+
+**Multi-node — `contrib/dockerswarm`, the `test_runtime` phase.** The store
+is on the HNP and the clients are elsewhere, so the interesting paths only
+exist with real daemons: a publish on one node found by a lookup on another,
+the range and userid rules between real processes, unpublish, and the
+`PMIX_WAIT` path where a lookup parks until a later publish satisfies it.
+
+**Not covered:** `PMIX_RANGE_CUSTOM` (no accessor list exists to test),
+`PMIX_PERSIST_FIRST_READ` end-to-end, and `ds_purge` (which is driven by
+process termination rather than by a client call).
+
+A note on the partial-lookup case, because it took both code bases to make
+it work. PRRTE returning the status *and* the values it found is only half
+of it: the PMIx client used to answer its lookup callback with
+`(status, NULL, 0)` for anything other than `PMIX_SUCCESS`, so a correct
+server still produced an empty answer. That is fixed upstream
+(`pmix_client_pub.c`), which means the swarm case needs a PMIx built from
+source — `PMIX_SRC=... ./build.sh` — to pass.

--- a/src/runtime/data_server/CLAUDE.md
+++ b/src/runtime/data_server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/runtime/data_server/ds_lookup.c
+++ b/src/runtime/data_server/ds_lookup.c
@@ -56,7 +56,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     int32_t count;
     int i, k;
     size_t nanswers;
-    pmix_status_t rc;
+    pmix_status_t rc, ret;
     pmix_proc_t requestor;
     size_t n, ninfo;
     char **keys = NULL, **cache = NULL;
@@ -215,6 +215,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             PMIX_LIST_DESTRUCT(&answers);
             PMIx_Argv_free(keys);
             PMIx_Argv_free(cache);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_DESTRUCT(&rq);
             return rc;
         }
         /* loop thru and pack the individual responses - this is somewhat less
@@ -230,6 +232,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
                 PMIX_LIST_DESTRUCT(&answers);
                 PMIx_Argv_free(keys);
                 PMIx_Argv_free(cache);
+                PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                PMIX_DESTRUCT(&rq);
                 return rc;
             }
             rc = PMIx_Data_pack(NULL, &pbkt, &rinfo->info, 1, PMIX_INFO);
@@ -238,6 +242,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
                 PMIX_LIST_DESTRUCT(&answers);
                 PMIx_Argv_free(keys);
                 PMIx_Argv_free(cache);
+                PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                PMIX_DESTRUCT(&rq);
                 return rc;
             }
         }
@@ -263,48 +269,72 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             pmix_list_append(&prte_data_store.pending, &req->super);
             PMIx_Argv_free(keys);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_DESTRUCT(&rq);
+            /* No answer goes back now - the request waits until a publish
+             * satisfies it. Our caller's contract is "PMIX_SUCCESS means the
+             * handler has disposed of the answer buffer", so dispose of it:
+             * the publish path builds a fresh reply of its own, and leaving
+             * this one behind leaked a buffer per waiting lookup. */
+            PMIX_DATA_BUFFER_RELEASE(answer);
             return PMIX_SUCCESS; // do not return an answer
         } else {
             PMIx_Argv_free(cache);
+            cache = NULL;
             if (0 == nanswers) {
                 /* nothing was found - indicate that situation */
                 rc = PMIX_ERR_NOT_FOUND;
                 PMIx_Argv_free(keys);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                PMIX_DESTRUCT(&rq);
                 return rc;
             } else {
                 rc = PMIX_ERR_PARTIAL_SUCCESS;
             }
         }
+    } else {
+        rc = PMIX_SUCCESS;
     }
     PMIx_Argv_free(keys);
+    PMIX_DESTRUCT(&rq);
 
     pmix_output_verbose(1, prte_data_store.output,
                         "%s data server:lookup: data found - status %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         PMIx_Error_string(rc));
 
-    if (PMIX_SUCCESS == rc) {
-        /* pack the status */
-        rc = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            return rc;
-        }
-        /* unload the packed values */
-        rc = PMIx_Data_unload(&pbkt, &pbo);
-        /* pack it into our reply */
-        rc = PMIx_Data_pack(NULL, answer, &pbo, 1, PMIX_BYTE_OBJECT);
-        PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
-        PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(answer);
-        }
+    /* We get here having found at least something, so the answer carries
+     * data whether the status is SUCCESS or PARTIAL_SUCCESS - a partial
+     * result used to fall straight through to "return rc", which handed the
+     * caller an error to relay and quietly dropped both the values we found
+     * and the buffer holding them. */
+    ret = rc;
+    /* pack the status */
+    rc = PMIx_Data_pack(NULL, answer, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+        return rc;
     }
-    return rc;
+    /* unload the packed values */
+    rc = PMIx_Data_unload(&pbkt, &pbo);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+        return rc;
+    }
+    /* pack it into our reply */
+    rc = PMIx_Data_pack(NULL, answer, &pbo, 1, PMIX_BYTE_OBJECT);
+    PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(answer);
+        return rc;
+    }
+    /* the answer has been sent - tell our caller not to send another */
+    return PMIX_SUCCESS;
 }

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -164,6 +164,9 @@ void prte_data_server(int status, pmix_proc_t *sender,
         return;
     }
 
+    /* From here on the handlers own "answer": each of them either sends it
+     * or releases it and returns PMIX_SUCCESS. Anything else comes back to
+     * us still holding the buffer, and we turn it into an error reply. */
     switch (command) {
         case PRTE_PMIX_PUBLISH_CMD:
             rc = prte_ds_publish(sender, buffer, answer);
@@ -193,18 +196,24 @@ void prte_data_server(int status, pmix_proc_t *sender,
     }
 
     if (PMIX_SUCCESS != rc) {
+        pmix_status_t ret;
+
         pmix_output_verbose(1, prte_data_store.output,
                             "%s data server: sending error %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                             PRTE_ERROR_NAME(rc));
-        /* pack the error code */
-        rc = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
+        /* pack the error code. Keep the pack status in its own variable:
+         * overwriting rc with it lost the very code we were reporting, and
+         * a failed pack then went out as a "successful" empty answer. */
+        ret = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(answer);
+            return;
         }
-        PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
+        PRTE_RML_RELIABLE_SEND(ret, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_RELEASE(answer);
         }
     }
@@ -282,6 +291,11 @@ pmix_status_t prte_data_server_check_range(prte_data_req_t *req,
 static void construct(prte_data_object_t *ptr)
 {
     ptr->index = -1;
+    /* proxy has to be initialized here as well as owner: it is what the
+     * PMIX_RANGE_LOCAL check compares against, and PMIX_NEW does not zero
+     * the allocation, so an object whose publisher never filled it in was
+     * matching requestors against uninitialized memory */
+    PMIX_PROC_CONSTRUCT(&ptr->proxy);
     PMIX_PROC_CONSTRUCT(&ptr->owner);
     ptr->uid = UINT32_MAX;
     ptr->range = PMIX_RANGE_SESSION;
@@ -301,6 +315,9 @@ PMIX_CLASS_INSTANCE(prte_data_object_t,
 
 static void rqcon(prte_data_req_t *p)
 {
+    PMIX_PROC_CONSTRUCT(&p->proxy);
+    PMIX_PROC_CONSTRUCT(&p->requestor);
+    p->room_number = -1;
     p->keys = NULL;
     p->uid = UINT32_MAX;
     p->range = PMIX_RANGE_UNDEF;

--- a/src/runtime/data_server/ds_publish.c
+++ b/src/runtime/data_server/ds_publish.c
@@ -134,6 +134,10 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             pmix_list_append(&data->info, &ds1->super);
         }
     }
+    /* the values we keep were copied into the data object above, so the
+     * unpacked array has done its job - it used to be freed only on the
+     * unpack-failure path, which leaked it on every successful publish */
+    PMIX_INFO_FREE(info, ninfo);
 
     // add this data to our store
     data->index = pmix_pointer_array_add(&prte_data_store.store, data);
@@ -224,29 +228,26 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
         rc = PMIx_Data_pack(NULL, reply, &req->room_number, 1, PMIX_INT);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(reply);
-            return rc;
+            goto reply_failed;
         }
         /* we are responding to a lookup cmd */
         command = PRTE_PMIX_LOOKUP_CMD;
         rc = PMIx_Data_pack(NULL, reply, &command, 1, PMIX_UINT8);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(reply);
-            return rc;
+            goto reply_failed;
         }
-        /* if we found all of the requested keys, then indicate so */
-        if (n == (size_t) PMIx_Argv_count(req->keys)) {
-            rc = PMIX_SUCCESS;
-        } else {
-            rc = PMIX_ERR_PARTIAL_SUCCESS;
-        }
+        /* If every key the request was still waiting on has now been
+         * resolved, the lookup completed. Do NOT re-derive that from
+         * req->keys: the unresolved remainder was swapped into it a few
+         * lines above, so comparing our answer count against it reported
+         * PARTIAL_SUCCESS for a request we had in fact satisfied in full. */
+        ret = complete_resolved ? PMIX_SUCCESS : PMIX_ERR_PARTIAL_SUCCESS;
         /* return the status */
-        rc = PMIx_Data_pack(NULL, reply, &rc, 1, PMIX_STATUS);
+        rc = PMIx_Data_pack(NULL, reply, &ret, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(reply);
-            return rc;
+            goto reply_failed;
         }
 
         /* pack the rest into a pmix_data_buffer_t */
@@ -257,8 +258,7 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             PMIX_ERROR_LOG(ret);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             rc = PRTE_ERR_PACK_FAILURE;
-            PMIX_DATA_BUFFER_RELEASE(reply);
-            return rc;
+            goto reply_failed;
         }
         /* loop thru and pack the individual responses - this is somewhat less
          * efficient than packing an info array, but avoids another malloc
@@ -269,25 +269,31 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             ret = PMIx_Data_pack(NULL, &pbkt, &data->owner, 1, PMIX_PROC);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
+                PMIX_RELEASE(ds3);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 rc = PRTE_ERR_PACK_FAILURE;
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return rc;
+                goto reply_failed;
             }
             /* pack the data */
             ret = PMIx_Data_pack(NULL, &pbkt, &ds3->info, 1, PMIX_INFO);
+            PMIX_RELEASE(ds3);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 rc = PRTE_ERR_PACK_FAILURE;
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return rc;
+                goto reply_failed;
             }
         }
         PMIX_LIST_DESTRUCT(&answers);
 
         /* unload the pmix buffer */
         rc = PMIx_Data_unload(&pbkt, &pbo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return rc;
+        }
 
         /* pack it into our reply */
         rc = PMIx_Data_pack(NULL, reply, &pbo, 1, PMIX_BYTE_OBJECT);
@@ -295,7 +301,9 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
-            PMIX_RELEASE(req);
+            /* Leave the request on the pending list. It used to be released
+             * right here while still linked into that list, which left a
+             * freed item behind for the next publish to walk into. */
             return rc;
         }
         PRTE_RML_RELIABLE_SEND(rc, req->proxy.rank, reply, PRTE_RML_TAG_DATA_CLIENT);
@@ -317,13 +325,26 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
         if (NULL == data) {
             break;
         }
+        continue;
+
+    reply_failed:
+        /* a reply to one waiting requestor could not be assembled. Drop it
+         * and let the publish itself report the failure - but not before
+         * releasing the partial reply and the answers we had collected,
+         * both of which used to leak straight out of the function. */
+        PMIX_LIST_DESTRUCT(&answers);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return rc;
     }
 
     if (PMIX_SUCCESS == rc) {
+        pmix_status_t st = PMIX_SUCCESS;
+
         // send back an answer
-        rc = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
+        rc = PMIx_Data_pack(NULL, answer, &st, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            return rc;
         }
         PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
         if (PRTE_SUCCESS != rc) {

--- a/src/runtime/data_server/ds_purge.c
+++ b/src/runtime/data_server/ds_purge.c
@@ -56,8 +56,9 @@ void prte_ds_purge(pmix_proc_t *sender,
     int32_t count;
     prte_data_object_t *data;
     int k;
-    pmix_status_t rc;
+    pmix_status_t rc, ret;
     pmix_proc_t requestor;
+    prte_data_req_t *req, *rqnext;
 
     /* unpack the proc whose data is to be purged - session
      * data is purged by providing a requestor whose rank
@@ -89,15 +90,35 @@ void prte_ds_purge(pmix_proc_t *sender,
         PMIX_RELEASE(data);
     }
 
-done:
-    // send back an answer
-    rc = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    /* Drop any lookup this process left parked on the pending list. Those
+     * requests outlived their requestor: a later publish would match one and
+     * try to reply to a process that no longer exists, and until then the
+     * request kept the (already purged) proc's keys alive. */
+    PMIX_LIST_FOREACH_SAFE(req, rqnext, &prte_data_store.pending, prte_data_req_t) {
+        if (!PMIX_CHECK_PROCID(&requestor, &req->requestor)) {
+            continue;
+        }
+        pmix_output_verbose(1, prte_data_store.output,
+                            "%s data server: dropping pending request from %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            PMIX_NAME_PRINT(&req->requestor));
+        pmix_list_remove_item(&prte_data_store.pending, &req->super);
+        PMIX_RELEASE(req);
     }
-    PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+
+done:
+    // send back an answer. Keep the pack status separate from the status
+    // being reported: packing into the same variable we are packing FROM
+    // discards the outcome the requestor asked about.
+    ret = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(answer);
+        return;
+    }
+    PRTE_RML_RELIABLE_SEND(ret, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(answer);
     }
 }

--- a/src/runtime/data_server/ds_unpublish.c
+++ b/src/runtime/data_server/ds_unpublish.c
@@ -77,6 +77,7 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &rq.requestor, &count, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_DESTRUCT(&rq);
         return rc;
     }
 
@@ -90,11 +91,13 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &count, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_DESTRUCT(&rq);
         return rc;
     }
     if (0 == ninfo) {
         /* they forgot to send us the keys?? */
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        PMIX_DESTRUCT(&rq);
         return PMIX_ERR_BAD_PARAM;
     }
 
@@ -116,6 +119,7 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &count, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        PMIX_DESTRUCT(&rq);
         return rc;
     }
     if (0 < ninfo) {
@@ -125,6 +129,7 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_INFO_FREE(info, ninfo);
+            PMIX_DESTRUCT(&rq);
             return rc;
         }
         /* scan the directives for things we care about */
@@ -178,10 +183,13 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
     PMIX_DESTRUCT(&rq);
 
     if (PMIX_SUCCESS == rc) {
+        pmix_status_t st = PMIX_SUCCESS;
+
         // send back an answer
-        rc = PMIx_Data_pack(NULL, answer, &rc, 1, PMIX_STATUS);
+        rc = PMIx_Data_pack(NULL, answer, &st, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            return rc;
         }
         PRTE_RML_RELIABLE_SEND(rc, sender->rank, answer, PRTE_RML_TAG_DATA_CLIENT);
         if (PRTE_SUCCESS != rc) {

--- a/src/runtime/data_type_support/AGENTS.md
+++ b/src/runtime/data_type_support/AGENTS.md
@@ -1,0 +1,155 @@
+# AGENTS.md — `src/runtime/data_type_support`
+
+Orientation for AI agents and human contributors. Read
+[`../AGENTS.md`](../AGENTS.md) first — the ownership rules there are what
+these functions have to honor. The project rules are in the top-level
+[`AGENTS.md`](../../../AGENTS.md); when this file and the docs disagree,
+**the docs win**.
+
+---
+
+## What this is
+
+Four operations over the runtime's core objects, one file each:
+
+| File | Provides |
+|------|----------|
+| `prte_dt_packing_fns.c` | `prte_{job,app,proc,node,map}_pack` |
+| `prte_dt_unpacking_fns.c` | `prte_{job,app,proc,node,map}_unpack` |
+| `prte_dt_copy_fns.c` | `prte_{job,app,proc,node,map}_copy` |
+| `prte_dt_print_fns.c` | `prte_{job,app,proc,node,map}_print` |
+
+All of it is plain C over `PMIx_Data_pack`/`PMIx_Data_unpack`; there is no
+framework, no registration, and no type-id table. The prototypes live in
+[`../prte_globals.h`](../prte_globals.h).
+
+---
+
+## Packing is deliberately partial
+
+The comment at the top of `prte_job_pack` is the important one:
+
+> We do not pack all of the job object's fields as many of them have no
+> value in sending them to another location. The only purpose in packing and
+> sending a job object is to communicate the data required to dynamically
+> spawn another job — so we only pack that limited set of required data.
+
+So this is **not** serialization of a `prte_job_t`. It is the launch
+message. `job->map` is packed for the policies it carries, not for the nodes
+it mapped (`prte_map_pack` sends `req_mapper`/`last_mapper`/mapping/ranking/
+binding/`num_nodes` and nothing else). Node procs, topologies, session
+backpointers, the session dir, `cli`, and the counters are all left behind.
+
+The two sides are hand-written mirrors with no format version and no
+self-description. **Every field added to the packer must be added to the
+unpacker in the same position, in the same PMIx type.** There is nothing
+that will catch a mismatch for you: a type of the same width (`PMIX_INT32`
+against `PMIX_UINT32`) silently produces wrong values, and a type of a
+different width desynchronizes everything after it.
+
+### The GLOBAL/LOCAL attribute split
+
+Only attributes marked `PRTE_ATTR_GLOBAL` are packed; the unpacker marks
+everything it reads back as `PRTE_ATTR_GLOBAL` ("obviously not a local
+value"). This asymmetry is load-bearing and is a recurring source of bugs
+elsewhere in the tree: **the mapper runs against an unpacked copy of the
+job**, so any attribute the mapper has to read must be set GLOBAL at the
+point it is created, or it simply is not there by the time anyone looks.
+
+---
+
+## Copying
+
+`prte_job_copy` and `prte_proc_copy` are `PMIX_RETAIN` + assign — aliases,
+not copies. `prte_node_copy`, `prte_app_copy`, and `prte_map_copy` are real
+deep copies. Only `prte_node_copy` has a caller today (the `ras`
+`multiplier`, which fabricates duplicate nodes for mapper testing); the rest
+are dead but exported.
+
+Three rules the copies have to obey, all of which were being broken:
+
+1. **A copy is only useful if it carries identity.** A node answers to its
+   `name`, its `rawname`, and every entry in `aliases`; it belongs to a
+   `session`; and its `attributes` carry the per-node settings that decide
+   how it is launched (`PRTE_NODE_USERNAME`, `PRTE_NODE_PORT`). A copy
+   missing any of those is a node that cannot be found by the names the
+   allocation used, or cannot be launched the same way.
+2. **Attributes are `prte_attribute_t`.** `prte_app_copy` walked
+   `app->attributes` as a list of `prte_value_t` — similar enough to
+   compile, different enough that the value came from the wrong offset and
+   the key (which `prte_value_t` does not have) was dropped, leaving every
+   copied attribute unfindable.
+3. **Copy into a pointer array through `pmix_pointer_array_set_item`.**
+   `prte_map_copy` used to blit the source array's `size`/`max_size`/
+   `block_size` over the destination's and then assign `addr[i]` directly.
+   The destination's `addr` is whatever `prte_job_map_construct` allocated —
+   `PRTE_GLOBAL_ARRAY_BLOCK_SIZE` (64) entries — so any map spanning more
+   nodes than that wrote off the end of the heap block, and the copied-in
+   metadata then told every later reader the array was bigger than it is.
+   And because `prte_job_map_destruct` releases every node it holds, a copy
+   that takes no reference leaves the two maps dropping one refcount too
+   many between them.
+
+---
+
+## Printing
+
+`prte_map_print` (called from `rmaps_base_map_job.c` for `--display map`)
+and `prte_app_print` (called from the odls) are the live entry points;
+`prte_job_print` and `prte_node_print`/`prte_proc_print` are reached from
+them.
+
+Three output shapes share the code, selected by job attributes:
+`PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT` (XML), `PRTE_JOB_DISPLAY_DEVEL_MAP`
+(the developer dump), and neither (the short user form). They are not
+symmetric — a guard added to one arm is not present in the others unless
+you put it there. `prte_proc_print` had NULL checks on
+`src->node->topology` in two of its three arms and none in the third, and
+none of the three checked `src->node` itself, which is NULL for an unmapped
+proc and for a proc that outlived its node.
+
+The string building is `pmix_asprintf`-and-free chaining: `tmp` always owns
+the accumulated string, each step builds `tmp2` from it, frees `tmp`, and
+reassigns. Any `continue` inside such a loop that skips the
+`free(tmp1); tmp1 = tmp2;` step both leaks the new string and drops that
+iteration's contribution from the output.
+
+---
+
+## Gotchas before you edit
+
+- **Pack and unpack are edited together, always.** There is no version and
+  no check.
+- **Match the PMIx type to the C type.** `prte_app_idx_t` is `uint32_t`,
+  `prte_node_state_t` is `int8_t`, `prte_local_rank_t`/`prte_node_rank_t`
+  are `uint16_t`, `prte_job_state_t`/`prte_exit_code_t` are `int32_t`. See
+  [`src/include/types.h`](../../include/types.h),
+  [`src/util/attr.h`](../../util/attr.h), and
+  [`src/mca/plm/plm_types.h`](../../mca/plm/plm_types.h).
+- **`PMIx_Data_unpack`'s count is in/out.** Reset it to 1 before each call
+  rather than relying on the previous call having left it there.
+- **An unpack that fails mid-object must release the partially built
+  object.** All of these do; keep it that way when adding a field.
+- **Do not add a new attribute to the packer and forget its disposition.**
+  If the receiving side needs it, it has to be `PRTE_ATTR_GLOBAL` where it
+  is set — packing is filtered on that flag, not chosen per call site.
+
+---
+
+## Testing
+
+**Unit — `test/unit/runtime/test_runtime.c`.** Round trips for job (with
+apps, procs, a map, personality, and both a GLOBAL and a LOCAL attribute,
+asserting the LOCAL one does *not* cross) and for node; the mapless-job
+case; and all three deep copies, including a map deliberately built with
+more nodes than one array block and a refcount check after both maps are
+released.
+
+**Multi-node — `contrib/dockerswarm`.** The packers' real exercise is any
+launch: `prte_job_pack` is what the odls sends and `prte_job_unpack` is what
+every daemon reads, so the whole existing suite covers them implicitly. A
+dynamic spawn (`test_runtime`'s spawn case) drives the
+`pmix_server_dyn.c` path specifically.
+
+**Not covered:** the print functions' XML arm, and `prte_job_copy` /
+`prte_proc_copy` (which have no callers to test through).

--- a/src/runtime/data_type_support/CLAUDE.md
+++ b/src/runtime/data_type_support/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/runtime/data_type_support/prte_dt_copy_fns.c
+++ b/src/runtime/data_type_support/prte_dt_copy_fns.c
@@ -33,6 +33,7 @@
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
+#include "src/util/attr.h"
 #include "src/util/pmix_argv.h"
 
 /**
@@ -52,11 +53,25 @@ int prte_job_copy(prte_job_t **dest, prte_job_t *src)
 int prte_node_copy(prte_node_t **dest, prte_node_t *src)
 {
     prte_node_t *node;
+    prte_attribute_t *kv, *kvnew;
+    pmix_status_t rc;
 
     node = PMIX_NEW(prte_node_t);
-    node->name = strdup(src->name);
+    if (NULL != src->name) {
+        node->name = strdup(src->name);
+    }
+    /* the alternate names a node answers to are part of its identity - a
+     * copy that lacks them is unreachable by any of the names the allocation
+     * actually used */
+    if (NULL != src->rawname) {
+        node->rawname = strdup(src->rawname);
+    }
+    if (NULL != src->aliases) {
+        node->aliases = PMIx_Argv_copy(src->aliases);
+    }
     node->state = src->state;
     node->slots = src->slots;
+    node->slots_available = src->slots_available;
     node->slots_inuse = src->slots_inuse;
     node->slots_max = src->slots_max;
     if (NULL != src->topology) {
@@ -65,6 +80,30 @@ int prte_node_copy(prte_node_t **dest, prte_node_t *src)
     }
     node->topology = src->topology;
     node->flags = src->flags;
+    /* the session backpointer is borrowed, not retained (see
+     * prte_node_destruct) - but it still has to come across, or a duplicated
+     * node silently joins the default pool instead of the reservation its
+     * original belongs to */
+    node->session = src->session;
+
+    /* attributes carry the launch-affecting per-node settings (username,
+     * port, ...); a copy without them cannot be launched the same way */
+    PMIX_LIST_FOREACH(kv, &src->attributes, prte_attribute_t)
+    {
+        kvnew = PMIX_NEW(prte_attribute_t);
+        kvnew->key = kv->key;
+        kvnew->local = kv->local;
+        PMIX_VALUE_XFER_DIRECT(rc, &kvnew->data, &kv->data);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(kvnew);
+            PMIX_RELEASE(node);
+            *dest = NULL;
+            return prte_pmix_convert_status(rc);
+        }
+        pmix_list_append(&node->attributes, &kvnew->super);
+    }
+
     (*dest) = node;
 
     return PRTE_SUCCESS;
@@ -85,7 +124,7 @@ int prte_proc_copy(prte_proc_t **dest, prte_proc_t *src)
  */
 int prte_app_copy(prte_app_context_t **dest, prte_app_context_t *src)
 {
-    prte_value_t *kv, *kvnew;
+    prte_attribute_t *kv, *kvnew;
     pmix_status_t rc;
 
     /* create the new object */
@@ -101,19 +140,31 @@ int prte_app_copy(prte_app_context_t **dest, prte_app_context_t *src)
         (*dest)->app = strdup(src->app);
     }
     (*dest)->num_procs = src->num_procs;
+    (*dest)->state = src->state;
+    (*dest)->first_rank = src->first_rank;
+    (*dest)->flags = src->flags;
     (*dest)->argv = PMIx_Argv_copy(src->argv);
     (*dest)->env = PMIx_Argv_copy(src->env);
     if (NULL != src->cwd) {
         (*dest)->cwd = strdup(src->cwd);
     }
 
-    PMIX_LIST_FOREACH(kv, &src->attributes, prte_value_t)
+    /* app->attributes is a list of prte_attribute_t. It was being walked as
+     * a list of prte_value_t, which has a different layout - so the value
+     * copied out came from the wrong offset, and the attribute's key (which
+     * prte_value_t does not have) was dropped entirely, leaving every copied
+     * attribute unfindable. */
+    PMIX_LIST_FOREACH(kv, &src->attributes, prte_attribute_t)
     {
-        kvnew = PMIX_NEW(prte_value_t);
-        PMIX_VALUE_XFER_DIRECT(rc, &kvnew->value, &kv->value);
+        kvnew = PMIX_NEW(prte_attribute_t);
+        kvnew->key = kv->key;
+        kvnew->local = kv->local;
+        PMIX_VALUE_XFER_DIRECT(rc, &kvnew->data, &kv->data);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(kvnew);
+            PMIX_RELEASE(*dest);
+            *dest = NULL;
             return prte_pmix_convert_status(rc);
         }
         pmix_list_append(&(*dest)->attributes, &kvnew->super);
@@ -130,6 +181,7 @@ int prte_map_copy(struct prte_job_map_t **d, struct prte_job_map_t *s)
     int32_t i;
     prte_job_map_t **dest = (prte_job_map_t **) d;
     prte_job_map_t *src = (prte_job_map_t *) s;
+    prte_node_t *node;
 
     if (NULL == src) {
         *dest = NULL;
@@ -144,23 +196,48 @@ int prte_map_copy(struct prte_job_map_t **d, struct prte_job_map_t *s)
     }
 
     /* copy data into it */
+    if (NULL != src->req_mapper) {
+        (*dest)->req_mapper = strdup(src->req_mapper);
+    }
+    if (NULL != src->last_mapper) {
+        (*dest)->last_mapper = strdup(src->last_mapper);
+    }
     (*dest)->mapping = src->mapping;
     (*dest)->ranking = src->ranking;
     (*dest)->binding = src->binding;
+    (*dest)->rtos_set = src->rtos_set;
     (*dest)->num_new_daemons = src->num_new_daemons;
     (*dest)->daemon_vpid_start = src->daemon_vpid_start;
     (*dest)->num_nodes = src->num_nodes;
 
-    /* copy the pointer array - have to do this manually
-     * as no dss.copy function is setup for that object
+    /* Copy the node array one entry at a time.
+     *
+     * This used to blit the source array's bookkeeping (size, max_size,
+     * block_size, ...) over the destination's and then memcpy addr[] across
+     * it. The destination's addr[] is whatever prte_job_map_construct
+     * allocated - PRTE_GLOBAL_ARRAY_BLOCK_SIZE entries - so any map spanning
+     * more nodes than that wrote off the end of the heap block, and the
+     * copied-in metadata then told every later reader the array was larger
+     * than it is. Going through pmix_pointer_array_set_item lets the array
+     * grow itself.
+     *
+     * Each node also has to be retained: prte_job_map_destruct releases
+     * every node it holds, so a copy that took no reference of its own left
+     * the two maps' destructors dropping one refcount too many between them.
      */
-    (*dest)->nodes->lowest_free = src->nodes->lowest_free;
-    (*dest)->nodes->number_free = src->nodes->number_free;
-    (*dest)->nodes->size = src->nodes->size;
-    (*dest)->nodes->max_size = src->nodes->max_size;
-    (*dest)->nodes->block_size = src->nodes->block_size;
     for (i = 0; i < src->nodes->size; i++) {
-        (*dest)->nodes->addr[i] = src->nodes->addr[i];
+        node = (prte_node_t *) pmix_pointer_array_get_item(src->nodes, i);
+        if (NULL == node) {
+            continue;
+        }
+        PMIX_RETAIN(node);
+        if (0 > pmix_pointer_array_set_item((*dest)->nodes, i, node)) {
+            PMIX_RELEASE(node);
+            PMIX_RELEASE(*dest);
+            *dest = NULL;
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
     }
 
     return PRTE_SUCCESS;

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -77,6 +77,12 @@ static void display_cpus(prte_topology_t *t,
         hwloc_bitmap_and(avail, obj->cpuset, allowed);
         if (hwloc_bitmap_iszero(avail)) {
             pmix_asprintf(&tmp2, "%s            <package id=\"%d\" cpus=\"%s\"/>\n", tmp1, pkg, "NONE");
+            /* fall through to the accumulate step below rather than
+             * continuing: skipping it both dropped this package from the
+             * output and leaked the string just built for it */
+            free(tmp1);
+            tmp1 = tmp2;
+            tmp2 = NULL;
             continue;
         }
         if (bits_as_cores) {
@@ -186,7 +192,7 @@ void prte_job_print(char **output, prte_job_t *src)
  */
 void prte_node_print(char **output, prte_job_t *jdata, prte_node_t *src)
 {
-    char *tmp, *tmp1, *tmp2, *tmp3;
+    char *tmp, *tmp1 = NULL, *tmp2, *tmp3;
     int32_t i,j;
     prte_proc_t *proc;
     prte_topology_t *t;
@@ -349,8 +355,8 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
     physical = prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_PHYSICAL_CPUS, NULL, PMIX_BOOL);
 
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL)) {
-        if (NULL != src->cpuset && NULL != src->node->topology &&
-            NULL != src->node->topology->topo) {
+        if (NULL != src->cpuset && NULL != src->node &&
+            NULL != src->node->topology && NULL != src->node->topology->topo) {
             mycpus = hwloc_bitmap_alloc();
             hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
 
@@ -385,8 +391,8 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
     }
 
     if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_DEVEL_MAP, NULL, PMIX_BOOL)) {
-        if (NULL != src->cpuset && NULL != src->node->topology
-            && NULL != src->node->topology->topo) {
+        if (NULL != src->cpuset && NULL != src->node
+            && NULL != src->node->topology && NULL != src->node->topology->topo) {
             mycpus = hwloc_bitmap_alloc();
             hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
             str = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus, physical,
@@ -419,12 +425,20 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
     free(tmp);
     tmp = tmp3;
 
-    if (NULL != src->cpuset) {
+    /* the topology has to be reachable to render a cpuset: a proc that was
+     * never mapped (or whose node has already been torn down - the node
+     * clears the backpointer on the procs it knows about) has no node, and
+     * this path had none of the guards its two siblings above carry */
+    if (NULL != src->cpuset && NULL != src->node &&
+        NULL != src->node->topology && NULL != src->node->topology->topo) {
         mycpus = hwloc_bitmap_alloc();
         hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
         tmp2 = prte_hwloc_base_cset2str(mycpus, use_hwthread_cpus,
                                         physical, src->node->topology->topo);
         hwloc_bitmap_free(mycpus);
+        if (NULL == tmp2) {
+            tmp2 = strdup("UNBOUND");
+        }
     } else {
         tmp2 = strdup("UNBOUND");
     }

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -39,6 +39,7 @@
 #include "src/mca/base/pmix_mca_base_alias.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/base/base.h"
 #include "src/mca/ess/ess.h"
 #include "src/runtime/prte_globals.h"
@@ -86,7 +87,15 @@ int prte_finalize(void)
     // we always must cleanup the session directory tree
     prte_job_session_dir_finalize(NULL);
 
-#ifdef PRTE_PICKY_COMPILERS
+    /* NOTE: everything below used to sit behind "#ifdef PRTE_PICKY_COMPILERS",
+     * which never excluded anything: configure emits that symbol with
+     * AC_DEFINE_UNQUOTED as 0 or 1, so it is always *defined* and #ifdef is
+     * always true. The teardown has therefore always run in every build, and
+     * it needs to - a persistent DVM's session directories and the PMIx
+     * server both depend on it. Spelling it "#if PRTE_PICKY_COMPILERS" to
+     * match the project rule would have silently deleted all of it from a
+     * normal (non-picky) build, so the guard is gone instead of corrected. */
+
     /* release the cache */
     PMIX_RELEASE(prte_cache);
     PMIX_RELEASE(prte_held_jobs);
@@ -94,9 +103,13 @@ int prte_finalize(void)
     PMIX_LIST_DESTRUCT(&prte_shrink_campaigns);
     PMIX_LIST_DESTRUCT(&prte_grow_campaigns);
 
-    /* call the finalize function for this environment */
-    if (PRTE_SUCCESS != (rc = prte_ess.finalize())) {
-        return rc;
+    /* call the finalize function for this environment. Report a failure but
+     * keep going: bailing out here would skip the rest of the teardown - and
+     * PMIx_server_finalize with it - leaving the session directory tree and
+     * the server's listener behind on the way out. */
+    rc = prte_ess.finalize();
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
     }
     (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
 
@@ -166,7 +179,6 @@ int prte_finalize(void)
     prte_proc_info_finalize();
 
     pmix_output_finalize();
-#endif
 
     /* now shutdown PMIx - need to do this last as it finalizes
      * the utilities and class system we depend upon */

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -58,6 +58,7 @@ int prte_finalize(void)
     prte_proc_t *p;
     prte_node_t *node;
     prte_topology_t *topo;
+    prte_session_t *session;
 
     PMIX_ACQUIRE_THREAD(&prte_init_lock);
     if (!prte_initialized) {
@@ -113,16 +114,60 @@ int prte_finalize(void)
     }
     (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
 
-    // clean up the node array
-    for (n = 0; n < prte_node_pool->size; n++) {
-        node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
-        if (NULL == node) {
-            continue;
+    /* Tear the sessions down, and with them the node pool.
+     *
+     * Order matters in three ways. A reservation holds a COUNTED reference on
+     * each of its nodes, so it has to give those back while the nodes are
+     * still alive - hence sessions before the pool. prte_default_session's
+     * node array IS prte_node_pool (prte_init substitutes it), so releasing
+     * that session performs the pool teardown itself and must therefore go
+     * last. And session_des asks the ras base to release the underlying
+     * allocation, which walks prte_ras_base.selected_modules: the ras
+     * framework is deliberately never closed - neither ess/hnp's rte_finalize
+     * nor ess/base's prted_finalize closes it - so that list is still valid
+     * here. If that ever changes, this block has to move ahead of the close.
+     *
+     * Note that release_allocation only cancels an allocation PRRTE itself
+     * created dynamically and still tracks; a user's own resource-manager
+     * allocation is left alone. So reaching it here is the correct cleanup
+     * for a DVM that exits still holding a sub-allocation, not a hazard.
+     *
+     * session->children is not walked separately: nothing in the tree ever
+     * populates it, and session_des empties it anyway. */
+    if (NULL != prte_sessions) {
+        for (n = 0; n < prte_sessions->size; n++) {
+            session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, n);
+            if (NULL == session || session == prte_default_session) {
+                continue;
+            }
+            pmix_pointer_array_set_item(prte_sessions, n, NULL);
+            PMIX_RELEASE(session);
         }
-        pmix_pointer_array_set_item(prte_node_pool, n, NULL);
-        PMIX_RELEASE(node);
+        if (NULL != prte_default_session) {
+            /* this is what releases prte_node_pool and every node in it */
+            PMIX_RELEASE(prte_default_session);
+            prte_default_session = NULL;
+            prte_node_pool = NULL;
+        }
+        PMIX_RELEASE(prte_sessions);
+        prte_sessions = NULL;
     }
-    PMIX_RELEASE(prte_node_pool);
+
+    /* Only reached if there was no default session to carry the pool away -
+     * a process that failed partway through prte_init, or one that never
+     * built one. */
+    if (NULL != prte_node_pool) {
+        for (n = 0; n < prte_node_pool->size; n++) {
+            node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
+            if (NULL == node) {
+                continue;
+            }
+            pmix_pointer_array_set_item(prte_node_pool, n, NULL);
+            PMIX_RELEASE(node);
+        }
+        PMIX_RELEASE(prte_node_pool);
+        prte_node_pool = NULL;
+    }
 
     for (n = 0; n < prte_job_data->size; n++) {
         jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, n);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -346,7 +346,7 @@ prte_session_t *prte_get_session_object_from_id(const char *id)
             continue;
         }
         if (NULL == session->alloc_refid) {
-	     continue;
+            continue;
         }
         if (0 == strcasecmp(session->alloc_refid, id)) {
             return session;
@@ -371,6 +371,9 @@ prte_session_t *prte_get_session_object_from_refid(const char *refid)
     for (i = 0; i < prte_sessions->size; i++) {
         session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i);
         if (NULL == session) {
+            continue;
+        }
+        if (NULL == session->user_refid) {
             continue;
         }
         if (0 == strcasecmp(session->user_refid, refid)) {
@@ -415,11 +418,15 @@ int prte_set_session_object(prte_session_t *session)
     return PRTE_SUCCESS;
 }
 
-bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2){
+bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2)
+{
     int n;
     prte_session_t *session_ptr;
 
-    if(session1->session_id == session2->session_id){
+    if (NULL == session1 || NULL == session2) {
+        return false;
+    }
+    if (session1->session_id == session2->session_id) {
         return true;
     }
 
@@ -493,11 +500,41 @@ prte_node_rank_t prte_get_proc_node_rank(const pmix_proc_t *proc)
     return proct->node_rank;
 }
 
+/* does this node answer to either the name as given or the name it was
+ * resolved to?  Kept in one place so the list walk and the pool walk below
+ * cannot drift apart. */
+static bool node_answers_to(prte_node_t *nptr, const char *name, const char *nm)
+{
+    int m;
+
+    if (NULL == nptr->name) {
+        return false;
+    }
+    if (0 == strcmp(nptr->name, nm)) {
+        return true;
+    }
+    if (NULL == nptr->aliases) {
+        return false;
+    }
+    /* no choice but an exhaustive search - fortunately, these lists are short! */
+    for (m = 0; NULL != nptr->aliases[m]; m++) {
+        if (0 == strcmp(name, nptr->aliases[m])) {
+            /* this is the node! */
+            return true;
+        }
+    }
+    return false;
+}
+
 prte_node_t* prte_node_match(pmix_list_t *nodes, const char *name)
 {
-    int m, n;
+    int n;
     prte_node_t *nptr;
     char *nm;
+
+    if (NULL == name) {
+        return NULL;
+    }
 
     /* does the name refer to me? */
     if (prte_check_host_is_local(name)) {
@@ -508,40 +545,25 @@ prte_node_t* prte_node_match(pmix_list_t *nodes, const char *name)
 
     if (NULL != nodes) {
         PMIX_LIST_FOREACH(nptr, nodes, prte_node_t) {
-            if (0 == strcmp(nptr->name, nm)) {
+            if (node_answers_to(nptr, name, nm)) {
                 return nptr;
-            }
-            if (NULL == nptr->aliases) {
-                continue;
-            }
-            /* no choice but an exhaustive search - fortunately, these lists are short! */
-            for (m = 0; NULL != nptr->aliases[m]; m++) {
-                if (0 == strcmp(name, nptr->aliases[m])) {
-                    /* this is the node! */
-                    return nptr;
-                }
             }
         }
-    } else {
-        /* check the node pool */
-        for (n=0; n < prte_node_pool->size; n++) {
-            nptr = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, n);
-            if (NULL == nptr) {
-                continue;
-            }
-            if (0 == strcmp(nptr->name, nm)) {
-                return nptr;
-            }
-            if (NULL == nptr->aliases) {
-                continue;
-            }
-            /* no choice but an exhaustive search - fortunately, these lists are short! */
-            for (m = 0; NULL != nptr->aliases[m]; m++) {
-                if (0 == strcmp(name, nptr->aliases[m])) {
-                    /* this is the node! */
-                    return nptr;
-                }
-            }
+        return NULL;
+    }
+
+    /* check the node pool - which may not exist yet if we are being
+     * called before prte_init laid out the global arrays */
+    if (NULL == prte_node_pool) {
+        return NULL;
+    }
+    for (n=0; n < prte_node_pool->size; n++) {
+        nptr = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, n);
+        if (NULL == nptr) {
+            continue;
+        }
+        if (node_answers_to(nptr, name, nm)) {
+            return nptr;
         }
     }
 

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1138,8 +1138,15 @@ bool prte_session_is_owned_by(prte_session_t *session,
     if (NULL == session || session == prte_default_session) {
         return true;
     }
-    /* the scheduler is an implicit owner of every session */
-    if (PMIX_CHECK_NSPACE(prte_pmix_server_globals.scheduler.nspace, nspace)) {
+    /* The scheduler is an implicit owner of every session - but only if
+     * there IS one. PMIX_CHECK_NSPACE answers "true" when either side is an
+     * empty nspace (that is its wildcard rule), and scheduler.nspace is
+     * empty until a scheduler connects. Testing it unguarded therefore
+     * declared every namespace to be the scheduler on every DVM running
+     * without one, which is the common case - and that turned the whole
+     * reservation ownership check into an unconditional "yes". */
+    if (!PMIX_NSPACE_INVALID(prte_pmix_server_globals.scheduler.nspace) &&
+        PMIX_CHECK_NSPACE(prte_pmix_server_globals.scheduler.nspace, nspace)) {
         return true;
     }
     if (NULL == session->owners) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1112,8 +1112,21 @@ static void session_des(prte_session_t *s)
         pmix_pointer_array_set_item(prte_sessions, s->index, NULL);
     }
 }
+/* The parent class here has to be pmix_object_t, because that is what
+ * prte_session_t actually embeds. Declaring pmix_list_item_t made the class
+ * system run pmix_list_item_t's constructor and destructor over a struct
+ * that has no room for one: next/prev and the debug bookkeeping land on top
+ * of the session's own leading fields. The constructor damage is masked
+ * because session_con runs afterwards and rewrites those fields, but the
+ * destructor is not - pmix_list_item_destruct asserts that the item is not
+ * still linked into a list, and reads that "refcount" out of the middle of
+ * the session's own data. Releasing any session under a debug PMIx
+ * therefore aborted the process; it went unnoticed only because the one
+ * session that always exists, prte_default_session, is never released.
+ * A session lives in prte_sessions (a pointer array) and is never placed on
+ * a pmix_list_t, so it needs nothing pmix_list_item_t provides. */
 PMIX_CLASS_INSTANCE(prte_session_t,
-                    pmix_list_item_t,
+                    pmix_object_t,
                     session_con, session_des);
 
 bool prte_session_is_owned_by(prte_session_t *session,

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1070,8 +1070,16 @@ static void session_des(prte_session_t *s)
     for (n=0; n < s->nodes->size; n++) {
         nd = (prte_node_t*)pmix_pointer_array_get_item(s->nodes, n);
         if (NULL != nd) {
-            PMIX_RELEASE(nd);
+            /* The node's session backpointer is borrowed, so it does not keep
+             * us alive - which means a node that survives this release (the
+             * global pool holds its own reference) would be left pointing at
+             * freed memory. Clear it while the node is still here. Must come
+             * BEFORE the release, which may be the node's last. */
+            if (nd->session == s) {
+                nd->session = NULL;
+            }
             pmix_pointer_array_set_item(s->nodes, n, NULL);
+            PMIX_RELEASE(nd);
         }
     }
     PMIX_RELEASE(s->nodes);

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -185,12 +185,27 @@ int prte_init_minimum(void)
      * cross version operations from inside of PRRTE.
      */
     rvers = PMIx_Get_version();
-    ret = sscanf(rvers, "%s %u.%u.%u",
-                 token, &major, &minor, &release);
-    ret = sscanf(PRTE_PMIX_MIN_VERSION_STRING, "%u.%u.%u",
-                 &reqmajor, &reqminor, &reqrelease);
-    ret = sscanf(PRTE_PMIX_MAX_VERSION_STRING, "%u.%u.%u",
-                 &maxmajor, &maxminor, &maxrelease);
+    /* Check what sscanf actually converted. These returns used to be
+     * assigned and thrown away, so a version string we could not parse left
+     * major/minor/release uninitialized and the range checks below then ran
+     * on whatever was on the stack - which can as easily pass as fail. */
+    if (4 != sscanf(rvers, "%s %u.%u.%u",
+                    token, &major, &minor, &release) ||
+        3 != sscanf(PRTE_PMIX_MIN_VERSION_STRING, "%u.%u.%u",
+                    &reqmajor, &reqminor, &reqrelease) ||
+        3 != sscanf(PRTE_PMIX_MAX_VERSION_STRING, "%u.%u.%u",
+                    &maxmajor, &maxminor, &maxrelease)) {
+        fprintf(stderr, "************************************************\n");
+        fprintf(stderr, "We were unable to parse the version of the PMIx\n");
+        fprintf(stderr, "library we were given:\n\n");
+        fprintf(stderr, "    Runtime:  %s\n", (NULL == rvers) ? "NULL" : rvers);
+        fprintf(stderr, "    Minimum:  %s\n", PRTE_PMIX_MIN_VERSION_STRING);
+        fprintf(stderr, "    Maximum:  %s\n\n", PRTE_PMIX_MAX_VERSION_STRING);
+        fprintf(stderr, "Please update your LD_LIBRARY_PATH to point\n");
+        fprintf(stderr, "us to the same PMIx version used to build PRRTE.\n");
+        fprintf(stderr, "************************************************\n");
+        return PRTE_ERR_SILENT;
+    }
 
     /* check the version triplet agains the min values
      * specified in VERSION
@@ -317,8 +332,19 @@ int prte_init_minimum(void)
         return 1;
     }
 
-    /* pre-load any default mca param files */
-    prte_preload_default_mca_params();
+    /* pre-load any default mca param files. A malformed file has to be
+     * fatal: the values in it steer component selection and launch, so
+     * silently carrying on with a partial set - which is what discarding
+     * this return did - starts a DVM configured differently from what the
+     * files say. */
+    ret = prte_preload_default_mca_params();
+    if (PRTE_SUCCESS != ret) {
+        if (PRTE_ERR_SILENT != ret) {
+            pmix_show_help("help-prte-runtime", "prte_init:startup:internal-failure", true,
+                           "prte preload mca params", PRTE_ERROR_NAME(ret), ret);
+        }
+        return ret;
+    }
 
     return PRTE_SUCCESS;
 }
@@ -599,7 +625,7 @@ int prte_preload_default_mca_params(void)
         free(file);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             // it is okay if the file isn't found
-            return rc;
+            goto failed;
         }
         /* now get the user-level defaults */
         file = pmix_os_path(false, home, ".prte", "mca-params.conf", NULL);
@@ -607,7 +633,7 @@ int prte_preload_default_mca_params(void)
         free(file);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             // it is okay if the file isn't found
-            return rc;
+            goto failed;
         }
     } else {
         // split the string on commas
@@ -618,7 +644,7 @@ int prte_preload_default_mca_params(void)
             if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
                 // it is okay if the file isn't found
                 PMIx_Argv_free(paths);
-                return rc;
+                goto failed;
             }
         }
         PMIx_Argv_free(paths);
@@ -655,16 +681,17 @@ int prte_preload_default_mca_params(void)
     PMIX_LIST_DESTRUCT(&params);
     PMIX_LIST_DESTRUCT(&params2);
 
-    // process any override params
+    // process any override params. Both lists are re-constructed (params2
+    // stays empty) so that the shared error exit below can destruct all
+    // three unconditionally.
     PMIX_CONSTRUCT(&params, pmix_list_t);
+    PMIX_CONSTRUCT(&params2, pmix_list_t);
     if (NULL != prte_override_param_file) {
         // process the file
         rc = pmix_mca_base_parse_paramfile(prte_override_param_file, &params);
         if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_FOUND != rc) {
             // it is okay if the file isn't found
-            PMIX_LIST_DESTRUCT(&params);
-            PMIX_LIST_DESTRUCT(&pfinal);
-            return rc;
+            goto failed;
         }
         if (0 < pmix_list_get_size(&params)) {
             // check the params against any given
@@ -713,7 +740,10 @@ int prte_preload_default_mca_params(void)
             }
         }
         PMIX_LIST_DESTRUCT(&params);
+        PMIX_CONSTRUCT(&params, pmix_list_t);
     }
+    PMIX_LIST_DESTRUCT(&params);
+    PMIX_LIST_DESTRUCT(&params2);
 
     /* now process the final list - but do not overwrite if the
      * user already has the param in our environment as their
@@ -740,4 +770,12 @@ int prte_preload_default_mca_params(void)
 
     PMIX_LIST_DESTRUCT(&pfinal);
     return PRTE_SUCCESS;
+
+failed:
+    /* every one of these bail-outs used to return with the three lists still
+     * holding their parsed entries */
+    PMIX_LIST_DESTRUCT(&params);
+    PMIX_LIST_DESTRUCT(&params2);
+    PMIX_LIST_DESTRUCT(&pfinal);
+    return rc;
 }

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -78,8 +78,10 @@ int prte_register_params(void)
     pmix_output_stream_t lds;
     char *string = NULL;
     char *fstype = NULL;
-    char *home;
     char cwd[MAXPATHLEN];
+#if PRTE_WANT_HOME_CONFIG_FILES
+    char *home;
+#endif
 
     /* only go thru this once - mpirun calls it twice, which causes
      * any error messages to show up twice
@@ -526,18 +528,19 @@ int prte_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_homo_nodes);
 
-    home = (char *) pmix_home_directory(geteuid());
     if (NULL == getcwd(cwd, MAXPATHLEN)) {
         return PRTE_ERROR;
     }
 
 #if PRTE_WANT_HOME_CONFIG_FILES
+    home = (char *) pmix_home_directory(geteuid());
     pmix_asprintf(&prte_param_files,
                    "%s" PMIX_PATH_SEP ".prte" PMIX_PATH_SEP "mca-params.conf%c%s" PMIX_PATH_SEP
                    "prte-mca-params.conf",
                    home, ',', prte_install_dirs.sysconfdir);
 #else
-    pmix_sprintf(&prte_param_files, "%s" PMIX_PATH_SEP "prte-mca-params.conf",
+    /* --disable-per-user-config-files: only the system file is consulted */
+    pmix_asprintf(&prte_param_files, "%s" PMIX_PATH_SEP "prte-mca-params.conf",
                   prte_install_dirs.sysconfdir);
 #endif
     /* the var system takes the current value as the default and then hands

--- a/src/runtime/prte_progress_threads.c
+++ b/src/runtime/prte_progress_threads.c
@@ -243,12 +243,72 @@ static void stop_progress_engine(prte_progress_tracker_t *trk)
     pmix_thread_join(&trk->engine, NULL);
 }
 
+/* Expand a comma-delimited list of cpu ranges - "0", "0,3", "2-5,8" - into
+ * cpus[], returning how many ids were stored or PRTE_ERR_BAD_PARAM if the
+ * specification does not parse. Always compiled, and reachable from the unit
+ * test, even though its one caller sits behind HAVE_PTHREAD_SETAFFINITY_NP:
+ * the parsing is where the bugs were, and leaving it inside the ifdef meant
+ * nothing could check it on a platform without pthread_setaffinity_np. */
+int prte_progress_thread_parse_cpus(const char *spec, int *cpus, int max)
+{
+    char **ranges, *dash, *end_ptr;
+    int n, k, ncpus = 0;
+    unsigned long start, end;
+
+    if (NULL == spec || NULL == cpus || 0 >= max) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    ranges = PMIx_Argv_split(spec, ',');
+    if (NULL == ranges) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    for (n = 0; NULL != ranges[n]; n++) {
+        // look for '-'. Note that strtoul always hands back a non-NULL end
+        // pointer - it points at the first character it did not consume - so
+        // the range test has to look at what that character IS. Testing the
+        // pointer itself let a bare "3" fall into the range branch, where the
+        // "skip the dash" step walked off the end of the string.
+        start = strtoul(ranges[n], &dash, 10);
+        if (dash == ranges[n]) {
+            /* no digits at all */
+            PMIx_Argv_free(ranges);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        if ('-' != *dash) {
+            if ('\0' != *dash) {
+                PMIx_Argv_free(ranges);
+                return PRTE_ERR_BAD_PARAM;
+            }
+            end = start;
+        } else {
+            ++dash;  // skip over the '-'
+            end = strtoul(dash, &end_ptr, 10);
+            if (end_ptr == dash || '\0' != *end_ptr || end < start) {
+                PMIx_Argv_free(ranges);
+                return PRTE_ERR_BAD_PARAM;
+            }
+        }
+        // the range is inclusive of its upper bound: "0-3" names four cpus,
+        // not three
+        for (k = (int) start; k <= (int) end; k++) {
+            if (ncpus >= max) {
+                PMIx_Argv_free(ranges);
+                return PRTE_ERR_BAD_PARAM;
+            }
+            cpus[ncpus++] = k;
+        }
+    }
+    PMIx_Argv_free(ranges);
+    return ncpus;
+}
+
 static int start_progress_engine(prte_progress_tracker_t *trk)
 {
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
     cpu_set_t cpuset;
-    char **ranges, *dash;
-    int k, n, start, end;
+    int cpus[PRTE_MAX_PROGRESS_THREAD_CPUS];
+    int ncpus, n;
 #endif
 
     assert(!trk->ev_active);
@@ -261,25 +321,24 @@ static int start_progress_engine(prte_progress_tracker_t *trk)
     int rc = pmix_thread_start(&trk->engine);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        /* no thread was created, so there is nothing to bind and nothing
+         * for a later stop_progress_engine to join */
+        trk->ev_active = false;
+        return rc;
     }
 
 #ifdef HAVE_PTHREAD_SETAFFINITY_NP
     if (NULL != prte_progress_thread_cpus) {
+        ncpus = prte_progress_thread_parse_cpus(prte_progress_thread_cpus, cpus,
+                                                PRTE_MAX_PROGRESS_THREAD_CPUS);
+        if (0 > ncpus) {
+            pmix_output(0, "Could not parse prte_progress_thread_cpus \"%s\"",
+                        prte_progress_thread_cpus);
+            return prte_bind_progress_thread_reqd ? PRTE_ERR_BAD_PARAM : PRTE_SUCCESS;
+        }
         CPU_ZERO(&cpuset);
-        // comma-delimited list of cpu ranges
-        ranges = PMIx_Argv_split(prte_progress_thread_cpus, ',');
-        for (n=0; NULL != ranges[n]; n++) {
-            // look for '-'
-            start = strtoul(ranges[n], &dash, 10);
-            if (NULL == dash) {
-                CPU_SET(start, &cpuset);
-            } else {
-                ++dash;  // skip over the '-'
-                end = strtoul(dash, NULL, 10);
-                for (k=start; k < end; k++) {
-                    CPU_SET(k, &cpuset);
-                }
-            }
+        for (n = 0; n < ncpus; n++) {
+            CPU_SET(cpus[n], &cpuset);
         }
         rc = pthread_setaffinity_np(trk->engine.t_handle, sizeof(cpu_set_t), &cpuset);
         if (0 != rc && prte_bind_progress_thread_reqd) {
@@ -404,20 +463,32 @@ int prte_progress_thread_pause(const char *name)
         return PRTE_ERR_NOT_FOUND;
     }
 
-    /* find the specified engine */
-    PMIX_LIST_FOREACH(trk, &tracking, prte_progress_tracker_t)
-    {
-        if (NULL == name || 0 == strcmp(name, trk->name)) {
+    /* a NULL name means "pause them all", and finding none is not an error */
+    if (NULL == name) {
+        PMIX_LIST_FOREACH(trk, &tracking, prte_progress_tracker_t)
+        {
             if (trk->ev_active) {
                 stop_progress_engine(trk);
             }
-            if (NULL != name) {
-                break;
+        }
+        return PRTE_SUCCESS;
+    }
+
+    /* find the specified engine */
+    PMIX_LIST_FOREACH(trk, &tracking, prte_progress_tracker_t)
+    {
+        if (0 == strcmp(name, trk->name)) {
+            if (trk->ev_active) {
+                stop_progress_engine(trk);
             }
+            return PRTE_SUCCESS;
         }
     }
 
-    return PRTE_SUCCESS;
+    /* the header promises PRTE_ERR_NOT_FOUND for a name we do not have, and
+     * its siblings resume/finalize deliver that - pause used to fall off the
+     * end and report success for a thread that does not exist */
+    return PRTE_ERR_NOT_FOUND;
 }
 
 #if PRTE_HAVE_LIBEV

--- a/src/runtime/prte_progress_threads.h
+++ b/src/runtime/prte_progress_threads.h
@@ -67,4 +67,19 @@ PRTE_EXPORT int prte_progress_thread_pause(const char *name);
  */
 PRTE_EXPORT int prte_progress_thread_resume(const char *name);
 
+/** Upper bound on how many cpu ids the prte_progress_thread_cpus
+ * specification may name.  Sized well past any plausible binding for a
+ * single service thread, and only used to bound the parse. */
+#define PRTE_MAX_PROGRESS_THREAD_CPUS 1024
+
+/**
+ * Expand the comma-delimited list of cpu ranges given in
+ * prte_progress_thread_cpus ("0", "0,3", "2-5,8") into cpus[], which must
+ * have room for max entries.  Ranges are inclusive of both bounds.
+ *
+ * Returns the number of cpu ids stored, or PRTE_ERR_BAD_PARAM if the
+ * specification does not parse or names more cpus than will fit.
+ */
+PRTE_EXPORT int prte_progress_thread_parse_cpus(const char *spec, int *cpus, int max);
+
 #endif

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps errmgr ess filem grpcomm odls iof plm prted rml ras schizo state
+SUBDIRS = rmaps runtime errmgr ess filem grpcomm odls iof plm prted rml ras schizo state

--- a/test/unit/runtime/Makefile.am
+++ b/test/unit/runtime/Makefile.am
@@ -1,0 +1,23 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_runtime
+
+test_runtime_SOURCES = \
+    test_runtime.c
+
+test_runtime_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_runtime
+
+# Run against the components in this build tree, not just an installed
+# one: without this a --enable-mca-dso build has no components to find.
+AM_TESTS_ENVIRONMENT = \
+    PRTE_MCA_mca_base_component_path=@PRTE_COMPONENT_BUILD_PATH@; \
+    export PRTE_MCA_mca_base_component_path;

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -1,0 +1,1342 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for src/runtime.
+ *
+ * This directory is the runtime's foundation: the three central data
+ * structures (prte_job_t, prte_node_t, prte_proc_t) with their constructors
+ * and destructors, the global registries every other framework looks things
+ * up in, the wire encoding used to ship a job to a daemon, the session
+ * (reservation) bookkeeping, and the publish/lookup data server.  Nothing
+ * here needs a live DVM, which is exactly why it is worth pinning down: a
+ * defect at this layer shows up somewhere else entirely.
+ *
+ * The cases below are built around the defects the review turned up:
+ *
+ *  - prte_get_session_object_from_refid() compared against
+ *    session->user_refid without checking it for NULL, so a single
+ *    reservation created without a user reference id (they are optional -
+ *    the sibling lookup on alloc_refid does check) crashed every subsequent
+ *    lookup by refid;
+ *  - prte_node_match() dereferenced prte_node_pool unconditionally when
+ *    asked to search the global pool, which is a NULL pointer until
+ *    prte_init has laid the global arrays out;
+ *  - prte_map_copy() blitted the source pointer-array's size/max_size over
+ *    the destination's and then copied addr[] element by element into an
+ *    allocation the destination constructor had sized at
+ *    PRTE_GLOBAL_ARRAY_BLOCK_SIZE.  A map spanning more nodes than that
+ *    wrote off the end of the heap block.  It also took no reference on the
+ *    nodes it copied, while prte_job_map_destruct releases every node it
+ *    holds - so the two maps between them dropped one refcount too many;
+ *  - prte_app_copy() walked app->attributes, a list of prte_attribute_t, as
+ *    a list of prte_value_t: it read the value from the wrong offset and
+ *    dropped the attribute key entirely, leaving every copied attribute
+ *    unfindable;
+ *  - prte_node_copy() carried neither the node's aliases nor its attributes
+ *    nor its session, so a duplicated node answered to only one of its
+ *    names and silently joined the default pool;
+ *  - the data server's object constructors left prte_data_object_t::proxy
+ *    and prte_data_req_t::proxy uninitialized (PMIX_NEW does not zero its
+ *    allocation), and those are precisely what the PMIX_RANGE_LOCAL access
+ *    check compares;
+ *  - the progress thread's cpu-range parser tested the strtoul end pointer
+ *    for NULL - which it never is - so a bare "3" took the range branch and
+ *    stepped past the terminating NUL, and ranges excluded their upper
+ *    bound.
+ *
+ * Everything is driven through the exported entry points, so the tests keep
+ * working if the internals are rearranged.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "constants.h"
+#include "types.h"
+
+#include "src/class/pmix_pointer_array.h"
+#include "src/mca/base/pmix_base.h"
+#include "src/mca/ras/base/base.h"
+#include "src/mca/rmaps/rmaps_types.h"
+#include "src/pmix/pmix-internal.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_progress_threads.h"
+#include "src/runtime/runtime.h"
+#include "src/util/attr.h"
+#include "src/util/proc_info.h"
+
+#include "src/runtime/data_server/ds.h"
+#include "src/runtime/data_server/prte_data_server.h"
+
+/* pmix_nspace_t is a char[256]; passing a string literal where one is
+ * expected trips -Wstringop-overread, so route literals through a buffer */
+static pmix_nspace_t ns_scratch;
+static const char *NS(const char *s)
+{
+    PMIX_LOAD_NSPACE(ns_scratch, s);
+    return (const char *) ns_scratch;
+}
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/* harness                                                            */
+/* ------------------------------------------------------------------ */
+
+/* prte_init_util() stops short of building the global job/node/session
+ * arrays - prte_init() does that, and it needs a selected ess module and a
+ * live event base.  Build them by hand so the lookup tests have registries
+ * to work against. */
+static void setup_globals(void)
+{
+    prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_job_data, 8, INT_MAX, 8);
+    prte_node_pool = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_node_pool, 8, INT_MAX, 8);
+    prte_node_topologies = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_node_topologies, 8, INT_MAX, 8);
+    prte_sessions = PMIX_NEW(pmix_pointer_array_t);
+    pmix_pointer_array_init(prte_sessions, 8, INT_MAX, 8);
+}
+
+static void empty_array(pmix_pointer_array_t *array)
+{
+    int i;
+    void *item;
+
+    if (NULL == array) {
+        return;
+    }
+    for (i = 0; i < array->size; i++) {
+        item = pmix_pointer_array_get_item(array, i);
+        if (NULL != item) {
+            pmix_pointer_array_set_item(array, i, NULL);
+            PMIX_RELEASE(item);
+        }
+    }
+}
+
+/* leave the registries empty between tests so one test's leftovers cannot
+ * satisfy another's lookup */
+static void reset_globals(void)
+{
+    empty_array(prte_job_data);
+    empty_array(prte_node_pool);
+    /* sessions null their own slot on destruct, so just walk and release */
+    empty_array(prte_sessions);
+}
+
+static prte_job_t *make_job(const char *nspace)
+{
+    prte_job_t *jdata = PMIX_NEW(prte_job_t);
+
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
+    return jdata;
+}
+
+static prte_node_t *make_node(const char *name)
+{
+    prte_node_t *node = PMIX_NEW(prte_node_t);
+
+    node->name = strdup(name);
+    node->slots = 4;
+    node->slots_available = 4;
+    node->state = PRTE_NODE_STATE_UP;
+    return node;
+}
+
+/* ------------------------------------------------------------------ */
+/* the global job registry                                            */
+/* ------------------------------------------------------------------ */
+
+static int test_job_registry(void)
+{
+    int failures = 0;
+    prte_job_t *j1, *j2, *dup;
+    int rc, saved_index;
+    pmix_nspace_t bogus;
+
+    reset_globals();
+
+    /* an unknown nspace is a miss, not a crash */
+    CHECK("job: unknown nspace misses", NULL == prte_get_job_data_object(NS("nosuchjob")));
+
+    j1 = make_job("job.one");
+    rc = prte_set_job_data_object(j1);
+    CHECK("job: first insert succeeds", PRTE_SUCCESS == rc);
+    CHECK("job: insert records an index", 0 <= j1->index);
+    CHECK("job: lookup finds it", j1 == prte_get_job_data_object(NS("job.one")));
+
+    j2 = make_job("job.two");
+    CHECK("job: second insert succeeds", PRTE_SUCCESS == prte_set_job_data_object(j2));
+    CHECK("job: both are findable",
+          j1 == prte_get_job_data_object(NS("job.one"))
+              && j2 == prte_get_job_data_object(NS("job.two")));
+
+    /* the registry is keyed on nspace, so re-registering one has to be
+     * refused rather than silently shadowing the live object */
+    dup = make_job("job.one");
+    CHECK("job: duplicate nspace is refused", PRTE_EXISTS == prte_set_job_data_object(dup));
+    CHECK("job: the original is still the one on file",
+          j1 == prte_get_job_data_object(NS("job.one")));
+    PMIX_RELEASE(dup);
+
+    /* an invalid nspace is rejected on both sides */
+    PMIX_LOAD_NSPACE(bogus, NULL);
+    CHECK("job: invalid nspace does not resolve", NULL == prte_get_job_data_object(bogus));
+    dup = PMIX_NEW(prte_job_t);
+    CHECK("job: invalid nspace cannot be registered", PRTE_ERROR == prte_set_job_data_object(dup));
+    PMIX_RELEASE(dup);
+
+    /* a freed job vacates its slot, and the next insert reuses it - the
+     * array is a slot map, not an append-only log */
+    saved_index = j1->index;
+    PMIX_RELEASE(j1);
+    CHECK("job: destruct vacates the global slot",
+          NULL == pmix_pointer_array_get_item(prte_job_data, saved_index));
+    CHECK("job: and the nspace no longer resolves", NULL == prte_get_job_data_object(NS("job.one")));
+
+    j1 = make_job("job.three");
+    CHECK("job: the vacated slot is reused", PRTE_SUCCESS == prte_set_job_data_object(j1));
+    CHECK("job: reuse lands in the freed slot", saved_index == j1->index);
+
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* sessions (reservations)                                            */
+/* ------------------------------------------------------------------ */
+
+static int test_session_registry(void)
+{
+    int failures = 0;
+    prte_session_t *s1, *s2, *dup;
+
+    reset_globals();
+
+    s1 = PMIX_NEW(prte_session_t);
+    s1->session_id = 100;
+    s1->alloc_refid = strdup("alloc-100");
+    s1->user_refid = strdup("user-100");
+    CHECK("session: insert succeeds", PRTE_SUCCESS == prte_set_session_object(s1));
+    CHECK("session: lookup by id", s1 == prte_get_session_object(100));
+    CHECK("session: lookup by alloc refid", s1 == prte_get_session_object_from_id("alloc-100"));
+    CHECK("session: lookup by user refid", s1 == prte_get_session_object_from_refid("user-100"));
+
+    /* A reservation may carry an alloc id without a user reference id -
+     * PMIX_ALLOC_REQ_ID is the requester's own optional label.  The refid
+     * lookup used to strcasecmp against that NULL, so one such session made
+     * every later lookup-by-refid a segfault.  The alloc-id lookup has
+     * always guarded; both must. */
+    s2 = PMIX_NEW(prte_session_t);
+    s2->session_id = 200;
+    s2->alloc_refid = strdup("alloc-200");
+    /* user_refid deliberately left NULL */
+    CHECK("session: second insert succeeds", PRTE_SUCCESS == prte_set_session_object(s2));
+    CHECK("session: refid lookup survives a session with no user refid",
+          s1 == prte_get_session_object_from_refid("user-100"));
+    CHECK("session: refid lookup misses cleanly",
+          NULL == prte_get_session_object_from_refid("user-999"));
+    CHECK("session: alloc-id lookup still works alongside it",
+          s2 == prte_get_session_object_from_id("alloc-200"));
+    /* symmetrically, a session with no alloc_refid must not break that one */
+    CHECK("session: id lookup misses cleanly", NULL == prte_get_session_object_from_id("nope"));
+
+    /* NULL keys are a miss, not a crash */
+    CHECK("session: NULL alloc id misses", NULL == prte_get_session_object_from_id(NULL));
+    CHECK("session: NULL user refid misses", NULL == prte_get_session_object_from_refid(NULL));
+    CHECK("session: unknown id misses", NULL == prte_get_session_object(4242));
+
+    /* session ids are unique */
+    dup = PMIX_NEW(prte_session_t);
+    dup->session_id = 100;
+    CHECK("session: duplicate id refused", PRTE_EXISTS == prte_set_session_object(dup));
+    PMIX_RELEASE(dup);
+
+    /* relatedness: identity, parent/child, and unrelated */
+    CHECK("session: a session is related to itself", prte_sessions_related(s1, s1));
+    CHECK("session: unrelated sessions are not related", !prte_sessions_related(s1, s2));
+    PMIX_RETAIN(s2);
+    pmix_pointer_array_add(s1->children, s2);
+    CHECK("session: a child is related to its parent", prte_sessions_related(s1, s2));
+    /* ...but the relation as implemented is one-way: only s1's children are
+     * consulted.  Pin the behavior so a change to it is deliberate. */
+    CHECK("session: the relation is checked parent-to-child only",
+          !prte_sessions_related(s2, s1));
+    CHECK("session: NULL operands are not related", !prte_sessions_related(NULL, s1));
+    CHECK("session: NULL operands are not related (2)", !prte_sessions_related(s1, NULL));
+
+    reset_globals();
+    return failures;
+}
+
+static int test_session_ownership(void)
+{
+    int failures = 0;
+    prte_session_t *s;
+    prte_session_t *saved_default;
+
+    reset_globals();
+    saved_default = prte_default_session;
+
+    s = PMIX_NEW(prte_session_t);
+    s->session_id = 7;
+    CHECK("owner: insert succeeds", PRTE_SUCCESS == prte_set_session_object(s));
+
+    /* a fresh reservation has no owners, so nobody may spawn into it */
+    CHECK("owner: an unowned reservation admits nobody", !prte_session_is_owned_by(s, NS("nsA")));
+
+    prte_session_add_owner(s, NS("nsA"));
+    CHECK("owner: the added namespace is admitted", prte_session_is_owned_by(s, NS("nsA")));
+    CHECK("owner: others are still refused", !prte_session_is_owned_by(s, NS("nsB")));
+
+    /* adding twice must not grow the list - owners accumulates one entry per
+     * namespace spawned into the session, and a job can be spawned into the
+     * same session repeatedly */
+    prte_session_add_owner(s, NS("nsA"));
+    CHECK("owner: re-adding is a no-op", 1 == PMIx_Argv_count(s->owners));
+    prte_session_add_owner(s, NS("nsB"));
+    CHECK("owner: a second namespace appends", 2 == PMIx_Argv_count(s->owners));
+    CHECK("owner: and is admitted", prte_session_is_owned_by(s, NS("nsB")));
+
+    /* the default session belongs to everyone and records no owners */
+    prte_default_session = s;
+    CHECK("owner: the default session admits anyone", prte_session_is_owned_by(s, NS("nsZ")));
+    prte_session_add_owner(s, NS("nsZ"));
+    CHECK("owner: the default session records nothing", 2 == PMIx_Argv_count(s->owners));
+    prte_default_session = saved_default;
+
+    /* a NULL session is the default pool */
+    CHECK("owner: NULL session admits anyone", prte_session_is_owned_by(NULL, NS("nsZ")));
+
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* proc lookups                                                       */
+/* ------------------------------------------------------------------ */
+
+static int test_proc_lookups(void)
+{
+    int failures = 0;
+    prte_job_t *jdata, *djob;
+    prte_proc_t *proc, *daemon;
+    prte_node_t *node;
+    pmix_proc_t name, unknown;
+
+    reset_globals();
+
+    /* build a daemon on a node, and an application proc mapped to it */
+    djob = make_job("prte-daemons");
+    prte_set_job_data_object(djob);
+    node = make_node("nodeA");
+    node->index = pmix_pointer_array_add(prte_node_pool, node);
+
+    daemon = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&daemon->name, "prte-daemons", 3);
+    daemon->node = node; /* borrowed backpointer */
+    PMIX_RETAIN(daemon); /* the node holds a real reference; the job holds one too */
+    node->daemon = daemon;
+    pmix_pointer_array_set_item(djob->procs, 3, daemon);
+
+    jdata = make_job("app.job");
+    prte_set_job_data_object(jdata);
+    proc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&proc->name, "app.job", 1);
+    proc->node = node;
+    proc->node_rank = 2;
+    pmix_pointer_array_set_item(jdata->procs, 1, proc);
+
+    PMIX_LOAD_PROCID(&name, "app.job", 1);
+    CHECK("proc: lookup finds the proc", proc == prte_get_proc_object(&name));
+    CHECK("proc: hostname resolves through the node",
+          NULL != prte_get_proc_hostname(&name)
+              && 0 == strcmp("nodeA", prte_get_proc_hostname(&name)));
+    CHECK("proc: node rank is reported", 2 == prte_get_proc_node_rank(&name));
+    CHECK("proc: the hosting daemon's vpid is reported",
+          3 == prte_get_proc_daemon_vpid(&name));
+
+    /* a rank the job does not have */
+    PMIX_LOAD_PROCID(&unknown, "app.job", 99);
+    CHECK("proc: unknown rank misses", NULL == prte_get_proc_object(&unknown));
+    CHECK("proc: unknown rank has no hostname", NULL == prte_get_proc_hostname(&unknown));
+    CHECK("proc: unknown rank has no daemon",
+          PMIX_RANK_INVALID == prte_get_proc_daemon_vpid(&unknown));
+
+    /* a job that does not exist */
+    PMIX_LOAD_PROCID(&unknown, "no.such.job", 0);
+    CHECK("proc: unknown job misses", NULL == prte_get_proc_object(&unknown));
+    CHECK("proc: unknown job has no daemon",
+          PMIX_RANK_INVALID == prte_get_proc_daemon_vpid(&unknown));
+
+    /* an unmapped proc has no node, so neither hostname nor daemon resolve */
+    proc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&proc->name, "app.job", 2);
+    pmix_pointer_array_set_item(jdata->procs, 2, proc);
+    PMIX_LOAD_PROCID(&name, "app.job", 2);
+    CHECK("proc: an unmapped proc has no hostname", NULL == prte_get_proc_hostname(&name));
+    CHECK("proc: an unmapped proc has no daemon",
+          PMIX_RANK_INVALID == prte_get_proc_daemon_vpid(&name));
+
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* node matching                                                      */
+/* ------------------------------------------------------------------ */
+
+static int test_node_matching(void)
+{
+    int failures = 0;
+    prte_node_t *n1, *n2, *found;
+    pmix_list_t nodes;
+    pmix_pointer_array_t *saved_pool;
+
+    reset_globals();
+
+    n1 = make_node("compute-01");
+    PMIx_Argv_append_nosize(&n1->aliases, "c01");
+    PMIx_Argv_append_nosize(&n1->aliases, "compute-01.cluster.example");
+    n2 = make_node("compute-02");
+
+    /* search a caller-supplied list */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    pmix_list_append(&nodes, &n1->super);
+    pmix_list_append(&nodes, &n2->super);
+
+    CHECK("match: by primary name", n1 == prte_node_match(&nodes, "compute-01"));
+    CHECK("match: by short alias", n1 == prte_node_match(&nodes, "c01"));
+    CHECK("match: by fqdn alias",
+          n1 == prte_node_match(&nodes, "compute-01.cluster.example"));
+    CHECK("match: the other node still resolves", n2 == prte_node_match(&nodes, "compute-02"));
+    CHECK("match: an unknown name misses", NULL == prte_node_match(&nodes, "compute-99"));
+    CHECK("match: a NULL name misses", NULL == prte_node_match(&nodes, NULL));
+
+    /* the same node object answers to all of its names */
+    CHECK("match: nptr_match on identical names", prte_nptr_match(n1, n1));
+    CHECK("match: nptr_match rejects different nodes", !prte_nptr_match(n1, n2));
+    CHECK("match: quickmatch on the primary name", prte_quickmatch(n1, "compute-01"));
+    CHECK("match: quickmatch on an alias", prte_quickmatch(n1, "c01"));
+    CHECK("match: quickmatch rejects a stranger", !prte_quickmatch(n1, "compute-42"));
+
+    /* an alias on one side matches the other's primary name */
+    {
+        prte_node_t *n3 = make_node("c01");
+        CHECK("match: nptr_match through an alias", prte_nptr_match(n1, n3));
+        PMIX_RELEASE(n3);
+    }
+
+    pmix_list_remove_first(&nodes);
+    pmix_list_remove_first(&nodes);
+    PMIX_DESTRUCT(&nodes);
+
+    /* now search the global pool */
+    n1->index = pmix_pointer_array_add(prte_node_pool, n1);
+    n2->index = pmix_pointer_array_add(prte_node_pool, n2);
+    found = prte_node_match(NULL, "compute-02");
+    CHECK("match: global pool by name", n2 == found);
+    CHECK("match: global pool by alias", n1 == prte_node_match(NULL, "c01"));
+    CHECK("match: global pool miss", NULL == prte_node_match(NULL, "compute-99"));
+
+    /* prte_node_match(NULL, ...) is reachable from parsing paths that run
+     * before prte_init has built the global arrays.  It used to walk
+     * prte_node_pool->size on a NULL pool. */
+    saved_pool = prte_node_pool;
+    prte_node_pool = NULL;
+    CHECK("match: an unbuilt node pool misses instead of crashing",
+          NULL == prte_node_match(NULL, "compute-01"));
+    prte_node_pool = saved_pool;
+
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* copy functions                                                     */
+/* ------------------------------------------------------------------ */
+
+static int test_node_copy(void)
+{
+    int failures = 0;
+    prte_node_t *src, *cpy = NULL;
+    prte_session_t *sess;
+    char *user = NULL;
+
+    reset_globals();
+
+    sess = PMIX_NEW(prte_session_t);
+    sess->session_id = 55;
+
+    src = make_node("bigmem-07");
+    PMIx_Argv_append_nosize(&src->aliases, "bm07");
+    src->rawname = strdup("bigmem-07.raw");
+    src->slots = 64;
+    src->slots_max = 128;
+    src->slots_available = 60;
+    src->session = sess;
+    prte_set_attribute(&src->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_LOCAL,
+                       "operator", PMIX_STRING);
+
+    CHECK("nodecopy: copy succeeds", PRTE_SUCCESS == prte_node_copy(&cpy, src));
+    if (NULL == cpy) {
+        PMIX_RELEASE(src);
+        PMIX_RELEASE(sess);
+        return failures + 1;
+    }
+    CHECK("nodecopy: name carried", NULL != cpy->name && 0 == strcmp("bigmem-07", cpy->name));
+    CHECK("nodecopy: slots carried", 64 == cpy->slots && 128 == cpy->slots_max);
+    CHECK("nodecopy: slots_available carried", 60 == cpy->slots_available);
+    /* the three that were being dropped */
+    CHECK("nodecopy: rawname carried",
+          NULL != cpy->rawname && 0 == strcmp("bigmem-07.raw", cpy->rawname));
+    CHECK("nodecopy: aliases carried",
+          NULL != cpy->aliases && 1 == PMIx_Argv_count(cpy->aliases)
+              && 0 == strcmp("bm07", cpy->aliases[0]));
+    CHECK("nodecopy: the copy answers to the alias too", prte_quickmatch(cpy, "bm07"));
+    CHECK("nodecopy: session carried", sess == cpy->session);
+    CHECK("nodecopy: attributes carried",
+          prte_get_attribute(&cpy->attributes, PRTE_NODE_USERNAME, (void **) &user, PMIX_STRING)
+              && NULL != user && 0 == strcmp("operator", user));
+    free(user);
+
+    /* the copy owns its own strings */
+    CHECK("nodecopy: name is not shared", cpy->name != src->name);
+    CHECK("nodecopy: the copy has no daemon of its own", NULL == cpy->daemon);
+
+    PMIX_RELEASE(cpy);
+    PMIX_RELEASE(src);
+    PMIX_RELEASE(sess);
+    reset_globals();
+    return failures;
+}
+
+static int test_app_copy(void)
+{
+    int failures = 0;
+    prte_app_context_t *src, *cpy = NULL;
+    char *ppr = NULL;
+    bool bval;
+
+    src = PMIX_NEW(prte_app_context_t);
+    src->idx = 2;
+    src->app = strdup("/bin/true");
+    src->num_procs = 8;
+    src->first_rank = 4;
+    src->cwd = strdup("/tmp/work");
+    PMIx_Argv_append_nosize(&src->argv, "true");
+    PMIx_Argv_append_nosize(&src->argv, "--flag");
+    PMIx_Argv_append_nosize(&src->env, "FOO=bar");
+    PRTE_FLAG_SET(src, PRTE_APP_FLAG_USED_ON_NODE);
+    prte_set_attribute(&src->attributes, PRTE_APP_PMIX_PREFIX, PRTE_ATTR_GLOBAL,
+                       "/opt/prte", PMIX_STRING);
+    prte_set_attribute(&src->attributes, PRTE_APP_PRELOAD_BIN, PRTE_ATTR_GLOBAL,
+                       NULL, PMIX_BOOL);
+
+    CHECK("appcopy: copy succeeds", PRTE_SUCCESS == prte_app_copy(&cpy, src));
+    if (NULL == cpy) {
+        PMIX_RELEASE(src);
+        return failures + 1;
+    }
+    CHECK("appcopy: idx carried", 2 == cpy->idx);
+    CHECK("appcopy: app carried", NULL != cpy->app && 0 == strcmp("/bin/true", cpy->app));
+    CHECK("appcopy: num_procs carried", 8 == cpy->num_procs);
+    CHECK("appcopy: first_rank carried", 4 == cpy->first_rank);
+    CHECK("appcopy: flags carried", PRTE_FLAG_TEST(cpy, PRTE_APP_FLAG_USED_ON_NODE));
+    CHECK("appcopy: argv carried",
+          2 == PMIx_Argv_count(cpy->argv) && 0 == strcmp("--flag", cpy->argv[1]));
+    CHECK("appcopy: env carried", 1 == PMIx_Argv_count(cpy->env));
+    CHECK("appcopy: cwd carried", NULL != cpy->cwd && 0 == strcmp("/tmp/work", cpy->cwd));
+
+    /* Attributes were being copied through the wrong struct type, which
+     * dropped the key: the copied list had the right length but nothing in
+     * it could be looked up. */
+    CHECK("appcopy: attribute count matches",
+          pmix_list_get_size(&src->attributes) == pmix_list_get_size(&cpy->attributes));
+    CHECK("appcopy: a string attribute is findable BY KEY",
+          prte_get_attribute(&cpy->attributes, PRTE_APP_PMIX_PREFIX, (void **) &ppr, PMIX_STRING));
+    CHECK("appcopy: ...with its value intact", NULL != ppr && 0 == strcmp("/opt/prte", ppr));
+    free(ppr);
+    bval = prte_get_attribute(&cpy->attributes, PRTE_APP_PRELOAD_BIN, NULL, PMIX_BOOL);
+    CHECK("appcopy: a bool attribute is findable by key", bval);
+    /* and nothing invented itself */
+    CHECK("appcopy: an unset attribute is still unset",
+          !prte_get_attribute(&cpy->attributes, PRTE_APP_NO_CACHEDIR, NULL, PMIX_BOOL));
+
+    PMIX_RELEASE(cpy);
+    PMIX_RELEASE(src);
+    return failures;
+}
+
+static int test_map_copy(void)
+{
+    int failures = 0;
+    prte_job_map_t *src, *cpy = NULL;
+    prte_node_t *nodes[PRTE_GLOBAL_ARRAY_BLOCK_SIZE * 2];
+    const int nnodes = PRTE_GLOBAL_ARRAY_BLOCK_SIZE * 2;
+    int i, live;
+    char name[64];
+
+    src = PMIX_NEW(prte_job_map_t);
+    src->mapping = 3;
+    src->ranking = 5;
+    src->binding = 7;
+    src->num_new_daemons = 11;
+    src->daemon_vpid_start = 13;
+    src->num_nodes = nnodes;
+    src->req_mapper = strdup("round_robin");
+    src->last_mapper = strdup("ppr");
+
+    /* Deliberately more nodes than PRTE_GLOBAL_ARRAY_BLOCK_SIZE, which is
+     * what the destination map's array is constructed with.  The old copy
+     * wrote src->nodes->size entries into that fixed allocation. */
+    for (i = 0; i < nnodes; i++) {
+        snprintf(name, sizeof(name), "n%03d", i);
+        nodes[i] = make_node(name);
+        pmix_pointer_array_set_item(src->nodes, i, nodes[i]);
+        /* the map holds a reference of its own; keep ours as well so we can
+         * check the refcount arithmetic below */
+        PMIX_RETAIN(nodes[i]);
+    }
+
+    CHECK("mapcopy: copy succeeds", PRTE_SUCCESS == prte_map_copy((struct prte_job_map_t **) &cpy,
+                                                                  (struct prte_job_map_t *) src));
+    if (NULL == cpy) {
+        for (i = 0; i < nnodes; i++) {
+            PMIX_RELEASE(nodes[i]);
+        }
+        PMIX_RELEASE(src);
+        return failures + 1;
+    }
+
+    CHECK("mapcopy: policies carried",
+          3 == cpy->mapping && 5 == cpy->ranking && 7 == cpy->binding);
+    CHECK("mapcopy: daemon counts carried",
+          11 == cpy->num_new_daemons && 13 == cpy->daemon_vpid_start);
+    CHECK("mapcopy: num_nodes carried", nnodes == (int) cpy->num_nodes);
+    /* the mapper names were not being copied at all */
+    CHECK("mapcopy: req_mapper carried",
+          NULL != cpy->req_mapper && 0 == strcmp("round_robin", cpy->req_mapper));
+    CHECK("mapcopy: last_mapper carried",
+          NULL != cpy->last_mapper && 0 == strcmp("ppr", cpy->last_mapper));
+    CHECK("mapcopy: mapper names are not shared", cpy->req_mapper != src->req_mapper);
+
+    /* every node came across, including the ones past the initial block */
+    live = 0;
+    for (i = 0; i < nnodes; i++) {
+        if (nodes[i] == (prte_node_t *) pmix_pointer_array_get_item(cpy->nodes, i)) {
+            live++;
+        }
+    }
+    CHECK("mapcopy: every node crossed, including past the first block",
+          nnodes == live);
+    CHECK("mapcopy: the destination array grew to fit", cpy->nodes->size >= nnodes);
+    CHECK("mapcopy: the source array was not disturbed",
+          nodes[nnodes - 1]
+              == (prte_node_t *) pmix_pointer_array_get_item(src->nodes, nnodes - 1));
+
+    /* Releasing both maps must leave our own references intact.  With no
+     * retain in the copy, the second map's destructor dropped a reference it
+     * never took and the nodes went away underneath us. */
+    PMIX_RELEASE(cpy);
+    PMIX_RELEASE(src);
+    live = 0;
+    for (i = 0; i < nnodes; i++) {
+        /* if the refcounts were balanced these are all still ours */
+        if (NULL != nodes[i]->name && 'n' == nodes[i]->name[0]) {
+            live++;
+        }
+        PMIX_RELEASE(nodes[i]);
+    }
+    CHECK("mapcopy: both maps released without dropping the caller's refs",
+          nnodes == live);
+
+    /* a NULL map copies to NULL rather than allocating */
+    cpy = (prte_job_map_t *) 0x1;
+    CHECK("mapcopy: NULL source yields NULL",
+          PRTE_SUCCESS == prte_map_copy((struct prte_job_map_t **) &cpy, NULL) && NULL == cpy);
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* pack / unpack round trips                                          */
+/* ------------------------------------------------------------------ */
+
+static int test_pack_roundtrip(void)
+{
+    int failures = 0;
+    pmix_data_buffer_t buf;
+    prte_job_t *src, *dst = NULL;
+    prte_app_context_t *app, *app2;
+    prte_proc_t *proc;
+    char *sval = NULL;
+    int rc;
+
+    reset_globals();
+
+    src = make_job("wire.job");
+    PMIX_LOAD_NSPACE(src->launcher, "the.launcher");
+    src->num_procs = 2;
+    src->offset = 16;
+    src->stdin_target = 1;
+    src->total_slots_alloc = 48;
+    src->state = PRTE_JOB_STATE_RUNNING;
+    PMIx_Argv_append_nosize(&src->personality, "prte");
+    PMIx_Argv_append_nosize(&src->personality, "ompi");
+    /* only PRTE_ATTR_GLOBAL attributes go on the wire - that asymmetry is
+     * load-bearing (the mapper reads an unpacked copy of the job), so test
+     * both dispositions */
+    prte_set_attribute(&src->attributes, PRTE_JOB_PPR, PRTE_ATTR_GLOBAL, "2:node", PMIX_STRING);
+    prte_set_attribute(&src->attributes, PRTE_JOB_DO_NOT_LAUNCH, PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+
+    app = PMIX_NEW(prte_app_context_t);
+    app->idx = 0;
+    app->app = strdup("/bin/hostname");
+    app->num_procs = 2;
+    app->first_rank = 0;
+    app->cwd = strdup("/home/user");
+    PMIx_Argv_append_nosize(&app->argv, "hostname");
+    PMIx_Argv_append_nosize(&app->argv, "-f");
+    PMIx_Argv_append_nosize(&app->env, "PATH=/bin");
+    prte_set_attribute(&app->attributes, PRTE_APP_PMIX_PREFIX, PRTE_ATTR_GLOBAL,
+                       "/opt/prte", PMIX_STRING);
+    pmix_pointer_array_set_item(src->apps, 0, app);
+    src->num_apps = 1;
+
+    proc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&proc->name, "wire.job", 0);
+    proc->parent = 1;
+    proc->local_rank = 0;
+    proc->node_rank = 0;
+    proc->app_rank = 0;
+    proc->app_idx = 0;
+    proc->state = PRTE_PROC_STATE_RUNNING;
+    proc->cpuset = strdup("0-3");
+    pmix_pointer_array_set_item(src->procs, 0, proc);
+
+    proc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&proc->name, "wire.job", 1);
+    proc->parent = 1;
+    proc->local_rank = 1;
+    proc->node_rank = 1;
+    proc->app_rank = 1;
+    proc->app_idx = 0;
+    proc->state = PRTE_PROC_STATE_RUNNING;
+    pmix_pointer_array_set_item(src->procs, 1, proc);
+
+    src->map = PMIX_NEW(prte_job_map_t);
+    src->map->mapping = 9;
+    src->map->ranking = 4;
+    src->map->binding = 6;
+    src->map->num_nodes = 3;
+    src->map->req_mapper = strdup("seq");
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = prte_job_pack(&buf, src);
+    CHECK("wire: job packs", PRTE_SUCCESS == rc);
+    if (PRTE_SUCCESS == rc) {
+        rc = prte_job_unpack(&buf, &dst);
+        CHECK("wire: job unpacks", PRTE_SUCCESS == rc && NULL != dst);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    if (NULL != dst) {
+        CHECK("wire: nspace round-trips", PMIX_CHECK_NSPACE(dst->nspace, "wire.job"));
+        CHECK("wire: launcher round-trips", PMIX_CHECK_NSPACE(dst->launcher, "the.launcher"));
+        CHECK("wire: num_procs round-trips", 2 == dst->num_procs);
+        CHECK("wire: offset round-trips", 16 == dst->offset);
+        CHECK("wire: stdin_target round-trips", 1 == dst->stdin_target);
+        CHECK("wire: total_slots round-trips", 48 == dst->total_slots_alloc);
+        CHECK("wire: state round-trips", PRTE_JOB_STATE_RUNNING == dst->state);
+        CHECK("wire: personality round-trips",
+              2 == PMIx_Argv_count(dst->personality)
+                  && 0 == strcmp("ompi", dst->personality[1]));
+        CHECK("wire: a GLOBAL attribute crosses",
+              prte_get_attribute(&dst->attributes, PRTE_JOB_PPR, (void **) &sval, PMIX_STRING)
+                  && NULL != sval && 0 == strcmp("2:node", sval));
+        free(sval);
+        sval = NULL;
+        /* a LOCAL attribute deliberately does not */
+        CHECK("wire: a LOCAL attribute does not cross",
+              !prte_get_attribute(&dst->attributes, PRTE_JOB_DO_NOT_LAUNCH, NULL, PMIX_BOOL));
+
+        CHECK("wire: num_apps round-trips", 1 == dst->num_apps);
+        app2 = (prte_app_context_t *) pmix_pointer_array_get_item(dst->apps, 0);
+        CHECK("wire: the app crossed", NULL != app2);
+        if (NULL != app2) {
+            CHECK("wire: app name round-trips",
+                  NULL != app2->app && 0 == strcmp("/bin/hostname", app2->app));
+            CHECK("wire: app num_procs round-trips", 2 == app2->num_procs);
+            CHECK("wire: app argv round-trips",
+                  2 == PMIx_Argv_count(app2->argv) && 0 == strcmp("-f", app2->argv[1]));
+            CHECK("wire: app env round-trips", 1 == PMIx_Argv_count(app2->env));
+            CHECK("wire: app cwd round-trips",
+                  NULL != app2->cwd && 0 == strcmp("/home/user", app2->cwd));
+            CHECK("wire: app attribute round-trips",
+                  prte_get_attribute(&app2->attributes, PRTE_APP_PMIX_PREFIX,
+                                     (void **) &sval, PMIX_STRING)
+                      && NULL != sval && 0 == strcmp("/opt/prte", sval));
+            free(sval);
+            sval = NULL;
+        }
+
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(dst->procs, 0);
+        CHECK("wire: proc 0 crossed", NULL != proc);
+        if (NULL != proc) {
+            CHECK("wire: proc name round-trips",
+                  PMIX_CHECK_NSPACE(proc->name.nspace, "wire.job") && 0 == proc->name.rank);
+            CHECK("wire: proc parent round-trips", 1 == proc->parent);
+            CHECK("wire: proc cpuset round-trips",
+                  NULL != proc->cpuset && 0 == strcmp("0-3", proc->cpuset));
+            CHECK("wire: proc state round-trips", PRTE_PROC_STATE_RUNNING == proc->state);
+        }
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(dst->procs, 1);
+        CHECK("wire: proc 1 crossed and has no cpuset",
+              NULL != proc && NULL == proc->cpuset && 1 == proc->local_rank);
+
+        CHECK("wire: the map crossed", NULL != dst->map);
+        if (NULL != dst->map) {
+            CHECK("wire: map policies round-trip",
+                  9 == dst->map->mapping && 4 == dst->map->ranking && 6 == dst->map->binding);
+            CHECK("wire: map num_nodes round-trips", 3 == dst->map->num_nodes);
+            CHECK("wire: req_mapper round-trips",
+                  NULL != dst->map->req_mapper && 0 == strcmp("seq", dst->map->req_mapper));
+        }
+        PMIX_RELEASE(dst);
+    }
+
+    /* a job with no map packs a flag instead, and unpacks with map == NULL */
+    PMIX_RELEASE(src->map);
+    src->map = NULL;
+    dst = NULL;
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    if (PRTE_SUCCESS == prte_job_pack(&buf, src)) {
+        rc = prte_job_unpack(&buf, &dst);
+        CHECK("wire: a mapless job round-trips", PRTE_SUCCESS == rc && NULL != dst);
+        if (NULL != dst) {
+            CHECK("wire: ...and still has no map", NULL == dst->map);
+            PMIX_RELEASE(dst);
+        }
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    PMIX_RELEASE(src);
+    reset_globals();
+    return failures;
+}
+
+static int test_node_pack_roundtrip(void)
+{
+    int failures = 0;
+    pmix_data_buffer_t buf;
+    prte_node_t *src, *dst = NULL;
+    char *sval = NULL;
+    int rc;
+
+    src = make_node("wire-node");
+    src->num_procs = 6;
+    src->state = PRTE_NODE_STATE_UP;
+    PRTE_FLAG_SET(src, PRTE_NODE_FLAG_OVERSUBSCRIBED);
+    prte_set_attribute(&src->attributes, PRTE_NODE_USERNAME, PRTE_ATTR_GLOBAL,
+                       "svc", PMIX_STRING);
+    prte_set_attribute(&src->attributes, PRTE_NODE_SERIAL_NUMBER, PRTE_ATTR_LOCAL, "wn", PMIX_STRING);
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    rc = prte_node_pack(&buf, src);
+    CHECK("wire: node packs", PRTE_SUCCESS == rc);
+    if (PRTE_SUCCESS == rc) {
+        rc = prte_node_unpack(&buf, &dst);
+        CHECK("wire: node unpacks", PRTE_SUCCESS == rc && NULL != dst);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    if (NULL != dst) {
+        CHECK("wire: node name round-trips",
+              NULL != dst->name && 0 == strcmp("wire-node", dst->name));
+        CHECK("wire: node num_procs round-trips", 6 == dst->num_procs);
+        CHECK("wire: node state round-trips", PRTE_NODE_STATE_UP == dst->state);
+        CHECK("wire: the oversubscribed flag round-trips",
+              PRTE_FLAG_TEST(dst, PRTE_NODE_FLAG_OVERSUBSCRIBED));
+        CHECK("wire: a GLOBAL node attribute crosses",
+              prte_get_attribute(&dst->attributes, PRTE_NODE_USERNAME, (void **) &sval,
+                                 PMIX_STRING)
+                  && NULL != sval && 0 == strcmp("svc", sval));
+        free(sval);
+        CHECK("wire: a LOCAL node attribute does not cross",
+              !prte_get_attribute(&dst->attributes, PRTE_NODE_SERIAL_NUMBER, NULL, PMIX_STRING));
+        PMIX_RELEASE(dst);
+    }
+
+    PMIX_RELEASE(src);
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* object lifetimes                                                   */
+/* ------------------------------------------------------------------ */
+
+static int test_object_lifetimes(void)
+{
+    int failures = 0;
+    prte_node_t *node;
+    prte_proc_t *proc, *daemon;
+
+    reset_globals();
+
+    /* A proc's node backpointer is BORROWED - retaining it would close a
+     * cycle with node->procs / node->daemon and nothing would ever be freed.
+     * The node clears the backpointer on the procs it knows about before it
+     * goes away, so a proc that outlives its node is left pointing at NULL
+     * rather than at freed memory. */
+    node = make_node("lifetime-node");
+    proc = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&proc->name, "life.job", 0);
+    proc->node = node;
+    pmix_pointer_array_set_item(node->procs, 0, proc);
+    PMIX_RETAIN(proc); /* our own reference, so the proc outlives the node */
+
+    daemon = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&daemon->name, "prte-daemons", 1);
+    daemon->node = node;
+    node->daemon = daemon;
+
+    PMIX_RELEASE(node);
+    CHECK("lifetime: a surviving proc's node backpointer was cleared", NULL == proc->node);
+    PMIX_RELEASE(proc);
+
+    /* the launch-fence campaign objects zero their own pointer fields:
+     * PMIX_NEW does not, and the destructor free()s them */
+    {
+        prte_shrink_campaign_t *sc = PMIX_NEW(prte_shrink_campaign_t);
+        prte_grow_campaign_t *gc = PMIX_NEW(prte_grow_campaign_t);
+
+        CHECK("lifetime: shrink campaign starts empty",
+              NULL == sc->targets && NULL == sc->alloc_id && NULL == sc->req_id
+                  && 0 == sc->ntargets && !sc->have_requester);
+        CHECK("lifetime: grow campaign starts empty",
+              NULL == gc->targets && NULL == gc->alloc_id && NULL == gc->req_id
+                  && 0 == gc->ntargets && !gc->have_requester);
+        /* destructing an untouched campaign must not free garbage */
+        PMIX_RELEASE(sc);
+        PMIX_RELEASE(gc);
+    }
+
+    /* a fresh session starts with an invalid id and no owners */
+    {
+        prte_session_t *s = PMIX_NEW(prte_session_t);
+
+        CHECK("lifetime: a fresh session has no owners", NULL == s->owners);
+        CHECK("lifetime: a fresh session has no index", -1 == s->index);
+        CHECK("lifetime: a fresh session has the default inheritance",
+              PRTE_INHERIT_DEFAULT_VALUE == s->inheritance);
+        PMIX_RELEASE(s);
+    }
+
+    reset_globals();
+    return failures;
+}
+
+/* The teardown ordering prte_finalize depends on.  A reservation holds a
+ * COUNTED reference on each of its nodes while the global pool holds its own,
+ * so releasing the reservation must hand back exactly one reference and leave
+ * the node standing.  Getting this wrong is a double free at every DVM exit,
+ * which is why it is pinned here rather than left to the swarm. */
+static int test_session_teardown(void)
+{
+    int failures = 0;
+    prte_session_t *sess;
+    prte_node_t *n1, *n2;
+    int i, live;
+
+    reset_globals();
+
+    n1 = make_node("res-01");
+    n2 = make_node("res-02");
+    n1->index = pmix_pointer_array_add(prte_node_pool, n1);
+    n2->index = pmix_pointer_array_add(prte_node_pool, n2);
+
+    sess = PMIX_NEW(prte_session_t);
+    sess->session_id = 900;
+    CHECK("teardown: session registered", PRTE_SUCCESS == prte_set_session_object(sess));
+
+    /* this is what create_reservation does: retain, then hand to the session */
+    PMIX_RETAIN(n1);
+    pmix_pointer_array_add(sess->nodes, n1);
+    n1->session = sess;
+    PMIX_RETAIN(n2);
+    pmix_pointer_array_add(sess->nodes, n2);
+    n2->session = sess;
+    CHECK("teardown: the nodes point back at their reservation",
+          sess == n1->session && sess == n2->session);
+
+    /* release the reservation - the pool still holds both nodes */
+    pmix_pointer_array_set_item(prte_sessions, sess->index, NULL);
+    PMIX_RELEASE(sess);
+
+    live = 0;
+    for (i = 0; i < prte_node_pool->size; i++) {
+        if (NULL != pmix_pointer_array_get_item(prte_node_pool, i)) {
+            live++;
+        }
+    }
+    CHECK("teardown: releasing a reservation leaves its nodes in the pool", 2 == live);
+    /* ...and the borrowed backpointer was cleared rather than left dangling */
+    CHECK("teardown: the nodes' session backpointer was cleared",
+          NULL == n1->session && NULL == n2->session);
+    /* the nodes are still usable, which they would not be after a double free */
+    CHECK("teardown: the surviving nodes are intact",
+          NULL != n1->name && 0 == strcmp("res-01", n1->name)
+              && NULL != n2->name && 0 == strcmp("res-02", n2->name));
+
+    reset_globals();
+
+    /* The default session is the other half of the ordering: its node array
+     * IS prte_node_pool, so releasing it performs the pool teardown.  Model
+     * that exactly as prte_init builds it. */
+    {
+        pmix_pointer_array_t *pool;
+        prte_session_t *dflt;
+        prte_node_t *nd;
+
+        pool = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(pool, 8, INT_MAX, 8);
+        nd = make_node("pool-01");
+        nd->index = pmix_pointer_array_add(pool, nd);
+
+        dflt = PMIX_NEW(prte_session_t);
+        dflt->session_id = UINT32_MAX;
+        PMIX_RELEASE(dflt->nodes);
+        dflt->nodes = pool;
+        CHECK("teardown: the default session registered",
+              PRTE_SUCCESS == prte_set_session_object(dflt));
+        CHECK("teardown: the default session carries the pool", pool == dflt->nodes);
+
+        /* Releasing it must take the pool and its nodes with it, and must not
+         * trip over the substituted array.  There is nothing to inspect
+         * afterwards - both the array and the node are gone - so the
+         * assertion is that we reach the next statement at all: a double
+         * free or a destructor run against the wrong parent class aborts
+         * here instead. */
+        pmix_pointer_array_set_item(prte_sessions, dflt->index, NULL);
+        PMIX_RELEASE(dflt);
+        CHECK("teardown: the default session took the node pool with it, intact",
+              NULL == pmix_pointer_array_get_item(prte_sessions, 0));
+    }
+
+    reset_globals();
+    return failures;
+}
+
+static int test_exit_status(void)
+{
+    int failures = 0;
+    int saved = prte_exit_status;
+
+    PRTE_RESET_EXIT_STATUS();
+    CHECK("exit: reset clears the status", 0 == prte_exit_status);
+
+    /* the first non-zero status wins: subsequent processes are killed as a
+     * consequence of the first failure, and reporting their status instead
+     * would hide the cause */
+    PRTE_UPDATE_EXIT_STATUS(17);
+    CHECK("exit: the first failure is recorded", 17 == prte_exit_status);
+    PRTE_UPDATE_EXIT_STATUS(9);
+    CHECK("exit: a later failure does not overwrite it", 17 == prte_exit_status);
+    PRTE_UPDATE_EXIT_STATUS(0);
+    CHECK("exit: a success does not clear it", 17 == prte_exit_status);
+    PRTE_RESET_EXIT_STATUS();
+    CHECK("exit: reset clears it again", 0 == prte_exit_status);
+    /* ...and a zero into a zero stays zero */
+    PRTE_UPDATE_EXIT_STATUS(0);
+    CHECK("exit: zero over zero is zero", 0 == prte_exit_status);
+
+    prte_exit_status = saved;
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* data server                                                        */
+/* ------------------------------------------------------------------ */
+
+static int test_data_server_objects(void)
+{
+    int failures = 0;
+    prte_data_object_t *obj;
+    prte_data_req_t *req;
+
+    /* PMIX_NEW does not zero what it allocates, so anything the access
+     * checks read has to be set by the constructor.  proxy on both objects
+     * is exactly that: it is what PMIX_RANGE_LOCAL compares. */
+    obj = PMIX_NEW(prte_data_object_t);
+    CHECK("ds: a new data object has an initialized proxy",
+          PMIX_RANK_UNDEF == obj->proxy.rank && 0 == strlen(obj->proxy.nspace));
+    CHECK("ds: a new data object has an initialized owner",
+          PMIX_RANK_UNDEF == obj->owner.rank && 0 == strlen(obj->owner.nspace));
+    CHECK("ds: a new data object defaults to session range",
+          PMIX_RANGE_SESSION == obj->range);
+    CHECK("ds: a new data object has no uid", UINT32_MAX == obj->uid);
+    PMIX_RELEASE(obj);
+
+    req = PMIX_NEW(prte_data_req_t);
+    CHECK("ds: a new request has an initialized proxy",
+          PMIX_RANK_UNDEF == req->proxy.rank && 0 == strlen(req->proxy.nspace));
+    CHECK("ds: a new request has an initialized requestor",
+          PMIX_RANK_UNDEF == req->requestor.rank && 0 == strlen(req->requestor.nspace));
+    CHECK("ds: a new request has no keys", NULL == req->keys);
+    /* the destructor free()s keys - it must not free garbage */
+    PMIX_RELEASE(req);
+
+    return failures;
+}
+
+static int test_data_server_range(void)
+{
+    int failures = 0;
+    prte_data_object_t *data;
+    prte_data_req_t *req;
+
+    data = PMIX_NEW(prte_data_object_t);
+    PMIX_LOAD_PROCID(&data->owner, "publisher.ns", 2);
+    PMIX_LOAD_PROCID(&data->proxy, "prte-daemons", 5);
+
+    req = PMIX_NEW(prte_data_req_t);
+    PMIX_LOAD_PROCID(&req->requestor, "other.ns", 0);
+    PMIX_LOAD_PROCID(&req->proxy, "prte-daemons", 9);
+
+    /* session/global/undef are open to everyone */
+    data->range = PMIX_RANGE_SESSION;
+    CHECK("range: SESSION admits a stranger", PMIX_SUCCESS == prte_data_server_check_range(req, data));
+    data->range = PMIX_RANGE_GLOBAL;
+    CHECK("range: GLOBAL admits a stranger", PMIX_SUCCESS == prte_data_server_check_range(req, data));
+    data->range = PMIX_RANGE_UNDEF;
+    CHECK("range: UNDEF admits a stranger", PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    /* NAMESPACE admits only the publisher's own namespace */
+    data->range = PMIX_RANGE_NAMESPACE;
+    CHECK("range: NAMESPACE refuses another namespace",
+          PMIX_SUCCESS != prte_data_server_check_range(req, data));
+    PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 7);
+    CHECK("range: NAMESPACE admits any rank of the publisher's namespace",
+          PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    /* LOCAL admits only requestors behind the same daemon.  This is the
+     * check that was reading an uninitialized data->proxy. */
+    data->range = PMIX_RANGE_LOCAL;
+    CHECK("range: LOCAL refuses a different daemon",
+          PMIX_SUCCESS != prte_data_server_check_range(req, data));
+    PMIX_LOAD_PROCID(&req->proxy, "prte-daemons", 5);
+    CHECK("range: LOCAL admits the same daemon",
+          PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    /* PROC_LOCAL admits only the publisher itself */
+    data->range = PMIX_RANGE_PROC_LOCAL;
+    CHECK("range: PROC_LOCAL refuses a peer in the same namespace",
+          PMIX_SUCCESS != prte_data_server_check_range(req, data));
+    PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 2);
+    CHECK("range: PROC_LOCAL admits the publisher",
+          PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    /* RM admits only our own (the host server's) namespace */
+    data->range = PMIX_RANGE_RM;
+    CHECK("range: RM refuses an application namespace",
+          PMIX_SUCCESS != prte_data_server_check_range(req, data));
+    PMIX_LOAD_NSPACE(req->requestor.nspace, PRTE_PROC_MY_NAME->nspace);
+    CHECK("range: RM admits the host's own namespace",
+          PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    /* CUSTOM has no accessor list implemented, so it must deny rather than
+     * fall through to a permit */
+    data->range = PMIX_RANGE_CUSTOM;
+    PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 2);
+    CHECK("range: CUSTOM denies (no accessor list is implemented)",
+          PMIX_SUCCESS != prte_data_server_check_range(req, data));
+
+    PMIX_RELEASE(req);
+    PMIX_RELEASE(data);
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* progress threads                                                   */
+/* ------------------------------------------------------------------ */
+
+static int test_progress_thread_cpus(void)
+{
+    int failures = 0;
+    int cpus[16];
+    int n;
+
+    /* A bare cpu number.  strtoul always returns a non-NULL end pointer, so
+     * the old "if (NULL == dash)" test never fired: "3" went down the range
+     * branch, which stepped the pointer past the terminating NUL and read
+     * whatever followed the string. */
+    n = prte_progress_thread_parse_cpus("3", cpus, 16);
+    CHECK("cpus: a bare number yields exactly one cpu", 1 == n);
+    CHECK("cpus: ...and it is the number given", 1 == n && 3 == cpus[0]);
+
+    n = prte_progress_thread_parse_cpus("0", cpus, 16);
+    CHECK("cpus: cpu 0 parses", 1 == n && 0 == cpus[0]);
+
+    /* A range is inclusive of its upper bound: "0-3" is four cpus.  The old
+     * loop was "k < end", so the last cpu of every range was dropped. */
+    n = prte_progress_thread_parse_cpus("0-3", cpus, 16);
+    CHECK("cpus: a range names all of its cpus", 4 == n);
+    CHECK("cpus: ...in order",
+          4 == n && 0 == cpus[0] && 1 == cpus[1] && 2 == cpus[2] && 3 == cpus[3]);
+
+    n = prte_progress_thread_parse_cpus("5-5", cpus, 16);
+    CHECK("cpus: a degenerate range is one cpu", 1 == n && 5 == cpus[0]);
+
+    /* mixed list */
+    n = prte_progress_thread_parse_cpus("1,4-6,9", cpus, 16);
+    CHECK("cpus: a mixed list expands fully", 5 == n);
+    CHECK("cpus: ...with the right members",
+          5 == n && 1 == cpus[0] && 4 == cpus[1] && 5 == cpus[2] && 6 == cpus[3]
+              && 9 == cpus[4]);
+
+    /* garbage is rejected instead of silently binding to cpu 0 */
+    CHECK("cpus: non-numeric input is rejected",
+          0 > prte_progress_thread_parse_cpus("abc", cpus, 16));
+    CHECK("cpus: a trailing dash is rejected",
+          0 > prte_progress_thread_parse_cpus("2-", cpus, 16));
+    CHECK("cpus: an inverted range is rejected",
+          0 > prte_progress_thread_parse_cpus("7-2", cpus, 16));
+    CHECK("cpus: trailing junk is rejected",
+          0 > prte_progress_thread_parse_cpus("3x", cpus, 16));
+    CHECK("cpus: NULL input is rejected",
+          0 > prte_progress_thread_parse_cpus(NULL, cpus, 16));
+    /* ...and the bound is honored rather than overrun */
+    CHECK("cpus: a list larger than the buffer is refused",
+          0 > prte_progress_thread_parse_cpus("0-99", cpus, 16));
+
+    return failures;
+}
+
+static int test_progress_thread_lifecycle(void)
+{
+    int failures = 0;
+    prte_event_base_t *b1, *b2;
+
+    b1 = prte_progress_thread_init("unit-test-thread");
+    CHECK("thread: init returns an event base", NULL != b1);
+
+    /* asking for the same name again hands back the same base rather than
+     * starting a second thread */
+    b2 = prte_progress_thread_init("unit-test-thread");
+    CHECK("thread: the same name reuses the same base", b1 == b2);
+
+    /* a different name is a different thread */
+    b2 = prte_progress_thread_init("unit-test-other");
+    CHECK("thread: a different name gets its own base", NULL != b2 && b1 != b2);
+
+    CHECK("thread: pause succeeds", PRTE_SUCCESS == prte_progress_thread_pause("unit-test-thread"));
+    /* resuming a running thread is refused; resuming a paused one works */
+    CHECK("thread: resume restarts it",
+          PRTE_SUCCESS == prte_progress_thread_resume("unit-test-thread"));
+    CHECK("thread: resuming a running thread is refused",
+          PRTE_ERR_RESOURCE_BUSY == prte_progress_thread_resume("unit-test-thread"));
+
+    /* unknown names are reported, not silently accepted */
+    CHECK("thread: pausing an unknown name is reported",
+          PRTE_ERR_NOT_FOUND == prte_progress_thread_pause("no-such-thread"));
+    CHECK("thread: resuming an unknown name is reported",
+          PRTE_ERR_NOT_FOUND == prte_progress_thread_resume("no-such-thread"));
+    CHECK("thread: finalizing an unknown name is reported",
+          PRTE_ERR_NOT_FOUND == prte_progress_thread_finalize("no-such-thread"));
+
+    CHECK("thread: finalize succeeds",
+          PRTE_SUCCESS == prte_progress_thread_finalize("unit-test-thread"));
+    CHECK("thread: the finalized name is gone",
+          PRTE_ERR_NOT_FOUND == prte_progress_thread_pause("unit-test-thread"));
+    CHECK("thread: the other thread survived",
+          PRTE_SUCCESS == prte_progress_thread_finalize("unit-test-other"));
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    int rc, failures = 0;
+    pmix_status_t prc;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+    /* several of the objects under test reference the event base through
+     * their destructors (timers on a job, for one) */
+    rc = prte_event_base_open();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_event_base_open failed: %d\n", rc);
+        return 1;
+    }
+    /* PMIx_Data_pack refuses to run until PMIx itself is up, and the wire
+     * tests below go straight through it.  A daemon reaches this state via
+     * PMIx_server_init, so do the same. */
+    prc = PMIx_server_init(NULL, NULL, 0);
+    if (PMIX_SUCCESS != prc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(prc));
+        return 1;
+    }
+
+    /* prte_session_t's destructor asks the ras base to release the
+     * underlying allocation, and that walks prte_ras_base.selected_modules -
+     * a list that does not exist until the framework is open */
+    rc = pmix_mca_base_framework_open(&prte_ras_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "ras framework open failed: %d\n", rc);
+        return 1;
+    }
+    setup_globals();
+    PMIX_LOAD_PROCID(PRTE_PROC_MY_NAME, "prte-hnp", 0);
+
+    failures += test_job_registry();
+    failures += test_session_registry();
+    failures += test_session_ownership();
+    failures += test_proc_lookups();
+    failures += test_node_matching();
+    failures += test_node_copy();
+    failures += test_app_copy();
+    failures += test_map_copy();
+    failures += test_pack_roundtrip();
+    failures += test_node_pack_roundtrip();
+    failures += test_object_lifetimes();
+    failures += test_session_teardown();
+    failures += test_exit_status();
+    failures += test_data_server_objects();
+    failures += test_data_server_range();
+    failures += test_progress_thread_cpus();
+    failures += test_progress_thread_lifecycle();
+
+    (void) pmix_mca_base_framework_close(&prte_ras_base_framework);
+    prte_event_base_close();
+    PMIx_server_finalize();
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all runtime unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d runtime unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
Deep review of `src/runtime` — the object model, the process lifecycle, the global
registries, the publish/lookup data server, and the pack/unpack/copy/print support.
Fifteen commits, one logical change each.

### The two that matter most

Both were invisible by construction, which is why they survived.

**`prte_session_t` was registered against the wrong base class.** The struct embeds a
`pmix_object_t`; `PMIX_CLASS_INSTANCE` named `pmix_list_item_t`. The class system runs
every constructor and destructor in the ancestor chain, so `pmix_list_item_t`'s pair ran
over a struct with no room for one — its `next`/`prev` and its debug bookkeeping land on
top of the session's own leading fields. The constructor half is masked, because
`session_con` runs afterwards and rewrites the same bytes. The destructor half is not:
`pmix_list_item_destruct` asserts the item is not still on a list, and reads that
"refcount" out of the middle of the session's data. **Under a debug PMIx, releasing any
session aborted the process.** It went unnoticed only because `prte_default_session` — the
one session that always exists — is never released, so on a DVM that creates no
reservation the destructor never runs.

**The reservation ownership gate was an unconditional yes.** `prte_session_is_owned_by`
grants access to the scheduler before consulting the owner list. `PMIX_CHECK_NSPACE`
returns true when *either* side is an empty nspace — its wildcard rule — and
`scheduler.nspace` is empty until a scheduler connects. So on every DVM running without
one, which is the common case, every namespace was declared to be the scheduler and the
owner list below was never reached.

### Also fixed

| | |
|---|---|
| `prte_map_copy` | blitted the source array's `size` over the destination's and wrote `addr[i]` past the constructor's 64-entry allocation — heap overflow past 64 nodes — and took no reference on nodes whose destructor releases them |
| `prte_app_copy` | walked a `prte_attribute_t` list as `prte_value_t`: wrong offset for the value, key dropped entirely, so every copied attribute was unfindable |
| `prte_node_copy` | dropped rawname, aliases, attributes and session — a duplicate answering to only one of its names, in the wrong pool |
| `prte_mca_params.c` | `pmix_sprintf` — no such function. `--disable-per-user-config-files` **did not build** |
| progress threads | `strtoul`'s end pointer is never NULL, so a bare `"3"` took the range branch and read past the terminating NUL; ranges excluded their upper bound; a failed thread start reported success |
| `ds_lookup` | the partial-success path discarded the values it had found; the `PMIX_WAIT` path leaked the answer buffer per parked lookup |
| `ds_publish` | leaked the unpacked info array on **every successful publish**; released a request still linked into the pending list; reported a fully-satisfied lookup as partial |
| `ds_main`/`ds_purge` | `proxy` never constructed, so the `LOCAL` range check read uninitialized heap; `PMIx_Data_pack(…, &rc, …)` assigned back to `rc`, discarding the code being reported |
| print functions | `free()` of an uninitialized pointer; unguarded `src->node->topology->topo` for an unmapped proc; a `continue` that leaked a string and dropped a package from the output |
| `prte_globals.c` | NULL deref in the lookup by refid; `prte_node_match` dereferenced `prte_node_pool` before `prte_init` builds it |
| `prte_init.c` | three `sscanf` returns discarded, leaving version fields uninitialized; the MCA-preload return ignored; its lists leaked on every early return |

### Session teardown at finalize

`prte_finalize` never touched `prte_sessions` or `prte_default_session`, which was left
holding a pointer to the node pool it had just released. It now tears them down, and three
constraints fix the order: reservations before the pool (they hold counted node
references); the default session last (its node array **is** the pool); and all of it
before anything closes the `ras` framework — nothing does today, and the comment says so
in as many words, because adding such a close would quietly turn `session_des` into a walk
over a destructed list.

### One trap worth naming

`prte_finalize`'s entire teardown sat behind `#ifdef PRTE_PICKY_COMPILERS`. Configure
emits that with `AC_DEFINE_UNQUOTED` as 0 or 1, so it is always *defined* and the `#ifdef`
never excluded anything. The obvious correction — spelling it `#if` to match the project
rule on logical macros — would have silently deleted the whole teardown from every normal
build. The guard is removed rather than fixed, with a comment saying why.

### Testing

New `test/unit/runtime/test_runtime.c`, 213 assertions under `make check`, plus a
`test_runtime` phase in `contrib/dockerswarm` with a new `dataserver` client. The swarm
phase covers what one node cannot show: a publish on one node found from another, a
partial lookup that must come back carrying the half it found, a lookup parked until a
later publish from a different node satisfies it, and `PMIX_RANGE_LOCAL` data that must
not leave its node.

Two harness fixes came out of writing it. A remote application inherits neither the head
node's PATH nor its library path, so a PMIx-linking helper was loading the PMIx baked into
the *image* rather than the one under test — silently, on every node but node1. Helpers now
carry an rpath. Both traps are written up in the dockerswarm guide.

The partial-lookup case needs openpmix/openpmix#4044, which fixes the mirror-image defect
on the client side: PMIx discarded the returned data for any non-`SUCCESS` status, so a
correct server still produced an empty answer.

`src/runtime` and its two subdirectories gain AGENTS.md files.

### Verification

Warning-free `--enable-debug` build; `make check` 15/15; `make -C test/offline
check-offline` 1180/1180; live DVM smoke test; full dockerswarm suite **242 passed, 0
failed, 0 skipped**.
