### PR TITLE
Serve any node's PMIx server URI to a querying tool

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -44,7 +44,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
-| `proctable.c` | A bare PMIx client for the **proc-table queries** (`proctable` in the install): `procs`/`localprocs`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
+| `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
@@ -413,6 +413,40 @@ is `proctable`, and it asserts:
 - `PMIX_QUERY_LOCAL_PROC_TABLE` returns *some but not all* of a job's procs.
   On one host "local" and "all" are the same set, so this case cannot exist
   there.
+- **every daemon serves every node's `PMIX_SERVER_URI`**. The consumer here
+  is a **tool**, not a daemon — daemons reach each other over the RML and
+  never form PMIx connections to one another; see `examples/tool.c --uri
+  <nodename>`. Each daemon ships its own server URI to the master in its
+  `PRTED_CALLBACK` rollup, and the master puts the whole set into the
+  `WIREUP` xcast alongside the nidmap, so the answer does not depend on
+  which daemon the tool attached to. (Before that the query asked for a key
+  nobody published and answered `NOT_FOUND` for every node but the one being
+  asked — the producing half of commit `6e481fbb95` was never written.)
+
+  The case asks a **non-master** daemon about three other nodes — the case
+  that needs the xcast rather than just the rollup — and requires three
+  **distinct** URIs, so an implementation that echoed the local server back
+  would not pass. It then checks the master and a non-master agree on a
+  third node's URI. An unknown node must come back with a specific status,
+  never the generic `PMIX_ERROR` that the wrong-direction conversion used to
+  manufacture out of every failure on this path.
+
+- a served URI is **actually reachable**. With `--prtemca
+  pmix_remote_connections 1` the servers bind a routable interface, and the
+  URI served for a *remote* node must carry that node's own address — not
+  loopback, and not the master's. Off (the default) every server binds
+  loopback, so the answer is truthful but only usable by a tool on that
+  node. This is the assertion that says the feature is worth having, and one
+  host cannot make it.
+
+- the URIs **follow the DVM across a grow and a shrink**. `vm_ready()` runs
+  on every `VM_READY` and re-sends the whole set, so a grow redistributes
+  with no code of its own — asserted rather than assumed. A shrink needs
+  nothing: the query resolves hostname → node → `node->daemon` and a shrink
+  NULLs that, so a departed node cannot be answered for at all. The case
+  shrinks node3 and requires its URI to stop being served while node2's is
+  unaffected, so that stays true rather than being an accident of the
+  current teardown order.
 
 **The daemon body and the PMIx server host module (`src/prted`,
 `test_prted`)**: `src/prted` is where the DVM actually lives, and almost

--- a/contrib/dockerswarm/proctable.c
+++ b/contrib/dockerswarm/proctable.c
@@ -20,6 +20,11 @@
  *       Same, but PMIX_QUERY_LOCAL_PROC_TABLE -- only the procs the
  *       answering daemon hosts.
  *
+ *   proctable serveruri [hostname] [seconds]
+ *       PMIx_Query(PMIX_SERVER_URI), optionally qualified by PMIX_HOSTNAME so
+ *       the answer must come from ANOTHER node's daemon record. Prints
+ *       "URI <uri>" or "ERR <status> <name>".
+ *
  * Why this exists, and why it cannot be a unit test:
  *
  * prte_pmix_convert_state() is the only thing standing between a
@@ -37,6 +42,22 @@
  * and ten. The local-vs-global proc table split has no meaning at all on a
  * single host.
  *
+ * PMIX_SERVER_URI qualified by hostname is here for the same reason: it is
+ * the one query that resolves a *different node's* daemon and then goes out
+ * over PRTE_MODEX_RECV_VALUE_OPTIONAL for its URI. That macro yields a PMIx
+ * status, and its caller used to run the result through
+ * prte_pmix_convert_rc() -- the PRRTE-to-PMIx direction -- so every failure
+ * on this path was reported to the tool as a bare PMIX_ERROR. On one host
+ * the hostname qualifier resolves to the local daemon and the interesting
+ * branch is never taken.
+ *
+ * Note that PMIX_SERVER_URI is the rendezvous address of a node's PMIx
+ * SERVER -- how a client or tool connects to it. It is not how daemons reach
+ * each other; that is the RML, using PMIX_PROC_URI. The qualified form works
+ * only against the master, which is the one that collects every daemon's URI
+ * from its rollup; a non-master daemon answers for its own node and
+ * NOT_FOUND for any other. This client reports the raw status rather than
+ * just succeeding or failing because the status is the interesting part.
  */
 
 #include <stdio.h>
@@ -161,13 +182,50 @@ static int do_proc_table(const char *key, int seconds)
     return 0;
 }
 
+static int do_server_uri(const char *hostname, int seconds)
+{
+    pmix_query_t query;
+    pmix_info_t *results = NULL;
+    size_t n, nresults = 0;
+    pmix_status_t rc;
+
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIX_ARGV_APPEND(rc, query.keys, PMIX_SERVER_URI);
+    if (NULL != hostname) {
+        PMIX_QUERY_QUALIFIERS_CREATE(&query, 1);
+        PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_HOSTNAME, hostname, PMIX_STRING);
+    }
+
+    rc = PMIx_Query_info(&query, 1, &results, &nresults);
+    if (PMIX_SUCCESS != rc) {
+        /* This is the interesting line for the harness: the status has to be
+         * a PMIx status that says something, not a blanket PMIX_ERROR
+         * manufactured by converting in the wrong direction. */
+        printf("ERR %d %s\n", (int) rc, PMIx_Error_string(rc));
+        PMIX_QUERY_DESTRUCT(&query);
+        return 1;
+    }
+    for (n = 0; n < nresults; n++) {
+        if (PMIX_STRING == results[n].value.type && NULL != results[n].value.data.string) {
+            printf("URI %s\n", results[n].value.data.string);
+        }
+    }
+    PMIX_INFO_FREE(results, nresults);
+    PMIX_QUERY_DESTRUCT(&query);
+
+    if (0 < seconds) {
+        sleep(seconds);
+    }
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
     int ret = 1;
 
     if (2 > argc) {
-        fprintf(stderr, "usage: %s procs|localprocs [args]\n", argv[0]);
+        fprintf(stderr, "usage: %s procs|localprocs|serveruri [args]\n", argv[0]);
         return 2;
     }
 
@@ -181,6 +239,9 @@ int main(int argc, char **argv)
         ret = do_proc_table(PMIX_QUERY_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
     } else if (0 == strcmp(argv[1], "localprocs")) {
         ret = do_proc_table(PMIX_QUERY_LOCAL_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
+    } else if (0 == strcmp(argv[1], "serveruri")) {
+        const char *host = (3 <= argc && 0 != strcmp(argv[2], "-")) ? argv[2] : NULL;
+        ret = do_server_uri(host, (4 <= argc) ? atoi(argv[3]) : 0);
     } else {
         fprintf(stderr, "unknown mode: %s\n", argv[1]);
         ret = 2;

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1375,6 +1375,14 @@ prted_dvm_start() {
     sleep 4
     RUN "test -s $PRTED_URI"
 }
+# ...and the same with extra MCA (or other) options appended: $2 is spliced
+# in ahead of --host so a case can turn on a daemon-side knob.
+prted_dvm_start_mca() {
+    RUN "rm -f $PRTED_URI" >/dev/null 2>&1
+    RUN "timeout -k 5 60 prte --daemonize --report-uri $PRTED_URI $2 --host $1" >/dev/null 2>&1
+    sleep 4
+    RUN "test -s $PRTED_URI"
+}
 # run a tool against that DVM, from the head node ($@ = argv after "prun")
 PRUN() { RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI $*"; }
 # ...and in the background, with its output captured on node1
@@ -1670,10 +1678,146 @@ test_pmix() {
         && ok "...and no local proc reported UNDEF" \
         || bad "$undef local procs reported UNDEF"
 
+    banner "pmix: every daemon serves every node's PMIX_SERVER_URI"
+    # The consumer of this query is a TOOL, not a daemon -- daemons reach
+    # each other over the RML and never form PMIx connections to one another.
+    # A tool asks the DVM "where is the PMIx server on node X?" so it can
+    # connect there directly (examples/tool.c --uri <nodename>).
+    #
+    # This only works because every daemon ships its own server URI to the
+    # master in its PRTED_CALLBACK rollup, and the master then puts the whole
+    # set into the WIREUP xcast alongside the nidmap -- so EVERY daemon can
+    # answer for EVERY node, not just the master.  That uniformity is the
+    # point: a tool must not get a different answer depending on which daemon
+    # it happened to connect to.  Before the collection existed the query was
+    # asking for a key nobody published and answered NOT_FOUND for every node
+    # but the one being asked.  One host cannot show any of this: there is
+    # only one daemon and it is the master.
+    #
+    # Ask a NON-MASTER daemon (a proc on node3) about the others -- that is
+    # the case that needs the xcast rather than just the rollup.  The URIs
+    # must all differ and each must name its own daemon vpid; an
+    # implementation that echoed the local server back would pass a weaker
+    # test.
+    uris=""
+    for target in node1 node2 node4; do
+        out=$(PRUN "--host node3:1 -n 1 $PT serveruri $target" 2>&1)
+        u=$(echo "$out" | grep -m1 '^URI ' | awk '{print $2}' | tr -d '\r')
+        if [ -n "$u" ]; then
+            ok "a non-master daemon served $target's server URI"
+            uris="$uris$u\n"
+        else
+            bad "non-master daemon could not serve $target's server URI: $(echo "$out" | grep -E '^ERR' | tr '\n' ' ' | tail -c 200)"
+        fi
+    done
+    n=$(printf "$uris" | sort -u | grep -c . | tr -d ' ')
+    [ "$n" = 3 ] \
+        && ok "...and the three URIs are distinct (not the local server echoed back)" \
+        || bad "expected 3 distinct server URIs, got $n: $(printf "$uris" | tr '\n' ' ')"
+    # ...and the master must give the same answers
+    out=$(PRUN "--host node1:1 -n 1 $PT serveruri node3" 2>&1)
+    m3=$(echo "$out" | grep -m1 '^URI ' | awk '{print $2}' | tr -d '\r')
+    out=$(PRUN "--host node3:1 -n 1 $PT serveruri node3" 2>&1)
+    d3=$(echo "$out" | grep -m1 '^URI ' | awk '{print $2}' | tr -d '\r')
+    if [ -n "$m3" ] && [ "$m3" = "$d3" ]; then
+        ok "master and a non-master daemon agree on node3's server URI"
+    elif [ -z "$m3" ] || [ -z "$d3" ]; then
+        bad "node3's server URI was missing from one of the two answers (master='$m3' daemon='$d3')"
+    else
+        bad "master and daemon disagree on node3's server URI: '$m3' vs '$d3'"
+    fi
+    # An unknown node must be refused with a status that SAYS something --
+    # not the generic PMIX_ERROR (-1) that the wrong-direction conversion
+    # used to manufacture out of every failure on this path.
+    out=$(PRUN "--host node1:1 -n 1 $PT serveruri nosuchnode" 2>&1)
+    rc=$(echo "$out" | grep -m1 '^ERR ' | awk '{print $2}' | tr -d '\r')
+    if echo "$out" | grep -q '^URI '; then
+        bad "an unknown node somehow produced a URI"
+    elif [ "$rc" = "-1" ]; then
+        bad "an unknown node reported the generic PMIX_ERROR -- the status was flattened"
+    elif [ -z "$rc" ]; then
+        bad "unknown node gave neither a URI nor an error: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    else
+        ok "an unknown node is refused with a specific status ($(echo "$out" | grep -m1 '^ERR ' | awk '{print $3}'))"
+    fi
+
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     n=$(prted_count 1 2 3 4)
     [ "$n" = 0 ] && ok "no daemons survived the pmix-shim teardown" \
                  || bad "$n daemons still running after pterm"
+    cleanup_swarm
+
+    banner "pmix: a served server URI is actually reachable when remote connections are on"
+    # The point of the whole query.  By default the PMIx server listens on
+    # loopback, so what the master hands back is truthful but only usable by
+    # a tool ON that node.  With prte_pmix_remote_connections set, the server
+    # binds a routable interface -- and the URI the master serves for a
+    # REMOTE node must then carry that node's own address, not 127.0.0.1 and
+    # not the master's.  This is what makes the feature worth having, and it
+    # cannot be observed on one host.
+    if ! prted_dvm_start_mca 'node1:1,node2:1,node3:1' '--prtemca pmix_remote_connections 1'; then
+        bad "could not start a DVM with remote connections enabled"
+    else
+        out=$(PRUN "--host node1:1 -n 1 $PT serveruri node2" 2>&1)
+        u=$(echo "$out" | grep -m1 '^URI ' | awk '{print $2}' | tr -d '\r')
+        n2ip=$(docker exec prte-node2 hostname -i 2>/dev/null | awk '{print $1}' | tr -d '\r')
+        if [ -z "$u" ]; then
+            bad "no server URI for node2 with remote connections on: $(echo "$out" | grep -E '^ERR' | tr '\n' ' ' | tail -c 200)"
+        elif echo "$u" | grep -q '127\.0\.0\.1'; then
+            bad "node2's server URI came back as loopback despite remote connections: $u"
+        elif [ -n "$n2ip" ] && echo "$u" | grep -qF "$n2ip"; then
+            ok "node2's server URI names node2's own address ($n2ip)"
+        else
+            bad "node2's server URI does not name node2 ($n2ip): $u"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "pmix: server URIs follow the DVM across a grow and a shrink"
+    # The URIs ride along in the WIREUP xcast that vm_ready() builds, and
+    # vm_ready() runs on VM_READY -- which fires again every time the daemon
+    # set changes.  So a GROW should redistribute the whole set (the new
+    # nodes' URIs to everyone, and everyone's to the new nodes) with no code
+    # of its own.  This case checks that rather than assuming it.
+    #
+    # A SHRINK needs nothing: the query resolves hostname -> node ->
+    # node->daemon, and a shrink NULLs that backpointer, so a departed node
+    # cannot be answered for at all.  The store entry keyed on its (never
+    # reused) vpid is orphaned but unreachable.  Asserted here so that stays
+    # true rather than being an accident of the current teardown order.
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if ! RUN 'pgrep -x prte >/dev/null'; then
+        bad "could not start an elastic DVM for the grow/shrink URI test"
+    else
+        out=$(RUN 'timeout 90 elastic grow node2:2,node3:2' 2>&1)
+        if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+            bad "grow did not complete -- cannot test URI redistribution"
+        else
+            ok "grew node2+node3"
+            for target in node2 node3; do
+                out=$(RUN "timeout 40 prun --host node1:1 -n 1 $PT serveruri $target" 2>&1)
+                echo "$out" | grep -q '^URI ' \
+                    && ok "a grown node's server URI ($target) is served after the grow" \
+                    || bad "no server URI for grown $target: $(echo "$out" | grep -E '^ERR' | tr '\n' ' ' | tail -c 200)"
+            done
+            out=$(RUN 'timeout 90 elastic shrink node3' 2>&1); sleep 3
+            if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+                bad "shrink did not complete -- cannot test the stale URI"
+            else
+                ok "shrank node3"
+                out=$(RUN "timeout 40 prun --host node1:1 -n 1 $PT serveruri node3" 2>&1)
+                echo "$out" | grep -q '^URI ' \
+                    && bad "a shrunk node's server URI is still being served -- stale entry" \
+                    || ok "...and node3's server URI is no longer served"
+                out=$(RUN "timeout 40 prun --host node1:1 -n 1 $PT serveruri node2" 2>&1)
+                echo "$out" | grep -q '^URI ' \
+                    && ok "...while node2's is unaffected" \
+                    || bad "node2's server URI was lost by the shrink"
+            fi
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
     cleanup_swarm
 }
 

--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -30,7 +30,15 @@ behind almost every DVM-wide action:
 
 - The `plm`/`state` code broadcasts launch messages, wireup (nidmap), and
   DAEMON commands with `prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, …)` /
-  `PRTE_RML_TAG_WIREUP`.
+  `PRTE_RML_TAG_WIREUP`. The receive side of the wireup lives here, in
+  `process_wireup()` (`direct/grpcomm_direct_xcast.c`): after the nidmap it
+  reads a **three-field record per daemon** — name, `PMIX_PROC_URI`
+  (RML contact info), `PMIX_SERVER_URI` (that node's PMIx server
+  rendezvous, redistributed only so any daemon can answer a tool's query;
+  PRRTE never connects to it). The sender is `vm_ready()` in `state/dvm`.
+  The loop skips storing what it already knows, so mind the invariant:
+  **every field of a record must be unpacked before any `continue`**, or
+  the next iteration reads the leftover string as a `pmix_proc_t`.
 - The PMIx server shim satisfies `PMIx_Fence` /
   `PMIx_server_register_resources` for local clients via
   `prte_grpcomm.fence(...)` (see `src/prted/pmix/pmix_server_fence.c`).

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -707,10 +707,12 @@ static void process_wireup(pmix_data_buffer_t *msg){
     }
 
     pmix_value_t val = PMIX_VALUE_STATIC_INIT;
+    pmix_value_t sval = PMIX_VALUE_STATIC_INIT;
     pmix_proc_t dmn;
     int cnt = 1;
     do {
         PMIx_Value_destruct(&val);
+        PMIx_Value_destruct(&sval);
         ret = PMIx_Data_unpack(NULL, msg, &dmn, &cnt, PMIX_PROC);
         if(PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == ret) return;
         if(PMIX_SUCCESS != ret){ PMIX_ERROR_LOG(ret); break; }
@@ -721,6 +723,26 @@ static void process_wireup(pmix_data_buffer_t *msg){
         ret = PMIx_Data_unpack(NULL, msg, &val.data.string, &cnt, PMIX_STRING);
         if(PMIX_SUCCESS != ret){ PMIX_ERROR_LOG(ret); break; }
 
+        /* that node's PMIx SERVER rendezvous URI - for tools asking where a
+         * given node's server is, never for reaching the daemon (that is the
+         * PROC_URI above). It is a per-record field, so it MUST be unpacked
+         * here, before any of the skips below: a `continue` that left it in
+         * the buffer would make the next iteration read this string as a
+         * pmix_proc_t. May be NULL if that daemon reported none. */
+        PMIx_Value_construct(&sval);
+        sval.type = PMIX_STRING;
+
+        ret = PMIx_Data_unpack(NULL, msg, &sval.data.string, &cnt, PMIX_STRING);
+        if(PMIX_SUCCESS != ret){ PMIX_ERROR_LOG(ret); break; }
+
+        /* store it for every daemon but ourselves - PMIx already holds our
+         * own server's URI, and unlike the PROC_URI skips below we have no
+         * other source for the HNP's or our parent's */
+        if(!PMIX_CHECK_PROCID(&dmn, PRTE_PROC_MY_NAME) && NULL != sval.data.string){
+            ret = PMIx_Store_internal(&dmn, PMIX_SERVER_URI, &sval);
+            if(PMIX_SUCCESS != ret){ PMIX_ERROR_LOG(ret); break; }
+        }
+
         if(PMIX_CHECK_PROCID(&dmn, PRTE_PROC_MY_HNP)) continue;
         if(PMIX_CHECK_PROCID(&dmn, PRTE_PROC_MY_NAME)) continue;
         if(PMIX_CHECK_PROCID(&dmn, PRTE_PROC_MY_PARENT)) continue;
@@ -730,6 +752,7 @@ static void process_wireup(pmix_data_buffer_t *msg){
     } while(PMIX_SUCCESS == ret);
 
     if(val.type != PMIX_UNDEF) PMIx_Value_destruct(&val);
+    if(sval.type != PMIX_UNDEF) PMIx_Value_destruct(&sval);
     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
     return;
 }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1458,6 +1458,38 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
         daemon->rml_uri = strdup(cnctinfo.data.string);
         PMIX_VALUE_DESTRUCT(&cnctinfo);
 
+        /* unload the rendezvous URI of that node's PMIx server. Nothing in
+         * PRRTE connects to it - daemons talk over the RML, using the URI
+         * above. We record it so that a TOOL can ask us where the server on
+         * a given node is (a hostname- or nodeid-qualified PMIX_SERVER_URI
+         * query). Storing it against the daemon's name is what makes that
+         * query work: it fetches with PMIx_Get() keyed on exactly this
+         * name, the same way the PMIX_PROC_URI above is fetched.
+         *
+         * A daemon that could not report one packs a NULL, which is not an
+         * error - the query then answers NOT_FOUND for that node, as it did
+         * for every node before this was collected at all. */
+        PMIX_VALUE_CONSTRUCT(&cnctinfo);
+        cnctinfo.type = PMIX_STRING;
+        idx = 1;
+        ret = PMIx_Data_unpack(NULL, buffer, &cnctinfo.data.string, &idx, PMIX_STRING);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_VALUE_DESTRUCT(&cnctinfo);
+            prted_failed_launch = true;
+            goto CLEANUP;
+        }
+        if (NULL != cnctinfo.data.string) {
+            ret = PMIx_Store_internal(&dname, PMIX_SERVER_URI, &cnctinfo);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                PMIX_VALUE_DESTRUCT(&cnctinfo);
+                prted_failed_launch = true;
+                goto CLEANUP;
+            }
+        }
+        PMIX_VALUE_DESTRUCT(&cnctinfo);
+
         /* unpack the node name */
         idx = 1;
         ret = PMIx_Data_unpack(NULL, buffer, &nodename, &idx, PMIX_STRING);

--- a/src/mca/state/dvm/AGENTS.md
+++ b/src/mca/state/dvm/AGENTS.md
@@ -101,9 +101,18 @@ so that a request to expand the DVM has a hook.
 
 ### `vm_ready`
 Runs when the DVM's daemons have all reported. For the daemon job it
-packs every daemon's `PMIX_PROC_URI` into a nidmap and `xcast`s
+builds a nidmap, appends **per daemon: its name, its `PMIX_PROC_URI`, and
+its `PMIX_SERVER_URI`** to that same buffer, and `xcast`s
 `PRTE_RML_TAG_WIREUP` to all daemons (skipped for a single-daemon or
-`DO_NOT_LAUNCH` DVM). On any pack/get failure it drives
+`DO_NOT_LAUNCH` DVM). The first two are the RML wireup; the third is not
+used by PRRTE at all — it is redistributed so that *any* daemon can answer
+a tool's hostname-qualified `PMIX_SERVER_URI` query, rather than only the
+master that collected it (see [`../../../pmix/AGENTS.md`](../../../pmix/AGENTS.md)).
+The receiving end is `process_wireup()` in `grpcomm/direct`, and the three
+fields are a **per-record group** — its skip-what-we-already-know
+`continue`s must not skip an unpack. Because this handler re-sends the
+whole set every time `VM_READY` fires, an elastic **grow** redistributes
+with no code of its own. On any pack/get failure it drives
 `PRTE_JOB_STATE_FORCED_EXIT` with a `NULL` job (tearing the whole DVM
 down) — **and each of those five bailouts must still release the
 caddy**; they did not, and every wireup failure leaked the caddy plus the

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -269,7 +269,7 @@ static void vm_ready(int fd, short args, void *cbdata)
     prte_job_t *jptr;
     prte_proc_t *dmn;
     int32_t v;
-    pmix_value_t *val;
+    pmix_value_t *val, *sval;
     pmix_status_t ret;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -337,6 +337,43 @@ static void vm_ready(int fd, short args, void *cbdata)
                     return;
                 }
                 PMIX_VALUE_RELEASE(val);
+
+                /* ...and that node's PMIx SERVER rendezvous URI. This is not
+                 * wireup in the RML sense - no daemon ever opens a PMIx
+                 * connection to another daemon, and the URI just above is
+                 * what they route with. It rides along here so that every
+                 * daemon can answer a TOOL asking "where is the PMIx server
+                 * on node X?" (a hostname/nodeid-qualified PMIX_SERVER_URI
+                 * query - see src/pmix/AGENTS.md). Collecting it only at the
+                 * master would mean the answer depended on which daemon the
+                 * tool happened to be connected to.
+                 *
+                 * Each daemon reported this in its PRTED_CALLBACK rollup and
+                 * we stored it against its name, so this is a local lookup.
+                 * A daemon that could not report one leaves nothing to find:
+                 * pack a NULL rather than failing the DVM over auxiliary
+                 * information. */
+                sval = NULL;
+                ret = PMIx_Get(&dmn->name, PMIX_SERVER_URI, NULL, 0, &sval);
+                if (PMIX_SUCCESS == ret && NULL != sval && PMIX_STRING == sval->type) {
+                    rc = PMIx_Data_pack(NULL, &buf, &sval->data.string, 1, PMIX_STRING);
+                } else {
+                    char *nulluri = NULL;
+                    rc = PMIx_Data_pack(NULL, &buf, &nulluri, 1, PMIX_STRING);
+                }
+                if (NULL != sval) {
+                    PMIX_VALUE_RELEASE(sval);
+                }
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                    /* the whole DVM is being torn down; held jobs will be
+                     * failed as part of that teardown, so leave the fence
+                     * untouched here */
+                    PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+                    PMIX_RELEASE(caddy);
+                    return;
+                }
             }
 
             /* goes to all daemons */

--- a/src/pmix/AGENTS.md
+++ b/src/pmix/AGENTS.md
@@ -187,6 +187,71 @@ shape.
 
 ---
 
+## `PMIX_SERVER_URI` is collected, and it is not an RML thing
+
+Worth stating because the name invites exactly the wrong assumption.
+
+`PMIX_SERVER_URI` is the rendezvous address of a node's **PMIx server** — how
+a *client or tool* connects to it. It is **not** how daemons reach each
+other; that is the RML, using `PMIX_PROC_URI`. No daemon ever opens a PMIx
+connection to another daemon, and nothing in PRRTE consumes this key
+internally.
+
+It exists for one consumer: a **tool** that asks the DVM "where is the PMIx
+server on node X?" so it can connect there directly —
+`PMIx_Query(PMIX_SERVER_URI)` qualified by `PMIX_HOSTNAME` or `PMIX_NODEID`,
+as in [`examples/tool.c`](../../examples/tool.c) (`--uri <nodename>`).
+
+The value travels the **same two hops as `PMIX_PROC_URI`**, one field later
+in each message — collect to the master, then hand the whole set back out:
+
+1. **Collect.** Each daemon fetches its own server URI from its PMIx server
+   and packs it into its `PRTE_RML_TAG_PRTED_CALLBACK` rollup, right after
+   `PMIX_PROC_URI` — [`src/tools/prted/prted.c`](../tools/prted/prted.c).
+   The master unpacks it in `prte_plm_base_daemon_callback()` and does
+   `PMIx_Store_internal(&dname, PMIX_SERVER_URI, ...)` against that daemon's
+   name — [`plm_base_launch_support.c`](../mca/plm/base/plm_base_launch_support.c).
+2. **Distribute.** `vm_ready()` builds the nidmap, appends every daemon's
+   name + `PMIX_PROC_URI` + `PMIX_SERVER_URI` to that same buffer, and
+   xcasts it on `PRTE_RML_TAG_WIREUP` —
+   [`state_dvm.c`](../mca/state/dvm/state_dvm.c). Every daemon stores what
+   it receives in `process_wireup()` —
+   [`grpcomm_direct_xcast.c`](../mca/grpcomm/direct/grpcomm_direct_xcast.c).
+3. **Serve.** The query fetches it with a `PMIx_Get` keyed on exactly that
+   name, which is what `PRTE_MODEX_RECV_VALUE_OPTIONAL` does — so the query
+   code needed no change at all.
+
+Consequences to keep in mind:
+
+- **Every daemon can answer for every node**, and that uniformity is the
+  point: a tool must not get a different answer depending on which daemon it
+  happened to connect to. Collecting only at the master would have made the
+  query's result depend on the tool's attachment point.
+- **Grow is covered by the same path; shrink needs nothing.** `vm_ready()`
+  runs on `VM_READY`, which fires again whenever the daemon set changes, and
+  it re-sends the *whole* set — so a grow redistributes without any code of
+  its own. A shrink NULLs `node->daemon`, and the query resolves
+  hostname → node → daemon, so a departed node simply cannot be answered
+  for; its store entry is orphaned under a vpid the DVM will never reuse.
+- **A daemon that cannot report one packs a NULL, and that is not an
+  error.** This is auxiliary information; it must never fail a launch or a
+  wireup.
+- **In `process_wireup()` the server URI must be unpacked before the
+  `continue`s.** It is a per-record field, so skipping it for a daemon whose
+  `PMIX_PROC_URI` we already have would leave it in the buffer and the next
+  iteration would read that string as a `pmix_proc_t`.
+- **The URI is only useful to a remote tool if the server accepts remote
+  connections** (`--prtemca pmix_remote_connections 1`,
+  `prte_pmix_server_globals.remote_connections`). Off — the default — every
+  server binds loopback, so the answer is truthful but only usable by a tool
+  on that node. That is the requester's business, not the DVM's; serve what
+  we have.
+- This closes the half-built feature from commit `6e481fbb95` (2019), whose
+  message promised the collection but whose diff only ever contained the
+  query side and the example.
+
+---
+
 ## Everything else in the header
 
 - **The list-item classes.** `prte_info_item_t` (a `pmix_info_t` on a list),
@@ -253,7 +318,16 @@ that is not the one you are standing on. The `proctable` client covers:
 - `PMIX_QUERY_PROC_TABLE` over a job spread across four nodes — every proc
   must report a state PMIx defines, and none may report `UNDEF`;
 - `PMIX_QUERY_LOCAL_PROC_TABLE`, whose local-vs-global distinction has no
-  meaning at all on one host.
+  meaning at all on one host;
+- the master serving **any** node's `PMIX_SERVER_URI`, and a failure
+  reporting a real status rather than a flattened `PMIX_ERROR` — the direct
+  regression test for the wrong-direction conversion described above.
+
+  Note who the consumer is: **not a daemon**. Daemons reach each other over
+  the RML and never form PMIx connections to one another. This query exists
+  for a *tool* — see `examples/tool.c --uri <nodename>` — which asks the DVM
+  where a particular node's PMIx server is so the tool can connect to it
+  directly. See the section below for how that value gets to the master.
 
 What is deliberately **not** tested anywhere automatically: the lock macros
 and `prte_pmix_shifted_wakeup()`. Their contract is a threading one — it

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -33,6 +33,19 @@ startup/rollup logic. `src/runtime/` holds the globals
 (`prte_job_t`, `prte_node_t`, `prte_proc_t`) that all of this code
 manipulates.
 
+**The rollup message is a wire format with two ends.** A daemon builds it in
+`src/tools/prted/prted.c` and the master unpacks it in
+`prte_plm_base_daemon_callback()`
+([`plm_base_launch_support.c`](../mca/plm/base/plm_base_launch_support.c)) —
+change one and you must change the other, in field order. Today it carries:
+the daemon's name, its `PMIX_PROC_URI` (RML contact info), its
+`PMIX_SERVER_URI` (the PMIx server rendezvous, for tools — see
+[`../pmix/AGENTS.md`](../pmix/AGENTS.md)), the node name, node aliases, and
+optionally the topology. Note that a tree-spawning parent relays a child's
+buffer by copying the payload wholesale and only *peeking* at the first two
+fields for its own use, so appending a field is safe there — but inserting
+one before `PMIX_PROC_URI` is not.
+
 ---
 
 ## Who executes what

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -617,6 +617,36 @@ int main(int argc, char *argv[])
         goto DONE;
     }
 
+    /* include our PMIx server's rendezvous URI. This is NOT how daemons
+     * reach each other - that is the RML's job, and the URI above is what
+     * it uses. This one exists solely so the master can answer a TOOL that
+     * asks "where is the PMIx server on node X?" (a hostname- or
+     * nodeid-qualified PMIX_SERVER_URI query - see pmix_server_queries.c
+     * and examples/tool.c). Only useful to a remote tool when the server
+     * was told to accept remote connections, but that is the requester's
+     * business, not ours.
+     *
+     * A PMIx that will not tell us our own server URI is not a reason to
+     * fail the launch - this is auxiliary information. Pack a NULL and let
+     * the master record nothing. */
+    vptr = NULL;
+    prc = PMIx_Get(&prte_process_info.myproc, PMIX_SERVER_URI, NULL, 0, &vptr);
+    if (PMIX_SUCCESS == prc && NULL != vptr && PMIX_STRING == vptr->type) {
+        prc = PMIx_Data_pack(NULL, buffer, &vptr->data.string, 1, PMIX_STRING);
+    } else {
+        char *nulluri = NULL;
+        prc = PMIx_Data_pack(NULL, buffer, &nulluri, 1, PMIX_STRING);
+    }
+    if (NULL != vptr) {
+        PMIX_VALUE_RELEASE(vptr);
+    }
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+        ret = PRTE_ERROR;
+        PMIX_DATA_BUFFER_RELEASE(buffer);
+        goto DONE;
+    }
+
     /* include our node name */
     prc = PMIx_Data_pack(NULL, buffer, &prte_process_info.nodename, 1, PMIX_STRING);
     if (PMIX_SUCCESS != prc) {


### PR DESCRIPTION
> **Stacked on #2582** — that PR's six commits appear here too. Merge #2582 first; this one is the last three commits (`plm, state, grpcomm, prted: serve any node's PMIx server URI` onward).

## The problem

A hostname- or nodeid-qualified `PMIX_QUERY(PMIX_SERVER_URI)` has never worked for any node but the one answering it.

Worth being precise about who wants this, because the name invites the wrong assumption: **not a daemon**. Daemons reach each other over the RML and never open PMIx connections to one another. `PMIX_SERVER_URI` is the rendezvous address of a node's *PMIx server* — how a client or tool connects to it. The consumer is a **tool** asking the DVM where a particular node's server is so it can connect there directly, which `examples/tool.c` has driven with `--uri <nodename>` since 2019.

The query side has been right all along. What was missing is the other half. Commit 6e481fbb95 (2019) says it "collect[s] and send[s] each server's PMIX_SERVER_URI to the PRRTE master for later dissemination" — but its diff only ever touched the query and the example. Nothing in PRRTE has set, packed or stored that key since, so the query was looking up something nobody published, and answered `NOT_FOUND` for every remote node. On the HNP too.

## What is here

The missing half, following exactly the route `PMIX_PROC_URI` already takes and sitting one field behind it in both messages:

1. **Collect** — each daemon adds its own server URI to its `PRTED_CALLBACK` rollup; the master stores it against that daemon's name.
2. **Distribute** — `vm_ready()` appends the whole set to the buffer it already builds for the `WIREUP` xcast; every daemon records what it receives.
3. **Serve** — the query finds it with the `PMIx_Get` it was already doing. `pmix_server_queries.c` is untouched.

Distributing rather than stopping at the master is deliberate: a tool must not get a different answer depending on which daemon it attached to.

**Grow and shrink need no code of their own**, but both are now asserted rather than assumed. `vm_ready()` runs on every `VM_READY` and re-sends the entire set, so a grow redistributes; a shrink clears `node->daemon`, which is what the query resolves through, so a departed node simply cannot be answered for and its entry is orphaned under a vpid the DVM will not reuse.

One subtlety for reviewers: in `process_wireup()` the new field must be unpacked **before** the "skip what we already know" `continue`s. The three fields are a per-record group, and leaving one in the buffer would make the next iteration read a string as a `pmix_proc_t`.

The URI is only usable by a *remote* tool when the server was told to accept remote connections (`prte_pmix_remote_connections`); with that off every server binds loopback and the answer is truthful but only good locally. That is the requester's business, so we serve what we have. A daemon that cannot report a URI packs a NULL — this is auxiliary information and must never fail a launch or a wireup.

## Testing

Dockerswarm suite 312 pass / 0 fail / 0 skip; warning-free build; `make check` 19/19; offline mapper 1180/0.

The multi-node cases ask a **non-master** daemon about three other nodes and require three distinct URIs (an implementation echoing the local server back would pass a weaker test), check master and non-master agree, require a routable address under `pmix_remote_connections`, and cover the grow/shrink behavior above. None of it is observable on one host, where there is a single daemon and it is the master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)