### PR TITLE
pmix: deep review of the PRRTE/PMIx translation shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,13 @@ Include paths for these symbols come from PMIx's installed headers (found
 via `pkg-config` or `--with-pmix=`).  The shim at `src/pmix/pmix-internal.h`
 and `src/pmix/pmix.c` is PRRTE's integration point — consult it before
 reaching for PMIx symbols elsewhere.
+[`src/pmix/AGENTS.md`](src/pmix/AGENTS.md) covers it, and in particular the
+one rule that governs every crossing of this boundary: **PRRTE's error codes
+and PMIx's status codes are different numbering schemes that overlap
+numerically**, so a code handed across unconverted does not look foreign —
+it looks like some other, real code.  Convert at the boundary with
+`prte_pmix_convert_rc()` / `prte_pmix_convert_status()`, and never spell a
+proc state as a bare integer.
 
 ### Check capability flags
 

--- a/config/prte_config_files.m4
+++ b/config/prte_config_files.m4
@@ -41,6 +41,7 @@ AC_DEFUN([PRTE_CONFIG_FILES],[
         test/unit/odls/Makefile
         test/unit/iof/Makefile
         test/unit/plm/Makefile
+        test/unit/pmix/Makefile
         test/unit/prted/Makefile
         test/unit/rml/Makefile
         test/unit/ras/Makefile

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -43,6 +43,8 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `elastic.c` | The elastic test client (`elastic` in the install): issues a PMIx allocation request and waits for the phase-two completion event. |
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
+| `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
+| `proctable.c` | A bare PMIx client for the **proc-table queries** (`proctable` in the install): `procs`/`localprocs`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
@@ -393,6 +395,24 @@ owning every core of it. Note that an assertion on a binding has to match the
 **whole** bracketed site list: a rank bound to `core:L0-7` starts with a `0`
 and slips past a pattern that only looks at the first number, which is
 exactly how that defect stayed hidden behind a passing test.
+
+**The PRRTE/PMIx translation shim (`src/pmix`, `test_pmix`)**: everything in
+`src/pmix/pmix.c` is a pure integer mapping and is covered exhaustively,
+without a DVM, by `test/unit/pmix`. What this phase adds is the one thing a
+table test cannot show — that the mapping is actually *reached*, with real
+proc states, on a daemon that is not the one you are standing on. The probe
+is `proctable`, and it asserts:
+
+- `PMIX_QUERY_PROC_TABLE` over a job spread across four nodes returns every
+  proc, the table spans more than one node, and **no proc reports
+  `PMIX_PROC_STATE_UNDEF`**. That last one is the whole point:
+  `prte_pmix_convert_state()` was written with bare integer cases against a
+  state space that does not number like PMIx's, so several real PRRTE states
+  fell through to `UNDEF` — a legal answer, so nothing anywhere logged an
+  error and the proc simply had no state.
+- `PMIX_QUERY_LOCAL_PROC_TABLE` returns *some but not all* of a job's procs.
+  On one host "local" and "all" are the same set, so this case cannot exist
+  there.
 
 **The daemon body and the PMIx server host module (`src/prted`,
 `test_prted`)**: `src/prted` is where the DVM actually lives, and almost

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -309,6 +309,17 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/dataserver.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # proctable: a bare PMIx client that queries the proc table and
+            # the server URI.  Those two queries are the only callers of
+            # prte_pmix_convert_state(), and the local-vs-global proc table
+            # split plus a hostname-qualified server URI have no meaning at
+            # all on a single host.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> proctable (query/state translation) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/proctable \
+                /prrte-src/contrib/dockerswarm/proctable.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # slowcat: a deliberately slow stdin reader (no PMIx at all).  The
             # stdin bugs in iof live in the back-pressure path, and a normal
             # "cat" drains its pipe as fast as the daemon fills it, so the

--- a/contrib/dockerswarm/proctable.c
+++ b/contrib/dockerswarm/proctable.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * proctable -- a minimal PMIx client for exercising the translators in
+ * src/pmix/pmix.c across a real, multi-node DVM.
+ *
+ *   proctable procs [seconds]
+ *       PMIx_Query(PMIX_QUERY_PROC_TABLE) for this process's OWN namespace.
+ *       Prints one "PROC <rank> <host> <state> <statename>" line per entry,
+ *       then "COUNT <n>".
+ *
+ *   proctable localprocs [seconds]
+ *       Same, but PMIX_QUERY_LOCAL_PROC_TABLE -- only the procs the
+ *       answering daemon hosts.
+ *
+ * Why this exists, and why it cannot be a unit test:
+ *
+ * prte_pmix_convert_state() is the only thing standing between a
+ * prte_proc_t's state and what a tool or an application is told about that
+ * proc, and PMIX_QUERY_PROC_TABLE is the one path that calls it (twice, in
+ * pmix_server_queries.c). It was written with bare integer cases, and the two
+ * state spaces do not number alike, so several PRRTE states fell through its
+ * switch to PMIX_PROC_STATE_UNDEF. UNDEF is a legal answer, so nothing
+ * anywhere reported an error -- a queried proc simply had no state.
+ *
+ * The unit test pins the mapping down as a table. What it cannot show is that
+ * the mapping is reached with a *real* proc state on a *real* daemon: the
+ * proc table is assembled from prte_proc_t objects the answering daemon
+ * holds, and which of those it holds is exactly what differs between one node
+ * and ten. The local-vs-global proc table split has no meaning at all on a
+ * single host.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+static const char *statename(pmix_proc_state_t s)
+{
+    switch (s) {
+    case PMIX_PROC_STATE_UNDEF:
+        return "UNDEF";
+    case PMIX_PROC_STATE_PREPPED:
+        return "PREPPED";
+    case PMIX_PROC_STATE_LAUNCH_UNDERWAY:
+        return "LAUNCH_UNDERWAY";
+    case PMIX_PROC_STATE_RESTART:
+        return "RESTART";
+    case PMIX_PROC_STATE_TERMINATE:
+        return "TERMINATE";
+    case PMIX_PROC_STATE_RUNNING:
+        return "RUNNING";
+    case PMIX_PROC_STATE_CONNECTED:
+        return "CONNECTED";
+    case PMIX_PROC_STATE_UNTERMINATED:
+        return "UNTERMINATED";
+    case PMIX_PROC_STATE_TERMINATED:
+        return "TERMINATED";
+    case PMIX_PROC_STATE_KILLED_BY_CMD:
+        return "KILLED_BY_CMD";
+    case PMIX_PROC_STATE_ABORTED:
+        return "ABORTED";
+    case PMIX_PROC_STATE_FAILED_TO_START:
+        return "FAILED_TO_START";
+    case PMIX_PROC_STATE_ABORTED_BY_SIG:
+        return "ABORTED_BY_SIG";
+    case PMIX_PROC_STATE_TERM_WO_SYNC:
+        return "TERM_WO_SYNC";
+    case PMIX_PROC_STATE_COMM_FAILED:
+        return "COMM_FAILED";
+    case PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED:
+        return "SENSOR_BOUND_EXCEEDED";
+    case PMIX_PROC_STATE_CALLED_ABORT:
+        return "CALLED_ABORT";
+    case PMIX_PROC_STATE_HEARTBEAT_FAILED:
+        return "HEARTBEAT_FAILED";
+    case PMIX_PROC_STATE_MIGRATING:
+        return "MIGRATING";
+    case PMIX_PROC_STATE_CANNOT_RESTART:
+        return "CANNOT_RESTART";
+    case PMIX_PROC_STATE_TERM_NON_ZERO:
+        return "TERM_NON_ZERO";
+    case PMIX_PROC_STATE_FAILED_TO_LAUNCH:
+        return "FAILED_TO_LAUNCH";
+    default:
+        return "UNRECOGNIZED";
+    }
+}
+
+/* Walk whatever the query returned looking for a PMIX_PROC_INFO array, and
+ * print each entry. The daemon returns the table as a data array inside the
+ * results, so this has to descend one level. */
+static int print_proc_table(pmix_info_t *results, size_t nresults)
+{
+    size_t n, m;
+    int found = 0;
+
+    for (n = 0; n < nresults; n++) {
+        pmix_data_array_t *da;
+        pmix_proc_info_t *pi;
+
+        if (PMIX_DATA_ARRAY != results[n].value.type) {
+            continue;
+        }
+        da = results[n].value.data.darray;
+        if (NULL == da || PMIX_PROC_INFO != da->type || NULL == da->array) {
+            continue;
+        }
+        pi = (pmix_proc_info_t *) da->array;
+        for (m = 0; m < da->size; m++) {
+            printf("PROC %u %s %d %s\n", pi[m].proc.rank,
+                   (NULL == pi[m].hostname) ? "-" : pi[m].hostname, (int) pi[m].state,
+                   statename(pi[m].state));
+            found++;
+        }
+    }
+    printf("COUNT %d\n", found);
+    return found;
+}
+
+static int do_proc_table(const char *key, int seconds)
+{
+    pmix_query_t query;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIX_ARGV_APPEND(rc, query.keys, key);
+    /* qualify with our own namespace - without it the daemon answers for
+     * whatever it feels like, and we want OUR job's table */
+    PMIX_QUERY_QUALIFIERS_CREATE(&query, 1);
+    PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_NSPACE, myproc.nspace, PMIX_STRING);
+
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    if (PMIX_SUCCESS != rc) {
+        printf("ERR %d %s\n", (int) rc, PMIx_Error_string(rc));
+        PMIX_QUERY_DESTRUCT(&query);
+        return 1;
+    }
+    print_proc_table(results, nresults);
+    PMIX_INFO_FREE(results, nresults);
+    PMIX_QUERY_DESTRUCT(&query);
+
+    if (0 < seconds) {
+        sleep(seconds);
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    int ret = 1;
+
+    if (2 > argc) {
+        fprintf(stderr, "usage: %s procs|localprocs [args]\n", argv[0]);
+        return 2;
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    if (0 == strcmp(argv[1], "procs")) {
+        ret = do_proc_table(PMIX_QUERY_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
+    } else if (0 == strcmp(argv[1], "localprocs")) {
+        ret = do_proc_table(PMIX_QUERY_LOCAL_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
+    } else {
+        fprintf(stderr, "unknown mode: %s\n", argv[1]);
+        ret = 2;
+    }
+
+    PMIx_Finalize(NULL, 0);
+    return ret;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1599,6 +1599,84 @@ test_runtime() {
     cleanup_swarm
 }
 
+########################################################################
+# src/pmix -- the shim that translates between PRRTE's code space and
+# PMIx's.  Every function in it is a pure integer mapping and is covered
+# exhaustively, without a DVM, by test/unit/pmix.  What lands here is the
+# one thing a table test cannot show: that the mapping is actually reached,
+# with real proc states, on a daemon that is not the one you are standing on.
+########################################################################
+# Absolute path -- an app launched into the DVM inherits the daemon PATH,
+# which does not contain the install bindir.  See the note on $DS.
+PT=/opt/prte/prte/bin/proctable
+
+test_pmix() {
+    local out rc n hosts undef
+
+    banner "pmix: the queried proc table carries a real state for every proc"
+    # PMIX_QUERY_PROC_TABLE is the only caller of prte_pmix_convert_state(),
+    # which was written with bare integer cases against a state space that
+    # does not number like PMIx's.  Several PRRTE states fell through to
+    # PMIX_PROC_STATE_UNDEF -- a legal answer, so nothing reported an error;
+    # the proc simply had no state.  The invariant worth asserting is
+    # therefore not "state X" but "not UNDEF": a running proc always has
+    # something truthful to say about itself.
+    cleanup_swarm
+    if ! RUN "test -x $PT"; then
+        skp "proctable client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the pmix shim tests"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node $PT procs" 2>&1)
+    n=$(echo "$out" | grep -m1 '^COUNT ' | awk '{print $2}' | tr -d '\r')
+    # every proc of the job, from whichever daemon answered
+    [ "$n" = 8 ] \
+        && ok "PMIX_QUERY_PROC_TABLE returned all 8 procs" \
+        || bad "proc table returned $n entries, expected 8: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    undef=$(echo "$out" | grep -c 'UNDEF' | tr -d ' ')
+    [ "$undef" = 0 ] \
+        && ok "...and no proc reported PMIX_PROC_STATE_UNDEF" \
+        || bad "$undef procs reported UNDEF: $(echo "$out" | grep UNDEF | tr '\n' ' ' | tail -c 300)"
+    # the table has to name the node each proc is on, and they must not all
+    # be the same one -- otherwise this is a single-host test wearing a hat
+    hosts=$(echo "$out" | awk '$1=="PROC" {print $3}' | sort -u | grep -c '^node')
+    [ "${hosts:-0}" -ge 2 ] \
+        && ok "...and the table spans $hosts nodes" \
+        || bad "proc table did not span nodes ($hosts): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    echo "$out" | grep -q 'UNRECOGNIZED' \
+        && bad "a proc reported a state PMIx does not define" \
+        || ok "...and every state was one PMIx defines"
+
+    banner "pmix: the LOCAL proc table is the answering daemon's own procs"
+    # The local/global split does not exist on one host.  Six procs spread
+    # over three nodes, two each: whichever daemon answers must report only
+    # the two it hosts, and again with real states.
+    out=$(PRUN "--host node2:2,node3:2,node4:2 -n 6 --map-by node $PT localprocs" 2>&1)
+    n=$(echo "$out" | grep -m1 '^COUNT ' | awk '{print $2}' | tr -d '\r')
+    if [ -z "$n" ]; then
+        bad "local proc table produced no COUNT: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    elif [ "$n" -gt 0 ] && [ "$n" -lt 6 ]; then
+        ok "PMIX_QUERY_LOCAL_PROC_TABLE returned $n of 6 -- only the local procs"
+    else
+        bad "local proc table returned $n of 6 (0 or all means the filter did nothing)"
+    fi
+    undef=$(echo "$out" | grep -c 'UNDEF' | tr -d ' ')
+    [ "$undef" = 0 ] \
+        && ok "...and no local proc reported UNDEF" \
+        || bad "$undef local procs reported UNDEF"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    n=$(prted_count 1 2 3 4)
+    [ "$n" = 0 ] && ok "no daemons survived the pmix-shim teardown" \
+                 || bad "$n daemons still running after pterm"
+    cleanup_swarm
+}
+
 test_prted() {
     local out rc ns n bpid
 
@@ -3055,6 +3133,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_schizo
 
     test_state
+
+    test_pmix
 
     test_prted
 

--- a/src/pmix/AGENTS.md
+++ b/src/pmix/AGENTS.md
@@ -1,0 +1,276 @@
+# AGENTS.md — `src/pmix`
+
+Orientation for AI agents and human contributors working in `src/pmix/`.
+This is a map, not the rulebook: the authoritative project guidance lives in
+the top-level [`AGENTS.md`](../../AGENTS.md) and under [`docs/`](../../docs/).
+When this file and those disagree, **the docs win** — and please fix this
+file.
+
+---
+
+## What lives here
+
+Two files, about 900 lines, compiled straight into `libprrte`. There is no
+framework here and no components.
+
+| File | What it is |
+|------|------------|
+| `pmix-internal.h` | The header essentially every `.c` file in PRRTE includes. It pulls in the PMIx public headers, defines the lock type and its macros, the small list-item classes, and declares the translators. |
+| `pmix.c` | The translators between PRRTE's and PMIx's integer spaces, the thread-shifted lock wakeup, and the class instantiations. |
+
+### What this directory is *not*
+
+It is easy to confuse three different things that all have "pmix" in the name:
+
+| | Where | What it is |
+|---|---|---|
+| **The shim** | `src/pmix/` (here) | Translation and glue. No PMIx server, no upcalls, no state. |
+| **The server host module** | [`src/prted/pmix/`](../prted/pmix/AGENTS.md) | The ~10k lines that answer PMIx's upcalls. This is what people usually mean by "the PMIx code". |
+| **PMIx itself** | An external installation | The library. PRRTE uses a great deal of its *internal* API (`pmix_list_t`, `pmix_output_*`, the MCA base) — not just the public one. |
+
+If you are looking for `spawn`, `fence`, `query`, or anything that talks to a
+client, you want `src/prted/pmix/`, not here.
+
+---
+
+## GOLDEN RULE: the two integer spaces overlap, so nothing may pass through
+
+This is the whole reason `pmix.c` exists, and the source of every defect it
+has had.
+
+- A PRRTE error code is `PRTE_ERR_BASE - n` for `n` in `[1, 72]`, or
+  `PRTE_ERR_SPLIT - n` — see [`src/include/constants.h`](../include/constants.h).
+- A PMIx status runs from `-1` down past `-160`.
+
+So **most PMIx statuses are also the numeric value of a real PRRTE
+constant**. Returning an unconverted status does not produce a
+recognisably foreign number that someone will notice; it produces a
+confidently wrong PRRTE code that `prte_strerror()` will happily name.
+`prte_pmix_convert_status()` used to end in `default: return status;`, which
+meant, among others:
+
+| PMIx status | value | arrived as |
+|---|---|---|
+| `PMIX_ERR_PACK_FAILURE` | -21 | `PRTE_ERR_FILE_OPEN_FAILURE` |
+| `PMIX_ERR_UNPACK_FAILURE` | -20 | `PRTE_ERR_FILE_WRITE_FAILURE` |
+| `PMIX_ERR_NOMEM` | -32 | `PRTE_ERR_DATA_OVERWRITE_ATTEMPT` |
+| `PMIX_ERR_EMPTY` | -60 | `PRTE_ERR_NODE_DOWN` |
+| `PMIX_ERR_NOT_AVAILABLE` | -64 | `PRTE_ERR_PROC_CHECKPOINT` |
+
+The pack/unpack ones are not hypothetical: PRRTE routes essentially every
+bfrops return through this function — there are ~270 call sites, most of them
+in `src/runtime/data_type_support/`.
+
+**So: every one of these functions must be total.** Every `case` lands on a
+constant in the target space, and so does `default`. A code you have no name
+for is `PRTE_ERROR` / `PMIX_ERROR`, never the input.
+
+The one legitimate identity is `PRTE_ERROR == PMIX_ERROR == -1`, and
+`PRTE_SUCCESS == PMIX_SUCCESS == 0`. `test/unit/pmix` sweeps both ranges to
+prove there are no others.
+
+## GOLDEN RULE: never spell a state as a bare integer
+
+The four state translators are the same trap in a second dimension. The two
+proc-state spaces share a *scheme* but not a *numbering*:
+
+```
+   PRRTE                     PMIx
+   UNDEF          0          UNDEF             0
+   INIT           1          PREPPED           1     <-- PRRTE has no PREPPED,
+   RESTART        2          LAUNCH_UNDERWAY   2         so everything below the
+   TERMINATE      3          RESTART           3         error boundary is
+   RUNNING        4          TERMINATE         4         shifted by one
+   REGISTERED     5          RUNNING           5
+                             CONNECTED         6
+   ...
+   UNTERMINATED  15          UNTERMINATED     15    <-- these do line up
+   TERMINATED    20          TERMINATED       20
+   ERROR         50          ERROR            50    <-- and from here the
+   KILLED_BY_CMD 51          KILLED_BY_CMD    51        offsets agree, name
+   ...                       ...                       for name, to +13
+```
+
+`prte_pmix_convert_state()` was written with bare integer cases. Because the
+error range *does* line up name-for-name, `case 59` looked harmless — and
+returned `PMIX_PROC_STATE_MIGRATING` for `PRTE_PROC_STATE_HEARTBEAT_FAILED`,
+while the real `MIGRATING` (60) fell through the switch. `TERMINATED` was
+absent altogether, so `PMIX_QUERY_PROC_TABLE` reported every proc of a
+finished job as `UNDEF`.
+
+Nothing about that is visible at the point of failure: `UNDEF` is a legal
+answer, so no error is logged anywhere. **Use the `PRTE_PROC_STATE_*` and
+`PMIX_PROC_STATE_*` names, always**, and when you add a state to
+[`plm_types.h`](../mca/plm/plm_types.h), add it here and to
+`test/unit/pmix`'s table in the same commit.
+
+---
+
+## The six translators
+
+| Function | Direction | Used by |
+|----------|-----------|---------|
+| `prte_pmix_convert_rc()` | PRRTE error → PMIx status | ~38 sites, mostly `src/prted/pmix/` returning from an upcall |
+| `prte_pmix_convert_status()` | PMIx status → PRRTE error | ~270 sites, mostly pack/unpack |
+| `prte_pmix_convert_state()` | PRRTE proc state → PMIx proc state | `pmix_server_queries.c`, the proc-table queries |
+| `prte_pmix_convert_pstate()` | PMIx proc state → PRRTE proc state | nothing today — it is the declared inverse of the above and is kept, and tested, so the pair stays consistent |
+| `prte_pmix_convert_job_state_to_error()` | PRRTE job state → PMIx status | `errmgr/dvm`, building the spawn response for a failed job |
+| `prte_pmix_convert_proc_state_to_error()` | PRRTE proc state → PMIx status | the proc-failure notification path |
+
+Two properties to preserve:
+
+- **Collapses must agree.** PRRTE has six ways to say "lost touch with a
+  peer" (`COMM_FAILED`, `UNABLE_TO_SEND_MSG`, `LIFELINE_LOST`,
+  `NO_PATH_TO_TARGET`, `FAILED_TO_CONNECT`, `PEER_UNKNOWN`). PMIx has one
+  bucket for each of the two questions — `PMIX_PROC_STATE_COMM_FAILED` and
+  `PMIX_ERR_COMM_FAILURE`. Both translators must collapse the *same* six, or
+  a tool asking twice about one event gets two stories.
+- **`PRTE_ERR_SILENT` must survive.** It means "this failure has already been
+  reported to the user, do not report it again". `convert_rc` used to have no
+  case for it, so every silent abort became a second, redundant error at the
+  tool.
+
+The round-trip tests in `test/unit/pmix` are what enforce both.
+
+---
+
+## The lock, and the thread rule
+
+`prte_pmix_lock_t` and its macros live in `pmix-internal.h`. The lock itself
+is ordinary — a mutex, a condvar, an `active` flag, a status, and an optional
+message — but **who may wake it is not**.
+
+The top-level [`AGENTS.md`](../../AGENTS.md) has the full golden rule. The
+part this directory owns is the helper:
+
+```c
+PRTE_EXPORT void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
+                                          pmix_status_t status,
+                                          char *msg);
+```
+
+A `prte_pmix_lock_t` is a **PRRTE** object. A callback running on the PMIx
+progress thread must not touch it — not even to set `active = false`. The
+reason is specific and was found the hard way: a waiter on the thread that
+*drives* `prte_event_base` waits by re-checking `lock.active` between
+`prte_event_loop(PRTE_EVLOOP_ONCE)` iterations, not by blocking in the
+condvar. A `pthread_cond_signal` delivered while that loop is parked inside
+the event backend is never observed, and the process hangs. Posting the
+wakeup as an event both wakes the loop and serializes the flag update.
+
+So:
+
+- **From a PMIx callback**, call `prte_pmix_shifted_wakeup()`. It takes
+  ownership of `msg`, which must be NULL or heap-allocated.
+- **From the PRRTE progress thread**, `PRTE_PMIX_WAKEUP_THREAD()` is correct
+  and is what the shifted handler itself uses.
+- **Waiting on the thread that drives `prte_event_base`** — `prte()` itself,
+  `prted`, `prte_daemon_recv` — uses the loop-driving idiom, *never*
+  `PRTE_PMIX_WAIT_THREAD`:
+
+  ```c
+  while (prte_event_base_active && lock.active) {
+      prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE);
+  }
+  ```
+
+- **`PRTE_PMIX_WAIT_THREAD` is for threads that do not drive the loop** —
+  `prun` (a tool, no PRRTE event base) and code inside `prte_init()` (the
+  loop does not exist yet). Anywhere else it is almost certainly a bug.
+
+There used to be `PRTE_PMIX_ACQUIRE_THREAD` and `PRTE_PMIX_RELEASE_THREAD`
+here too. Nothing used them, and `RELEASE`'s non-debug branch asserted on a
+`pmix_mutex_trylock()` — a side effect inside `assert()`, which vanishes
+under `NDEBUG` and, when it did run, tried to lock a non-recursive mutex the
+caller was required to already hold. They are gone; do not reintroduce that
+shape.
+
+---
+
+## Everything else in the header
+
+- **The list-item classes.** `prte_info_item_t` (a `pmix_info_t` on a list),
+  `prte_info_array_item_t` (a list of those), `prte_value_t`, and
+  `prte_pmix_app_t`. They exist because PMIx's arrays are fixed-size and the
+  command-line parsers accumulate before they know the count.
+  `prte_pmix_app_t` additionally holds `mapby`/`rankby`/`bindto` aside until
+  the whole command line is parsed, because a directive given *once* belongs
+  to the job rather than to any app — `prte_parse_locals()` decides and
+  distributes them.
+- **`PRTE_MODEX_RECV_VALUE_OPTIONAL`.** A `PMIx_Get` with `PMIX_OPTIONAL`.
+  **It yields a `pmix_status_t`, not a PRRTE code** — this has caught people:
+  `pmix_server_queries.c` fed its result to `prte_pmix_convert_rc()`, the
+  PRRTE→PMIx direction, turning every failure on the `PMIX_SERVER_URI` query
+  into a bare `PMIX_ERROR`. It works by accident when compared against
+  `PRTE_SUCCESS`, since both spaces agree on 0.
+- **`prte_attribute_t`** is *declared* here but instantiated in
+  [`src/runtime/prte_globals.c`](../runtime/prte_globals.c) and used through
+  [`src/util/attr.h`](../util/attr.h). That split is historical, not
+  principled.
+
+---
+
+## Conventions
+
+Everything in the top-level [`AGENTS.md`](../../AGENTS.md) applies. Two
+things bite here in particular:
+
+- **No `PMIX_`/`pmix_`-prefixed names for PRRTE symbols.** This header once
+  defined `PMIX_PROC_NTOH`/`PMIX_PROC_HTON` and two `pmix_proc_*_intr()`
+  inlines in PRRTE's own header — squarely in PMIx's namespace, and a
+  collision waiting for PMIx to define the same names. They are gone.
+- **No compatibility shims.** The header used to `#ifndef` a fallback
+  definition of `PMIX_DATA_BUFFER_STATIC_INIT` for PMIx versions that lacked
+  it. PRRTE requires PMIx ≥ 6.1.0, which has it; a local copy is a second
+  maintenance path. Raise the requirement in `configure` instead.
+
+---
+
+## Testing
+
+**Unit — `test/unit/pmix/test_pmix` (`make check`).** Everything in `pmix.c`
+is a pure integer mapping with no state and no I/O, so the coverage is
+essentially total and should stay that way:
+
+- every named `PRTE_PROC_STATE_*`, as an explicit table, in both directions,
+  plus a round-trip requirement so the two converters cannot drift apart
+  (which is exactly how the 59/60 transposition survived — `convert_pstate`
+  had `MIGRATING → 60` all along);
+- a sweep of the whole PMIx status range proving nothing passes through
+  unconverted and no error status can produce `PRTE_SUCCESS`;
+- the same sweep outbound over both PRRTE code families;
+- round trips for the codes that must survive one, `PRTE_ERR_SILENT` first;
+- the two `*_to_error()` tables.
+
+**Add to the table in the same commit as any new state or code.** A
+translator that answers `UNDEF`/`PMIX_ERROR` for an input it simply forgot is
+indistinguishable from one answering correctly.
+
+**Multi-node — `contrib/dockerswarm`, the `test_pmix` phase.** The table test
+cannot show that the mapping is *reached*, with real proc states, on a daemon
+that is not the one you are standing on. The `proctable` client covers:
+
+- `PMIX_QUERY_PROC_TABLE` over a job spread across four nodes — every proc
+  must report a state PMIx defines, and none may report `UNDEF`;
+- `PMIX_QUERY_LOCAL_PROC_TABLE`, whose local-vs-global distinction has no
+  meaning at all on one host.
+
+What is deliberately **not** tested anywhere automatically: the lock macros
+and `prte_pmix_shifted_wakeup()`. Their contract is a threading one — it
+needs a live `prte_event_base` and a second thread to say anything
+meaningful — and it is exercised implicitly by every live smoke test, since a
+violation manifests as a hang.
+
+---
+
+## Where to go next
+
+- [`../prted/pmix/AGENTS.md`](../prted/pmix/AGENTS.md) — the PMIx server host
+  module: the upcalls, the request trackers, and the relay pattern. This is
+  where the translators are called from.
+- [`../runtime/AGENTS.md`](../runtime/AGENTS.md) — `prte_job_t` /
+  `prte_node_t` / `prte_proc_t`, and where `prte_attribute_t` really lives.
+- [`../mca/plm/plm_types.h`](../mca/plm/plm_types.h) — the job and proc state
+  definitions the state translators mirror.
+- [`../include/constants.h`](../include/constants.h) — the PRRTE error codes
+  the status translators mirror.

--- a/src/pmix/CLAUDE.md
+++ b/src/pmix/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -25,7 +25,6 @@
 
 #include "src/class/pmix_list.h"
 #include "src/event/event-internal.h"
-#include "src/include/hash_string.h"
 #include "src/mca/mca.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/error.h"
@@ -88,22 +87,6 @@ typedef struct {
 } prte_value_t;
 PMIX_CLASS_DECLARATION(prte_value_t);
 
-#if !defined(WORDS_BIGENDIAN)
-#    define PMIX_PROC_NTOH(guid) pmix_proc_ntoh_intr(&(guid))
-static inline __prte_attribute_always_inline__ void pmix_proc_ntoh_intr(pmix_proc_t *name)
-{
-    name->rank = ntohl(name->rank);
-}
-#    define PMIX_PROC_HTON(guid) pmix_proc_hton_intr(&(guid))
-static inline __prte_attribute_always_inline__ void pmix_proc_hton_intr(pmix_proc_t *name)
-{
-    name->rank = htonl(name->rank);
-}
-#else
-#    define PMIX_PROC_NTOH(guid)
-#    define PMIX_PROC_HTON(guid)
-#endif
-
 #define prte_pmix_condition_wait(a, b) pthread_cond_wait(a, &(b)->m_lock_pthread)
 
 #define PRTE_PMIX_CONSTRUCT_LOCK(l)                \
@@ -125,75 +108,30 @@ static inline __prte_attribute_always_inline__ void pmix_proc_hton_intr(pmix_pro
         pthread_cond_destroy(&(l)->cond); \
         if (NULL != (l)->msg) {           \
             free((l)->msg);               \
+            (l)->msg = NULL;              \
         }                                 \
     } while (0)
 
-#if PRTE_ENABLE_DEBUG
-#    define PRTE_PMIX_ACQUIRE_THREAD(lck)                                       \
-        do {                                                                    \
-            pmix_mutex_lock(&(lck)->mutex);                                     \
-            while ((lck)->active) {                                             \
-                prte_pmix_condition_wait(&(lck)->cond, &(lck)->mutex);          \
-            }                                                                   \
-            (lck)->active = true;                                               \
-        } while (0)
-#else
-#    define PRTE_PMIX_ACQUIRE_THREAD(lck)                              \
-        do {                                                           \
-            pmix_mutex_lock(&(lck)->mutex);                            \
-            while ((lck)->active) {                                    \
-                prte_pmix_condition_wait(&(lck)->cond, &(lck)->mutex); \
-            }                                                          \
-            (lck)->active = true;                                      \
-        } while (0)
-#endif
+/* Block the calling thread until someone wakes the lock. Never use this
+ * on the thread that drives prte_event_base - see the discussion of
+ * prte_pmix_shifted_wakeup() below and in the top-level AGENTS.md. */
+#define PRTE_PMIX_WAIT_THREAD(lck)                                 \
+    do {                                                           \
+        pmix_mutex_lock(&(lck)->mutex);                            \
+        while ((lck)->active) {                                    \
+            prte_pmix_condition_wait(&(lck)->cond, &(lck)->mutex); \
+        }                                                          \
+        PMIX_ACQUIRE_OBJECT(lck);                                  \
+        pmix_mutex_unlock(&(lck)->mutex);                          \
+    } while (0)
 
-#if PRTE_ENABLE_DEBUG
-#    define PRTE_PMIX_WAIT_THREAD(lck)                                          \
-        do {                                                                    \
-            pmix_mutex_lock(&(lck)->mutex);                                     \
-            while ((lck)->active) {                                             \
-                prte_pmix_condition_wait(&(lck)->cond, &(lck)->mutex);          \
-            }                                                                   \
-            PMIX_ACQUIRE_OBJECT(&lck);                                          \
-            pmix_mutex_unlock(&(lck)->mutex);                                   \
-        } while (0)
-#else
-#    define PRTE_PMIX_WAIT_THREAD(lck)                                 \
-        do {                                                           \
-            pmix_mutex_lock(&(lck)->mutex);                            \
-            while ((lck)->active) {                                    \
-                prte_pmix_condition_wait(&(lck)->cond, &(lck)->mutex); \
-            }                                                          \
-            PMIX_ACQUIRE_OBJECT(lck);                                  \
-            pmix_mutex_unlock(&(lck)->mutex);                          \
-        } while (0)
-#endif
-
-#if PRTE_ENABLE_DEBUG
-#    define PRTE_PMIX_RELEASE_THREAD(lck)                                     \
-        do {                                                                  \
-            (lck)->active = false;                                            \
-            pthread_cond_signal(&(lck)->cond);                             \
-            pmix_mutex_unlock(&(lck)->mutex);                                 \
-        } while (0)
-#else
-#    define PRTE_PMIX_RELEASE_THREAD(lck)                   \
-        do {                                                \
-            assert(0 != pmix_mutex_trylock(&(lck)->mutex)); \
-            (lck)->active = false;                          \
-            pthread_cond_signal(&(lck)->cond);           \
-            pmix_mutex_unlock(&(lck)->mutex);               \
-        } while (0)
-#endif
-
-#define PRTE_PMIX_WAKEUP_THREAD(lck)          \
-    do {                                      \
-        pmix_mutex_lock(&(lck)->mutex);       \
-        (lck)->active = false;                \
-        PMIX_POST_OBJECT(lck);                \
+#define PRTE_PMIX_WAKEUP_THREAD(lck)       \
+    do {                                   \
+        pmix_mutex_lock(&(lck)->mutex);    \
+        (lck)->active = false;             \
+        PMIX_POST_OBJECT(lck);             \
         pthread_cond_signal(&(lck)->cond); \
-        pmix_mutex_unlock(&(lck)->mutex);     \
+        pmix_mutex_unlock(&(lck)->mutex);  \
     } while (0)
 
 /* Caddy for shifting a lock wakeup from the PMIx progress thread
@@ -223,21 +161,15 @@ PRTE_EXPORT void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
                                           pmix_status_t status,
                                           char *msg);
 
-/*
- * Count the hash for the the external RM
- */
-#define PRTE_HASH_JOBID(str, hash) \
-    {                              \
-        PRTE_HASH_STR(str, hash);  \
-        hash &= ~(0x8000);         \
-    }
-
 /**
  * Provide a simplified macro for retrieving modex data
  * from another process when we don't want the PMIx module
  * to request it from the server if not found:
  *
- * r - the integer return status from the modex op (int)
+ * r - lvalue receiving the PMIx status of the modex op
+ *     (pmix_status_t) - NOT a PRTE error code. Feed it to
+ *     prte_pmix_convert_status() before comparing it against
+ *     anything but PMIX_SUCCESS.
  * s - string key (char*)
  * p - pointer to the pmix_proc_t of the proc that posted
  *     the data (pmix_proc_t*)
@@ -256,23 +188,23 @@ PRTE_EXPORT void prte_pmix_shifted_wakeup(prte_pmix_lock_t *lock,
                              PRTE_NAME_PRINT((p)), (s)));                              \
         PMIX_INFO_LOAD(&_info, PMIX_OPTIONAL, NULL, PMIX_BOOL);                        \
         (r) = PMIx_Get((p), (s), &(_info), 1, &(_kv));                                 \
-        if (NULL == _kv) {                                                             \
+        PMIX_INFO_DESTRUCT(&_info);                                                    \
+        if (PMIX_SUCCESS != (r)) {                                                     \
+            /* leave the library's status alone - it says why */                       \
+        } else if (NULL == _kv) {                                                      \
             (r) = PMIX_ERR_NOT_FOUND;                                                  \
         } else if (_kv->type != (t)) {                                                 \
             (r) = PMIX_ERR_TYPE_MISMATCH;                                              \
-        } else if (PMIX_SUCCESS == (r)) {                                              \
+        } else {                                                                       \
             PMIX_VALUE_UNLOAD((r), _kv, (void **) (d), &_sz);                          \
         }                                                                              \
         if (NULL != _kv) {                                                             \
             PMIX_VALUE_RELEASE(_kv);                                                   \
         }                                                                              \
-    } while (0);
-
-#define PRTE_PMIX_SHOW_HELP "prte.show.help"
+    } while (0)
 
 /* PRTE attribute */
 typedef uint16_t prte_attribute_key_t;
-#define PRTE_ATTR_KEY_T PRTE_UINT16
 typedef struct {
     pmix_list_item_t super;   /* required for this to be on lists */
     prte_attribute_key_t key; /* key identifier */
@@ -281,26 +213,17 @@ typedef struct {
 } prte_attribute_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_attribute_t);
 
-/* some helper functions */
+/* Translators between PRRTE's and PMIx's code spaces. Every one of
+ * these is total: an input the switch does not name still yields a
+ * legal code in the target space, never a raw pass-through of the
+ * input. See src/pmix/AGENTS.md for why that matters - the two spaces
+ * overlap numerically. */
 PRTE_EXPORT pmix_proc_state_t prte_pmix_convert_state(int state);
 PRTE_EXPORT int prte_pmix_convert_pstate(pmix_proc_state_t);
 PRTE_EXPORT pmix_status_t prte_pmix_convert_rc(int rc);
 PRTE_EXPORT int prte_pmix_convert_status(pmix_status_t status);
 PRTE_EXPORT pmix_status_t prte_pmix_convert_job_state_to_error(int state);
 PRTE_EXPORT pmix_status_t prte_pmix_convert_proc_state_to_error(int state);
-
-PRTE_EXPORT int prte_pmix_register_cleanup(char *path, bool directory, bool ignore, bool jobscope);
-
-#ifndef PMIX_DATA_BUFFER_STATIC_INIT
-    #define PMIX_DATA_BUFFER_STATIC_INIT    \
-    {                                       \
-        .base_ptr = NULL,                   \
-        .pack_ptr = NULL,                   \
-        .unpack_ptr = NULL,                 \
-        .bytes_allocated = 0,               \
-        .bytes_used = 0                     \
-    }
-#endif
 
 #define PRTE_MCA_BASE_VERSION_3_0_0(type, type_major, type_minor, type_release) \
     PMIX_MCA_BASE_VERSION_2_1_0("prte", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION, \

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -21,20 +21,11 @@
 #include "prte_config.h"
 #include "src/include/constants.h"
 
-#include <regex.h>
+#include <stdlib.h>
 
-#include <string.h>
-#include <time.h>
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-
-#include "src/class/pmix_hash_table.h"
-#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/plm/plm_types.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
-#include "src/threads/pmix_threads.h"
-#include "src/util/proc_info.h"
 
 pmix_status_t prte_pmix_convert_rc(int rc)
 {
@@ -126,6 +117,41 @@ pmix_status_t prte_pmix_convert_rc(int rc)
     case PRTE_ERR_OUT_OF_RESOURCE:
         return PMIX_ERR_OUT_OF_RESOURCE;
 
+    case PRTE_ERR_RESOURCE_BUSY:
+        return PMIX_ERR_RESOURCE_BUSY;
+
+    case PRTE_ERR_NOT_AVAILABLE:
+        return PMIX_ERR_NOT_AVAILABLE;
+
+    case PRTE_ERR_COMM_FAILURE:
+        return PMIX_ERR_COMM_FAILURE;
+
+    /* PRTE_ERR_SILENT means "this failure has already been reported to
+     * the user, do not report it again". Dropping it on the floor here
+     * turned every silent abort into a second, redundant error at the
+     * tool. */
+    case PRTE_ERR_SILENT:
+        return PMIX_ERR_SILENT;
+
+    /* the pack/unpack family - see the note on prte_pmix_convert_status() */
+    case PRTE_ERR_PACK_FAILURE:
+        return PMIX_ERR_PACK_FAILURE;
+
+    case PRTE_ERR_UNPACK_FAILURE:
+        return PMIX_ERR_UNPACK_FAILURE;
+
+    case PRTE_ERR_UNPACK_INADEQUATE_SPACE:
+        return PMIX_ERR_UNPACK_INADEQUATE_SPACE;
+
+    case PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+
+    case PRTE_ERR_TYPE_MISMATCH:
+        return PMIX_ERR_TYPE_MISMATCH;
+
+    case PRTE_ERR_UNKNOWN_DATA_TYPE:
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+
     case PRTE_ERR_DATA_VALUE_NOT_FOUND:
         return PMIX_ERR_DATA_VALUE_NOT_FOUND;
 
@@ -164,6 +190,14 @@ pmix_status_t prte_pmix_convert_rc(int rc)
     }
 }
 
+/* The two code spaces overlap numerically: a PRRTE error is
+ * PRTE_ERR_BASE - n for n in [1,72] and a PMIx status runs from -1 down
+ * past -160, so most PMIx statuses are *also* the value of some real
+ * PRRTE constant. Falling through with the input unconverted therefore
+ * does not produce a recognisably foreign code, it produces a
+ * confidently wrong one - PMIX_ERR_PACK_FAILURE arrived as
+ * PRTE_ERR_FILE_OPEN_FAILURE, PMIX_ERR_EMPTY as PRTE_ERR_NODE_DOWN.
+ * Every case must land on a PRRTE constant, and the default must too. */
 int prte_pmix_convert_status(pmix_status_t status)
 {
     switch (status) {
@@ -246,6 +280,45 @@ int prte_pmix_convert_status(pmix_status_t status)
     case PMIX_MODEL_DECLARED:
         return PRTE_ERR_MODEL_DECLARED;
 
+    /* the pack/unpack family. These are far and away the most common
+     * thing this function is handed - PRRTE routes essentially every
+     * bfrops return through here - and every one of them used to fall
+     * through to the raw-status default and land on an unrelated
+     * file-I/O code. */
+    case PMIX_ERR_PACK_FAILURE:
+        return PRTE_ERR_PACK_FAILURE;
+    case PMIX_ERR_UNPACK_FAILURE:
+        return PRTE_ERR_UNPACK_FAILURE;
+    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
+        return PRTE_ERR_UNPACK_INADEQUATE_SPACE;
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    case PMIX_ERR_TYPE_MISMATCH:
+        return PRTE_ERR_TYPE_MISMATCH;
+    case PMIX_ERR_UNKNOWN_DATA_TYPE:
+        return PRTE_ERR_UNKNOWN_DATA_TYPE;
+
+    case PMIX_ERR_NOMEM:
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    case PMIX_ERR_RESOURCE_BUSY:
+        return PRTE_ERR_RESOURCE_BUSY;
+    case PMIX_ERR_NOT_AVAILABLE:
+        return PRTE_ERR_NOT_AVAILABLE;
+    case PMIX_ERR_COMM_FAILURE:
+        return PRTE_ERR_COMM_FAILURE;
+    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
+        return PRTE_ERR_DATA_VALUE_NOT_FOUND;
+    case PMIX_ERR_EXISTS_OUTSIDE_SCOPE:
+        return PRTE_EXISTS;
+    case PMIX_ERR_JOB_APP_NOT_EXECUTABLE:
+        return PRTE_ERR_EXE_NOT_ACCESSIBLE;
+    case PMIX_ERR_JOB_NO_EXE_SPECIFIED:
+        return PRTE_ERR_NO_EXE_SPECIFIED;
+    case PMIX_ERR_JOB_FAILED_TO_MAP:
+        return PRTE_ERR_FAILED_TO_MAP;
+    case PMIX_ERR_JOB_CANCELED:
+        return PRTE_ERR_JOB_CANCELLED;
+
     case PMIX_ERROR:
         return PRTE_ERROR;
     case PMIX_ERR_SILENT:
@@ -253,51 +326,90 @@ int prte_pmix_convert_status(pmix_status_t status)
     case PMIX_SUCCESS:
     case PMIX_OPERATION_SUCCEEDED:
         return PRTE_SUCCESS;
-    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
-        return PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
 
     default:
-        return status;
+        /* an unrecognized PMIx status is an error we have no PRRTE name
+         * for. It is NOT a PRRTE error code, so do not hand it back as
+         * though it were. */
+        return PRTE_ERROR;
     }
 }
 
+/* Never spell these cases as bare integers. The two state spaces share
+ * a numbering scheme but not a numbering: PRRTE has no PREPPED, so its
+ * pre-termination states sit one below PMIx's all the way up to
+ * CONNECTED, while from PRTE_PROC_STATE_ERROR/PMIX_PROC_STATE_ERROR on
+ * up the offsets do line up. Writing "case 59" rather than the name is
+ * how PRTE_PROC_STATE_HEARTBEAT_FAILED came to report itself as
+ * PMIX_PROC_STATE_MIGRATING while PRTE_PROC_STATE_MIGRATING fell
+ * through to UNDEF. */
 pmix_proc_state_t prte_pmix_convert_state(int state)
 {
     switch (state) {
-    case 0:
+    case PRTE_PROC_STATE_UNDEF:
         return PMIX_PROC_STATE_UNDEF;
-    case 1:
+    case PRTE_PROC_STATE_INIT:
         return PMIX_PROC_STATE_LAUNCH_UNDERWAY;
-    case 2:
+    case PRTE_PROC_STATE_RESTART:
         return PMIX_PROC_STATE_RESTART;
-    case 3:
+    case PRTE_PROC_STATE_TERMINATE:
         return PMIX_PROC_STATE_TERMINATE;
-    case 4:
+    case PRTE_PROC_STATE_RUNNING:
         return PMIX_PROC_STATE_RUNNING;
-    case 5:
+    case PRTE_PROC_STATE_REGISTERED:
         return PMIX_PROC_STATE_CONNECTED;
-    case 51:
+
+    /* PRRTE tracks a few more milestones on the way to reaping a proc
+     * than PMIx names. All of them sit below the UNTERMINATED boundary,
+     * so the proc is still alive as far as a querying tool is
+     * concerned - saying UNDEF would be a lie. */
+    case PRTE_PROC_STATE_IOF_COMPLETE:
+    case PRTE_PROC_STATE_WAITPID_FIRED:
+    case PRTE_PROC_STATE_MODEX_READY:
+    case PRTE_PROC_STATE_READY_FOR_DEBUG:
+        return PMIX_PROC_STATE_RUNNING;
+
+    case PRTE_PROC_STATE_UNTERMINATED:
+        return PMIX_PROC_STATE_UNTERMINATED;
+    case PRTE_PROC_STATE_TERMINATED:
+        return PMIX_PROC_STATE_TERMINATED;
+
+    case PRTE_PROC_STATE_KILLED_BY_CMD:
         return PMIX_PROC_STATE_KILLED_BY_CMD;
-    case 52:
+    case PRTE_PROC_STATE_ABORTED:
         return PMIX_PROC_STATE_ABORTED;
-    case 53:
+    case PRTE_PROC_STATE_FAILED_TO_START:
         return PMIX_PROC_STATE_FAILED_TO_START;
-    case 54:
+    case PRTE_PROC_STATE_ABORTED_BY_SIG:
         return PMIX_PROC_STATE_ABORTED_BY_SIG;
-    case 55:
+    case PRTE_PROC_STATE_TERM_WO_SYNC:
         return PMIX_PROC_STATE_TERM_WO_SYNC;
-    case 56:
-        return PMIX_PROC_STATE_COMM_FAILED;
-    case 58:
+    case PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED:
+        return PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED;
+    case PRTE_PROC_STATE_CALLED_ABORT:
         return PMIX_PROC_STATE_CALLED_ABORT;
-    case 59:
+    case PRTE_PROC_STATE_HEARTBEAT_FAILED:
+        return PMIX_PROC_STATE_HEARTBEAT_FAILED;
+    case PRTE_PROC_STATE_MIGRATING:
         return PMIX_PROC_STATE_MIGRATING;
-    case 61:
+    case PRTE_PROC_STATE_CANNOT_RESTART:
         return PMIX_PROC_STATE_CANNOT_RESTART;
-    case 62:
+    case PRTE_PROC_STATE_TERM_NON_ZERO:
         return PMIX_PROC_STATE_TERM_NON_ZERO;
-    case 63:
+    case PRTE_PROC_STATE_FAILED_TO_LAUNCH:
         return PMIX_PROC_STATE_FAILED_TO_LAUNCH;
+
+    /* every way PRRTE describes losing touch with a peer. PMIx has
+     * the one bucket - the same collapse prte_pmix_convert_proc_state_to_error()
+     * makes onto PMIX_ERR_COMM_FAILURE. */
+    case PRTE_PROC_STATE_COMM_FAILED:
+    case PRTE_PROC_STATE_UNABLE_TO_SEND_MSG:
+    case PRTE_PROC_STATE_LIFELINE_LOST:
+    case PRTE_PROC_STATE_NO_PATH_TO_TARGET:
+    case PRTE_PROC_STATE_FAILED_TO_CONNECT:
+    case PRTE_PROC_STATE_PEER_UNKNOWN:
+        return PMIX_PROC_STATE_COMM_FAILED;
+
     default:
         return PMIX_PROC_STATE_UNDEF;
     }
@@ -307,46 +419,50 @@ int prte_pmix_convert_pstate(pmix_proc_state_t state)
 {
     switch (state) {
     case PMIX_PROC_STATE_UNDEF:
-        return 0;
+        return PRTE_PROC_STATE_UNDEF;
     case PMIX_PROC_STATE_PREPPED:
     case PMIX_PROC_STATE_LAUNCH_UNDERWAY:
-        return 1;
+        return PRTE_PROC_STATE_INIT;
     case PMIX_PROC_STATE_RESTART:
-        return 2;
+        return PRTE_PROC_STATE_RESTART;
     case PMIX_PROC_STATE_TERMINATE:
-        return 3;
+        return PRTE_PROC_STATE_TERMINATE;
     case PMIX_PROC_STATE_RUNNING:
-        return 4;
+        return PRTE_PROC_STATE_RUNNING;
     case PMIX_PROC_STATE_CONNECTED:
-        return 5;
+        return PRTE_PROC_STATE_REGISTERED;
     case PMIX_PROC_STATE_UNTERMINATED:
-        return 15;
+        return PRTE_PROC_STATE_UNTERMINATED;
     case PMIX_PROC_STATE_TERMINATED:
-        return 20;
+        return PRTE_PROC_STATE_TERMINATED;
     case PMIX_PROC_STATE_KILLED_BY_CMD:
-        return 51;
+        return PRTE_PROC_STATE_KILLED_BY_CMD;
     case PMIX_PROC_STATE_ABORTED:
-        return 52;
+        return PRTE_PROC_STATE_ABORTED;
     case PMIX_PROC_STATE_FAILED_TO_START:
-        return 53;
+        return PRTE_PROC_STATE_FAILED_TO_START;
     case PMIX_PROC_STATE_ABORTED_BY_SIG:
-        return 54;
+        return PRTE_PROC_STATE_ABORTED_BY_SIG;
     case PMIX_PROC_STATE_TERM_WO_SYNC:
-        return 55;
+        return PRTE_PROC_STATE_TERM_WO_SYNC;
     case PMIX_PROC_STATE_COMM_FAILED:
-        return 56;
+        return PRTE_PROC_STATE_COMM_FAILED;
+    case PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED:
+        return PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED;
     case PMIX_PROC_STATE_CALLED_ABORT:
-        return 58;
+        return PRTE_PROC_STATE_CALLED_ABORT;
+    case PMIX_PROC_STATE_HEARTBEAT_FAILED:
+        return PRTE_PROC_STATE_HEARTBEAT_FAILED;
     case PMIX_PROC_STATE_MIGRATING:
-        return 60;
+        return PRTE_PROC_STATE_MIGRATING;
     case PMIX_PROC_STATE_CANNOT_RESTART:
-        return 61;
+        return PRTE_PROC_STATE_CANNOT_RESTART;
     case PMIX_PROC_STATE_TERM_NON_ZERO:
-        return 62;
+        return PRTE_PROC_STATE_TERM_NON_ZERO;
     case PMIX_PROC_STATE_FAILED_TO_LAUNCH:
-        return 63;
+        return PRTE_PROC_STATE_FAILED_TO_LAUNCH;
     default:
-        return 0; // undef
+        return PRTE_PROC_STATE_UNDEF;
     }
 }
 
@@ -429,71 +545,6 @@ pmix_status_t prte_pmix_convert_proc_state_to_error(int state)
     }
 }
 
-static void cleanup_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
-                           pmix_release_cbfunc_t release_fn, void *release_cbdata)
-{
-    prte_pmix_lock_t *lk = (prte_pmix_lock_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(info, ninfo);
-
-    PMIX_POST_OBJECT(lk);
-
-    /* let the library release the data and cleanup from
-     * the operation */
-    if (NULL != release_fn) {
-        release_fn(release_cbdata);
-    }
-
-    /* release the block */
-    lk->status = status;
-    PRTE_PMIX_WAKEUP_THREAD(lk);
-}
-
-int prte_pmix_register_cleanup(char *path, bool directory, bool ignore, bool jobscope)
-{
-    prte_pmix_lock_t lk;
-    pmix_info_t pinfo[3];
-    size_t n, ninfo = 0;
-    pmix_status_t rc, ret;
-
-    PRTE_PMIX_CONSTRUCT_LOCK(&lk);
-
-    if (ignore) {
-        /* they want this path ignored */
-        PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_CLEANUP_IGNORE, path, PMIX_STRING);
-        ++ninfo;
-    } else {
-        if (directory) {
-            PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_REGISTER_CLEANUP_DIR, path, PMIX_STRING);
-            ++ninfo;
-            /* recursively cleanup directories */
-            PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_CLEANUP_RECURSIVE, NULL, PMIX_BOOL);
-            ++ninfo;
-        } else {
-            /* order cleanup of the provided path */
-            PMIX_INFO_LOAD(&pinfo[ninfo], PMIX_REGISTER_CLEANUP, path, PMIX_STRING);
-            ++ninfo;
-        }
-    }
-
-    /* if they want this applied to the job, then indicate so */
-    if (jobscope) {
-        rc = PMIx_Job_control_nb(NULL, 0, pinfo, ninfo, cleanup_cbfunc, (void *) &lk);
-    } else {
-        rc = PMIx_Job_control_nb(PRTE_PROC_MY_NAME, 1, pinfo, ninfo, cleanup_cbfunc, (void *) &lk);
-    }
-    if (PMIX_SUCCESS != rc) {
-        ret = rc;
-    } else {
-        PRTE_PMIX_WAIT_THREAD(&lk);
-        ret = lk.status;
-    }
-    PRTE_PMIX_DESTRUCT_LOCK(&lk);
-    for (n = 0; n < ninfo; n++) {
-        PMIX_INFO_DESTRUCT(&pinfo[n]);
-    }
-    return ret;
-}
-
 /* handler side of prte_pmix_shifted_wakeup - executes on the
  * PRRTE progress thread */
 static void shifted_wakeup(int fd, short args, void *cbdata)
@@ -505,7 +556,11 @@ static void shifted_wakeup(int fd, short args, void *cbdata)
     cd->lock->status = cd->status;
     if (NULL != cd->msg) {
         /* transfer ownership to the lock - the caddy destructor
-         * must not free it */
+         * must not free it. A lock reused across operations may still
+         * be holding the previous message. */
+        if (NULL != cd->lock->msg) {
+            free(cd->lock->msg);
+        }
         cd->lock->msg = cd->msg;
         cd->msg = NULL;
     }

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -265,10 +265,22 @@ it is enforced here:
 - **PMIx status vs. PRRTE status.** Functions reachable from an upcall
   must return `pmix_status_t`; functions in the PRRTE half return `int`
   PRRTE codes. They are *different numbering schemes* that happen to
-  agree on 0. Convert with `prte_pmix_convert_rc()` /
+  agree on 0 — and, worse, that **overlap** everywhere else, so a code
+  used in the wrong space is not obviously foreign, it is some other
+  real code. Convert with `prte_pmix_convert_rc()` /
   `prte_pmix_convert_status()` at the boundary, and log with
   `PMIX_ERROR_LOG` or `PRTE_ERROR_LOG` to match. Mixing them silently
-  reports the wrong error to the application.
+  reports the wrong error to the application. See
+  [`../../pmix/AGENTS.md`](../../pmix/AGENTS.md) for the table of what
+  collides with what.
+  - **Converting the wrong *direction* is the easy version of this
+    mistake**, because it type-checks and the success case still works
+    (both spaces call success 0). `pmix_server_queries.c` ran the result
+    of `PRTE_MODEX_RECV_VALUE_OPTIONAL` — which yields a **PMIx**
+    status — through `prte_pmix_convert_rc()`, the PRRTE→PMIx direction,
+    so every failure of the `PMIX_SERVER_URI` query reached the tool as a
+    bare `PMIX_ERROR`. Before converting, ask which space the value is
+    already in.
 - **A helper must not answer for its caller.** `process_directive()` in
   `pmix_server_session.c` used to invoke `req->infocbfunc` itself on an
   error and then return to a caller that also invokes it — a double

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -490,8 +490,12 @@ static void _query(int sd, short args, void *cbdata)
                  * an PRTE progress thread */
                 PRTE_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_SERVER_URI, &proct->name,
                                                (char **) &uri, PMIX_STRING);
-                if (PRTE_SUCCESS != rc) {
-                    ret = prte_pmix_convert_rc(rc);
+                if (PMIX_SUCCESS != rc) {
+                    /* the macro yields a PMIx status - it is already in the
+                     * space this function returns. Running it through
+                     * prte_pmix_convert_rc() converts the wrong direction
+                     * and turned every failure here into PMIX_ERROR. */
+                    ret = rc;
                     goto done;
                 }
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_SERVER_URI, uri, PMIX_STRING);

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -145,6 +145,12 @@ In a launcher-less (bootstrapped) DVM daemons boot independently, so:
 - **`prte_oob_base_send_nb` runs on a *hop*, and the hop can be
   `PMIX_RANK_INVALID`** when the target sits behind a hole the tree cannot
   reach past. Handle that before it reaches the peer lookup.
+- **`PRTE_MODEX_RECV_VALUE_OPTIONAL` yields a `pmix_status_t`.** The URI
+  lookup in `prte_oob_base_send_nb` is the only use of it in this directory.
+  Comparing its result against `PRTE_SUCCESS` works — both spaces call
+  success 0 — but it is comparing against the wrong space, and anything
+  beyond the success test needs `prte_pmix_convert_status()` first. See
+  [`../../pmix/AGENTS.md`](../../pmix/AGENTS.md).
 - **Don't tear down a peer over one bad address.** `set_addr` parses a URI that
   may name several addresses, and the peer object it is filling in may be an
   existing one with a live socket and queued sends. A malformed address is a

--- a/src/rml/oob/oob_base_stubs.c
+++ b/src/rml/oob/oob_base_stubs.c
@@ -103,8 +103,9 @@ void prte_oob_base_send_nb(int fd, short args, void *cbdata)
             }
         }
         // see if we know the contact info for it
+        /* the macro reports a PMIx status, not a PRRTE error code */
         PRTE_MODEX_RECV_VALUE_OPTIONAL(rc, PMIX_PROC_URI, &hop, (char **) &uri, PMIX_STRING);
-        if (PRTE_SUCCESS == rc && NULL != uri) {
+        if (PMIX_SUCCESS == rc && NULL != uri) {
             peer = process_uri(uri);
             /* process_uri only reads (and temporarily splits) the string - the
              * copy the modex handed us is ours to release */

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -609,6 +609,7 @@ int main(int argc, char *argv[])
         goto DONE;
     }
     prc = PMIx_Data_pack(NULL, buffer, &vptr->data.string, 1, PMIX_STRING);
+    PMIX_VALUE_RELEASE(vptr);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);
         ret = PRTE_ERROR;

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -2,4 +2,4 @@
 # Additional copyrights may follow
 # $HEADER$
 
-SUBDIRS = rmaps runtime errmgr ess filem grpcomm hwloc odls iof plm prted rml ras schizo state tools util
+SUBDIRS = rmaps runtime errmgr ess filem grpcomm hwloc odls iof plm pmix prted rml ras schizo state tools util

--- a/test/unit/pmix/.gitignore
+++ b/test/unit/pmix/.gitignore
@@ -1,0 +1,1 @@
+test_pmix

--- a/test/unit/pmix/Makefile.am
+++ b/test/unit/pmix/Makefile.am
@@ -1,0 +1,17 @@
+# $COPYRIGHT$
+# Additional copyrights may follow
+# $HEADER$
+
+AM_CPPFLAGS = \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/include \
+    -I$(top_srcdir)
+
+check_PROGRAMS = test_pmix
+
+test_pmix_SOURCES = \
+    test_pmix.c
+
+test_pmix_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_pmix

--- a/test/unit/pmix/test_pmix.c
+++ b/test/unit/pmix/test_pmix.c
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for src/pmix -- the shim between PRRTE's code space and PMIx's.
+ *
+ * Everything in src/pmix/pmix.c is a total function from one integer space to
+ * another, with no state and no I/O, which makes it about as testable as code
+ * gets. It had never been tested, and the reason is worth recording: a
+ * mistranslation here is invisible. Both spaces are small signed integers,
+ * every value looks plausible in the other, and the wrong answer surfaces as a
+ * misleading error message or a wrong proc state somewhere else entirely --
+ * never as a failure in this file.
+ *
+ * The traps these tests pin down:
+ *
+ *  - The two spaces OVERLAP numerically. A PRRTE error is PRTE_ERR_BASE - n
+ *    for n in [1,72]; a PMIx status runs -1 down past -160. So most PMIx
+ *    statuses are also the value of a real PRRTE constant.
+ *    prte_pmix_convert_status() used to `return status` for anything its
+ *    switch did not name, which did not yield a recognisably foreign code --
+ *    it yielded a confidently wrong one. PMIX_ERR_PACK_FAILURE arrived as
+ *    PRTE_ERR_FILE_OPEN_FAILURE and PMIX_ERR_EMPTY as PRTE_ERR_NODE_DOWN.
+ *    test_status_no_passthrough() sweeps the whole PMIx range to prove no
+ *    input can produce a code that is not deliberately chosen.
+ *
+ *  - The two PROC STATE spaces share a numbering scheme but not a numbering.
+ *    PRRTE has no PREPPED, so below the error boundary its states sit one
+ *    under PMIx's; from PRTE_PROC_STATE_ERROR / PMIX_PROC_STATE_ERROR (both
+ *    50) on up, the offsets do line up. prte_pmix_convert_state() was written
+ *    with bare integer cases, and `case 59` -- PRTE_PROC_STATE_HEARTBEAT_FAILED
+ *    -- returned PMIX_PROC_STATE_MIGRATING, while the real MIGRATING (60) fell
+ *    through to UNDEF. PRTE_PROC_STATE_TERMINATED was missing outright, so
+ *    PMIX_QUERY_PROC_TABLE reported every proc of a finished job as UNDEF.
+ *
+ *  - A converter that answers UNDEF/PMIX_ERROR for an input it simply forgot
+ *    is indistinguishable from one answering correctly. So the state tests are
+ *    written as an explicit table over every named constant rather than as
+ *    spot checks, and test_state_roundtrip() requires the pair to agree.
+ *
+ * What is deliberately NOT here: the lock macros and prte_pmix_shifted_wakeup(),
+ * which need a live prte_event_base and a second thread to say anything
+ * meaningful. Their contract is a threading one and belongs to the live smoke
+ * test and to contrib/dockerswarm.
+ */
+
+#include "prte_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "constants.h"
+
+#include "src/mca/plm/plm_types.h"
+#include "src/pmix/pmix-internal.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/* proc state translation                                             */
+/* ------------------------------------------------------------------ */
+
+/* Every state PRRTE can put on a prte_proc_t, and the PMIx state a tool
+ * querying that proc must be told. Where PRRTE is more specific than PMIx the
+ * mapping collapses; nothing may map to UNDEF except UNDEF itself. */
+static struct {
+    const char *name;
+    int prte;
+    pmix_proc_state_t pmix;
+} state_map[] = {
+    {"UNDEF", PRTE_PROC_STATE_UNDEF, PMIX_PROC_STATE_UNDEF},
+    {"INIT", PRTE_PROC_STATE_INIT, PMIX_PROC_STATE_LAUNCH_UNDERWAY},
+    {"RESTART", PRTE_PROC_STATE_RESTART, PMIX_PROC_STATE_RESTART},
+    {"TERMINATE", PRTE_PROC_STATE_TERMINATE, PMIX_PROC_STATE_TERMINATE},
+    {"RUNNING", PRTE_PROC_STATE_RUNNING, PMIX_PROC_STATE_RUNNING},
+    {"REGISTERED", PRTE_PROC_STATE_REGISTERED, PMIX_PROC_STATE_CONNECTED},
+
+    /* PRRTE tracks more milestones on the way to reaping a proc than PMIx
+     * names. All sit below the UNTERMINATED boundary, so the proc is still
+     * alive as far as a querying tool is concerned. */
+    {"IOF_COMPLETE", PRTE_PROC_STATE_IOF_COMPLETE, PMIX_PROC_STATE_RUNNING},
+    {"WAITPID_FIRED", PRTE_PROC_STATE_WAITPID_FIRED, PMIX_PROC_STATE_RUNNING},
+    {"MODEX_READY", PRTE_PROC_STATE_MODEX_READY, PMIX_PROC_STATE_RUNNING},
+    {"READY_FOR_DEBUG", PRTE_PROC_STATE_READY_FOR_DEBUG, PMIX_PROC_STATE_RUNNING},
+
+    {"UNTERMINATED", PRTE_PROC_STATE_UNTERMINATED, PMIX_PROC_STATE_UNTERMINATED},
+    {"TERMINATED", PRTE_PROC_STATE_TERMINATED, PMIX_PROC_STATE_TERMINATED},
+
+    {"KILLED_BY_CMD", PRTE_PROC_STATE_KILLED_BY_CMD, PMIX_PROC_STATE_KILLED_BY_CMD},
+    {"ABORTED", PRTE_PROC_STATE_ABORTED, PMIX_PROC_STATE_ABORTED},
+    {"FAILED_TO_START", PRTE_PROC_STATE_FAILED_TO_START, PMIX_PROC_STATE_FAILED_TO_START},
+    {"ABORTED_BY_SIG", PRTE_PROC_STATE_ABORTED_BY_SIG, PMIX_PROC_STATE_ABORTED_BY_SIG},
+    {"TERM_WO_SYNC", PRTE_PROC_STATE_TERM_WO_SYNC, PMIX_PROC_STATE_TERM_WO_SYNC},
+    {"COMM_FAILED", PRTE_PROC_STATE_COMM_FAILED, PMIX_PROC_STATE_COMM_FAILED},
+    {"SENSOR_BOUND_EXCEEDED", PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED,
+     PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED},
+    {"CALLED_ABORT", PRTE_PROC_STATE_CALLED_ABORT, PMIX_PROC_STATE_CALLED_ABORT},
+    {"HEARTBEAT_FAILED", PRTE_PROC_STATE_HEARTBEAT_FAILED, PMIX_PROC_STATE_HEARTBEAT_FAILED},
+    {"MIGRATING", PRTE_PROC_STATE_MIGRATING, PMIX_PROC_STATE_MIGRATING},
+    {"CANNOT_RESTART", PRTE_PROC_STATE_CANNOT_RESTART, PMIX_PROC_STATE_CANNOT_RESTART},
+    {"TERM_NON_ZERO", PRTE_PROC_STATE_TERM_NON_ZERO, PMIX_PROC_STATE_TERM_NON_ZERO},
+    {"FAILED_TO_LAUNCH", PRTE_PROC_STATE_FAILED_TO_LAUNCH, PMIX_PROC_STATE_FAILED_TO_LAUNCH},
+
+    /* every way PRRTE describes losing touch with a peer collapses onto
+     * PMIx's single bucket */
+    {"UNABLE_TO_SEND_MSG", PRTE_PROC_STATE_UNABLE_TO_SEND_MSG, PMIX_PROC_STATE_COMM_FAILED},
+    {"LIFELINE_LOST", PRTE_PROC_STATE_LIFELINE_LOST, PMIX_PROC_STATE_COMM_FAILED},
+    {"NO_PATH_TO_TARGET", PRTE_PROC_STATE_NO_PATH_TO_TARGET, PMIX_PROC_STATE_COMM_FAILED},
+    {"FAILED_TO_CONNECT", PRTE_PROC_STATE_FAILED_TO_CONNECT, PMIX_PROC_STATE_COMM_FAILED},
+    {"PEER_UNKNOWN", PRTE_PROC_STATE_PEER_UNKNOWN, PMIX_PROC_STATE_COMM_FAILED},
+};
+
+static int test_convert_state(void)
+{
+    int failures = 0;
+    size_t n;
+
+    for (n = 0; n < sizeof(state_map) / sizeof(state_map[0]); n++) {
+        pmix_proc_state_t got = prte_pmix_convert_state(state_map[n].prte);
+        if (got != state_map[n].pmix) {
+            fprintf(stderr,
+                    "FAIL [convert_state]: PRTE_PROC_STATE_%s (%d) -> %d, expected %d\n",
+                    state_map[n].name, state_map[n].prte, (int) got, (int) state_map[n].pmix);
+            failures++;
+        }
+    }
+
+    /* The two defects that motivated the table. 59 and 60 are adjacent and
+     * were transposed; TERMINATED was simply absent. */
+    CHECK("heartbeat is not migrating",
+          PMIX_PROC_STATE_HEARTBEAT_FAILED
+              == prte_pmix_convert_state(PRTE_PROC_STATE_HEARTBEAT_FAILED));
+    CHECK("migrating survives",
+          PMIX_PROC_STATE_MIGRATING == prte_pmix_convert_state(PRTE_PROC_STATE_MIGRATING));
+    CHECK("a finished proc is not UNDEF",
+          PMIX_PROC_STATE_TERMINATED == prte_pmix_convert_state(PRTE_PROC_STATE_TERMINATED));
+
+    /* UNDEF is a real answer for a real input, and must not double as the
+     * "I forgot this one" answer for anything else. */
+    CHECK("undef is reserved",
+          PMIX_PROC_STATE_UNDEF == prte_pmix_convert_state(PRTE_PROC_STATE_UNDEF));
+    CHECK("unknown state is undef", PMIX_PROC_STATE_UNDEF == prte_pmix_convert_state(-12345));
+
+    return failures;
+}
+
+static int test_convert_pstate(void)
+{
+    int failures = 0;
+    size_t n;
+
+    /* The reverse direction. Several PRRTE states share a PMIx state, so only
+     * check the entries where the PMIx side is unambiguous -- i.e. where this
+     * PMIx state appears exactly once in the table. */
+    for (n = 0; n < sizeof(state_map) / sizeof(state_map[0]); n++) {
+        size_t m, count = 0;
+        int got;
+
+        for (m = 0; m < sizeof(state_map) / sizeof(state_map[0]); m++) {
+            if (state_map[m].pmix == state_map[n].pmix) {
+                count++;
+            }
+        }
+        if (1 != count) {
+            continue;
+        }
+        got = prte_pmix_convert_pstate(state_map[n].pmix);
+        if (got != state_map[n].prte) {
+            fprintf(stderr, "FAIL [convert_pstate]: PMIx state %d -> %d, expected %d (%s)\n",
+                    (int) state_map[n].pmix, got, state_map[n].prte, state_map[n].name);
+            failures++;
+        }
+    }
+
+    /* PMIx has two states PRRTE spells one way */
+    CHECK("prepped is init", PRTE_PROC_STATE_INIT == prte_pmix_convert_pstate(PMIX_PROC_STATE_PREPPED));
+
+    /* these were missing entirely, so a heartbeat failure or a sensor trip
+     * arriving from PMIx was recorded as PRTE_PROC_STATE_UNDEF */
+    CHECK("heartbeat survives inbound",
+          PRTE_PROC_STATE_HEARTBEAT_FAILED
+              == prte_pmix_convert_pstate(PMIX_PROC_STATE_HEARTBEAT_FAILED));
+    CHECK("sensor bound survives inbound",
+          PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED
+              == prte_pmix_convert_pstate(PMIX_PROC_STATE_SENSOR_BOUND_EXCEEDED));
+
+    return failures;
+}
+
+/* A state that survives a round trip is one both converters agree about. This
+ * is what would have caught the 59/60 transposition on the day it was written:
+ * convert_pstate had MIGRATING -> 60 all along, so the pair disagreed. */
+static int test_state_roundtrip(void)
+{
+    int failures = 0;
+    size_t n;
+
+    for (n = 0; n < sizeof(state_map) / sizeof(state_map[0]); n++) {
+        pmix_proc_state_t out;
+        int back;
+
+        /* the lossy collapses cannot round trip and are not expected to */
+        if (PMIX_PROC_STATE_RUNNING == state_map[n].pmix
+            && PRTE_PROC_STATE_RUNNING != state_map[n].prte) {
+            continue;
+        }
+        if (PMIX_PROC_STATE_COMM_FAILED == state_map[n].pmix
+            && PRTE_PROC_STATE_COMM_FAILED != state_map[n].prte) {
+            continue;
+        }
+
+        out = prte_pmix_convert_state(state_map[n].prte);
+        back = prte_pmix_convert_pstate(out);
+        if (back != state_map[n].prte) {
+            fprintf(stderr, "FAIL [state roundtrip]: %s: %d -> %d -> %d\n", state_map[n].name,
+                    state_map[n].prte, (int) out, back);
+            failures++;
+        }
+    }
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* status translation                                                 */
+/* ------------------------------------------------------------------ */
+
+/* Is this value a legal PRRTE return code? The two families are
+ * PRTE_ERR_BASE - n and PRTE_ERR_SPLIT - n, both descending, so the test is a
+ * range test rather than a membership test -- close enough to catch a raw PMIx
+ * status, which is what we care about. */
+static bool is_prte_code(int rc)
+{
+    if (rc <= PRTE_ERR_BASE && rc > (PRTE_ERR_BASE - 100)) {
+        return true;
+    }
+    if (rc <= PRTE_ERR_SPLIT && rc > (PRTE_ERR_SPLIT - 100)) {
+        return true;
+    }
+    return false;
+}
+
+/* The headline defect: nothing prte_pmix_convert_status() returns may be a
+ * value it was simply handed. Sweep the whole plausible PMIx range. */
+static int test_status_no_passthrough(void)
+{
+    int failures = 0;
+    pmix_status_t s;
+    int leaked = 0;
+
+    for (s = -1; s > -2000; s--) {
+        int rc = prte_pmix_convert_status(s);
+
+        if (!is_prte_code(rc)) {
+            if (0 == leaked) {
+                fprintf(stderr,
+                        "FAIL [status passthrough]: PMIx status %d converted to %d, which is "
+                        "not a PRRTE code\n",
+                        (int) s, rc);
+            }
+            leaked++;
+        }
+        /* PRTE_SUCCESS means "the operation worked". No error status may
+         * produce it -- a caller that checks `if (PRTE_SUCCESS != rc)` would
+         * walk straight on. */
+        if (PRTE_SUCCESS == rc && PMIX_OPERATION_SUCCEEDED != s) {
+            fprintf(stderr, "FAIL [status success]: PMIx status %d converted to PRTE_SUCCESS\n",
+                    (int) s);
+            failures++;
+        }
+    }
+    if (0 < leaked) {
+        fprintf(stderr, "       (%d PMIx statuses leaked through unconverted)\n", leaked);
+        failures++;
+    }
+
+    CHECK("success converts", PRTE_SUCCESS == prte_pmix_convert_status(PMIX_SUCCESS));
+    CHECK("op succeeded converts", PRTE_SUCCESS == prte_pmix_convert_status(PMIX_OPERATION_SUCCEEDED));
+
+    return failures;
+}
+
+/* Likewise outbound: a PRRTE code must never be handed to PMIx unconverted.
+ * Sweep both PRRTE families. */
+static int test_rc_no_passthrough(void)
+{
+    int failures = 0;
+    int rc;
+    int leaked = 0;
+
+    for (rc = PRTE_ERR_BASE - 1; rc > (PRTE_ERR_BASE - 100); rc--) {
+        pmix_status_t s = prte_pmix_convert_rc(rc);
+        if (PMIX_SUCCESS == s) {
+            fprintf(stderr, "FAIL [rc success]: PRRTE code %d converted to PMIX_SUCCESS\n", rc);
+            failures++;
+        }
+        if (s == rc && PRTE_ERROR != rc) {
+            /* PRTE_ERROR and PMIX_ERROR are both -1 and mean the same thing,
+             * so that identity is deliberate. Any other code coming back
+             * unchanged is a value that fell through the switch. */
+            fprintf(stderr, "FAIL [rc passthrough]: PRRTE code %d returned unconverted\n", rc);
+            leaked++;
+        }
+    }
+    for (rc = PRTE_ERR_SPLIT - 1; rc > (PRTE_ERR_SPLIT - 100); rc--) {
+        pmix_status_t s = prte_pmix_convert_rc(rc);
+        if (PMIX_SUCCESS == s) {
+            fprintf(stderr, "FAIL [rc success]: PRRTE code %d converted to PMIX_SUCCESS\n", rc);
+            failures++;
+        }
+    }
+    if (0 < leaked) {
+        fprintf(stderr, "FAIL [rc passthrough]: %d PRRTE codes returned unconverted\n", leaked);
+        failures++;
+    }
+
+    CHECK("success converts", PMIX_SUCCESS == prte_pmix_convert_rc(PRTE_SUCCESS));
+
+    return failures;
+}
+
+/* The specific mistranslations the old default produced. Each of these is a
+ * real PMIx status whose numeric value is also a real, unrelated PRRTE code. */
+static int test_status_known_collisions(void)
+{
+    int failures = 0;
+
+    CHECK("pack failure is not a file-open failure",
+          PRTE_ERR_PACK_FAILURE == prte_pmix_convert_status(PMIX_ERR_PACK_FAILURE));
+    CHECK("unpack failure is not a file-write failure",
+          PRTE_ERR_UNPACK_FAILURE == prte_pmix_convert_status(PMIX_ERR_UNPACK_FAILURE));
+    CHECK("inadequate space is not a file-read failure",
+          PRTE_ERR_UNPACK_INADEQUATE_SPACE
+              == prte_pmix_convert_status(PMIX_ERR_UNPACK_INADEQUATE_SPACE));
+    CHECK("read past end survives",
+          PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER
+              == prte_pmix_convert_status(PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER));
+    CHECK("type mismatch is not out-of-bounds",
+          PRTE_ERR_TYPE_MISMATCH == prte_pmix_convert_status(PMIX_ERR_TYPE_MISMATCH));
+    CHECK("nomem is out of resource",
+          PRTE_ERR_OUT_OF_RESOURCE == prte_pmix_convert_status(PMIX_ERR_NOMEM));
+    CHECK("comm failure is comm failure",
+          PRTE_ERR_COMM_FAILURE == prte_pmix_convert_status(PMIX_ERR_COMM_FAILURE));
+
+    /* PMIX_ERR_EMPTY (-60) has the value of PRTE_ERR_NODE_DOWN. Nothing in
+     * PRRTE should ever conclude a node died because a buffer was empty. */
+    CHECK("empty is not node-down", PRTE_ERR_NODE_DOWN != prte_pmix_convert_status(PMIX_ERR_EMPTY));
+    /* PMIX_ERR_NOT_AVAILABLE (-64) has the value of PRTE_ERR_PROC_CHECKPOINT */
+    CHECK("not-available is not a checkpoint",
+          PRTE_ERR_PROC_CHECKPOINT != prte_pmix_convert_status(PMIX_ERR_NOT_AVAILABLE));
+
+    return failures;
+}
+
+/* PRTE_ERR_SILENT means "already reported to the user, do not report again".
+ * It has to survive the trip out to PMIx or the tool prints a second,
+ * redundant error. */
+static int test_status_roundtrip(void)
+{
+    int failures = 0;
+    static const int codes[] = {
+        PRTE_ERR_SILENT,
+        PRTE_ERR_OUT_OF_RESOURCE,
+        PRTE_ERR_BAD_PARAM,
+        PRTE_ERR_NOT_FOUND,
+        PRTE_ERR_NOT_SUPPORTED,
+        PRTE_ERR_TIMEOUT,
+        PRTE_ERR_WOULD_BLOCK,
+        PRTE_EXISTS,
+        PRTE_ERR_PACK_FAILURE,
+        PRTE_ERR_UNPACK_FAILURE,
+        PRTE_ERR_UNPACK_INADEQUATE_SPACE,
+        PRTE_ERR_UNPACK_READ_PAST_END_OF_BUFFER,
+        PRTE_ERR_TYPE_MISMATCH,
+        PRTE_ERR_UNKNOWN_DATA_TYPE,
+        PRTE_ERR_COMM_FAILURE,
+        PRTE_ERR_RESOURCE_BUSY,
+        PRTE_ERR_NOT_AVAILABLE,
+        PRTE_ERR_NODE_DOWN,
+        PRTE_ERR_NODE_OFFLINE,
+        PRTE_ERR_PROC_ABORTED,
+        PRTE_ERR_PROC_RESTART,
+        PRTE_ERR_PROC_MIGRATE,
+        PRTE_ERR_EVENT_REGISTRATION,
+        PRTE_ERR_DATA_VALUE_NOT_FOUND,
+        PRTE_SUCCESS,
+    };
+    size_t n;
+
+    for (n = 0; n < sizeof(codes) / sizeof(codes[0]); n++) {
+        pmix_status_t out = prte_pmix_convert_rc(codes[n]);
+        int back = prte_pmix_convert_status(out);
+        if (back != codes[n]) {
+            fprintf(stderr, "FAIL [status roundtrip]: %d -> %d -> %d\n", codes[n], (int) out, back);
+            failures++;
+        }
+    }
+
+    CHECK("silent stays silent", PMIX_ERR_SILENT == prte_pmix_convert_rc(PRTE_ERR_SILENT));
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* job/proc state -> error                                            */
+/* ------------------------------------------------------------------ */
+
+/* These two feed the spawn response and the failure notification a tool
+ * receives, so PMIX_ERROR ("something went wrong, no idea what") is the answer
+ * of last resort and must not be the answer for a state PRRTE actually
+ * reaches. */
+static int test_job_state_to_error(void)
+{
+    int failures = 0;
+    static const struct {
+        const char *name;
+        int state;
+        pmix_status_t expect;
+    } tbl[] = {
+        {"ALLOC_FAILED", PRTE_JOB_STATE_ALLOC_FAILED, PMIX_ERR_JOB_ALLOC_FAILED},
+        {"MAP_FAILED", PRTE_JOB_STATE_MAP_FAILED, PMIX_ERR_JOB_FAILED_TO_MAP},
+        {"NEVER_LAUNCHED", PRTE_JOB_STATE_NEVER_LAUNCHED, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"FAILED_TO_LAUNCH", PRTE_JOB_STATE_FAILED_TO_LAUNCH, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"FAILED_TO_START", PRTE_JOB_STATE_FAILED_TO_START, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"CANNOT_LAUNCH", PRTE_JOB_STATE_CANNOT_LAUNCH, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"KILLED_BY_CMD", PRTE_JOB_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
+        {"ABORTED", PRTE_JOB_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
+        {"CALLED_ABORT", PRTE_JOB_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
+        {"SILENT_ABORT", PRTE_JOB_STATE_SILENT_ABORT, PMIX_ERR_JOB_ABORTED},
+        {"ABORTED_BY_SIG", PRTE_JOB_STATE_ABORTED_BY_SIG, PMIX_ERR_JOB_ABORTED_BY_SIG},
+        {"ABORTED_WO_SYNC", PRTE_JOB_STATE_ABORTED_WO_SYNC, PMIX_ERR_JOB_TERM_WO_SYNC},
+        {"TERMINATED", PRTE_JOB_STATE_TERMINATED, PMIX_EVENT_JOB_END},
+    };
+    size_t n;
+
+    for (n = 0; n < sizeof(tbl) / sizeof(tbl[0]); n++) {
+        pmix_status_t got = prte_pmix_convert_job_state_to_error(tbl[n].state);
+        if (got != tbl[n].expect) {
+            fprintf(stderr, "FAIL [job state]: %s (%d) -> %d, expected %d\n", tbl[n].name,
+                    tbl[n].state, (int) got, (int) tbl[n].expect);
+            failures++;
+        }
+    }
+
+    CHECK("unknown job state is a generic error",
+          PMIX_ERROR == prte_pmix_convert_job_state_to_error(-12345));
+
+    return failures;
+}
+
+static int test_proc_state_to_error(void)
+{
+    int failures = 0;
+    static const struct {
+        const char *name;
+        int state;
+        pmix_status_t expect;
+    } tbl[] = {
+        {"KILLED_BY_CMD", PRTE_PROC_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
+        {"ABORTED", PRTE_PROC_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
+        {"CALLED_ABORT", PRTE_PROC_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
+        {"ABORTED_BY_SIG", PRTE_PROC_STATE_ABORTED_BY_SIG, PMIX_ERR_JOB_ABORTED_BY_SIG},
+        {"FAILED_TO_LAUNCH", PRTE_PROC_STATE_FAILED_TO_LAUNCH, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"FAILED_TO_START", PRTE_PROC_STATE_FAILED_TO_START, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
+        {"TERM_WO_SYNC", PRTE_PROC_STATE_TERM_WO_SYNC, PMIX_ERR_JOB_TERM_WO_SYNC},
+        {"COMM_FAILED", PRTE_PROC_STATE_COMM_FAILED, PMIX_ERR_COMM_FAILURE},
+        {"UNABLE_TO_SEND_MSG", PRTE_PROC_STATE_UNABLE_TO_SEND_MSG, PMIX_ERR_COMM_FAILURE},
+        {"LIFELINE_LOST", PRTE_PROC_STATE_LIFELINE_LOST, PMIX_ERR_COMM_FAILURE},
+        {"NO_PATH_TO_TARGET", PRTE_PROC_STATE_NO_PATH_TO_TARGET, PMIX_ERR_COMM_FAILURE},
+        {"FAILED_TO_CONNECT", PRTE_PROC_STATE_FAILED_TO_CONNECT, PMIX_ERR_COMM_FAILURE},
+        {"PEER_UNKNOWN", PRTE_PROC_STATE_PEER_UNKNOWN, PMIX_ERR_COMM_FAILURE},
+        {"CANNOT_RESTART", PRTE_PROC_STATE_CANNOT_RESTART, PMIX_ERR_PROC_RESTART},
+        {"TERM_NON_ZERO", PRTE_PROC_STATE_TERM_NON_ZERO, PMIX_ERR_JOB_NON_ZERO_TERM},
+        {"SENSOR_BOUND_EXCEEDED", PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED,
+         PMIX_ERR_JOB_SENSOR_BOUND_EXCEEDED},
+    };
+    size_t n;
+
+    for (n = 0; n < sizeof(tbl) / sizeof(tbl[0]); n++) {
+        pmix_status_t got = prte_pmix_convert_proc_state_to_error(tbl[n].state);
+        if (got != tbl[n].expect) {
+            fprintf(stderr, "FAIL [proc state]: %s (%d) -> %d, expected %d\n", tbl[n].name,
+                    tbl[n].state, (int) got, (int) tbl[n].expect);
+            failures++;
+        }
+    }
+
+    /* The comm-failure group must be treated identically by both the
+     * state translator and the error translator -- they describe the same
+     * event to the same tool by two different routes. */
+    CHECK("comm group agrees",
+          (PMIX_PROC_STATE_COMM_FAILED == prte_pmix_convert_state(PRTE_PROC_STATE_LIFELINE_LOST))
+              && (PMIX_ERR_COMM_FAILURE
+                  == prte_pmix_convert_proc_state_to_error(PRTE_PROC_STATE_LIFELINE_LOST)));
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    int failures = 0;
+
+    failures += test_convert_state();
+    failures += test_convert_pstate();
+    failures += test_state_roundtrip();
+    failures += test_status_no_passthrough();
+    failures += test_rc_no_passthrough();
+    failures += test_status_known_collisions();
+    failures += test_status_roundtrip();
+    failures += test_job_state_to_error();
+    failures += test_proc_state_to_error();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all pmix shim unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d pmix shim unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
## The problem

`src/pmix` is the boundary between PRRTE's error/state codes and PMIx's, and the two integer spaces **overlap numerically**. A PRRTE error is `PRTE_ERR_BASE - n` for n in [1,72]; a PMIx status runs from -1 down past -160. So most PMIx statuses are also the value of some real PRRTE constant.

That makes a mistranslation here uniquely hard to notice. A code passed across unconverted does not arrive as a recognisably foreign number that someone eventually questions — it arrives as a confidently wrong code that `prte_strerror()` will happily name, three subsystems away from where it was produced.

`prte_pmix_convert_status()` ended in `default: return status`, so every status its switch did not name was handed back verbatim:

| PMIx status | value | arrived as |
|---|---|---|
| `PMIX_ERR_PACK_FAILURE` | -21 | `PRTE_ERR_FILE_OPEN_FAILURE` |
| `PMIX_ERR_UNPACK_FAILURE` | -20 | `PRTE_ERR_FILE_WRITE_FAILURE` |
| `PMIX_ERR_NOMEM` | -32 | `PRTE_ERR_DATA_OVERWRITE_ATTEMPT` |
| `PMIX_ERR_EMPTY` | -60 | `PRTE_ERR_NODE_DOWN` |
| `PMIX_ERR_NOT_AVAILABLE` | -64 | `PRTE_ERR_PROC_CHECKPOINT` |

The pack/unpack rows are not hypothetical — PRRTE routes essentially every bfrops return through this function, ~270 call sites.

The state translators had the same disease in a second dimension. PRRTE has no `PREPPED`, so below the error boundary its proc states sit one under PMIx's, while from `*_STATE_ERROR` upward the offsets agree name for name. `prte_pmix_convert_state()` was written with bare integer cases, which looked harmless *because* the error range does line up: `case 59` returned `PMIX_PROC_STATE_MIGRATING` for `PRTE_PROC_STATE_HEARTBEAT_FAILED`, while the real `MIGRATING` fell through to `UNDEF`. `TERMINATED` was missing outright, so a proc-table query on a finished job reported every proc as `UNDEF` — and `UNDEF` is a legal answer, so nothing anywhere logged an error.

## What is here

- **Translators made total** — every case, and the default, lands on a constant in the target space. Missing states added in both directions; `PRTE_ERR_SILENT` now survives the trip out (it used to become a second, redundant error at the tool).
- **Header cleanup** — removes `PRTE_PMIX_ACQUIRE_THREAD`/`RELEASE_THREAD` (unused, and `RELEASE`'s non-debug branch had a side effect inside `assert()` that tried to lock a mutex the caller already held), `PMIX_PROC_NTOH`/`HTON` (unused, and defined in PMIx's namespace from PRRTE's header), several other dead macros, a compat shim for a PMIx older than we require, and `prte_pmix_register_cleanup()` (unused, and it woke a `prte_pmix_lock_t` from the PMIx thread — the pattern `prte_pmix_shifted_wakeup()` exists to prevent).
- **Two callers fixed** that treated `PRTE_MODEX_RECV_VALUE_OPTIONAL`'s result as a PRRTE code. One ran it through `prte_pmix_convert_rc()` — the wrong direction — turning every `PMIX_SERVER_URI` query failure into a bare `PMIX_ERROR`.
- **A drive-by leak** in the daemon rollup, landed separately.
- **Tests and docs**, including the first `AGENTS.md` for this directory.

## Testing

Warning-free `--enable-debug` build; `make check` 19/19 (new `test/unit/pmix`); offline mapper harness 1180/0; dockerswarm suite 312 pass / 0 fail / 0 skip; live DVM smoke test including the error path.

The unit test checks properties rather than spot values — a sweep of both ranges proving nothing passes through unconverted, and round-trips so the paired converters cannot drift apart (which is how the 59/60 transposition survived: the reverse function had it right all along). Writing that sweep turned up two further gaps on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)