### PR TITLE
Close the frameworks the daemon and the HNP actually opened

### DIFF
--- a/src/mca/ess/AGENTS.md
+++ b/src/mca/ess/AGENTS.md
@@ -42,7 +42,7 @@ prte_finalize()
 
 Nothing else in the process is usable until `prte_ess.init()` returns.
 The selected module's `init` is where `state`, `errmgr`, `plm`,
-`grpcomm`, `odls`, `rmaps`, `ras` (HNP only), `iof`, `filem`,
+`grpcomm`, `odls`, `rmaps` and `ras` (both HNP only), `iof`, `filem`,
 `prtereachable`, and the `rml` are opened and selected, the PMIx server
 is started, and the process's own job/proc/node data objects are
 created. In other words, **`ess` is the orchestrator of startup**; the
@@ -257,7 +257,14 @@ after setting their name. In order, it:
 8. Starts the PMIx server (`pmix_server_init` → later
    `pmix_server_start`), gathers interface aliases.
 9. Opens/selects the communication stack: `prtereachable`, `rml`.
-10. Selects `errmgr`; opens/selects `grpcomm`, `odls`, `rmaps`.
+10. Selects `errmgr`; opens/selects `grpcomm`, `odls`. **Not `rmaps`, and
+    not `ras`** — both are HNP-only. A daemon never maps and never
+    allocates: the mapper is driven by the DVM state machine, which no
+    daemon runs, and the launch path does not even forward the `rmaps`
+    MCA params out to a `prted`. The base parsers/printers a daemon does
+    use (translating a local client's `map-by`/`rank-by` spawn directives
+    in `pmix_server_dyn`) are compiled into `libprrte` and need no open
+    framework behind them.
 11. Adds the local topology to `prte_node_topologies`.
 12. If a PLM was opened, calls `prte_plm.init()` (must come after comms).
 13. Opens/selects `iof` and `filem`.

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -340,20 +340,17 @@ int prte_ess_base_prted_setup(void)
         error = "prte_odls_base_select";
         goto error;
     }
-    if (PRTE_SUCCESS
-        != (ret = pmix_mca_base_framework_open(&prte_rmaps_base_framework,
-                                               PMIX_MCA_BASE_OPEN_DEFAULT))) {
-        PRTE_ERROR_LOG(ret);
-        error = "prte_rmaps_base_open";
-        goto error;
-    }
-    if (PRTE_SUCCESS != (ret = prte_rmaps_base_select())) {
-        PRTE_ERROR_LOG(ret);
-        error = "prte_rmaps_base_select";
-        goto error;
-    }
+    /* NOTE: a daemon does NOT open the rmaps framework. Mapping is the
+     * HNP's job - the mapper is driven by the DVM state machine, which a
+     * daemon does not run, and the launch path deliberately does not even
+     * forward the rmaps MCA params out to us. The parsers and printers a
+     * daemon does use (translating a local client's map-by/rank-by spawn
+     * directives in pmix_server_dyn) live in the base and are compiled
+     * into libprrte, so they need no open framework behind them. Neither
+     * is ras opened here: only the HNP allocates.
+     */
 
-    /* if a topology file was given, then the rmaps framework open
+    /* if a topology file was given, then the framework opens above
      * will have reset our topology. Ensure we always get the right
      * one by setting our node topology afterwards
      */

--- a/src/mca/ess/env/AGENTS.md
+++ b/src/mca/ess/env/AGENTS.md
@@ -55,7 +55,7 @@ claims the process.
 2. **`env_set_name()`** — establish this daemon's identity from the base
    MCA params (see below).
 3. **`prte_ess_base_prted_setup()`** — the entire shared daemon bring-up
-   (signals, topology, state/errmgr/grpcomm/odls/rmaps/iof/filem/comms,
+   (signals, topology, state/errmgr/grpcomm/odls/iof/filem/comms,
    PMIx server, session dir, job/proc objects). See the framework guide.
 
 `rte_finalize` is just `prte_ess_base_prted_finalize()`.

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -51,7 +51,6 @@
 #include "src/mca/grpcomm/base/base.h"
 #include "src/mca/iof/base/base.h"
 #include "src/mca/plm/base/base.h"
-#include "src/mca/ras/base/base.h"
 #include "src/rml/rml.h"
 
 #include "src/mca/filem/base/base.h"

--- a/src/mca/ess/hnp/AGENTS.md
+++ b/src/mca/ess/hnp/AGENTS.md
@@ -106,10 +106,20 @@ allocation and name/launch daemons. Conversely, the daemon path opens
 ## `rte_finalize` — HNP tear-down
 
 Reverse order: finalize `errmgr`; close
-`filem`/`grpcomm`/`iof`/`plm`; kill local procs
+`filem`/`grpcomm`/`iof`/`plm`/`rmaps`; kill local procs
 (`prte_odls.kill_local_procs`) unless `prte_abnormal_term_ordered`; close
 `odls`; close the `rml`; close `prtereachable`/`errmgr`/`state`; emit the
 XML end tag; finalize the PMIx server; flush stdout/stderr.
+
+**`ras` is the one framework this module opens and does not close.** A
+`prte_session_t` destructor asks the ras base to release the underlying
+allocation, and the sessions are torn down *after* `prte_ess.finalize()`
+returns — so closing `ras` here would leave that release with no modules
+to call, silently stranding a dynamically-acquired allocation.
+`prte_finalize` closes it instead, immediately after the session
+teardown and under a `PRTE_PROC_IS_MASTER` guard so no daemon ever
+touches it. See [`src/runtime/AGENTS.md`](../../../runtime/AGENTS.md),
+"Session teardown at finalize".
 
 ---
 

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -445,6 +445,13 @@ static int rte_finalize(void)
     (void) pmix_mca_base_framework_close(&prte_filem_base_framework);
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     (void) pmix_mca_base_framework_close(&prte_iof_base_framework);
+    /* mapping is over, so rmaps can go here - the close frees the base's
+     * hwloc bitmaps and runs each mapper's finalize. The ras framework we
+     * also opened is NOT closed here: a session destructor asks it to
+     * release the underlying allocation, and the sessions are torn down
+     * after this function returns, so prte_finalize closes it once that
+     * teardown is done. */
+    (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
     (void) pmix_mca_base_framework_close(&prte_plm_base_framework);
     if (!prte_abnormal_term_ordered) {
         /* make sure our local procs are dead */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -354,6 +354,20 @@ documented in each component's guide.
   DECLARE; there is no separate close file. (An orphaned
   `ras_base_close.c` — never in `base/Makefile.am`, referencing
   long-gone `active_module`/`ras_opened` fields — was removed.)
+- **`ess/hnp` opens the framework; `prte_finalize` closes it.** That
+  split is deliberate and is the one thing to know before moving either
+  call. `session_des` → `prte_ras_base_release_allocation` walks
+  `selected_modules`, and the sessions are torn down *after*
+  `prte_ess.finalize()` has returned, so the close has to wait for them;
+  `prte_finalize` does it immediately after that teardown, guarded by
+  `PRTE_PROC_IS_MASTER` (a daemon never opens `ras` — only the HNP may
+  allocate — so a daemon must never close it either). Closing it is what
+  gives every selected module its `finalize`: `ras/slurm` frees its
+  session stack, its shrink trackers and its pending extend requests
+  there, and until the close existed none of that ever ran. Get the
+  order backwards and nothing crashes — `PMIX_LIST_DESTRUCT` leaves the
+  list empty but walkable — the allocation is just silently never
+  released.
 - **A `prte_node_t` only acquires a `topology` when its daemon reports
   in.** Any pool walk that dereferences `node->topology` must NULL-check
   first — the pool routinely holds allocated-but-not-yet-launched nodes

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -224,10 +224,16 @@ Three constraints fix the order, and all three have to hold:
    partway through `prte_init`).
 3. **Before the `ras` framework closes.** `session_des` calls
    `prte_ras_base_release_allocation`, which walks
-   `prte_ras_base.selected_modules`. Today nothing closes that framework —
-   neither `ess/hnp`'s `rte_finalize` nor `ess/base`'s `prted_finalize` — so
-   the list is still valid at finalize. **If you ever add that close, this
-   block has to move ahead of it**, or the walk runs over a destructed list.
+   `prte_ras_base.selected_modules`, so `ras` has to still be open while the
+   sessions go down. `prte_finalize` therefore closes it **itself**,
+   immediately after this block and under a `PRTE_PROC_IS_MASTER` guard —
+   `ess/hnp` opens it (no other role may allocate) but cannot close it,
+   because `prte_ess.finalize()` runs long before the sessions do. Nothing
+   may be inserted between the teardown and that close. Note the failure
+   mode if you get this backwards is silent, not a crash:
+   `PMIX_LIST_DESTRUCT` leaves the list empty but walkable, so the release
+   simply never reaches a module and a dynamically-acquired allocation is
+   never handed back.
 
 Reaching `release_allocation` here is deliberate, not collateral: it only
 cancels an allocation PRRTE itself created dynamically and still tracks, so

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -42,6 +42,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/base/base.h"
 #include "src/mca/ess/ess.h"
+#include "src/mca/ras/base/base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_locks.h"
 #include "src/runtime/prte_progress_threads.h"
@@ -122,10 +123,10 @@ int prte_finalize(void)
      * node array IS prte_node_pool (prte_init substitutes it), so releasing
      * that session performs the pool teardown itself and must therefore go
      * last. And session_des asks the ras base to release the underlying
-     * allocation, which walks prte_ras_base.selected_modules: the ras
-     * framework is deliberately never closed - neither ess/hnp's rte_finalize
-     * nor ess/base's prted_finalize closes it - so that list is still valid
-     * here. If that ever changes, this block has to move ahead of the close.
+     * allocation, which walks prte_ras_base.selected_modules, so the ras
+     * framework has to still be open while this runs - which is why it is
+     * closed just below this block rather than by the ess module that
+     * opened it. Nothing may be inserted between the two.
      *
      * Note that release_allocation only cancels an allocation PRRTE itself
      * created dynamically and still tracks; a user's own resource-manager
@@ -164,6 +165,17 @@ int prte_finalize(void)
         }
         PMIX_RELEASE(prte_node_pool);
         prte_node_pool = NULL;
+    }
+
+    /* Every session has now had its chance to give its allocation back, so
+     * the ras framework can go - which is what runs each selected module's
+     * finalize, letting a component release whatever it is still holding
+     * (ras/slurm, for one, carries its session stack, its shrink trackers
+     * and its pending extend requests). Only the HNP ever opens ras -
+     * ess/hnp does it, since no other role is permitted to allocate - so
+     * only the HNP closes it. */
+    if (PRTE_PROC_IS_MASTER) {
+        (void) pmix_mca_base_framework_close(&prte_ras_base_framework);
     }
 
     for (n = 0; n < prte_job_data->size; n++) {


### PR DESCRIPTION
Two related holes in framework teardown, both of which left components with no chance to clean up after themselves.

### `ras` was never closed at all

Nothing in the tree closed the `ras` framework — not `ess/hnp`'s `rte_finalize`, not `prte_finalize`. So no selected module ever got its `finalize`, and `ras/slurm` has real work waiting there: its per-jobid session stack, its shrink trackers, and its pending extend-request records were all abandoned at exit.

The close cannot go where the open is. `ess/hnp` opens `ras` (the only role permitted to allocate), but `session_des` → `prte_ras_base_release_allocation` walks `prte_ras_base.selected_modules`, and the sessions are torn down *after* `prte_ess.finalize()` has returned. Closing `ras` from `rte_finalize` would leave that release with no modules to call — and it would do so **silently**: `PMIX_LIST_DESTRUCT` leaves the list empty but perfectly walkable, so a dynamically acquired allocation would simply never be handed back and nothing would report it.

`prte_finalize` closes it instead, immediately after the session teardown it already owns, guarded by `PRTE_PROC_IS_MASTER` so no daemon ever touches the framework. The ordering constraint is now written down in `src/runtime/AGENTS.md`, `src/mca/ras/AGENTS.md` and `ess/hnp/AGENTS.md` rather than being folklore.

### A `prted` was opening `rmaps`

`prte_ess_base_prted_setup()` opened *and selected* `rmaps` — which `ess/hnp/AGENTS.md` already forbids ("`ras` and `rmaps` are HNP-only … daemons must never open them"), and which nothing in a daemon needs:

- mapping is driven by the DVM state machine, which no daemon runs, so the mapper modules a `prted` selected could never be invoked;
- the launch path deliberately does not forward the `rmaps` MCA params out to a `prted` at all;
- the base parsers/printers a daemon *does* use — translating a local client's `map-by`/`rank-by` spawn directives in `pmix_server_dyn` — are compiled into `libprrte` and read nothing that the open sets up (`available`/`baseset`/`require_hwtcpus` are touched only on HNP-side mapping and launch paths).

So the daemon no longer opens `rmaps`, rather than gaining a close for it. `ess/env` also drops a vestigial `#include` of the ras base header. The HNP does now close `rmaps`, which additionally frees the two hwloc bitmaps `rmaps_base_open` allocates.

### Testing

- Warning-free `--enable-debug` build from a clean tree; `make check` 15/15.
- Live DVM: start, `prun -n 2 hostname`, `prun -n 2 --map-by node hostname`, `pterm`.
- `contrib/dockerswarm` full suite (`run-tests.sh linux`): **242 passed, 0 failed, 0 skipped** — the multi-node harness is where the `prted` path, the daemon-side `PMIx_Spawn` path and `ras/slurm`'s modify surface actually run.