### PR TITLE
Make I/O work for a tool attached to a non-master daemon (fixes #2568)

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -288,6 +288,27 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                        [$prte_pmix_cli_order],
                        [Whether PMIx records where each command line option occurred])
 
+    dnl A tool can attach to any daemon, not just the DVM master, and the
+    dnl output of the job it launches has to reach it there.  The master is
+    dnl the only process that sees all of a job's output, so it relays a
+    dnl copy to the daemon hosting the tool - but that daemon must hand the
+    dnl copy to its PMIx server WITHOUT emitting it, since the daemon that
+    dnl actually hosts those processes has already written whatever the
+    dnl output directives called for.  Two servers writing one --output file
+    dnl is the failure that guards against.  PMIx has to be able to be told
+    dnl that per delivery; without it we cannot relay safely and a tool on a
+    dnl non-master daemon sees only the output of processes its own daemon
+    dnl happens to host.
+    AC_MSG_CHECKING([for PMIx per-delivery IOF local-output control])
+    PRTE_CHECK_PMIX_CAP([IOF_DELIVER_LOCAL],
+                        [AC_MSG_RESULT([yes])
+                         prte_pmix_iof_deliver_local=1],
+                        [AC_MSG_RESULT([no])
+                         prte_pmix_iof_deliver_local=0])
+    AC_DEFINE_UNQUOTED([PRTE_PMIX_IOF_DELIVER_LOCAL],
+                       [$prte_pmix_iof_deliver_local],
+                       [Whether PMIx honors PMIX_IOF_LOCAL_OUTPUT on an IOF delivery])
+
     AC_MSG_CHECKING([for LTO compatibility])
     PRTE_CHECK_PMIX_CAP([LTO],
                         [PRTE_PMIX_LTO_CAPABILITY=1

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -80,6 +80,12 @@ bounded() {
 RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
             "${NODE}1" bash -lc ". /opt/prte/env.sh; $*"; }
 ON()  { docker exec "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+# ...and the same for a case that drives a TOOL from a node other than the
+# head. ON alone is enough for shell housekeeping, but every PRRTE tool
+# refuses to run as root without these two, and the refusal text is long
+# enough to bury whatever the case was actually asserting.
+ONT() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "$NODE$1" bash -lc ". /opt/prte/env.sh; ${*:2}"; }
 
 # What must not survive into the next test, on one node.  Each tool has its
 # OWN session-dir prefix -- prte.<pid> for the HNP, prtrn.<pid> for prterun,
@@ -2003,6 +2009,105 @@ test_prted() {
             bad "could not get two concurrent jobs running on node2 (saw $n procs)"
         fi
         RUN 'pkill -f "sleep 120"' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "prted: a tool attached to a NON-MASTER daemon completes its job"
+    # A prun started on a compute node of a persistent DVM, with no --dvm-uri,
+    # finds its LOCAL daemon's rendezvous file and attaches there instead of to
+    # the HNP.  Everything about that tool then runs through the relay paths:
+    # tool-connect goes to the master as PRTE_PLM_TOOL_ATTACHED_CMD, the spawn
+    # goes as a relayed request, and -- the part that broke -- the stdin the
+    # tool pushes goes to its own daemon's iof module.  Only the HNP module
+    # implemented push_stdin, so on any other daemon that was a NULL call: the
+    # daemon segfaulted, and the tool, whose PMIx server had just died, waited
+    # for a PMIX_EVENT_JOB_END that could no longer reach it.  Issue #2568.
+    #
+    # Every prun pushes stdin even with nothing to send -- the zero-byte
+    # end-of-input marker -- so this needs no piped input to reproduce.  Run it
+    # WITHOUT --dvm-uri, deliberately: pointing the tool at the master's URI is
+    # exactly what the test must not do.
+    cleanup_swarm
+    if ! prted_dvm_start 'node1:2,node2:2,node3:2'; then
+        bad "could not start a DVM for the non-master tool test"
+    else
+        out=$(ONT 2 'timeout -k 5 45 prun --host node2:1 -n 1 hostname 2>&1; echo RC=$?')
+        echo "$out" | grep -q 'RC=0' \
+            && ok "a tool attached to node2's daemon saw its job end and exited" \
+            || bad "tool on a non-master daemon did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        echo "$out" | grep -qE '^node2$' \
+            && ok "...and its job's output reached it" \
+            || bad "...but the job produced no output: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        n=$(prted_count 2)
+        [ "$n" = 1 ] \
+            && ok "...and node2's daemon survived the tool's stdin push" \
+            || bad "node2's daemon died while the tool pushed stdin"
+
+        # ...and the stdin itself has to arrive, not merely fail to crash.  Send
+        # it to a proc on ANOTHER node, so the daemon's relay to the HNP and the
+        # HNP's routing back out are both exercised; read the result from the
+        # file rather than the terminal, because output from a proc the tool's
+        # own daemon does not host has no path back to that tool.
+        ON 1 'rm -f /tmp/tool-stdin.txt' >/dev/null 2>&1
+        ONT 2 'printf "STDIN-RELAY-OK\n" | timeout -k 5 45 prun --host node1:1 -n 1 sh -c "cat > /tmp/tool-stdin.txt"' >/dev/null 2>&1
+        out=$(ON 1 'cat /tmp/tool-stdin.txt 2>&1')
+        echo "$out" | grep -q 'STDIN-RELAY-OK' \
+            && ok "stdin pushed through a non-master daemon reached a proc on another node" \
+            || bad "stdin was lost on the relay to the HNP: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        # A second tool on the same node must still find exactly one server.
+        # The hung prun of #2568 never released its own pmix.* rendezvous file,
+        # so the next tool reported "multiple possible servers" and gave up --
+        # which is how the hang first showed itself, looking nothing like its
+        # cause.
+        out=$(ONT 2 'timeout -k 5 45 prun --host node2:1 -n 1 hostname 2>&1; echo RC=$?')
+        echo "$out" | grep -q 'RC=0' \
+            && ok "a second tool on that node still finds exactly one server" \
+            || bad "a stale rendezvous file blocked the next tool: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        # ...and the OTHER direction.  A daemon hands its own procs' output to
+        # its own PMIx server, so a tool has always seen the ranks that landed
+        # on its own node -- which is exactly what hid the gap: the symptom was
+        # PARTIAL output, not none.  Put the tool on node3 and the ranks on
+        # node1 and node2, so every byte it should see has to come back out
+        # from the master.  node1 is the HNP (its own children take the
+        # read-handler path) and node2 is an ordinary daemon (the forwarded
+        # path); both relay points are covered by requiring both names.
+        out=$(ONT 3 'timeout -k 5 45 prun --host node1:1,node2:1 -n 2 --map-by node hostname 2>&1')
+        if echo "$out" | grep -qE '^node1$' && echo "$out" | grep -qE '^node2$'; then
+            ok "a tool on a non-master daemon saw output from ranks on both other nodes"
+        else
+            bad "output never reached the tool on node3: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+
+        # Every line exactly once.  The relay skips the daemon that already
+        # delivered a chunk to its own PMIx server, and if that dedup were
+        # dropped a tool would see its own node's ranks twice.
+        out=$(ONT 2 'timeout -k 5 60 prun --host node1:2,node2:2,node3:2 -n 6 --map-by node sh -c "for i in \$(seq 1 50); do echo RELAYLINE-\$i; done" 2>&1')
+        n=$(echo "$out" | grep -c '^RELAYLINE-')
+        u=$(echo "$out" | grep '^RELAYLINE-' | sort | uniq -c | awk '{print $1}' | sort -u | tr '\n' ' ')
+        [ "$n" = 300 ] && [ "$u" = "6 " ] \
+            && ok "300 lines from 6 ranks reached the tool, each exactly once" \
+            || bad "relayed output was lost or duplicated (got $n lines, per-line counts '$u'; expected 300 and '6 ')"
+
+        # The relayed copy must not be EMITTED where it lands.  Every daemon
+        # registers the job's namespace with the same output directives, so a
+        # daemon handed another node's output writes its own copy of that
+        # rank's file unless the delivery says not to -- and node3 hosts none
+        # of these ranks, so any file appearing there is a duplicate of one
+        # node1 or node2 already wrote.  Measured, not assumed: flipping the
+        # PMIX_IOF_LOCAL_OUTPUT directive to true puts a full set here.
+        for i in 1 2 3; do ON $i 'rm -rf /tmp/relayout; mkdir -p /tmp/relayout' >/dev/null 2>&1; done
+        ONT 3 'timeout -k 5 45 prun --output file=/tmp/relayout/out --host node1:1,node2:1 -n 2 --map-by node hostname' >/dev/null 2>&1
+        n=$(ON 3 'find /tmp/relayout -type f 2>/dev/null | wc -l' | tr -d ' \r')
+        m=$(ON 2 'find /tmp/relayout -type f 2>/dev/null | wc -l' | tr -d ' \r')
+        [ "$n" = 0 ] \
+            && ok "the tool's daemon wrote no output files for ranks it does not host" \
+            || bad "relayed output was emitted on the tool's node too ($n files); two daemons are writing one --output file"
+        [ "$m" = 1 ] \
+            && ok "...and the daemon that does host a rank still wrote its file" \
+            || bad "output-to-file broke on the hosting daemon ($m files, expected 1)"
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3365,6 +3365,56 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             && ok "large stdin ($insz bytes) survived a SLOW HNP-local reader (short writes)" \
             || bad "slow-reader stdin corrupted on the HNP (rc=$rc, sent=$insz received=$got, md5 $insum vs $outsum): $(RUN 'head -c 200 /tmp/iof_slow_err.txt')"
 
+        # --- output-to-file: the terminal is supposed to stay CLEAN ---------
+        # NOCOPY is the documented default for --output (see
+        # docs/prrte-rst-content/cli-output.rst), so "file=" means the output
+        # goes to files and NOT to the tool's stdout.  It leaked: a tool learns
+        # that its spawned job is not to be written locally only when the spawn
+        # REPLY lands, and output arriving before that found no namespace record
+        # and fell back to the process-wide flag - which for a tool says "yes,
+        # write it".  So a nondeterministic subset of the job appeared on a
+        # terminal the user had asked to keep quiet: whichever ranks' first
+        # chunk beat the reply, typically one rank in two.
+        #
+        # That is why this runs several times.  A single pass is not evidence:
+        # before the fix the same command printed nothing on roughly a third of
+        # runs, so one clean run proves nothing at all.
+        if ! pmix_cap PMIX_CAP_IOF_DELIVER_LOCAL; then
+            # No flag marks this fix by itself; this one stands in for "a PMIx
+            # carrying the IOF work these cases assert", and the baked PMIx
+            # goes stale as a matter of course (see AGENTS.md).
+            skp "PMIx predates the output-file terminal fix -- skipping"
+        else
+            RUN 'rm -rf /tmp/ofterm; mkdir -p /tmp/ofterm' >/dev/null 2>&1
+            ON 2 'rm -rf /tmp/ofterm; mkdir -p /tmp/ofterm' >/dev/null 2>&1
+            leaked=0
+            copied=0
+            for i in 1 2 3 4 5; do
+                n=$(RUN 'timeout -k 5 45 prun --output file=/tmp/ofterm/out \
+                             --host node1:1,node2:1 -n 2 --map-by node hostname 2>&1' \
+                        | grep -cE '^node[12]$')
+                [ "$n" = 0 ] || leaked=$((leaked+1))
+                n=$(RUN 'timeout -k 5 45 prun --output file=/tmp/ofterm/out:copy \
+                             --host node1:1,node2:1 -n 2 --map-by node hostname 2>&1' \
+                        | grep -cE '^node[12]$')
+                [ "$n" = 2 ] && copied=$((copied+1))
+            done
+            [ "$leaked" = 0 ] \
+                && ok "--output file= kept the terminal clean on all 5 runs" \
+                || bad "--output file= leaked job output to the terminal on $leaked of 5 runs"
+            [ "$copied" = 5 ] \
+                && ok "...and the copy qualifier still delivers every rank" \
+                || bad "--output file=:copy delivered both ranks on only $copied of 5 runs"
+            # the files themselves must still be there - "clean terminal" must
+            # not have been achieved by dropping the output on the floor
+            n=$(RUN 'ls /tmp/ofterm | wc -l' | tr -d ' \r')
+            [ "$n" -gt 0 ] \
+                && ok "...and the output files were written ($n on the head node)" \
+                || bad "--output file= wrote no files at all"
+            RUN 'rm -rf /tmp/ofterm' >/dev/null 2>&1
+            ON 2 'rm -rf /tmp/ofterm' >/dev/null 2>&1
+        fi
+
         RUN 'rm -f /tmp/iof_stdin_in.txt /tmp/iof_stdin_out.txt /tmp/iof_stdin_err.txt \
                    /tmp/iof_slow_out.txt /tmp/iof_slow_err.txt' >/dev/null 2>&1
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1

--- a/src/mca/iof/AGENTS.md
+++ b/src/mca/iof/AGENTS.md
@@ -46,6 +46,8 @@ functions gate on process type, so only one ever returns a module. See
    │  read_handler: read(fd) ──► PMIx_server_IOF_deliver (local echo)   │
    │              └──► pack+RML ─► HNP (PRTE_RML_TAG_IOF_HNP)           │
    │  recv (PRTE_RML_TAG_IOF_PROXY): stdin ─► write_output ─► proc pipe │
+   │            ...and relayed output ─► PMIx_server_IOF_deliver        │
+   │  push_stdin (from an attached tool): ─► RML relay to the HNP       │
    └──────────────────────────────────────────────────┘
                     │ RML                        ▲ RML
                     ▼                            │
@@ -53,6 +55,7 @@ functions gate on process type, so only one ever returns a module. See
    │  hnp iof (DVM master)                             │
    │  recv (PRTE_RML_TAG_IOF_HNP): ─► PMIx_server_IOF_deliver           │
    │  read_local_handler (my own children): ─► PMIx_server_IOF_deliver  │
+   │  relay_to_tool: ─► RML to the daemon hosting the launching tool    │
    │  push_stdin: ─► RML to hosting daemon / local proc pipe            │
    └──────────────────────────────────────────────────┘
                     │
@@ -74,7 +77,10 @@ historical [`README.txt`](README.txt) and the stale docstrings in
 [`iof.h`](iof.h) get wrong relative to today's code.
 
 There is **no proxy-to-proxy traffic**: a daemon never sends output to
-another daemon. Everything funnels HNP-ward and the HNP fans back out.
+another daemon. Everything funnels HNP-ward and the HNP fans back out —
+stdin to the daemon hosting the target, and output to the daemon hosting a
+tool that asked for it. See [A tool is not always on the
+master](#a-tool-is-not-always-on-the-master).
 
 ---
 
@@ -118,7 +124,7 @@ struct prte_iof_base_module_2_0_0_t {
     prte_iof_base_close_fn_t      close;       /* (peer, tag) -> int */
     prte_iof_base_complete_fn_t   complete;    /* (jdata) -> void */
     prte_iof_base_finalize_fn_t   finalize;    /* void -> int */
-    prte_iof_base_push_stdin_fn_t push_stdin;  /* (dst, data, sz) -> int (hnp only) */
+    prte_iof_base_push_stdin_fn_t push_stdin;  /* (dst, data, sz) -> int */
 };
 ```
 
@@ -130,7 +136,7 @@ struct prte_iof_base_module_2_0_0_t {
 | `close` | Tear down the read events and/or sink for the named peer for the streams in `source_tag`; drop the proc from `procs` once all three are gone. | teardown paths |
 | `complete` | Job finished: purge any lingering `prte_iof_proc_t`s belonging to `jdata->nspace`. | `state` machine on `JOB`/`PROC` completion |
 | `finalize` | Cancel the RML receive and destruct the `procs` list. | framework close |
-| `push_stdin` | **Inject stdin.** HNP-only: route a chunk of stdin to a target proc (or wildcard) — to the hosting daemon over RML, or to a local proc's sink. `NULL` in the `prted` module. | PMIx server glue (`pmix_server_gen.c`) |
+| `push_stdin` | **Inject stdin.** Deliver a chunk of stdin to a target proc (or wildcard). In the `hnp` module that means routing it — to the hosting daemon over RML, or to a local proc's sink. In the `prted` module it means relaying to the HNP, which is the only process that can do the routing. Implemented in **both**; a tool can attach to any daemon. | PMIx server glue (`pmix_server_gen.c`) |
 
 Note the naming is a little counter-intuitive and the [`iof.h`](iof.h)
 docstrings are stale: **`push` handles the OUTPUT (read) side**, **`pull`
@@ -139,6 +145,10 @@ header prose.
 
 `init`/`finalize`/`push_stdin`/`complete` may legitimately be `NULL` in a
 module; the base and callers all guard with `if (NULL != prte_iof.xxx)`.
+Both shipped modules do fill all seven — `push_stdin` was `NULL` in `prted`
+until a tool attaching to a non-master daemon turned that into a segfault
+([#2568](https://github.com/openpmix/prrte/issues/2568)) — but the guards
+are the contract, so keep them.
 
 ---
 
@@ -310,8 +320,55 @@ Called by `odls` around the `fork()` of each app proc:
 - `prte_iof` (in [`iof_base_frame.c`](base/iof_base_frame.c)) is the
   selected module; everything outside the framework calls through it
   (`prte_iof.push_stdin(...)`, `prte_iof.complete(...)`).
-- `PRTE_RML_TAG_IOF_HNP` — daemons → HNP (forwarded output and XON/XOFF).
-- `PRTE_RML_TAG_IOF_PROXY` — HNP → daemons (stdin, and xcast stdin to all).
+- `PRTE_RML_TAG_IOF_HNP` — daemons → HNP (forwarded output, XON/XOFF, and
+  stdin a daemon is relaying on behalf of a tool attached to it; the leading
+  stream tag is what tells the three apart).
+- `PRTE_RML_TAG_IOF_PROXY` — HNP → daemons (stdin, xcast stdin to all, and
+  output relayed to the daemon hosting a launching tool; again the leading
+  stream tag distinguishes them).
+
+---
+
+## A tool is not always on the master
+
+A tool attaches to whichever PMIx server it found, and for a `prun` started
+on a compute node of a persistent DVM with no `--dvm-uri` that is the
+**local daemon**, not the HNP. PMIx registers the tool's IOF request with
+that daemon's server (`pmix_server_process_iof` on the spawn), and that
+server is the only one that can deliver to it. Both directions therefore
+need a relay through the master, which is the only process that can route:
+
+| Direction | Path |
+|-----------|------|
+| tool's stdin → the job | tool → its daemon's `push_stdin` → RML (`IOF_HNP`, stream `STDIN`) → HNP's `push_stdin` → hosting daemon → proc's stdin pipe |
+| the job's output → tool | hosting daemon → RML (`IOF_HNP`) → HNP → `relay_to_tool` → RML (`IOF_PROXY`, stream `STDOUT`/`STDERR`) → tool's daemon → `PMIx_server_IOF_deliver` → tool |
+
+Two things make the output half less obvious than it looks:
+
+- **Part of it already works, which is what hides the rest.** A daemon
+  hands its own procs' output to its own PMIx server as well as forwarding
+  it, so a tool always sees the ranks that happen to land on its own node.
+  Only the other ranks go missing, so the symptom is partial output, not
+  none.
+- **The relayed copy must not be emitted where it lands.** Every daemon
+  registers the job's namespace with the same output directives, so a
+  daemon handed another node's output would write it out again — and with
+  `--output file=` that is two daemons writing one file. The delivery
+  therefore carries `PMIX_IOF_LOCAL_OUTPUT=false`, which tells the PMIx
+  server "deliver this to your registered requestors; it is not yours to
+  write." That needs `PMIX_CAP_IOF_DELIVER_LOCAL`; without it the HNP does
+  not relay at all (`PRTE_PMIX_IOF_DELIVER_LOCAL`, set by
+  [`config/prte_setup_pmix.m4`](../../../config/prte_setup_pmix.m4)) rather
+  than relay unsafely.
+
+Who the tool's daemon is comes from `jdata->originator`. On the master that
+field is the **daemon that relayed the spawn** — `plm_base_receive`
+overwrites the requesting tool's own procID with the sender — so an
+originator in the daemon namespace names the daemon to relay to, and an
+originator in any other namespace is a tool that spawned through the master
+and is already a client of its server. Deduplication is by the same handle:
+the daemon that forwarded a chunk has already delivered it locally, so the
+master skips the relay when that daemon is the tool's.
 
 ---
 

--- a/src/mca/iof/hnp/AGENTS.md
+++ b/src/mca/iof/hnp/AGENTS.md
@@ -36,12 +36,13 @@ The component keeps one piece of state (in
 | `iof_hnp.c` | The module vtable: `init`, `hnp_push`, `hnp_pull`, `hnp_close`, `hnp_complete`, `finalize`, `push_stdin`, and the local `stdin_write_handler`. |
 | `iof_hnp_read.c` | `prte_iof_hnp_read_local_handler` — reads the HNP's *own* children's stdout/stderr and emits them via the PMIx server. |
 | `iof_hnp_receive.c` | `prte_iof_hnp_recv` — the `PRTE_RML_TAG_IOF_HNP` handler: unpacks daemon-forwarded output and emits it via the PMIx server. |
-| `iof_hnp_send.c` | `prte_iof_hnp_send_data_to_endpoint` — packs stdin and sends it to a daemon (or xcasts to all) over `PRTE_RML_TAG_IOF_PROXY`. |
+| `iof_hnp_send.c` | `prte_iof_hnp_send_data_to_endpoint` — packs a payload and sends it to a daemon (or xcasts to all) over `PRTE_RML_TAG_IOF_PROXY` — plus `prte_iof_hnp_relay_to_tool`, which uses it to send a job's output to the daemon hosting the tool that launched it. |
 | `iof_hnp.h` | Component struct + prototypes for the above. |
 
-The module vtable (`prte_iof_hnp_module`) sets `push_stdin` — the HNP is
-the **only** component that implements it, because injecting stdin into
-the job is inherently a master-side operation.
+The module vtable (`prte_iof_hnp_module`) sets `push_stdin`. The `prted`
+module sets it too, but only to relay: *routing* stdin — resolving which
+daemon hosts the target, or xcasting a wildcard — is inherently a
+master-side operation, so a daemon asked to inject stdin sends it here.
 
 ---
 
@@ -85,6 +86,15 @@ destination as Path 1 — the PMIx server — just sourced from a remote node.
 XON/XOFF flow-control messages arrive on this same tag (tag-only buffers);
 they are consumed here as part of the stdin back-pressure protocol.
 
+**One message on this tag runs the other way.** A leading tag of
+`PRTE_IOF_STDIN` is not output at all: it is stdin that a daemon is relaying
+on behalf of a tool attached to *it* rather than to us, and the proc that
+follows is the intended **recipient**, not a source. That branch unpacks the
+same trailing count and bytes and hands them to `push_stdin` below. It is
+screened ahead of the "nothing to do" test on a zero-length payload, because
+a zero-byte stdin push is the sentinel that closes the target's stdin. See
+[`../prted/AGENTS.md`](../prted/AGENTS.md), "Relaying a tool's stdin".
+
 ---
 
 ## Stdin injection (`push_stdin`, `hnp_pull`, `iof_hnp_send.c`)
@@ -127,6 +137,44 @@ re-arm; `numbytes == 0` → close). It differs from the base
 ways: it dumps pending data immediately if `prte_abnormal_term_ordered`
 (the DVM is aborting), and it honors the sink's `closed` flag, releasing
 the sink once the last queued byte is written.
+
+---
+
+## Relaying output to a tool on another daemon (`relay_to_tool`)
+
+`PMIx_server_IOF_deliver` reaches the tools connected to **our** server. A
+tool that attached to some other daemon — a `prun` started on a compute node
+of a persistent DVM — registered its IOF request there, and only that
+server can deliver to it. We are the only process that sees all of the job's
+output, so we send a copy back out.
+
+`prte_iof_hnp_relay_to_tool(source, stream, data, numbytes, already_delivered)`
+is called from **both** output paths, just before the local delivery: from
+`prte_iof_hnp_recv` (passing the forwarding daemon's rank) and from
+`prte_iof_hnp_read_local_handler` (passing our own). It sends on
+`PRTE_RML_TAG_IOF_PROXY` with the stream tag leading, which is how the
+daemon tells it from stdin.
+
+Three tests decide whether a copy is owed, and each is there for a reason:
+
+- **`jdata->originator` must be in the daemon namespace.** On the master that
+  field is the daemon that relayed the spawn (`plm_base_receive` overwrites
+  the tool's own procID with the sender). An originator in any other
+  namespace is a tool that spawned through *us* and is a client of our own
+  server — already served by the local delivery.
+- **...and must not be us.** Same reason.
+- **...and must not be `already_delivered`.** A daemon hands its own procs'
+  output to its own PMIx server before forwarding it to us, so if that
+  daemon is also the tool's, the tool already has this chunk and a relayed
+  copy would duplicate it. This is why a tool sees the ranks on its own node
+  correctly even with no relay at all — and why the bug looked like partial
+  output rather than none.
+
+The receiving daemon must not *emit* the copy; see
+[`../prted/AGENTS.md`](../prted/AGENTS.md), "Relayed output". The whole
+function is compiled out when `PRTE_PMIX_IOF_DELIVER_LOCAL` is 0, because
+without that PMIx capability the relayed copy cannot be marked
+non-emitting and relaying would make two daemons write one output file.
 
 ---
 

--- a/src/mca/iof/hnp/iof_hnp.h
+++ b/src/mca/iof/hnp/iof_hnp.h
@@ -83,6 +83,11 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
                                        prte_iof_tag_t tag,
                                        unsigned char *data, int numbytes);
 
+void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
+                                prte_iof_tag_t stream,
+                                unsigned char *data, int numbytes,
+                                pmix_rank_t already_delivered);
+
 END_C_DECLS
 
 #endif

--- a/src/mca/iof/hnp/iof_hnp_read.c
+++ b/src/mca/iof/hnp/iof_hnp_read.c
@@ -137,6 +137,10 @@ void prte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
     }
     memcpy(p->bo.bytes, data, numbytes);
     p->bo.size = numbytes;
+    /* a tool watching this job may be attached to another daemon, which never
+     * sees the output of the children we forked ourselves - send it a copy */
+    prte_iof_hnp_relay_to_tool(&proct->name, rev->tag, data, numbytes,
+                               PRTE_PROC_MY_NAME->rank);
     prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, NULL, 0, lkcbfunc, (void*)p);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);

--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -72,6 +72,7 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
     prte_iof_tag_t stream;
     int32_t count, numbytes;
     int rc;
+    unsigned char *stdindata = NULL;
     prte_iof_proc_t *proct;
     pmix_iof_channel_t pchan;
     prte_iof_deliver_t *p;
@@ -101,6 +102,59 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
     PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                          "%s received IOF cmd for source %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          PRTE_NAME_PRINT(&origin)));
+
+    /* a daemon that is hosting a tool cannot route the tool's stdin - only
+     * we know which daemon hosts the target proc - so it relays the push to
+     * us and we inject it exactly as if the tool were attached here. In that
+     * case the proc we just unpacked is the intended recipient rather than
+     * the source of some output. This is screened ahead of the zero-length
+     * test below because a zero-byte stdin push is the sentinel that closes
+     * the target's stdin, not an empty message to be dropped */
+    if (PRTE_IOF_STDIN & stream) {
+        count = 1;
+        rc = PMIx_Data_unpack(NULL, buffer, &numbytes, &count, PMIX_INT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto CLEAN_RETURN;
+        }
+        if (0 > numbytes) {
+            /* corrupted message */
+            PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
+            goto CLEAN_RETURN;
+        }
+        if (0 < numbytes) {
+            stdindata = (unsigned char *) malloc(numbytes);
+            if (NULL == stdindata) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                goto CLEAN_RETURN;
+            }
+            count = numbytes;
+            rc = PMIx_Data_unpack(NULL, buffer, stdindata, &count, PMIX_BYTE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                free(stdindata);
+                goto CLEAN_RETURN;
+            }
+            /* count holds the number of bytes actually delivered */
+            numbytes = count;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                             "%s injecting %d relayed stdin bytes for %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
+                             PRTE_NAME_PRINT(&origin)));
+        rc = prte_iof.push_stdin(&origin, stdindata, (size_t) numbytes);
+        /* a target that has already finalized (ADDRESSEE_UNKNOWN) and a sink
+         * that has backed up (OUT_OF_RESOURCE) are both expected outcomes
+         * here, exactly as they are for a locally-attached tool */
+        if (PRTE_SUCCESS != rc && PRTE_ERR_ADDRESSEE_UNKNOWN != rc
+            && PRTE_ERR_OUT_OF_RESOURCE != rc) {
+            PRTE_ERROR_LOG(rc);
+        }
+        if (NULL != stdindata) {
+            free(stdindata);
+        }
+        goto CLEAN_RETURN;
+    }
 
     /* this must have come from a daemon forwarding output - unpack the data */
     count = 1;
@@ -160,6 +214,13 @@ NSTEP:
     if (PRTE_IOF_STDDIAG & stream) {
         pchan |= PMIX_FWD_STDDIAG_CHANNEL;
     }
+    /* a tool watching this job may be attached to some other daemon, which
+     * cannot see this output - only we do. Send it a copy, unless the daemon
+     * that forwarded this to us is that same daemon, in which case it already
+     * gave its own PMIx server a copy before forwarding */
+    prte_iof_hnp_relay_to_tool(&origin, stream, (unsigned char *) p->bo.bytes,
+                               numbytes, sender->rank);
+
     /* output this thru our PMIx server */
     prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, NULL, 0, lkcbfunc, (void*)p);
     if (PMIX_SUCCESS != prc) {

--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -127,3 +127,71 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
 
     return PRTE_SUCCESS;
 }
+
+/*
+ * Relay a job's output to the daemon hosting the tool that launched it.
+ *
+ * A tool need not attach to the DVM master. A prun started on a compute node
+ * of a persistent DVM finds its LOCAL daemon's rendezvous file and attaches
+ * there, and PMIx registers its IOF request with THAT daemon's server - the
+ * only server that can deliver to it. Output, though, converges here: a
+ * daemon hands its own processes' output to its own PMIx server (which is why
+ * a tool already sees the processes its own daemon happens to host) and
+ * forwards it to us, and we are the only process that sees all of it.
+ *
+ * So we send a copy back out to the tool's daemon, which hands it to its PMIx
+ * server. Two things decide whether a copy is owed:
+ *
+ *   - the requestor has to be reachable through a daemon at all. On the
+ *     master, jdata->originator is the daemon that relayed the spawn request
+ *     (plm_base_receive overwrites the tool's own procID with the sender), so
+ *     an originator in the daemon namespace names that daemon. An originator
+ *     in any other namespace is a tool that spawned through US, and it is a
+ *     client of our own PMIx server - already served.
+ *   - somebody must not have delivered it already. The daemon that hosts the
+ *     process delivered to its own server before forwarding to us, so if that
+ *     is also the tool's daemon the tool has its copy and a second one would
+ *     duplicate it. Same for output from our own children when the tool is
+ *     attached to us.
+ */
+void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
+                                prte_iof_tag_t stream,
+                                unsigned char *data, int numbytes,
+                                pmix_rank_t already_delivered)
+{
+#if PRTE_PMIX_IOF_DELIVER_LOCAL
+    prte_job_t *jdata;
+    pmix_proc_t host;
+    int rc;
+
+    jdata = prte_get_job_data_object(source->nspace);
+    if (NULL == jdata || PMIX_NSPACE_INVALID(jdata->originator.nspace)) {
+        return;
+    }
+    /* an originator outside the daemon namespace is a tool attached to us */
+    if (!PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace)) {
+        return;
+    }
+    if (jdata->originator.rank == PRTE_PROC_MY_NAME->rank ||
+        jdata->originator.rank == already_delivered) {
+        return;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s iof:hnp relaying %d bytes of %s output to the tool on daemon %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
+                         PRTE_NAME_PRINT(source),
+                         PMIX_RANK_PRINT(jdata->originator.rank)));
+
+    PMIX_LOAD_PROCID(&host, PRTE_PROC_MY_NAME->nspace, jdata->originator.rank);
+    rc = prte_iof_hnp_send_data_to_endpoint(&host, source, stream, data, numbytes);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+    }
+#else
+    /* without a PMIx that can be told not to emit a delivery, relaying would
+     * make the tool's daemon write its own copy of every output file the
+     * hosting daemon already wrote - see config/prte_setup_pmix.m4 */
+    PRTE_HIDE_UNUSED_PARAMS(source, stream, data, numbytes, already_delivered);
+#endif
+}

--- a/src/mca/iof/prted/AGENTS.md
+++ b/src/mca/iof/prted/AGENTS.md
@@ -38,13 +38,14 @@ HNP.
 | File | Contents |
 |------|----------|
 | `iof_prted_component.c` | Registration + `query` (gate on `PRTE_PROC_IS_DAEMON`, priority 80). |
-| `iof_prted.c` | The module vtable: `init`, `prted_push`, `prted_pull`, `prted_close`, `prted_complete`, `finalize`, and the local `stdin_write_handler`. **No `push_stdin`** — that's HNP-only. |
+| `iof_prted.c` | The module vtable: `init`, `prted_push`, `prted_pull`, `prted_close`, `prted_complete`, `finalize`, `prted_push_stdin`, and the local `stdin_write_handler`. |
 | `iof_prted_read.c` | `prte_iof_prted_read_handler` — reads a local proc's stdout/stderr, echoes locally via the PMIx server, and forwards to the HNP. |
-| `iof_prted_receive.c` | `prte_iof_prted_recv` (the `PRTE_RML_TAG_IOF_PROXY` handler for incoming stdin) + `prte_iof_prted_send_xonxoff` (flow control back to the HNP). |
+| `iof_prted_receive.c` | `prte_iof_prted_recv` (the `PRTE_RML_TAG_IOF_PROXY` handler — incoming stdin, and output relayed for a tool of ours) + `deliver_relayed_output` + `prte_iof_prted_send_xonxoff` (flow control back to the HNP). |
 | `iof_prted.h` | Component struct + prototypes. |
 
-The vtable leaves `push_stdin` unset (`NULL`): a daemon receives stdin
-passively over the RML rather than being asked to inject it.
+A daemon receives stdin passively over the RML — but it can also be *asked*
+to inject it, so `push_stdin` is implemented here too. See
+[Relaying a tool's stdin](#relaying-a-tools-stdin-prted_push_stdin) below.
 
 ---
 
@@ -102,7 +103,10 @@ posted by `init()`. Incoming buffers carry `{ stream (uint16), target
 proc, numbytes (int32), bytes }` — the same shape the daemon uses when
 forwarding output HNP-ward:
 
-1. Unpack the stream; if it isn't `PRTE_IOF_STDIN` it's a protocol error
+1. Unpack the stream. An output stream (`PRTE_IOF_STDOUTALL`) is relayed
+   output for a tool of ours — see [Relayed
+   output](#relayed-output-deliver_relayed_output). Anything that is not
+   that and not `PRTE_IOF_STDIN` is a protocol error
    (`PRTE_ERR_COMM_FAILURE`). (Flow-control tags are handled by the HNP,
    not here.)
 2. Unpack the target proc, then the byte count, then `malloc` storage of
@@ -134,6 +138,56 @@ the backlog has fallen below `PRTE_IOF_MAX_INPUT_BUFFERS`, it clears the
 latch and sends `PRTE_IOF_XON` to resume stdin from the HNP. The inline
 `RHC:` comment flags the unsolved case of several procs fighting over
 XON/XOFF at different consumption rates.
+
+### Relaying a tool's stdin (`prted_push_stdin`)
+
+A tool does not have to attach to the master. A `prun` started on a compute
+node of a persistent DVM, with no `--dvm-uri`, finds its **local** daemon's
+rendezvous file and attaches there — and then pushes its stdin through that
+daemon's PMIx server, which lands in `prte_iof.push_stdin`. Every `prun` does
+this even with nothing to send, because the zero-byte end-of-input marker
+goes down the same path.
+
+A daemon cannot route that itself: only the master can resolve which daemon
+hosts the target proc, and only the master can xcast a wildcard target. So
+`prted_push_stdin` packs `{ PRTE_IOF_STDIN, target proc, numbytes, bytes }`
+— the same shape the daemon uses to forward output — and reliable-sends it to
+the HNP on `PRTE_RML_TAG_IOF_HNP`. `prte_iof_hnp_recv` recognizes the leading
+stdin tag, treats the proc that follows as the *recipient* rather than the
+source, and hands it to the HNP's own `push_stdin`. From there it is
+indistinguishable from stdin pushed by a tool attached to the master.
+
+This slot used to be `NULL`, which made that push a NULL call: the daemon
+segfaulted, and the tool — whose PMIx server had just died — hung forever
+waiting for a `PMIX_EVENT_JOB_END`
+([#2568](https://github.com/openpmix/prrte/issues/2568)). If you are tempted
+to drop it again, note that a zero-byte push is unavoidable and arrives on
+*every* job a non-master-attached tool runs.
+
+### Relayed output (`deliver_relayed_output`)
+
+The mirror image of `prted_push_stdin`. A tool attached to us registered its
+IOF request with **our** PMIx server, so we are the only server that can
+deliver to it — but we only ever see the output of procs we host. The master
+sees all of it, and relays what we are missing on
+`PRTE_RML_TAG_IOF_PROXY` with an output stream tag leading. We unpack
+`{ source proc, numbytes, bytes }` and hand it to `PMIx_server_IOF_deliver`.
+
+**With `PMIX_IOF_LOCAL_OUTPUT` set false**, and that is the point. Every
+daemon registers the job's namespace with the same output directives, and
+the daemon that hosts those procs has already written whatever they called
+for. Delivering here without the directive would emit a second copy — with
+`--output file=` in effect, two daemons writing one file. The directive says
+"deliver to your registered requestors; this is not yours to write."
+
+The info array is a function-scope `static` built on first use, not a stack
+variable: the delivery is non-blocking, so PMIx reads the directive on its
+own progress thread after we have returned. It holds nothing allocated and
+never varies, so one copy serves every delivery and never needs releasing.
+
+The whole path is compiled out when `PRTE_PMIX_IOF_DELIVER_LOCAL` is 0 — the
+master does not relay against such a PMIx, so nothing should arrive, and if
+something does it is logged rather than emitted.
 
 ### `prte_iof_prted_send_xonxoff` (`iof_prted_receive.c`)
 

--- a/src/mca/iof/prted/iof_prted.c
+++ b/src/mca/iof/prted/iof_prted.c
@@ -75,6 +75,8 @@ static void prted_complete(const prte_job_t *jdata);
 
 static int finalize(void);
 
+static int prted_push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz);
+
 /* The API's in this module are solely used to support LOCAL
  * procs - i.e., procs that are co-located to the daemon. Output
  * from local procs is automatically sent to the HNP for output
@@ -88,6 +90,7 @@ prte_iof_base_module_t prte_iof_prted_module = {
     .close = prted_close,
     .complete = prted_complete,
     .finalize = finalize,
+    .push_stdin = prted_push_stdin,
 };
 
 static int init(void)
@@ -295,6 +298,94 @@ static void prted_complete(const prte_job_t *jdata)
             PMIX_RELEASE(proct);
         }
     }
+}
+
+/**
+ * Inject stdin into the job.
+ *
+ * Only the DVM master can resolve which daemon hosts a given target proc,
+ * so a daemon cannot route stdin itself - but it can be asked to. A tool
+ * that attaches to an ordinary daemon rather than the master (a prun run
+ * on a compute node of a persistent DVM, which finds its local daemon's
+ * rendezvous file) pushes its stdin through our PMIx server, and always
+ * pushes at least the zero-byte end-of-input marker. Relay that to the
+ * HNP on the same tag we forward output over, tagged as stdin so it is
+ * told apart from output, and let the HNP's push_stdin do the routing -
+ * exactly as if the tool had attached there.
+ */
+static int prted_push_stdin(const pmix_proc_t *dst_name, uint8_t *data, size_t sz)
+{
+    pmix_data_buffer_t *buf;
+    prte_iof_tag_t tag = PRTE_IOF_STDIN;
+    int32_t nbytes;
+    int rc;
+
+    /* don't do this if the dst vpid is invalid */
+    if (PMIX_RANK_INVALID == dst_name->rank) {
+        return PRTE_SUCCESS;
+    }
+
+    /* a zero count is the sentinel that closes the target's stdin, so an
+     * empty push is meaningful and must still be relayed */
+    if (NULL == data || 0 == sz) {
+        nbytes = 0;
+    } else if (INT32_MAX < sz) {
+        /* the wire format counts bytes in an int32 - nothing legitimate
+         * hands us 2GB of stdin in a single push */
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    } else {
+        nbytes = (int32_t) sz;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s iof:prted relaying stdin for process %s (size %d) to HNP",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(dst_name), nbytes));
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+
+    /* pack the stream tag first - as with forwarded output, it leads the
+     * message so the HNP can tell what this is before unpacking further */
+    rc = PMIx_Data_pack(NULL, buf, &tag, 1, PMIX_UINT16);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return prte_pmix_convert_status(rc);
+    }
+
+    /* pack the intended recipient */
+    rc = PMIx_Data_pack(NULL, buf, (void *) dst_name, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return prte_pmix_convert_status(rc);
+    }
+
+    /* pack the number of bytes that follow */
+    rc = PMIx_Data_pack(NULL, buf, &nbytes, 1, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return prte_pmix_convert_status(rc);
+    }
+
+    if (0 < nbytes) {
+        rc = PMIx_Data_pack(NULL, buf, data, nbytes, PMIX_BYTE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return prte_pmix_convert_status(rc);
+        }
+    }
+
+    PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_IOF_HNP);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return rc;
+    }
+
+    return PRTE_SUCCESS;
 }
 
 static int finalize(void)

--- a/src/mca/iof/prted/iof_prted_receive.c
+++ b/src/mca/iof/prted/iof_prted_receive.c
@@ -74,13 +74,143 @@ void prte_iof_prted_send_xonxoff(prte_iof_tag_t tag)
     }
 }
 
+#if PRTE_PMIX_IOF_DELIVER_LOCAL
+static void lkcbfunc(pmix_status_t status, void *cbdata)
+{
+    prte_iof_deliver_t *p = (prte_iof_deliver_t *) cbdata;
+
+    /* nothing to do here - we use this solely to
+     * ensure that IOF_deliver doesn't block */
+    if (PMIX_SUCCESS != status) {
+        PMIX_ERROR_LOG(status);
+    }
+    PMIX_RELEASE(p);
+}
+#endif
+
 /*
- * The only messages coming to an prted are either:
+ * Output from a process on another node, relayed to us by the master because
+ * a tool attached to US asked for it.
+ *
+ * A tool need not attach to the DVM master, and PMIx registers its IOF
+ * request with whichever server it did attach to - ours. Our own processes'
+ * output already reaches that tool, because the read handler hands every
+ * chunk to our PMIx server as well as forwarding it. Output from processes
+ * we do not host never passed through here at all, which is why such a tool
+ * used to see only the part of its job that happened to land on this node.
+ *
+ * The one thing we must NOT do is emit it. The daemon hosting those processes
+ * has already written whatever the job's output directives called for, and
+ * this server holds the same directives - it registered the same namespace.
+ * Emitting here would duplicate the terminal copy and, with --output file=,
+ * would have two daemons writing one file. PMIX_IOF_LOCAL_OUTPUT=false on the
+ * delivery says "deliver this to your registered requestors, but it is not
+ * yours to write."
+ */
+static void deliver_relayed_output(prte_iof_tag_t stream,
+                                   pmix_data_buffer_t *buffer)
+{
+#if PRTE_PMIX_IOF_DELIVER_LOCAL
+    pmix_proc_t source;
+    int32_t count, numbytes;
+    pmix_iof_channel_t pchan;
+    prte_iof_deliver_t *p;
+    pmix_status_t prc;
+    static pmix_info_t relay_directive;
+    static bool directive_ready = false;
+    bool flag = false;
+    int rc;
+
+    /* unpack the process the output came from */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &source, &count, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &numbytes, &count, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 >= numbytes) {
+        /* nothing to deliver - a negative count is a corrupted message */
+        if (0 > numbytes) {
+            PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
+        }
+        return;
+    }
+
+    p = PMIX_NEW(prte_iof_deliver_t);
+    PMIX_XFER_PROCID(&p->source, &source);
+    p->bo.bytes = (char *) malloc(numbytes);
+    if (NULL == p->bo.bytes) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        PMIX_RELEASE(p);
+        return;
+    }
+    count = numbytes;
+    rc = PMIx_Data_unpack(NULL, buffer, p->bo.bytes, &count, PMIX_BYTE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(p);
+        return;
+    }
+    p->bo.size = count;
+
+    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s delivering %d relayed bytes from %s to our tool",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) p->bo.size,
+                         PRTE_NAME_PRINT(&source)));
+
+    pchan = 0;
+    if (PRTE_IOF_STDOUT & stream) {
+        pchan |= PMIX_FWD_STDOUT_CHANNEL;
+    }
+    if (PRTE_IOF_STDERR & stream) {
+        pchan |= PMIX_FWD_STDERR_CHANNEL;
+    }
+    if (PRTE_IOF_STDDIAG & stream) {
+        pchan |= PMIX_FWD_STDDIAG_CHANNEL;
+    }
+
+    /* The delivery is non-blocking, so PMIx reads the directive on its own
+     * progress thread after we have returned - the array has to outlive this
+     * function. It never varies and holds nothing allocated, so one static
+     * built on first use serves every delivery and never needs releasing. */
+    if (!directive_ready) {
+        PMIX_INFO_LOAD(&relay_directive, PMIX_IOF_LOCAL_OUTPUT, &flag, PMIX_BOOL);
+        directive_ready = true;
+    }
+    prc = PMIx_server_IOF_deliver(&p->source, pchan, &p->bo, &relay_directive, 1,
+                                  lkcbfunc, (void *) p);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+        PMIX_RELEASE(p);
+    }
+#else
+    /* the master does not relay output without a PMIx that can be told not to
+     * emit it, so nothing should ever arrive here */
+    PRTE_HIDE_UNUSED_PARAMS(stream, buffer);
+    PRTE_ERROR_LOG(PRTE_ERR_NOT_SUPPORTED);
+#endif
+}
+
+/*
+ * The messages coming to a prted on this tag are:
  *
  * (a) stdin, which is to be copied to whichever local
  *     procs "pull'd" a copy
  *
- * (b) flow control messages
+ * (b) output from processes on OTHER nodes, which the master is relaying
+ *     to us because a tool attached to us asked for it - see
+ *     deliver_relayed_output() below
+ *
+ * (c) flow control messages
+ *
+ * The leading stream tag says which.
  */
 void prte_iof_prted_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                          prte_rml_tag_t tag, void *cbdata)
@@ -101,7 +231,13 @@ void prte_iof_prted_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *bu
         return;
     }
 
-    /* if this isn't stdin, then we have an error */
+    /* output being relayed to us for a tool of ours */
+    if (PRTE_IOF_STDOUTALL & stream) {
+        deliver_relayed_output(stream, buffer);
+        return;
+    }
+
+    /* anything else on this tag has to be stdin */
     if (PRTE_IOF_STDIN != stream) {
         PRTE_ERROR_LOG(PRTE_ERR_COMM_FAILURE);
         return;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1324,6 +1324,15 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
         return rc;
     }
 
+    /* the requestor has now been told, so record it - this is what makes the
+     * "already responded" test at the top of this function mean anything on
+     * the relay path. Only the local-notification branch above used to set it
+     * (inside pmix_server_notify_spawn), so a process that answered by sending
+     * would answer again on every later call - and each of those extra
+     * responses arrives at a requestor whose request is long retired */
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_NOTIFIED,
+                       PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+
     return PRTE_SUCCESS;
 }
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1093,19 +1093,42 @@ static void pmix_server_stdin_push(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     pmix_byte_object_t *bo = (pmix_byte_object_t *) cd->server_object;
-    size_t n;
+    uint8_t *bytes;
+    size_t nbytes, n;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* a client that pushed no data at all leaves us no byte object - PMIx
+     * frees it rather than handing us an empty one - and that is precisely
+     * how a tool signals end-of-input, so treat it as the zero-length push
+     * it is rather than dereferencing it */
+    if (NULL == bo) {
+        bytes = NULL;
+        nbytes = 0;
+    } else {
+        bytes = (uint8_t *) bo->bytes;
+        nbytes = bo->size;
+    }
+
+    /* the vtable slot is optional, so a module that left it unset would
+     * otherwise take the daemon down with a NULL call - which is what used
+     * to happen on every daemon but the master, killing the very daemon the
+     * requesting tool was attached to */
+    if (NULL == prte_iof.push_stdin) {
+        cd->cbfunc(PMIX_ERR_NOT_SUPPORTED, cd->cbdata);
+        PMIX_RELEASE(cd);
+        return;
+    }
 
     for (n = 0; n < cd->nprocs; n++) {
         PMIX_OUTPUT_VERBOSE((1, prte_pmix_server_globals.output,
                              "%s pmix_server_stdin_push to dest %s: size %zu",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                              PRTE_NAME_PRINT(&cd->procs[n]),
-                             bo->size));
-        prte_iof.push_stdin(&cd->procs[n], (uint8_t *) bo->bytes, bo->size);
+                             nbytes));
+        prte_iof.push_stdin(&cd->procs[n], bytes, nbytes);
     }
 
-    if (NULL == bo->bytes || 0 == bo->size) {
+    if (NULL == bytes || 0 == nbytes) {
         cd->cbfunc(PMIX_ERR_IOF_COMPLETE, cd->cbdata);
     } else {
         cd->cbfunc(PMIX_SUCCESS, cd->cbdata);

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -739,11 +739,22 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
              * was already cleaned up, or it was a tool */
             goto CLEANUP;
         }
-        /* if would be rare, but a very fast terminating job could conceivably
-         * reach here prior to the spawn requestor being notified of spawn */
-        ret = prte_plm_base_spawn_response(PMIX_SUCCESS, jdata);
-        if (PRTE_SUCCESS != ret) {
-            PRTE_ERROR_LOG(ret);
+        /* It would be rare, but a very fast terminating job could conceivably
+         * reach here prior to the spawn requestor being notified of spawn.
+         * Only two of us can say anything useful about that: the master, which
+         * knows the launch result, and the daemon hosting the requestor, whose
+         * notification is local. This command is xcast to every daemon, and the
+         * rest of them hold nothing but an unpacked copy of the job - having
+         * them each fire a spawn response at the requestor's daemon means it
+         * gets one real response and one per bystander, and every one after
+         * the first finds its request already retired and logs a spurious
+         * "not found". */
+        if (PRTE_PROC_IS_MASTER ||
+            PMIX_CHECK_PROCID(&jdata->originator, PRTE_PROC_MY_NAME)) {
+            ret = prte_plm_base_spawn_response(PMIX_SUCCESS, jdata);
+            if (PRTE_SUCCESS != ret) {
+                PRTE_ERROR_LOG(ret);
+            }
         }
 
         /* Deregister the nspace and, once that completes, clear any pending

--- a/test/unit/iof/test_iof.c
+++ b/test/unit/iof/test_iof.c
@@ -27,10 +27,13 @@
  *      (EXCLUSIVE, XON/XOFF, PULL/CLOSE) must not collide with the stream
  *      bits, since a single uint16 carries both.
  *
- *   2. The module contract (iof.h).  Both components fill a 7-slot vtable.
- *      The daemon relay intentionally leaves push_stdin NULL (stdin
- *      injection is master-only); the HNP hub must implement all seven.  A
- *      regression that swapped those would crash or silently drop stdin.
+ *   2. The module contract (iof.h).  Both components fill a 7-slot vtable,
+ *      and both must implement push_stdin: the HNP hub routes stdin to the
+ *      hosting daemon, and the daemon relay hands it up to the HNP, which
+ *      is the only process that can do that routing.  A daemon that left
+ *      the slot NULL segfaulted the moment a tool attached to it pushed
+ *      stdin -- which every prun does, if only to mark end-of-input --
+ *      taking the DVM node down and hanging the tool (issue #2568).
  *
  *   3. The component identities: "hnp" and "prted" (selection needs them).
  *
@@ -137,11 +140,11 @@ static int test_tag_model(void)
 }
 
 /*
- * Both components publish a prte_iof_base_module_t.  Only the HNP hub
- * implements push_stdin (injecting stdin is a master-side operation); the
- * daemon relay must leave it NULL and callers guard on that.  Every other
- * slot must be wired in both, since the base and its callers only NULL-check
- * the optional entry points.
+ * Both components publish a prte_iof_base_module_t, and every slot must be
+ * wired in both.  push_stdin is the one worth stating explicitly: a tool can
+ * attach to any daemon, not just the master, and the first thing prun does
+ * when its job ends is push end-of-input.  The daemon's implementation only
+ * relays to the HNP -- but it must exist, or that push is a NULL call.
  */
 /*
  * Ask the framework for a component by name, and for the module that
@@ -220,14 +223,15 @@ static int test_module_contract(void)
     CHECK("hnp finalize set", NULL != hnp->finalize);
     CHECK("hnp push_stdin set", NULL != hnp->push_stdin);
 
-    /* the daemon relay wires six and deliberately leaves push_stdin NULL */
+    /* the daemon relay wires all seven too - its push_stdin relays to the
+     * HNP rather than routing, but a tool attached to this daemon calls it */
     CHECK("prted init set", NULL != prted->init);
     CHECK("prted push set", NULL != prted->push);
     CHECK("prted pull set", NULL != prted->pull);
     CHECK("prted close set", NULL != prted->close);
     CHECK("prted complete set", NULL != prted->complete);
     CHECK("prted finalize set", NULL != prted->finalize);
-    CHECK("prted push_stdin NULL (HNP-only)", NULL == prted->push_stdin);
+    CHECK("prted push_stdin set", NULL != prted->push_stdin);
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_module_contract\n");


### PR DESCRIPTION
A tool does not have to attach to the DVM master. A `prun` started on a
compute node of a persistent DVM, with no `--dvm-uri`, finds its **local**
daemon's rendezvous file and attaches there, and PMIx registers its IOF
request with that daemon's server — the only server that can deliver to it.
Neither direction of I/O worked from there.

Requires a PMIx carrying openpmix/openpmix#4061 (merged): the output half
is gated on `PMIX_CAP_IOF_DELIVER_LOCAL` and compiles out without it.

## Stdin took the daemon down — issue #2568

Only the `hnp` module implemented `push_stdin`, because routing stdin means
resolving which daemon hosts the target and only the master can do that.
The `prted` module left the vtable slot `NULL` and the PMIx server glue
called it unguarded, so the first push from an attached tool was a NULL
call. Every `prun` pushes at least the zero-byte end-of-input marker, so
this happened on **every job**. The tool then waited forever for a
`PMIX_EVENT_JOB_END` from a server that had just died — which is the hang
#2568 reports.

The reported symptom pointed at event delivery; it is not that. The
`JOB_END` xcast reaches every daemon and is re-notified correctly.
`prun --stdin none` on a non-master daemon exits 0 on unfixed code, which
is the one-line confirmation.

A daemon now relays the push to the master, which routes it as if the tool
had attached there. Also fixed alongside: PMIx hands us no byte object at
all when a client pushed no data, and the zero-length case dereferenced it.

## Output arrived only in part, which is why it looked like it worked

A daemon hands its own procs' output to its own PMIx server as well as
forwarding it, so such a tool always saw the ranks that happened to land on
its own node — and never any others, because output converges on the master
and stopped there. The symptom was *partial* output, not none, which is why
it went unnoticed. `prun --host node1:2 -n 2 hostname` run from a third node
printed nothing at all.

The master now sends a copy back out to the daemon hosting the launching
tool. Who that is comes from `jdata->originator`: on the master that field
is the daemon that relayed the spawn, so an originator in the daemon
namespace names the daemon to reach, and one in any other namespace is a
tool that spawned through us and is already a client of our own server. The
daemon that forwarded a chunk has already delivered it locally, so a copy is
owed only when that is not the tool's daemon.

**The relayed copy must not be emitted where it lands.** Every daemon
registers the job's namespace with the same output directives, so a daemon
handed another node's output writes its own copy of every output file the
hosting daemon already wrote — two daemons writing one `--output file=`.
Hence the PMIx dependency. Measured rather than assumed: flipping the
directive to `true` and rebuilding puts a full duplicate set of the job's
output files on a node hosting none of its ranks.

## Also here

- **A bystander daemon answering a spawn request.** `DVM_CLEANUP_JOB` is
  xcast to every daemon and each called `prte_plm_base_spawn_response()`, so
  the requestor's daemon got one real response and one per bystander. Every
  one after the first logged `PRTE_ERR_NOT_FOUND`, once per job, on any DVM
  where the tool was not on the master. The guard meant to prevent this was
  only ever set by the local-notification branch. Separate commit.
- **A swarm case for `--output file=`.** `NOCOPY` is the documented default,
  so `file=` means output goes to files and not to the terminal; it leaked,
  nondeterministically. That was an openpmix defect (fixed in #4061), but
  nothing here would have caught it. Separate commit.

## Testing

- `contrib/dockerswarm` suite: **363 passed, 0 failed**, including twelve
  new cases — both I/O directions for a non-master tool, exactly-once
  delivery (300 lines from 6 ranks), and no duplicate output files.
- `make check` 21/21, built with the capability **absent** so the
  compiled-out paths are exercised too.
- Each new guard was confirmed to fail with its fix reverted and the tree
  rebuilt, rather than assumed to have teeth.
- Every commit builds on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)