### PR TITLE
Stop re-sending stdin a slow reader only partly took

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -515,6 +515,31 @@ runs `/pmix-src/configure` from a VPATH directory over a read-only bind
 mount, so a tree with its own `config.status` is refused ("source directory
 already configured") and a fresh `git clone` has no `configure` at all.
 
+A `git worktree` off an existing clone is the clean way to get one (and it
+keeps you out of a tree another session may be building in). Two things it
+needs beyond `autogen.pl`:
+
+```sh
+git -c submodule.config/oac.url=<clone>/config/oac submodule update --init config/oac
+```
+
+because openpmix's `.gitmodules` points `config/oac` at a local path that
+will not exist on your machine — and nothing else, because **`build.sh` now
+pre-generates the flex output itself**. That was the other trap: a pristine
+checkout has a `*.l` with no generated `*.c`, automake produces it at build
+time *in the source directory*, and the builder mounts the source
+read-only, so the build died with
+
+```
+config/ylwrap: line 204: .../keyval_lex.c: Read-only file system
+```
+
+A tree that has been built in place once already carries the file, which is
+why this only ever bit a fresh clone — exactly what `PMIX_SRC` is usually
+pointed at. `gen_lex` in `build.sh` runs `flex` on the host for any missing
+one (taking the `-P` symbol prefix from the sibling `Makefile.am`), for the
+PRRTE tree as well as the PMIx one.
+
 ### The build dirs persist, so configure arguments are sticky
 
 The VPATH build dirs live in the shared volume and outlive any one run.

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -43,6 +43,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `elastic.c` | The elastic test client (`elastic` in the install): issues a PMIx allocation request and waits for the phase-two completion event. |
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
+| `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
 ## 2. How it works
@@ -274,6 +275,24 @@ locally, `push_stdin` writes straight into the proc's sink and the wire format
 is never exercised. The payload is deliberately far larger than the 4096-byte
 read fragment and the 8192-byte write chunk. A companion case pipes a short
 line with `--stdin all` to check the wildcard/xcast delivery.
+
+**Slow-reader stdin (`iof`)**: the same payload again, but read by `slowcat`
+instead of `cat` — and this is the case that finds real bugs, because volume
+alone does not reach the interesting code. `cat` drains its stdin pipe as
+fast as the daemon can fill it, so the daemon's non-blocking `write(2)`
+essentially always completes in full and the **short-write** path is never
+taken. `slowcat` keeps the pipe saturated, so once the input passes the pipe
+capacity (64 KB on Linux) nearly every write is partial. That is the state
+in which [#2579](https://github.com/openpmix/prrte/issues/2579) lived for
+years behind a passing 256 KB `cat` test: re-basing a queued chunk without
+also decrementing its count re-sent the tail of the chunk on every retry, so
+the application received its input **duplicated** — measured here as 354 KB
+in, 37 MB out, and then a hang, since the backlog could never drain. The
+assertion is therefore on the byte count first (`SLOWCAT-BYTES` must equal
+what was piped in) and the md5 second. It runs twice, once with the rank on
+node2 and once on node1, because the HNP and the daemon carry **separate**
+copies of the write handler — the HNP copy was fixed upstream in 2025 and
+the daemon copy was missed.
 
 **Grow** (`elastic grow node2:2,node3:2`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, and `prted` now running on node2 and node3.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -265,6 +265,16 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/dataserver.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # slowcat: a deliberately slow stdin reader (no PMIx at all).  The
+            # stdin bugs in iof live in the back-pressure path, and a normal
+            # "cat" drains its pipe as fast as the daemon fills it, so the
+            # daemon short-write path is never taken.  slowcat keeps the pipe
+            # saturated so every write the daemon attempts is a partial one.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> slowcat (slow stdin reader) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/slowcat \
+                /prrte-src/contrib/dockerswarm/slowcat.c
+
             # examples/dynamic.c is the PMIx_Spawn example shipped in this
             # tree: rank 0 spawns "client" from its cwd as a CHILD JOB.  It
             # is the only way this harness can produce a parent/child job

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -92,6 +92,45 @@ srcdir_has_intree() {
     [ -n "$(find "$root/src" -name '*.lo' -print -quit 2>/dev/null)" ]
 }
 
+# --- generate the flex output the builder cannot generate itself ------------
+# In a pristine checkout a *.l has no companion *.c: automake produces it at
+# build time, and ylwrap writes it into the SOURCE directory next to the .l --
+# but the builder mounts both source trees READ-ONLY, so the build dies with
+#
+#     config/ylwrap: line 204: .../keyval_lex.c: Read-only file system
+#
+# A tree that has been built in place at least once already carries the file,
+# which is why this only ever bites a *fresh* clone -- precisely what PMIX_SRC
+# usually points at.  Generate it here on the host the way automake would; the
+# -P symbol prefix lives in the sibling Makefile.am AM_LFLAGS.  These are
+# git-ignored maintainer files, so writing them into the checkout is exactly
+# what building it normally does.
+gen_lex() {
+    local tree="$1" lfile cfile prefix
+    while IFS= read -r lfile; do
+        [ -n "$lfile" ] || continue
+        cfile="${lfile%.l}.c"
+        if [ -f "$cfile" ]; then
+            continue
+        fi
+        if ! command -v flex >/dev/null 2>&1; then
+            echo ">>> WARNING: $lfile has no generated .c and flex is not" \
+                 "installed; the read-only builder cannot make one"
+            return 0
+        fi
+        prefix="$(sed -n 's/^AM_LFLAGS *= *-P//p' "$(dirname "$lfile")/Makefile.am" \
+                  2>/dev/null | head -1)"
+        echo ">>> flex $lfile (the builder mounts this tree read-only)"
+        if [ -n "$prefix" ]; then
+            flex "-P$prefix" -o "$cfile" "$lfile"
+        else
+            flex -o "$cfile" "$lfile"
+        fi
+    done <<EOF
+$(find "$tree" -name '*.l' 2>/dev/null)
+EOF
+}
+
 # --- make the source tree VPATH-ready (idempotent) --------------------------
 prep_srcdir() {
     if srcdir_has_intree && [ "$distclean" != never ]; then
@@ -128,6 +167,8 @@ prep_srcdir() {
         echo ">>> autogen.pl"
         ( cd "$root" && ./autogen.pl )
     fi
+
+    gen_lex "$root"
 }
 
 # --- (re)build the base image if needed -------------------------------------
@@ -152,7 +193,10 @@ build_linux() {
     prep_srcdir linux
 
     local pmix_mount=()
-    [ -n "$PMIX_SRC" ] && pmix_mount=(-v "$(cd "$PMIX_SRC" && pwd)":/pmix-src:ro)
+    if [ -n "$PMIX_SRC" ]; then
+        gen_lex "$(cd "$PMIX_SRC" && pwd)"
+        pmix_mount=(-v "$(cd "$PMIX_SRC" && pwd)":/pmix-src:ro)
+    fi
 
     echo ">>> building PRRTE (and PMIx if PMIX_SRC set) into volume $VOLUME"
     docker run --rm \

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1396,6 +1396,8 @@ PRUN_BG() {
 # So a helper added since the containers came up is not on the app PATH, and a
 # bare name fails with PMIX_ERR_JOB_FAILED_TO_LAUNCH and no diagnostic.
 DS=/opt/prte/prte/bin/dataserver
+# ...and the same for the slow stdin reader, for the same reason.
+SC=/opt/prte/prte/bin/slowcat
 
 test_runtime() {
     local out n rc
@@ -2597,7 +2599,50 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             && ok "wildcard stdin (--stdin all) reached the HNP-local and the remote proc" \
             || bad "wildcard stdin reached $n/2 procs (rc=$rc): $(echo "$out" | tr '\n' ' ')"
 
-        RUN 'rm -f /tmp/iof_stdin_in.txt /tmp/iof_stdin_out.txt /tmp/iof_stdin_err.txt' >/dev/null 2>&1
+        # Same wire, different consumer: a proc that reads its stdin SLOWLY.
+        # "cat" above drains the pipe as fast as the daemon can fill it, so
+        # the daemon non-blocking write(2) nearly always completes in full and
+        # the short-write path is never taken -- which is why a 256 KB "cat"
+        # test passed for years while piping a large file into a real
+        # application corrupted it (issue #2579).  slowcat keeps the pipe
+        # saturated, so once the input passes the pipe capacity (64 KB on
+        # Linux) essentially every write the daemon attempts is partial.
+        #
+        # The failure mode is DUPLICATION, not loss: re-basing the queued
+        # chunk data without also decrementing its count left the tail of the
+        # chunk holding bytes that had already gone out, and each retry sent
+        # them again -- the reporter measured a 2,064-line input arriving as
+        # 1,089,247 lines.  So the assertion is on the byte count first: the
+        # app must receive exactly what was piped in, no more.
+        insum=$(RUN 'md5sum < /tmp/iof_stdin_in.txt' | awk '{print $1}')
+        insz=$(RUN 'wc -c < /tmp/iof_stdin_in.txt' | tr -d ' ')
+        out=$(RUN 'cd /tmp && timeout 180 prun --host node2:1 -n 1 \
+                     '"$SC"' /tmp/iof_slow_out.txt 256 1000 < iof_stdin_in.txt \
+                     2>iof_slow_err.txt; echo "rc=$?"')
+        rc=$(echo "$out" | sed -n 's/^rc=//p')
+        got=$(echo "$out" | sed -n 's/^SLOWCAT-BYTES //p')
+        outsum=$(ON 2 'md5sum < /tmp/iof_slow_out.txt 2>/dev/null' | awk '{print $1}')
+        [ "$rc" = 0 ] && [ -n "$got" ] && [ "$got" = "$insz" ] && [ "$insum" = "$outsum" ] \
+            && ok "large stdin ($insz bytes) survived a SLOW remote reader (short writes)" \
+            || bad "slow-reader stdin corrupted (rc=$rc, sent=$insz received=$got, md5 $insum vs $outsum): $(RUN 'head -c 200 /tmp/iof_slow_err.txt')"
+        ON 2 'rm -f /tmp/iof_slow_out.txt' >/dev/null 2>&1
+
+        # And the same slow reader on the HNP node, where push_stdin writes
+        # into the proc sink directly instead of going out over the RML: the
+        # HNP and the daemon carry separate copies of the write handler, so a
+        # short-write fix in one says nothing about the other.
+        out=$(RUN 'cd /tmp && timeout 180 prun --host node1:1 -n 1 \
+                     '"$SC"' /tmp/iof_slow_out.txt 256 1000 < iof_stdin_in.txt \
+                     2>iof_slow_err.txt; echo "rc=$?"')
+        rc=$(echo "$out" | sed -n 's/^rc=//p')
+        got=$(echo "$out" | sed -n 's/^SLOWCAT-BYTES //p')
+        outsum=$(RUN 'md5sum < /tmp/iof_slow_out.txt 2>/dev/null' | awk '{print $1}')
+        [ "$rc" = 0 ] && [ -n "$got" ] && [ "$got" = "$insz" ] && [ "$insum" = "$outsum" ] \
+            && ok "large stdin ($insz bytes) survived a SLOW HNP-local reader (short writes)" \
+            || bad "slow-reader stdin corrupted on the HNP (rc=$rc, sent=$insz received=$got, md5 $insum vs $outsum): $(RUN 'head -c 200 /tmp/iof_slow_err.txt')"
+
+        RUN 'rm -f /tmp/iof_stdin_in.txt /tmp/iof_stdin_out.txt /tmp/iof_stdin_err.txt \
+                   /tmp/iof_slow_out.txt /tmp/iof_slow_err.txt' >/dev/null 2>&1
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM for the stdin tests"

--- a/contrib/dockerswarm/slowcat.c
+++ b/contrib/dockerswarm/slowcat.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * slowcat -- copy stdin to a file, deliberately slowly.
+ *
+ * The interesting stdin bugs in IOF are not about volume, they are about
+ * back-pressure: they only appear once the application stops keeping up
+ * with the daemon that is feeding it.  A normal "cat" drains its stdin
+ * pipe as fast as the daemon can fill it, so the daemon's non-blocking
+ * write(2) almost always completes in full and the short-write path is
+ * never taken.  Real applications are not like that -- the code that
+ * exposed issue #2579 was a Fortran solver that copied its stdin to a
+ * scratch file before parsing it, one small read at a time -- and once
+ * the pipe is saturated every write the daemon attempts is a *partial*
+ * write, which is exactly the path that used to re-send the tail of each
+ * queued chunk.
+ *
+ * So this reads its stdin in small bites with a pause between them, keeping
+ * the pipe full, and copies every byte it receives to the named file.  The
+ * test then compares that file with what was piped in: it must match byte
+ * for byte, with nothing lost and -- the #2579 symptom -- nothing
+ * duplicated.
+ *
+ *   slowcat <outfile> [bytes-per-read] [microseconds-between-reads]
+ *
+ * Deliberately has no PMIx dependency: it says nothing about the runtime,
+ * it just consumes stdin the way a slow application does.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SLOWCAT_MAX_READ 65536
+
+int main(int argc, char **argv)
+{
+    char buf[SLOWCAT_MAX_READ];
+    size_t nread = 256;
+    unsigned long pause_usec = 1000;
+    long long total = 0;
+    FILE *out;
+    ssize_t n;
+
+    if (2 > argc) {
+        fprintf(stderr, "usage: %s <outfile> [bytes-per-read] [usec-between-reads]\n", argv[0]);
+        return 2;
+    }
+    if (2 < argc) {
+        nread = (size_t) strtoul(argv[2], NULL, 10);
+        if (0 == nread || SLOWCAT_MAX_READ < nread) {
+            nread = 256;
+        }
+    }
+    if (3 < argc) {
+        pause_usec = strtoul(argv[3], NULL, 10);
+    }
+
+    out = fopen(argv[1], "w");
+    if (NULL == out) {
+        fprintf(stderr, "slowcat: cannot open %s: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+
+    while (1) {
+        n = read(0, buf, nread);
+        if (0 > n) {
+            if (EINTR == errno || EAGAIN == errno) {
+                continue;
+            }
+            fprintf(stderr, "slowcat: read failed: %s\n", strerror(errno));
+            fclose(out);
+            return 1;
+        }
+        if (0 == n) {
+            /* EOF -- the runtime delivered the close sentinel */
+            break;
+        }
+        if ((size_t) n != fwrite(buf, 1, (size_t) n, out)) {
+            fprintf(stderr, "slowcat: short write to %s: %s\n", argv[1], strerror(errno));
+            fclose(out);
+            return 1;
+        }
+        total += n;
+        if (0 < pause_usec) {
+            usleep(pause_usec);
+        }
+    }
+
+    if (0 != fclose(out)) {
+        fprintf(stderr, "slowcat: close of %s failed: %s\n", argv[1], strerror(errno));
+        return 1;
+    }
+    /* the byte count goes to stdout so the caller can see it without
+     * having to trust the file
+     */
+    fprintf(stdout, "SLOWCAT-BYTES %lld\n", total);
+    fflush(stdout);
+    return 0;
+}

--- a/src/mca/iof/AGENTS.md
+++ b/src/mca/iof/AGENTS.md
@@ -235,8 +235,9 @@ This is the heart of the **stdin / output-to-fd** path:
   writes:
   - `EAGAIN`/`EINTR` → prepend the chunk back and leave the event armed to
     retry;
-  - **partial write** → `memmove` the unwritten tail to the front, fix
-    `numbytes`, prepend, retry;
+  - **partial write** → re-base the chunk with
+    `prte_iof_base_adjust_short_write` (slide the unwritten tail to the
+    front **and** drop `numbytes` by what went out), prepend, retry;
   - `numbytes == 0` chunk → close the stream by releasing the sink.
 
   If the backlog ever exceeds `prte_iof_base_output_limit` it declares IOF
@@ -249,7 +250,14 @@ This is the heart of the **stdin / output-to-fd** path:
   components each define their **own** near-identical
   `stdin_write_handler` (with subtly different close/`xoff` semantics) and
   pass it to `PRTE_IOF_SINK_DEFINE` — so when editing write semantics,
-  check all three copies.
+  check all three copies. That triplication has already cost once: the
+  short-write adjustment was fixed in the HNP copy (2025,
+  [#2220](https://github.com/openpmix/prrte/issues/2220)) and missed in the
+  daemon copy, so piping a large file into a remote rank still duplicated
+  it ([#2579](https://github.com/openpmix/prrte/issues/2579)). The
+  adjustment itself now lives in **one** place,
+  `prte_iof_base_adjust_short_write`, and all three handlers call it — keep
+  it that way rather than re-inlining the `memmove`.
 
 ### Sink macros (`base.h`)
 
@@ -430,11 +438,22 @@ what *is* exercisable without them:
 - the chunk-splitting of an oversized write (every chunk within
   `PRTE_IOF_BASE_TAGGED_OUT_MAX`, the pieces reassembling to the original
   bytes) and the negative-count degradation to the close sentinel;
+- the **consumer side**'s one pure piece —
+  `prte_iof_base_adjust_short_write`, driven by draining a chunk through a
+  run of short writes and comparing the bytes that came out with the bytes
+  that went in (the #2579 failure mode is duplication, so the byte count is
+  the assertion that matters);
 - the `prte_iof_base_fd_always_ready` predicate (pipe vs. regular file vs.
   `/dev/null`).
 
 The end-to-end capture/relay/inject behavior is covered by the integration
 harness (`prte --daemonize` → `prun` → `pterm`), not by `make check`.
+Note that the *interesting* stdin behavior needs a **slow** reader as well
+as a live DVM: a proc that drains its pipe as fast as the daemon fills it
+never produces a short write, which is why a large-payload `cat` test
+passed throughout the life of #2579. The swarm harness
+([`contrib/dockerswarm`](../../../contrib/dockerswarm/)) has a `slowcat`
+client for exactly this.
 
 ## Debugging
 

--- a/src/mca/iof/base/base.h
+++ b/src/mca/iof/base/base.h
@@ -17,7 +17,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -253,6 +253,16 @@ PRTE_EXPORT int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag
                                            const unsigned char *data, int numbytes,
                                            prte_iof_write_event_t *channel);
 PRTE_EXPORT void prte_iof_base_write_handler(int fd, short event, void *cbdata);
+
+/* Re-base a queued chunk after a short write: discard the "num_written"
+ * bytes that made it out and slide the remainder to the front of the
+ * chunk so the next write resumes where this one stopped. Every write
+ * handler that re-queues a partially written chunk must call this - both
+ * halves matter, and adjusting the data without the count re-sends the
+ * tail of the chunk on every retry (see the comment in the function).
+ */
+PRTE_EXPORT void prte_iof_base_adjust_short_write(prte_iof_write_output_t *output,
+                                                  int num_written);
 
 /* Emit "string" as though it were output from "source" on the given channel.
  * NOTE: this takes ownership of "string" - it must be a heap allocation, and

--- a/src/mca/iof/base/iof_base_output.c
+++ b/src/mca/iof/base/iof_base_output.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
- * Copyright (c) 2021-2022 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -109,6 +109,27 @@ int prte_iof_base_write_output(const pmix_proc_t *name, prte_iof_tag_t stream,
     return num_buffered;
 }
 
+void prte_iof_base_adjust_short_write(prte_iof_write_output_t *output, int num_written)
+{
+    if (0 >= num_written || num_written >= output->numbytes) {
+        /* nothing made it out, or the chunk is complete - either way
+         * there is nothing to re-base
+         */
+        return;
+    }
+
+    /* Both the count and the data have to move. Sliding the unwritten
+     * tail to the front while leaving numbytes alone leaves the last
+     * "num_written" bytes of the chunk holding a stale copy of data we
+     * already wrote, and the next write emits them again - so a stream
+     * that takes short writes (any pipe whose reader falls behind, i.e.
+     * any input larger than the pipe's capacity) comes out of the far
+     * end with chunks duplicated, once per retry.
+     */
+    output->numbytes -= num_written;
+    memmove(output->data, &output->data[num_written], output->numbytes);
+}
+
 void prte_iof_base_write_handler(int _fd, short event, void *cbdata)
 {
     prte_iof_sink_t *sink = (prte_iof_sink_t *) cbdata;
@@ -154,10 +175,10 @@ void prte_iof_base_write_handler(int _fd, short event, void *cbdata)
             PMIX_RELEASE(output);
             goto ABORT;
         } else if (num_written < output->numbytes) {
-            /* incomplete write - adjust data to avoid duplicate output */
-            memmove(output->data, &output->data[num_written], output->numbytes - num_written);
-            /* adjust the number of bytes remaining to be written */
-            output->numbytes -= num_written;
+            /* incomplete write - drop what went out and re-base the
+             * remainder to avoid duplicate output
+             */
+            prte_iof_base_adjust_short_write(output, num_written);
             /* push this item back on the front of the list */
             pmix_list_prepend(&wev->outputs, item);
             /* if the list is getting too large, abort */

--- a/src/mca/iof/hnp/AGENTS.md
+++ b/src/mca/iof/hnp/AGENTS.md
@@ -121,8 +121,9 @@ send (but still forwards to non-daemon tools that may be watching an abort).
 
 The HNP's own sink write callback drains `wev->outputs` to the proc's
 stdin fd with the standard non-blocking dance (EAGAIN/EINTR → prepend and
-re-arm; partial write → `memmove` + prepend + re-arm; `numbytes == 0` →
-close). It differs from the base `prte_iof_base_write_handler` in two
+re-arm; partial write → `prte_iof_base_adjust_short_write` + prepend +
+re-arm; `numbytes == 0` → close). It differs from the base
+`prte_iof_base_write_handler` in two
 ways: it dumps pending data immediately if `prte_abnormal_term_ordered`
 (the DVM is aborting), and it honors the sink's `closed` flag, releasing
 the sink once the last queued byte is written.

--- a/src/mca/iof/hnp/iof_hnp.c
+++ b/src/mca/iof/hnp/iof_hnp.c
@@ -474,9 +474,10 @@ static void stdin_write_handler(int fd, short event, void *cbdata)
             PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                                  "%s hnp:stdin:write:handler incomplete write %d - adjusting data",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_written));
-            /* incomplete write - adjust data and count to avoid duplicate output */
-            output->numbytes -= num_written;
-            memmove(output->data, &output->data[num_written], output->numbytes);
+            /* incomplete write - drop what went out and re-base the
+             * remainder to avoid duplicate output
+             */
+            prte_iof_base_adjust_short_write(output, num_written);
             /* push this item back on the front of the list */
             pmix_list_prepend(&wev->outputs, item);
             /* leave the write event running so it will call us again

--- a/src/mca/iof/prted/AGENTS.md
+++ b/src/mca/iof/prted/AGENTS.md
@@ -125,8 +125,9 @@ preceding data and then closes the proc's stdin fd.
 
 The daemon's sink write callback drains `wev->outputs` to the local proc's
 stdin fd with the usual non-blocking handling (EAGAIN/EINTR → prepend +
-re-arm; partial write → `memmove` + prepend + re-arm; `numbytes == 0` →
-release the write event and null `sink->wev` to close). Its distinctive
+re-arm; partial write → `prte_iof_base_adjust_short_write` + prepend +
+re-arm; `numbytes == 0` → release the write event and null `sink->wev` to
+close). Its distinctive
 behavior is **flow-control recovery**: on a fatal write error it sends
 `PRTE_IOF_XOFF`, and at the `CHECK` label, whenever `xoff` is latched and
 the backlog has fallen below `PRTE_IOF_MAX_INPUT_BUFFERS`, it clears the

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -372,8 +372,10 @@ static void stdin_write_handler(int _fd, short event, void *cbdata)
                 (1, prte_iof_base_framework.framework_output,
                  "%s prted:stdin:write:handler incomplete write %d - adjusting data",
                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_written));
-            /* incomplete write - adjust data to avoid duplicate output */
-            memmove(output->data, &output->data[num_written], output->numbytes - num_written);
+            /* incomplete write - drop what went out and re-base the
+             * remainder to avoid duplicate output
+             */
+            prte_iof_base_adjust_short_write(output, num_written);
             /* push this item back on the front of the list */
             pmix_list_prepend(&wev->outputs, item);
             /* leave the write event running so it will call us again

--- a/test/unit/iof/test_iof.c
+++ b/test/unit/iof/test_iof.c
@@ -46,6 +46,12 @@
  *      it with the write event pre-marked pending so no libevent activation
  *      is needed, exercising the enqueue/accounting logic directly.
  *
+ *      Its consumer-side counterpart is equally pure: what every write
+ *      handler does with a chunk the fd only partly accepted
+ *      (prte_iof_base_adjust_short_write).  Getting that wrong duplicates
+ *      the stream rather than dropping it, so the test drains a chunk
+ *      through short writes and compares the result byte for byte.
+ *
  *   6. The always-readable/always-writable fd predicate
  *      (prte_iof_base_fd_always_ready), which decides timer-vs-fd events
  *      for every stream.
@@ -451,6 +457,94 @@ static int test_write_output_chunking(void)
 }
 
 /*
+ * The consumer side of the sink write engine: what the write handlers do
+ * with a chunk the fd only partially accepted.
+ *
+ * A non-blocking write to a pipe whose reader has fallen behind returns a
+ * short count, and the handler must resume from exactly where that write
+ * stopped: prte_iof_base_adjust_short_write drops the bytes that made it
+ * out and slides the remainder to the front of the chunk.  Sliding the
+ * data without decrementing the count leaves the tail of the chunk holding
+ * a stale copy of already-written bytes and re-sends them on every retry,
+ * which is how a stdin file larger than the pipe capacity reached the
+ * application duplicated many times over (issue #2579).
+ *
+ * So the invariant under test is a stream one: drain a chunk through a
+ * sequence of short writes and the bytes that came out must be the bytes
+ * that went in -- no loss, no duplication.
+ */
+static int test_short_write_adjust(void)
+{
+    int failures = 0;
+    prte_iof_write_output_t *chunk;
+    unsigned char source[300];
+    /* room for far more than the source, so a handler that re-sends data
+     * overruns the expected length instead of looping forever */
+    unsigned char drained[4 * sizeof(source)];
+    const int bite = 64;
+    size_t i, ndrained = 0;
+    int nwritten, rounds = 0;
+
+    for (i = 0; i < sizeof(source); i++) {
+        source[i] = (unsigned char) (i % 251);
+    }
+
+    chunk = PMIX_NEW(prte_iof_write_output_t);
+    memcpy(chunk->data, source, sizeof(source));
+    chunk->numbytes = (int) sizeof(source);
+
+    /* drain the chunk the way a write handler does: take what the fd
+     * accepted, re-base the chunk, come back for the rest
+     */
+    while (0 < chunk->numbytes && 100 > rounds) {
+        rounds++;
+        nwritten = (bite < chunk->numbytes) ? bite : chunk->numbytes;
+        if (sizeof(drained) < ndrained + (size_t) nwritten) {
+            fprintf(stderr, "FAIL [short_write_adjust]: chunk is re-sending data\n");
+            failures++;
+            break;
+        }
+        memcpy(&drained[ndrained], chunk->data, nwritten);
+        ndrained += nwritten;
+        if (nwritten == chunk->numbytes) {
+            /* the chunk went out completely - the handler releases it */
+            break;
+        }
+        prte_iof_base_adjust_short_write(chunk, nwritten);
+    }
+
+    CHECK("short writes drain exactly the original byte count",
+          sizeof(source) == ndrained);
+    CHECK("short writes deliver the original bytes in order",
+          ndrained <= sizeof(drained) && 0 == memcmp(drained, source, ndrained));
+
+    PMIX_RELEASE(chunk);
+
+    /* the degenerate counts must leave the chunk alone: nothing went out,
+     * or everything did (the handler releases the chunk in that case and
+     * must not be handed a re-based copy of it)
+     */
+    chunk = PMIX_NEW(prte_iof_write_output_t);
+    memcpy(chunk->data, source, sizeof(source));
+    chunk->numbytes = (int) sizeof(source);
+
+    prte_iof_base_adjust_short_write(chunk, 0);
+    CHECK("zero-byte write leaves the count alone", (int) sizeof(source) == chunk->numbytes);
+    CHECK("zero-byte write leaves the data alone", 0 == memcmp(chunk->data, source, sizeof(source)));
+
+    prte_iof_base_adjust_short_write(chunk, (int) sizeof(source));
+    CHECK("complete write leaves the count alone", (int) sizeof(source) == chunk->numbytes);
+    CHECK("complete write leaves the data alone", 0 == memcmp(chunk->data, source, sizeof(source)));
+
+    PMIX_RELEASE(chunk);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_short_write_adjust\n");
+    }
+    return failures;
+}
+
+/*
  * prte_iof_base_fd_always_ready decides whether a stream is driven by a
  * zero-length timer (regular files / non-tty char devs / block devs, which
  * never signal readiness through the event loop) or by a real fd event.
@@ -526,6 +620,7 @@ int main(void)
     failures += test_classes();
     failures += test_write_output_accounting();
     failures += test_write_output_chunking();
+    failures += test_short_write_adjust();
     failures += test_fd_always_ready();
 
     (void) pmix_mca_base_framework_close(&prte_iof_base_framework);


### PR DESCRIPTION
## The problem

A daemon delivers stdin to a local process by writing 8 KB chunks into the process's stdin pipe with a non-blocking `write(2)`. While the pipe has room that write completes in full, but once the application falls behind, the pipe fills and the write starts returning short counts. The handler is supposed to drop what went out and resume from there. What it did instead was slide the unwritten tail to the front of the chunk and leave the byte count at the full 8192 — so the last `num_written` bytes still held data that had already been written, and the next attempt sent them again, once per retry.

The application receives its input with contiguous stretches duplicated many times over. And because the chunk can never fully drain while every write is short, the backlog never clears and the process never sees EOF, so the job hangs as well.

This was fixed once, in the HNP's copy of the handler (8f936a84e8, refs #2220). The framework carries **three** near-identical copies of that loop, and the daemon's copy was missed — so the defect survived for every process not co-located with the HNP, which on a multi-node job is most of them.

That is #2579. Its reporter saw the surviving half from the other side: their input arrived duplicated on Open MPI 5.0.8 (PRRTE v3.0.11, before the HNP fix) and cleanly on 5.0.10 (v3.0.13, after it) because their rank 0 happened to be local. For the record, the HNP fix first shipped in Open MPI 5.0.9 / PRRTE v3.0.12.

## The fix

Rather than fix the same two lines a third time, the adjustment moves into a single `prte_iof_base_adjust_short_write()` that all three handlers call. A short write is the whole of the interesting behavior here, and it was triplicated with no test on it — which is precisely how a fix reached one copy and not the others.

## Verification

Reproduced and then confirmed fixed on the 10-node container swarm, piping 354,128 bytes into a rank on another node that reads its stdin in small bites:

| daemon copy | result |
|---|---|
| unfixed | 354,128 bytes sent → **37,134,336 received** (105x), then hung |
| fixed | 354,128 sent → 354,128 received, md5 match |

- `test/unit/iof` drains a chunk through a run of short writes and requires the bytes that came out to be the bytes that went in. Verified to fail against the old logic (3 assertions) and pass against the new.
- `make check`: passes.
- Full swarm suite: **292 passed, 0 failed, 0 skipped** (against openpmix master).

## Why the existing test missed it

The swarm already pipes 256 KB into a remote rank and checks the md5, and it passed throughout. The reason is the reader: `cat` drains its pipe as fast as the daemon fills it, so the short-write path is never entered at all. Volume does not reach this — the application has to fall behind. So the second commit adds `slowcat`, a reader that copies stdin to a file in small reads with a pause between them (the field case was a solver copying its stdin to a scratch file before parsing), and runs the payload through it twice: once with the rank remote and once on the head node, since the two handlers are separate copies.

The third commit is an unrelated drive-by: `PMIX_SRC` pointed at a *pristine* openpmix checkout could not build at all, because a `*.l` with no generated `*.c` makes automake write into the read-only source mount. `build.sh` now generates any missing one on the host first.
