### PR TITLE
dockerswarm, docs: make out-of-tree builds the rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,13 @@
 .gdb*
 cov-int
 
-# Out-of-tree (VPATH) build dirs used by contrib/dockerswarm/build.sh
+# Out-of-tree (VPATH) build dirs.  vpath-linux/vpath-macos are the ones
+# contrib/dockerswarm/build.sh creates; build/ is the conventional name
+# for your own, which AGENTS.md tells you to use rather than configuring
+# in the source tree.
 /vpath-linux/
 /vpath-macos/
+/build/
 
 .hgrc
 .hgignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,10 +398,12 @@ This must be re-run whenever `configure.ac` or any `*.m4` file under
 `config/` is modified or added.  Editing a `Makefile.am` does **not** require the
 full `autogen.pl` + `./configure` cycle — PRRTE builds in maintainer
 mode, so a plain `make` regenerates the affected `Makefile[.in]` files and
-completes the build.  After `autogen.pl`:
+completes the build.  After `autogen.pl`, build **out of tree** (see the
+golden rule below):
 
 ```sh
-./configure [options]
+mkdir build && cd build
+../configure [options]
 make -j$(nproc)
 make install
 ```
@@ -423,26 +425,72 @@ Common configure options:
 
 Version requirements: PMIx ≥ 6.1.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
 
-### GOLDEN RULE: build with `make` from the repository root — never try to short-circuit the build
+### GOLDEN RULE: build with `make` from the top of your build tree — never try to short-circuit the build
 
 Do not waste effort trying to compile a single `.c` file by hand or
 otherwise short-circuit the build system (invoking the compiler
 directly, replaying a compile command, building one object in
-isolation).  Just go to the repository root and run `make` — it is
-quick, it only rebuilds what changed, and it always builds what you
-need.
+isolation).  Just go to the top of your build tree and run
+`make -j$(nproc)` — it is quick, it only rebuilds what changed, and it
+always builds what you need.
 
-Build from the repository root with `make -j$(nproc)`.  Running `make`
-from the root is what respects the generated headers and the per-target
-compiler flags; building from deep inside a subdirectory can miss a
-regenerated header and give you a misleading result.
+Running `make` from the top is what respects the generated headers and
+the per-target compiler flags; building from deep inside a subdirectory
+can miss a regenerated header and give you a misleading result.
 
 If you configured with `--enable-mca-dso` (components built as separate
 DSOs rather than statically linked into the tools), you can rebuild a
 single component after editing it by running `make install` in that
 component's build directory — you do not have to relink every tool.  In
 the default static build, a component change requires a normal
-root-level `make` so the tools are relinked.
+top-level `make` so the tools are relinked.
+
+### GOLDEN RULE: build out of tree — the source tree holds sources, not objects
+
+**Do not run `./configure` or `make` at the repository root.**  Configure
+from a separate build directory, and the source tree stays exactly what
+its name says.  This is a rule, not a preference for tidiness — an
+in-tree build actively costs you two things:
+
+- **It is destroyed the moment you use the container harness.**
+  [`contrib/dockerswarm/build.sh`](contrib/dockerswarm/) compiles your
+  live tree out of tree, and automake sets `VPATH = srcdir`, so an
+  incremental out-of-tree `make` will happily resolve an object target
+  from a stale in-tree `src/**/*.lo` — and pick up the source tree's
+  stale `prte_config.h` ahead of the one configure just wrote.  So
+  `build.sh` distcleans any in-tree build it finds, every time.  Keeping
+  one means every multi-node test run wipes it and costs you a full
+  reconfigure and rebuild.  See
+  [`contrib/dockerswarm/AGENTS.md`](contrib/dockerswarm/AGENTS.md),
+  "When a distclean is actually needed", for why that cannot be
+  narrowed.
+- **It puts you in maintainer mode's way.**  A root-level `make` against
+  stale timestamps can kick off the partial in-tree Autotools
+  regeneration described in the next section, which frequently fails and
+  leaves the tree unbuildable — recoverable only with the full
+  `autogen.pl` + `configure` cycle.
+
+Out of tree, neither happens, several builds coexist from one pristine
+checkout (a debug build and a release build, or a macOS host build and a
+Linux container build), and the tree is always ready to hand to the
+harness:
+
+```sh
+./autogen.pl
+mkdir -p build/debug && cd build/debug
+../../configure --enable-debug [options]
+make -j$(nproc)
+make check
+make -C test/offline check-offline
+```
+
+If you work with the container harness, its `build.sh` will set the host
+side up for you — `./build.sh macos` builds into `vpath-macos/` and
+installs into `vpath-macos/install`, and `make -C vpath-macos check` runs
+the unit tests from there.
+
+`vpath-*/` and `build/` are git-ignored.  Whatever you name your build
+directory, keep it out of the source tree's way and never commit it.
 
 ### Modifying the configure / build system
 
@@ -458,12 +506,18 @@ reconfigure explicitly:
 
 ```sh
 ./autogen.pl
-./configure <same options as the original configure>
+cd <your build dir> && ../<path>/configure <same options as before>
 make -j
 ```
 
-Recover the original configure invocation options from the existing tree
-with `./config.status --config` (or read the header of `config.log`).
+Recover the original configure invocation options from the existing build
+directory with `./config.status --config` (or read the header of
+`config.log`).
+
+Note this failure is not confined to build-system edits: a stale set of
+timestamps is enough to make an ordinary `make` attempt the regeneration
+and wedge on it.  An out-of-tree build (see the golden rule above) keeps
+you clear of it, which is one of the reasons that rule exists.
 This process is slow but mandatory after any build-system source change —
 there is no safe shortcut.  As noted above, editing a `Makefile.am` alone
 is the exception: a plain `make` regenerates the relevant `Makefile[.in]`

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -167,13 +167,13 @@ exactly what this harness was built to do.
 
 The habit worth forming is: **the source tree is sources.** If you find
 yourself running `./configure` or `make` at the repo root, you are
-setting up the next distclean and the next twenty-minute rebuild. This
-does not conflict with the top-level
-[`AGENTS.md`](../../AGENTS.md) golden rule about building with `make`
-from the repository root — that rule is about not hand-compiling single
-files or building from deep inside a subdirectory. Run `make` from the
-top of the *build* directory and it is satisfied; VPATH is which
-directory that is, not a shortcut around the build system.
+setting up the next distclean and the next twenty-minute rebuild. That is
+now stated project-wide — see the top-level
+[`AGENTS.md`](../../AGENTS.md), "GOLDEN RULE: build out of tree" — and it
+sits alongside, not against, the golden rule about running `make` from
+the top of your build tree: that one is about not hand-compiling single
+files or building from deep inside a subdirectory, and VPATH only changes
+*which* directory the top is.
 
 The trap to know about if you *do* end up with an in-tree build that gets
 cleaned: a distcleaned tree does not announce itself. `make check` says

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -102,8 +102,22 @@ bites:
    incremental rebuild.
 
 So `build.sh` distcleans whenever it finds in-tree artifacts, and says
-so. `--no-distclean` skips it (only safe if the tree really is clean);
-`--distclean` forces it.
+so. `--distclean` forces it. `--no-distclean` skips the *detection* — it
+is an assertion that the tree really is clean, and if it is not,
+`build.sh` **stops with an error** rather than building the tree it has
+just been told to poison. That is deliberate: it used to warn and carry
+on, but nobody reads a warning scrolled off the top of a build whose test
+results come out looking fine. The failure mode it was hiding is the
+quiet one — same platform, different `--with-pmix`, a suite that passes
+against a library nobody chose.
+
+Note what this means for who decides. It is tempting to move the call to
+the caller entirely ("the person running it knows whether a distclean is
+needed"), and that is wrong: the trigger is *"does the source tree hold
+an in-tree build right now"*, which is a property of the tree, not of
+your intent. Another worktree, another agent, or your own previous
+session may have put one there. `build.sh` can look; you can only guess,
+and the two ways of being wrong cost wildly different amounts.
 
 **Do not try to narrow this to "only when configure has to run."** It is
 the obvious optimization — an incremental out-of-tree build already has
@@ -133,11 +147,38 @@ whole tree first. That failure is easy to misread, because a distcleaned
 tree does not announce itself — `make check` just says *"No rule to make
 target `check'"* and `make` at the root exits 0 having done nothing.
 
-If you run the host-side suites often, **stop keeping an in-tree build**:
-build the host side out of tree too (`./build.sh macos`, which installs
-into `vpath-macos/install`) and run `make check` from `vpath-macos`. Then
-the source tree stays pristine, both builds coexist exactly as this
-harness intends, and there is never anything to clean.
+### Build both sides out of tree — that is the intended workflow
+
+**Do not keep an in-tree build.** Build the host side out of tree too and
+the whole problem above stops existing:
+
+```sh
+./build.sh macos                    # -> <repo>/vpath-macos, install in vpath-macos/install
+make -C vpath-macos check           # unit tests
+make -C vpath-macos/test/offline check-offline
+./build.sh                          # -> /opt/prte/vpath-linux in the volume
+```
+
+Then the source tree is never configured at all: `srcdir_has_intree` is
+never true, the distclean never fires, nothing you built gets destroyed,
+and the tree is always ready to hand to the swarm without a reconfigure
+first. Both builds coexist from the same pristine sources, which is
+exactly what this harness was built to do.
+
+The habit worth forming is: **the source tree is sources.** If you find
+yourself running `./configure` or `make` at the repo root, you are
+setting up the next distclean and the next twenty-minute rebuild. This
+does not conflict with the top-level
+[`AGENTS.md`](../../AGENTS.md) golden rule about building with `make`
+from the repository root — that rule is about not hand-compiling single
+files or building from deep inside a subdirectory. Run `make` from the
+top of the *build* directory and it is satisfied; VPATH is which
+directory that is, not a shortcut around the build system.
+
+The trap to know about if you *do* end up with an in-tree build that gets
+cleaned: a distcleaned tree does not announce itself. `make check` says
+*"No rule to make target `check'"* and a root-level `make` exits 0 having
+done nothing.
 
 ## 3. Prerequisites
 
@@ -155,16 +196,23 @@ harness intends, and there is never anything to clean.
 # from this directory (contrib/dockerswarm/)
 
 # ---- Linux swarm ----
-./build.sh                 # autogen (+ distclean only if a VPATH configure
-                           #   must run), build image, build PRRTE into the
-                           #   shared volume from your live tree
+./build.sh                 # autogen (+ distclean if the source tree holds an
+                           #   in-tree build -- see §2), build image, build
+                           #   PRRTE into the shared volume from your live tree
 docker compose up -d       # start prte-node1 .. prte-node10
 ./run-tests.sh linux       # full suite: prterun, elastic grow/shrink, relay
 
 # ---- native macOS (single host) ----
 ./build.sh macos           # native VPATH build into <repo>/vpath-macos
 ./run-tests.sh macos       # build + single-host launch smoke
+
+# ---- and run the host-side suites from that build, not the source tree ----
+make -C ../../vpath-macos check
+make -C ../../vpath-macos/test/offline check-offline
 ```
+
+Keeping the host side out of tree as well is the intended workflow, not
+an optimization for heavy users — see §2, "Build both sides out of tree".
 
 **On macOS, say which dependencies to build against.** Unlike the container,
 this host is whatever you have installed, and the two knobs are:

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -55,7 +55,9 @@
 # there is nothing to clean.
 #
 #   --distclean      force it
-#   --no-distclean   skip it (only safe if the tree really is clean)
+#   --no-distclean   skip it -- an assertion that the tree really is clean.
+#                    If it is not, this script STOPS rather than building a
+#                    tree it has just been told to poison.
 #
 # See AGENTS.md, "When a distclean is actually needed".
 #
@@ -187,8 +189,22 @@ prep_srcdir() {
         find "$root/src" -name '*.lo' -delete 2>/dev/null || true
         find "$root/src" -name '.libs' -type d -exec rm -rf {} + 2>/dev/null || true
     elif srcdir_has_intree; then
-        echo ">>> WARNING: --no-distclean, but the source tree holds an in-tree" \
-             "build; the out-of-tree build may pick up its objects via VPATH"
+        # Refuse rather than warn.  --no-distclean asserts "the tree really is
+        # clean"; it is not, so the assertion is false and proceeding builds
+        # exactly the poisoned tree everything above exists to prevent.  The
+        # cheap failure is stopping here.  The expensive one is a build that
+        # succeeds -- same platform, different --with-pmix -- and quietly
+        # tests a library nobody chose, with nothing in the output to say so.
+        # A warning does not stop that, because the run continues and the next
+        # thing anyone reads is the test results.
+        echo ">>> ERROR: --no-distclean, but the source tree holds an in-tree" \
+             "build." >&2
+        echo ">>>        VPATH=srcdir means this build would link objects out" \
+             "of the SOURCE tree, and pick up its stale prte_config.h ahead of" \
+             "the one configure just wrote." >&2
+        echo ">>>        Drop --no-distclean, or clean the tree yourself" \
+             "(make distclean at $root)." >&2
+        exit 2
     fi
 
     if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then


### PR DESCRIPTION
Two related changes: one behavioral, one to the rules.

## 1. `build.sh` refuses `--no-distclean` over an in-tree build

`build.sh` distcleans the source tree when it finds an in-tree build there, because automake sets `VPATH=srcdir` and an out-of-tree `make` will otherwise link objects out of the source tree and pick up its stale `prte_config.h` ahead of the one configure just wrote. `--no-distclean` skips that check, and is documented as "only safe if the tree really is clean".

When it was **not** clean, the script printed a warning and carried on. That is the wrong shape for this failure:

- The loud version — objects of the wrong architecture — at least stops the build.
- The quiet version is same-platform with a different `--with-pmix`, where everything succeeds and the suite then tests a library nobody chose, with nothing in the output to say so.

A warning does not protect against the second one, because the run continues and the next thing anyone reads is the test results. So treat `--no-distclean` as what it says it is — an assertion — and stop if it is false:

```
>>> ERROR: --no-distclean, but the source tree holds an in-tree build.
>>>        VPATH=srcdir means this build would link objects out of the SOURCE
>>>        tree, and pick up its stale prte_config.h ahead of the one configure
>>>        just wrote.
>>>        Drop --no-distclean, or clean the tree yourself (make distclean at ...).
```

The harness guide also now records **why the decision cannot simply be handed to the caller**, since that is a natural thing to propose: the trigger is *"does the source tree hold an in-tree build right now"*, a property of the tree rather than of anyone's intent. Another worktree, another agent, or your own earlier session may have left one. `build.sh` can look; a caller can only guess, and the two ways of guessing wrong cost very different amounts.

## 2. Out-of-tree building becomes a top-level golden rule

The harness has recommended keeping the host build out of tree for a while, but only in its own guide and only as an optimization for people who run its suites often. That framing is too weak — an in-tree build is not merely untidy, it is *destroyed* by any use of the multi-node harness, and it puts you in maintainer mode's way.

So `AGENTS.md` gains **"GOLDEN RULE: build out of tree — the source tree holds sources, not objects"**, with both reasons and a worked recipe, plus the surrounding adjustments needed to keep the document self-consistent:

- The existing golden rule said to build "from the repository root", which directly contradicts the new one. Its actual subject is not the repository root but the top of whatever tree you are building in — the point being that building from deep inside a subdirectory can miss a regenerated header. Retitled and reworded so the two agree.
- The opening build recipe and the reconfigure recipe now show the out-of-tree form, and `config.status` is looked for in the build directory where it actually is.
- The maintainer-mode warning read as a hazard of editing `configure.ac`. It is not — a stale set of timestamps is enough to make an ordinary `make` attempt the regeneration and wedge on it, and the recovery is the full `autogen.pl` + `configure` cycle. Said explicitly.
- `.gitignore` gains `/build/`, since the recipe names it and the two `vpath-*` directories were already ignored.
- The harness guide keeps its own longer treatment — that is where the VPATH-poisoning detail belongs — and now points at the top-level rule rather than restating it.

## Verification

- `--no-distclean` against a tree holding an in-tree build exits 2 having done nothing.
- The default (auto) path still works: `./build.sh macos` distcleaned and built into `vpath-macos`, and the full unit suite runs from there.
- The documented recipe was run end to end rather than assumed — `mkdir -p build/debug && cd build/debug && ../../configure --enable-debug …`, then `make` (zero compiler warnings), `make check`, and `make -C test/offline check-offline` resolving correctly against the VPATH `top_srcdir`.
- Unit tests pass except `test_prted`, which fails identically on master (the known open PMIx envar-order dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)