### PR TITLE
dockerswarm: let two clones drive the harness without wrecking each other

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -39,7 +39,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `build.sh` | Builds PRRTE (and optionally PMIx) from your **live** tree via VPATH: into a shared volume for the Linux swarm, or natively for macOS. Start here. |
 | `run-tests.sh` | Runs the test suite and reports PASS/FAIL: the full multi-node suite on Linux, a single-host subset on macOS. |
 | `Dockerfile` | Base image: toolchain, a baked PMIx, SSH wiring, and a node entrypoint. It does **not** contain PRRTE. |
-| `docker-compose.yml` | The ten nodes `prte-node1`..`prte-node10`, each mounting the shared `prte-build` volume. |
+| `docker-compose.yml` | The ten nodes `prte-node1`..`prte-node10`, each mounting the shared `prte-build` volume. Every one of those names derives from `$PRTE_SWARM`, so two clones can each run a swarm — see §4. |
 | `elastic.c` | The elastic test client (`elastic` in the install): issues a PMIx allocation request and waits for the phase-two completion event. |
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
@@ -186,6 +186,52 @@ exactly this — a build against a stale second PMIx.)
 Rebuild after editing PRRTE: just rerun `./build.sh` (incremental). No image
 rebuild, no `docker compose` restart needed — the nodes read the shared volume.
 To also test an openpmix change, add `PMIX_SRC=/path/to/openpmix`.
+
+### Two clones on one host: `PRTE_SWARM`
+
+Every global name this harness claims — the compose project, the ten container
+names, the build volume, the docker network — is derived from `$PRTE_SWARM`,
+so a second clone (or a second agent) can drive its own swarm:
+
+```sh
+export PRTE_SWARM=alt      # for the WHOLE shell; see the warning below
+./build.sh                 # -> volume alt-build
+docker compose up -d       # -> project altswarm, containers alt-node1..10
+./run-tests.sh linux       #    on network altswarm_dvm
+```
+
+Unset, it is `prte` and every name is exactly what it has always been:
+project `prteswarm`, containers `prte-node1..10`, volume `prte-build`.
+
+Both swarms contain a container whose **hostname is `node1`**, and that is
+fine: each user-defined bridge network runs its own embedded DNS serving only
+the containers attached to it, so `node2` inside a swarm can only ever mean
+that swarm's node2. The tests need no changes — `--host node2:2` means the
+right machine in either.
+
+> **Export it, don't prefix one command.** `docker compose` interpolates
+> `docker-compose.yml` itself, so `PRTE_SWARM` has to be in *that* command's
+> environment. A `docker compose up -d` without it quietly brings up the
+> **default** swarm instead, against the default volume, and your build sits
+> in `alt-build` unused. `run-tests.sh` says which swarm it looked for when it
+> finds nothing, and `build.sh` prints the exact next command including the
+> variable.
+
+**What is still shared, and what that costs.** The base image
+(`prte-swarm:latest`) is read-only to a running swarm and expensive to build,
+so both instances use the same one — but `./build.sh image` (or a
+`docker build`) replaces it under the other swarm's feet, and that swarm's
+containers then fail the "containers are running the current image" preflight
+until they are recreated. Nothing else crosses: separate containers, separate
+`/tmp`, separate install, separate network.
+
+**The macOS subset needs no such knob** — its install is already per-clone
+(`<repo>/vpath-macos`), and it isolates the two things that are not: it starts
+every tool by absolute path out of its own install and matches on that path
+when it reaps strays (a bare `pkill -x prte` would kill the other clone's DVM,
+and a bare `pgrep -x prte` would *report the other clone's DVM as its own* and
+pass a case on it), and it runs PRRTE under a private `TMPDIR` it creates and
+removes, so no session dir it deletes was ever anyone else's.
 
 ## 5. Driving the DVM by hand
 
@@ -585,19 +631,44 @@ running straight away produced twenty-one failures with nothing in them
 pointing at the cause — the first launch simply came back killed.
 
 If you drive things by hand, clear stale state on **every** node between
-DVM runs:
+DVM runs — the same sweep `cleanup_swarm` does:
 
 ```sh
 for n in $(seq 1 10); do
-  docker exec prte-node$n sh -c 'pkill -9 -x prted; pkill -9 -x prte;
-    rm -rf /tmp/prte.* /tmp/prun.session.*; true'
+  docker exec prte-node$n sh -c '
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* /tmp/pmix.*
+    find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} +
+    true'
 done
 ```
+
+**Every tool has its own session-dir prefix, and one missed prefix is enough.**
+`prte.<pid>` is the HNP, `prtrn.<pid>` is `prterun`, `prted.<pid>` is a
+bootstrapped daemon standing on its own, `prun.<pid>` is `prun` itself, and
+`ompi.<pid>` is anything run under the ompi personality. Each of them holds a
+`pmix.*` server rendezvous file, a system-level server drops `pmix.sys.<host>`
+straight into `/tmp`, and any one left behind makes the next tool report
+*"multiple possible servers … connection handles have been read from files
+named pmix.\*"* and fail to find the DVM. That is why the sweep ends with a
+`find`: it catches the rendezvous file of a session dir whose prefix this list
+has not heard of. Leaving `pmix.*` out of `cleanup_swarm` is
+[#2526](https://github.com/openpmix/prrte/issues/2526) — a hand-driven
+`prterun` before a suite run made the elastic block fail for reasons that had
+nothing to do with the code.
+
+The tools are killed, not just the daemons: a live `prun` or `pterm` is
+holding a rendezvous file of its own, and reaping it is the point of a
+teardown.
 
 A detached `prted --daemonize` **survives an HNP kill**; orphans on other nodes
 make the next DVM trip over stale rendezvous files ("multiple possible
 servers"). `pterm` is the clean shutdown; still run the loop afterward to be
 safe.
+
+If you are running a second swarm (`PRTE_SWARM`, §4), the loop above is
+per-swarm — use that swarm's container names. Nothing in it can reach the
+other swarm's `/tmp`, because the containers are different containers.
 
 ## 8. Rebuilding / resetting
 
@@ -608,6 +679,7 @@ safe.
 | force a clean PRRTE rebuild | `docker volume rm prte-build && ./build.sh` |
 | rebuild the base image (new baked PMIx) | `docker build --no-cache --build-arg PMIX_REF=master -t prte-swarm:latest .` — `./build.sh image` reuses docker's cached `git clone`; then wipe the volume's VPATH dirs and recreate the containers (see "The containers persist too") |
 | tear down the swarm | `docker compose down` (the `prte-build` volume persists) |
+| run a second, independent swarm | `export PRTE_SWARM=alt` and repeat the quick start — see §4. Every command in this table then names that swarm's volume (`alt-build`) and containers (`alt-node*`), and **a `docker compose down` without the variable takes down the *default* swarm** |
 
 ## 9. Grow after a shrink
 
@@ -652,10 +724,15 @@ not complete otherwise wedges the whole suite rather than failing one case.
 | `prte-node1` | node1 | head node (HNP) — start `prte` here, run all tools here |
 | `prte-node2`..`prte-node10` | node2..node10 | DVM nodes (grow/shrink targets) |
 
-Network: bridge `dvm`. All nodes mount the shared `prte-build` volume read-only
-at `/opt/prte`, where `build.sh` installs PRRTE (`/opt/prte/prte`) and writes
-`/opt/prte/env.sh`. To add or remove nodes, copy or delete a service block in
-`docker-compose.yml` (and adjust the `seq 1 10` loops to match).
+Network: bridge `prteswarm_dvm`. All nodes mount the shared `prte-build`
+volume read-only at `/opt/prte`, where `build.sh` installs PRRTE
+(`/opt/prte/prte`) and writes `/opt/prte/env.sh`. To add or remove nodes, copy
+or delete a service block in `docker-compose.yml` (and adjust the `seq 1 10`
+loops to match).
+
+The container, volume, and network names above are the `PRTE_SWARM=prte`
+default; under another name they all shift together (§4). The **hostnames**
+never do — `node1`..`node10` is what the tests name, in every swarm.
 
 ## 11. Spawning a child job (`dynamic`)
 

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -18,6 +18,10 @@
 #   ./build.sh macos    # build natively on this host into <repo>/vpath-macos
 #   ./build.sh image    # (re)build just the base container image
 #
+# Two clones on one host: set PRTE_SWARM (see below) in the whole shell, and
+# each gets its own containers, volume, and network.  The macOS build is
+# already per-clone -- it lives in <repo>/vpath-macos.
+#
 # Distcleaning the source tree
 # ----------------------------
 # An out-of-tree build cannot share a source tree with an in-tree build: VPATH
@@ -66,8 +70,32 @@ set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(git -C "$here" rev-parse --show-toplevel)"
 
+# Which swarm this is.  Every global name the harness claims -- the compose
+# project, the ten container names, the build volume, the docker network --
+# is derived from it, so two clones on one host can each drive their own
+# swarm without touching the other's containers, install, or /tmp.  Unset, it
+# is "prte" and every name is what it has always been.  Set it for the whole
+# shell, because `docker compose` interpolates docker-compose.yml itself:
+#
+#   export PRTE_SWARM=alt
+#   ./build.sh && docker compose up -d && ./run-tests.sh linux
+#
+# The image is deliberately NOT per-swarm (see docker-compose.yml).
+PRTE_SWARM="${PRTE_SWARM:-prte}"
+# Rejected here rather than left to docker.  Filtering through LC_ALL=C tr,
+# not a shell [a-z] range: in a UTF-8 locale that range follows collation
+# order and matches 'B', so the obvious form of this test accepts names
+# docker then refuses.  Same reason the leading-character check is a literal
+# set.
+case "$PRTE_SWARM" in [_-]*) PRTE_SWARM="" ;; esac
+if [ -z "$PRTE_SWARM" ] || \
+   [ "$PRTE_SWARM" != "$(printf '%s' "$PRTE_SWARM" | LC_ALL=C tr -cd 'a-z0-9_-')" ]; then
+    echo "PRTE_SWARM must be lowercase [a-z0-9_-] and start with a letter or digit" >&2
+    exit 2
+fi
+
 IMAGE="${IMAGE:-prte-swarm:latest}"
-VOLUME="${VOLUME:-prte-build}"
+VOLUME="${VOLUME:-$PRTE_SWARM-build}"
 PMIX_REF="${PMIX_REF:-master}"          # baked-image PMIx branch
 PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
 PMIX_SRC="${PMIX_SRC:-}"                # optional openpmix checkout to build
@@ -361,7 +389,17 @@ build_linux() {
             echo ">>>> done: install in /opt/prte/prte"
         '
     echo ">>> Linux build complete."
-    echo ">>> next: docker compose up -d && ./run-tests.sh linux"
+    if [ "$PRTE_SWARM" = prte ]; then
+        echo ">>> next: docker compose up -d && ./run-tests.sh linux"
+    else
+        # Say it with the variable: compose reads PRTE_SWARM from the
+        # environment of the compose command, and a `docker compose up -d`
+        # without it brings up the DEFAULT swarm against the default volume,
+        # leaving this build sitting in $VOLUME unused.
+        echo ">>> next: PRTE_SWARM=$PRTE_SWARM docker compose up -d &&" \
+             "PRTE_SWARM=$PRTE_SWARM ./run-tests.sh linux"
+        echo ">>>       (swarm '$PRTE_SWARM': containers $PRTE_SWARM-node1..10, volume $VOLUME)"
+    fi
 }
 
 # --- macOS build (native, on this host) -------------------------------------

--- a/contrib/dockerswarm/docker-compose.yml
+++ b/contrib/dockerswarm/docker-compose.yml
@@ -3,31 +3,50 @@
 # node2..node10 are spare nodes the DVM can grow onto and shrink back out of.
 #
 # PRRTE is NOT baked into the image: build.sh compiles your live working tree
-# out-of-tree into the shared `prte-build` volume, which every node mounts
-# read-only at /opt/prte.  So `docker compose up -d` must be preceded by a
-# `./build.sh` (which populates the volume).  See README.md.
+# out-of-tree into the shared build volume, which every node mounts read-only
+# at /opt/prte.  So `docker compose up -d` must be preceded by a `./build.sh`
+# (which populates the volume).  See AGENTS.md.
 #
 # The larger node count (was four) lets a shrink campaign target several daemons
 # sitting on one branch of the radix routing tree at once, which is the scenario
 # the collective-shrink-completion work (openpmix/prrte#2492) needs to exercise.
 
-# Pin the compose project.  Without this, the project name comes from the
-# directory - "dockerswarm" - which is also the name of openpmix's identical
-# harness directory, so `docker compose up -d` run here adopts THAT project's
-# containers: it stopped the pmix-node* swarm, renamed our own containers out
-# from under themselves, and then failed on the name collision, leaving the
-# ten prte-node* containers running the PREVIOUS image while
-# prte-swarm:latest had moved on.  A swarm whose containers predate the
-# image is the single most confusing state this harness can be in - the
-# daemons run one PMIx and the build in the volume was compiled against
+# ---------------------------------------------------------------------------
+# EVERY global name this harness claims is derived from $PRTE_SWARM, so that
+# two clones on one host can each run their own swarm.  Unset, it is "prte" and
+# every name below is exactly what it has always been.
+#
+#   PRTE_SWARM=alt ./build.sh
+#   PRTE_SWARM=alt docker compose up -d
+#   PRTE_SWARM=alt ./run-tests.sh linux
+#
+# The variable has to be in the environment of the `docker compose` command
+# itself -- compose interpolates this file, the scripts do not.  Set it for the
+# whole shell (`export PRTE_SWARM=alt`) and every step agrees.
+#
+# What is NOT per-swarm: the image.  It is read-only to a running swarm and
+# expensive to build, so both instances share it -- but `./build.sh image`
+# rebuilds it under the other swarm's feet, and that swarm's containers then
+# fail run-tests.sh's "containers are running the current image" preflight
+# until they are recreated.
+#
+# Pinning the project name matters even for a single swarm.  Without it the
+# project name comes from the directory - "dockerswarm" - which is also the
+# name of openpmix's identical harness directory, so `docker compose up -d`
+# run here adopts THAT project's containers: it stopped the pmix-node* swarm,
+# renamed our own containers out from under themselves, and then failed on the
+# name collision, leaving the ten prte-node* containers running the PREVIOUS
+# image while prte-swarm:latest had moved on.  A swarm whose containers
+# predate the image is the single most confusing state this harness can be in
+# - the daemons run one PMIx and the build in the volume was compiled against
 # another, and the symptom is an undefined-symbol failure in an unrelated
 # test.  Verify with:
 #   docker inspect prte-node1 --format '{{.Image}}'
 #   docker images --no-trunc --format '{{.ID}}' prte-swarm:latest
-name: prteswarm
+name: ${PRTE_SWARM:-prte}swarm
 
 x-node: &node
-  image: prte-swarm:latest
+  image: ${IMAGE:-prte-swarm:latest}
   networks: [dvm]
   tty: true
   volumes:
@@ -37,51 +56,58 @@ services:
   node1:
     <<: *node
     hostname: node1
-    container_name: prte-node1
+    container_name: ${PRTE_SWARM:-prte}-node1
   node2:
     <<: *node
     hostname: node2
-    container_name: prte-node2
+    container_name: ${PRTE_SWARM:-prte}-node2
   node3:
     <<: *node
     hostname: node3
-    container_name: prte-node3
+    container_name: ${PRTE_SWARM:-prte}-node3
   node4:
     <<: *node
     hostname: node4
-    container_name: prte-node4
+    container_name: ${PRTE_SWARM:-prte}-node4
   node5:
     <<: *node
     hostname: node5
-    container_name: prte-node5
+    container_name: ${PRTE_SWARM:-prte}-node5
   node6:
     <<: *node
     hostname: node6
-    container_name: prte-node6
+    container_name: ${PRTE_SWARM:-prte}-node6
   node7:
     <<: *node
     hostname: node7
-    container_name: prte-node7
+    container_name: ${PRTE_SWARM:-prte}-node7
   node8:
     <<: *node
     hostname: node8
-    container_name: prte-node8
+    container_name: ${PRTE_SWARM:-prte}-node8
   node9:
     <<: *node
     hostname: node9
-    container_name: prte-node9
+    container_name: ${PRTE_SWARM:-prte}-node9
   node10:
     <<: *node
     hostname: node10
-    container_name: prte-node10
+    container_name: ${PRTE_SWARM:-prte}-node10
 
+# Left to compose to name (it becomes <project>_dvm), which is what keeps two
+# swarms apart: every node sets hostname node<N>, so both swarms contain a
+# "node1".  Each user-defined bridge network has its own embedded DNS serving
+# only the containers attached to it, so "node2" from inside one swarm can
+# only ever mean that swarm's node2.
 networks:
   dvm:
     driver: bridge
 
-# Populated by build.sh (docker volume create prte-build) and shared,
-# read-only, by every node.  Declared external so the builder container and
-# these services reference the exact same volume name (no compose prefix).
+# Populated by build.sh (docker volume create) and shared, read-only, by every
+# node of THIS swarm.  Declared external so the builder container and these
+# services reference the exact same volume name (no compose prefix) -- which
+# also means the name has to carry the swarm identity itself.
 volumes:
   prte-build:
+    name: ${PRTE_SWARM:-prte}-build
     external: true

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -18,14 +18,41 @@
 # The multi-node grow/shrink/relay tests only exist in the 'linux' suite --
 # native macOS has a single node, so it covers build + single-host launch,
 # which is what catches Darwin-specific regressions.
+#
+# Two clones on one host can each run a suite: set PRTE_SWARM (below) for the
+# linux swarm, and note that the macOS subset isolates itself automatically --
+# it drives only its own install by absolute path and gives PRRTE a private
+# TMPDIR, so neither its pkill nor its cleanup can reach the other clone.
 
 set -uo pipefail
 
 mode="${1:-linux}"
 pass=0 fail=0 skip=0
+# Which swarm to drive.  Must match the PRTE_SWARM that build.sh and
+# `docker compose up -d` ran under -- see docker-compose.yml.  Unset, this is
+# "prte" and every name below is what it has always been.
+PRTE_SWARM="${PRTE_SWARM:-prte}"
+# Reject what docker would reject, before it turns into a confusing compose
+# error.  The filter runs through LC_ALL=C tr rather than a shell [a-z] range
+# because in a UTF-8 locale that range follows collation order and matches
+# 'B' quite happily -- which let "Bad_Name" through the obvious version of
+# this test.  The leading-character check uses a literal set for the same
+# reason.
+case "$PRTE_SWARM" in [_-]*) PRTE_SWARM="" ;; esac
+if [ -z "$PRTE_SWARM" ] || \
+   [ "$PRTE_SWARM" != "$(printf '%s' "$PRTE_SWARM" | LC_ALL=C tr -cd 'a-z0-9_-')" ]; then
+    echo "PRTE_SWARM must be lowercase [a-z0-9_-] and start with a letter or digit" >&2
+    exit 2
+fi
+NODE="$PRTE_SWARM-node"                 # container names: ${NODE}1 .. ${NODE}10
+# Prefix for the compose commands we suggest in diagnostics: empty for the
+# default swarm, "PRTE_SWARM=<name> " otherwise, because compose reads the
+# variable from the environment of the compose command itself.
+SWARM_ENV=""
+[ "$PRTE_SWARM" = prte ] || SWARM_ENV="PRTE_SWARM=$PRTE_SWARM "
 # must match build.sh -- the bootstrap tests reach into the shared install
 IMAGE="${IMAGE:-prte-swarm:latest}"
-VOLUME="${VOLUME:-prte-build}"
+VOLUME="${VOLUME:-$PRTE_SWARM-build}"
 ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
 skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
@@ -51,29 +78,39 @@ bounded() {
 
 # run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
 RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-            prte-node1 bash -lc ". /opt/prte/env.sh; $*"; }
-ON()  { docker exec "prte-node$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+            "${NODE}1" bash -lc ". /opt/prte/env.sh; $*"; }
+ON()  { docker exec "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
 
+# What must not survive into the next test, on one node.  Each tool has its
+# OWN session-dir prefix -- prte.<pid> for the HNP, prtrn.<pid> for prterun,
+# prted.<pid> for a bootstrapped daemon standing on its own, prun.<pid> for
+# prun itself, and ompi.<pid> for anything run under the ompi personality --
+# and every one of them holds a pmix.* server rendezvous file.  A system-level
+# server drops one (pmix.sys.<host>) straight into the tmpdir as well.  Leaving
+# any behind is what makes a later prun report "multiple possible servers ...
+# connection handles have been read from files named pmix.*" and fail to find
+# the DVM, so clear them all: the prefixes we know by name, and then whatever
+# pmix.* is still standing in the tmpdir or one level below it, which catches
+# the session dir of a tool this list has not heard of.  The nodes leave TMPDIR
+# unset, so that tmpdir is /tmp -- as every other path in this suite assumes.
+# Kill the tools too, not just the daemons: a live prun or pterm is holding a
+# rendezvous file of its own, and killing it is the point of a teardown.
+SWARM_CLEAN='
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t 2>/dev/null; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* \
+           /tmp/pmix.* 2>/dev/null
+    find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} + 2>/dev/null
+    true'
 cleanup_swarm() {
     for n in $(seq 1 10); do
-        # NOTE: each tool has its OWN session-dir prefix -- prte.<pid> for the
-        # HNP, prtrn.<pid> for prterun, and prted.<pid> for a bootstrapped
-        # daemon standing on its own. Every one of them holds a pmix.* server
-        # rendezvous file, and leaving any behind is what makes a later prun
-        # report "multiple possible servers ... connection handles have been
-        # read from files named pmix.*" and fail to find the DVM. Clear them all.
-        docker exec "prte-node$n" sh -c \
-            'pkill -9 -x prted 2>/dev/null; pkill -9 -x prte 2>/dev/null;
-             pkill -9 -x prterun 2>/dev/null;
-             rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/pmix.* \
-                    /tmp/prun.session.* 2>/dev/null; true'
+        docker exec "$NODE$n" sh -c "$SWARM_CLEAN"
     done
 }
 prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
 # how many prted PROCESSES are running on one node (not how many nodes have
 # one) -- two daemons on a single machine is what a duplicated node-pool
 # entry produces
-prted_procs() { docker exec "prte-node$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
+prted_procs() { docker exec "$NODE$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
 
 # --- fake-SLURM helpers -----------------------------------------------------
 # ras/slurm reaches its scheduler by shelling out to sbatch/scontrol/scancel,
@@ -84,10 +121,10 @@ prted_procs() { docker exec "prte-node$1" sh -c 'pgrep -x prted 2>/dev/null | wc
 FS_BIN=/opt/prte/fakeslurm/bin
 # run on the head node inside a faked SLURM allocation
 SL() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-           prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+           "${NODE}1" bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
                                 eval \"\$(fake-slurm env)\"; $*"; }
 # run a fake-slurm housekeeping command (no SLURM_* env needed)
-FS() { docker exec prte-node1 bash -lc "export PATH=$FS_BIN:\$PATH; fake-slurm $*"; }
+FS() { docker exec "${NODE}1" bash -lc "export PATH=$FS_BIN:\$PATH; fake-slurm $*"; }
 # "node2,node4" -> "2 4", for prted_count
 fs_idx() { echo "$1" | tr ',' '\n' | sed 's/^node//' | tr '\n' ' '; }
 # the sbatch argv that created a given fake job
@@ -116,11 +153,11 @@ bootstrap_restore_conf() {
 bootstrap_start() {
     local ctrl=$1; shift
     docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        "prte-node$ctrl" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
+        "$NODE$ctrl" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
     sleep 6
     for n in "$@"; do
         docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-            "prte-node$n" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
+            "$NODE$n" bash -lc '. /opt/prte/env.sh; prted --bootstrap > /tmp/boot.out 2>&1'
     done
     sleep 14
 }
@@ -153,7 +190,7 @@ bootstrap_start() {
 slurm_dvm_start() {
     SL 'rm -f /tmp/prte.out' >/dev/null 2>&1
     docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+        "${NODE}1" bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
             eval \"\$(fake-slurm env)\"; cd /root &&
             prte --prtemca ras_base_verbose 5 $* >/tmp/prte.out 2>&1"
     sleep 8
@@ -265,7 +302,7 @@ test_slurm() {
     fi
     SL 'rm -f /tmp/prte.out /tmp/pwned' >/dev/null 2>&1
     docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+        "${NODE}1" bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
             eval \"\$(fake-slurm env)\"; cd /root &&
             prte --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5 \
                  >/tmp/prte.out 2>&1"
@@ -491,7 +528,7 @@ test_slurm() {
     # exactly those two arguments and leave the rest of the line intact.
     FS 'init --jobid 1000 --base node1 --tasks 2 --pool node2,node3' >/dev/null
     docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        prte-node1 bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
+        "${NODE}1" bash -lc ". /opt/prte/env.sh; export PATH=$FS_BIN:\$PATH;
             eval \"\$(fake-slurm env)\"; cd /root &&
             prte --prtemca prte_elastic_mode 1 --prtemca ras_slurm_propagate_qos 0 \
                  --prtemca ras_slurm_propagate_time 0 >/tmp/prte.out 2>&1"
@@ -1310,7 +1347,7 @@ test_state() {
     # report the agent failure and exit promptly rather than hang.
     t0=$(date +%s)
     bounded 90 docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        prte-node1 bash -lc '. /opt/prte/env.sh;
+        "${NODE}1" bash -lc '. /opt/prte/env.sh;
             prterun --mca plm_ssh_agent /no/such/launch/agent --host node2:1,node3:1 -np 2 hostname'
     rc=$?
     t1=$(date +%s); dt=$((t1-t0))
@@ -1381,7 +1418,7 @@ PRUN() { RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI $*"; }
 PRUN_BG() {
     local outf=$1; shift
     docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
-        prte-node1 bash -lc ". /opt/prte/env.sh;
+        "${NODE}1" bash -lc ". /opt/prte/env.sh;
             prun --dvm-uri file:$PRTED_URI $* > $outf 2>&1"
 }
 ########################################################################
@@ -1687,7 +1724,7 @@ test_prted() {
     # cleanup_swarm reaps daemons and tools but not the application procs
     # they left behind, and this case counts procs on node2 - a stray sleep
     # from an earlier run would make the precondition check nonsense
-    for n in 1 2; do docker exec "prte-node$n" sh -c 'pkill -9 -x sleep 2>/dev/null; true'; done
+    for n in 1 2; do docker exec "$NODE$n" sh -c 'pkill -9 -x sleep 2>/dev/null; true'; done
     if ! prted_dvm_start 'node1:4,node2:4'; then
         bad "could not start a DVM for the job-scoped signal test"
     else
@@ -2444,8 +2481,16 @@ test_rml() {
 }
 
 test_linux() {
-    if ! docker ps --format '{{.Names}}' | grep -qx prte-node1; then
-        echo "swarm not up -- run: docker compose up -d" >&2; exit 2
+    if ! docker ps --format '{{.Names}}' | grep -qx "${NODE}1"; then
+        # Name the swarm we looked for. Forgetting PRTE_SWARM on the compose
+        # command (it interpolates docker-compose.yml, so it has to be in that
+        # command's environment) brings up the DEFAULT swarm instead, and
+        # "swarm not up" alone sends you looking for a docker problem.
+        echo "swarm '$PRTE_SWARM' not up -- no container named ${NODE}1" >&2
+        echo "run: ${SWARM_ENV}docker compose up -d" >&2
+        [ -z "$SWARM_ENV" ] || \
+            echo "     (and ${SWARM_ENV}./build.sh first, so volume $VOLUME exists)" >&2
+        exit 2
     fi
     # Start from a clean slate rather than trusting the last run to have
     # tidied up. The nodes are long-lived containers while the install they
@@ -2487,14 +2532,17 @@ test_linux() {
     imgid=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
     stalenodes=""
     for imgn in $(seq 1 10); do
-        cimg=$(docker inspect "prte-node$imgn" --format '{{.Image}}' 2>/dev/null)
+        cimg=$(docker inspect "$NODE$imgn" --format '{{.Image}}' 2>/dev/null)
         [ "$cimg" = "$imgid" ] || stalenodes="$stalenodes node$imgn"
     done
     if [ -z "$stalenodes" ]; then
         ok "all 10 containers are on the current $IMAGE"
     else
         bad "containers predate $IMAGE:$stalenodes"
-        echo "     Recreate them: docker compose up -d --force-recreate" >&2
+        # The image is shared by every swarm on this host, so the other clone
+        # rebuilding it is one way to land here without having touched
+        # anything yourself.
+        echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
         echo "     (from contrib/dockerswarm, so the pinned project name applies)" >&2
         return
     fi
@@ -2521,7 +2569,7 @@ test_linux() {
     # points at. This exercises the real cross-daemon delivery path (xcast ->
     # recv_files -> write_handler -> link_local_files), which a single-host run
     # cannot prove because the source file is already present locally.
-    docker exec prte-node1 bash -lc '. /opt/prte/env.sh 2>/dev/null; cat > /root/staged_marker.c <<"CEOF"
+    docker exec "${NODE}1" bash -lc '. /opt/prte/env.sh 2>/dev/null; cat > /root/staged_marker.c <<"CEOF"
 #include <unistd.h>
 #include <stdio.h>
 int main(void){ char h[64]; gethostname(h, sizeof(h)); printf("STAGED-BIN-OK %s\n", h); return 0; }
@@ -2543,7 +2591,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     else
         bad "could not compile the marker binary on node1 (need gcc in the image)"
     fi
-    docker exec prte-node1 sh -c 'rm -f /root/staged_marker /root/staged_marker.c' 2>/dev/null
+    docker exec "${NODE}1" sh -c 'rm -f /root/staged_marker /root/staged_marker.c' 2>/dev/null
 
     banner "iof: stdin forwarded to a REMOTE proc (HNP -> prted -> proc)"
     # Rank 0 is mapped onto node2, not the head node, so every stdin byte must
@@ -3156,10 +3204,58 @@ test_macos() {
     if [ ! -x "$prefix/bin/prterun" ]; then
         echo "native build missing -- run: ./build.sh macos" >&2; exit 2
     fi
-    export PATH="$prefix/bin:$PATH"
     export DYLD_LIBRARY_PATH="$prefix/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
     export PRTE_ALLOW_RUN_AS_ROOT=1 PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1
-    macpk() { pkill -9 -x prterun 2>/dev/null; pkill -9 -x prte 2>/dev/null; pkill -9 -x prted 2>/dev/null; true; }
+
+    # Unlike the swarm, this subset runs on the developer's own machine, where
+    # another clone of PRRTE may be running this very same subset.  Nothing
+    # here may reach a process or a file that clone owns, which takes both of:
+    #
+    #  - every tool is started by ABSOLUTE path out of THIS clone's install
+    #    ($B below, never PATH), so "is this process mine" is a question about
+    #    the argv, which is what mypgrep/mypkill ask.  A bare `pkill -x prte`
+    #    kills the other clone's DVM; a bare `pgrep -x prte` is worse still,
+    #    because it reports the other clone's DVM as ours and the case then
+    #    PASSES on a process this run never started.
+    #  - PRRTE gets a PRIVATE TMPDIR, so the session dirs -- and the pmix.*
+    #    rendezvous files inside them, which a -9'd tool never removes -- land
+    #    somewhere only this run will ever delete.  It is made under /tmp
+    #    rather than beside the build because the rendezvous socket path has
+    #    to fit in sun_path (104 bytes on Darwin), and the per-user $TMPDIR a
+    #    Mac hands out is already ~50 of them.
+    # MAC_BRE and MAC_TMP are deliberately NOT `local`: the traps below fire
+    # after this function has returned, and a local is out of scope by then --
+    # which would silently leave the private directory behind on every run.
+    local B="$prefix/bin"
+    MAC_BRE="$(printf '%s' "$B" | sed 's/[].[^$*+?(){}|\\]/\\&/g')"
+    mypgrep() { pgrep -f "^$MAC_BRE/$1( |\$)" >/dev/null 2>&1; }
+    mypkill() { pkill -9 -f "^$MAC_BRE/$1( |\$)" 2>/dev/null; true; }
+    MAC_TMP="$(mktemp -d /tmp/prtesuite.XXXXXX)" || {
+        echo "cannot create a private TMPDIR under /tmp" >&2; exit 2; }
+    export TMPDIR="$MAC_TMP"
+    # Take the private dir down however we leave, ^C included -- it holds only
+    # this run's session dirs, so there is nothing in it worth keeping.
+    macdone() {
+        local t
+        for t in prterun prte prted prun pterm; do mypkill "$t"; done
+        [ -n "${MAC_TMP:-}" ] && rm -rf "$MAC_TMP"
+        true
+    }
+    trap macdone EXIT
+    trap 'macdone; exit 130' INT TERM
+
+    # Reap this run's strays between cases.  Session dirs only, not the whole
+    # private dir: `bounded` puts its capture file there too (mktemp honors
+    # TMPDIR) and a case reads that file after the macpk in its own error
+    # branch has run.  Everything named here is unambiguously ours, pmix.*
+    # included, because the directory it sits in is.
+    macpk() {
+        local t
+        for t in prterun prte prted prun pterm; do mypkill "$t"; done
+        rm -rf "${TMPDIR:?}"/prte.* "${TMPDIR:?}"/prted.* "${TMPDIR:?}"/prtrn.* \
+               "${TMPDIR:?}"/prun.* "${TMPDIR:?}"/ompi.* "${TMPDIR:?}"/pmix.* 2>/dev/null
+        true
+    }
 
     banner "macOS: native Darwin build"
     ok "PRRTE built and installed for Darwin ($prefix)"
@@ -3170,7 +3266,7 @@ test_macos() {
 
     banner "macOS: prterun (one-shot, single host)"
     macpk; sleep 1
-    if bounded 60 prterun -np 4 hostname; then
+    if bounded 60 "$B/prterun" -np 4 hostname; then
         # count hostname lines only -- ignore any libxml/DNS stderr noise
         [ "$(grep -Fc "$hn" "$BOUT")" = 4 ] \
             && ok "prterun -np 4 -> 4 procs on $hn, exit 0" \
@@ -3196,7 +3292,7 @@ test_macos() {
     # would never see EOF and would hang on a defect that is not PRRTE's.
     macpk; sleep 1
     printf 'STDIN-DELIVERY-OK\n' > "$root/vpath-macos/stdin_probe.txt"
-    if bounded 60 sh -c "prterun -np 2 head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
+    if bounded 60 sh -c "'$B/prterun' -np 2 head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
         [ "$(grep -Fc STDIN-DELIVERY-OK "$BOUT")" = 1 ] \
             && ok "directed stdin (default rank 0) -> 1 proc" \
             || bad "directed stdin: $(tr '\n' ' ' <"$BOUT")"
@@ -3205,7 +3301,7 @@ test_macos() {
     fi
     rm -f "$BOUT"
     macpk; sleep 1
-    if bounded 60 sh -c "prterun -np 2 --stdin all head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
+    if bounded 60 sh -c "'$B/prterun' -np 2 --stdin all head -1 < '$root/vpath-macos/stdin_probe.txt'"; then
         [ "$(grep -Fc STDIN-DELIVERY-OK "$BOUT")" = 2 ] \
             && ok "wildcard stdin (--stdin all) -> both procs" \
             || bad "wildcard stdin reached $(grep -Fc STDIN-DELIVERY-OK "$BOUT")/2 procs: $(tr '\n' ' ' <"$BOUT")"
@@ -3216,15 +3312,15 @@ test_macos() {
 
     banner "macOS: persistent DVM + prun + pterm (single host)"
     macpk; sleep 1
-    bounded 60 prte --daemonize; sleep 3
-    if pgrep -x prte >/dev/null; then
+    bounded 60 "$B/prte" --daemonize; sleep 3
+    if mypgrep prte; then
         ok "prte --daemonize started"
-        if bounded 30 prun -np 2 hostname && [ "$(grep -Fc "$hn" "$BOUT")" = 2 ]; then
+        if bounded 30 "$B/prun" -np 2 hostname && [ "$(grep -Fc "$hn" "$BOUT")" = 2 ]; then
             ok "prun -np 2 -> 2 procs on $hn, exit 0"
         else skp "prun timed out/short (native Darwin DVM unstable)"; fi
-        bounded 20 pterm >/dev/null 2>&1 || true
+        bounded 20 "$B/pterm" >/dev/null 2>&1 || true
         sleep 1
-        pgrep -x prte >/dev/null && { skp "pterm did not stop the DVM (native Darwin instability)"; macpk; } \
+        mypgrep prte && { skp "pterm did not stop the DVM (native Darwin instability)"; macpk; } \
                                   || ok "pterm cleanly terminated the DVM"
     else
         skp "prte --daemonize did not come up -- native Darwin DVM is unstable on this host (pre-existing); build is verified"
@@ -3239,11 +3335,11 @@ test_macos() {
     # every other job on the machine with it. Single host is enough - the
     # request is rejected at the HNP, before any daemon is involved.
     macpk; sleep 1
-    bounded 60 prte --daemonize; sleep 3
-    if pgrep -x prte >/dev/null; then
+    bounded 60 "$B/prte" --daemonize; sleep 3
+    if mypgrep prte; then
         for badarg in "--map-by NOSUCHPOLICY" "--bind-to NOSUCHOBJECT" "--rank-by NOSUCHTHING"; do
-            bounded 30 sh -c "prun $badarg -np 1 hostname" >/dev/null 2>&1
-            if pgrep -x prte >/dev/null; then
+            bounded 30 sh -c "'$B/prun' $badarg -np 1 hostname" >/dev/null 2>&1
+            if mypgrep prte; then
                 ok "DVM survived a rejected 'prun $badarg'"
             else
                 bad "DVM died on 'prun $badarg'"
@@ -3251,14 +3347,14 @@ test_macos() {
             fi
         done
         # and it must still be able to run a job afterwards
-        if pgrep -x prte >/dev/null; then
-            if bounded 30 prun -np 2 hostname && [ "$(grep -Fc "$hn" "$BOUT")" = 2 ]; then
+        if mypgrep prte; then
+            if bounded 30 "$B/prun" -np 2 hostname && [ "$(grep -Fc "$hn" "$BOUT")" = 2 ]; then
                 ok "DVM still launches jobs after the rejected requests"
             else
                 skp "post-rejection prun timed out (native Darwin DVM unstable)"
             fi
         fi
-        bounded 20 pterm >/dev/null 2>&1 || true; sleep 1; macpk
+        bounded 20 "$B/pterm" >/dev/null 2>&1 || true; sleep 1; macpk
     else
         skp "prte --daemonize did not come up -- cannot test spawn rejection"
     fi
@@ -3270,7 +3366,7 @@ test_macos() {
     # daemon command line was assembled. One host cannot exercise the daemon
     # side of either, but both must at least remain launchable.
     macpk; sleep 1
-    if bounded 60 prterun --uniform-nodes -np 2 hostname; then
+    if bounded 60 "$B/prterun" --uniform-nodes -np 2 hostname; then
         [ "$(grep -Fc "$hn" "$BOUT")" = 2 ] \
             && ok "prterun --uniform-nodes -> 2 procs on $hn" \
             || bad "uniform-nodes launch wrong output: $(tr '\n' ' ' <"$BOUT")"
@@ -3279,7 +3375,7 @@ test_macos() {
     fi
     rm -f "$BOUT"
     macpk; sleep 1
-    if bounded 60 sh -c "PRTE_MCA_prte_test_kv='a=b' prterun -np 2 hostname"; then
+    if bounded 60 sh -c "PRTE_MCA_prte_test_kv='a=b' '$B/prterun' -np 2 hostname"; then
         [ "$(grep -Fc "$hn" "$BOUT")" = 2 ] \
             && ok "launch works with an '='-bearing mca value in the environment" \
             || bad "'='-bearing mca value broke the launch: $(tr '\n' ' ' <"$BOUT")"


### PR DESCRIPTION
## The problem

The harness claimed every one of its names globally. `docker-compose.yml` pinned the compose project to `prteswarm` and hardcoded `container_name: prte-node1`..`prte-node10` and the `prte-build` volume, so a second clone of the tree on the same host did **not** get a second swarm — it got the same ten containers and the same install. One clone's `build.sh` replaced the `/opt/prte` the other was mid-suite against; one clone's `cleanup_swarm` killed the other's daemons and deleted its session directories out of the containers they shared. Nothing announced any of it.

The macOS subset had a smaller version of the same problem. Its install is already per-clone, but its `pkill -9 -x prte` killed the other clone's DVM, and its `pgrep -x prte` matched the other clone's DVM too — which is the worse half, because the case then *passes* on a process the run never started.

## The change

Everything global is derived from `$PRTE_SWARM`: compose project, the ten container names, the build volume, and (via the project name) the network.

```sh
export PRTE_SWARM=alt
./build.sh && docker compose up -d && ./run-tests.sh linux
```

Unset, it is `prte` and every name is exactly what it has always been — the rendered compose file is identical to today's, so the default flow and the docs describing it do not change.

The **hostnames deliberately do not move**: both swarms contain a `node1`. Each user-defined bridge network runs its own embedded DNS, so `node2` inside a swarm can only mean that swarm's node2, and no test needs to know which swarm it runs in. The image stays shared (read-only to a running swarm, expensive to build); the one cost of that is documented.

macOS now starts every tool by absolute path out of its own install, matches on that path when it reaps strays, and runs PRRTE under a private `TMPDIR` it creates and removes — under `/tmp`, because the rendezvous socket path must fit in `sun_path` (104 bytes on Darwin, and the per-user `$TMPDIR` is already half of it).

Also finishes what `cleanup_swarm` was supposed to do — **fixes #2526**. It knew three session-dir prefixes; there are five (`prun` and the ompi personality name their own), each holding a `pmix.*` rendezvous file that makes the next tool report *"multiple possible servers"*. A `find` over the tmpdir catches a prefix the list has not heard of, and the tools are killed alongside the daemons, since a live `prun` holds a rendezvous file too.

## Testing

Two swarms brought up side by side on one host:

- `node2` resolved to `172.21.0.10` from `prte-node1` and `172.23.0.9` from `alt-node1` — each its own swarm's node2, despite identical hostnames
- separate `/tmp`, separate volumes (`prte-build` / `alt-build`), separate networks
- `PRTE_SWARM=alt ./run-tests.sh linux` drove only the `alt-*` containers and left the default swarm running and un-recreated
- `docker compose config` with `PRTE_SWARM` unset renders byte-identical to before

macOS half, against a stub install plus a second "clone" holding a live DVM: the foreign DVM and its session dirs survived a full suite run, the private `TMPDIR` was removed on exit, and with this clone's own `prte` failing to start while the foreign one ran, the suite reported SKIP rather than passing on the other process.

Name validation rejects what docker would (`Bad_Name`, `a b`, `-lead`), filtered through `LC_ALL=C tr` rather than a shell `[a-z]` range — in a UTF-8 locale that range follows collation order and accepts `Bad_Name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)