### PR TITLE
Retire a tool's job when the tool departs

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -394,17 +394,39 @@ the daemon copy was missed.
 **Grow** (`elastic grow node2:2,node3:2`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, and `prted` now running on node2 and node3.
 
-> The grown nodes join the **reservation** created by the request, so a plain
-> `prun -n 3 --map-by node hostname` still lands only on node1 — its default job
-> allocation is node1's base pool, not the reservation. Confirm a grow by
-> `prted` presence on the targets and the `PMIX_DVM_IS_READY` event, not by
-> plain-`prun` placement.
+> The grown nodes join the **reservation** created by the request, and for as
+> long as the requesting tool is alive they belong to it alone: a plain
+> `prun -n 3 --map-by node hostname` still lands only on node1, because its
+> default job allocation is node1's base pool, not the reservation. While the
+> tool is running, confirm a grow by `prted` presence on the targets and the
+> `PMIX_DVM_IS_READY` event, not by plain-`prun` placement.
 >
-> To actually **run something on a grown node**, spawn into the reservation:
-> `elastic grow node4:2 -- <cmd>` takes the `PMIX_ALLOC_ID` the request handed
-> back and spawns `<cmd>` with `PMIX_SPAWN_TARGET` naming it. The grow and the
-> spawn must happen in one `elastic` invocation — the HNP only lets a namespace
-> target a reservation it owns, and the owner is the tool that created it.
+> To **run something on a grown node while the reservation is still held**,
+> spawn into it: `elastic grow node4:2 -- <cmd>` takes the `PMIX_ALLOC_ID` the
+> request handed back and spawns `<cmd>` with `PMIX_SPAWN_TARGET` naming it.
+> A **later** command of the same user can reach it too:
+> `prun --alloc-id <id>` spawns into the reservation from a separate tool.
+> Ownership is namespace *and* user — the namespace test is what keeps other
+> jobs in the DVM out, and the uid is what keeps the allocation usable after
+> the one-shot tool that created it has gone. An allocation the DVM does not
+> know is still `PMIX_ERR_NOT_FOUND`, and a job whose namespace is not an
+> owner is refused with `PMIX_ERR_NO_PERMISSIONS` (`PRTE_ERR_PERM`) — the two
+> answers are deliberately distinct, so "you may not" cannot be read as
+> "there is no such allocation".
+>
+> **Once that tool exits, the reservation is gone.** Its inheritance
+> disposition fires — by default "unreserve into the general pool" — so the
+> nodes it grew become ordinary pool members and a plain `prun --host node4`
+> reaches them with no allocation directive at all. This needs a PMIx defining
+> `PMIX_CAP_TOOL_FINALIZED`: a tool that finalizes cleanly is reported to the
+> host by nothing else (it is not a child, so no waitpid; and the connection
+> drop that follows raises no lost-connection event, because the peer is
+> already marked finalized). Against an older PMIx the DVM never learns the
+> tool went away, the disposition never runs, and the grown nodes stay
+> stranded for the life of the DVM — outside the general pool and unreachable
+> through the reservation too, since the only namespace allowed to name it no
+> longer exists. `run-tests.sh` skips the cases that assert the released-pool
+> behavior when the capability is absent (`pmix_cap`).
 
 **Shrink** (`elastic shrink node3`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, plus a **"PRRTE has lost communication with a remote

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3502,6 +3502,94 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     [ "$out" = node1 ] && ok "prun works post-shrink" || bad "prun broken post-shrink"
     RUN 'pterm' >/dev/null 2>&1; cleanup_swarm
 
+    banner "elastic DVM: a departing tool releases the allocation it reserved"
+    # A grow creates a RESERVATION owned by the namespace that asked for it,
+    # and every reservation carries a disposition saying what becomes of it
+    # when that namespace terminates. The default -- and what the elastic
+    # client asks for by saying nothing -- is to unreserve the nodes into the
+    # general pool. For a command-line tool "that namespace terminates" means
+    # the tool exited, and nothing else ever will: it is not a child, so no
+    # waitpid fires, and the connection it drops afterwards raises no
+    # lost-connection event because PMIx has already marked the peer
+    # finalized. Until PMIX_CAP_TOOL_FINALIZED the host was simply never
+    # told, so the disposition never ran and a grow driven from a command
+    # line stranded its nodes for the life of the DVM -- outside the general
+    # pool, and unreachable through the reservation too, since the only
+    # namespace permitted to name it no longer existed.
+    #
+    # Two nodes, so the assertion cannot pass on a job that quietly fell back
+    # to the head node.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 90 elastic grow node2:2,node3:2' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "grow node2,node3 completed" || bad "grow did not complete"
+        if pmix_cap PMIX_CAP_TOOL_FINALIZED; then
+            # the disposition runs on the HNP's progress thread once the
+            # tool's finalize lands, so give it a beat before asking
+            sleep 2
+            out=$(RUN 'timeout 60 prun --host node2:2,node3:2 -np 2 --map-by node hostname' 2>&1)
+            n=$(echo "$out" | grep -cE '^node[23]$')
+            [ "$n" = 2 ] \
+                && ok "the grown nodes joined the general pool when the tool exited" \
+                || bad "prun reached $n/2 grown nodes: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            skp "released-reservation placement (PMIx predates PMIX_CAP_TOOL_FINALIZED)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the reservation-release test"
+    fi
+    cleanup_swarm
+
+    banner "elastic DVM: the user who reserved an allocation can use it again"
+    # A reservation is owned by the namespace that requested it, which is what
+    # keeps other JOBS in the DVM out of it. That cannot be the whole rule for
+    # a TOOL, though: a tool namespace is minted per invocation, so a user's
+    # second command could never name the allocation their first one made, and
+    # once that first command exited nothing could name it at all. So the user
+    # is recorded alongside the namespace, and a tool presenting the same uid
+    # may act on the reservation -- here, spawn into it by --alloc-id from a
+    # completely separate prun. Naming an allocation the DVM does not have is
+    # still NOT_FOUND, and the case checks that too, so "allowed" cannot
+    # quietly become "not checked at all".
+    #
+    # A reservation only exists while its owner does, so the probe has to run
+    # while the elastic client is still alive -- hence the background client,
+    # holding its reservation open with a job of its own.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'rm -f /tmp/owner.out' >/dev/null 2>&1
+        RUN_BG /tmp/owner.out "timeout 120 elastic grow node2:4 -- sleep 40"
+        for _ in $(seq 1 40); do
+            RUN 'grep -q "^>>> SPAWNED" /tmp/owner.out' >/dev/null 2>&1 && break
+            sleep 2
+        done
+        aid=$(RUN 'sed -n "s/^>>> ALLOC_ID //p" /tmp/owner.out' | tr -d '\r')
+        if [ -n "$aid" ]; then
+            ok "the grow handed back an allocation id ($aid)"
+            out=$(RUN "timeout 60 prun --alloc-id $aid -np 1 hostname" 2>&1)
+            [ "$(echo "$out" | grep -c '^node2$')" = 1 ] \
+                && ok "another tool of the same user may spawn into the reservation" \
+                || bad "prun --alloc-id did not run on the reserved node: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+            out=$(RUN "timeout 60 prun --alloc-id no-such-allocation -np 1 hostname" 2>&1)
+            echo "$out" | grep -q NOT_FOUND \
+                && ok "an allocation the DVM does not know is NOT_FOUND" \
+                || bad "wrong refusal for an unknown allocation: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+            RUN 'pgrep -x prte >/dev/null' && ok "the HNP survived the refusal" \
+                                           || bad "the HNP died on a refused --alloc-id"
+        else
+            bad "no allocation id from the background grow: $(RUN 'tr "\n" " " < /tmp/owner.out' | tail -c 200)"
+        fi
+        RUN 'pkill -x elastic' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the reservation-ownership test"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: grow AFTER a shrink completes (phase-two event)"
     # A grow launches a daemon onto every node that lacks one -- which after a
     # shrink includes the shrunk node, since releasing the reservation reverts

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -112,6 +112,29 @@ prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/nu
 # entry produces
 prted_procs() { docker exec "$NODE$1" sh -c 'pgrep -x prted 2>/dev/null | wc -l' | tr -d ' \r'; }
 
+# Run something on the head node detached, capturing its output to a file --
+# for a tool that has to stay alive while the case pokes at the DVM around it.
+RUN_BG() {
+    local outf=$1; shift
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        "${NODE}1" bash -lc ". /opt/prte/env.sh; $* > $outf 2>&1"
+}
+
+# Does the PMIx this install was BUILT against define a given capability flag?
+# The harness can be pointed at either of two PMIx installs -- the one baked
+# into the image or a PMIX_SRC build -- and the only record of which one is in
+# play is the --with-pmix that build.sh stamped into the VPATH build dir, so
+# read the prefix from there rather than guessing at a path.  A case that
+# asserts behavior an older PMIx cannot produce skips on this rather than
+# failing: the baked PMIx goes stale as a matter of course (see AGENTS.md),
+# and red for that reads as "your tree is broken" when it is not.
+pmix_cap() {
+    ON 1 "p=\$(sed -n 's|.*--with-pmix=\\([^ ]*\\).*|\\1|p' \
+                  /opt/prte/vpath-linux/.configure-args 2>/dev/null); \
+          [ -n \"\$p\" ] || p=/usr/local; \
+          grep -qs $1 \"\$p/include/pmix_version.h\"" >/dev/null 2>&1
+}
+
 # --- fake-SLURM helpers -----------------------------------------------------
 # ras/slurm reaches its scheduler by shelling out to sbatch/scontrol/scancel,
 # so the harness supplies them: build.sh installs fake-slurm.py into the shared
@@ -3351,13 +3374,24 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     # already filled", which is what a NULL topology on the grown node looks
     # like from the outside.
     #
-    # Proving the node is usable means running something on it, and a grown
-    # node joins the reservation the grow created rather than the default
-    # pool -- so "prun --host node4" has no allocation to map onto no matter
-    # what its topology says. The elastic client therefore spawns INTO that
-    # reservation, naming it with the PMIX_ALLOC_ID the grow handed back
-    # (PMIX_SPAWN_TARGET). The grow and the spawn have to happen in one tool
-    # session: the HNP only lets a namespace target a reservation it owns.
+    # Proving the node is usable means running something on it, and that is
+    # asserted twice over, because the two ways of reaching a grown node are
+    # different code:
+    #
+    #   - WHILE the requesting tool still holds the reservation, only that
+    #     tool can put work on it -- the HNP lets a namespace target a
+    #     reservation only if it owns it, which is why the grow and the spawn
+    #     happen in one "elastic" invocation, naming the reservation with the
+    #     PMIX_ALLOC_ID the grow handed back (PMIX_SPAWN_TARGET).
+    #   - ONCE that tool exits, the reservation's inheritance disposition
+    #     fires and (by default) unreserves its nodes into the general pool,
+    #     so a plain "prun --host node4" reaches them with no allocation
+    #     directive at all.
+    #
+    # The second half is gated on the PMIx capability, because a tool that
+    # finalizes cleanly is reported to the host only by a PMIx that has
+    # PMIX_CAP_TOOL_FINALIZED; without it the DVM never learns the tool went
+    # away and the nodes stay withheld for the life of the DVM.
     cleanup_swarm
     ON 4 'rm -f /tmp/survivor.out' >/dev/null 2>&1
     RUN 'nohup prte --daemonize --uniform-nodes --prtemca prte_elastic_mode 1 \
@@ -3384,6 +3418,25 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         [ "$marker" = node4 ] \
             && ok "the grown node ran the job - it inherited from a survivor" \
             || bad "grown node never ran the job (marker='$marker')"
+        # The elastic client has exited by now, so its reservation is gone
+        # and the node it grew is back in the general pool -- reachable by a
+        # plain --host with no allocation directive of any kind. This is the
+        # assertion the topology question is really about: a node whose
+        # topology stayed NULL fails to map here with "All nodes which are
+        # allocated for this job are already filled".
+        if pmix_cap PMIX_CAP_TOOL_FINALIZED; then
+            sleep 2
+            # spell the slot count out: --host with a bare name contributes
+            # ONE slot, so -np 2 would fail as oversubscription rather than
+            # for any reason this case is about
+            out=$(RUN 'timeout 60 prun --host node4:2 -np 2 hostname' 2>&1)
+            n=$(echo "$out" | grep -c '^node4$')
+            [ "$n" = 2 ] \
+                && ok "plain prun maps onto the grown node once its reservation is released" \
+                || bad "prun --host node4 placed $n/2 procs: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            skp "prun onto the released reservation (PMIx predates PMIX_CAP_TOOL_FINALIZED)"
+        fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the survivor-topology test"

--- a/src/docs/prrte-rst-content/cli-alloc-id.rst
+++ b/src/docs/prrte-rst-content/cli-alloc-id.rst
@@ -18,10 +18,19 @@ it was created. The DVM reports this value back to the requester when
 an allocation request completes, and it is the value returned by a
 query of the allocation.
 
-The named allocation must be one the requester owns |mdash| a job can
-only be spawned onto resources its requester has been granted. Naming
-an allocation the DVM does not know about, or one the requester does
-not own, is an unrecoverable error: the job is not launched.
+The named allocation must be one the requester is entitled to use
+|mdash| a job can only be spawned onto resources its requester has been
+granted. Entitlement is by namespace and by user: the namespace that
+requested the allocation holds it, as does every job spawned into it,
+and so does any tool run by the user the allocation was granted to.
+That last part is what lets a later command reach an allocation an
+earlier one created, since a tool's namespace lasts only as long as the
+command that made it.
+
+Naming an allocation the DVM does not know about is an unrecoverable
+error and reports ``PMIX_ERR_NOT_FOUND``; naming one the requester may
+not use is likewise unrecoverable and reports
+``PMIX_ERR_NO_PERMISSIONS``. In either case the job is not launched.
 
 If no allocation is named, the job is mapped onto the allocation of the
 session that requested it (the DVM's default session, in the case of a

--- a/src/docs/prrte-rst-content/cli-alloc-refid.rst
+++ b/src/docs/prrte-rst-content/cli-alloc-refid.rst
@@ -19,10 +19,19 @@ allocation was made. This is the convenient counterpart to
 chose itself, without having to capture the identifier the host
 environment later assigned to it.
 
-The named allocation must be one the requester owns |mdash| a job can
-only be spawned onto resources its requester has been granted. Naming
-an allocation the DVM does not know about, or one the requester does
-not own, is an unrecoverable error: the job is not launched.
+The named allocation must be one the requester is entitled to use
+|mdash| a job can only be spawned onto resources its requester has been
+granted. Entitlement is by namespace and by user: the namespace that
+requested the allocation holds it, as does every job spawned into it,
+and so does any tool run by the user the allocation was granted to.
+That last part is what lets a later command reach an allocation an
+earlier one created, since a tool's namespace lasts only as long as the
+command that made it.
+
+Naming an allocation the DVM does not know about is an unrecoverable
+error and reports ``PMIX_ERR_NOT_FOUND``; naming one the requester may
+not use is likewise unrecoverable and reports
+``PMIX_ERR_NO_PERMISSIONS``. In either case the job is not launched.
 
 If no allocation is named, the job is mapped onto the allocation of the
 session that requested it (the DVM's default session, in the case of a

--- a/src/docs/prrte-rst-content/cli-session-id.rst
+++ b/src/docs/prrte-rst-content/cli-session-id.rst
@@ -21,10 +21,19 @@ allocation request completes.
 The value must be an unsigned 32-bit integer; anything else is rejected
 before the job is submitted.
 
-The named session must be one the requester owns |mdash| a job can only
-be spawned onto resources its requester has been granted. Naming a
-session the DVM does not know about, or one the requester does not own,
-is an unrecoverable error: the job is not launched.
+The named session must be one the requester is entitled to use |mdash|
+a job can only be spawned onto resources its requester has been
+granted. Entitlement is by namespace and by user: the namespace that
+requested the session's allocation holds it, as does every job spawned
+into it, and so does any tool run by the user it was granted to. That
+last part is what lets a later command reach a session an earlier one
+created, since a tool's namespace lasts only as long as the command
+that made it.
+
+Naming a session the DVM does not know about is an unrecoverable error
+and reports ``PMIX_ERR_NOT_FOUND``; naming one the requester may not
+use is likewise unrecoverable and reports ``PMIX_ERR_NO_PERMISSIONS``.
+In either case the job is not launched.
 
 If no session is named, the job is mapped onto the session that
 requested it (the DVM's default session, in the case of a tool such as

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -254,6 +254,45 @@ static void proc_errors(int fd, short args, void *cbdata)
 
     if (PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         /* NOTE: this is a daemon process that had the error */
+
+        /* Failing to send to a daemon that has never reported for duty says
+         * nothing about that daemon: it has been recorded and launched, and
+         * has simply not started listening yet.  Answering that as a comm
+         * failure takes the whole DVM down - PEER_UNKNOWN is not even among
+         * the states handled below, so it reaches the "unsupported" fallback,
+         * which forces DAEMONS_TERMINATED.
+         *
+         * Any job that terminates while daemons are being added produces
+         * exactly this: the job's completion notice is xcast over a routing
+         * tree that already holds them, because the tree is built from the
+         * expected daemon count precisely so wireup can route to them.  An
+         * `elastic extend` is the reliable way to see it, since it returns to
+         * its caller as soon as the scheduler answers, so the tool exits (and
+         * its job terminates) while the launch is still in flight.
+         *
+         * The test for "has not reported" is that we hold no contact info for
+         * it, which is both exact and the very reason the send failed - there
+         * was no address to send to.  Neither PRTE_PROC_FLAG_ALIVE nor a
+         * RUNNING state can serve: plm/ssh sets both when it *records* the
+         * launch, long before the daemon says anything.  rml_uri is written
+         * only by prte_plm_base_daemon_callback, i.e. only by the daemon
+         * itself reporting in.
+         *
+         * Only send failures are swallowed here.  A daemon that genuinely
+         * fails to come up reports FAILED_TO_START and is handled below, and
+         * a daemon that has departed still carries the contact info it
+         * reported with, so it does not land here either. */
+        if ((PRTE_PROC_STATE_UNABLE_TO_SEND_MSG == state ||
+             PRTE_PROC_STATE_PEER_UNKNOWN == state ||
+             PRTE_PROC_STATE_NO_PATH_TO_TARGET == state) &&
+            NULL == pptr->rml_uri) {
+            PMIX_OUTPUT_VERBOSE((5, prte_errmgr_base_framework.framework_output,
+                                 "%s Comm failure for daemon %s, not yet reported - ignoring it",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(proc)));
+            goto cleanup;
+        }
+
         /* we MUST handle a communication failure with special care to
          * avoid normal termination issues */
         if (PRTE_PROC_STATE_COMM_FAILED == state ||

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -94,7 +94,7 @@ codes). A few load-bearing boundaries and values:
 | Proc state | `UNTERMINATED = 15`; `RUNNING = 4`, `REGISTERED = 5`; `TERMINATED = 20`; `ERROR = 50` (error codes are offsets from it — `FAILED_TO_START = ERROR+3`, `COMM_FAILED = ERROR+6`, `ABORTED = ERROR+2`, …). Anything `< UNTERMINATED` means still-running. |
 | Job state | `LAUNCH_DAEMONS = 8`, `DAEMONS_LAUNCHED = 9`, `DAEMONS_REPORTED = 10`, `VM_READY = 11`, `RUNNING = 14`; `UNTERMINATED = 30`, `TERMINATED = 31`; `ERROR = 50` (`FAILED_TO_START = ERROR+3`, `NEVER_LAUNCHED = ERROR+10`, `MAP_FAILED = ERROR+19`, …). |
 | Node state | `UP = 3`, `DOWN = 2`, `DO_NOT_USE = 5`, `NOT_INCLUDED = 6`, `ADDED = 7`. |
-| PLM commands | `LAUNCH_JOB_CMD = 1`, `UPDATE_PROC_STATE = 2`, `REGISTERED_CMD = 3`, `TOOL_ATTACHED_CMD = 4`, `READY_FOR_DEBUG_CMD = 5`, `LOCAL_LAUNCH_COMP_CMD = 6`. |
+| PLM commands | `LAUNCH_JOB_CMD = 1`, `UPDATE_PROC_STATE = 2`, `REGISTERED_CMD = 3`, `TOOL_ATTACHED_CMD = 4`, `READY_FOR_DEBUG_CMD = 5`, `LOCAL_LAUNCH_COMP_CMD = 6`, `TOOL_DEPARTED_CMD = 7`. |
 
 Note the sequences deliberately **skip** some offsets (e.g. job error
 `ERROR+15`) — do not reuse a gap assuming it is free.
@@ -312,6 +312,14 @@ thread-safe on the progress thread) and switches on
   procs launched (pid + state); advances to `STARTED` on the first and
   `RUNNING` when `num_launched == num_procs`.
 - **`PRTE_PLM_TOOL_ATTACHED_CMD`** — register a connecting tool as a job.
+- **`PRTE_PLM_TOOL_DEPARTED_CMD`** — the partner of the above: a tool the
+  master registered has gone. Only the master holds a tool's job object, so
+  a daemon the tool connected *through* has nothing local to retire and
+  reports the departure instead. The master vets the namespace's
+  `PRTE_JOB_FLAG_TOOL` before acting — the reporting daemon can only say
+  "this peer was not a client of mine", and a namespace that turns out to be
+  an application job must not be terminated on the strength of that. An
+  unknown namespace is not an error; the DVM may have discarded it already.
 
 ### orted command-line construction
 

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -221,6 +221,8 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     prte_app_context_t *app, *child_app;
     pmix_proc_t name, *nptr = NULL;
     pid_t pid;
+    uid_t tooluid = PRTE_INVALID_UID;
+    gid_t toolgid = PRTE_INVALID_GID;
     bool debugging, found;
     int i, room, *rmptr = &room;
     char *tmp;
@@ -314,11 +316,31 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
                 free(tmp);
                 goto CLEANUP;
             }
+            // and who is running it
+            count = 1;
+            rc = PMIx_Data_unpack(NULL, buffer, &ui32, &count, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                free(tmp);
+                goto CLEANUP;
+            }
+            tooluid = (uid_t) ui32;
+            count = 1;
+            rc = PMIx_Data_unpack(NULL, buffer, &ui32, &count, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                free(tmp);
+                goto CLEANUP;
+            }
+            toolgid = (gid_t) ui32;
 
             // need to add the tool job
             jdata = PMIX_NEW(prte_job_t);
             PMIX_LOAD_NSPACE(jdata->nspace, name.nspace);
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
+            /* record who is running the tool - see prte_session_is_owned_by */
+            jdata->uid = tooluid;
+            jdata->gid = toolgid;
             rc = prte_set_job_data_object(jdata);
             app = PMIX_NEW(prte_app_context_t);
             if (NULL != tmp) {
@@ -418,6 +440,17 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
             rc = PRTE_ERR_NOT_FOUND;
             goto ANSWER_LAUNCH;
+        }
+
+        /* The job belongs to whoever asked for it. Identity descends the job
+         * tree from the tool that started it, so an allocation an application
+         * requests is recorded against the user who launched that application
+         * - not left anonymous because the job itself never presented
+         * credentials. */
+        parent = prte_get_job_data_object(nptr->nspace);
+        if (NULL != parent) {
+            jdata->uid = parent->uid;
+            jdata->gid = parent->gid;
         }
 
         /* A spawn-target list takes precedence and may name multiple sessions

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -878,6 +878,32 @@ moveon:
         }
         break;
 
+    case PRTE_PLM_TOOL_DEPARTED_CMD:
+        /* The partner of TOOL_ATTACHED above. A daemon other than the master
+         * holds no job object for a tool that connected to it, so it cannot
+         * retire one - it tells us instead, and we drive the tool's proc into
+         * TERMINATED here. Vet the namespace before doing so: the daemon is
+         * reporting a peer it could not identify beyond "not a client of
+         * mine", and acting on one that turns out to be an application job
+         * would terminate that job. Nothing is wrong with a namespace we no
+         * longer know - the DVM may already have discarded it - so that is
+         * not an error either. */
+        count = 1;
+        rc = PMIx_Data_unpack(NULL, buffer, &name, &count, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto CLEANUP;
+        }
+        PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                             "%s plm:base:receive tool %s departed (reported by %s)",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&name),
+                             PRTE_NAME_PRINT(sender)));
+        jdata = prte_get_job_data_object(name.nspace);
+        if (NULL != jdata && PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+            PRTE_ACTIVATE_PROC_STATE(&name, PRTE_PROC_STATE_TERMINATED);
+        }
+        break;
+
     case PRTE_PLM_LOCAL_LAUNCH_COMP_CMD:
         PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                             "%s plm:base:receive local launch complete command from %s",

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -229,6 +229,7 @@ typedef uint8_t prte_plm_cmd_flag_t;
 #define PRTE_PLM_TOOL_ATTACHED_CMD      4
 #define PRTE_PLM_READY_FOR_DEBUG_CMD    5
 #define PRTE_PLM_LOCAL_LAUNCH_COMP_CMD  6
+#define PRTE_PLM_TOOL_DEPARTED_CMD      7
 
 END_C_DECLS
 

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -285,6 +285,22 @@ elastic-DVM or PMIx_Allocation code:
 | `prte_ras_base_teardown_reservation()` | Drop a reservation's hold on its nodes (clear `node->session` back to the default pool), deregister it, and — if `return_to_scheduler` — shrink its daemon-carrying nodes out of the DVM. |
 | `prte_ras_base_check_reservations_on_term()` | On namespace termination, fire each reservation's inheritance disposition (`PMIX_ALLOC_INHERIT_NONE`/`CHILD`/`CHILD_DEFAULT`/`DEFAULT`). |
 
+**A reservation requested by a tool lives and dies with that tool**, and
+that hangs on the daemon being told when the tool goes. It is not a child,
+so no waitpid fires for it; the connection drop that follows a clean
+`PMIx_tool_finalize` raises no lost-connection event either, because PMIx
+has already marked the peer finalized. The only notice is PMIx's
+`client_finalized` upcall, which reaches tools from
+`PMIX_CAP_TOOL_FINALIZED` onwards — `_client_finalized()`
+([`src/prted/pmix/pmix_server_gen.c`](../../prted/pmix/pmix_server_gen.c))
+turns it into `PRTE_PROC_STATE_TERMINATED` for a job flagged
+`PRTE_JOB_FLAG_TOOL`, which is what eventually walks the table above.
+Without that the disposition never runs at all, and a grow driven from a
+command line strands its nodes for the life of the DVM: out of the general
+pool, and unreachable through the reservation as well, since
+`prte_session_is_owned_by` will only admit a namespace that no longer
+exists.
+
 Elastic shrink is a two-phase collective: `PMIX_ALLOC_RELEASE` records a
 `prte_shrink_campaign_t`, xcasts the shrink command with a completion
 callback (`shrink_xcast_complete` → thread-shifted

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -816,6 +816,11 @@ static prte_session_t *create_reservation(const char *nspace, uint8_t inherit,
     if (NULL != ownerjob) {
         PMIX_RETAIN(ownerjob);
         s->owner_job = ownerjob;
+        /* Record the user as well as the namespace. A tool's namespace lives
+         * only as long as the command that made it, so a reservation
+         * identified by namespace alone becomes unusable - by anyone - the
+         * moment the requester exits. See prte_session_is_owned_by. */
+        s->owner_uid = ownerjob->uid;
     }
     /* seed the owner set with the owning namespace */
     prte_session_add_owner(s, nspace);

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -96,7 +96,13 @@ pmix_status_t prte_pmix_convert_rc(int rc)
     case PRTE_ERR_NOT_FOUND:
         return PMIX_ERR_NOT_FOUND;
 
+    /* keep "you may not" distinct from "I could not get there". They used to
+     * share PMIX_ERR_UNREACH, so a job refused for want of permission - the
+     * ownership check on an allocation is the live case - reached the user as
+     * a connectivity failure, which is neither true nor actionable. */
     case PRTE_ERR_PERM:
+        return PMIX_ERR_NO_PERMISSIONS;
+
     case PRTE_ERR_UNREACH:
     case PRTE_ERR_SERVER_NOT_AVAIL:
         return PMIX_ERR_UNREACH;
@@ -253,8 +259,10 @@ int prte_pmix_convert_status(pmix_status_t status)
         return PRTE_ERR_BAD_PARAM;
 
     case PMIX_ERR_UNREACH:
-    case PMIX_ERR_NO_PERMISSIONS:
         return PRTE_ERR_UNREACH;
+
+    case PMIX_ERR_NO_PERMISSIONS:
+        return PRTE_ERR_PERM;
 
     case PMIX_ERR_TIMEOUT:
         return PRTE_ERR_TIMEOUT;

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -40,7 +40,7 @@ upcall; each file below implements a related group of them.
 | `pmix_server_register_fns.c` | Turning a `prte_job_t` into the info arrays PMIx needs (`PMIx_server_register_nspace`, `register_client`, tool registration). |
 | `pmix_server_dyn.c` | `spawn` — plus `prte_pmix_xfer_job_info()`/`prte_pmix_xfer_app()`, the translators from PMIx directives to PRRTE job/app attributes. Also `connect`/`disconnect`. |
 | `pmix_server_queries.c` | `query` — namespaces, proc tables, psets, groups, allocations. |
-| `pmix_server_gen.c` | `abort`, `client_finalized`, `client_connected2`, `tool_connected`, `iof_pull`, `push_stdin`, `log`. |
+| `pmix_server_gen.c` | `abort`, `client_finalized`, `client_connected2`, `tool_connected`, `iof_pull`, `push_stdin`, `log`. `client_finalized` is how a **tool**'s departure is learned as well — see below. |
 | `pmix_server_fence.c` | `fence_nb` and `direct_modex`. |
 | `pmix_server_pub.c` | `publish`/`lookup`/`unpublish` (relayed to the data server). |
 | `pmix_server_notify.c` | `notify_event` (up), and the RML receive that fans a peer's event out to local clients (down). |
@@ -240,6 +240,34 @@ onto PRRTE job and app attributes. Notes for extending them:
   handled early makes a later `else if` on the same key dead code —
   `PMIX_TIMEOUT` was matched by the `SPAWN_TIMEOUT` branch and its own
   branch was unreachable.
+
+---
+
+## A tool's departure
+
+`_client_finalized()` is the **only** notice a daemon gets that a tool has
+gone. A tool is not a child, so no waitpid fires for it, and the connection
+it drops afterwards raises no `PMIX_ERR_LOST_CONNECTION` either — PMIx
+suppresses that event for a peer it has already marked finalized. So the
+handler retires the tool's job object itself
+(`PRTE_ACTIVATE_PROC_STATE(..., PRTE_PROC_STATE_TERMINATED)` when the job
+carries `PRTE_JOB_FLAG_TOOL`), which is what drives the tool's namespace
+through the state machine and, with it, the inheritance disposition of any
+allocation the tool reserved (see
+[`../../mca/ras/AGENTS.md`](../../mca/ras/AGENTS.md)). PMIx delivers this
+upcall for a tool only from `PMIX_CAP_TOOL_FINALIZED` onwards; before that
+the tool's job object, and anything it held, simply accumulated for the
+life of the DVM.
+
+`lost_connection_hdlr()` in `pmix_server.c` is the other half — the
+*abnormal* departure — and it is registered at the end of
+`pmix_server_init()`. Watch what precedes that registration: an early
+`return` anywhere above it silently costs the daemon this handler and the
+allocation-timeout relay. That happened, and was invisible from both ends,
+because the blocking form of `PMIx_server_register_resources()` reports
+success as `PMIX_OPERATION_SUCCEEDED` and `prte_pmix_convert_status()` maps
+that onto `PRTE_SUCCESS`. **Any PMIx call in this file whose completion
+callback is `NULL` can return `PMIX_OPERATION_SUCCEEDED`; test for both.**
 
 ---
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1098,7 +1098,18 @@ int pmix_server_init(void)
     ninfo = darray.size;
     prc = PMIx_server_register_resources(info, ninfo, NULL, NULL);
     PMIX_INFO_FREE(info, ninfo);
-    if (PMIX_SUCCESS != prc) {
+    /* the blocking form of this call reports success as
+     * PMIX_OPERATION_SUCCEEDED, not PMIX_SUCCESS. Treating that as a
+     * failure returned from here with everything below it skipped - and
+     * because prte_pmix_convert_status maps OPERATION_SUCCEEDED onto
+     * PRTE_SUCCESS, the caller saw a clean init and nothing complained.
+     * What silently went missing were the two event handlers registered
+     * below, most consequentially "lost connection": without it a daemon
+     * never learns that a tool departed, so the tool's job object is
+     * never terminated and any allocation it reserved is never disposed
+     * of - the nodes stay withheld from the general pool for the life of
+     * the DVM, unusable by anyone. */
+    if (PMIX_SUCCESS != prc && PMIX_OPERATION_SUCCEEDED != prc) {
         return prte_pmix_convert_status(prc);
     }
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -574,20 +574,21 @@ static void _lost_conn(int sd, short args, void *cbdata)
 
      // check the source to see if it is a client or tool
      jdata = prte_get_job_data_object(cd->proc.nspace);
-     if (NULL == jdata) {
-        // we don't know this job
-        goto complete;
-     }
-
-     if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+     if (NULL != jdata && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
         // client - do nothing, the ODLS will see it go away
         goto complete;
      }
 
-     // tool - since the tool isn't a child of ours, we cannot
-     // see a waitpid fire, so this is the only notice we will
-     // receive that the tool is no longer connected to us
-     PRTE_ACTIVATE_PROC_STATE(&cd->proc, PRTE_PROC_STATE_TERMINATED);
+     // Either a tool, or a peer we hold no job object for - which on a
+     // daemon other than the master is what a tool looks like, since only
+     // the master keeps one. Not knowing the job is therefore not a reason
+     // to do nothing here; prte_pmix_server_tool_departed() decides, and on
+     // the master it re-checks the TOOL flag before acting.
+     //
+     // A tool isn't a child of ours, so we cannot see a waitpid fire: this
+     // is the only notice we get that a tool has dropped without finalizing
+     // (a clean finalize arrives as the client_finalized upcall instead).
+     prte_pmix_server_tool_departed(&cd->proc);
 
 complete:
     // progress the PMIx event notification chain

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -511,6 +511,7 @@ static void _toolconn(int sd, short args, void *cbdata)
     prte_pmix_server_req_t *cd = (prte_pmix_server_req_t *) cbdata;
     int rc;
     char *tmp;
+    uint32_t u32;
     size_t n;
     pmix_data_buffer_t *buf;
     prte_plm_cmd_flag_t command = PRTE_PLM_TOOL_ATTACHED_CMD;
@@ -698,6 +699,20 @@ static void _toolconn(int sd, short args, void *cbdata)
     }
     // and the pid
     rc = PMIx_Data_pack(NULL, buf, &cd->pid, 1, PMIX_PID);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    // and who is running it - the master records this on the tool's job so a
+    // reservation the tool creates can be reached by another command the same
+    // user runs. Only the master keeps a job object for a tool, so this is the
+    // only chance to tell it.
+    u32 = (uint32_t) cd->uid;
+    rc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    u32 = (uint32_t) cd->gid;
+    rc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -193,6 +193,58 @@ pmix_status_t pmix_server_client_connected2_fn(const pmix_proc_t *proc,
     return PRTE_SUCCESS;
 }
 
+/* Report that a tool has left us.
+ *
+ * On the DVM master the tool's job object is right here, so drive its proc
+ * into TERMINATED and let the state machine retire the namespace. Anywhere
+ * else there is nothing local to drive: a daemon relays a tool connection to
+ * the master and keeps no job object of its own, so the departure has to
+ * travel the same way the connection did. It goes as its own command rather
+ * than as a proc-state update because only the master can tell a tool from
+ * anything else it holds - it checks the job's TOOL flag before acting on
+ * this, and an update naming a namespace it could not vet would be a way to
+ * terminate somebody else's job.
+ *
+ * Getting this wrong is quiet rather than loud: the master is told the tool
+ * arrived and never told it left, so the tool's job object - and any
+ * allocation it reserved - outlives it by the life of the DVM.
+ */
+void prte_pmix_server_tool_departed(pmix_proc_t *tool)
+{
+    pmix_data_buffer_t *alert;
+    prte_plm_cmd_flag_t cmd = PRTE_PLM_TOOL_DEPARTED_CMD;
+    prte_job_t *jdata;
+    pmix_status_t ret;
+    int rc;
+
+    if (PRTE_PROC_IS_MASTER) {
+        jdata = prte_get_job_data_object(tool->nspace);
+        if (NULL != jdata && PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+            PRTE_ACTIVATE_PROC_STATE(tool, PRTE_PROC_STATE_TERMINATED);
+        }
+        return;
+    }
+
+    PMIX_DATA_BUFFER_CREATE(alert);
+    ret = PMIx_Data_pack(NULL, alert, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(alert);
+        return;
+    }
+    ret = PMIx_Data_pack(NULL, alert, tool, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(alert);
+        return;
+    }
+    PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_HNP->rank, alert, PRTE_RML_TAG_PLM);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(alert);
+    }
+}
+
 static void _client_finalized(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
@@ -202,11 +254,27 @@ static void _client_finalized(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     if (NULL != cd->server_object) {
-        /* we were passed back the prte_proc_t */
+        /* we were passed back the prte_proc_t - so this is a process we
+         * launched, and the ODLS will see it go away. Nothing more to do:
+         * its termination is driven by waitpid and IOF completion, and
+         * declaring it terminated here would do so before either. */
         p = (prte_proc_t *) cd->server_object;
         PRTE_FLAG_SET(p, PRTE_PROC_FLAG_HAS_DEREG);
+        goto release;
     }
 
+    /* No server object means we did not register this peer as a client of
+     * ours - it attached as a tool. A tool that finalized cleanly gets us
+     * here and nowhere else: it is not a child, so no waitpid fires for it,
+     * and the connection drop that follows raises no lost-connection event
+     * either, because PMIx has already marked the peer finalized. Nothing
+     * else would ever retire the tool's job object - and with it the
+     * inheritance disposition that hangs off the owning namespace
+     * terminating, which is what hands the nodes of an allocation the tool
+     * reserved back to the general pool. */
+    prte_pmix_server_tool_departed(&cd->proc);
+
+release:
     /* release the caller */
     if (NULL != cd->cbfunc) {
         cd->cbfunc(PMIX_SUCCESS, cd->cbdata);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -45,7 +45,6 @@
 #include "src/mca/iof/iof.h"
 #include "src/mca/plm/base/plm_private.h"
 #include "src/mca/plm/plm.h"
-#include "src/mca/plm/base/plm_private.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/rml/rml.h"
 #include "src/mca/schizo/schizo.h"

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -236,6 +236,10 @@ PRTE_EXPORT extern pmix_status_t pmix_server_client_finalized_fn(const pmix_proc
                                                                  void *server_object,
                                                                  pmix_op_cbfunc_t cbfunc,
                                                                  void *cbdata);
+/* Retire a tool that has left us - locally if we are the DVM master, else by
+ * telling the master, which is the only place a tool's job object lives. */
+PRTE_EXPORT void prte_pmix_server_tool_departed(pmix_proc_t *tool);
+
 PRTE_EXPORT extern pmix_status_t pmix_server_abort_fn(const pmix_proc_t *proc, void *server_object,
                                                       int status, const char msg[],
                                                       pmix_proc_t procs[], size_t nprocs,

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -874,6 +874,11 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     jdata = PMIX_NEW(prte_job_t);
     PMIX_LOAD_NSPACE(jdata->nspace, cd->target.nspace);
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
+    /* remember who ran this tool - a tool's namespace lasts only as long as
+     * the command, so the user is the durable half of its identity and is
+     * what lets a later command of theirs reach an allocation this one made */
+    jdata->uid = cd->uid;
+    jdata->gid = cd->gid;
     rc = prte_set_job_data_object(jdata);
     app = PMIX_NEW(prte_app_context_t);
     app->argv = PMIx_Argv_split(cd->cmdline, ' ');

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1356,7 +1356,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
      * get properly recorded - e.g., forwarding IOF */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
     ret = PMIx_Spawn_nb(iptr, ninfo, papps, napps, spcbfunc, &lock);
-    if (PRTE_SUCCESS != ret) {
+    if (PMIX_SUCCESS != ret) {
         pmix_output(0, "PMIx_Spawn failed (%d): %s", ret, PMIx_Error_string(ret));
         rc = ret;
         PRTE_UPDATE_EXIT_STATUS(rc);

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -711,7 +711,7 @@ int prun_common(pmix_cli_result_t *results,
     }
 
     ret = PMIx_Spawn(iptr, ninfo, papps, napps, spawnednspace);
-    if (PRTE_SUCCESS != ret) {
+    if (PMIX_SUCCESS != ret) {
         pmix_output(0, "PMIx_Spawn failed (%d): %s", ret, PMIx_Error_string(ret));
         rc = ret;
         goto DONE;

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -139,7 +139,20 @@ unreserved pool; it is special-cased everywhere:
 - `prte_ras_base_release_allocation` returns immediately for it.
 
 `prte_session_is_owned_by` is the ownership gate for spawning into a
-reservation. Note the trap it stepped in: **`PMIX_CHECK_NSPACE` answers
+reservation, and it answers on **two** identities. The namespace test — the
+`owners[]` array, seeded with the requester and extended with each job
+spawned in — is what keeps other jobs in the DVM out of somebody else's
+allocation, and for a job it is the whole answer. It cannot be the whole
+answer for a **tool**: a tool namespace is minted per invocation, so the
+reservation a user's first command created could never be named by their
+second, and once the first exited its namespace was gone and the allocation
+was unreachable by anyone. So a reservation also records `owner_uid`, and a
+job flagged `PRTE_JOB_FLAG_TOOL` carrying that uid passes. `prte_job_t.uid`
+is recorded when a tool connects (from the `PMIX_USERID` it presents) and
+descends the job tree from there, so an allocation an *application* requests
+is attributed to the user who launched it rather than to nobody.
+
+Note the trap this function stepped in: **`PMIX_CHECK_NSPACE` answers
 "true" when either side is an empty nspace** — that is its wildcard rule.
 `prte_pmix_server_globals.scheduler.nspace` is empty until a scheduler
 connects, so testing it unguarded declared every namespace to be the

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -700,6 +700,8 @@ static void prte_job_construct(prte_job_t *job)
     PMIX_DATA_BUFFER_CONSTRUCT(&job->launch_msg);
     PMIX_CONSTRUCT(&job->children, pmix_list_t);
     PMIX_LOAD_NSPACE(job->launcher, NULL);
+    job->uid = PRTE_INVALID_UID;
+    job->gid = PRTE_INVALID_GID;
     job->target_sessions = NULL;
     job->num_target_sessions = 0;
     job->ntraces = 0;
@@ -1040,6 +1042,7 @@ static void session_con(prte_session_t *s)
     PMIX_LOAD_NSPACE(s->owner, NULL);
     s->owner_job = NULL;
     PMIX_LOAD_PROCID(&s->requestor, NULL, PMIX_RANK_INVALID);
+    s->owner_uid = PRTE_INVALID_UID;
     s->inheritance = PRTE_INHERIT_DEFAULT_VALUE;
 }
 static void session_des(prte_session_t *s)
@@ -1125,6 +1128,7 @@ PMIX_CLASS_INSTANCE(prte_session_t,
 bool prte_session_is_owned_by(prte_session_t *session,
                               const pmix_nspace_t nspace)
 {
+    prte_job_t *jdata;
     int n;
 
     /* the default session is usable by everyone */
@@ -1142,15 +1146,34 @@ bool prte_session_is_owned_by(prte_session_t *session,
         PMIX_CHECK_NSPACE(prte_pmix_server_globals.scheduler.nspace, nspace)) {
         return true;
     }
-    if (NULL == session->owners) {
-        return false;
-    }
-    for (n = 0; NULL != session->owners[n]; n++) {
-        if (PMIX_CHECK_NSPACE(session->owners[n], nspace)) {
-            return true;
+    if (NULL != session->owners) {
+        for (n = 0; NULL != session->owners[n]; n++) {
+            if (PMIX_CHECK_NSPACE(session->owners[n], nspace)) {
+                return true;
+            }
         }
     }
-    return false;
+
+    /* The namespace test above is what keeps other JOBS in this DVM out of
+     * somebody else's allocation, and it is the whole answer for them. It is
+     * not the whole answer for a TOOL: a tool namespace is minted per
+     * invocation, so the reservation a user's first command created could
+     * never be named by their second one - and once that first command
+     * exited, its namespace was gone and the allocation was unreachable by
+     * anybody at all. The user is the other half of the identity here, so a
+     * tool presenting the uid the reservation was granted to may act on it:
+     * spawn into it, extend it, release it. An application job never reaches
+     * this - it is not a tool, and its namespace is its identity. */
+    if (PRTE_INVALID_UID == session->owner_uid) {
+        return false;
+    }
+    jdata = prte_get_job_data_object(nspace);
+    if (NULL == jdata ||
+        !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL) ||
+        PRTE_INVALID_UID == jdata->uid) {
+        return false;
+    }
+    return (jdata->uid == session->owner_uid);
 }
 
 void prte_session_add_owner(prte_session_t *session,

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -86,6 +86,12 @@ PRTE_EXPORT extern bool prte_elastic_mode;
 PRTE_EXPORT extern hwloc_cpuset_t
     prte_proc_applied_binding; /* instantiated in src/runtime/prte_init.c */
 
+/* "no user recorded". uid_t/gid_t are unsigned, and (uid_t)-1 is the value
+ * the setresuid family already reserves for "leave this alone", so no real
+ * account can carry it. */
+#define PRTE_INVALID_UID ((uid_t) -1)
+#define PRTE_INVALID_GID ((gid_t) -1)
+
 /* Shortcut for some commonly used names */
 #define PRTE_NAME_WILDCARD (&prte_name_wildcard)
 PRTE_EXPORT extern pmix_proc_t prte_name_wildcard; /** instantiated in src/runtime/prte_init.c */
@@ -248,6 +254,14 @@ typedef struct{
     /* The process that requested this allocation (req->tproc). Target of the
      * relayed PMIX_ALLOC_TIMEOUT_WARNING. Refreshed on EXTEND. */
     pmix_proc_t requestor;
+    /* The user the reservation was granted to, taken from the requesting
+     * tool's connection. A namespace owns the reservation, but the USER owns
+     * it too: a tool namespace lasts only as long as the command that made
+     * it, so without this the allocation would be unusable by every later
+     * command the same person ran - including the one that releases it.
+     * PRTE_INVALID_UID when the requester presented no identity, which
+     * matches nothing. */
+    uid_t owner_uid;
     /* Disposition recorded at creation, governing teardown when the owning
      * namespace (NONE/DEFAULT) or the last derived child (CHILD/CHILD_DEFAULT)
      * terminates. Stored as the uint8_t underlying pmix_alloc_inheritance_t so
@@ -428,6 +442,16 @@ typedef struct prte_job_t {
     pmix_list_t children;
     /* track the launcher of these jobs */
     pmix_nspace_t launcher;
+    /* The user this job belongs to. Recorded only for a TOOL job, from the
+     * PMIX_USERID/PMIX_GRPID the tool presented when it connected, and left
+     * PRTE_INVALID_UID/GID everywhere else - an application job's identity is
+     * its namespace, and nothing consults these for one. HNP-local; never
+     * packed. This is what lets a reservation be reached by a LATER tool the
+     * same user ran: a tool namespace is minted per invocation, so namespace
+     * identity alone would make an allocation unusable by everything except
+     * the one command that asked for it. */
+    uid_t uid;
+    gid_t gid;
     /* Sessions this job may map onto, resolved from PRTE_JOB_SPAWN_TARGET on the
      * HNP after the ownership check. HNP-local; never packed (rebuilt from the
      * attribute if ever needed). Defaults to { jdata->session } when no spawn

--- a/test/unit/pmix/test_pmix.c
+++ b/test/unit/pmix/test_pmix.c
@@ -368,6 +368,18 @@ static int test_status_known_collisions(void)
     CHECK("not-available is not a checkpoint",
           PRTE_ERR_PROC_CHECKPOINT != prte_pmix_convert_status(PMIX_ERR_NOT_AVAILABLE));
 
+    /* "you may not" and "I could not get there" used to share
+     * PMIX_ERR_UNREACH, so a job refused by the allocation ownership check
+     * reached the user as a connectivity failure. */
+    CHECK("a permission failure says so",
+          PMIX_ERR_NO_PERMISSIONS == prte_pmix_convert_rc(PRTE_ERR_PERM));
+    CHECK("a permission failure is not unreachable",
+          PMIX_ERR_UNREACH != prte_pmix_convert_rc(PRTE_ERR_PERM));
+    CHECK("unreachable is still unreachable",
+          PMIX_ERR_UNREACH == prte_pmix_convert_rc(PRTE_ERR_UNREACH));
+    CHECK("no-permissions comes back as a permission failure",
+          PRTE_ERR_PERM == prte_pmix_convert_status(PMIX_ERR_NO_PERMISSIONS));
+
     return failures;
 }
 
@@ -402,6 +414,8 @@ static int test_status_roundtrip(void)
         PRTE_ERR_PROC_MIGRATE,
         PRTE_ERR_EVENT_REGISTRATION,
         PRTE_ERR_DATA_VALUE_NOT_FOUND,
+        PRTE_ERR_PERM,
+        PRTE_ERR_UNREACH,
         PRTE_SUCCESS,
     };
     size_t n;


### PR DESCRIPTION
A DVM is told when a tool connects to it and is never told when one goes
away. Following that out turned up the reason a grown node could not be
used, and four more defects on the way.

**Depends on openpmix/openpmix#4057** for the clean-departure half; the
rest stands alone, and the harness cases that need the capability skip
without it.

### What was wrong

**The daemon's event handlers were never registered.** The blocking form of
`PMIx_server_register_resources` reports success as
`PMIX_OPERATION_SUCCEEDED`; `pmix_server_init` tested only for
`PMIX_SUCCESS` and returned on anything else — and since
`prte_pmix_convert_status` maps `OPERATION_SUCCEEDED` onto `PRTE_SUCCESS`,
the caller saw a clean init. Every daemon silently lost its lost-connection
handler and the allocation-timeout relay, with nothing visible at either
end. A swept check of every other PMIx call site that can return
`OPERATION_SUCCEEDED` found no second instance.

**A departing tool was never noticed.** A tool is nobody's child, so no
waitpid fires; and PMIx raises no lost-connection event for a peer that
finalized cleanly. So the tool's job object accumulated — one per `prun` —
for the life of the DVM, and with it went the disposition of any allocation
the tool had reserved. That disposition is keyed on the owning namespace
terminating, so it never fired: the nodes of a command-line `elastic grow`
stayed out of the general pool permanently *and* were unreachable through
the reservation, since the only namespace allowed to name it no longer
existed.

**Only the master holds a tool's job object,** so a tool that attached
through any other daemon could not be retired at all. New
`PRTE_PLM_TOOL_DEPARTED_CMD` relays it; the master vets the job's `TOOL`
flag before acting, since the reporting daemon can only say "this peer was
not a client of mine".

**A reservation was reachable only by the command that made it.** Ownership
was namespace-only, and a tool's namespace is minted per invocation — so a
user's second command could never name the allocation their first one
created, and nobody could once that command exited. Ownership is now
namespace *and* uid: the namespace test still keeps other jobs out, and a
job flagged `TOOL` presenting the reservation's uid may spawn into it,
extend it or release it. The uid comes from the `PMIX_USERID` a tool
presents and descends the job tree, so an allocation an application
requests is attributed to whoever launched it.

**An unanswered daemon was read as a dead one.** Failing to send to a
daemon that has not yet reported took the whole DVM down —
`PRTE_PROC_STATE_PEER_UNKNOWN` is not among the states the errmgr handles,
so it reached the "unsupported daemon error state" fallback, which forces
`DAEMONS_TERMINATED`. Any job terminating while daemons are being added
produces it, because the completion notice is xcast over a routing tree
that already contains them. Note the test for "has not reported" is
`NULL == proc->rml_uri`: `plm/ssh` sets both `PRTE_PROC_FLAG_ALIVE` and a
`RUNNING` state when it *records* a launch, so neither of those can serve.

**A permission failure was reported as unreachable.** `PRTE_ERR_PERM`
converted to `PMIX_ERR_UNREACH` (and back the other way), so a job refused
by the ownership check reached the user as a connectivity failure. It is
now `PMIX_ERR_NO_PERMISSIONS`, in both directions.

Two drive-by fixes ride along as their own commits: `PMIx_Spawn`'s return
compared against `PRTE_SUCCESS` in two places, and a duplicated include.

### Testing

`contrib/dockerswarm` gains three cases and a `pmix_cap` gate that skips
the ones an older PMIx cannot produce:

- a departing tool's reservation returns to the general pool;
- the user who reserved an allocation can spawn into it from a separate
  `prun --alloc-id`, while an unknown id is still `NOT_FOUND`;
- **the assertion this started from** — after shrinking the topology
  reporter out of a `--uniform-nodes` DVM, a plain `prun --host node4:2`
  runs on the grown node, which it can only do if that node inherited a
  topology from a survivor. That case previously had to spawn from inside
  the `elastic` client because no separate tool could reach the
  reservation.

Full suite 351 passed / 0 failed / 0 skipped, `make check` green across all
21 unit binaries (`test/unit/pmix` gains the permission/unreachable
assertions), warning-free `--enable-debug` build.
