### PR TITLE
grpcomm: convert the group-release wait to a continuation (#2534)

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -45,6 +45,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
 | `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
+| `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives `grpcomm/direct`'s `grp_release` on daemons that merely *received* the broadcast. See §15. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
@@ -1002,3 +1003,55 @@ docker exec prte-node4 sh -c 'ldd /opt/prte/prte/bin/<helper> | grep pmix'
 The daemons themselves are fine — `prted` is launched with the right
 environment and loads the volume's PMIx on every node. It is only the
 application processes they fork that lose it.
+
+## 15. Group collectives (`groupcon`, `test_grpcomm`)
+
+`PMIx_Group_construct` is a two-phase collective — an up-tree rollup to
+the HNP, then an xcast of the assembled result back down — and the half
+worth testing across nodes is the **down-tree** one. `grp_release()` runs
+on *every* daemon: it takes the broadcast, hands the group's context id,
+group info and endpoint data to its **own** local PMIx server via
+`PMIx_server_register_resources()`, and only then releases the local
+participants of the collective. On one host there is exactly one daemon
+and it is also the HNP, so a daemon that merely *received* the release is
+never exercised at all.
+
+That registration used to be waited on, parking the daemon's whole event
+loop on every construct; it is now a continuation
+(`grp_release_regcbfunc` → `grp_release_resume` →
+`grp_release_complete`). **That continuation is what this phase guards.**
+Lose the caddy anywhere between issuing the registration and resuming and
+the local participants are never released — the construct does not fail,
+it *hangs*, on every daemon at once. Deleting the thread-shift and
+re-running turns 7 of the phase's 10 assertions red, which is how the
+teeth were confirmed rather than assumed.
+
+The probe is `groupcon`, compiled by `build.sh` the same way as
+`elastic`/`dataserver`/`proctable`:
+
+```sh
+groupcon <groupID> [secs]
+```
+
+Every rank contributes `PMIX_GROUP_LOCAL_CID` = 1234 + rank as
+`PMIX_GROUP_INFO`, requests `PMIX_GROUP_ASSIGN_CONTEXT_ID`, constructs,
+reads **every** rank's local cid back, and destructs. Output is one
+grep-friendly `GRP <rank> <what> …` line per step.
+
+**One thing this phase deliberately does not claim.** The read-back runs
+with no fence after the construct returns, which looks like an assertion
+that the daemon registered the group with its PMIx server before
+releasing its clients. It is not, and saying so would be wrong: the
+construct hands the same group info back to the client in its *results*,
+so the client library answers those reads out of its own cache —
+skipping `PMIx_server_register_resources` entirely still passes them
+(measured). What the reads are good for is checking that the membership
+and group info each daemon returned are complete and identical, which is
+a genuinely per-daemon property.
+
+The other two assertions in the phase are shape checks worth keeping: the
+group must actually span more than one node (or the case is a
+single-host test wearing a hat), and three back-to-back constructs
+followed by a plain job must all succeed — a caddy leak or a tracker that
+is never deleted shows up as drift across runs rather than as one bad
+one.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -348,6 +348,19 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/proctable.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # groupcon: a bare PMIx client that drives a group construct and
+            # destruct.  The interesting half of a group collective runs in
+            # grp_release on EVERY daemon: it registers the result with its
+            # own PMIx server and only then releases the local participants.
+            # On one host there is one daemon and it is also the HNP, so the
+            # down-tree release and the per-daemon registration are never
+            # exercised against a daemon that merely received the broadcast.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> groupcon (group construct/destruct) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/groupcon \
+                /prrte-src/contrib/dockerswarm/groupcon.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # slowcat: a deliberately slow stdin reader (no PMIx at all).  The
             # stdin bugs in iof live in the back-pressure path, and a normal
             # "cat" drains its pipe as fast as the daemon fills it, so the

--- a/contrib/dockerswarm/groupcon.c
+++ b/contrib/dockerswarm/groupcon.c
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * groupcon -- a minimal PMIx client that drives PMIx_Group_construct /
+ * PMIx_Group_destruct across a real, multi-node DVM.
+ *
+ *   groupcon <groupID> [seconds]
+ *       Every rank contributes a PMIX_GROUP_LOCAL_CID of its own
+ *       (1234 + rank) as PMIX_GROUP_INFO, asks for a context id, and
+ *       constructs the group.  As soon as construct returns -- with NO
+ *       fence in between -- each rank reads back EVERY rank's local cid
+ *       and checks the value.  Then it destructs the group.
+ *
+ * Output lines, one per rank, all prefixed GRP so the harness can grep:
+ *
+ *   GRP <rank> HOST <hostname>
+ *   GRP <rank> CONSTRUCT <status> CID <cid> ASSIGNED <T|F>
+ *   GRP <rank> MEMBERS <n>
+ *   GRP <rank> CID-OK <n>            (read back n peers' local cids)
+ *   GRP <rank> CID-FAIL <peer> <status>
+ *   GRP <rank> DESTRUCT <status>
+ *   GRP <rank> DONE <rc>
+ *
+ * Why this exists, and why it cannot be a unit test:
+ *
+ * A group construct is a two-phase collective -- an up-tree rollup to the
+ * HNP, then an xcast of the result back down -- and the interesting half
+ * runs in grp_release() on EVERY daemon, not just the master.  Each daemon
+ * takes the broadcast result, hands the group's context id, group info and
+ * endpoint data to its OWN local PMIx server via
+ * PMIx_server_register_resources(), and only then releases the local
+ * participants of the collective.  On one host there is exactly one daemon
+ * and that is also the HNP, so the down-tree path, the per-daemon
+ * registration, and the tracker bookkeeping that goes with it are never
+ * exercised against a daemon that merely received the release.
+ *
+ * That registration used to be waited on, which stalled the daemon's whole
+ * event loop for its duration; it is now a continuation off the
+ * registration's completion.  What this client is really probing is that
+ * continuation: lose the caddy anywhere between issuing the registration and
+ * resuming, and the local participants are never released at all -- the
+ * construct does not fail, it hangs, on every daemon at once.
+ *
+ * Be careful about what the read-back does and does not show.  It reads
+ * every rank local cid with NO fence after the construct returns, which
+ * looks like proof that the daemon registered the group with its PMIx server
+ * before releasing us.  It is not: the construct hands the same group info
+ * back to the client in its results, so the client library answers these
+ * reads out of its own cache -- skipping the registration entirely still
+ * passes them (measured, not assumed).  Their value is that they check the
+ * returned membership and group info are complete and identical on every
+ * daemon, which is a per-daemon property.
+ *
+ * Note the timeout on each read.  A regression here should fail this case,
+ * not wedge the suite behind it.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+#define GROUPCON_BASE_CID 1234UL
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc, ret;
+    pmix_value_t *val = NULL;
+    pmix_value_t value;
+    pmix_proc_t proc, *procs = NULL;
+    pmix_info_t *results = NULL, *info = NULL;
+    pmix_info_t tinfo[2];
+    pmix_data_array_t darray;
+    void *grpinfo, *list;
+    size_t nresults = 0, ninfo = 0, cid = 0, lcid, m;
+    uint32_t nprocs = 0, n, ok = 0;
+    uint32_t get_timeout = 30;
+    char hostname[256];
+    const char *grpid;
+    int seconds = 0;
+    int failures = 0;
+    bool idassigned = false;
+
+    if (2 > argc) {
+        fprintf(stderr, "usage: %s <groupID> [seconds]\n", argv[0]);
+        return 2;
+    }
+    grpid = argv[1];
+    if (3 <= argc) {
+        seconds = atoi(argv[2]);
+    }
+
+    gethostname(hostname, sizeof(hostname));
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    printf("GRP %u HOST %s\n", myproc.rank, hostname);
+    fflush(stdout);
+
+    /* how many of us are there? */
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Get job size: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+
+    /* put a little modex data so the construct has endpoints to carry -
+     * an empty group is a different (and less interesting) path */
+    value.type = PMIX_STRING;
+    value.data.string = strdup(hostname);
+    rc = PMIx_Put(PMIX_GLOBAL, "groupcon-host", &value);
+    free(value.data.string);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Put: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Commit: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+
+    PMIX_PROC_CREATE(procs, nprocs);
+    for (n = 0; n < nprocs; n++) {
+        PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    /* ask for a context id, and contribute our own local cid as group info */
+    grpinfo = PMIx_Info_list_start();
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR list_add ctxid: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    list = PMIx_Info_list_start();
+    lcid = GROUPCON_BASE_CID + (size_t) myproc.rank;
+    rc = PMIx_Info_list_add(list, PMIX_GROUP_LOCAL_CID, &lcid, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR list_add lcid: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_convert(list, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR list_convert lcid: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_INFO, &darray, PMIX_DATA_ARRAY);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR list_add grpinfo: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    PMIx_Info_list_release(list);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    rc = PMIx_Info_list_convert(grpinfo, &darray);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR list_convert grpinfo: %s\n", PMIx_Error_string(rc));
+        goto done;
+    }
+    info = (pmix_info_t *) darray.array;
+    ninfo = darray.size;
+    PMIx_Info_list_release(grpinfo);
+
+    rc = PMIx_Group_construct(grpid, procs, nprocs, info, ninfo, &results, &nresults);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    if (PMIX_SUCCESS != rc) {
+        printf("GRP %u CONSTRUCT %s CID 0 ASSIGNED F\n", myproc.rank, PMIx_Error_string(rc));
+        fflush(stdout);
+        failures++;
+        goto done;
+    }
+    for (m = 0; m < nresults; m++) {
+        if (PMIX_CHECK_KEY(&results[m], PMIX_GROUP_CONTEXT_ID)) {
+            PMIx_Value_get_number(&results[m].value, &cid, PMIX_SIZE);
+            idassigned = true;
+        } else if (PMIX_CHECK_KEY(&results[m], PMIX_GROUP_MEMBERSHIP)) {
+            if (PMIX_DATA_ARRAY == results[m].value.type && NULL != results[m].value.data.darray) {
+                printf("GRP %u MEMBERS %u\n", myproc.rank,
+                       (unsigned) results[m].value.data.darray->size);
+            }
+        }
+    }
+    printf("GRP %u CONSTRUCT %s CID %lu ASSIGNED %s\n", myproc.rank,
+           PMIx_Error_string(PMIX_SUCCESS), (unsigned long) cid, idassigned ? "T" : "F");
+    fflush(stdout);
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+        results = NULL;
+    }
+
+    /* Read every rank's local cid back RIGHT NOW.  No fence: if our daemon
+     * released us before it finished registering the group's resources with
+     * its own PMIx server, this is where that shows up. */
+    PMIX_INFO_CONSTRUCT(&tinfo[0]);
+    PMIX_INFO_LOAD(&tinfo[0], PMIX_GROUP_CONTEXT_ID, &cid, PMIX_SIZE);
+    PMIX_INFO_SET_QUALIFIER(&tinfo[0]);
+    PMIX_INFO_CONSTRUCT(&tinfo[1]);
+    PMIX_INFO_LOAD(&tinfo[1], PMIX_TIMEOUT, &get_timeout, PMIX_UINT32);
+
+    for (n = 0; n < nprocs; n++) {
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, n);
+        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, tinfo, 2, &val);
+        if (PMIX_SUCCESS != rc) {
+            printf("GRP %u CID-FAIL %u %s\n", myproc.rank, n, PMIx_Error_string(rc));
+            fflush(stdout);
+            failures++;
+            continue;
+        }
+        if (PMIX_SIZE != val->type || (GROUPCON_BASE_CID + (size_t) n) != val->data.size) {
+            printf("GRP %u CID-FAIL %u BADVALUE\n", myproc.rank, n);
+            fflush(stdout);
+            failures++;
+            PMIX_VALUE_RELEASE(val);
+            continue;
+        }
+        ok++;
+        PMIX_VALUE_RELEASE(val);
+    }
+    PMIX_INFO_DESTRUCT(&tinfo[0]);
+    PMIX_INFO_DESTRUCT(&tinfo[1]);
+    printf("GRP %u CID-OK %u\n", myproc.rank, ok);
+    fflush(stdout);
+
+    rc = PMIx_Group_destruct(grpid, NULL, 0);
+    printf("GRP %u DESTRUCT %s\n", myproc.rank, PMIx_Error_string(rc));
+    fflush(stdout);
+    if (PMIX_SUCCESS != rc) {
+        failures++;
+    }
+
+done:
+    if (NULL != procs) {
+        PMIX_PROC_FREE(procs, nprocs);
+    }
+    if (0 < seconds) {
+        sleep(seconds);
+    }
+    ret = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != ret) {
+        fprintf(stderr, "ERROR PMIx_Finalize: %s\n", PMIx_Error_string(ret));
+        failures++;
+    }
+    printf("GRP %u DONE %d\n", myproc.rank, failures);
+    fflush(stdout);
+    return (0 == failures) ? 0 : 1;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2536,6 +2536,118 @@ test_hwloc() {
     cleanup_swarm
 }
 
+# Absolute path, deliberately -- see the note above DS.
+GC=/opt/prte/prte/bin/groupcon
+
+test_grpcomm() {
+    local out n g ranks hosts fails
+
+    banner "grpcomm: a group construct releases on every daemon, in order"
+    # The interesting half of a group collective is grp_release(), and it runs
+    # on EVERY daemon: it takes the HNP's down-tree broadcast, hands the
+    # group's context id / group info / endpoints to its OWN local PMIx server
+    # via PMIx_server_register_resources(), and only then releases the local
+    # participants.  On one host there is one daemon and it is also the HNP,
+    # so neither the down-tree release nor the per-daemon registration is ever
+    # exercised against a daemon that merely RECEIVED the broadcast.
+    #
+    # The registration used to be waited on, which parked the daemon event
+    # loop for its duration on every construct; it is now a continuation, and
+    # what these cases guard is that continuation.  Lose the caddy anywhere
+    # between issuing the registration and resuming, and the local
+    # participants are simply never released: the construct does not fail, it
+    # HANGS, on every daemon at once.  Verified by deleting the thread-shift
+    # and re-running -- 7 of these 10 assertions go red.
+    #
+    # Note what this does NOT show.  groupcon reads every rank local cid back
+    # with no fence, which looks like an assertion that the daemon registered
+    # the group with its PMIx server before releasing us -- it is not.  The
+    # construct hands the same group info back to the client in its results,
+    # so the client library answers those reads out of its own cache; skipping
+    # PMIx_server_register_resources entirely still passes them.  The reads
+    # are worth keeping as a check that the returned membership and group info
+    # are complete and identical on every daemon, but do not read them as
+    # coverage of the registration itself.
+    cleanup_swarm
+    if ! RUN "test -x $GC"; then
+        skp "groupcon client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the grpcomm tests"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node $GC g1" 2>&1)
+    n=$(echo "$out" | grep -c 'CONSTRUCT PMIX_SUCCESS')
+    [ "$n" = 8 ] \
+        && ok "all 8 ranks completed the group construct" \
+        || bad "$n of 8 ranks constructed the group: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # spread across nodes, or this is a single-host test wearing a hat
+    hosts=$(echo "$out" | awk '$1=="GRP" && $3=="HOST" {print $4}' | sort -u | grep -c '^node')
+    [ "${hosts:-0}" -ge 2 ] \
+        && ok "...spread over $hosts nodes, so non-HNP daemons ran the release" \
+        || bad "the group did not span nodes ($hosts)"
+    # every rank must have been handed the same context id
+    n=$(echo "$out" | awk '$1=="GRP" && $3=="CONSTRUCT" {print $6}' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 1 ] \
+        && ok "...and every rank got the same context id" \
+        || bad "ranks disagreed on the context id ($n distinct values)"
+    echo "$out" | grep -q 'ASSIGNED T' \
+        && ok "...which the HNP actually assigned" \
+        || bad "no rank reported an assigned context id"
+
+    banner "grpcomm: every daemon returns the same complete group to its clients"
+    # Each rank reads back all 8 local cids -- the group info every OTHER rank
+    # contributed, which reached it only because its own daemon assembled the
+    # broadcast result and handed it over.  A daemon that dropped, truncated,
+    # or mismatched what it returned shows up here as a short or wrong set.
+    ranks=$(echo "$out" | grep -c 'CID-OK 8')
+    [ "$ranks" = 8 ] \
+        && ok "all 8 ranks read back all 8 peer local cids" \
+        || bad "only $ranks of 8 ranks read back a full set: $(echo "$out" | grep -E 'CID-(OK|FAIL)' | tr '\n' ' ' | tail -c 400)"
+    # Assert on the DONE lines rather than on the absence of CID-FAIL: a run
+    # in which nothing got far enough to print either has no CID-FAIL in it,
+    # and would sail through an absence test.
+    n=$(echo "$out" | grep -c 'DESTRUCT PMIX_SUCCESS')
+    [ "$n" = 8 ] \
+        && ok "...and all 8 ranks destructed the group" \
+        || bad "$n of 8 ranks destructed the group"
+    fails=$(echo "$out" | awk '$1=="GRP" && $3=="DONE" {s+=$4} END {print s+0}')
+    n=$(echo "$out" | grep -c 'DONE ')
+    if [ "$n" != 8 ]; then
+        bad "only $n of 8 ranks reached the end of the client"
+    elif [ "$fails" = 0 ]; then
+        ok "...with all 8 clients finishing and reporting no failures"
+    else
+        bad "clients reported $fails failures: $(echo "$out" | grep -E 'CID-FAIL' | tr '\n' ' ' | tail -c 300)"
+    fi
+
+    banner "grpcomm: repeated constructs do not wedge the daemons"
+    # The release path allocates a caddy per construct and hands it to a
+    # continuation, so a leak or a missed release shows up as drift rather
+    # than as one bad run.  Three back-to-back groups on the same DVM, then a
+    # plain job, is enough to catch a daemon that stopped servicing its event
+    # loop or never let go of a tracker.
+    n=0
+    for g in g2 g3 g4; do
+        out=$(PRUN "--host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node $GC $g" 2>&1)
+        [ "$(echo "$out" | grep -c 'CID-OK 8')" = 8 ] && n=$((n+1))
+    done
+    [ "$n" = 3 ] \
+        && ok "three successive group constructs all completed" \
+        || bad "only $n of 3 successive group constructs completed"
+    out=$(PRUN "--host node1:1,node2:1,node3:1 -n 3 --map-by node hostname" 2>&1)
+    n=$(echo "$out" | grep -c '^node')
+    [ "$n" = 3 ] \
+        && ok "...and the DVM still launches an ordinary job afterwards" \
+        || bad "the DVM did not run a plain job after the group tests ($n of 3)"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+}
+
 test_rml() {
     local out rc n c
 
@@ -3339,6 +3451,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_runtime
 
     test_rml
+
+    test_grpcomm
 
     test_slurm_alloc
     test_slurm

--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -259,6 +259,14 @@ constructs with the documented defaults (all rollup counters zero, the
 group tracker's info-lists opened) and destructs without leaking or
 crashing. Extend it when you add a class or change a constructor default.
 
+The live collectives are covered by the
+[dockerswarm harness](../../../contrib/dockerswarm/AGENTS.md): `xcast`
+and `fence` fall out of nearly every phase, and `test_grpcomm` drives
+`PMIx_Group_construct`/`_destruct` across four nodes with the `groupcon`
+client. That phase exists because `grp_release()` runs on **every**
+daemon, and a daemon that merely *received* the down-tree broadcast —
+rather than originating it as the HNP — does not exist on one host.
+
 ---
 
 ## Debugging

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -244,11 +244,71 @@ much richer signature and payload.
 - **`grp_release`** (`PRTE_RML_TAG_GROUP_RELEASE`, via the xcast). For a
   **destruct** it removes the group from the server's pset list and
   completes the local participants. For a **construct** it unpacks the
-  final membership / context-id / grpinfo / endpoints, calls
-  `PMIx_server_register_resources` (blocking on a caddy lock), records the
-  new group in `prte_pmix_server_globals.groups`, and returns the assembled
-  info to local clients via `coll->cbfunc`. Finally it deletes the tracker
+  final membership / context-id / grpinfo / endpoints and calls
+  `PMIx_server_register_resources`. It is **split in two** around that
+  call — see below. The continuation, `grp_release_complete`, records the
+  new group in `prte_pmix_server_globals.groups`, returns the assembled
+  info to local clients via `coll->cbfunc`, and deletes the tracker
   (`find_delete_tracker`, keyed by groupID).
+
+#### `grp_release` is a continuation, not a wait
+
+The registration used to be waited on with `PMIX_WAIT_THREAD`. Nothing
+raced — the lock is a `pmix_lock_t`, so the wakeup from the PMIx thread
+touched no PRRTE object — but the wait parked the **progress thread**,
+and `prte_event_base` has no thread of its own (`event.c`: "PRTE tools
+block in their own loop over the event base"). While it sat there the
+daemon was deaf: no RML, no IOF, no other job's state transitions. And
+unlike the teardown waits converted for
+[#2534](https://github.com/openpmix/prrte/issues/2534), this one is not
+a once-per-job cost — it runs on **every daemon for every group
+construct**, so a session-heavy job pays it over and over.
+
+So the ordering the wait was enforcing — the group's resources have to
+be in the local PMIx server before the local participants are told the
+construct succeeded — is now expressed by chaining:
+
+```c
+rc = PMIx_server_register_resources(cd->info, cd->ninfo,
+                                    grp_release_regcbfunc, cd);
+if (PMIX_SUCCESS == rc) {
+    return;                 /* the completion callback owns the caddy */
+}
+```
+
+`grp_release_regcbfunc` runs on the PMIx thread and does nothing but
+record the status and `PRTE_PMIX_THREADSHIFT` to `grp_release_resume`,
+which calls `grp_release_complete` on the progress thread. Three things
+about the shape are load-bearing:
+
+- **A file-local caddy owns everything that has to survive the gap** —
+  `prte_grpcomm_release_caddy_t` carries the signature, the status, the
+  `nlist`, and every array unpacked from the broadcast, and frees all of
+  it in its destructor. The unpacking writes into caddy fields directly
+  so that the dozen `goto notify` error paths need no per-path transfer.
+- **The tracker is re-looked-up in the continuation, not carried.** The
+  progress thread is free while PMIx works, so an abort or a duplicate
+  release can complete and delete the tracker in the interim — in which
+  case the local participants have already been serviced and there is
+  nothing to do. A cached `coll` pointer would be dangling.
+- **`PMIX_OPERATION_SUCCEEDED` means it already finished**, and we are
+  still on the progress thread, so that path falls straight through to
+  `grp_release_complete` rather than waiting for a callback that will
+  never come.
+
+Two defects went with the conversion. The registration status was
+assigned to a dead local and discarded, so a group whose resources never
+made it into the server was still reported to clients as successfully
+constructed; it now propagates. And both `PMIX_INFO_LIST_CONVERT` calls
+ignored their result while reading `darray` unconditionally — on an
+empty list (a construct with no context-id request, no group info and no
+endpoints) `darray` is left untouched, so `cd->info` picked up whatever
+the *previous* assignment had put there, which on the ilist path was the
+`pmix_proc_t` membership array about to be handed to
+`PMIx_server_register_resources` as `pmix_info_t` and then freed twice.
+
+Coverage is `test_grpcomm` in the dockerswarm harness — one host cannot
+exercise a daemon that merely *received* the release.
 
 ### Group fault tolerance (`#if PRTE_PMIX_HAVE_GROUP_FT`)
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -973,13 +973,104 @@ static void relcb(void *cbdata)
     PMIX_RELEASE(cd);
 }
 
-static void lkopcbfunc(int status, void *cbdata)
-{
-    prte_pmix_grp_caddy_t *cd = (prte_pmix_grp_caddy_t*)cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(status);
+/* Carrier for the second half of grp_release.
+ *
+ * A construct's resources are registered with our local PMIx server BEFORE
+ * we tell our local clients the construct completed, so that anything asking
+ * that server about the group finds it already there.  That ordering used to
+ * be enforced by waiting on the registration, but we must not wait here:
+ * grp_release runs on the progress thread, and prte_event_base
+ * has no thread of its own (event.c: "PRTE tools block in their own loop over
+ * the event base"), so parking it makes the daemon deaf - no RML, no IOF, no
+ * other job's state transitions - for the duration of the registration.  That
+ * is not a once-per-job teardown cost either: this path runs on every daemon
+ * for every group construct, so a session-heavy job pays it repeatedly.
+ *
+ * The ordering is therefore expressed as a continuation: the caddy carries
+ * everything the remainder of grp_release needs, and the registration's
+ * completion callback hands it back to our progress thread.
+ */
+typedef struct {
+    pmix_object_t super;
+    prte_event_t ev;
+    prte_grpcomm_direct_group_signature_t *sig;
+    pmix_status_t st;
+    void *nlist;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_proc_t *finalmembership;
+    size_t nfinal;
+    pmix_info_t *grpinfo;
+    size_t ngrpinfo;
+    pmix_info_t *endpts;
+    size_t nendpts;
+} prte_grpcomm_release_caddy_t;
 
-    cd->lock.status = status;
-    PMIX_WAKEUP_THREAD(&cd->lock);
+static void rlcon(prte_grpcomm_release_caddy_t *p)
+{
+    p->sig = NULL;
+    p->st = PMIX_SUCCESS;
+    p->nlist = NULL;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->finalmembership = NULL;
+    p->nfinal = 0;
+    p->grpinfo = NULL;
+    p->ngrpinfo = 0;
+    p->endpts = NULL;
+    p->nendpts = 0;
+}
+static void rldes(prte_grpcomm_release_caddy_t *p)
+{
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    if (NULL != p->grpinfo) {
+        PMIX_INFO_FREE(p->grpinfo, p->ngrpinfo);
+    }
+    if (NULL != p->endpts) {
+        PMIX_INFO_FREE(p->endpts, p->nendpts);
+    }
+    if (NULL != p->finalmembership) {
+        PMIX_PROC_FREE(p->finalmembership, p->nfinal);
+    }
+    if (NULL != p->nlist) {
+        PMIX_INFO_LIST_RELEASE(p->nlist);
+    }
+    if (NULL != p->sig) {
+        PMIX_RELEASE(p->sig);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_grpcomm_release_caddy_t, pmix_object_t,
+                           rlcon, rldes);
+
+static void grp_release_complete(prte_grpcomm_release_caddy_t *cd);
+
+/* Resumption point for the continuation - runs on the PRRTE progress
+ * thread, where every object the completion touches belongs. */
+static void grp_release_resume(int fd, short args, void *cbdata)
+{
+    prte_grpcomm_release_caddy_t *cd = (prte_grpcomm_release_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+    grp_release_complete(cd);
+}
+
+/* Completion of the resource registration.  Runs on the PMIx progress
+ * thread, so it does nothing but record the status and hand the caddy
+ * back to ours. */
+static void grp_release_regcbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_grpcomm_release_caddy_t *cd = (prte_grpcomm_release_caddy_t *) cbdata;
+
+    /* a group whose resources did not make it into our server is not a
+     * group our local clients can use - report the failure rather than
+     * handing them one whose endpoint lookups will quietly come up empty */
+    if (PMIX_SUCCESS != status) {
+        cd->st = status;
+    }
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, grp_release_resume);
 }
 
 static void find_delete_tracker(prte_grpcomm_direct_group_signature_t *sig)
@@ -1002,22 +1093,14 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
 {
     prte_grpcomm_group_t *coll;
     prte_grpcomm_direct_group_signature_t *sig = NULL;
-    prte_pmix_grp_caddy_t cd2, *cd;
+    prte_grpcomm_release_caddy_t *cd;
     int32_t cnt;
     pmix_status_t rc = PMIX_SUCCESS, st = PMIX_SUCCESS;
-    pmix_proc_t *finalmembership = NULL;
-    size_t nfinal = 0;
-    size_t nendpts = 0;
-    size_t ngrpinfo = 0;
     size_t n;
     pmix_data_array_t darray;
-    pmix_info_t *grpinfo = NULL;
-    pmix_info_t *endpts = NULL;
     prte_pmix_server_pset_t *pset;
-    void *ilist, *nlist;
+    void *ilist;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
-
-    PMIX_ACQUIRE_OBJECT(cd);
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s group release recvd",
@@ -1030,10 +1113,6 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* check for the tracker - okay if not found, it just
-     * means that we had no local participants */
-    coll = get_tracker(sig, false);
-
     // unpack the status
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &st, &cnt, PMIX_STATUS);
@@ -1045,6 +1124,9 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
     /* if this was a destruct operation, then there is nothing
      * further to unpack */
     if (PMIX_GROUP_DESTRUCT == sig->op) {
+        /* check for the tracker - okay if not found, it just
+         * means that we had no local participants */
+        coll = get_tracker(sig, false);
         /* find this group ID on our list of groups */
         PMIX_LIST_FOREACH(pset, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
         {
@@ -1066,10 +1148,18 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
 
     // setup to cache info
     ilist = PMIx_Info_list_start();
-    nlist = PMIx_Info_list_start();
+
+    /* everything from here on has to survive the registration of the
+     * group's resources with our local PMIx server, which we are not
+     * allowed to wait for - hand it to the continuation caddy, which
+     * takes over ownership of the signature as well */
+    cd = PMIX_NEW(prte_grpcomm_release_caddy_t);
+    cd->sig = sig;
+    cd->st = st;
+    cd->nlist = PMIx_Info_list_start();
 
     // must be a construct operation - continue unpacking
-    if (PMIX_SUCCESS != st) {
+    if (PMIX_SUCCESS != cd->st) {
         PMIX_INFO_LIST_RELEASE(ilist);
         goto notify;
     }
@@ -1078,14 +1168,14 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
         PMIX_INFO_LIST_ADD(rc, ilist, PMIX_GROUP_CONTEXT_ID, &sig->ctxid, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
             goto notify;
         }
-        PMIX_INFO_LIST_ADD(rc, nlist, PMIX_GROUP_CONTEXT_ID, &sig->ctxid, PMIX_SIZE);
+        PMIX_INFO_LIST_ADD(rc, cd->nlist, PMIX_GROUP_CONTEXT_ID, &sig->ctxid, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
             goto notify;
         }
@@ -1093,32 +1183,33 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
 
     // unpack the final membership
     cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &nfinal, &cnt, PMIX_SIZE);
+    rc = PMIx_Data_unpack(NULL, buffer, &cd->nfinal, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        st = rc;
+        cd->st = rc;
+        cd->nfinal = 0;
         PMIX_INFO_LIST_RELEASE(ilist);
         goto notify;
     }
-    if (0 < nfinal) {
-        PMIX_PROC_CREATE(finalmembership, nfinal);
-        cnt = nfinal;
-        rc = PMIx_Data_unpack(NULL, buffer, finalmembership, &cnt, PMIX_PROC);
+    if (0 < cd->nfinal) {
+        PMIX_PROC_CREATE(cd->finalmembership, cd->nfinal);
+        cnt = cd->nfinal;
+        rc = PMIx_Data_unpack(NULL, buffer, cd->finalmembership, &cnt, PMIX_PROC);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
             goto notify;
         }
         // pass back the final group membership
         darray.type = PMIX_PROC;
-        darray.array = finalmembership;
-        darray.size = nfinal;
+        darray.array = cd->finalmembership;
+        darray.size = cd->nfinal;
         // load the array - note: this copies the array!
-        PMIX_INFO_LIST_ADD(rc, nlist, PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
+        PMIX_INFO_LIST_ADD(rc, cd->nlist, PMIX_GROUP_MEMBERSHIP, &darray, PMIX_DATA_ARRAY);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
             goto notify;
         }
@@ -1126,87 +1217,83 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
 
     // unpack group info
     cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &ngrpinfo, &cnt, PMIX_SIZE);
+    rc = PMIx_Data_unpack(NULL, buffer, &cd->ngrpinfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        st = rc;
+        cd->st = rc;
+        cd->ngrpinfo = 0;
         PMIX_INFO_LIST_RELEASE(ilist);
         goto notify;
     }
-    if (0 < ngrpinfo) {
-        PMIX_INFO_CREATE(grpinfo, ngrpinfo);
-        cnt = ngrpinfo;
-        rc = PMIx_Data_unpack(NULL, buffer, grpinfo, &cnt, PMIX_INFO);
+    if (0 < cd->ngrpinfo) {
+        PMIX_INFO_CREATE(cd->grpinfo, cd->ngrpinfo);
+        cnt = cd->ngrpinfo;
+        rc = PMIx_Data_unpack(NULL, buffer, cd->grpinfo, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
-            PMIX_INFO_FREE(grpinfo, ngrpinfo);
             goto notify;
         }
         // transfer them to both lists
-        for (n=0; n < ngrpinfo; n++) {
-            rc = PMIx_Info_list_add_value(ilist, PMIX_GROUP_INFO, &grpinfo[n].value);
+        for (n=0; n < cd->ngrpinfo; n++) {
+            rc = PMIx_Info_list_add_value(ilist, PMIX_GROUP_INFO, &cd->grpinfo[n].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                st = rc;
+                cd->st = rc;
                 PMIX_INFO_LIST_RELEASE(ilist);
-                PMIX_INFO_FREE(grpinfo, ngrpinfo);
                 goto notify;
             }
-            rc = PMIx_Info_list_add_value(nlist, PMIX_GROUP_INFO, &grpinfo[n].value);
+            rc = PMIx_Info_list_add_value(cd->nlist, PMIX_GROUP_INFO, &cd->grpinfo[n].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                st = rc;
+                cd->st = rc;
                 PMIX_INFO_LIST_RELEASE(ilist);
-                PMIX_INFO_FREE(grpinfo, ngrpinfo);
                 goto notify;
             }
         }
-        PMIX_INFO_FREE(grpinfo, ngrpinfo);
+        PMIX_INFO_FREE(cd->grpinfo, cd->ngrpinfo);
     }
 
 
     // unpack endpts
     cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &nendpts, &cnt, PMIX_SIZE);
+    rc = PMIx_Data_unpack(NULL, buffer, &cd->nendpts, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        st = rc;
+        cd->st = rc;
+        cd->nendpts = 0;
         PMIX_INFO_LIST_RELEASE(ilist);
         goto notify;
     }
-    if (0 < nendpts) {
-        PMIX_INFO_CREATE(endpts, nendpts);
-        cnt = nendpts;
-        rc = PMIx_Data_unpack(NULL, buffer, endpts, &cnt, PMIX_INFO);
+    if (0 < cd->nendpts) {
+        PMIX_INFO_CREATE(cd->endpts, cd->nendpts);
+        cnt = cd->nendpts;
+        rc = PMIx_Data_unpack(NULL, buffer, cd->endpts, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            st = rc;
+            cd->st = rc;
             PMIX_INFO_LIST_RELEASE(ilist);
-            PMIX_INFO_FREE(endpts, nendpts);
             goto notify;
         }
         // transfer them to both lists
-        for (n=0; n < nendpts; n++) {
-            rc = PMIx_Info_list_add_value(ilist, PMIX_GROUP_ENDPT_DATA, &endpts[n].value);
+        for (n=0; n < cd->nendpts; n++) {
+            rc = PMIx_Info_list_add_value(ilist, PMIX_GROUP_ENDPT_DATA, &cd->endpts[n].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                st = rc;
+                cd->st = rc;
                 PMIX_INFO_LIST_RELEASE(ilist);
-                PMIX_INFO_FREE(endpts, nendpts);
                 goto notify;
             }
-            rc = PMIx_Info_list_add_value(nlist, PMIX_GROUP_ENDPT_DATA, &endpts[n].value);
+            rc = PMIx_Info_list_add_value(cd->nlist, PMIX_GROUP_ENDPT_DATA, &cd->endpts[n].value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
-                st = rc;
+                cd->st = rc;
                 PMIX_INFO_LIST_RELEASE(ilist);
-                PMIX_INFO_FREE(endpts, nendpts);
                 goto notify;
             }
         }
-        PMIX_INFO_FREE(endpts, nendpts);
+        PMIX_INFO_FREE(cd->endpts, cd->nendpts);
     }
 
     // PRRTE automatically ensures that all daemons register all jobs
@@ -1215,33 +1302,76 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
     // do not need to collect/pass job data for participants
     // in the group construct
 
-    // pass the information down to the PMIx server
+    /* pass the information down to the PMIx server.  This completes before
+     * we service our local clients, so that anything asking that server
+     * about the group finds it already there - but the rest of this
+     * operation runs as a continuation off the registration rather than
+     * waiting on it here. */
     PMIX_INFO_LIST_CONVERT(rc, ilist, &darray);
-    PMIX_CONSTRUCT(&cd2, prte_pmix_grp_caddy_t);
-    cd2.info = (pmix_info_t*)darray.array;
-    cd2.ninfo = darray.size;
     PMIX_INFO_LIST_RELEASE(ilist);
-
-    rc = PMIx_server_register_resources(cd2.info, cd2.ninfo, lkopcbfunc, &cd2);
-    if (PMIX_SUCCESS == rc) {
-        PMIX_WAIT_THREAD(&cd2.lock);
-        rc = cd2.lock.status;
+    if (PMIX_SUCCESS != rc) {
+        /* an empty list just means the construct carried nothing the server
+         * needs to cache, so there is simply nothing to register - anything
+         * else is a real failure.  Either way darray was left untouched, so
+         * we must not reach for it. */
+        if (PMIX_ERR_EMPTY != rc) {
+            PMIX_ERROR_LOG(rc);
+            cd->st = rc;
+        }
+        goto notify;
     }
-    PMIX_DESTRUCT(&cd2);
+    cd->info = (pmix_info_t *) darray.array;
+    cd->ninfo = darray.size;
 
-    if (PMIX_SUCCESS == st) {
+    rc = PMIx_server_register_resources(cd->info, cd->ninfo,
+                                        grp_release_regcbfunc, cd);
+    if (PMIX_SUCCESS == rc) {
+        /* the completion callback owns the caddy now */
+        return;
+    }
+    if (PMIX_OPERATION_SUCCEEDED != rc) {
+        PMIX_ERROR_LOG(rc);
+        cd->st = rc;
+    }
+    /* it completed immediately, and we are already on the progress
+     * thread - so just carry straight on */
+
+notify:
+    grp_release_complete(cd);
+}
+
+/* The remainder of grp_release, run once the group's resources are in our
+ * local PMIx server.  Always executes on the PRRTE progress thread. */
+static void grp_release_complete(prte_grpcomm_release_caddy_t *cd)
+{
+    prte_grpcomm_group_t *coll;
+    prte_pmix_grp_caddy_t *ccd;
+    prte_pmix_server_pset_t *pset;
+    pmix_data_array_t darray;
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS == cd->st) {
        /* add it to our list of known groups */
         pset = PMIX_NEW(prte_pmix_server_pset_t);
-        pset->name = strdup(sig->groupID);
-        if (NULL != finalmembership) {
-            pset->num_members = nfinal;
+        pset->name = strdup(cd->sig->groupID);
+        if (NULL != cd->finalmembership) {
+            pset->num_members = cd->nfinal;
             PMIX_PROC_CREATE(pset->members, pset->num_members);
-            memcpy(pset->members, finalmembership, nfinal * sizeof(pmix_proc_t));
+            memcpy(pset->members, cd->finalmembership,
+                   cd->nfinal * sizeof(pmix_proc_t));
         }
         pmix_list_append(&prte_pmix_server_globals.groups, &pset->super);
     }
 
-notify:
+    /* Look the tracker up now instead of carrying it across the
+     * registration: the progress thread was free while PMIx worked, so an
+     * abort or a duplicate release could have completed and deleted it in
+     * the interim - in which case our local participants have already been
+     * serviced and there is nothing left here to do.  It is equally fine
+     * for it to have never existed, which simply means we had no local
+     * participants. */
+    coll = get_tracker(cd->sig, false);
+
     // regardless of prior error, we MUST notify any pending clients
     // so they don't hang
 
@@ -1249,34 +1379,28 @@ notify:
         // service the procs that are part of the collective
 
         // convert for returning to PMIx server library
-        cd = PMIX_NEW(prte_pmix_grp_caddy_t);
-        if (PMIX_SUCCESS == st) {
-            PMIX_INFO_LIST_CONVERT(rc, nlist, &darray);
-            if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
-                PMIX_ERROR_LOG(rc);
+        ccd = PMIX_NEW(prte_pmix_grp_caddy_t);
+        if (PMIX_SUCCESS == cd->st) {
+            PMIX_INFO_LIST_CONVERT(rc, cd->nlist, &darray);
+            if (PMIX_SUCCESS != rc) {
+                if (PMIX_ERR_EMPTY != rc) {
+                    PMIX_ERROR_LOG(rc);
+                }
+            } else {
+                ccd->info = (pmix_info_t*)darray.array;
+                ccd->ninfo = darray.size;
             }
-            cd->info = (pmix_info_t*)darray.array;
-            cd->ninfo = darray.size;
         }
 
         /* return to the PMIx server library for relay to
          * local procs in the operation */
-        coll->cbfunc(st, cd->info, cd->ninfo, coll->cbdata, relcb, (void*)cd);
+        coll->cbfunc(cd->st, ccd->info, ccd->ninfo, coll->cbdata, relcb, (void*)ccd);
     }
 
-    if (0 < nendpts) {
-        PMIX_INFO_FREE(endpts, nendpts);
-    }
-    if (0 < ngrpinfo) {
-        PMIX_INFO_FREE(grpinfo, ngrpinfo);
-    }
-    if (0 < nfinal) {
-        PMIX_PROC_FREE(finalmembership, nfinal);
-    }
-    PMIX_INFO_LIST_RELEASE(nlist);
     // remove this collective from our tracker
-    find_delete_tracker(sig);
-    PMIX_RELEASE(sig);
+    find_delete_tracker(cd->sig);
+    /* the caddy owns the signature and everything we unpacked into it */
+    PMIX_RELEASE(cd);
 }
 
 


### PR DESCRIPTION
## Problem

`grp_release()` handed the assembled group to its local PMIx server with `PMIx_server_register_resources()` and then sat in `PMIX_WAIT_THREAD` until it completed. Nothing raced — the lock is a `pmix_lock_t`, so the wakeup from the PMIx thread touched no PRRTE object — but the wait parked the progress thread, and `prte_event_base` has no thread of its own. While it sat there the daemon was deaf: no RML, no IOF, no other job's state transitions.

This is the last of the blocking waits tracked in #2534, and the one that costs the most: the teardown waits already converted run once per job, but this one runs **on every daemon for every group construct**.

While confirming that, note that four of the five sites #2534 lists are already fixed on master — `state/dvm` and `state/prted` by #2567, `prted_comm`'s three by #2570, and `state_base_fns`' site no longer exists. Neither PR referenced the issue, so it still reads as fully open. `state_dvm.c`'s `PMIx_server_IOF_deliver` wait remains a deliberate, documented exception (NULL callback, so PMIx blocks on its own lock and no PRRTE object is touched from the PMIx thread).

## Fix

Express the ordering the wait was enforcing — the group's resources have to be in the local PMIx server before the local participants are told the construct succeeded — by chaining instead of blocking. A file-local caddy carries the signature, status, client info list and every array unpacked from the broadcast across the gap and frees them in its destructor; the unpacking writes into caddy fields directly, so the dozen error paths need no per-path transfer. The registration's completion callback records the status and thread-shifts; `PMIX_OPERATION_SUCCEEDED` means it already finished and we are still on the progress thread, so that path carries straight on.

The continuation deliberately looks the tracker up again rather than carrying it: the progress thread is now free while PMIx works, so an abort or duplicate release can complete and delete the tracker in the interim, and a cached pointer would be dangling.

Two defects come out with it:

- The registration status was assigned to a local nothing read, so a group whose resources never reached the server was still reported to clients as successfully constructed. It now propagates.
- Both `PMIX_INFO_LIST_CONVERT` calls ignored their result while reading `darray` unconditionally. On an empty list — which a construct with no context-id request, no group info and no endpoints produces — `darray` is left untouched, so the info pointer picked up whatever the previous assignment left there. On the server path that was the `pmix_proc_t` membership array, about to be handed to `PMIx_server_register_resources` as `pmix_info_t` and then freed twice.

## Test coverage

The swarm suite had no group coverage at all, which left the half of a group collective that matters across nodes untested: `grp_release()` runs on every daemon, and on one host there is exactly one daemon which is also the HNP. The second commit adds `groupcon` (a bare PMIx client in the shape of `elastic`/`dataserver`/`proctable`) and a `test_grpcomm` phase — 8 ranks on 4 nodes, construct → read-back → destruct, plus three back-to-back constructs and a plain job to catch a caddy leak or an undeleted tracker.

What it guards is the continuation: deleting the thread-shift turns 7 of the phase's 10 assertions red, because the participants are never released and the construct *hangs* rather than failing. That was measured, not assumed.

One thing the phase explicitly does **not** claim, and says so in the client, the phase, and the harness guide: the read-back runs with no fence after the construct returns, which looks like an assertion that the daemon registered the group before releasing its clients. It is not — the construct hands the same group info back in its results, so the client library answers from its own cache, and patching out `PMIx_server_register_resources` entirely still passes. Their value is that the membership and group info each daemon returned are complete and identical, which is a genuinely per-daemon property.

## Verification

- Warning-free `--enable-debug` build.
- `make check`: all pass except `test_prted`, which fails identically (480/720 envar orderings, 499 total) with the change reverted — pre-existing, the known open PMIx envar-order dependency.
- Live DVM against PMIx's `group`, `group_dmodex`, `group_leave`, `group_lcl_cid`, `multi_nspace_group`, `group_die`, `group_destruct_die`, plus repeat runs.
- Full dockerswarm linux suite: **321 passed, 0 failed, 0 skipped**.

Closes #2534

🤖 Generated with [Claude Code](https://claude.com/claude-code)