### PR TITLE
Drop the session child array nothing ever filled

### DIFF
--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -103,7 +103,7 @@ This is the part that bites. The rules, and the reason for each:
 | `node->session` | **no** — borrowed | same reason, against `session->nodes`. `prte_ras_base_release_allocation` clears it when a reservation is torn down. |
 | `session->nodes[]` | yes | a reservation withholds its nodes |
 | `session->jobs[]` | **no** — borrowed | a job's lifetime is governed by the global job pool, not by the session it ran in |
-| `session->children[]`, `session->owner_job` | yes | |
+| `session->owner_job` | yes | |
 | `job->target_sessions[]` | **no** — borrowed | owned via `prte_set_session_object`; the destructor frees only the array |
 | `node->topology` | yes | a topology outlives any one node pointing at it |
 | `map->nodes[]` | yes | `prte_job_map_destruct` releases every node it holds — so anything that *puts* a node in a map must retain it |
@@ -234,9 +234,11 @@ cancels an allocation PRRTE itself created dynamically and still tracks, so
 a DVM that exits still holding a sub-allocation gives it back, while a
 user's own resource-manager allocation is left alone.
 
-`session->children` needs no separate walk. Nothing in the tree ever
-populates that array — which also means `prte_sessions_related()` can only
-ever report identity, and its parent/child branch is unreachable today.
+Sessions do not form a tree. `prte_session_t` used to carry a `children`
+array and a `prte_sessions_related()` predicate over it, but nothing in the
+tree ever populated the array, so the predicate could only ever report
+identity; both are gone. If a reservation hierarchy is ever needed, build it
+deliberately rather than reviving these.
 
 ## Known gaps
 

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -130,10 +130,7 @@ int prte_finalize(void)
      * Note that release_allocation only cancels an allocation PRRTE itself
      * created dynamically and still tracks; a user's own resource-manager
      * allocation is left alone. So reaching it here is the correct cleanup
-     * for a DVM that exits still holding a sub-allocation, not a hazard.
-     *
-     * session->children is not walked separately: nothing in the tree ever
-     * populates it, and session_des empties it anyway. */
+     * for a DVM that exits still holding a sub-allocation, not a hazard. */
     if (NULL != prte_sessions) {
         for (n = 0; n < prte_sessions->size; n++) {
             session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, n);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -418,29 +418,6 @@ int prte_set_session_object(prte_session_t *session)
     return PRTE_SUCCESS;
 }
 
-bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2)
-{
-    int n;
-    prte_session_t *session_ptr;
-
-    if (NULL == session1 || NULL == session2) {
-        return false;
-    }
-    if (session1->session_id == session2->session_id) {
-        return true;
-    }
-
-    for (n = 0; n < session1->children->size; n++){
-        session_ptr = (prte_session_t *) pmix_pointer_array_get_item(session1->children, n);
-        if (NULL != session_ptr) {
-            if (session_ptr->session_id == session2->session_id) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 prte_proc_t *prte_get_proc_object(const pmix_proc_t *proc)
 {
     prte_job_t *jdata;
@@ -1059,10 +1036,6 @@ static void session_con(prte_session_t *s)
     pmix_pointer_array_init(s->jobs, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
                             PRTE_GLOBAL_ARRAY_MAX_SIZE,
                             PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
-    s->children = PMIX_NEW(pmix_pointer_array_t);
-    pmix_pointer_array_init(s->children, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
-                            PRTE_GLOBAL_ARRAY_MAX_SIZE,
-                            PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
     s->owners = NULL;
     PMIX_LOAD_NSPACE(s->owner, NULL);
     s->owner_job = NULL;
@@ -1074,7 +1047,6 @@ static void session_des(prte_session_t *s)
     int n;
     prte_node_t *nd;
     prte_job_t *job;
-    prte_session_t *session;
 
     /* notify the RAS so it can release the underlying allocation */
     prte_ras_base_release_allocation(s);
@@ -1118,15 +1090,6 @@ static void session_des(prte_session_t *s)
         }
     }
     PMIX_RELEASE(s->jobs);
-
-    for (n=0; n < s->children->size; n++) {
-        session = (prte_session_t*)pmix_pointer_array_get_item(s->children, n);
-        if (NULL != session) {
-            PMIX_RELEASE(session);
-            pmix_pointer_array_set_item(s->children, n, NULL);
-        }
-    }
-    PMIX_RELEASE(s->children);
 
     if (NULL != s->owners) {
         PMIx_Argv_free(s->owners);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -231,7 +231,6 @@ typedef struct{
     struct timeval timeout;  // time limit on session
     pmix_pointer_array_t *nodes;
     pmix_pointer_array_t *jobs;
-    pmix_pointer_array_t *children;
     /* namespaces entitled to spawn onto this session's nodes. Seeded with the
      * namespace the reservation was created for, then extended with each job
      * spawned into the session. Empty for the default session (which everyone
@@ -508,8 +507,6 @@ PRTE_EXPORT prte_session_t *prte_get_session_object_from_id(const char *id);
 PRTE_EXPORT prte_session_t *prte_get_session_object_from_refid(const char *refid);
 
 PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
-
-PRTE_EXPORT bool prte_sessions_related(prte_session_t *session1, prte_session_t *session2);
 
 /* True if nspace is in session->owners, or session is the default session,
  * or nspace is the scheduler. */

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -268,19 +268,6 @@ static int test_session_registry(void)
     CHECK("session: duplicate id refused", PRTE_EXISTS == prte_set_session_object(dup));
     PMIX_RELEASE(dup);
 
-    /* relatedness: identity, parent/child, and unrelated */
-    CHECK("session: a session is related to itself", prte_sessions_related(s1, s1));
-    CHECK("session: unrelated sessions are not related", !prte_sessions_related(s1, s2));
-    PMIX_RETAIN(s2);
-    pmix_pointer_array_add(s1->children, s2);
-    CHECK("session: a child is related to its parent", prte_sessions_related(s1, s2));
-    /* ...but the relation as implemented is one-way: only s1's children are
-     * consulted.  Pin the behavior so a change to it is deliberate. */
-    CHECK("session: the relation is checked parent-to-child only",
-          !prte_sessions_related(s2, s1));
-    CHECK("session: NULL operands are not related", !prte_sessions_related(NULL, s1));
-    CHECK("session: NULL operands are not related (2)", !prte_sessions_related(s1, NULL));
-
     reset_globals();
     return failures;
 }


### PR DESCRIPTION
### Problem

`prte_session_t` carries a `children` pointer array, and `prte_sessions_related()` reports whether one session is the other or one of its children.

Nothing in the tree ever adds anything to that array — not the allocation paths, not the reservation paths, not the scheduler path. The consequences:

- `prte_sessions_related()` can only ever report identity; its child-scanning branch is unreachable. It also has no callers anywhere in the tree.
- Every session allocates, initializes, walks and releases a `pmix_pointer_array_t` that is always empty, to express a hierarchy that does not exist.
- The runtime documentation and `prte_finalize`'s teardown comment both had to carry an explanation of why the array needs no separate teardown walk — upkeep for a structure that is never used.

### Change

Remove the field, its construction, its destructor walk, and the predicate built over it.

`prte_sessions_related()` is deleted rather than reduced: once the child branch goes, all that is left is a `session_id` comparison under a name that promises rather more, and it has no callers to preserve. The unit test's relatedness block — which had to populate `children` by hand to reach the branch at all — goes with it.

`src/runtime/AGENTS.md` and the `prte_finalize` comment now record that sessions deliberately do not form a tree, so that if a reservation hierarchy is ever wanted it gets built on purpose rather than by reviving an empty array.

### Testing

- Clean `--enable-debug` build (warnings are errors), no new warnings.
- `make check` passes, including `test/unit/runtime/test_runtime`.