### PR TITLE
Resolve the fences a daemon failure breaks, not the DVM

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -46,6 +46,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
 | `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives `grpcomm/direct`'s `grp_release` on daemons that merely *received* the broadcast. See §15. |
+| `fencer.c` | A bare PMIx client that parks a job inside **`PMIx_Fence`** (`fencer` in the install), with rank 0 holding the collective open, so a daemon can be killed while a fence is provably in flight. Drives `grpcomm/direct`'s fence fault handler. See §15. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `fake-slurm.py` | A stand-in SLURM control plane (`sbatch`/`scontrol`/`scancel`) so `ras/slurm`'s elastic modify surface can be exercised. See §12. |
 
@@ -1143,6 +1144,39 @@ single-host test wearing a hat), and three back-to-back constructs
 followed by a plain job must all succeed — a caddy leak or a tracker that
 is never deleted shows up as drift across runs rather than as one bad
 one.
+
+### A daemon lost during a fence (`fencer`)
+
+The last case in the phase is about the *other* collective, and about the
+DVM rather than the job:
+[#2528](https://github.com/openpmix/prrte/issues/2528). The fence fault
+handler had no recovery path — any in-flight fence when a daemon died
+activated `PRTE_JOB_STATE_COMM_FAILED` with no job, which the errmgr reads
+as the **daemon** job failing, so one lost daemon during any fence took the
+whole DVM down. It now completes those fences with an error and leaves the
+DVM standing. On one host neither half exists: there is a single daemon, it
+is the HNP, and killing it ends the DVM whatever the handler does.
+
+```sh
+fencer [delay] [skip]
+```
+
+Every rank puts a scrap of modex data and calls `PMIx_Fence` over its whole
+namespace; rank 0 waits `delay` seconds first, and with `skip` it leaves
+without ever entering. Output is one `FENCE <rank> <what> …` line per step.
+
+Two things about how the case is written are deliberate:
+
+- **The window is constructed, not raced for.** Rank 0 sits out 30s, so the
+  other three ranks are provably still inside the fence — their daemons have
+  rolled their contributions up to the HNP, which is waiting on rank 0's —
+  when the daemon is killed. And rank 0 uses `skip`, because a laggard that
+  entered a *fresh* fence after the abort would block waiting for
+  participants who have already gone home, which looks exactly like the
+  hang the case is meant to detect and has nothing to do with the fault.
+- **The daemon that is killed hosts none of the job's procs.** Killing one
+  that did would abort the job through the errmgr and say nothing about the
+  fence: those clients would be dead either way.
 
 ## 16. The event base and the constants (`test_event`, `test_include`)
 

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -392,6 +392,19 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/groupcon.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # fencer: a bare PMIx client that parks a job inside PMIx_Fence
+            # so a daemon can be killed while the collective is in flight.
+            # Rank 0 delays entering, so every other rank is provably still
+            # inside the fence when the harness kills a daemon.  A lost
+            # daemon during a fence used to take the whole DVM down; it now
+            # completes the fence with an error and leaves the DVM standing,
+            # and neither half of that exists on a single host.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> fencer (fence under daemon loss) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/fencer \
+                /prrte-src/contrib/dockerswarm/fencer.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # slowcat: a deliberately slow stdin reader (no PMIx at all).  The
             # stdin bugs in iof live in the back-pressure path, and a normal
             # "cat" drains its pipe as fast as the daemon fills it, so the

--- a/contrib/dockerswarm/fencer.c
+++ b/contrib/dockerswarm/fencer.c
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * fencer -- a minimal PMIx client that parks a job inside PMIx_Fence so a
+ * daemon can be killed while the collective is in flight.
+ *
+ *   fencer [delay] [skip]
+ *       Every rank puts a scrap of modex data, commits, and calls
+ *       PMIx_Fence over the whole namespace.  Rank 0 waits <delay>
+ *       seconds before entering, so every other rank is blocked in the
+ *       fence -- and their daemons have rolled their contributions up to
+ *       the HNP -- for that whole window.
+ *
+ *       With "skip", rank 0 never enters the fence at all: it waits out
+ *       the delay and leaves.  That is what a test wants when it intends
+ *       to break the collective rather than complete it -- the ranks that
+ *       did enter must be released by the fault, and rank 0 must not then
+ *       sit down in a fresh fence whose other participants have already
+ *       gone home.
+ *
+ * Output lines, one per rank, all prefixed FENCE so the harness can grep:
+ *
+ *   FENCE <rank> HOST <hostname>
+ *   FENCE <rank> ENTER
+ *   FENCE <rank> RESULT <status-string>
+ *   FENCE <rank> DONE <failures>
+ *
+ * Why this exists, and why it cannot be a unit test:
+ *
+ * A fence is an up-tree rollup to the HNP followed by an xcast release
+ * back down, and what is being tested here is what happens to that
+ * rollup when a daemon dies underneath it.  The fence fault handler used
+ * to answer that by activating PRTE_JOB_STATE_COMM_FAILED with no job,
+ * which the errmgr reads as the DAEMON job failing -- so a single lost
+ * daemon during any fence took the whole DVM down with it
+ * (https://github.com/openpmix/prrte/issues/2528).  It now completes the
+ * in-flight fences with an error instead, and the DVM stands.
+ *
+ * Neither half of that can be seen on one host: there is one daemon,
+ * it is the HNP, and killing it is not a fault -- it is the end of the
+ * DVM either way.  The rank that delays is what gives the harness a
+ * window in which the collective is provably still in flight rather
+ * than a race against a fence that already completed.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc, ret;
+    pmix_value_t value;
+    pmix_proc_t proc;
+    char hostname[256];
+    int delay = 0;
+    int failures = 0;
+    int skip = 0;
+
+    if (2 <= argc) {
+        delay = atoi(argv[1]);
+    }
+    if (3 <= argc && 0 == strcmp("skip", argv[2])) {
+        skip = 1;
+    }
+
+    gethostname(hostname, sizeof(hostname));
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    printf("FENCE %u HOST %s\n", myproc.rank, hostname);
+    fflush(stdout);
+
+    /* give the fence something to gather - a barrier and an allgather take
+     * the same path here, but a payload makes the rollup buckets real */
+    value.type = PMIX_STRING;
+    value.data.string = strdup(hostname);
+    rc = PMIx_Put(PMIX_GLOBAL, "fencer-host", &value);
+    free(value.data.string);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Put: %s\n", PMIx_Error_string(rc));
+        failures++;
+        goto done;
+    }
+    rc = PMIx_Commit();
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Commit: %s\n", PMIx_Error_string(rc));
+        failures++;
+        goto done;
+    }
+
+    /* rank 0 holds the collective open so the harness has a window in which
+     * every other rank is provably inside it */
+    if (0 == myproc.rank && 0 < delay) {
+        sleep(delay);
+    }
+    if (0 == myproc.rank && skip) {
+        printf("FENCE %u SKIP\n", myproc.rank);
+        fflush(stdout);
+        goto done;
+    }
+
+    printf("FENCE %u ENTER\n", myproc.rank);
+    fflush(stdout);
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Fence(&proc, 1, NULL, 0);
+    printf("FENCE %u RESULT %s\n", myproc.rank, PMIx_Error_string(rc));
+    fflush(stdout);
+    if (PMIX_SUCCESS != rc) {
+        failures++;
+    }
+
+done:
+    ret = PMIx_Finalize(NULL, 0);
+    if (PMIX_SUCCESS != ret) {
+        fprintf(stderr, "ERROR PMIx_Finalize: %s\n", PMIx_Error_string(ret));
+    }
+    printf("FENCE %u DONE %d\n", myproc.rank, failures);
+    fflush(stdout);
+    return (0 == failures) ? 0 : 1;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2840,11 +2840,12 @@ test_hwloc() {
     cleanup_swarm
 }
 
-# Absolute path, deliberately -- see the note above DS.
+# Absolute paths, deliberately -- see the note above DS.
 GC=/opt/prte/prte/bin/groupcon
+FN=/opt/prte/prte/bin/fencer
 
 test_grpcomm() {
-    local out n g ranks hosts fails
+    local out n c g ranks hosts fails
 
     banner "grpcomm: a group construct releases on every daemon, in order"
     # The interesting half of a group collective is grp_release(), and it runs
@@ -2948,6 +2949,89 @@ test_grpcomm() {
         && ok "...and the DVM still launches an ordinary job afterwards" \
         || bad "the DVM did not run a plain job after the group tests ($n of 3)"
 
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+
+    banner "grpcomm: a daemon lost during a fence resolves the fence, not the DVM"
+    # https://github.com/openpmix/prrte/issues/2528.  A fence rolls up over the
+    # routing tree to the HNP and comes back down as an xcast release.  The
+    # fence fault handler had no recovery path at all: if ANY fence was in
+    # flight when a daemon died it activated PRTE_JOB_STATE_COMM_FAILED with no
+    # job, which the errmgr reads as the DAEMON job failing -- so one lost
+    # daemon during any fence terminated the entire DVM.  It now completes the
+    # in-flight fences with an error and leaves the DVM standing.
+    #
+    # Neither half of that exists on one host: there is a single daemon, it is
+    # the HNP, and killing it ends the DVM whatever the handler does.
+    #
+    # The window is made deterministic rather than raced for: rank 0 sits out
+    # 30s before it would enter the fence, so the other three ranks are
+    # provably still inside it (their daemons have rolled their contributions
+    # up to the HNP, which is waiting on rank 0's) when the daemon is killed.
+    # Rank 0 then leaves without fencing -- it must not sit down in a fresh
+    # fence whose other participants have already gone home, which would hang
+    # for reasons that have nothing to do with the fault.
+    #
+    # The daemon that is killed hosts NONE of the job's procs, on purpose.
+    # Killing one that did would abort the job through the errmgr and tell us
+    # nothing about the fence: the clients would be dead either way.
+    cleanup_swarm
+    if ! RUN "test -x $FN"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:1,node2:1,node3:1,node4:1,node5:1'; then
+        bad "could not start a DVM for the fence fault test"
+        cleanup_swarm
+        return
+    fi
+    PRUN_BG /tmp/fence-fault.out \
+        "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $FN 30 skip"
+    # wait for the three non-laggard ranks to be inside the fence
+    n=0
+    while [ "$n" -lt 40 ]; do
+        c=$(RUN 'grep -c " ENTER" /tmp/fence-fault.out 2>/dev/null' 2>/dev/null \
+            | tr -cd '0-9')
+        [ -n "$c" ] && [ "$c" -ge 3 ] && break
+        sleep 1; n=$((n+1))
+    done
+    if [ "$n" -ge 40 ]; then
+        bad "the job never got three ranks into the fence: $(RUN 'cat /tmp/fence-fault.out' 2>&1 | tr '\n' ' ' | tail -c 300)"
+    elif ! ON 5 'pgrep -x prted' >/dev/null 2>&1; then
+        bad "node5 has no daemon to kill -- the DVM did not form as expected"
+    else
+        ok "three ranks are blocked in the fence with the DVM whole (${n}s)"
+        ON 5 'pkill -9 -x prted' >/dev/null 2>&1
+        n=0
+        while [ "$n" -lt 60 ]; do
+            RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+            sleep 1; n=$((n+1))
+        done
+        out=$(RUN 'cat /tmp/fence-fault.out' 2>&1)
+        [ "$n" -lt 60 ] \
+            && ok "...and the fence did not hang once its daemon set was broken (${n}s)" \
+            || bad "the job never returned after the daemon died: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        # the fence has to RESOLVE, not silently succeed and not vanish: every
+        # rank that entered it must come back out with a status
+        c=$(echo "$out" | grep -c 'RESULT ')
+        [ "$c" -ge 3 ] \
+            && ok "...all $c waiting ranks were released with a status" \
+            || bad "only $c of 3 waiting ranks came out of the fence: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        c=$(echo "$out" | grep -c 'RESULT PMIX_SUCCESS')
+        [ "$c" = 0 ] \
+            && ok "...and none of them was told the collective succeeded" \
+            || bad "$c ranks were told a broken fence succeeded"
+        # the point of the issue: the DVM must still be there
+        RUN 'pgrep -x prte' >/dev/null 2>&1 \
+            && ok "the HNP survived a daemon lost during a fence" \
+            || bad "the DVM went down with the daemon -- the fence fault killed it"
+        # ...and still able to run a job, fence included
+        out=$(PRUN "--host node1:1,node2:1,node3:1 -n 3 --map-by node $FN 0" 2>&1)
+        c=$(echo "$out" | grep -c 'RESULT PMIX_SUCCESS')
+        [ "$c" = 3 ] \
+            && ok "...and still completes a fence on the surviving nodes" \
+            || bad "the DVM could not complete a fence afterwards ($c of 3): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    fi
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 }

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -192,9 +192,52 @@ Message flow:
 participant. The tracker lives on `component.fence_ops`, keyed by exact
 proc-signature match.
 
-The fence `fault_handler` is currently **not resilient**: a TODO. If any
-fence op is in flight when a daemon fails it activates
-`PRTE_JOB_STATE_COMM_FAILED` (kills the job) rather than repairing.
+### Fence fault handling
+
+`prte_grpcomm_direct_fence_fault_handler` resolves every in-flight fence
+when a daemon fails, rather than tearing the DVM down. It used to activate
+`PRTE_JOB_STATE_COMM_FAILED` with a NULL job — which the errmgr reads as
+the *daemon* job failing, so one lost daemon during any fence terminated
+the whole DVM ([#2528](https://github.com/openpmix/prrte/issues/2528)).
+Each tracker is now unlinked and its local participants completed through
+the same callback `fence_release` uses, with `PMIX_ERR_COMM_FAILURE`; the
+PMIx server hands that status to every client blocked in `PMIx_Fence`.
+
+Three properties of the shape are load-bearing:
+
+- **It runs in the GLOBAL-scope pass, on every daemon.** Unlike `group`'s
+  handler this is not HNP-driven, and it emits no message. The global notice
+  is delivered to every daemon by the reliable xcast, and *every* xcast — the
+  fence releases included — is forwarded in the order of the op-id the HNP
+  stamps on it. So every daemon reaches the handler at the same point in one
+  ordered stream: a fence released ahead of the failure notice has completed
+  normally everywhere, and one that was not is aborted everywhere. An
+  HNP-driven abort would also have a hole this does not: the HNP holds no
+  tracker for a fence whose rollup has not reached it yet, so it could not
+  name the collective its descendants are blocked on.
+- **Every in-flight fence is resolved, not just those with a participant on
+  the failed daemon.** A fence rolls up over the routing tree, so a daemon
+  hosting none of the participants can still have been carrying a subtree's
+  contribution. The tracker counts contributions (`nreported`) rather than
+  recording which arrived, so a contribution that transited the failed daemon
+  can be neither proven delivered nor re-driven — and the decision has to come
+  out the same on every daemon or half the DVM would abort while the other
+  half waited. Repairing the unaffected cases instead needs per-contributor
+  accounting and an idempotent re-drive: a protocol change, not a fault
+  handler.
+- **A contribution already in flight when the abort runs still arrives**, and
+  `fence_recv` will create a tracker nobody completes — the same window
+  `abort_group_op()` leaves for groups. Closing it needs a collective
+  generation number every daemon agrees on, *including* one that joined an
+  elastic DVM after the failure. Short of that, dropping "stale" traffic on a
+  daemon whose idea of the generation is behind its peers' turns a rare leaked
+  tracker into a hang, so do not add a bare epoch counter here.
+
+Coverage: `test_fence_fault_handler` in `test/unit/grpcomm` drives the handler
+directly (scope gating, the callback status, relay-only trackers), and the
+dockerswarm `test_grpcomm` phase kills a daemon while three ranks are parked
+in a real fence — the DVM-death half of this cannot exist on one host, where
+the only daemon is the HNP.
 
 ---
 
@@ -368,10 +411,12 @@ deletes the tracker — so a cancel/abort tears down the collective cleanly
   Note the fault-handler abort loop itself is *unguarded* (it uses only
   status fields and `abort_group_op`), but the `PMIX_GROUP_CANCEL` handling
   is guarded — preserve that split.
-- **The fence fault handler is a known gap.** It kills the job on any
-  in-flight fence when a daemon fails (TODO to make it resilient). If you
-  are adding fence resilience, that is the place — do not weaken it into a
-  silent no-op.
+- **The two fault handlers resolve collectives in deliberately different
+  ways** — `fence` locally on every daemon, `group` by an HNP-driven
+  broadcast — and neither may be weakened into a silent no-op. A collective
+  a fault has broken must resolve one way or the other, or its local clients
+  block forever. See *Fence fault handling* above for why the fence one is
+  not modelled on the group one.
 - **Free every allocation the handler still owns before it returns.** The
   entry-point handlers (`begin_xcast`, `fence`, `group`) own the caddy/op
   they were thread-shifted; the recv handlers own the info arrays / darrays

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -81,17 +81,73 @@ int prte_grpcomm_direct_fence(const pmix_proc_t procs[], size_t nprocs,
     return PRTE_SUCCESS;
 }
 
+/* Resolve an in-flight fence that a daemon failure has broken, instead of
+ * tearing down the DVM.  Completing the local participants with a non-success
+ * status through the same callback the release path uses is all it takes: the
+ * PMIx server hands that status back to every client blocked in PMIx_Fence, so
+ * they learn the collective failed and can act, and the tracker goes away.
+ * The tracker is unlinked before the callback runs so the list is consistent no
+ * matter what the callback does with it. */
+static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st)
+{
+    PMIX_OUTPUT_VERBOSE((0, prte_grpcomm_base_framework.framework_output,
+                         "%s grpcomm:direct:fence aborting fence op - a daemon "
+                         "failed while it was in flight",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+
+    pmix_list_remove_item(&prte_mca_grpcomm_direct_component.fence_ops,
+                          &coll->super);
+    /* a daemon that is only relaying this fence has no local participants and
+     * hence no callback - it just drops the tracker */
+    if (NULL != coll->cbfunc) {
+        coll->cbfunc(st, NULL, 0, coll->cbdata, NULL, NULL);
+    }
+    PMIX_RELEASE(coll);
+}
+
 void prte_grpcomm_direct_fence_fault_handler(const prte_rml_recovery_status_t* status)
 {
-    PRTE_HIDE_UNUSED_PARAMS(status);
-    /* TODO: make this actually resilient
-     * For now, we'll just kill the job if any ops are active */
-    if(0 < pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops)){
-        PMIX_OUTPUT_VERBOSE((0, prte_grpcomm_base_framework.framework_output,
-                             "%s grpcomm:direct:fence daemon failed during"
-                             " active fence operation(s)",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
+    prte_grpcomm_fence_t *coll, *nxt;
+
+    /* Act in the global-scope pass.  The global notice is delivered to every
+     * daemon by the reliable xcast, and every xcast - the fence releases
+     * included - is forwarded in the order of the op-id the HNP stamps on it.
+     * So each daemon reaches this point at the same place in that one ordered
+     * stream: a fence whose release was broadcast ahead of the failure notice
+     * has already completed normally on every daemon, and one whose release was
+     * not is aborted on every daemon.  Aborting in the local pass instead would
+     * resolve the fence on the daemons that noticed the failure while their
+     * peers went on waiting for a rollup that can never arrive. */
+    if (PRTE_RML_FAULT_SCOPE_GLOBAL != status->scope) {
+        return;
+    }
+    if (0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops)) {
+        return;
+    }
+
+    /* Every in-flight fence is resolved, not just those with a participant on
+     * the failed daemon.  A fence rolls up over the routing tree, so a daemon
+     * that hosts none of the participants can still have been carrying a
+     * subtree's contribution when it died - and nothing here can tell whether
+     * it was: the tracker counts contributions (nreported) rather than
+     * recording which ones arrived, so a contribution that transited the failed
+     * daemon can neither be shown to have been delivered nor re-driven.  Nor
+     * could the decision be made per-daemon even if the local one could tell,
+     * because it has to come out the same everywhere or half the DVM would
+     * abort while the other half waited.  Repairing the unaffected cases rather
+     * than aborting them needs per-contributor accounting and an idempotent
+     * re-drive, which is a protocol change, not a fault handler.
+     *
+     * A contribution that was already in flight when we abort still arrives
+     * afterwards and creates a tracker nobody will complete - the same window
+     * abort_group_op() leaves for groups.  Closing it needs a collective
+     * generation number that every daemon agrees on, including one that joined
+     * an elastic DVM after the failure; short of that, dropping "stale" traffic
+     * on a daemon whose idea of the generation is behind its peers' would turn
+     * a rare leaked tracker into a hang. */
+    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
+                           prte_grpcomm_fence_t) {
+        abort_fence_op(coll, PMIX_ERR_COMM_FAILURE);
     }
 }
 

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -40,6 +40,10 @@
  *      every counter must start at zero so a rollup cannot complete
  *      early), and their destructors must free their owned members --
  *      including the NULL case -- without crashing.
+ *
+ *   5. The fence fault handler.  It needs no DVM: it reads the tracker
+ *      list and the scope of the recovery notice, and its whole job is to
+ *      resolve every in-flight fence rather than kill the job (#2528).
  */
 
 #include "prte_config.h"
@@ -49,12 +53,14 @@
 
 #include "constants.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 
 #include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/grpcomm/base/base.h"
 #include "src/mca/grpcomm/direct/grpcomm_direct.h"
+#include "src/rml/rml_types.h"
 
 #define CHECK(label, cond)                                              \
     do {                                                                \
@@ -300,6 +306,119 @@ static int test_classes(void)
     return failures;
 }
 
+#if PRTE_TEST_GRPCOMM_DIRECT
+/* Records what the fence completion callback was handed, standing in for the
+ * PMIx server that would hand it on to the clients blocked in PMIx_Fence. */
+typedef struct {
+    int ncalls;
+    pmix_status_t status;
+    const char *data;
+    size_t ndata;
+} fence_cb_record_t;
+
+static void fence_cb(pmix_status_t status, const char *data, size_t ndata,
+                     void *cbdata, pmix_release_cbfunc_t release_fn,
+                     void *release_cbdata)
+{
+    fence_cb_record_t *rec = (fence_cb_record_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(release_fn, release_cbdata);
+
+    rec->ncalls++;
+    rec->status = status;
+    rec->data = data;
+    rec->ndata = ndata;
+}
+
+/* Append a tracker standing in for a fence that is rolling up right now. */
+static void add_fence_op(fence_cb_record_t *rec)
+{
+    prte_grpcomm_fence_t *coll = PMIX_NEW(prte_grpcomm_fence_t);
+
+    coll->sig = PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
+    coll->sig->sz = 1;
+    coll->sig->signature = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
+    PMIX_LOAD_PROCID(&coll->sig->signature[0], "unit-test-nspace",
+                     PMIX_RANK_WILDCARD);
+    coll->nexpected = 2;
+    coll->nreported = 1;
+    if (NULL != rec) {
+        coll->cbfunc = fence_cb;
+        coll->cbdata = rec;
+    }
+    pmix_list_append(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);
+}
+#endif
+
+/*
+ * A daemon failure while a fence is rolling up used to activate
+ * PRTE_JOB_STATE_COMM_FAILED - it killed the job rather than resolving the
+ * collective (#2528).  The handler must now complete every in-flight fence
+ * with a non-success status and drop its tracker, and it must do that in the
+ * global-scope pass: that is the one notice every daemon receives, in the
+ * order the HNP stamped it into the xcast stream, so all of them resolve the
+ * same fences at the same point.  Acting in the local pass would abort the
+ * fence on the daemons nearest the failure while their peers waited forever.
+ */
+static int test_fence_fault_handler(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_DIRECT
+    prte_rml_recovery_status_t status;
+    fence_cb_record_t rec = {0};
+    fence_cb_record_t rec2 = {0};
+
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+
+    /* nothing in flight: the handler must not care */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("no ops, list still empty",
+          0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+
+    /* the local-scope pass must leave the collective alone */
+    add_fence_op(&rec);
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_LOCAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("local scope leaves op in flight",
+          1 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    CHECK("local scope fires no callback", 0 == rec.ncalls);
+
+    /* a second fence, this one relayed only - no local participants, so no
+     * callback to fire.  It must still be dropped, and without crashing. */
+    add_fence_op(NULL);
+
+    /* the global-scope pass resolves every in-flight fence */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("global scope drops every tracker",
+          0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    CHECK("participants completed once", 1 == rec.ncalls);
+    CHECK("completed with an error", PMIX_SUCCESS != rec.status);
+    CHECK("completed with no data", NULL == rec.data && 0 == rec.ndata);
+
+    /* and the job is resolved, not killed: a fence started afterwards is
+     * tracked from scratch rather than colliding with a leftover */
+    add_fence_op(&rec2);
+    CHECK("later fence tracked cleanly",
+          1 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    CHECK("later fence not yet completed", 0 == rec2.ncalls);
+
+    PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.fence_ops);
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fence_fault_handler\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -324,6 +443,7 @@ int main(void)
     failures += test_component_identity();
     failures += test_base_context_id();
     failures += test_classes();
+    failures += test_fence_fault_handler();
 
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     prte_finalize();


### PR DESCRIPTION
Fixes #2528.

### The problem

`grpcomm/direct`'s fence fault handler was a TODO. Any fence in flight when a daemon failed activated `PRTE_JOB_STATE_COMM_FAILED` with a NULL job — and the errmgr reads a NULL job as the **daemon** job, whose failure means "there really isn't much else we can do". So one lost daemon during any fence (the launch and modex barriers included) terminated the **entire DVM**, while the `xcast` and `group` collectives beside it were made to survive exactly that.

### The change

Every in-flight fence is resolved instead: the tracker is unlinked and its local participants completed through the same callback the release path uses, with `PMIX_ERR_COMM_FAILURE`. Clients blocked in `PMIx_Fence` learn the collective failed; the DVM stands.

Three decisions worth reviewing:

- **Global scope, on every daemon, with no message of its own.** The global notice reaches every daemon by the reliable xcast, and every xcast — fence releases included — is forwarded in op-id order, so all daemons act at the same point in one ordered stream: a fence released ahead of the failure notice completed normally everywhere; one that was not is aborted everywhere. Driving it from the HNP the way `abort_group_op()` does would leave a hole — the HNP holds no tracker for a fence whose rollup has not reached it yet, so it could not name the collective its descendants are blocked on.
- **Every in-flight fence, not just those with a participant on the failed daemon.** A fence rolls up over the routing tree, so a daemon hosting none of the participants can still have been carrying a subtree's contribution; `nreported` is a count, not a record of which contributions arrived, so one that transited the failed daemon can be neither proven delivered nor re-driven. And the decision has to come out the same everywhere, or half the DVM aborts while the other half waits. Repairing the unaffected cases needs per-contributor accounting and an idempotent re-drive — a protocol change, not a fault handler.
- **The residual window is documented, not papered over.** A contribution already in flight when the abort runs still arrives and creates a tracker nobody completes — the same window `abort_group_op()` leaves for groups. Closing it needs a collective generation number every daemon agrees on, *including* one that joined an elastic DVM after the failure; short of that, dropping "stale" traffic on a daemon whose idea of the generation is behind its peers' turns a rare leaked tracker into a hang. The comment in the handler and `direct/AGENTS.md` both say so, so the next person does not add a bare epoch counter.

### Testing

- `test/unit/grpcomm`: new `test_fence_fault_handler` drives the handler with no DVM — the scope gate, the completion status handed to participants, and a relay-only tracker with no callback. Against the old handler the tracker list never empties and the case goes red.
- `contrib/dockerswarm`: new `fencer` client and a `test_grpcomm` case that kills a daemon while three ranks are parked in a real fence. Rank 0 holds the collective open, so the window is constructed rather than raced for, and the daemon killed hosts none of the job's procs — killing one that did would abort the job through the errmgr and say nothing about the fence. Asserts the waiting ranks come back out with a non-success status, the HNP survives, and the DVM completes a fence afterwards. Neither half of this exists on one host, where the only daemon is the HNP.
- Full Linux swarm suite: 387 passed, 0 failed, 2 skipped (the two known `PMIX_CAP_IOF_DELIVER_LOCAL` skips). `make check` clean on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)