### PR TITLE
Apply the environment directives in the order they were given

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -269,6 +269,25 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        [$prte_pmix_iof_file_pattern],
                        [Whether PMIx can expand an output-file name pattern])
 
+    dnl The environment directives (--set-env, --prepend-env, --append-env,
+    dnl --unset-env, -x) edit each other, so the order the user gave them in
+    dnl is the value the process ends up with.  Recovering that order from a
+    dnl parse result requires PMIx to have recorded where each value was
+    dnl given: the result groups every occurrence of an option onto that
+    dnl option's single instance, so an option repeated after another has
+    dnl intervened cannot be placed from the grouped view alone.  Without the
+    dnl stamps we fall back to that view, which is right for every command
+    dnl line that does not interleave repeats.
+    AC_MSG_CHECKING([for PMIx command-line occurrence order])
+    PRTE_CHECK_PMIX_CAP([CLI_ORDER],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_cli_order=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_cli_order=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_CLI_ORDER],
+                       [$prte_pmix_cli_order],
+                       [Whether PMIx records where each command line option occurred])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/src/docs/prrte-rst-content/cli-append-env.rst
+++ b/src/docs/prrte-rst-content/cli-append-env.rst
@@ -19,3 +19,9 @@ the value.
 Example: ``--append-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
 
 ``LD_LIBRARY_PATH=$LD_LIBRARY_PATH:foo/lib``
+
+These directives are applied in the order they are given on the command
+line. ``--set-env`` replaces a value outright while ``--prepend-env`` and
+``--append-env`` edit the value already there, so the order is the result:
+``--set-env FOO=1 --prepend-env FOO[:] x`` leaves ``FOO=x:1``, while
+``--prepend-env FOO[:] x --set-env FOO=1`` leaves ``FOO=1``.

--- a/src/docs/prrte-rst-content/cli-prepend-env.rst
+++ b/src/docs/prrte-rst-content/cli-prepend-env.rst
@@ -19,3 +19,9 @@ the value.
 Example: ``--prepend-envar LD_LIBRARY_PATH[:] foo/lib`` will result in:
 
 ``LD_LIBRARY_PATH=foo/lib:$LD_LIBRARY_PATH``
+
+These directives are applied in the order they are given on the command
+line. ``--set-env`` replaces a value outright while ``--prepend-env`` and
+``--append-env`` edit the value already there, so the order is the result:
+``--set-env FOO=1 --prepend-env FOO[:] x`` leaves ``FOO=x:1``, while
+``--prepend-env FOO[:] x --set-env FOO=1`` leaves ``FOO=1``.

--- a/src/docs/prrte-rst-content/cli-set-env.rst
+++ b/src/docs/prrte-rst-content/cli-set-env.rst
@@ -14,3 +14,9 @@
 
 Set the named environmental variable to the specified value. This will overwrite the
 existing value, if it exists. Equivalent to the "-x foo=val" option
+
+These directives are applied in the order they are given on the command
+line. ``--set-env`` replaces a value outright while ``--prepend-env`` and
+``--append-env`` edit the value already there, so the order is the result:
+``--set-env FOO=1 --prepend-env FOO[:] x`` leaves ``FOO=x:1``, while
+``--prepend-env FOO[:] x --set-env FOO=1`` leaves ``FOO=1``.

--- a/src/docs/prrte-rst-content/cli-unset-env.rst
+++ b/src/docs/prrte-rst-content/cli-unset-env.rst
@@ -14,3 +14,9 @@
 
 Unset the named environmental variable. Note ``--unset-env foo*`` unsets all
 current environmental variables starting with "foo"
+
+These directives are applied in the order they are given on the command
+line. ``--set-env`` replaces a value outright while ``--prepend-env`` and
+``--append-env`` edit the value already there, so the order is the result:
+``--set-env FOO=1 --prepend-env FOO[:] x`` leaves ``FOO=x:1``, while
+``--prepend-env FOO[:] x --set-env FOO=1`` leaves ``FOO=1``.

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -57,6 +57,246 @@
 
 #include "src/prted/prted.h"
 
+/* One occurrence of one option: the option's name, and one of the values
+ * it was given. */
+typedef struct {
+    const char *key;
+    const char *value;
+} prte_cli_occ_t;
+
+/*
+ * Collect every value the cmd line carried, in the order it was given.
+ *
+ * A parse result groups the occurrences of an option onto that option's
+ * single instance, which loses the interleaving: once a key exists, a
+ * later occurrence of it is filed behind whatever came in between. PMIx
+ * therefore also stamps each stored value with the position it was given
+ * at, and reports the flat, ordered view built from those stamps.
+ *
+ * Built against a PMIx that predates PMIX_CAP_CLI_ORDER there are no
+ * stamps, so fall back to walking the instances in list order. That is
+ * correct for every command line except one that repeats an option after
+ * another has intervened - which is precisely the case the stamps exist
+ * for, and the reason to prefer a PMIx that has them.
+ *
+ * Either way the entries point into the result, so the array is valid
+ * for as long as the result is and is released with a plain free().
+ */
+static int collect_ordered(pmix_cli_result_t *results,
+                           prte_cli_occ_t **ordered, size_t *nordered)
+{
+    pmix_cli_item_t *opt;
+    prte_cli_occ_t *out;
+    size_t num = 0, m = 0;
+
+    *ordered = NULL;
+    *nordered = 0;
+
+    PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+        num += (size_t) PMIx_Argv_count(opt->values);
+    }
+    if (0 == num) {
+        return PRTE_SUCCESS;
+    }
+    out = (prte_cli_occ_t *) malloc(num * sizeof(prte_cli_occ_t));
+    if (NULL == out) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+#if PRTE_PMIX_CLI_ORDER
+    {
+        pmix_cli_occurrence_t *occ = NULL;
+        size_t nocc = 0, n;
+
+        if (PMIX_SUCCESS != pmix_cmd_line_get_ordered(results, &occ, &nocc)) {
+            free(out);
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        for (n = 0; n < nocc; n++) {
+            if (NULL == occ[n].value) {
+                /* an option given without a value carries no directive -
+                 * it is its own presence that says something */
+                continue;
+            }
+            out[m].key = occ[n].key;
+            out[m].value = occ[n].value;
+            ++m;
+        }
+        free(occ);
+    }
+#else
+    {
+        int n;
+
+        PMIX_LIST_FOREACH(opt, &results->instances, pmix_cli_item_t) {
+            for (n = 0; NULL != opt->values && NULL != opt->values[n]; n++) {
+                out[m].key = opt->key;
+                out[m].value = opt->values[n];
+                ++m;
+            }
+        }
+    }
+#endif
+
+    *ordered = out;
+    *nordered = m;
+    return PRTE_SUCCESS;
+}
+
+/*
+ * Turn the environment options into directives on the app's info list.
+ *
+ * These are applied to the process environment IN THE ORDER GIVEN, and
+ * the info list is what carries that order downstream (see the
+ * PRTE_JOB_*_ENVAR loop in odls_base_default_fns.c). The order matters
+ * because the directives edit each other: SET replaces a value outright
+ * while PREPEND/APPEND edit the one already there, so
+ *
+ *     --prepend-env "FOO[:]" x --set-env FOO=1     leaves  FOO=1
+ *     --set-env FOO=1 --prepend-env "FOO[:]" x     leaves  FOO=x:1
+ *
+ * Both are what the user asked for; neither is a merge policy we get to
+ * choose. So walk the occurrences in the order they were given rather
+ * than looking each key up in a fixed sequence - and rather than walking
+ * the instances list, which orders keys by first appearance and so puts
+ * the second --set-env of
+ *
+ *     --set-env FOO=1 --prepend-env "FOO[:]" x --set-env FOO=2
+ *
+ * ahead of the prepend, arriving at FOO=x:2 where the user asked for
+ * FOO=2.
+ */
+static int add_envar_directives(prte_pmix_app_t *app,
+                                pmix_cli_result_t *results)
+{
+    prte_cli_occ_t *ordered = NULL;
+    size_t nordered = 0, k;
+    char *param, *value, *ptr, *tval;
+    const char *key;
+    pmix_envar_t envt;
+    int i, rc;
+
+    rc = collect_ordered(results, &ordered, &nordered);
+    if (PRTE_SUCCESS != rc) {
+        return rc;
+    }
+
+    for (k = 0; k < nordered; k++) {
+        key = ordered[k].key;
+
+        if (0 == strcmp(key, PRTE_CLI_FWD_ENVAR)) {
+            param = strdup(ordered[k].value);
+            /* if there is an '=' in it, then they are setting a value */
+            if (NULL != (value = strchr(param, '='))) {
+                *value = '\0';
+                ++value;
+                envt.envar = param;
+                envt.value = strdup(value);
+                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                PMIX_ENVAR_DESTRUCT(&envt);
+            } else {
+                // have to support the wildcard here
+                if (NULL != (ptr = strchr(param, '*'))) {
+                    *ptr = '\0';
+                    for (i=0; NULL != environ[i]; i++) {
+                        if (0 == strncmp(environ[i], param, strlen(param))) {
+                            // this is a var to fwd
+                            // extract the name and value
+                            ptr = strdup(environ[i]);
+                            value = strchr(ptr, '=');
+                            *value = '\0';
+                            ++value;
+                            envt.envar = ptr;
+                            envt.value = strdup(value);
+                            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                            PMIX_ENVAR_DESTRUCT(&envt);
+                        }
+                    }
+                    free(param);
+                } else {
+                    // given a unique name
+                    value = getenv(param);
+                    if (NULL == value) {
+                        pmix_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
+                        free(param);
+                    } else {
+                        envt.envar = param;
+                        envt.value = strdup(value);
+                        PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+                        PMIX_ENVAR_DESTRUCT(&envt);
+                    }
+                }
+            }
+
+        } else if (0 == strcmp(key, PMIX_CLI_PREPEND_ENVAR) ||
+                   0 == strcmp(key, PMIX_CLI_APPEND_ENVAR)) {
+            /* these two store the variable's name and the value as SEPARATE
+             * occurrences, given one immediately after the other */
+            bool prepend = (0 == strcmp(key, PMIX_CLI_PREPEND_ENVAR));
+            param = strdup(ordered[k].value);
+            if (k + 1 >= nordered || 0 != strcmp(ordered[k + 1].key, key)) {
+                // the value it edits with is missing
+                pmix_show_help("help-prun.txt", "malformed-envar", true,
+                               prepend ? "prepend" : "append", app->app.cmd, param);
+                rc = PRTE_ERR_SILENT;
+                free(param);
+                goto done;
+            }
+            // find the [] enclosing the separator
+            i = strlen(param);
+            if (3 > i || ']' != param[i-1] || '[' != param[i-3]) {
+                pmix_show_help("help-prun.txt", "malformed-envar", true,
+                               prepend ? "prepend" : "append", app->app.cmd, param);
+                rc = PRTE_ERR_SILENT;
+                free(param);
+                goto done;
+            }
+            param[i-3] = '\0';
+            envt.envar = param;
+            envt.value = strdup(ordered[k + 1].value);
+            envt.separator = param[i-2];
+            PMIX_INFO_LIST_ADD(rc, app->info,
+                               prepend ? PMIX_PREPEND_ENVAR : PMIX_APPEND_ENVAR,
+                               &envt, PMIX_ENVAR);
+            PMIX_ENVAR_DESTRUCT(&envt);
+            // the value has now been consumed
+            ++k;
+
+        } else if (0 == strcmp(key, PMIX_CLI_SET_ENVAR)) {
+            /* --set-env stores ONE value per occurrence ("NAME=value"),
+             * unlike --prepend-env/--append-env above */
+            param = strdup(ordered[k].value);
+            // find the '=' separating name from value
+            tval = strchr(param, '=');
+            if (NULL == tval) {
+                pmix_show_help("help-prun.txt", "malformed-envar", true,
+                               "set", app->app.cmd, param);
+                rc = PRTE_ERR_SILENT;
+                free(param);
+                goto done;
+            }
+            *tval = '\0';
+            ++tval;
+            PMIX_ENVAR_CONSTRUCT(&envt);
+            envt.envar = param;
+            envt.value = strdup(tval);
+            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+            PMIX_ENVAR_DESTRUCT(&envt);
+
+        } else if (0 == strcmp(key, PMIX_CLI_UNSET_ENVAR)) {
+            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_UNSET_ENVAR,
+                               (char *) ordered[k].value, PMIX_STRING);
+        }
+    }
+    rc = PRTE_SUCCESS;
+
+done:
+    if (NULL != ordered) {
+        free(ordered);
+    }
+    return rc;
+}
+
 /*
  * This function takes a "char ***app_env" parameter to handle the
  * specific case:
@@ -83,14 +323,13 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                       char ***hostfiles, char ***hosts, pmix_list_t *jobdata)
 {
     char cwd[PRTE_PATH_MAX];
-    int i, n, count, rc;
+    int i, count, rc;
     char *param, *value, *ptr;
     prte_pmix_app_t *app = NULL;
     pmix_cli_item_t *opt, *opt2;
     pmix_cli_result_t results;
     char *tval;
     prte_info_item_t *iptr;
-    pmix_envar_t envt;
     PRTE_HIDE_UNUSED_PARAMS(app_env);
 
     *made_app = false;
@@ -344,125 +583,10 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         goto cleanup;
     }
 
-    /* Check for any envar directives.
-     *
-     * These are applied to the process environment IN THE ORDER GIVEN. That
-     * matters: SET replaces a value outright while PREPEND/APPEND edit the
-     * one already there, so "--prepend-env FOO[:] x --set-env FOO=1" leaves
-     * FOO=1 and "--set-env FOO=1 --prepend-env FOO[:] x" leaves FOO=x:1.
-     * Both are what the user asked for; neither is a merge policy we get to
-     * choose.
-     *
-     * So walk results->instances in list order rather than looking each key
-     * up in a fixed sequence - pmix_cmd_line_parse appends instances in the
-     * order their options were first seen, which IS command-line order.
-     * (Repeating one option type after another has intervened is the one
-     * case this cannot reproduce: every occurrence of an option is grouped
-     * onto that option's single instance, so it is applied at the position
-     * of its FIRST appearance.)
-     */
-    PMIX_LIST_FOREACH(opt, &results.instances, pmix_cli_item_t) {
-        if (0 == strcmp(opt->key, PRTE_CLI_FWD_ENVAR)) {
-            for (n=0; NULL != opt->values[n]; n++) {
-                param = strdup(opt->values[n]);
-                /* if there is an '=' in it, then they are setting a value */
-                if (NULL != (value = strchr(param, '='))) {
-                    *value = '\0';
-                    ++value;
-                    envt.envar = param;
-                    envt.value = strdup(value);
-                    PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                    PMIX_ENVAR_DESTRUCT(&envt);
-                } else {
-                    // have to support the wildcard here
-                    if (NULL != (ptr = strchr(param, '*'))) {
-                        *ptr = '\0';
-                        for (i=0; NULL != environ[i]; i++) {
-                            if (0 == strncmp(environ[i], param, strlen(param))) {
-                                // this is a var to fwd
-                                // extract the name and value
-                                ptr = strdup(environ[i]);
-                                value = strchr(ptr, '=');
-                                *value = '\0';
-                                ++value;
-                                envt.envar = ptr;
-                                envt.value = strdup(value);
-                                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                                PMIX_ENVAR_DESTRUCT(&envt);
-                            }
-                        }
-                        free(param);
-                    } else {
-                        // given a unique name
-                        value = getenv(param);
-                        if (NULL == value) {
-                            pmix_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
-                            free(param);
-                        } else {
-                            envt.envar = param;
-                            envt.value = strdup(value);
-                            PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                            PMIX_ENVAR_DESTRUCT(&envt);
-                        }
-                    }
-                }
-            }
-
-        } else if (0 == strcmp(opt->key, PMIX_CLI_PREPEND_ENVAR) ||
-                   0 == strcmp(opt->key, PMIX_CLI_APPEND_ENVAR)) {
-            /* these two store the variable's name and the value as SEPARATE
-             * entries, so they are read two at a time */
-            bool prepend = (0 == strcmp(opt->key, PMIX_CLI_PREPEND_ENVAR));
-            for (n=0; NULL != opt->values[n] && NULL != opt->values[n+1]; n+=2) {
-                param = strdup(opt->values[n]);
-                // find the [] enclosing the separator
-                i = strlen(param);
-                if (3 > i || ']' != param[i-1] || '[' != param[i-3]) {
-                    pmix_show_help("help-prun.txt", "malformed-envar", true,
-                                   prepend ? "prepend" : "append", app->app.cmd, param);
-                    rc = PRTE_ERR_SILENT;
-                    free(param);
-                    goto cleanup;
-                }
-                param[i-3] = '\0';
-                envt.envar = param;
-                envt.value = strdup(opt->values[n+1]);
-                envt.separator = param[i-2];
-                PMIX_INFO_LIST_ADD(rc, app->info,
-                                   prepend ? PMIX_PREPEND_ENVAR : PMIX_APPEND_ENVAR,
-                                   &envt, PMIX_ENVAR);
-                PMIX_ENVAR_DESTRUCT(&envt);
-            }
-
-        } else if (0 == strcmp(opt->key, PMIX_CLI_SET_ENVAR)) {
-            /* --set-env stores ONE value per occurrence ("NAME=value"),
-             * unlike --prepend-env/--append-env above.  Striding by two here
-             * skipped every other --set-env on the command line, silently. */
-            for (n=0; NULL != opt->values[n]; n++) {
-                param = strdup(opt->values[n]);
-                // find the '=' separating name from value
-                tval = strchr(param, '=');
-                if (NULL == tval) {
-                    pmix_show_help("help-prun.txt", "malformed-envar", true,
-                                   "set", app->app.cmd, param);
-                    rc = PRTE_ERR_SILENT;
-                    free(param);
-                    goto cleanup;
-                }
-                *tval = '\0';
-                ++tval;
-                PMIX_ENVAR_CONSTRUCT(&envt);
-                envt.envar = param;
-                envt.value = strdup(tval);
-                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
-                PMIX_ENVAR_DESTRUCT(&envt);
-            }
-
-        } else if (0 == strcmp(opt->key, PMIX_CLI_UNSET_ENVAR)) {
-            for (n=0; NULL != opt->values[n]; n++) {
-                PMIX_INFO_LIST_ADD(rc, app->info, PMIX_UNSET_ENVAR, opt->values[n], PMIX_STRING);
-            }
-        }
+    // check for any envar directives
+    rc = add_envar_directives(app, &results);
+    if (PRTE_SUCCESS != rc) {
+        goto cleanup;
     }
 
     // check for PMIx prefix for the application

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -42,6 +42,13 @@
  *    owns on an error return -- it used to PMIX_RELEASE(jdata) on a getcwd
  *    failure, leaving the caller with a dangling pointer.
  *
+ *  - create_app()'s environment directives, reached through
+ *    prte_parse_locals().  --set-env/--prepend-env/--append-env/--unset-env/-x
+ *    edit each other, so the order the user gave them in is the value the
+ *    process ends up with; these check that a command line comes back out in
+ *    the order it went in, case by case and then over every ordering of a
+ *    pool of directives.
+ *
  * The tests run without a DVM: prte_init_util() plus the rmaps/schizo/state
  * frameworks is enough for the translation paths.
  */
@@ -391,9 +398,569 @@ static int test_job_info_cache(void)
     return failures;
 }
 
+/*
+ * Environment directives, and the order they are applied in.
+ *
+ * --set-env replaces a variable's value outright; --prepend-env and
+ * --append-env edit the value already there; --unset-env removes it; -x
+ * forwards one.  So the order the user gave them in IS the result:
+ *
+ *   --prepend-env "FOO[:]" x --set-env FOO=1     must leave  FOO=1
+ *   --set-env FOO=1 --prepend-env "FOO[:]" x     must leave  FOO=x:1
+ *
+ * Both are what the user asked for; neither is a merge policy the runtime
+ * gets to choose.  create_app() therefore has to emit the directives onto
+ * the app's info list in command-line order, because that list is applied
+ * in order (see the PRTE_JOB_*_ENVAR loop in odls_base_default_fns.c).
+ *
+ * The hard case is an option repeated after another has intervened:
+ *
+ *   --set-env FOO=1 --prepend-env "FOO[:]" x --set-env FOO=2
+ *
+ * The parse result groups every occurrence of an option onto that option's
+ * single instance, so walking those instances applies BOTH sets and then
+ * the prepend, arriving at FOO=x:2 where the user asked for FOO=2.  The
+ * ordering has to come from the position each value was given at, which is
+ * what pmix_cmd_line_get_ordered() reports.
+ *
+ * Each case below is checked twice: the sequence of directives emitted,
+ * and the value a process would actually end up with after they are
+ * applied the way the odls applies them.  The second is the one that
+ * matters to a user; the first says where it went wrong when it does.
+ */
+
+/* Find "name" in an env array and return a pointer to its value, or NULL.
+ * Mirrors envar_value() in odls_base_default_fns.c. */
+static char *test_envar_value(char *envstr, const char *name)
+{
+    size_t len = strlen(name);
+
+    if (0 != strncmp(envstr, name, len) || '=' != envstr[len]) {
+        return NULL;
+    }
+    return envstr + len + 1;
+}
+
+/* Apply one directive to an environment exactly as the odls does. */
+static void test_apply_envar(pmix_info_t *info, char ***env)
+{
+    pmix_envar_t *envar;
+    char *ptr, *tmp;
+    bool found;
+    int n, m;
+
+    if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
+        for (n = 0; NULL != (*env) && NULL != (*env)[n]; n++) {
+            if (NULL != test_envar_value((*env)[n], info->value.data.string)) {
+                free((*env)[n]);
+                for (m = n; NULL != (*env)[m + 1]; m++) {
+                    (*env)[m] = (*env)[m + 1];
+                }
+                (*env)[m] = NULL;
+                break;
+            }
+        }
+        return;
+    }
+    if (PMIX_ENVAR != info->value.type) {
+        return;
+    }
+    envar = &info->value.data.envar;
+
+    if (PMIX_CHECK_KEY(info, PMIX_SET_ENVAR) ||
+        PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
+        PMIx_Setenv(envar->envar, envar->value, true, env);
+        return;
+    }
+
+    found = false;
+    for (n = 0; NULL != (*env) && NULL != (*env)[n]; n++) {
+        ptr = test_envar_value((*env)[n], envar->envar);
+        if (NULL == ptr) {
+            continue;
+        }
+        if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
+            pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, envar->value,
+                          envar->separator, ptr);
+        } else {
+            pmix_asprintf(&tmp, "%s=%s%c%s", envar->envar, ptr,
+                          envar->separator, envar->value);
+        }
+        free((*env)[n]);
+        (*env)[n] = tmp;
+        found = true;
+        break;
+    }
+    if (!found) {
+        // nothing to edit - the directive sets the variable
+        PMIx_Setenv(envar->envar, envar->value, true, env);
+    }
+    return;
+}
+
+/* Render one directive as "KEY NAME[sep]=value", so a mismatch reports
+ * what was emitted rather than just that something was. */
+static char *test_render_envar(pmix_info_t *info)
+{
+    pmix_envar_t *envar;
+    char *out = NULL;
+
+    if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
+        pmix_asprintf(&out, "unset %s", info->value.data.string);
+        return out;
+    }
+    if (PMIX_ENVAR != info->value.type) {
+        return NULL;
+    }
+    envar = &info->value.data.envar;
+    if (PMIX_CHECK_KEY(info, PMIX_SET_ENVAR)) {
+        pmix_asprintf(&out, "set %s=%s", envar->envar, envar->value);
+    } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
+        pmix_asprintf(&out, "prepend %s[%c]=%s", envar->envar,
+                      envar->separator, envar->value);
+    } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
+        pmix_asprintf(&out, "append %s[%c]=%s", envar->envar,
+                      envar->separator, envar->value);
+    }
+    return out;
+}
+
+/* Reach the "prte" personality through the framework: its module belongs
+ * to a component that may be a DSO, and is not visible outside libprrte in
+ * a hidden-visibility build. */
+static prte_schizo_base_module_t *envar_test_schizo(void)
+{
+    prte_schizo_base_active_module_t *mod;
+
+    PMIX_LIST_FOREACH(mod, &prte_schizo_base.active_modules,
+                      prte_schizo_base_active_module_t)
+    {
+        if (NULL != mod->module->name &&
+            0 == strcmp("prte", mod->module->name)) {
+            return mod->module;
+        }
+    }
+    fprintf(stderr, "FAIL [envar]: no prte schizo module\n");
+    return NULL;
+}
+
+typedef struct {
+    const char *desc;
+    const char *argv[24];
+    const char *seq;    /* '|'-joined directives, in the order emitted */
+    const char *foo;    /* value of FOO afterwards, NULL if it is not set */
+    const char *bar;    /* value of BAR afterwards, NULL if it is not set */
+} envar_case_t;
+
+static envar_case_t envar_cases[] = {
+
+    /* ---- the two orderings that must not be confused ---------------- */
+    {"set then prepend",
+     {"prterun", "--set-env", "FOO=1", "--prepend-env", "FOO[:]", "x",
+      "myapp", NULL},
+     "set FOO=1|prepend FOO[:]=x", "x:1", NULL},
+
+    {"prepend then set",
+     {"prterun", "--prepend-env", "FOO[:]", "x", "--set-env", "FOO=1",
+      "myapp", NULL},
+     "prepend FOO[:]=x|set FOO=1", "1", NULL},
+
+    /* ---- THE case: an option repeated after another intervened ------ */
+    {"set, prepend, set",
+     {"prterun", "--set-env", "FOO=1", "--prepend-env", "FOO[:]", "x",
+      "--set-env", "FOO=2", "myapp", NULL},
+     "set FOO=1|prepend FOO[:]=x|set FOO=2", "2", NULL},
+
+    {"prepend, set, prepend",
+     {"prterun", "--prepend-env", "FOO[:]", "a", "--set-env", "FOO=1",
+      "--prepend-env", "FOO[:]", "b", "myapp", NULL},
+     "prepend FOO[:]=a|set FOO=1|prepend FOO[:]=b", "b:1", NULL},
+
+    /* ---- all four directives interleaved ---------------------------- */
+    {"set, append, set, prepend",
+     {"prterun", "--set-env", "FOO=1", "--append-env", "FOO[:]", "z",
+      "--set-env", "FOO=2", "--prepend-env", "FOO[:]", "y", "myapp", NULL},
+     "set FOO=1|append FOO[:]=z|set FOO=2|prepend FOO[:]=y", "y:2", NULL},
+
+    {"append, prepend, append",
+     {"prterun", "--append-env", "FOO[,]", "a", "--prepend-env", "FOO[,]",
+      "b", "--append-env", "FOO[,]", "c", "myapp", NULL},
+     "append FOO[,]=a|prepend FOO[,]=b|append FOO[,]=c", "b,a,c", NULL},
+
+    /* ---- unset in the middle ---------------------------------------- */
+    {"set, unset, set",
+     {"prterun", "--set-env", "FOO=1", "--unset-env", "FOO",
+      "--set-env", "FOO=2", "myapp", NULL},
+     "set FOO=1|unset FOO|set FOO=2", "2", NULL},
+
+    {"set, unset",
+     {"prterun", "--set-env", "FOO=1", "--unset-env", "FOO", "myapp", NULL},
+     "set FOO=1|unset FOO", NULL, NULL},
+
+    /* a prepend onto a variable that was just unset has nothing to edit,
+     * so it sets it - the ordering has to survive to get that right */
+    {"set, unset, prepend",
+     {"prterun", "--set-env", "FOO=1", "--unset-env", "FOO",
+      "--prepend-env", "FOO[:]", "x", "myapp", NULL},
+     "set FOO=1|unset FOO|prepend FOO[:]=x", "x", NULL},
+
+    /* ---- -x, which forwards a variable and can also set one --------- */
+    {"-x, prepend, -x",
+     {"prterun", "-x", "FOO=1", "--prepend-env", "FOO[:]", "x",
+      "-x", "FOO=2", "myapp", NULL},
+     "set FOO=1|prepend FOO[:]=x|set FOO=2", "2", NULL},
+
+    /* ---- two variables interleaved: no cross-talk -------------------- */
+    {"two variables interleaved",
+     {"prterun", "--set-env", "FOO=1", "--set-env", "BAR=1",
+      "--prepend-env", "FOO[:]", "x", "--append-env", "BAR[:]", "y",
+      "myapp", NULL},
+     "set FOO=1|set BAR=1|prepend FOO[:]=x|append BAR[:]=y", "x:1", "1:y"},
+
+    /* ---- the plain repeats, which the grouped walk got right and must
+     * still get right --------------------------------------------------*/
+    {"set repeated with nothing between",
+     {"prterun", "--set-env", "FOO=1", "--set-env", "FOO=2", "myapp", NULL},
+     "set FOO=1|set FOO=2", "2", NULL},
+
+    {"prepend repeated with nothing between",
+     {"prterun", "--prepend-env", "FOO[:]", "a", "--prepend-env", "FOO[:]",
+      "b", "myapp", NULL},
+     "prepend FOO[:]=a|prepend FOO[:]=b", "b:a", NULL},
+
+    /* ---- a long alternation, to be sure nothing drifts --------------- */
+    {"six alternating directives",
+     {"prterun", "--set-env", "FOO=1", "--prepend-env", "FOO[:]", "a",
+      "--set-env", "FOO=2", "--prepend-env", "FOO[:]", "b",
+      "--set-env", "FOO=3", "--prepend-env", "FOO[:]", "c",
+      "myapp", NULL},
+     "set FOO=1|prepend FOO[:]=a|set FOO=2|prepend FOO[:]=b|"
+     "set FOO=3|prepend FOO[:]=c", "c:3", NULL},
+
+    /* ---- an unrelated option in between must not disturb the order --- */
+    {"an unrelated option between the two sets",
+     {"prterun", "--set-env", "FOO=1", "--prepend-env", "FOO[:]", "x",
+      "--np", "2", "--set-env", "FOO=2", "myapp", NULL},
+     "set FOO=1|prepend FOO[:]=x|set FOO=2", "2", NULL},
+
+    {NULL, {NULL}, NULL, NULL, NULL}
+};
+
+/* Collect the envar directives an app carries, in list order, and the
+ * environment they produce. */
+static int check_envar_app(const char *desc, prte_pmix_app_t *app,
+                           const envar_case_t *c)
+{
+    pmix_data_array_t darray;
+    pmix_info_t *infos;
+    char **rendered = NULL, **env = NULL;
+    char *got = NULL, *entry, *val;
+    int failures = 0, rc;
+    size_t n;
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 0, PMIX_INFO);
+    rc = PMIx_Info_list_convert(app->info, &darray);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
+        fprintf(stderr, "FAIL [%s]: info list convert: %s\n", desc,
+                PMIx_Error_string(rc));
+        return 1;
+    }
+    infos = (pmix_info_t *) darray.array;
+    for (n = 0; n < darray.size; n++) {
+        entry = test_render_envar(&infos[n]);
+        if (NULL == entry) {
+            continue;
+        }
+        PMIx_Argv_append_nosize(&rendered, entry);
+        free(entry);
+        test_apply_envar(&infos[n], &env);
+    }
+    got = (NULL == rendered) ? strdup("") : PMIx_Argv_join(rendered, '|');
+
+    if (0 != strcmp(got, c->seq)) {
+        fprintf(stderr, "FAIL [%s]: directives\n   wanted %s\n   got    %s\n",
+                desc, c->seq, got);
+        ++failures;
+    }
+
+    val = NULL;
+    for (n = 0; NULL != env && NULL != env[n]; n++) {
+        if (NULL != (entry = test_envar_value(env[n], "FOO"))) {
+            val = entry;
+            break;
+        }
+    }
+    if ((NULL == c->foo) != (NULL == val) ||
+        (NULL != c->foo && NULL != val && 0 != strcmp(c->foo, val))) {
+        fprintf(stderr, "FAIL [%s]: FOO wanted \"%s\", got \"%s\"\n", desc,
+                (NULL == c->foo) ? "(unset)" : c->foo,
+                (NULL == val) ? "(unset)" : val);
+        ++failures;
+    }
+
+    if (NULL != c->bar) {
+        val = NULL;
+        for (n = 0; NULL != env && NULL != env[n]; n++) {
+            if (NULL != (entry = test_envar_value(env[n], "BAR"))) {
+                val = entry;
+                break;
+            }
+        }
+        if (NULL == val || 0 != strcmp(c->bar, val)) {
+            fprintf(stderr, "FAIL [%s]: BAR wanted \"%s\", got \"%s\"\n", desc,
+                    c->bar, (NULL == val) ? "(unset)" : val);
+            ++failures;
+        }
+    }
+
+    free(got);
+    PMIx_Argv_free(rendered);
+    PMIx_Argv_free(env);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    return failures;
+}
+
+static int test_envar_order(void)
+{
+    prte_schizo_base_module_t *schizo;
+    envar_case_t *c;
+    pmix_list_t apps;
+    prte_pmix_app_t *app;
+    int failures = 0, rc;
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+
+    for (c = envar_cases; NULL != c->desc; c++) {
+        PMIX_CONSTRUCT(&apps, pmix_list_t);
+        rc = prte_parse_locals(schizo, &apps, (char **) c->argv,
+                               NULL, NULL, NULL);
+        if (PRTE_SUCCESS != rc) {
+            fprintf(stderr, "FAIL [%s]: parse failed: %s\n", c->desc,
+                    prte_strerror(rc));
+            ++failures;
+            PMIX_LIST_DESTRUCT(&apps);
+            continue;
+        }
+        if (1 != pmix_list_get_size(&apps)) {
+            fprintf(stderr, "FAIL [%s]: %d apps, wanted 1\n", c->desc,
+                    (int) pmix_list_get_size(&apps));
+            ++failures;
+            PMIX_LIST_DESTRUCT(&apps);
+            continue;
+        }
+        app = (prte_pmix_app_t *) pmix_list_get_first(&apps);
+        failures += check_envar_app(c->desc, app, c);
+        PMIX_LIST_DESTRUCT(&apps);
+    }
+
+    return failures;
+}
+
+/*
+ * The same claim, made mechanically instead of case by case.
+ *
+ * Every ordering of a pool of directives is generated, run through the
+ * parser, and checked against the order it was given in - an expectation
+ * derived from the input rather than written out by hand, so it cannot be
+ * quietly fitted to whatever the code happens to do.  The pool mixes all
+ * five spellings, and repeats one of them, because a repeat is what the
+ * grouped view cannot place: with six entries, 720 orderings.
+ */
+typedef struct {
+    const char *tok1;     /* the option */
+    const char *tok2;     /* its first value */
+    const char *tok3;     /* its second value, or NULL */
+    const char *rendered; /* the directive it must produce */
+} envar_directive_t;
+
+static envar_directive_t envar_pool[] = {
+    {"--set-env", "FOO=1", NULL, "set FOO=1"},
+    {"--set-env", "FOO=2", NULL, "set FOO=2"},
+    {"--prepend-env", "FOO[:]", "a", "prepend FOO[:]=a"},
+    {"--append-env", "FOO[:]", "b", "append FOO[:]=b"},
+    {"--unset-env", "FOO", NULL, "unset FOO"},
+    {"-x", "FOO=3", NULL, "set FOO=3"},
+};
+#define ENVAR_POOL_SIZE ((int) (sizeof(envar_pool) / sizeof(envar_pool[0])))
+
+static int check_envar_permutation(prte_schizo_base_module_t *schizo,
+                                   const int *order)
+{
+    char **argv = NULL, **wanted = NULL, **rendered = NULL;
+    char *want = NULL, *got = NULL, *desc = NULL, *entry;
+    pmix_data_array_t darray;
+    pmix_info_t *infos;
+    pmix_list_t apps;
+    prte_pmix_app_t *app;
+    int failures = 0, rc, i;
+    size_t n;
+
+    PMIx_Argv_append_nosize(&argv, "prterun");
+    for (i = 0; i < ENVAR_POOL_SIZE; i++) {
+        PMIx_Argv_append_nosize(&argv, envar_pool[order[i]].tok1);
+        PMIx_Argv_append_nosize(&argv, envar_pool[order[i]].tok2);
+        if (NULL != envar_pool[order[i]].tok3) {
+            PMIx_Argv_append_nosize(&argv, envar_pool[order[i]].tok3);
+        }
+        PMIx_Argv_append_nosize(&wanted, envar_pool[order[i]].rendered);
+    }
+    PMIx_Argv_append_nosize(&argv, "myapp");
+    want = PMIx_Argv_join(wanted, '|');
+    desc = PMIx_Argv_join(argv, ' ');
+
+    PMIX_CONSTRUCT(&apps, pmix_list_t);
+    rc = prte_parse_locals(schizo, &apps, argv, NULL, NULL, NULL);
+    if (PRTE_SUCCESS != rc || 1 != pmix_list_get_size(&apps)) {
+        fprintf(stderr, "FAIL [permute]: %s: parse failed (%s)\n", desc,
+                prte_strerror(rc));
+        ++failures;
+        goto cleanup;
+    }
+    app = (prte_pmix_app_t *) pmix_list_get_first(&apps);
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 0, PMIX_INFO);
+    rc = PMIx_Info_list_convert(app->info, &darray);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
+        fprintf(stderr, "FAIL [permute]: %s: convert failed\n", desc);
+        ++failures;
+        PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        goto cleanup;
+    }
+    infos = (pmix_info_t *) darray.array;
+    for (n = 0; n < darray.size; n++) {
+        entry = test_render_envar(&infos[n]);
+        if (NULL == entry) {
+            continue;
+        }
+        PMIx_Argv_append_nosize(&rendered, entry);
+        free(entry);
+    }
+    got = (NULL == rendered) ? strdup("") : PMIx_Argv_join(rendered, '|');
+    if (0 != strcmp(want, got)) {
+        fprintf(stderr, "FAIL [permute]: %s\n   wanted %s\n   got    %s\n",
+                desc, want, got);
+        ++failures;
+    }
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+cleanup:
+    PMIX_LIST_DESTRUCT(&apps);
+    PMIx_Argv_free(argv);
+    PMIx_Argv_free(wanted);
+    PMIx_Argv_free(rendered);
+    free(want);
+    free(got);
+    free(desc);
+    return failures;
+}
+
+/* Heap's algorithm - every ordering of the pool, each exactly once */
+static int permute_envar(prte_schizo_base_module_t *schizo, int *order,
+                         int k, int *ncases)
+{
+    int failures = 0, i, tmp;
+
+    if (1 == k) {
+        ++(*ncases);
+        return check_envar_permutation(schizo, order);
+    }
+    for (i = 0; i < k; i++) {
+        failures += permute_envar(schizo, order, k - 1, ncases);
+        if (0 == (k % 2)) {
+            tmp = order[i];
+            order[i] = order[k - 1];
+            order[k - 1] = tmp;
+        } else {
+            tmp = order[0];
+            order[0] = order[k - 1];
+            order[k - 1] = tmp;
+        }
+    }
+    return failures;
+}
+
+static int test_envar_order_permutations(void)
+{
+    prte_schizo_base_module_t *schizo;
+    int order[ENVAR_POOL_SIZE];
+    int failures, ncases = 0, i;
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+    for (i = 0; i < ENVAR_POOL_SIZE; i++) {
+        order[i] = i;
+    }
+    failures = permute_envar(schizo, order, ENVAR_POOL_SIZE, &ncases);
+    fprintf(stdout, "envar order: %d orderings checked, %d failed\n",
+            ncases, failures);
+    return failures;
+}
+
+/*
+ * Each app segment of an MPMD command line carries its own directives, and
+ * they are parsed into separate results - so the ordering has to hold
+ * per segment, not just for the first one.
+ */
+static int test_envar_order_mpmd(void)
+{
+    static envar_case_t first = {
+        "mpmd/app1", {NULL},
+        "set FOO=1|prepend FOO[:]=x|set FOO=2", "2", NULL};
+    static envar_case_t second = {
+        "mpmd/app2", {NULL},
+        "prepend FOO[:]=y|set FOO=9|prepend FOO[:]=z", "z:9", NULL};
+    char *argv[] = {"prterun",
+                    "--set-env", "FOO=1", "--prepend-env", "FOO[:]", "x",
+                    "--set-env", "FOO=2", "myapp",
+                    ":",
+                    "--prepend-env", "FOO[:]", "y", "--set-env", "FOO=9",
+                    "--prepend-env", "FOO[:]", "z", "myotherapp", NULL};
+    prte_schizo_base_module_t *schizo;
+    pmix_list_t apps;
+    prte_pmix_app_t *app;
+    int failures = 0, rc;
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+
+    PMIX_CONSTRUCT(&apps, pmix_list_t);
+    rc = prte_parse_locals(schizo, &apps, argv, NULL, NULL, NULL);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "FAIL [mpmd]: parse failed: %s\n", prte_strerror(rc));
+        PMIX_LIST_DESTRUCT(&apps);
+        return 1;
+    }
+    if (2 != pmix_list_get_size(&apps)) {
+        fprintf(stderr, "FAIL [mpmd]: %d apps, wanted 2\n",
+                (int) pmix_list_get_size(&apps));
+        PMIX_LIST_DESTRUCT(&apps);
+        return 1;
+    }
+    app = (prte_pmix_app_t *) pmix_list_get_first(&apps);
+    failures += check_envar_app(first.desc, app, &first);
+    app = (prte_pmix_app_t *) pmix_list_get_next(&app->super);
+    failures += check_envar_app(second.desc, app, &second);
+
+    PMIX_LIST_DESTRUCT(&apps);
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
+
+    /* the schizo modules pick their option table off prte_tool_actual and
+     * put prte_tool_basename in their error text - a tool sets both in
+     * main() long before schizo is opened */
+    prte_tool_actual = "prterun";
+    prte_tool_basename = "prterun";
 
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
@@ -424,12 +991,37 @@ int main(void)
         return 1;
     }
 
+    /* create_app() runs the cmd line through a schizo personality */
+    rc = pmix_mca_base_framework_open(&prte_schizo_base_framework, PMIX_MCA_BASE_OPEN_DEFAULT);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "schizo framework open failed: %d\n", rc);
+        (void) pmix_mca_base_framework_close(&prte_state_base_framework);
+        (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
+        prte_event_base_close();
+        prte_finalize();
+        return 1;
+    }
+    rc = prte_schizo_base_select();
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "schizo select failed: %d\n", rc);
+        (void) pmix_mca_base_framework_close(&prte_schizo_base_framework);
+        (void) pmix_mca_base_framework_close(&prte_state_base_framework);
+        (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
+        prte_event_base_close();
+        prte_finalize();
+        return 1;
+    }
+
     failures += test_prefix_normalization();
     failures += test_singleton_id();
     failures += test_xfer_job_info();
     failures += test_xfer_app();
     failures += test_job_info_cache();
+    failures += test_envar_order();
+    failures += test_envar_order_permutations();
+    failures += test_envar_order_mpmd();
 
+    (void) pmix_mca_base_framework_close(&prte_schizo_base_framework);
     (void) pmix_mca_base_framework_close(&prte_state_base_framework);
     (void) pmix_mca_base_framework_close(&prte_rmaps_base_framework);
     prte_event_base_close();


### PR DESCRIPTION
Requires openpmix/openpmix#4051 (PMIx issue openpmix/openpmix#4037), which has **merged** to PMIx master as 036df851. Building against a PMIx from before that commit still works and still passes the non-interleaved tests, but only reaches the correct behavior with it — see "Without the capability" below.

## The problem

`--set-env` replaces a variable's value outright; `--prepend-env` and `--append-env` edit the value already there; `--unset-env` removes it. They therefore edit each other, and the order the user gave them in is the value the process ends up with:

```
--prepend-env "FOO[:]" x --set-env FOO=1     leaves  FOO=1
--set-env FOO=1 --prepend-env "FOO[:]" x     leaves  FOO=x:1
```

Both are what the user asked for; neither is a merge policy we get to choose.

`create_app()` walked the parse result's instances list to honor this, which is command-line order right up until an option is repeated after another has intervened: every occurrence of an option is grouped onto that option's single instance, so a later one is applied at the position of its **first** appearance.

Measured against stock master, the damage is wider than just a wrong merge:

| command line | user asked for | master produced |
|---|---|---|
| `--set-env FOO=1 --prepend-env FOO[:] x --set-env FOO=2` | `FOO=2` | `FOO=x:2` |
| `--prepend-env FOO[:] a --set-env FOO=1 --prepend-env FOO[:] b` | `FOO=b:1` | `FOO=1` (second prepend dropped) |
| `--set-env FOO=1 --unset-env FOO --set-env FOO=2` | `FOO=2` | unset entirely |
| `--set-env FOO=1 --append-env FOO[:] z --set-env FOO=2 --prepend-env FOO[:] y` | `FOO=y:2` | `FOO=y:2:z` |

All silently wrong rather than diagnosable.

## The fix

PMIx now records where each stored value was given (`PMIX_CAP_CLI_ORDER`) and reports the flat, occurrence-ordered view built from those stamps, so take the order from there.

The directive loop moves into `add_envar_directives()` and handles one occurrence at a time rather than iterating an option's grouped values — the loop got simpler, not more complex. `--prepend-env`/`--append-env` store the variable's name and the value as two separate occurrences, which the stamps keep adjacent; a name with no value following it is now reported as malformed rather than silently dropped by the old `n += 2` stride.

## Without the capability

`collect_ordered()` falls back to the instances walk when `PRTE_PMIX_CLI_ORDER` is not defined, so PRRTE still builds and runs against a PMIx that predates the flag. That fallback is correct for every command line that does not interleave repeats — which is exactly the case the stamps exist for. The configure check is therefore the soft kind (like `IOF_FILE_PATTERN`), not a hard error.

## Testing

`test/unit/prted` gains the ordering coverage, reached through `prte_parse_locals()` so the real parse path is exercised. Each case is checked twice: the directives emitted onto the app's info list, and the value a process ends up with after they are applied the way `odls_base_default_fns.c` applies them. Cases cover the two base orderings, the interleaved repeats, all four spellings mixed, `-x`, unset-in-the-middle, two variables interleaved, the plain repeats that already worked, and per-segment ordering on an MPMD command line.

Then the same claim made mechanically: **every ordering of a pool of six directives — 720 — with the expected order derived from the input rather than written out by hand.**

- With the capability: `720 orderings checked, 0 failed`; full `make check` green (18 suites).
- Against stock master: 19 failures across the hand-written cases.
- Compiling the fallback branch deliberately: `720 orderings checked, 480 failed` — the fallback's documented limitation behaving exactly as described, and confirmation that the test is genuinely discriminating rather than tautological.

Confirmed end to end with real `prterun` launches, so the order survives the whole path (`create_app` → info list → spawn → odls):

```
set 1 | prepend x                    -> FOO=x:1
prepend x | set 1                    -> FOO=1
set 1 | prepend x | set 2            -> FOO=2
prepend a | set 1 | prepend b        -> FOO=b:1
set 1 | append z | set 2 | prepend y -> FOO=y:2
set 1 | unset | set 2                -> FOO=2
set 1 | unset FOO                    -> FOO=(unset)
```

The ordering guarantee is now also stated in the four `cli-*-env.rst` doc snippets; it was a real contract that was not written down anywhere.