### PR TITLE
Carry out the session control directives PRRTE can honor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,7 @@ examples/client-threaded
 examples/dynamic-dep
 examples/abort
 examples/elastic
+examples/sessionctrl
 
 src/sys/powerpc/atomic-32.s
 src/sys/powerpc/atomic-64.s

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -415,6 +415,19 @@ build_linux() {
                 /prrte-src/examples/dynamic.c -I/prrte-src/examples \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # sessionctrl: the PMIx_Session_control example shipped in this
+            # tree.  Session control is a DVM-master operation whose whole
+            # point is a set of nodes, so the parts that matter -- carving a
+            # reservation out of the pool, a request relayed from a NON-master
+            # daemon, a signal reaching the jobs on every node of the session
+            # -- do not exist on one host.
+            # NOTE: this whole block is inside bash -c ..., so an apostrophe
+            # anywhere in it (even in a comment) ends the script.
+            echo ">>>> sessionctrl (PMIx_Session_control) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/sessionctrl \
+                /prrte-src/examples/sessionctrl.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # The fake SLURM control plane, installed under its own prefix --
             # NOT into the install bin/, which the node entrypoint symlinks
             # onto the default PATH of every node. ras/slurm gates on SLURM_JOBID,

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2327,6 +2327,158 @@ test_prted() {
 # behavior that only shows up when there is more than one node or more than
 # one DVM to be wrong about:
 #
+########################################################################
+# src/prted/pmix/pmix_server_session.c -- PMIx_Session_control.
+#
+# A session is a set of NODES, so nothing interesting about it exists on one
+# host.  What only appears here:
+#
+#   * a reservation actually withholding its nodes -- a job that names no
+#     session must land somewhere else, which needs more nodes than one
+#   * a request arriving at a NON-MASTER daemon and being relayed to the DVM
+#     master, which is the only way the PRTE_PMIX_SESSION_CTRL relay runs at all
+#   * a signal reaching the jobs of a session on every node they occupy
+#   * a session terminate killing its jobs across nodes and giving the nodes
+#     back to the general pool
+########################################################################
+# sessionctrl is installed by build.sh; use the absolute path for the same
+# reason DS and SC do (an app inherits the daemon PATH, not the install bin).
+SESSCTL=/opt/prte/prte/bin/sessionctrl
+
+test_session() {
+    local out rc n ns
+
+    banner "session: instantiate reserves its nodes out of the general pool"
+    # The DVM spans node1-node4.  Instantiate a session holding node3+node4
+    # and put a long-lived job in it.  A SECOND job, naming no session, must
+    # then be unable to reach node3/node4 at all -- that is what "reserved"
+    # means, and with a single node there is nothing to observe.
+    cleanup_swarm
+    # the session jobs below are bare "sleep" processes, and this phase counts
+    # them to decide whether a signal landed -- so make sure none is left over
+    # from anything else (cleanup_swarm only reaps PRRTE tools and daemons)
+    for n in $(seq 1 10); do docker exec "$NODE$n" sh -c 'pkill -9 -x sleep 2>/dev/null; true'; done
+    if ! RUN "test -x $SESSCTL"; then
+        skp "sessionctrl not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the session-control tests"
+    else
+        # name the slot counts explicitly: a node list is parsed by the
+        # dash-host rules, so a bare name means ONE slot -- and it overwrites
+        # the count the pool already had for that node.
+        out=$(RUN "timeout 60 $SESSCTL instantiate 4242 --hosts node3:2,node4:2 \
+                       --np 2 --mapby node -- /bin/sleep 240" 2>&1)
+        ns=$(echo "$out" | grep -m1 'pmix.nspace' | awk -F'= ' '{print $2}' | tr -d '\r')
+        if echo "$out" | grep -q PMIX_SUCCESS && [ -n "$ns" ]; then
+            ok "session 4242 instantiated on node3,node4 running $ns"
+        else
+            bad "instantiate failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+
+        # a general job may now only use node1/node2
+        sleep 3
+        out=$(PRUN '-n 4 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -cE '^node(3|4)$')
+        [ "$n" = 0 ] \
+            && ok "a general job was kept off the reserved nodes" \
+            || bad "a general job landed on reserved nodes: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+        banner "session: a request relayed from a non-master daemon is served"
+        # node3 is not the DVM master, so this goes out on PRTE_RML_TAG_SCHED
+        # and comes back on ..._SCHED_RESP.  With one daemon that relay never
+        # runs.  Run the tool THROUGH node3 by executing it there: it attaches
+        # to its local daemon, which is not the master.
+        out=$(ONT 3 "timeout 60 $SESSCTL pause 4242" 2>&1)
+        echo "$out" | grep -q PMIX_SUCCESS \
+            && ok "pause relayed through node3 was served by the master" \
+            || bad "relayed pause failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        # the procs of the session are stopped -- on BOTH nodes
+        sleep 2
+        n=0
+        for h in 3 4; do
+            ON $h 'ps -o stat= -C sleep 2>/dev/null | grep -q T' && n=$((n+1))
+        done
+        [ "$n" = 2 ] \
+            && ok "both nodes of the session have stopped procs" \
+            || skp "could not confirm stopped procs on both nodes (saw $n); ps may not report state here"
+
+        out=$(ONT 3 "timeout 60 $SESSCTL resume 4242" 2>&1)
+        echo "$out" | grep -q PMIX_SUCCESS \
+            && ok "resume relayed through node3 was served" \
+            || bad "relayed resume failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        banner "session: signal reaches the session jobs on every node"
+        # SIGTERM through the session, not through prun.  This is the path
+        # that packed the target namespace: it used to pack the ADDRESS OF THE
+        # POINTER rather than the name, so every daemon matched no job and the
+        # signal was silently dropped -- invisible on one node too, but this
+        # is where it is checked.
+        out=$(RUN "timeout 60 $SESSCTL signal 4242 15" 2>&1)
+        echo "$out" | grep -q PMIX_SUCCESS \
+            && ok "session signal accepted" \
+            || bad "session signal failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        sleep 5
+        n=0
+        for h in 1 2 3 4; do
+            ON $h 'pgrep -x sleep >/dev/null' && n=$((n+1))
+        done
+        [ "$n" = 0 ] \
+            && ok "the signal reached the session procs on every node" \
+            || bad "session procs survived the signal on $n node(s)"
+
+        banner "session: a session created to run apps is reclaimed when they end"
+        # 4242 was instantiated WITH apps, so it exists in order to run them
+        # and is finished when the last of them retires -- which the signal
+        # above just caused.  It must be gone, and its nodes must be back in
+        # the general pool without anyone having asked.
+        sleep 4
+        out=$(RUN "timeout 60 $SESSCTL pause 4242" 2>&1)
+        echo "$out" | grep -q PMIX_ERR_NOT_FOUND \
+            && ok "the session retired with its jobs" \
+            || bad "session 4242 outlived its only job: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        out=$(PRUN '-n 8 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 4 ] \
+            && ok "all four nodes are back in the general pool" \
+            || bad "expected 4 usable nodes after the session ended, saw $n: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+        banner "session: a standing reservation persists until it is terminated"
+        # Instantiated with NO apps, so nothing retires and nothing reclaims
+        # it.  It holds node4 until an explicit terminate says otherwise.
+        out=$(RUN "timeout 60 $SESSCTL instantiate 4243 --hosts node4:2" 2>&1)
+        echo "$out" | grep -q PMIX_SUCCESS \
+            && ok "standing reservation 4243 instantiated" \
+            || bad "instantiate failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        sleep 2
+        out=$(PRUN '-n 6 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -cE '^node4$')
+        [ "$n" = 0 ] \
+            && ok "the standing reservation is withholding its node" \
+            || bad "a general job used the reserved node: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        out=$(RUN "timeout 60 $SESSCTL terminate 4243" 2>&1)
+        echo "$out" | grep -q PMIX_SUCCESS \
+            && ok "session 4243 terminated on request" \
+            || bad "terminate failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        sleep 4
+        out=$(PRUN '-n 8 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 4 ] \
+            && ok "the terminated reservation gave its node back" \
+            || bad "expected 4 usable nodes after terminate, saw $n: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+        banner "session: an unknown session and a conflicting request are refused"
+        out=$(RUN "timeout 60 $SESSCTL pause 9999" 2>&1)
+        echo "$out" | grep -q PMIX_ERR_NOT_FOUND \
+            && ok "an unknown session id is refused with NOT_FOUND" \
+            || bad "unknown session was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    for n in $(seq 1 10); do docker exec "$NODE$n" sh -c 'pkill -9 -x sleep 2>/dev/null; true'; done
+    cleanup_swarm
+}
+
 #   * prte-info describing the build that is actually installed on each node
 #     -- a swarm running a stale install on some nodes is otherwise a launch
 #     failure with no obvious cause
@@ -4127,6 +4279,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_pmix
 
     test_prted
+
+    test_session
 
     test_tools
 

--- a/docs/how-things-work/schedulers/flow_of_control.rst
+++ b/docs/how-things-work/schedulers/flow_of_control.rst
@@ -25,4 +25,7 @@ pass the request on to the scheduler, and transport the reply back
 to the requestor.
 
 PRRTE only creates a session object as a result of a call from the
-scheduler via ``PMIx_Session_control``.
+scheduler via ``PMIx_Session_control``. What it does with each directive
+of that API - and where it deviates from the letter of the attribute
+description, as it must for preemption - is documented in
+:ref:`Session Control <session-control-label>`.

--- a/docs/how-things-work/schedulers/index.rst
+++ b/docs/how-things-work/schedulers/index.rst
@@ -11,3 +11,4 @@ with schedulers.
    overview.rst
    structures.rst
    flow_of_control.rst
+   session_control.rst

--- a/docs/how-things-work/schedulers/session_control.rst
+++ b/docs/how-things-work/schedulers/session_control.rst
@@ -1,0 +1,229 @@
+.. _session-control-label:
+
+Session Control
+===============
+
+A *session* in PRRTE is an allocation: a named set of nodes, together with
+the jobs running on them. The ``PMIx_Session_control`` API is how a
+scheduler creates, operates on, and reclaims one. This section describes
+what PRRTE does with each directive of that API, and — where PRRTE cannot
+do exactly what the directive describes — what it does instead and why.
+
+Who answers a request
+---------------------
+
+A session control request can reach PRRTE from the scheduler, from a tool,
+or from an application process, and it can arrive at any daemon in the DVM.
+Where it is decided depends on who asked:
+
+* A request arriving at a **non-master daemon** is relayed to the DVM master.
+  The master applies the same rules it would to a request that arrived
+  directly, so a caller gets the same answer whichever daemon it happens to
+  be attached to.
+
+* A request that **originated with the scheduler** is a directive *to* this
+  DVM, and the DVM master executes it.
+
+* A request from **anyone else**, when a scheduler is attached, is passed up
+  to the scheduler. The scheduler owns the decision and calls back down to
+  the DVM to carry it out. The requestor's identity is added to the
+  forwarded request as ``PMIX_REQUESTOR``.
+
+* A request from anyone else when **no scheduler is attached** is executed by
+  the DVM master, which is the only authority present. This is what makes
+  session control usable on a standalone ``prte`` DVM.
+
+In the last case the requestor must be entitled to act on the session. A
+reservation records both the namespaces that own it and the user it was
+granted to, and either is sufficient — so a second command run by the same
+person reaches an allocation their first command created, even though the
+tool namespace of the first command is long gone.
+
+Operations
+----------
+
+The operational directives are alternatives, not a program: naming more than
+one in a single request is refused with ``PMIX_ERR_BAD_PARAM``. A session id
+of ``UINT32_MAX`` applies the operation to every session the requestor
+controls (never to the DVM's own unreserved node pool).
+
+Instantiation
+^^^^^^^^^^^^^
+
+``PMIX_SESSION_INSTANTIATE`` creates the session named by the request's
+session id. The resources it is to hold are named by ``PMIX_SESSION_RESOURCES``
+(an array that may carry ``PMIX_ALLOC_NODE_LIST``, ``PMIX_ALLOC_ID``,
+``PMIX_ALLOC_REQ_ID``, ``PMIX_ALLOC_TIME`` and ``PMIX_ALLOC_INHERITANCE``), or
+by those same keys given directly on the request. Those nodes join the DVM's
+node pool and are then withheld from general use: a job may map onto them only
+if it is running in this session.
+
+``PMIX_SESSION_APP`` supplies the applications to start once the session
+exists, and ``PMIX_SESSION_JOB`` the job-level directives that go with them
+(job info without apps is an error, as is either one outside an
+instantiation). The job is launched into the new session. If the DVM had to
+be extended across newly-named nodes, the job waits until those daemons are
+up before it is mapped.
+
+The answer carries ``PMIX_SESSION_ID``, the ``PMIX_ALLOC_ID`` assigned to the
+session, and — when apps were given — the ``PMIX_NSPACE`` of the launched job.
+For a request that named apps, the answer is deferred until the launch
+completes, so a successful return means the job is running.
+
+Two constraints are worth knowing:
+
+* **A session must be given resources if it is given apps.** A session
+  withholds the nodes named for it, so one created with no resource
+  description holds nothing and no job in it can be mapped. PRRTE refuses
+  such a request up front rather than letting it appear to succeed and then
+  fail in the mapper with "no nodes are available".
+
+* **An instantiation that names no apps is a standing reservation.** It
+  persists until it is explicitly terminated (or its time limit expires). One
+  that *does* name apps exists in order to run them, and is reclaimed when the
+  last of them retires — at which point its nodes return to the general pool
+  and, if a scheduler instantiated it, ``PMIX_SESSION_COMPLETE`` is sent.
+
+Pause and resume
+^^^^^^^^^^^^^^^^
+
+``PMIX_SESSION_PAUSE`` stops every process of every job in the session with
+``SIGSTOP``; ``PMIX_SESSION_RESUME`` continues them with ``SIGCONT``. PRRTE
+tracks which jobs it has stopped, so a resume does not signal a job that was
+never paused and a pause does not re-signal one that already is.
+
+Note what this does **not** do: the processes keep their memory and their
+slots. PRRTE has no checkpoint facility with which to vacate a paused job and
+reinstate it later.
+
+Preempt and restore
+^^^^^^^^^^^^^^^^^^^
+
+``PMIX_SESSION_PREEMPT`` and ``PMIX_SESSION_RESTORE`` are the same mechanism
+applied to selected jobs: the jobs named by ``PMIX_NSPACE`` qualifiers, or all
+of them if none is given.
+
+**PRRTE's preemption is suspension-based, and this is a deliberate
+deviation.** The attribute describes preemption as halting the jobs *and
+recovering their resources*. Recovering them would mean checkpointing the
+jobs out of memory and restoring them later; PRRTE has no such facility, and
+terminating them instead would make the paired ``PMIX_SESSION_RESTORE``
+impossible to honor at all. So a preempted job stops and holds its
+resources, and a restored job resumes exactly where it was. A scheduler that
+genuinely needs the nodes back should terminate the session.
+
+Signal
+^^^^^^
+
+``PMIX_SESSION_SIGNAL`` delivers the given signal to every process of every
+job in the session, or to the jobs named by ``PMIX_NSPACE`` qualifiers.
+
+Terminate
+^^^^^^^^^
+
+``PMIX_SESSION_TERMINATE`` kills every job in the session. A job that was
+paused is continued first, since a stopped process cannot act on a
+termination order. The session itself is reclaimed once the last job has
+retired, so that its nodes are not pulled out from under processes still
+being killed.
+
+Extend
+^^^^^^
+
+``PMIX_SESSION_EXTEND`` adds nodes to a session (``PMIX_ALLOC_NODE_LIST``,
+which also extends the DVM across them), revises its time limit
+(``PMIX_ALLOC_TIME`` or ``PMIX_TIMEOUT``), or revises what becomes of its
+nodes at the end (``PMIX_ALLOC_INHERITANCE``). An extend that extends nothing
+is an error.
+
+Separation
+^^^^^^^^^^
+
+``PMIX_SESSION_SEP`` detaches a session from the namespace that owns it, so
+that the two terminate independently. It may accompany any other operation, or
+stand alone to change the disposition of an existing session.
+
+**A session created through this API is detached by default**, which is the
+opposite of an allocation reservation and is deliberate. A reservation is
+nodes a tool took for its own use, and it dies with that tool. A session is
+named, addressable by anyone authorized, and destroyed by an explicit
+terminate, by its own time limit, or — when it was created to run apps — when
+those apps finish. Tying it to the requester instead would make the API
+unusable for the thing it exists to do: the requester is a tool, its namespace
+lasts only as long as the request, and the session would be reclaimed out from
+under its own jobs the moment the caller disconnected. Giving
+``PMIX_SESSION_SEP`` a **false** value on the instantiation opts back into
+requester lifetime.
+
+Completion
+^^^^^^^^^^
+
+``PMIX_SESSION_COMPLETE`` is what the RTE says to its scheduler, not the
+other way round: PRRTE is the only party that knows when the jobs have
+finished and the nodes are free. A request carrying it is refused with
+``PMIX_ERR_NOT_SUPPORTED``.
+
+PRRTE **sends** it when a session the scheduler instantiated is reclaimed.
+The notification carries the session id, the allocation id, and a
+``PMIX_JOB_INFO_ARRAY`` for each job that ran in the session, giving that
+job's ``PMIX_NSPACE`` and ``PMIX_JOB_TERM_STATUS``. Those statuses are
+accumulated as the jobs retire, because the job objects themselves do not
+survive to the end of the session. The PRRTE-side teardown is completed
+before the notification is sent, so the claim it makes — that the resources
+have been recovered — is already true when the scheduler receives it.
+
+Session lifetime
+----------------
+
+A scheduler may impose a time limit on a session with ``PMIX_ALLOC_TIME`` (in
+``months:days:hours:minutes:seconds``, scanned from the right, so a bare
+``"2"`` is two seconds) or ``PMIX_TIMEOUT`` (in seconds) on the instantiation.
+When the limit expires PRRTE terminates the session exactly as an explicit
+``PMIX_SESSION_TERMINATE`` would. ``PMIX_SESSION_EXTEND`` re-arms the limit.
+No limit is in force unless one was asked for.
+
+When a session is reclaimed, ``PMIX_ALLOC_INHERITANCE`` decides what becomes
+of its nodes: ``PMIX_ALLOC_INHERIT_NONE`` and ``PMIX_ALLOC_INHERIT_CHILD``
+hand them back to the scheduler, and the default returns them to the DVM's
+general pool. Handing the nodes away is the destructive choice, so it is the
+one a scheduler has to ask for rather than the one it gets by saying nothing.
+The DVM master's own node is never shrunk out of its own DVM, even when it is
+a member of the reservation being handed back.
+
+What PRRTE does not support
+---------------------------
+
+* **Provisioning.** ``PMIX_SESSION_PROVISION_NODES`` and
+  ``PMIX_SESSION_PROVISION_IMAGE`` are refused with
+  ``PMIX_ERR_NOT_SUPPORTED``. PRRTE runs on the machines it is given, in the
+  state it finds them.
+
+* **Resource selection.** A resource description that asks PRRTE to *choose*
+  machines — a node count, a cpu count, a memory size, a queue — is refused.
+  PRRTE is the thing being scheduled; naming the nodes is the scheduler's
+  job. Node lists (plain, regex, or regex2) are what PRRTE acts on.
+
+* **Credentials.** ``PMIX_USERID`` on an instantiation is recorded as the
+  user the reservation is granted to, and is honored when deciding who may
+  later act on it. ``PMIX_GRPID`` is accepted and ignored: PRRTE never
+  changes credentials, so every process it starts runs as the user running
+  the DVM.
+
+An unrecognized directive is not an error. A request may be addressed at more
+than one kind of RTE, and refusing on a key PRRTE simply has no opinion about
+would break a caller it otherwise serves.
+
+Trying it out
+-------------
+
+``examples/sessionctrl.c`` is a tool that drives each of these operations
+against a running DVM. Because a DVM with no scheduler answers for itself,
+it works against an ordinary ``prte --daemonize``::
+
+    prte --daemonize
+    ./sessionctrl instantiate 42 --hosts $(hostname -s) -- /bin/sleep 300
+    ./sessionctrl pause 42
+    ./sessionctrl resume 42
+    ./sessionctrl signal 42 15
+    ./sessionctrl terminate 42
+    pterm

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -66,6 +66,7 @@ EXAMPLES = \
 	dynamic-dep \
 	abort \
 	elastic \
+	sessionctrl \
 	slurm/elastic-coordination
 
 all: $(EXAMPLES)

--- a/examples/sessionctrl.c
+++ b/examples/sessionctrl.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * Drive PMIx_Session_control against a running DVM.
+ *
+ * Sessions are the scheduler's business, so a DVM that has a scheduler
+ * attached forwards everything this tool asks to that scheduler. Run against
+ * a DVM with no scheduler - the ordinary "prte --daemonize" case - the DVM
+ * master is its own authority and executes the request itself, which is what
+ * makes this usable as a test client.
+ *
+ *   sessionctrl instantiate <id> [--hosts LIST] [--time SPEC] [--sep]
+ *                                [-- <cmd> [args...]]
+ *   sessionctrl pause      <id>
+ *   sessionctrl resume     <id>
+ *   sessionctrl preempt    <id> [--nspace NS]
+ *   sessionctrl restore    <id> [--nspace NS]
+ *   sessionctrl signal     <id> <signum>
+ *   sessionctrl extend     <id> [--hosts LIST] [--time SPEC]
+ *   sessionctrl terminate  <id>
+ *
+ * <id> may be given as "all" to address every session under our control.
+ */
+
+#include <pmix.h>
+#include <pmix_tool.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* tiny lock so the main thread can block on the async callback */
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+    volatile int active;
+    pmix_status_t status;
+} lock_t;
+
+static void lock_init(lock_t *l)
+{
+    pthread_mutex_init(&l->mtx, NULL);
+    pthread_cond_init(&l->cond, NULL);
+    l->active = 1;
+    l->status = PMIX_SUCCESS;
+}
+static void lock_wait(lock_t *l)
+{
+    pthread_mutex_lock(&l->mtx);
+    while (l->active) {
+        pthread_cond_wait(&l->cond, &l->mtx);
+    }
+    pthread_mutex_unlock(&l->mtx);
+}
+static void lock_wake(lock_t *l, pmix_status_t st)
+{
+    pthread_mutex_lock(&l->mtx);
+    l->status = st;
+    l->active = 0;
+    pthread_cond_signal(&l->cond);
+    pthread_mutex_unlock(&l->mtx);
+}
+
+static void ctrl_cb(pmix_status_t status, pmix_info_t *info, size_t ninfo, void *cbdata,
+                    pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    lock_t *l = (lock_t *) cbdata;
+    size_t n;
+
+    fprintf(stderr, "SESSION CONTROL returned %s\n", PMIx_Error_string(status));
+    for (n = 0; n < ninfo; n++) {
+        switch (info[n].value.type) {
+        case PMIX_STRING:
+            fprintf(stderr, "    %s = %s\n", info[n].key, info[n].value.data.string);
+            break;
+        case PMIX_UINT32:
+            fprintf(stderr, "    %s = %u\n", info[n].key, info[n].value.data.uint32);
+            break;
+        default:
+            fprintf(stderr, "    %s (type %s)\n", info[n].key,
+                    PMIx_Data_type_string(info[n].value.type));
+            break;
+        }
+    }
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    lock_wake(l, status);
+}
+
+static void usage(const char *me)
+{
+    fprintf(stderr,
+            "usage: %s <operation> <sessionid|all> [options] [-- cmd [args...]]\n"
+            "  operations: instantiate pause resume preempt restore signal extend terminate\n"
+            "  options:    --hosts LIST   comma-delimited node names\n"
+            "              --time SPEC    [[[[months:]days:]hours:]minutes:]seconds\n"
+            "              --np N         procs to start (default 1)\n"
+            "              --mapby POLICY mapping policy for those procs (e.g. node)\n"
+            "              --nspace NS    limit preempt/restore to one job\n"
+            "              --sep          session terminates independently of its parent\n",
+            me);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_proc_t myproc;
+    pmix_info_t *dirs = NULL;
+    pmix_app_t *apps = NULL;
+    pmix_info_t *jobinfo = NULL;
+    pmix_data_array_t appdarray, jobdarray;
+    size_t ndirs = 0, n = 0;
+    uint32_t sessionid;
+    const char *op, *hosts = NULL, *timespec = NULL, *nspace = NULL;
+    const char *mapby = NULL;
+    int signum = 0, i, cmdstart = 0, np = 1;
+    bool sep = false, all = false;
+    lock_t lock;
+    char *end;
+
+    if (3 > argc) {
+        usage(argv[0]);
+        return 1;
+    }
+    op = argv[1];
+    if (0 == strcmp(argv[2], "all")) {
+        all = true;
+        sessionid = UINT32_MAX;
+    } else {
+        errno = 0;
+        sessionid = (uint32_t) strtoul(argv[2], &end, 10);
+        if (0 != errno || '\0' != *end) {
+            fprintf(stderr, "%s: bad session id \"%s\"\n", argv[0], argv[2]);
+            return 1;
+        }
+    }
+    (void) all;
+
+    for (i = 3; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--")) {
+            cmdstart = i + 1;
+            break;
+        } else if (0 == strcmp(argv[i], "--hosts") && i + 1 < argc) {
+            hosts = argv[++i];
+        } else if (0 == strcmp(argv[i], "--time") && i + 1 < argc) {
+            timespec = argv[++i];
+        } else if (0 == strcmp(argv[i], "--np") && i + 1 < argc) {
+            np = (int) strtol(argv[++i], &end, 10);
+            if ('\0' != *end || 1 > np) {
+                fprintf(stderr, "%s: bad proc count \"%s\"\n", argv[0], argv[i]);
+                return 1;
+            }
+        } else if (0 == strcmp(argv[i], "--mapby") && i + 1 < argc) {
+            mapby = argv[++i];
+        } else if (0 == strcmp(argv[i], "--nspace") && i + 1 < argc) {
+            nspace = argv[++i];
+        } else if (0 == strcmp(argv[i], "--sep")) {
+            sep = true;
+        } else if (0 == strcmp(op, "signal") && 0 == signum) {
+            signum = (int) strtol(argv[i], &end, 10);
+            if ('\0' != *end) {
+                fprintf(stderr, "%s: bad signal \"%s\"\n", argv[0], argv[i]);
+                return 1;
+            }
+        } else {
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
+    /* count the directives we are about to build */
+    ndirs = 2;                                          /* operation + ctrl id */
+    if (NULL != hosts) {
+        ndirs++;
+    }
+    if (NULL != timespec) {
+        ndirs++;
+    }
+    if (NULL != nspace) {
+        ndirs++;
+    }
+    if (sep) {
+        ndirs++;
+    }
+    if (0 < cmdstart) {
+        ndirs++;                                     /* PMIX_SESSION_APP */
+        if (NULL != mapby) {
+            ndirs++;                                 /* PMIX_SESSION_JOB */
+        }
+    }
+    PMIX_INFO_CREATE(dirs, ndirs);
+
+    PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_CTRL_ID, "sessionctrl-example", PMIX_STRING);
+
+    if (0 == strcmp(op, "instantiate")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_INSTANTIATE, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "pause")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_PAUSE, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "resume")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_RESUME, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "preempt")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_PREEMPT, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "restore")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_RESTORE, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "extend")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_EXTEND, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "terminate")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_TERMINATE, NULL, PMIX_BOOL);
+    } else if (0 == strcmp(op, "signal")) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_SIGNAL, &signum, PMIX_INT);
+    } else {
+        usage(argv[0]);
+        PMIX_INFO_FREE(dirs, ndirs);
+        return 1;
+    }
+
+    if (NULL != hosts) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_ALLOC_NODE_LIST, hosts, PMIX_STRING);
+    }
+    if (NULL != timespec) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_ALLOC_TIME, timespec, PMIX_STRING);
+    }
+    if (NULL != nspace) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_NSPACE, nspace, PMIX_STRING);
+    }
+    if (sep) {
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_SEP, NULL, PMIX_BOOL);
+    }
+    if (0 < cmdstart) {
+        PMIX_APP_CREATE(apps, 1);
+        apps[0].cmd = strdup(argv[cmdstart]);
+        apps[0].maxprocs = np;
+        for (i = cmdstart; i < argc; i++) {
+            PMIx_Argv_append_nosize(&apps[0].argv, argv[i]);
+        }
+        appdarray.type = PMIX_APP;
+        appdarray.size = 1;
+        appdarray.array = apps;
+        PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_APP, &appdarray, PMIX_DATA_ARRAY);
+
+        /* job-level directives that go with those apps - PMIX_SESSION_JOB is
+         * only meaningful alongside PMIX_SESSION_APP */
+        if (NULL != mapby) {
+            PMIX_INFO_CREATE(jobinfo, 1);
+            PMIX_INFO_LOAD(&jobinfo[0], PMIX_MAPBY, mapby, PMIX_STRING);
+            jobdarray.type = PMIX_INFO;
+            jobdarray.size = 1;
+            jobdarray.array = jobinfo;
+            PMIX_INFO_LOAD(&dirs[n++], PMIX_SESSION_JOB, &jobdarray, PMIX_DATA_ARRAY);
+        }
+    }
+
+    rc = PMIx_tool_init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_tool_init failed: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_FREE(dirs, ndirs);
+        return 1;
+    }
+
+    lock_init(&lock);
+    rc = PMIx_Session_control(sessionid, dirs, n, ctrl_cb, &lock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Session_control failed: %s\n", PMIx_Error_string(rc));
+        lock_wake(&lock, rc);
+    } else {
+        lock_wait(&lock);
+    }
+
+    PMIX_INFO_FREE(dirs, ndirs);
+    if (NULL != apps) {
+        PMIX_APP_FREE(apps, 1);
+    }
+    if (NULL != jobinfo) {
+        PMIX_INFO_FREE(jobinfo, 1);
+    }
+    PMIx_tool_finalize();
+    return (PMIX_SUCCESS == lock.status) ? 0 : 1;
+}

--- a/src/mca/plm/base/plm_base_prted_cmds.c
+++ b/src/mca/plm/base/plm_base_prted_cmds.c
@@ -170,10 +170,19 @@ int prte_plm_base_prted_signal_local_procs(pmix_nspace_t job, int32_t signal)
     int rc;
     pmix_data_buffer_t cmd;
     prte_daemon_cmd_flag_t command = PRTE_DAEMON_SIGNAL_LOCAL_PROCS;
+    /* A pmix_nspace_t is an array type, so as a PARAMETER it has decayed to a
+     * char* - and &job is therefore the address of that pointer variable, not
+     * of the name. Packing PMIX_PROC_NSPACE reads PMIX_MAX_NSLEN+1 bytes from
+     * whatever it is handed, so passing &job packed a stack fragment and the
+     * receiving daemon matched no job at all: every signal delivered through
+     * this entry point was silently dropped. Copy into real storage first. */
+    pmix_nspace_t jobid;
 
     PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                          "%s plm:base:prted_cmd sending signal_local_procs cmds",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+
+    PMIX_LOAD_NSPACE(jobid, job);
 
     PMIX_DATA_BUFFER_CONSTRUCT(&cmd);
 
@@ -186,7 +195,7 @@ int prte_plm_base_prted_signal_local_procs(pmix_nspace_t job, int32_t signal)
     }
 
     /* pack the jobid */
-    rc = PMIx_Data_pack(NULL, &cmd, &job, 1, PMIX_PROC_NSPACE);
+    rc = PMIx_Data_pack(NULL, &cmd, &jobid, 1, PMIX_PROC_NSPACE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_DESTRUCT(&cmd);

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -114,6 +114,19 @@ PRTE_EXPORT void prte_ras_base_check_reservations_on_term(prte_job_t *jdata);
 
 PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
 
+/* Render the node specification carried by a PMIX_ALLOC_NODE_LIST-style info
+ * (a string, a regex, or a regex2) into a comma-delimited node-name string the
+ * caller must free. Returns PMIX_ERR_BAD_PARAM for any other value type. */
+PRTE_EXPORT pmix_status_t prte_ras_base_parse_node_list(pmix_info_t *info,
+                                                        char **ndstring);
+
+/* Add the named nodes to the global pool, marking each PRTE_NODE_STATE_ADDED,
+ * and register them with the destination reservation (which withholds them
+ * from general use). Pass NULL or the default session to leave them in the
+ * general pool. Returns a PRRTE code. */
+PRTE_EXPORT int prte_ras_base_insert_node_string(char *ndstring,
+                                                 prte_session_t *dest);
+
 PRTE_EXPORT char *prte_ras_base_flag_string(prte_node_t *node);
 
 PRTE_EXPORT void prte_ras_base_activate_dvm_grow(void);

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -896,6 +896,15 @@ void prte_ras_base_teardown_reservation(prte_session_t *session,
                 if (NULL == nd || NULL == nd->daemon) {
                     continue;
                 }
+                /* Never shrink ourselves out of our own DVM. A reservation may
+                 * legitimately include the head node - a single-node DVM whose
+                 * whole allocation is carved into one session is the extreme
+                 * case - and ordering the master's own daemon to depart takes
+                 * the DVM down with it, losing every other job still running
+                 * on it. The head node simply reverts to the general pool. */
+                if (nd->daemon->name.rank == PRTE_PROC_MY_NAME->rank) {
+                    continue;
+                }
                 ranks[m++] = nd->daemon->name.rank;
             }
         }

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1071,6 +1071,13 @@ void prte_ras_base_check_reservations_on_term(prte_job_t *jdata)
         if (!(s->flags & PRTE_SESSION_FLAG_RESERVED)) {
             continue;
         }
+        /* a session separated from its parent (PMIX_SESSION_SEP) terminates
+         * independently of the namespace that owns it, so no namespace
+         * termination fires its inheritance disposition. It is released only
+         * by an explicit PMIX_SESSION_TERMINATE or at DVM teardown. */
+        if (s->flags & PRTE_SESSION_FLAG_DETACHED) {
+            continue;
+        }
 
         switch (s->inheritance) {
 #if defined(PMIX_ALLOC_INHERIT_NONE)
@@ -1110,7 +1117,7 @@ void prte_ras_base_check_reservations_on_term(prte_job_t *jdata)
     }
 }
 
-static pmix_status_t ras_base_parse_node_list(pmix_info_t *info, char **ndstring)
+pmix_status_t prte_ras_base_parse_node_list(pmix_info_t *info, char **ndstring)
 {
     pmix_status_t rc;
     char **nodes = NULL;
@@ -1251,7 +1258,7 @@ static pmix_status_t ras_base_prepare_grow(prte_pmix_server_req_t *req,
     return PMIX_SUCCESS;
 }
 
-static int ras_base_insert_node_string(char *ndstring, prte_session_t *dest)
+int prte_ras_base_insert_node_string(char *ndstring, prte_session_t *dest)
 {
     pmix_list_t ndlist;
     prte_node_t *snap;
@@ -1383,13 +1390,13 @@ static void ras_base_complete_grow_request(prte_pmix_server_req_t *req)
             continue;
         }
 
-        rc = ras_base_parse_node_list(&req->info[n], &ndstring);
+        rc = prte_ras_base_parse_node_list(&req->info[n], &ndstring);
         if (PMIX_SUCCESS != rc) {
             req->pstatus = rc;
             return;
         }
 
-        ret = ras_base_insert_node_string(ndstring, dest);
+        ret = prte_ras_base_insert_node_string(ndstring, dest);
         free(ndstring);
         if (PRTE_SUCCESS != ret) {
             req->pstatus = prte_pmix_convert_rc(ret);
@@ -1670,7 +1677,7 @@ static void ras_base_complete_release_request(prte_pmix_server_req_t *req)
             continue;
         }
 
-        rc = ras_base_parse_node_list(&req->info[n], &ndstring);
+        rc = prte_ras_base_parse_node_list(&req->info[n], &ndstring);
         if (PMIX_SUCCESS != rc) {
             req->pstatus = rc;
             return;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -875,6 +875,12 @@ release:
                 }
             }
         }
+        /* Tell the session-control layer the job is gone. It records the
+         * termination status for the completion report the scheduler is owed,
+         * and reclaims a session that exists only to run the jobs it was
+         * instantiated with. Must follow the removal above, since that is what
+         * it tests to decide the session has drained. */
+        prte_pmix_server_session_job_terminated(session, jdata);
     }
     if (NULL != jdata->map) {
         map = jdata->map;

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -47,7 +47,8 @@ upcall; each file below implements a related group of them.
 | `pmix_server_group.c` | `group` — a thin pass-through to grpcomm. |
 | `pmix_server_job_ctrl.c` | `job_control` — kill/terminate/signal/define-pset, as daemon commands. |
 | `pmix_server_monitor.c` | `monitor` — heartbeat/file monitoring, fanned out to all daemons and collected. |
-| `pmix_server_alloc*.c`, `pmix_server_session.c` | `allocate` and `session_control`, relayed to the DVM master and on to a scheduler. |
+| `pmix_server_alloc*.c` | `allocate`, relayed to the DVM master and on to a scheduler. |
+| `pmix_server_session.c` | `session_control` — see its own section below. |
 
 ---
 
@@ -243,6 +244,75 @@ onto PRRTE job and app attributes. Notes for extending them:
 
 ---
 
+## Session control (`pmix_server_session.c`)
+
+`PMIx_Session_control` is the scheduler's API for creating, operating on and
+reclaiming a `prte_session_t` — PRRTE's allocation object. The whole surface
+is implemented here; the user-facing description of what each directive does
+(and where PRRTE deliberately deviates) is
+[`docs/how-things-work/schedulers/session_control.rst`](../../../docs/how-things-work/schedulers/session_control.rst).
+The parts that matter when editing this file:
+
+- **Who decides.** A request from the scheduler is a directive *to* this DVM
+  and is executed here. One from anybody else is forwarded to the scheduler —
+  **unless there is no scheduler**, in which case the DVM master is the
+  authority and answers for itself, gated on `prte_session_is_owned_by`. That
+  decision is made in **two** places, `pass_request()` here and
+  `pmix_server_sched()` in `pmix_server.c` (the relay from a peer daemon), and
+  they must agree: otherwise the same request is served or refused depending
+  on which daemon the caller happened to attach to.
+- **Parse first, act second.** `parse_directives()` walks the whole array and
+  records; nothing acts during the walk. An info array has no defined order,
+  and the previous single-pass version mis-handled an `INSTANTIATE` that
+  arrived *before* its `SESSION_JOB` — the job was built but never attached to
+  the session. Operations are alternatives, not a program: more than one is
+  `PMIX_ERR_BAD_PARAM`.
+- **An unrecognized directive is not an error.** A request may be addressed at
+  more than one kind of RTE. Refuse only what PRRTE is being asked to do and
+  cannot (`PROVISION_*`, anything asking it to *choose* machines).
+- **`answer_request()` owns the completion for both callers**, because they
+  answer through different callbacks: a local client's answer goes to PMIx's
+  own callback (synchronous), a relayed one to `send_alloc_resp` (which
+  thread-shifts and packs later). A response array this file built is
+  therefore **detached** from the request and handed over with its own release
+  callback — tying it to the request instead would free it under the deferred
+  half. The same detach is why `local_index` is invalidated after the slot is
+  cleared: `_send_alloc_resp` clears it again from the other side, by which
+  time the index may belong to somebody else.
+- **A deferred answer returns `PMIX_OPERATION_IN_PROGRESS`.** Only an
+  instantiation that launches apps does this — the answer carries the launched
+  nspace, so it waits for the launch. Everything else answers inline.
+- **The relayed path must be thread-shifted, and must arrive holding an extra
+  reference.** `pmix_server_sched()` is an RML *receive* callback, and serving
+  a session control drives the PLM and xcasts daemon commands — re-entering
+  the RML from inside its own dispatch. Post an event (the allocation branch
+  of that same handler already does). And `_send_alloc_resp` releases the
+  request **twice** — explicitly, and again through its caddy's destructor —
+  so the request has to be handed over with the `PMIX_RETAIN` the allocation
+  branch takes. Without it the last release runs the destructor while the
+  object lock is held and the master deadlocks against itself
+  (`futex_wait_queue` in `pmix_obj_update`, from `ardes`).
+- **A session created here is DETACHED by default**, unlike a reservation. A
+  reservation dies with the tool that took it; a session is named and
+  addressable and must outlive the request that created it, or its own jobs
+  would be reclaimed the moment the requesting tool exited.
+- **Reclaiming a session is `reclaim_session()`, and it is not a terminate.**
+  It runs when the last job of an auto-completing or terminating session
+  retires (`prte_pmix_server_session_job_terminated()`, called from
+  `state_dvm.c`'s `check_complete`). Whether the nodes go back to the
+  *scheduler* or back to the DVM's general pool is the session's
+  `PMIX_ALLOC_INHERITANCE` disposition, and the default is the general pool:
+  handing them away is destructive and must be asked for. Note that
+  `prte_ras_base_teardown_reservation` never shrinks the master's own daemon
+  out of the DVM — a single-node DVM whose whole allocation is one session
+  would otherwise terminate itself when that session ended.
+- **The completion report is accumulated, not gathered.** `PMIX_SESSION_COMPLETE`
+  must carry every job's termination status, and the job objects do not survive
+  to the end of the session — so each one is recorded on `session->results` as
+  it retires.
+
+---
+
 ## A tool's departure
 
 `_client_finalized()` is the **only** notice a daemon gets that a tool has
@@ -329,8 +399,9 @@ it is enforced here:
 ## Testing
 
 **Unit — `test/unit/prted/`.** The directive translators
-(`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`) and the job-info cache
-are pure data transforms and are covered there. Most of the rest of this
+(`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`), the job-info cache, and
+the session time-limit parser (`prte_pmix_server_parse_session_time`) are
+pure data transforms and are covered there. Most of the rest of this
 directory needs a live PMIx server and at least one peer daemon.
 
 **Live smoke test.** `prte --daemonize && prun -n 4 hostname && pterm`
@@ -345,7 +416,11 @@ only exist with more than one daemon:
   `target` bug hung;
 - a **tool connecting through a non-master daemon**, which exercises the
   `TCONN` relay rather than the HNP's local shortcut;
-- **job-scoped signal delivery** in a DVM running more than one job.
+- **job-scoped signal delivery** in a DVM running more than one job;
+- **session control** (`test_session`) — a reservation actually withholding
+  its nodes from a general job, a request relayed from a non-master daemon,
+  and a session signal reaching the jobs on every node they occupy. It is
+  driven by `examples/sessionctrl.c`, which `build.sh` installs.
 
 ---
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -363,6 +363,10 @@ static prte_regattr_input_t prte_attributes[] = {
                          NULL}},
     {.function = "PMIx_Session_control",
      .attrs = (char *[]){"PMIX_SESSION_CTRL_ID",
+                         "PMIX_REQUESTOR",
+                         "PMIX_SESSION_INSTANTIATE",
+                         "PMIX_SESSION_RESOURCES",
+                         "PMIX_SESSION_JOB",
                          "PMIX_SESSION_APP",
                          "PMIX_SESSION_PAUSE",
                          "PMIX_SESSION_RESUME",
@@ -370,7 +374,16 @@ static prte_regattr_input_t prte_attributes[] = {
                          "PMIX_SESSION_PREEMPT",
                          "PMIX_SESSION_RESTORE",
                          "PMIX_SESSION_SIGNAL",
-                         "PMIX_SESSION_COMPLETE",
+                         "PMIX_SESSION_EXTEND",
+                         "PMIX_SESSION_SEP",
+                         "PMIX_ALLOC_ID",
+                         "PMIX_ALLOC_REQ_ID",
+                         "PMIX_ALLOC_NODE_LIST",
+                         "PMIX_ALLOC_TIME",
+                         "PMIX_PERSONALITY",
+                         "PMIX_USERID",
+                         "PMIX_NSPACE",
+                         "PMIX_TIMEOUT",
                          NULL}},
     {.function = ""},
 };
@@ -2196,6 +2209,10 @@ static void _send_alloc_resp(int sd, short args, void *cbdata)
     }
 
     /* send the response */
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s sending sched response to %s for their req %d",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(&req->proxy), req->remote_index);
     PRTE_RML_RELIABLE_SEND(rc, req->proxy.rank, buf, PRTE_RML_TAG_SCHED_RESP);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
@@ -2216,6 +2233,23 @@ cleanup:
     pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
     PMIX_RELEASE(cd);
+}
+
+/* Run a relayed session-control directive on the progress thread.
+ *
+ * pmix_server_sched() is an RML RECEIVE callback, and serving a session
+ * control means driving the PLM and xcasting daemon commands - work that
+ * re-enters the RML to send while we are still inside its dispatch. The
+ * allocation branch of that same handler posts an event to reach
+ * prte_ras_base_modify for exactly this reason; do the same here rather than
+ * calling inline, which wedged the master's event loop outright. */
+static void _relayed_session_ctrl(int sd, short args, void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(req);
+    prte_pmix_server_session_ctrl_local(req);
 }
 
 static void send_alloc_resp(pmix_status_t status,
@@ -2367,19 +2401,9 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
 
     // session control request
 
-    /* we are the DVM master, so handle this ourselves - start
-     * by ensuring the scheduler is connected to us */
-    rc = prte_pmix_set_scheduler();
-    if (PMIX_SUCCESS != rc) {
-        /* the scheduler has not attached to us - there is
-         * nothing we can do */
-        rc = PMIX_ERR_NOT_SUPPORTED;
-        PMIX_INFO_FREE(info, ninfo);
-        goto reply;
-    }
-
     req = PMIX_NEW(prte_pmix_server_req_t);
     pmix_asprintf(&req->operation, "SESSIONCTRL: %u", sessionID);
+    req->sessionID = sessionID;
     req->remote_index = refid;
     req->copy = true;
     req->info = info;
@@ -2392,6 +2416,38 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
      * release callback on this path belongs to the PMIx library),
      * so an extra retain would leak it */
     req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    req->infocbfunc = send_alloc_resp;
+    req->cbdata = req;
+
+    /* see whether a scheduler is available to us - this is allowed to fail,
+     * since a DVM running without one is its own authority over its sessions */
+    rc = prte_pmix_set_scheduler();
+
+    /* A directive that originated with the scheduler is a directive to this
+     * DVM and is executed here; so is one from anybody else when there is no
+     * scheduler to defer to. This has to match the decision pass_request()
+     * makes for a request that arrives at the master directly, or the same
+     * request would be served or refused depending on which daemon the caller
+     * happened to be attached to. */
+    if (PMIX_SUCCESS != rc ||
+        PMIX_CHECK_PROCID(&prte_pmix_server_globals.scheduler, &req->tproc)) {
+        /* Hand it to the progress thread; it takes over the request from
+         * there, answering through send_alloc_resp.
+         *
+         * Take the extra reference the allocation branch above takes, and for
+         * the same reason: completing through send_alloc_resp consumes TWO
+         * releases - the explicit one in _send_alloc_resp and the one its
+         * caddy's destructor performs - whereas the answering side here
+         * (answer_request) drops only the reference the request was created
+         * with. Without this the last release runs the destructor while the
+         * object lock is held, and the DVM master deadlocks against itself. */
+        PMIX_RETAIN(req);
+        prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE,
+                       _relayed_session_ctrl, req);
+        PMIX_POST_OBJECT(req);
+        prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+        return;
+    }
 
     rc = PMIx_Session_control(sessionID, req->info, req->ninfo,
                               send_alloc_resp, req);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -765,6 +765,7 @@ int pmix_server_init(void)
     PMIX_CONSTRUCT(&prte_pmix_server_globals.notifications, pmix_list_t);
     prte_pmix_server_globals.server = *PRTE_NAME_INVALID;
     prte_pmix_server_globals.scheduler_connected = false;
+    prte_pmix_server_globals.scheduler_lookup_done = false;
     prte_pmix_server_globals.scheduler_set_as_server = false;
 
     PMIX_INFO_LIST_START(ilist);

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -14,6 +14,7 @@
 #include "src/rml/rml.h"
 #include "src/util/dash_host/dash_host.h"
 #include "src/mca/ras/base/base.h"
+#include "src/util/name_fns.h"
 
 void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
                                     pmix_data_buffer_t *buffer,
@@ -47,9 +48,20 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
         return;
     }
 
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s sched response received for local req %d: %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req_index,
+                        PMIx_Error_string(ret));
+
     req = pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, req_index);
     if (NULL == req) {
-        // nothing we can do
+        /* The index arrived on the wire, so it is untrusted - but it is also
+         * OUR index, echoed back, so a miss means the request was retired
+         * early and whoever is waiting on it will wait forever. There is
+         * nothing to complete, so say so rather than returning in silence. */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s sched response names local req %d, which is gone",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req_index);
         return;
     }
 
@@ -85,9 +97,18 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
 
 ANSWER:
     if (NULL != req->infocbfunc) {
-        // pass the response back to the requestor
-        req->infocbfunc(ret, req->info, req->ninfo, req, prte_pmix_server_req_release, req);
+        /* Pass the response back to the requestor.  The callback's cbdata is
+         * the one the ORIGINAL caller gave us (req->cbdata) - PMIx uses it to
+         * find the request it is completing.  Handing it the tracker instead
+         * meant every allocation and every session-control request issued
+         * from a non-master daemon was answered into the void: the client sat
+         * in its PMIx call until it timed out, or the library faulted on the
+         * unrecognized pointer. */
+        req->infocbfunc(ret, req->info, req->ninfo, req->cbdata,
+                        prte_pmix_server_req_release, req);
     } else {
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                    req->local_index, NULL);
         PMIX_RELEASE(req);
     }
 }

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -119,13 +119,36 @@ pmix_status_t prte_pmix_set_scheduler(void)
     pmix_info_t info[2];
 
     if (!prte_pmix_server_globals.scheduler_connected) {
-        /* the scheduler has not attached to us - see if we
-         * can attach to it, make it optional so we don't
-         * hang if there is no scheduler available */
+        /* Look for a scheduler to attach to - ONCE.
+         *
+         * PMIx_tool_attach_to_server is a BLOCKING call, and this runs on the
+         * PRRTE progress thread, which is the only thread driving the DVM. It
+         * hunts for a rendezvous and tries to connect to what it finds, so
+         * repeating it per request puts a filesystem scan and a connect
+         * attempt in front of every allocation and every session-control
+         * request. Against a DVM with no scheduler - the ordinary case, where
+         * it can only ever fail - that is pure cost on the one thread that
+         * must not be spent.
+         *
+         * Nothing is lost by looking only once. A scheduler that appears
+         * later announces itself by attaching to US, and the tool-connect
+         * upcall (pmix_server_gen.c) sets scheduler_connected from there. */
+        if (prte_pmix_server_globals.scheduler_lookup_done) {
+            return PMIX_ERR_UNREACH;
+        }
+        prte_pmix_server_globals.scheduler_lookup_done = true;
+        /* make it optional so we don't hang if there is no scheduler */
         PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SCHEDULER, NULL, PMIX_BOOL);
         PMIX_INFO_LOAD(&info[1], PMIX_TOOL_CONNECT_OPTIONAL, NULL, PMIX_BOOL);
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s looking for a scheduler to attach to",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         rc = PMIx_tool_attach_to_server(NULL, &prte_pmix_server_globals.scheduler,
                                         info, 2);
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s scheduler attach returned %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            PMIx_Error_string(rc));
         PMIX_INFO_DESTRUCT(&info[0]);
         PMIX_INFO_DESTRUCT(&info[1]);
         if (PMIX_SUCCESS != rc) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -195,6 +195,21 @@ callback:
     PMIX_RELEASE(req);
 }
 
+/* Submit a fully-constructed job for launch.  This is the same path a
+ * PMIx_Spawn takes once interim() has finished translating it, exposed so
+ * that a caller which builds its own job object - notably a session
+ * instantiation carrying PMIX_SESSION_APP definitions - can hand it to the
+ * PLM without duplicating the request-tracking and packing in spawn().
+ *
+ * MUST be called on the PRRTE progress thread. cbfunc is invoked with the
+ * launched job's namespace once the HNP answers, or with a NULL namespace
+ * and a PMIx error if the request could not be sent. */
+void prte_pmix_server_launch_job(prte_job_t *jdata,
+                                 pmix_spawn_cbfunc_t cbfunc, void *cbdata)
+{
+    PRTE_SPN_REQ(jdata, spawn, cbfunc, cbdata);
+}
+
 int prte_pmix_xfer_job_info(prte_job_t *jdata,
                             pmix_info_t *iptr,
                             size_t ninfo)

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -432,6 +432,9 @@ typedef struct {
     bool no_foreign_tools;
     bool system_controller;
     bool scheduler_connected;
+    /* we have already looked for a scheduler to attach to and found none - do
+     * not look again. See prte_pmix_set_scheduler(). */
+    bool scheduler_lookup_done;
     bool remote_connections;
     bool tool_support;
     bool require_pid_match;

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -343,6 +343,28 @@ PRTE_EXPORT extern pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *reque
                                                         const pmix_info_t directives[], size_t ndirs,
                                                         pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Hand a caller-constructed job object to the PLM for launch, exactly as a
+ * PMIx_Spawn would once its directives have been translated. Must be called
+ * on the PRRTE progress thread; cbfunc reports the launched namespace. */
+PRTE_EXPORT extern void prte_pmix_server_launch_job(prte_job_t *jdata,
+                                                    pmix_spawn_cbfunc_t cbfunc,
+                                                    void *cbdata);
+
+/* Report to the scheduler that a session it instantiated has completed - all
+ * of its jobs have terminated and its resources have been recovered. Called
+ * from the DVM state machine as each job retires. A no-op for a session the
+ * scheduler did not instantiate. */
+PRTE_EXPORT extern void prte_pmix_server_session_complete(prte_session_t *session);
+
+/* Notice from the DVM state machine that a job in the given session has
+ * terminated. Records the job's termination status for the completion report
+ * and, when the session was defined to run that job (or is being torn down)
+ * and nothing is left running in it, reclaims the session. Must be called
+ * AFTER the job has been removed from session->jobs, and only on the DVM
+ * master. */
+PRTE_EXPORT extern void prte_pmix_server_session_job_terminated(prte_session_t *session,
+                                                                prte_job_t *jdata);
+
 /* declare the RML recv functions for responses */
 PRTE_EXPORT extern void pmix_server_launch_resp(int status, pmix_proc_t *sender,
                                                 pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
@@ -404,6 +426,20 @@ pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                             uint32_t sessionID,
                             const pmix_info_t directives[], size_t ndirs,
                             pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+/* Interpret a PMIX_ALLOC_TIME session time limit -
+ * "[[[[months:]days:]hours:]minutes:]seconds", scanned from the right - and
+ * return it in seconds, or -1 if the string is not a well-formed time. */
+PRTE_EXPORT extern long prte_pmix_server_parse_session_time(const char *str);
+
+/* Execute a session control directive against this DVM's own sessions, and
+ * answer the request. Used when the directive came from the scheduler (a
+ * directive TO us) or when there is no scheduler to defer to, in which case
+ * the DVM master is the authority over its own sessions. Takes over the
+ * request: the caller must neither answer nor release it afterwards. Must be
+ * called on the PRRTE progress thread, on the DVM master. */
+PRTE_EXPORT extern void
+prte_pmix_server_session_ctrl_local(prte_pmix_server_req_t *req);
 
 
 /* exposed shared variables */

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -7,268 +7,1444 @@
  * $HEADER$
  */
 
+/*
+ * PRRTE's implementation of the PMIx_Session_control host callback.
+ *
+ * A "session" here is a prte_session_t - PRRTE's allocation object. The
+ * scheduler is the authority over sessions: it instantiates them onto a set
+ * of nodes, operates on them while they run, and reclaims them. Requests
+ * that reach a daemon from anyone else are relayed to the scheduler, which
+ * decides and calls back down to us. When no scheduler is present the DVM
+ * master is the authority and answers for itself, subject to the ownership
+ * check every reservation carries.
+ *
+ * What PRRTE can and cannot do with each directive is recorded at the
+ * operation that implements it. The two it cannot do at all are
+ * PMIX_SESSION_PROVISION_NODES and PMIX_SESSION_PROVISION_IMAGE: PRRTE does
+ * not image machines.
+ */
+
 #include "prte_config.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
 
 #include "src/pmix/pmix-internal.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/rml/rml.h"
 #include "src/util/dash_host/dash_host.h"
+#include "src/mca/plm/plm.h"
 #include "src/mca/ras/base/base.h"
 #include "src/mca/rmaps/rmaps.h"
+#include "src/mca/rmaps/base/base.h"
 #include "src/mca/schizo/base/base.h"
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_wait.h"
+#include "src/util/name_fns.h"
 #include "src/util/pmix_show_help.h"
 
-/* Process the session control directive from the scheduler.
- *
- * Returns a pmix_status_t - NOT a PRRTE return code.  The caller
- * (pass_request) hands the result straight to req->infocbfunc, which is a
- * PMIx callback, so every exit from here must already be in PMIx's numbering.
- * This function must also never invoke that callback itself: pass_request
- * falls through to its "callback:" tail on return, so answering here too
- * would deliver the response twice and release the request twice. */
-static pmix_status_t process_directive(prte_pmix_server_req_t *req)
-{
-    char *user_refid = NULL, *alloc_refid = NULL;
-    pmix_info_t *personality = NULL, *iptr;
-    pmix_proc_t *requestor = NULL;
-    char *hosts = NULL;
-    prte_session_t *session = NULL;
-    prte_job_t *jdata = NULL;
-    prte_app_context_t *app;
-    pmix_app_t *apps;
+/* the mutually-exclusive operations a session control request may ask for */
+typedef enum {
+    PRTE_SESSCTRL_NONE = 0,
+    PRTE_SESSCTRL_INSTANTIATE,
+    PRTE_SESSCTRL_TERMINATE,
+    PRTE_SESSCTRL_PAUSE,
+    PRTE_SESSCTRL_RESUME,
+    PRTE_SESSCTRL_PREEMPT,
+    PRTE_SESSCTRL_RESTORE,
+    PRTE_SESSCTRL_SIGNAL,
+    PRTE_SESSCTRL_EXTEND,
+    PRTE_SESSCTRL_COMPLETE,
+    PRTE_SESSCTRL_MODIFY        /* no operation, only modifiers (e.g. SEP) */
+} prte_sessctrl_op_t;
+
+/* The parsed form of one request. Every pointer in here is BORROWED from the
+ * caller's directive array, which PMIx keeps alive until we answer - with the
+ * single exception of the nodelist/nspaces argv arrays, which we build and
+ * which sessctrl_destruct frees. */
+typedef struct {
+    prte_sessctrl_op_t op;
+    int nops;                   /* number of operations named - >1 is an error */
+    char *ctrl_id;              /* PMIX_SESSION_CTRL_ID, echoed in the answer */
+    pmix_proc_t requestor;      /* PMIX_REQUESTOR if given, else the caller */
+    bool have_sep;
+    bool sep;
+    /* instantiation */
+    pmix_info_t *jobinfo;       /* PMIX_SESSION_JOB payload */
+    size_t njobinfo;
+    pmix_app_t *apps;           /* PMIX_SESSION_APP payload */
     size_t napps;
-    size_t n, i;
-    int j, prc;
+    pmix_info_t *personality;
+    char **nodelists;           /* rendered PMIX_ALLOC_NODE_LIST strings */
+    char *alloc_refid;          /* PMIX_ALLOC_ID */
+    char *user_refid;           /* PMIX_ALLOC_REQ_ID */
+    uid_t uid;
+    bool have_uid;
+    uint8_t inheritance;        /* PMIX_ALLOC_INHERITANCE disposition */
+    bool have_inheritance;
+    long timelimit;             /* seconds; -1 if not specified */
+    /* operational */
+    int sigvalue;
+    char **nspaces;             /* PMIX_NSPACE targets for preempt/restore */
+} prte_sessctrl_t;
+
+static void sessctrl_construct(prte_sessctrl_t *ctl)
+{
+    memset(ctl, 0, sizeof(prte_sessctrl_t));
+    PMIX_LOAD_PROCID(&ctl->requestor, NULL, PMIX_RANK_INVALID);
+    ctl->timelimit = -1;
+    ctl->uid = PRTE_INVALID_UID;
+    ctl->inheritance = PRTE_INHERIT_DEFAULT_VALUE;
+}
+
+static void sessctrl_destruct(prte_sessctrl_t *ctl)
+{
+    if (NULL != ctl->nodelists) {
+        PMIx_Argv_free(ctl->nodelists);
+        ctl->nodelists = NULL;
+    }
+    if (NULL != ctl->nspaces) {
+        PMIx_Argv_free(ctl->nspaces);
+        ctl->nspaces = NULL;
+    }
+}
+
+/*****   DIRECTIVE PARSING   *****/
+
+/* Convert a PMIX_ALLOC_TIME specification into seconds. The format is
+ * "months:days:hours:minutes:seconds" scanned from the RIGHT, so a bare "2"
+ * means two seconds and "1:30" means a minute and a half. A month is taken as
+ * 30 days, which is the only fixed value available without a calendar date to
+ * anchor it. Returns -1 if the string is not a well-formed time.
+ *
+ * Exported solely so test/unit/prted can cover it: it is a pure function of
+ * its argument, and it is the one place a scheduler's time limit is
+ * interpreted. */
+long prte_pmix_server_parse_session_time(const char *str)
+{
+    /* multiplier for each field, right to left */
+    static const long mult[] = {1, 60, 3600, 86400, 2592000};
+    char **fields;
+    int n, nf, ncolons = 0;
+    long total = 0, val;
+    char *end;
+    const char *p;
+
+    if (NULL == str || '\0' == str[0]) {
+        return -1;
+    }
+    for (p = str; '\0' != *p; p++) {
+        if (':' == *p) {
+            ncolons++;
+        }
+    }
+    fields = PMIx_Argv_split(str, ':');
+    if (NULL == fields) {
+        return -1;
+    }
+    nf = PMIx_Argv_count(fields);
+    if (0 == nf || nf > (int) (sizeof(mult) / sizeof(mult[0]))) {
+        PMIx_Argv_free(fields);
+        return -1;
+    }
+    /* PMIx_Argv_split DISCARDS empty tokens, so ":30", "1:" and "1::2" all
+     * come back as a shorter field list rather than as an error - and each
+     * would then be read as a different, perfectly plausible duration. A
+     * misread time limit terminates a user's session at the wrong moment, so
+     * reject anything whose separator count does not match the fields it
+     * produced. */
+    if (ncolons != nf - 1) {
+        PMIx_Argv_free(fields);
+        return -1;
+    }
+    /* walk right to left so the rightmost field is always seconds */
+    for (n = 0; n < nf; n++) {
+        const char *f = fields[nf - 1 - n];
+        errno = 0;
+        val = strtol(f, &end, 10);
+        /* strtol always hands back a non-NULL end pointer aimed at the first
+         * character it did not consume, so the test is on *end */
+        if (0 != errno || '\0' != *end || 0 > val) {
+            PMIx_Argv_free(fields);
+            return -1;
+        }
+        total += val * mult[n];
+    }
+    PMIx_Argv_free(fields);
+    return total;
+}
+
+/* record that another operation was named - the caller rejects nops > 1 */
+static void set_op(prte_sessctrl_t *ctl, prte_sessctrl_op_t op, bool flag)
+{
+    if (!flag) {
+        return;
+    }
+    ctl->op = op;
+    ctl->nops++;
+}
+
+/* Scan the resource description carried by PMIX_SESSION_RESOURCES. Only the
+ * node-naming forms mean anything to PRRTE: it does not select machines, it is
+ * told which ones it has. A request that asks PRRTE to choose (a node COUNT, a
+ * cpu count, a memory size) is refused rather than silently granted whatever
+ * the caller happened to also name. */
+static pmix_status_t scan_resources(prte_sessctrl_t *ctl,
+                                    pmix_info_t *info, size_t ninfo)
+{
+    size_t n;
     pmix_status_t rc;
-    bool terminate = false;
-    bool pause = false;
-    bool resume = false;
-    bool preempt = false;
-    bool restore = false;
-    bool signal = false;
-    bool extend = false;
-    int sigvalue = 0, tval = 0;
+    char *ndstring;
 
-    /* cycle across the directives to see what we are being asked to do */
-    for (n = 0; n < req->ninfo; n++) {
-
-        if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_INSTANTIATE)) {
-            // check to see if we already have this session
-            session = prte_get_session_object(req->sessionID);
-            if (NULL != session) {
-                // this is an error - cannot instantiate a preexisting
-                // session
-                return PMIX_ERR_BAD_PARAM;
-            }
-            /* create a new session object */
-            session = PMIX_NEW(prte_session_t);
-            if (NULL == session) {
-                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-                return PMIX_ERR_NOMEM;
-            }
-            session->session_id = req->sessionID;
-            prc = prte_set_session_object(session);
-            if (PRTE_SUCCESS != prc) {
-                PMIX_RELEASE(session);
-                return prte_pmix_convert_rc(prc);
-            }
-            // if a job has already been described, add it here
-            if (NULL != jdata) {
-                pmix_pointer_array_add(session->jobs, jdata);
-            }
-            if (NULL != alloc_refid) {
-                session->alloc_refid = strdup(alloc_refid);
-                alloc_refid = NULL;
-            }
-            if (NULL != user_refid) {
-                session->user_refid = strdup(user_refid);
-                user_refid = NULL;
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_JOB)) {
-            if (NULL == jdata) {
-                jdata = PMIX_NEW(prte_job_t);
-                jdata->map = PMIX_NEW(prte_job_map_t);
-                /* default to the requestor as the originator */
-                if (NULL != requestor) {
-                    PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
-                }
-            }
-            // transfer the job description across
-            iptr = (pmix_info_t*)req->info[n].value.data.darray->array;
-            i = req->info[n].value.data.darray->size;
-            prc = prte_pmix_xfer_job_info(jdata, iptr, i);
-            if (PRTE_SUCCESS != prc) {
-                PRTE_ERROR_LOG(prc);
-                return prte_pmix_convert_rc(prc);
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_APP)) {
-            // the apps that are to be started in the session
-            if (NULL == jdata) {
-                jdata = PMIX_NEW(prte_job_t);
-                jdata->map = PMIX_NEW(prte_job_map_t);
-                /* default to the requestor as the originator */
-                if (NULL != requestor) {
-                    PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
-                }
-            }
-            apps = (pmix_app_t*)req->info[n].value.data.darray->array;
-            napps = req->info[n].value.data.darray->size;
-            for (i=0; i < napps; i++) {
-                prc = prte_pmix_xfer_app(jdata, &apps[i]);
-                if (PRTE_SUCCESS != prc) {
-                    PRTE_ERROR_LOG(prc);
-                    return prte_pmix_convert_rc(prc);
-                }
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_PERSONALITY)) {
-            personality = &req->info[n];
-            if (NULL != jdata && NULL == jdata->personality) {
-                jdata->personality = PMIx_Argv_split(personality->value.data.string, ',');
-                jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
-                pmix_server_cache_job_info(jdata, personality);
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_REQUESTOR)) {
-            requestor = req->info[n].value.data.proc;
-            if (NULL != jdata) {
-                PMIX_LOAD_PROCID(&jdata->originator, requestor->nspace, requestor->rank);
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_NODES) ||
-                   PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PROVISION_IMAGE)) {
-            // we don't support these directives
-            return PMIX_ERR_NOT_SUPPORTED;
-
-        } else if(PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_ID)) {
-            if (NULL != session) {
-                session->alloc_refid = strdup(req->info[n].value.data.string);
-            } else {
-                alloc_refid = req->info[n].value.data.string;
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_REQ_ID)) {
-            if (NULL != session) {
-                session->user_refid = strdup(req->info[n].value.data.string);
-            } else {
-                user_refid = req->info[n].value.data.string;
-            }
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_NODE_LIST)) {
-            hosts = req->info[n].value.data.string;
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_ALLOC_NUM_CPU_LIST)) {
-            // we don't support this directive
-            return PMIX_ERR_NOT_SUPPORTED;
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PAUSE)) {
-            pause = PMIX_INFO_TRUE(&req->info[n]);
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_RESUME)) {
-            resume = PMIX_INFO_TRUE(&req->info[n]);
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_TERMINATE)) {
-            terminate = PMIX_INFO_TRUE(&req->info[n]);
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_PREEMPT)) {
-            preempt = PMIX_INFO_TRUE(&req->info[n]);
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_RESTORE)) {
-            restore = PMIX_INFO_TRUE(&req->info[n]);
-
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_SIGNAL)) {
-            signal = true;
-            PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, sigvalue, int);
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NODE_LIST)) {
+            rc = prte_ras_base_parse_node_list(&info[n], &ndstring);
             if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            PMIx_Argv_append_nosize(&ctl->nodelists, ndstring);
+            free(ndstring);
+
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_ID)) {
+            ctl->alloc_refid = info[n].value.data.string;
+
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_REQ_ID)) {
+            ctl->user_refid = info[n].value.data.string;
+
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_TIME)) {
+            ctl->timelimit = prte_pmix_server_parse_session_time(info[n].value.data.string);
+            if (0 > ctl->timelimit) {
                 return PMIX_ERR_BAD_PARAM;
             }
 
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_SESSION_EXTEND)) {
-            extend = PMIX_INFO_TRUE(&req->info[n]);
+#if defined(PMIX_ALLOC_INHERITANCE)
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_INHERITANCE)) {
+            ctl->inheritance = info[n].value.data.uint8;
+            ctl->have_inheritance = true;
+#endif
 
-        } else if (PMIX_CHECK_KEY(&req->info[n], PMIX_TIMEOUT)) {
-            PMIX_VALUE_GET_NUMBER(rc, &req->info[n].value, tval, int);
-            if (PMIX_SUCCESS != rc) {
-                return PMIX_ERR_BAD_PARAM;
-            }
-        }
-    }  // for loop
-
-
-    if (NULL == session) {
-        // this operation is referring to a previously instantiated session
-        session = prte_get_session_object(req->sessionID);
-        if (NULL == session) {
-            // we don't know about it
-            return PMIX_ERR_NOT_FOUND;
-        }
-        // TODO: execute the specified operation on this session
-        if (terminate || pause || resume || restore || preempt ||
-            signal || extend || 0 < tval || 0 < sigvalue) {
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NUM_NODES) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NUM_CPUS) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NUM_CPU_LIST) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_CPU_LIST) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_MEM_SIZE) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_FABRIC) ||
+                   PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_QUEUE)) {
+            /* these describe resources PRRTE would have to go and find - that
+             * is the scheduler's job, and PRRTE is the thing being scheduled */
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s session ctrl: unsupported resource directive %s",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), info[n].key);
             return PMIX_ERR_NOT_SUPPORTED;
         }
-        return PMIX_SUCCESS;
-    }
-
-    // continue working on a new instantiation
-    if (NULL != jdata) {
-        /* find the personality being passed - we need this info to direct
-         * option parsing */
-        if (NULL == personality) {
-            // do a quick search for it
-            for (i=0; i < req->ninfo; i++) {
-                if (PMIX_CHECK_KEY(&req->info[i], PMIX_PERSONALITY)) {
-                    personality = &req->info[i];
-                    break;
-                }
-            }
-        }
-        if (NULL == personality) {
-            /* use the default */
-            jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(NULL);
-        } else if (NULL == jdata->personality) {
-            /* only resolve it once - the info scan above may already have
-             * done so, and repeating the split leaks the first argv and
-             * caches the same job info twice */
-            jdata->personality = PMIx_Argv_split(personality->value.data.string, ',');
-            jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(personality->value.data.string);
-            pmix_server_cache_job_info(jdata, personality);
-        }
-        if (NULL == jdata->schizo) {
-            /* no component claims the requested personality - refuse the
-             * request instead of leaving the job with a NULL personality
-             * for someone downstream to dereference */
-            pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
-                           (NULL == personality) ? "NULL" : personality->value.data.string);
-            return PMIX_ERR_NOT_FOUND;
-        }
-    }
-
-    if (NULL != hosts) {
-        /* add the designation to the apps in the job, if one was provided. These
-         * will be added to the global pool when the job is setup for launch */
-        if (NULL != jdata) {
-            for (j=0; j < jdata->apps->size; j++) {
-                app = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, j);
-                if (NULL == app) {
-                    continue;
-                }
-                // the add_host attribute will be removed after processing
-                prte_set_attribute(&app->attributes, PRTE_APP_ADD_HOST, PRTE_ATTR_GLOBAL,
-                                   hosts, PMIX_STRING);
-                /* also provide it as dash-host (if not already specified) so the
-                 * job will use those nodes */
-                if (!prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, NULL, PMIX_STRING)) {
-                    prte_set_attribute(&app->attributes, PRTE_APP_DASH_HOST, PRTE_ATTR_GLOBAL,
-                                       hosts, PMIX_STRING);
-                }
-            }
-        }
+        /* anything else in the resource description is ignored - it may well
+         * be meaningful to a different RTE */
     }
     return PMIX_SUCCESS;
 }
+
+/* Walk the request once, recording everything. Nothing is acted on here: an
+ * info array has no defined order, and the operations below depend on values
+ * that may appear after them (the whole reason the previous single-pass
+ * version mis-handled an INSTANTIATE that preceded its SESSION_JOB). */
+static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
+                                      prte_sessctrl_t *ctl)
+{
+    size_t n;
+    pmix_status_t rc;
+    char *ndstring;
+    pmix_data_array_t *darray;
+
+    /* the caller is the requestor unless a relaying daemon named the original */
+    PMIX_XFER_PROCID(&ctl->requestor, &req->tproc);
+
+    for (n = 0; n < req->ninfo; n++) {
+        pmix_info_t *info = &req->info[n];
+
+        if (PMIX_CHECK_KEY(info, PMIX_SESSION_CTRL_ID)) {
+            ctl->ctrl_id = info->value.data.string;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_REQUESTOR)) {
+            if (PMIX_PROC != info->value.type || NULL == info->value.data.proc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            PMIX_XFER_PROCID(&ctl->requestor, info->value.data.proc);
+
+            /***   INSTANTIATION   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_INSTANTIATE)) {
+            set_op(ctl, PRTE_SESSCTRL_INSTANTIATE, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_RESOURCES)) {
+            darray = info->value.data.darray;
+            if (PMIX_DATA_ARRAY != info->value.type || NULL == darray ||
+                PMIX_INFO != darray->type) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            rc = scan_resources(ctl, (pmix_info_t *) darray->array, darray->size);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_JOB)) {
+            darray = info->value.data.darray;
+            if (PMIX_DATA_ARRAY != info->value.type || NULL == darray ||
+                PMIX_INFO != darray->type) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            ctl->jobinfo = (pmix_info_t *) darray->array;
+            ctl->njobinfo = darray->size;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_APP)) {
+            darray = info->value.data.darray;
+            if (PMIX_DATA_ARRAY != info->value.type || NULL == darray ||
+                PMIX_APP != darray->type) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            ctl->apps = (pmix_app_t *) darray->array;
+            ctl->napps = darray->size;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_PROVISION_NODES) ||
+                   PMIX_CHECK_KEY(info, PMIX_SESSION_PROVISION_IMAGE)) {
+            /* PRRTE does not provision machines - it runs on the ones it is
+             * given, in the state it finds them */
+            return PMIX_ERR_NOT_SUPPORTED;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_PERSONALITY)) {
+            ctl->personality = info;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_USERID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, ctl->uid, uid_t);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            ctl->have_uid = true;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_GRPID)) {
+            /* Accepted and ignored. PRRTE never changes credentials - every
+             * process it starts runs as the user running the DVM - so a group
+             * id is not something it can act on. The user id IS recorded,
+             * because reservation ownership is checked against it. */
+            continue;
+
+            /***   RESOURCES NAMED DIRECTLY ON THE REQUEST   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_NODE_LIST)) {
+            rc = prte_ras_base_parse_node_list(info, &ndstring);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            PMIx_Argv_append_nosize(&ctl->nodelists, ndstring);
+            free(ndstring);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_ID)) {
+            ctl->alloc_refid = info->value.data.string;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_REQ_ID)) {
+            ctl->user_refid = info->value.data.string;
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_TIME)) {
+            ctl->timelimit = prte_pmix_server_parse_session_time(info->value.data.string);
+            if (0 > ctl->timelimit) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+
+#if defined(PMIX_ALLOC_INHERITANCE)
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_INHERITANCE)) {
+            /* governs what becomes of the session's nodes when it is reclaimed:
+             * handed back to the scheduler, or returned to the DVM's general
+             * pool. See returns_to_scheduler(). */
+            ctl->inheritance = info->value.data.uint8;
+            ctl->have_inheritance = true;
+#endif
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_NUM_CPU_LIST) ||
+                   PMIX_CHECK_KEY(info, PMIX_ALLOC_NUM_NODES) ||
+                   PMIX_CHECK_KEY(info, PMIX_ALLOC_NUM_CPUS) ||
+                   PMIX_CHECK_KEY(info, PMIX_ALLOC_MEM_SIZE)) {
+            return PMIX_ERR_NOT_SUPPORTED;
+
+            /***   OPERATIONS   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_PAUSE)) {
+            set_op(ctl, PRTE_SESSCTRL_PAUSE, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_RESUME)) {
+            set_op(ctl, PRTE_SESSCTRL_RESUME, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_TERMINATE)) {
+            set_op(ctl, PRTE_SESSCTRL_TERMINATE, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_PREEMPT)) {
+            set_op(ctl, PRTE_SESSCTRL_PREEMPT, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_RESTORE)) {
+            set_op(ctl, PRTE_SESSCTRL_RESTORE, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_COMPLETE)) {
+            set_op(ctl, PRTE_SESSCTRL_COMPLETE, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_EXTEND)) {
+            set_op(ctl, PRTE_SESSCTRL_EXTEND, PMIX_INFO_TRUE(info));
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_SIGNAL)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, ctl->sigvalue, int);
+            if (PMIX_SUCCESS != rc || 0 >= ctl->sigvalue) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            set_op(ctl, PRTE_SESSCTRL_SIGNAL, true);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_SESSION_SEP)) {
+            ctl->have_sep = true;
+            ctl->sep = PMIX_INFO_TRUE(info);
+
+            /***   QUALIFIERS   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_NSPACE)) {
+            /* names a job within the session - preempt/restore target these */
+            PMIx_Argv_append_nosize(&ctl->nspaces, info->value.data.string);
+
+        } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, ctl->timelimit, long);
+            if (PMIX_SUCCESS != rc || 0 > ctl->timelimit) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+        }
+        /* an unrecognized directive is not an error: the request may be
+         * addressed at more than one RTE, and refusing on a key we simply
+         * have no opinion about would break a caller we otherwise serve */
+    }
+
+    if (1 < ctl->nops) {
+        /* the operations are alternatives, not a program - "pause and
+         * terminate" has no meaning and no safe interpretation */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: %d conflicting operations requested",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), ctl->nops);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (0 == ctl->nops) {
+        /* a request carrying only modifiers still has work to do */
+        ctl->op = (ctl->have_sep) ? PRTE_SESSCTRL_MODIFY : PRTE_SESSCTRL_NONE;
+    }
+    /* the header is explicit that job info without apps is an error - there is
+     * nothing for it to describe */
+    if (NULL != ctl->jobinfo && NULL == ctl->apps) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if ((NULL != ctl->apps || NULL != ctl->jobinfo) &&
+        PRTE_SESSCTRL_INSTANTIATE != ctl->op) {
+        /* apps are only launched as part of instantiating the session that is
+         * to hold them */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    return PMIX_SUCCESS;
+}
+
+/*****   OPERATIONS   *****/
+
+/* True if the requestor may operate on this session. prte_session_is_owned_by
+ * is the whole answer: it admits the scheduler (when one is connected),
+ * the namespaces recorded as owners, and - for a tool - the user the
+ * reservation was granted to, which is what lets a second command from the
+ * same person reach an allocation their first command created. */
+#define AUTHORIZED(s, r) prte_session_is_owned_by((s), (r)->nspace)
+
+static bool nspace_named(char **nspaces, const pmix_nspace_t nspace)
+{
+    int i;
+
+    if (NULL == nspaces) {
+        return true;    /* no filter - every job matches */
+    }
+    for (i = 0; NULL != nspaces[i]; i++) {
+        if (PMIX_CHECK_NSPACE(nspaces[i], nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Deliver a signal to every job in the session, or to just the named ones.
+ * When mark is true the jobs are additionally flagged suspended (or, when
+ * clear is true, un-flagged), which is what makes a later resume/restore able
+ * to tell a stopped job from a running one. */
+static pmix_status_t session_signal(prte_session_t *session, char **nspaces,
+                                    int32_t sig, bool mark, bool suspend)
+{
+    int k, rc;
+    prte_job_t *jdata;
+    bool found = false;
+    pmix_status_t ret = PMIX_SUCCESS;
+
+    for (k = 0; k < session->jobs->size; k++) {
+        jdata = (prte_job_t *) pmix_pointer_array_get_item(session->jobs, k);
+        if (NULL == jdata) {
+            continue;
+        }
+        if (!nspace_named(nspaces, jdata->nspace)) {
+            continue;
+        }
+        found = true;
+        if (mark) {
+            /* do not stop a job twice, and do not continue one that was never
+             * stopped - either would leave the flag disagreeing with the
+             * process state, and SIGCONT to a running job is a wasted xcast */
+            if (suspend == (bool) PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_SUSPENDED)) {
+                continue;
+            }
+        }
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: signal %d to job %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) sig,
+                            PRTE_JOBID_PRINT(jdata->nspace));
+        rc = prte_plm.signal_job(jdata->nspace, sig);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            ret = prte_pmix_convert_rc(rc);
+            continue;
+        }
+        if (mark) {
+            if (suspend) {
+                PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_SUSPENDED);
+            } else {
+                PRTE_FLAG_UNSET(jdata, PRTE_JOB_FLAG_SUSPENDED);
+            }
+        }
+    }
+
+    if (NULL != nspaces && !found) {
+        /* the caller named jobs and none of them are in this session */
+        return PMIX_ERR_NOT_FOUND;
+    }
+    return ret;
+}
+
+/* Arm (or re-arm) the session's time limit. Passing 0 seconds disarms it. */
+static void session_timeout_cb(int fd, short args, void *cbdata);
+
+static void arm_session_timer(prte_session_t *session, long seconds)
+{
+    if (NULL != session->timer) {
+        prte_event_evtimer_del(session->timer->ev);
+        PMIX_RELEASE(session->timer);
+        session->timer = NULL;
+    }
+    session->timeout.tv_sec = seconds;
+    session->timeout.tv_usec = 0;
+    if (0 >= seconds) {
+        return;
+    }
+    session->timer = PMIX_NEW(prte_timer_t);
+    session->timer->payload = session;
+    prte_event_evtimer_set(prte_event_base, session->timer->ev,
+                           session_timeout_cb, session);
+    prte_event_evtimer_add(session->timer->ev, &session->timeout);
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl: session %u time limit set to %ld sec",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        session->session_id, seconds);
+}
+
+/* True when the session's disposition says its nodes go back to the scheduler
+ * rather than back to the DVM's general pool. Mirrors what
+ * prte_ras_base_check_reservations_on_term applies on namespace termination,
+ * and defaults - as that does - to unreserving into the DVM: handing the nodes
+ * away is the destructive choice, and it must be the one the caller asked for
+ * rather than the one it gets by saying nothing. */
+static bool returns_to_scheduler(prte_session_t *session)
+{
+#if defined(PMIX_ALLOC_INHERIT_NONE)
+    if (PMIX_ALLOC_INHERIT_NONE == session->inheritance) {
+        return true;
+    }
+#endif
+#if defined(PMIX_ALLOC_INHERIT_CHILD)
+    if (PMIX_ALLOC_INHERIT_CHILD == session->inheritance) {
+        return true;
+    }
+#endif
+    return false;
+}
+
+/* Reclaim a session whose jobs have all retired: give up its hold on its
+ * nodes and, if the scheduler instantiated it, tell the scheduler it is done.
+ * Runs on the PRRTE progress thread. */
+static void reclaim_session(prte_session_t *session)
+{
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl: reclaiming session %u",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), session->session_id);
+
+    /* disarm the clock before the session goes - the event carries a bare
+     * pointer to it */
+    arm_session_timer(session, 0);
+
+    /* Do the PRRTE-side teardown first, while we are on the thread that owns
+     * these objects. Only then report completion, so the statement we make to
+     * the scheduler - "all resources have been recovered" - is already true
+     * when we make it. */
+    prte_ras_base_teardown_reservation(session, returns_to_scheduler(session));
+
+    prte_pmix_server_session_complete(session);
+}
+
+/* Terminate every job in the session. The session itself is reclaimed once
+ * the last of them retires (prte_pmix_server_session_job_terminated), so that
+ * the nodes are not pulled out from under processes still being killed. */
+static pmix_status_t session_terminate(prte_session_t *session)
+{
+    int k, rc;
+    prte_job_t *jdata;
+    bool running = false;
+    pmix_status_t ret = PMIX_SUCCESS;
+
+    session->flags |= PRTE_SESSION_FLAG_TERMINATING;
+
+    for (k = 0; k < session->jobs->size; k++) {
+        jdata = (prte_job_t *) pmix_pointer_array_get_item(session->jobs, k);
+        if (NULL == jdata) {
+            continue;
+        }
+        running = true;
+        /* a stopped process cannot act on a termination order, so let it run
+         * again first - otherwise the kill only lands when something else
+         * happens to continue it */
+        if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_SUSPENDED)) {
+            prte_plm.signal_job(jdata->nspace, SIGCONT);
+            PRTE_FLAG_UNSET(jdata, PRTE_JOB_FLAG_SUSPENDED);
+        }
+        rc = prte_plm.terminate_job(jdata->nspace);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            ret = prte_pmix_convert_rc(rc);
+        }
+    }
+    session->flags &= ~PRTE_SESSION_FLAG_PAUSED;
+
+    if (!running) {
+        /* nothing to wait for */
+        reclaim_session(session);
+    }
+    return ret;
+}
+
+/* The session's time limit expired. Treat it exactly as a terminate from the
+ * scheduler: that is what the limit means. */
+static void session_timeout_cb(int fd, short args, void *cbdata)
+{
+    prte_session_t *session = (prte_session_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl: session %u time limit expired",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), session->session_id);
+
+    /* the event is not persistent and has now fired, so drop our hold on it
+     * before anything below can release the session */
+    if (NULL != session->timer) {
+        PMIX_RELEASE(session->timer);
+        session->timer = NULL;
+    }
+    session->timeout.tv_sec = 0;
+
+    session_terminate(session);
+}
+
+/* Add resources to an existing session, extend its time limit, or both. */
+static pmix_status_t session_extend(prte_session_t *session, prte_sessctrl_t *ctl)
+{
+    int i, ret;
+    bool grew = false;
+
+    if (NULL != ctl->nodelists) {
+        for (i = 0; NULL != ctl->nodelists[i]; i++) {
+            ret = prte_ras_base_insert_node_string(ctl->nodelists[i], session);
+            if (PRTE_SUCCESS != ret) {
+                PRTE_ERROR_LOG(ret);
+                return prte_pmix_convert_rc(ret);
+            }
+            grew = true;
+        }
+    }
+    if (0 <= ctl->timelimit) {
+        arm_session_timer(session, ctl->timelimit);
+    }
+    if (ctl->have_inheritance) {
+        /* an extend may also revise what becomes of the nodes at the end */
+        session->inheritance = ctl->inheritance;
+    }
+    if (!grew && 0 > ctl->timelimit && !ctl->have_inheritance) {
+        /* an extend that extends nothing */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (grew) {
+        /* launch daemons onto the newly added nodes */
+        prte_ras_base_activate_dvm_grow();
+    }
+    return PMIX_SUCCESS;
+}
+
+/*****   INSTANTIATION   *****/
+
+/* Build the job described by the request's PMIX_SESSION_APP/PMIX_SESSION_JOB
+ * directives. Mirrors interim() in pmix_server_dyn.c, and in the same order:
+ * the apps have to exist before the personality's default runtime options can
+ * be resolved, and both have to precede the job info. Returns NULL on failure
+ * with a PMIx status in *status. */
+static prte_job_t *build_session_job(prte_sessctrl_t *ctl, prte_session_t *session,
+                                     pmix_status_t *status)
+{
+    prte_job_t *jdata;
+    prte_app_context_t *app;
+    prte_rmaps_options_t options;
+    prte_schizo_base_module_t *schizo;
+    size_t i;
+    int j, rc;
+
+    *status = PMIX_SUCCESS;
+
+    jdata = PMIX_NEW(prte_job_t);
+    jdata->map = PMIX_NEW(prte_job_map_t);
+    PMIX_LOAD_PROCID(&jdata->originator, ctl->requestor.nspace, ctl->requestor.rank);
+
+    if (NULL != ctl->personality) {
+        jdata->personality = PMIx_Argv_split(ctl->personality->value.data.string, ',');
+        jdata->schizo = (struct prte_schizo_base_module_t *)
+            prte_schizo_base_detect_proxy(ctl->personality->value.data.string);
+        pmix_server_cache_job_info(jdata, ctl->personality);
+    } else {
+        jdata->schizo = (struct prte_schizo_base_module_t *)
+            prte_schizo_base_detect_proxy(NULL);
+    }
+    if (NULL == jdata->schizo) {
+        /* no component claims the requested personality. Every later use of
+         * jdata->schizo is an unchecked dereference, so refuse here rather
+         * than let a bad personality string take down the DVM */
+        pmix_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
+                       (NULL == ctl->personality) ? "NULL"
+                                                  : ctl->personality->value.data.string);
+        *status = PMIX_ERR_NOT_FOUND;
+        goto error;
+    }
+
+    for (i = 0; i < ctl->napps; i++) {
+        rc = prte_pmix_xfer_app(jdata, &ctl->apps[i]);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            *status = prte_pmix_convert_rc(rc);
+            goto error;
+        }
+    }
+
+    /* some runtime options are for the apps themselves, so this has to follow
+     * the transfer above */
+    memset(&options, 0, sizeof(prte_rmaps_options_t));
+    options.stream = prte_rmaps_base_framework.framework_output;
+    options.verbosity = 5;
+    schizo = (prte_schizo_base_module_t *) jdata->schizo;
+    rc = schizo->set_default_rto(jdata, &options);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        *status = prte_pmix_convert_rc(rc);
+        goto error;
+    }
+
+    if (NULL != ctl->jobinfo) {
+        rc = prte_pmix_xfer_job_info(jdata, ctl->jobinfo, ctl->njobinfo);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            *status = prte_pmix_convert_rc(rc);
+            goto error;
+        }
+    }
+
+    /* the job runs in the session we just created, whatever the job info may
+     * have said - the session is the point of the request */
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID, PRTE_ATTR_GLOBAL,
+                       &session->session_id, PMIX_UINT32);
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_ALLOC_ID);
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_REF_ID);
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_TARGET);
+
+    /* nodes the session holds are the ones this job may use */
+    if (NULL != ctl->nodelists) {
+        char *hosts = PMIx_Argv_join(ctl->nodelists, ',');
+        if (NULL != hosts) {
+            for (j = 0; j < jdata->apps->size; j++) {
+                app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, j);
+                if (NULL == app) {
+                    continue;
+                }
+                if (!prte_get_attribute(&app->attributes, PRTE_APP_DASH_HOST, NULL,
+                                        PMIX_STRING)) {
+                    prte_set_attribute(&app->attributes, PRTE_APP_DASH_HOST,
+                                       PRTE_ATTR_GLOBAL, hosts, PMIX_STRING);
+                }
+            }
+            free(hosts);
+        }
+    }
+
+    /* identifies the proc whose ownership and bookmark the launch path uses */
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, PRTE_ATTR_GLOBAL,
+                       &jdata->originator, PMIX_PROC);
+    PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_FORWARD_OUTPUT);
+
+    return jdata;
+
+error:
+    PMIX_RELEASE(jdata);
+    return NULL;
+}
+
+/* Build the answer for a completed request. Replaces req->info, taking care
+ * not to strand an array the request already owned. */
+static void set_response(prte_pmix_server_req_t *req, prte_sessctrl_t *ctl,
+                         prte_session_t *session, const pmix_nspace_t nspace)
+{
+    pmix_info_t *rinfo;
+    size_t n = 0, nresp = 0;
+
+    if (NULL != ctl->ctrl_id) {
+        nresp++;
+    }
+    if (NULL != session) {
+        nresp++;                                     /* PMIX_SESSION_ID */
+        if (NULL != session->alloc_refid) {
+            nresp++;
+        }
+        if (NULL != session->user_refid) {
+            nresp++;
+        }
+    }
+    if (NULL != nspace && !PMIX_NSPACE_INVALID(nspace)) {
+        nresp++;
+    }
+    if (0 == nresp) {
+        return;
+    }
+
+    PMIX_INFO_CREATE(rinfo, nresp);
+    if (NULL != ctl->ctrl_id) {
+        PMIX_INFO_LOAD(&rinfo[n++], PMIX_SESSION_CTRL_ID, ctl->ctrl_id, PMIX_STRING);
+    }
+    if (NULL != session) {
+        PMIX_INFO_LOAD(&rinfo[n++], PMIX_SESSION_ID, &session->session_id, PMIX_UINT32);
+        if (NULL != session->alloc_refid) {
+            PMIX_INFO_LOAD(&rinfo[n++], PMIX_ALLOC_ID, session->alloc_refid, PMIX_STRING);
+        }
+        if (NULL != session->user_refid) {
+            PMIX_INFO_LOAD(&rinfo[n++], PMIX_ALLOC_REQ_ID, session->user_refid, PMIX_STRING);
+        }
+    }
+    if (NULL != nspace && !PMIX_NSPACE_INVALID(nspace)) {
+        PMIX_INFO_LOAD(&rinfo[n++], PMIX_NSPACE, (void *) nspace, PMIX_STRING);
+    }
+
+    /* the request's own array is normally borrowed from the PMIx caller and
+     * needs no action, but one relayed from a peer owns its copy and would be
+     * stranded here */
+    if (req->copy && NULL != req->info) {
+        PMIX_INFO_FREE(req->info, req->ninfo);
+    }
+    req->info = rinfo;
+    req->ninfo = nresp;
+    req->copy = true;
+}
+
+/* Carries a response array to whatever eventually finishes with it. Plain
+ * heap storage holding no PRRTE object, so the release callback may run on
+ * either progress thread. */
+typedef struct {
+    pmix_info_t *info;
+    size_t ninfo;
+} prte_sessctrl_array_t;
+
+static void free_response_array(void *cbdata)
+{
+    prte_sessctrl_array_t *ar = (prte_sessctrl_array_t *) cbdata;
+
+    if (NULL == ar) {
+        return;
+    }
+    PMIX_INFO_FREE(ar->info, ar->ninfo);
+    free(ar);
+}
+
+/* Answer a request this daemon processed itself and retire it.
+ *
+ * A response array we built is DETACHED from the request and handed over with
+ * its own release callback, because the consumer may not be finished with it
+ * when this returns: the local-client path (PMIx's own callback) consumes it
+ * synchronously, but the relayed path (send_alloc_resp) thread-shifts and packs
+ * it later. Tying the array's lifetime to the release callback rather than to
+ * the request is what lets one function serve both. */
+static void answer_request(prte_pmix_server_req_t *req, pmix_status_t status)
+{
+    prte_sessctrl_array_t *ar = NULL;
+    pmix_info_t *info = req->info;
+    size_t ninfo = req->ninfo;
+
+    if (NULL != req->infocbfunc) {
+        if (req->copy && NULL != info) {
+            ar = (prte_sessctrl_array_t *) malloc(sizeof(prte_sessctrl_array_t));
+        }
+        if (NULL != ar) {
+            ar->info = info;
+            ar->ninfo = ninfo;
+            req->info = NULL;
+            req->ninfo = 0;
+            req->copy = false;
+        }
+        req->infocbfunc(status, info, ninfo, req->cbdata,
+                        (NULL == ar) ? NULL : free_response_array, ar);
+    }
+    /* Retire the request. send_alloc_resp, the relayed path's callback, has
+     * retained it for its own deferred half and will clear this slot again
+     * from there - by which time the index may have been handed to somebody
+     * else's request, so invalidate it and let that second clear no-op on the
+     * negative index rather than blank out a stranger. */
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                req->local_index, NULL);
+    req->local_index = -1;
+    PMIX_RELEASE(req);
+}
+
+/* Completion of the job launched by a session instantiation. Runs on the
+ * PRRTE progress thread (pmix_server_launch_resp is an RML receive). */
+static void instantiate_spawn_cb(pmix_status_t status, pmix_nspace_t nspace,
+                                 void *cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    prte_session_t *session;
+    prte_sessctrl_t ctl;
+
+    session = prte_get_session_object(req->sessionID);
+
+    if (PMIX_SUCCESS != status) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: job launch for session %u failed: %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->sessionID,
+                            PMIx_Error_string(status));
+        /* the session exists only to run this job, so give the resources back
+         * rather than leave them held by a session that will never run */
+        if (NULL != session) {
+            reclaim_session(session);
+        }
+        answer_request(req, status);
+        return;
+    }
+
+    /* rebuild just enough of the parsed request to render the answer - the
+     * original directive array is still ours until we call back */
+    sessctrl_construct(&ctl);
+    ctl.ctrl_id = req->key;
+    set_response(req, &ctl, session, nspace);
+    sessctrl_destruct(&ctl);
+
+    answer_request(req, PMIX_SUCCESS);
+}
+
+/* Instantiate a new session: create it, give it its resources, and start
+ * whatever jobs it was defined to run. */
+static pmix_status_t session_instantiate(prte_pmix_server_req_t *req,
+                                         prte_sessctrl_t *ctl)
+{
+    prte_session_t *session;
+    prte_job_t *jdata = NULL;
+    pmix_status_t rc = PMIX_SUCCESS;
+    int i, ret;
+    bool grew = false;
+
+    if (UINT32_MAX == req->sessionID) {
+        /* UINT32_MAX names every session, and is PRRTE's own id for the
+         * default (unreserved) pool - neither can be instantiated */
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL != prte_get_session_object(req->sessionID)) {
+        return PMIX_ERR_EXISTS;
+    }
+    if (NULL != ctl->apps && NULL == ctl->nodelists) {
+        /* A session withholds the nodes named for it from general use, so one
+         * created with no resource description holds nothing and no job in it
+         * can be mapped. Refuse here rather than let the request succeed and
+         * the job fail later with "no nodes are available", which says nothing
+         * about the cause. The caller is required to describe the resources
+         * (PMIX_SESSION_RESOURCES, or PMIX_ALLOC_NODE_LIST directly). */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: instantiate of session %u names apps "
+                            "but no resources for them to run on",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->sessionID);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    session = PMIX_NEW(prte_session_t);
+    if (NULL == session) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_NOMEM;
+    }
+    session->session_id = req->sessionID;
+    session->flags |= PRTE_SESSION_FLAG_DYNAMIC | PRTE_SESSION_FLAG_RESERVED |
+                      PRTE_SESSION_FLAG_SCHEDULER;
+    /* A session is DETACHED by default - i.e. its lifetime does not follow
+     * the namespace that asked for it. That is the opposite of an allocation
+     * reservation, deliberately: a reservation is nodes a tool took for its
+     * own use, and dies with the tool, but a session is named, addressable by
+     * anyone authorized, and destroyed by an explicit terminate, by its own
+     * time limit, or - when it was created to run apps - when those apps
+     * finish. Following the requester instead makes the API unusable for the
+     * thing it exists to do: the requester is a tool, its namespace lasts
+     * only as long as the request, and the session would be reclaimed out
+     * from under its own jobs the moment the caller disconnected.
+     * PMIX_SESSION_SEP given as FALSE opts back into requester-lifetime. */
+    if (!(ctl->have_sep && !ctl->sep)) {
+        session->flags |= PRTE_SESSION_FLAG_DETACHED;
+    }
+    if (NULL != ctl->apps) {
+        /* the session was defined to run these jobs, so it is finished when
+         * they are. An instantiation that named no apps is a standing
+         * reservation and persists until explicitly terminated. */
+        session->flags |= PRTE_SESSION_FLAG_AUTO_COMPLETE;
+    }
+    if (NULL != ctl->alloc_refid) {
+        session->alloc_refid = strdup(ctl->alloc_refid);
+    } else {
+        pmix_asprintf(&session->alloc_refid, "%s.%u", ctl->requestor.nspace,
+                      session->session_id);
+    }
+    if (NULL != ctl->user_refid) {
+        session->user_refid = strdup(ctl->user_refid);
+    }
+    session->inheritance = ctl->inheritance;
+    PMIX_LOAD_NSPACE(session->owner, ctl->requestor.nspace);
+    PMIX_XFER_PROCID(&session->requestor, &ctl->requestor);
+    prte_session_add_owner(session, ctl->requestor.nspace);
+    if (ctl->have_uid) {
+        session->owner_uid = ctl->uid;
+    } else {
+        prte_job_t *reqjob = prte_get_job_data_object(ctl->requestor.nspace);
+        if (NULL != reqjob) {
+            session->owner_uid = reqjob->uid;
+        }
+    }
+
+    ret = prte_set_session_object(session);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_RELEASE(session);
+        return prte_pmix_convert_rc(ret);
+    }
+
+    /* give the session its nodes. They join the global pool and are then
+     * withheld from general use by their session backpointer. */
+    if (NULL != ctl->nodelists) {
+        for (i = 0; NULL != ctl->nodelists[i]; i++) {
+            ret = prte_ras_base_insert_node_string(ctl->nodelists[i], session);
+            if (PRTE_SUCCESS != ret) {
+                PRTE_ERROR_LOG(ret);
+                rc = prte_pmix_convert_rc(ret);
+                goto error;
+            }
+            grew = true;
+        }
+    }
+
+    if (0 < ctl->timelimit) {
+        arm_session_timer(session, ctl->timelimit);
+    }
+
+    if (NULL != ctl->apps) {
+        jdata = build_session_job(ctl, session, &rc);
+        if (NULL == jdata) {
+            goto error;
+        }
+    }
+
+    if (grew) {
+        /* extend the DVM across the new nodes. This clears prte_dvm_ready, so
+         * a job submitted below is held in the job cache and released once the
+         * daemons are up - which is exactly the ordering we need. */
+        prte_ras_base_activate_dvm_grow();
+    }
+
+    if (NULL == jdata) {
+        /* a standing reservation - nothing to wait for */
+        return PMIX_SUCCESS;
+    }
+
+    /* the answer carries the launched namespace, so it has to wait for the
+     * launch. Stash the request id for the completion to echo back. */
+    if (NULL != ctl->ctrl_id) {
+        if (NULL != req->key) {
+            free(req->key);
+        }
+        req->key = strdup(ctl->ctrl_id);
+    }
+    prte_pmix_server_launch_job(jdata, instantiate_spawn_cb, req);
+    return PMIX_OPERATION_IN_PROGRESS;
+
+error:
+    /* unwind the half-built session, returning any nodes it took */
+    prte_ras_base_teardown_reservation(session, false);
+    PMIX_RELEASE(session);
+    return rc;
+}
+
+/*****   DISPATCH   *****/
+
+/* Apply an operation to one session. Returns a PMIx status, or
+ * PMIX_OPERATION_IN_PROGRESS if it has taken over answering the request. */
+static pmix_status_t apply_to_session(prte_pmix_server_req_t *req,
+                                      prte_sessctrl_t *ctl,
+                                      prte_session_t *session)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    if (!AUTHORIZED(session, &ctl->requestor)) {
+        return PMIX_ERR_NO_PERMISSIONS;
+    }
+
+    /* a modifier may accompany any operation, and may stand alone */
+    if (ctl->have_sep) {
+        if (ctl->sep) {
+            session->flags |= PRTE_SESSION_FLAG_DETACHED;
+        } else {
+            session->flags &= ~PRTE_SESSION_FLAG_DETACHED;
+        }
+    }
+
+    switch (ctl->op) {
+    case PRTE_SESSCTRL_MODIFY:
+        break;
+
+    case PRTE_SESSCTRL_PAUSE:
+        /* PRRTE stops the processes where they stand. Their memory and their
+         * slots are retained - it has no checkpoint facility with which to
+         * vacate and later reinstate them. */
+        rc = session_signal(session, NULL, SIGSTOP, true, true);
+        if (PMIX_SUCCESS == rc) {
+            session->flags |= PRTE_SESSION_FLAG_PAUSED;
+        }
+        break;
+
+    case PRTE_SESSCTRL_RESUME:
+        rc = session_signal(session, NULL, SIGCONT, true, false);
+        if (PMIX_SUCCESS == rc) {
+            session->flags &= ~PRTE_SESSION_FLAG_PAUSED;
+        }
+        break;
+
+    case PRTE_SESSCTRL_PREEMPT:
+        /* Preemption is suspension-based: the named jobs (all of them, absent
+         * a PMIX_NSPACE qualifier) are stopped and hold their resources. The
+         * attribute speaks of recovering those resources, which would require
+         * checkpointing the jobs out and restoring them later - PRRTE has no
+         * such facility, and terminating them instead would make the paired
+         * PMIX_SESSION_RESTORE impossible to honor. A scheduler that wants
+         * the nodes back should terminate the session. */
+        rc = session_signal(session, ctl->nspaces, SIGSTOP, true, true);
+        break;
+
+    case PRTE_SESSCTRL_RESTORE:
+        rc = session_signal(session, ctl->nspaces, SIGCONT, true, false);
+        break;
+
+    case PRTE_SESSCTRL_SIGNAL:
+        rc = session_signal(session, ctl->nspaces, ctl->sigvalue, false, false);
+        break;
+
+    case PRTE_SESSCTRL_TERMINATE:
+        rc = session_terminate(session);
+        /* the session is going away - do not report it back */
+        session = NULL;
+        break;
+
+    case PRTE_SESSCTRL_EXTEND:
+        rc = session_extend(session, ctl);
+        break;
+
+    case PRTE_SESSCTRL_COMPLETE:
+        /* PMIX_SESSION_COMPLETE is what an RTE says to its scheduler, not
+         * something a scheduler says to its RTE: PRRTE is the only party that
+         * knows when the jobs have finished and the nodes are free. Accepting
+         * it here would mean discarding a session while its processes may
+         * still be running. */
+        rc = PMIX_ERR_NOT_SUPPORTED;
+        break;
+
+    case PRTE_SESSCTRL_INSTANTIATE:
+        /* the session already exists */
+        rc = PMIX_ERR_EXISTS;
+        break;
+
+    default:
+        rc = PMIX_ERR_BAD_PARAM;
+        break;
+    }
+
+    if (PMIX_SUCCESS == rc) {
+        set_response(req, ctl, session, NULL);
+    }
+    return rc;
+}
+
+/* Apply an operation to every session this requestor controls - what a
+ * sessionID of UINT32_MAX asks for. The default (unreserved) pool is not a
+ * session anyone instantiated, so it is never a target. */
+static pmix_status_t apply_to_all(prte_pmix_server_req_t *req,
+                                  prte_sessctrl_t *ctl)
+{
+    prte_session_t *session;
+    pmix_status_t rc, ret = PMIX_ERR_NOT_FOUND;
+    int i;
+
+    if (NULL == prte_sessions) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    /* snapshot the size: terminating a session can remove it from the array,
+     * and can do so from under the walk */
+    for (i = 0; i < prte_sessions->size; i++) {
+        session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i);
+        if (NULL == session || session == prte_default_session) {
+            continue;
+        }
+        if (!AUTHORIZED(session, &ctl->requestor)) {
+            continue;
+        }
+        rc = apply_to_session(req, ctl, session);
+        if (PMIX_OPERATION_IN_PROGRESS == rc) {
+            /* nothing in the all-sessions set can defer its answer: only an
+             * instantiation does that, and instantiate is rejected above */
+            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+            return PMIX_ERR_BAD_PARAM;
+        }
+        if (PMIX_SUCCESS != rc) {
+            ret = rc;           /* report the last failure */
+        } else if (PMIX_ERR_NOT_FOUND == ret) {
+            ret = PMIX_SUCCESS; /* at least one session was served */
+        }
+    }
+    return ret;
+}
+
+/* Process a session control directive addressed to this DVM.
+ *
+ * Returns a pmix_status_t - NOT a PRRTE return code. The result is handed to
+ * req->infocbfunc, which is a PMIx callback, so every exit from here must
+ * already be in PMIx's numbering. A return of PMIX_OPERATION_IN_PROGRESS means
+ * this function has taken over answering the request; on every other return
+ * the answer, if any, is left on the request as req->info and the caller
+ * delivers it. Answering here as well would deliver the response twice and
+ * release the request twice. */
+static pmix_status_t process_directive(prte_pmix_server_req_t *req)
+{
+    prte_sessctrl_t ctl;
+    prte_session_t *session;
+    pmix_status_t rc;
+
+    sessctrl_construct(&ctl);
+
+    rc = parse_directives(req, &ctl);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl: op %d on session %u for %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) ctl.op,
+                        req->sessionID, PRTE_NAME_PRINT(&ctl.requestor));
+
+    if (PRTE_SESSCTRL_NONE == ctl.op) {
+        /* nothing was asked of us */
+        rc = PMIX_ERR_BAD_PARAM;
+        goto done;
+    }
+
+    if (PRTE_SESSCTRL_INSTANTIATE == ctl.op) {
+        rc = session_instantiate(req, &ctl);
+        if (PMIX_SUCCESS == rc) {
+            session = prte_get_session_object(req->sessionID);
+            set_response(req, &ctl, session, NULL);
+        }
+        goto done;
+    }
+
+    if (UINT32_MAX == req->sessionID) {
+        rc = apply_to_all(req, &ctl);
+        goto done;
+    }
+
+    session = prte_get_session_object(req->sessionID);
+    if (NULL == session || session == prte_default_session) {
+        /* the default pool is not a session anyone may operate on - pausing
+         * or terminating "the session" would take the whole DVM with it */
+        rc = PMIX_ERR_NOT_FOUND;
+        goto done;
+    }
+
+    rc = apply_to_session(req, &ctl, session);
+
+done:
+    sessctrl_destruct(&ctl);
+    return rc;
+}
+
+/* Execute a session control directive against this DVM's own sessions and
+ * answer the request. The two callers - pass_request, for a request that
+ * arrived at this daemon directly, and pmix_server_sched, for one a peer
+ * daemon relayed here - deliver their answers through different callbacks,
+ * which is why the completion is done here rather than left to them.
+ *
+ * MUST be called on the PRRTE progress thread, on the DVM master. */
+void prte_pmix_server_session_ctrl_local(prte_pmix_server_req_t *req)
+{
+    pmix_status_t rc;
+
+    rc = process_directive(req);
+    if (PMIX_OPERATION_IN_PROGRESS == rc) {
+        /* the operation will answer for itself when it completes */
+        return;
+    }
+    answer_request(req, rc);
+}
+
+/*****   SESSION COMPLETION REPORTING   *****/
+
+/* PMIx invokes this on its own progress thread once it is done with the
+ * notification. It touches nothing but the array we allocated for the call. */
+static void session_complete_cbfunc(pmix_status_t status,
+                                    pmix_info_t *info, size_t ninfo,
+                                    void *cbdata,
+                                    pmix_release_cbfunc_t rel, void *relcbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(status, info, ninfo);
+
+    if (NULL != rel) {
+        rel(relcbdata);
+    }
+    free_response_array(cbdata);
+}
+
+void prte_pmix_server_session_complete(prte_session_t *session)
+{
+    prte_sessctrl_array_t *ar;
+    pmix_info_t *info;
+    size_t n, k, ninfo, nresults;
+    pmix_status_t rc;
+
+    if (NULL == session || session == prte_default_session) {
+        return;
+    }
+    if (!(session->flags & PRTE_SESSION_FLAG_SCHEDULER)) {
+        /* nobody asked us for this session, so nobody is waiting to hear that
+         * it is done */
+        return;
+    }
+    /* report it exactly once */
+    session->flags &= ~PRTE_SESSION_FLAG_SCHEDULER;
+
+    rc = prte_pmix_set_scheduler();
+    if (PMIX_SUCCESS != rc) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: no scheduler to report completion "
+                            "of session %u to", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            session->session_id);
+        return;
+    }
+
+    nresults = session->nresults;
+    /* the completion directive, the session id, the per-job results, and the
+     * allocation id if the session carries one */
+    ninfo = 2 + nresults + ((NULL == session->alloc_refid) ? 0 : 1);
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[0], PMIX_SESSION_COMPLETE, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_SESSION_ID, &session->session_id, PMIX_UINT32);
+    n = 2;
+    if (NULL != session->alloc_refid) {
+        PMIX_INFO_LOAD(&info[n++], PMIX_ALLOC_ID, session->alloc_refid, PMIX_STRING);
+    }
+    for (k = 0; k < nresults; k++) {
+        PMIX_INFO_XFER(&info[n++], &session->results[k]);
+    }
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s session ctrl: reporting completion of session %u "
+                        "with %" PRIsize_t " job results",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), session->session_id,
+                        nresults);
+
+    ar = (prte_sessctrl_array_t *) malloc(sizeof(prte_sessctrl_array_t));
+    if (NULL == ar) {
+        PMIX_INFO_FREE(info, ninfo);
+        return;
+    }
+    ar->info = info;
+    ar->ninfo = ninfo;
+
+    /* the non-blocking form: the blocking one would park this - the PRRTE
+     * progress - thread inside PMIx while it waits for a reply */
+    rc = PMIx_Session_control(session->session_id, info, ninfo,
+                              session_complete_cbfunc, ar);
+    if (PMIX_SUCCESS != rc) {
+        /* PMIx does not invoke the callback when the call itself fails */
+        if (PMIX_OPERATION_SUCCEEDED != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        free_response_array(ar);
+    }
+}
+
+void prte_pmix_server_session_job_terminated(prte_session_t *session,
+                                             prte_job_t *jdata)
+{
+    pmix_info_t *results;
+    pmix_data_array_t darray;
+    pmix_info_t jinfo[2];
+    pmix_status_t jstatus;
+    int k;
+
+    if (NULL == session || session == prte_default_session || NULL == jdata) {
+        return;
+    }
+
+    /* Record what became of the job. The job object does not survive to the
+     * end of the session, and the completion notification is required to carry
+     * the status of every job the session ran. */
+    if (session->flags & PRTE_SESSION_FLAG_SCHEDULER) {
+        jstatus = prte_pmix_convert_job_state_to_error(jdata->state);
+        PMIX_INFO_LOAD(&jinfo[0], PMIX_NSPACE, jdata->nspace, PMIX_STRING);
+        PMIX_INFO_LOAD(&jinfo[1], PMIX_JOB_TERM_STATUS, &jstatus, PMIX_STATUS);
+        darray.type = PMIX_INFO;
+        darray.size = 2;
+        darray.array = jinfo;
+
+        results = (pmix_info_t *) realloc(session->results,
+                                          (session->nresults + 1) * sizeof(pmix_info_t));
+        if (NULL != results) {
+            session->results = results;
+            PMIX_INFO_CONSTRUCT(&session->results[session->nresults]);
+            PMIX_INFO_LOAD(&session->results[session->nresults],
+                           PMIX_JOB_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
+            session->nresults++;
+        }
+        PMIX_INFO_DESTRUCT(&jinfo[0]);
+        PMIX_INFO_DESTRUCT(&jinfo[1]);
+    }
+
+    /* a session that exists to run its jobs, or one being torn down, is
+     * finished once the last of them has gone */
+    if (!(session->flags & (PRTE_SESSION_FLAG_AUTO_COMPLETE |
+                            PRTE_SESSION_FLAG_TERMINATING))) {
+        return;
+    }
+    for (k = 0; k < session->jobs->size; k++) {
+        if (NULL != pmix_pointer_array_get_item(session->jobs, k)) {
+            return;     /* still running */
+        }
+    }
+
+    reclaim_session(session);
+}
+
+/*****   REQUEST PLUMBING   *****/
 
 /* Callbacks to process a session control answer from the scheduler
  * and pass on any results to the requesting client
@@ -388,6 +1564,9 @@ static void pass_request(int sd, short args, void *cbdata)
     if (!PRTE_PROC_IS_MASTER) {
         /* if we are not the DVM master, then we have to send
          * this request to the master for processing */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: relaying to the master as local req %d",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->local_index);
         rc = prte_server_send_request(PRTE_PMIX_SESSION_CTRL, req);
         if (PRTE_SUCCESS != rc) {
             goto callback;
@@ -396,17 +1575,20 @@ static void pass_request(int sd, short args, void *cbdata)
     }
 
     /* if we are the DVM master, then handle this ourselves - start
-     * by ensuring the scheduler is connected to us */
+     * by seeing whether a scheduler is available to us. This is allowed
+     * to fail: a DVM running without a scheduler is its own authority
+     * over its sessions. */
     rc = prte_pmix_set_scheduler();
-    if (PMIX_SUCCESS != rc) {
-        goto callback;
-    }
 
-    /* if the requestor is the scheduler, then this is a directive
-     * to the DVM - e.g., to instantiate or terminate a session.
-     * In that case, we process it here */
-    if (PMIX_CHECK_PROCID(&prte_pmix_server_globals.scheduler, &req->tproc)) {
-        rc = process_directive(req);
+    /* A directive from the scheduler is a directive to this DVM and is
+     * executed here. So is one from anybody else when there is no scheduler
+     * to defer to - otherwise a standalone DVM could not control its own
+     * sessions at all. Everything else is passed up to the scheduler, which
+     * owns the decision and will call back down to us to carry it out. */
+    if (PMIX_SUCCESS != rc ||
+        PMIX_CHECK_PROCID(&prte_pmix_server_globals.scheduler, &req->tproc)) {
+        prte_pmix_server_session_ctrl_local(req);
+        return;
     } else {
         // we need to pass the request on to the scheduler
         // need to add the requestor's ID to the info array
@@ -431,12 +1613,7 @@ static void pass_request(int sd, short args, void *cbdata)
 callback:
     /* this section gets executed solely upon an error or if this was a
      * directive to us from the scheduler */
-    if (NULL != req->infocbfunc) {
-        req->infocbfunc(rc, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);
-        return;
-    }
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-    PMIX_RELEASE(req);
+    answer_request(req, rc);
 }
 
 /* this is the upcall from the PMIx server for the session

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1022,6 +1022,9 @@ static void session_con(prte_session_t *s)
     s->alloc_refid = NULL;
     s->alloc_module = NULL;
     memset(&s->timeout, 0, sizeof(struct timeval));
+    s->timer = NULL;
+    s->results = NULL;
+    s->nresults = 0;
     s->nodes = PMIX_NEW(pmix_pointer_array_t);
     pmix_pointer_array_init(s->nodes, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
                             PRTE_GLOBAL_ARRAY_MAX_SIZE,
@@ -1045,6 +1048,19 @@ static void session_des(prte_session_t *s)
 
     /* notify the RAS so it can release the underlying allocation */
     prte_ras_base_release_allocation(s);
+
+    /* disarm the session time limit, if one was in force - the event holds a
+     * bare pointer to us and would fire on freed memory */
+    if (NULL != s->timer) {
+        prte_event_evtimer_del(s->timer->ev);
+        PMIX_RELEASE(s->timer);
+        s->timer = NULL;
+    }
+    if (NULL != s->results) {
+        PMIX_INFO_FREE(s->results, s->nresults);
+        s->results = NULL;
+        s->nresults = 0;
+    }
 
     if (NULL != s->user_refid) {
         free(s->user_refid);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -235,6 +235,20 @@ typedef struct{
     char *alloc_refid;  // PMIX_ALLOC_ID
     char *alloc_module; // name of RAS module that created this allocation
     struct timeval timeout;  // time limit on session
+    /* Armed event that terminates the session when its time limit expires.
+     * Set only when an instantiating scheduler asked for one (PMIX_ALLOC_TIME
+     * or PMIX_TIMEOUT on a PMIX_SESSION_INSTANTIATE); re-armed by
+     * PMIX_SESSION_EXTEND and cancelled when the session is torn down. NULL
+     * whenever no limit is in force - which is every session PRRTE creates
+     * for itself, since only a scheduler imposes a session lifetime. */
+    prte_timer_t *timer;
+    /* Termination status of each job that ran in this session, accumulated as
+     * the jobs retire because the job objects themselves do not survive to
+     * the end of the session. Reported to the instantiating scheduler in the
+     * PMIX_SESSION_COMPLETE notification, which is required to carry them.
+     * Only populated for a scheduler-instantiated session. */
+    pmix_info_t *results;
+    size_t nresults;
     pmix_pointer_array_t *nodes;
     pmix_pointer_array_t *jobs;
     /* namespaces entitled to spawn onto this session's nodes. Seeded with the

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -1189,6 +1189,18 @@ char* prte_print_session_flags(struct prte_session_t *ptr)
     } else {
         PMIx_Argv_append_nosize(&tmp, "STATIC");
     }
+    if (PRTE_FLAG_TEST(p, PRTE_SESSION_FLAG_RESERVED)) {
+        PMIx_Argv_append_nosize(&tmp, "RESERVED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_SESSION_FLAG_DETACHED)) {
+        PMIx_Argv_append_nosize(&tmp, "DETACHED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_SESSION_FLAG_PAUSED)) {
+        PMIx_Argv_append_nosize(&tmp, "PAUSED");
+    }
+    if (PRTE_FLAG_TEST(p, PRTE_SESSION_FLAG_SCHEDULER)) {
+        PMIx_Argv_append_nosize(&tmp, "SCHEDULER");
+    }
     ans = PMIx_Argv_join(tmp, '|');
     PMIx_Argv_free(tmp);
     return ans;

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -128,6 +128,8 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_FLAG_FORWARD_OUTPUT    0x0020 // forward output from the apps
 #define PRTE_JOB_FLAG_DO_NOT_MONITOR    0x0040 // do not monitor apps for termination
 #define PRTE_JOB_FLAG_FORWARD_COMM      0x0080 //
+#define PRTE_JOB_FLAG_SUSPENDED         0x0100 // job's procs have been stopped by a session
+                                               // pause/preempt directive and await a resume/restore
 #define PRTE_JOB_FLAG_RESTART           0x0200 //
 #define PRTE_JOB_FLAG_PROCS_MIGRATING   0x0400 // some procs in job are migrating from one node to another
 #define PRTE_JOB_FLAG_OVERSUBSCRIBED    0x0800 // at least one node in the job is oversubscribed
@@ -338,6 +340,20 @@ typedef uint16_t prte_proc_flags_t;
 typedef uint16_t prte_session_flags_t;
 #define PRTE_SESSION_FLAG_DYNAMIC       0x0001 // session was dynamically allocated
 #define PRTE_SESSION_FLAG_RESERVED      0x0002 // nodes withheld from default pool
+#define PRTE_SESSION_FLAG_DETACHED      0x0004 // session lifetime is independent of its owning
+                                               // namespace (PMIX_SESSION_SEP) - the inheritance
+                                               // disposition is not fired when that namespace ends
+#define PRTE_SESSION_FLAG_PAUSED        0x0008 // every job in the session has been stopped by a
+                                               // PMIX_SESSION_PAUSE directive
+#define PRTE_SESSION_FLAG_SCHEDULER     0x0010 // session was instantiated by the scheduler via
+                                               // PMIx_Session_control, so its completion must be
+                                               // reported back to the scheduler
+#define PRTE_SESSION_FLAG_TERMINATING   0x0020 // a PMIX_SESSION_TERMINATE is in flight - the
+                                               // session is reclaimed once its jobs have retired
+#define PRTE_SESSION_FLAG_AUTO_COMPLETE 0x0040 // the session exists to run the jobs it was
+                                               // instantiated with, so it is reclaimed when the
+                                               // last of them retires rather than persisting
+                                               // until an explicit terminate
 
 
 /*** FLAG OPS ***/

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1198,6 +1198,56 @@ static int test_directive_distribution(void)
     return failures;
 }
 
+
+/*
+ * A scheduler's session time limit (PMIX_ALLOC_TIME) is the one directive
+ * whose whole meaning is a string parse, and getting it wrong terminates a
+ * user's session early or never. The format is scanned from the RIGHT, so a
+ * bare "2" is two seconds - not two months.
+ */
+static const struct {
+    const char *spec;
+    long expected;      /* -1 == must be rejected */
+} session_time_cases[] = {
+    /* right-to-left: seconds, minutes, hours, days, months */
+    {"0",                       0},
+    {"2",                       2},
+    {"90",                     90},
+    {"1:30",                   90},
+    {"0:01",                    1},
+    {"2:00:00",              7200},
+    {"1:00:00:00",          86400},
+    {"1:00:00:00:00",     2592000},
+    {"1:2:3:4:5",         2592000 + 2*86400 + 3*3600 + 4*60 + 5},
+    /* malformed */
+    {NULL,                     -1},
+    {"",                       -1},
+    {"abc",                    -1},
+    {"1:",                     -1},
+    {":1",                     -1},
+    {"1::2",                   -1},
+    {"-5",                     -1},
+    {"5s",                     -1},
+    {"1:2:3:4:5:6",            -1},   /* one field too many */
+};
+
+static int test_session_time(void)
+{
+    size_t n;
+    long got;
+    int failures = 0;
+    char desc[128];
+
+    for (n = 0; n < sizeof(session_time_cases) / sizeof(session_time_cases[0]); n++) {
+        got = prte_pmix_server_parse_session_time(session_time_cases[n].spec);
+        snprintf(desc, sizeof(desc), "sessiontime/%s",
+                 (NULL == session_time_cases[n].spec) ? "NULL"
+                                                      : session_time_cases[n].spec);
+        CHECK(desc, got == session_time_cases[n].expected);
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0, skipped = 0;
@@ -1263,6 +1313,7 @@ int main(void)
     failures += test_xfer_job_info();
     failures += test_xfer_app();
     failures += test_job_info_cache();
+    failures += test_session_time();
     failures += test_directive_distribution();
     failures += test_envar_order(&skipped);
     failures += test_envar_order_permutations(&skipped);


### PR DESCRIPTION
Fixes #2589 

## The problem

`PMIx_Session_control` is the API a scheduler uses to create a session, operate on
it while it runs, and reclaim it. PRRTE accepted the call and did almost none of
it: every operational directive returned `PMIX_ERR_NOT_SUPPORTED`, and an
instantiation built a session and a job object but never launched anything.

So a scheduler driving PRRTE had no way to start work in a session it had just
created, and no way to pause, signal, extend or terminate one afterwards. The
placeholder in `docs/how-things-work/schedulers/flow_of_control.rst` has been
waiting for this.

## What this does

Implements the whole surface. Instantiation gives the session the nodes it was
described with, extends the DVM across any that are new, and launches the
applications it was given into it — answering with the session id, the allocation
id, and the launched namespace. Pause and resume stop and continue every job in
the session; preempt and restore do the same for the jobs a `PMIX_NSPACE`
qualifier names; signal delivers an arbitrary signal; extend adds nodes or revises
the time limit; terminate kills the jobs and reclaims the session once they have
retired. A session id of `UINT32_MAX` addresses every session the caller controls.

A scheduler may impose a lifetime on a session (`PMIX_ALLOC_TIME`/`PMIX_TIMEOUT`);
when it expires the session is terminated exactly as an explicit request would.
What becomes of a reclaimed session's nodes follows its `PMIX_ALLOC_INHERITANCE`
disposition, defaulting to the DVM's general pool — handing them back to the
scheduler is the destructive choice and has to be asked for.

The user-facing description of every directive, including where PRRTE deviates and
why, is the new `docs/how-things-work/schedulers/session_control.rst`.

### Two deliberate deviations

**Preemption is suspension-based.** The attribute describes preemption as halting
the jobs *and recovering their resources*. Recovering them means checkpointing the
jobs out and restoring them later, which PRRTE cannot do — and terminating them
instead would make the paired `PMIX_SESSION_RESTORE` impossible to honor at all.
So a preempted job stops and holds its resources, and a restored job resumes where
it was. A scheduler that genuinely needs the nodes back should terminate the
session.

**`PMIX_SESSION_COMPLETE` is outbound only.** It is what an RTE says to its
scheduler, not the other way round: PRRTE is the only party that knows when the
jobs have finished and the nodes are free. Inbound it is refused; PRRTE now *sends*
it — carrying each job's termination status — when a session the scheduler
instantiated is reclaimed.

### Two design points worth review

**A session created through this API is detached by default**, which is the
opposite of an allocation reservation. A reservation is nodes a tool took for its
own use and dies with that tool. A session is named, addressable by anyone
authorized, and destroyed by an explicit terminate, by its own time limit, or —
when it was created to run apps — when those apps finish. Following the requester
instead makes the API unusable for what it exists to do: the requester is a tool,
its namespace lasts only as long as the request, and the session was being
reclaimed out from under its own jobs the moment the caller disconnected (this is
not hypothetical — it is what the multi-node harness caught first).
`PMIX_SESSION_SEP` given as **false** opts back into requester lifetime.

**A DVM with no scheduler answers for itself.** The scheduler owns sessions when
there is one, but refusing session control outright when there is not left the
capability unreachable on an ordinary `prte` DVM — and impossible to test. Requests
are gated on the same ownership check that governs spawning into a reservation, so
a caller can only act on an allocation it owns. The relay from a non-master daemon
makes the same decision, so a caller gets the same answer whichever daemon it
happens to be attached to.

## Pre-existing bugs this uncovered

Each is a separate commit ahead of the feature, so they can be reviewed and
bisected on their own. The middle two were only ever reachable from a **non-master
daemon**, which is why they had survived: both APIs are normally driven from the
head node, where the master answers directly and the relay never runs.

1. **`prte_plm_base_prted_signal_local_procs()` packed the wrong bytes as the
   target namespace.** A `pmix_nspace_t` is an array type, so as a *parameter* it
   has decayed to a `char *` — and `&job` is the address of that pointer variable,
   not of the name. `PMIX_PROC_NSPACE` copies `PMIX_MAX_NSLEN+1` bytes from
   whatever it is handed, so a stack fragment went on the wire, every daemon
   matched no job, and the signal was silently dropped. Every signal delivered
   through `prte_plm.signal_job()` was lost; `PMIx_Job_control` signals were
   unaffected (that path uses a real local array).

2. **`pmix_server_alloc_request_resp()` answered a relayed request into the void.**
   It passed the request *tracker* as the callback data where the original caller's
   `cbdata` belongs. PMIx uses that value to find the operation it is completing,
   so it was handed a pointer it had never issued: the client sat in its PMIx call
   until it timed out, or the library faulted on the unrecognized pointer and took
   the daemon with it. This affected **every allocation request** as well as every
   session-control request issued from a non-master daemon.

3. **`prte_pmix_set_scheduler()` re-probed on every request.**
   `PMIx_tool_attach_to_server` is a blocking call that hunts the filesystem for a
   rendezvous and tries to connect to what it finds — and it ran on the PRRTE
   progress thread, the only thread driving the DVM, in front of every allocation
   and every session-control request. On a DVM with no scheduler (the ordinary case,
   where it can only ever fail) that is pure cost on the one thread that must not be
   spent. It now looks once; a scheduler that appears later announces itself by
   attaching to us.

4. **`prte_ras_base_teardown_reservation()` could shrink the master out of its own
   DVM.** When handing a reservation's nodes back to the scheduler it collected the
   daemon rank of every member node, with nothing excluding our own. A reservation
   may legitimately contain the head node, and ordering our own daemon to depart
   terminates the DVM, taking every other job with it.

## Testing

- **Unit** — new coverage for the session time-limit parser in
  `test/unit/prted/`. (Writing it caught that `PMIx_Argv_split` discards empty
  tokens, so `":30"` and `"1::2"` were being silently reinterpreted as valid
  durations rather than refused.)
- **`make check`** — all suites pass.
- **Offline mapper harness** — 1180/1180.
- **Docs** — build warning-free; new `session_control.rst` wired into the
  scheduler-integration section.
- **Single node** — `examples/sessionctrl.c` drives the full lifecycle:
  instantiate + launch, pause (procs observably in `T`), resume, preempt/restore,
  signal, time-limit expiry, terminate, and the error cases.
- **Multi node** — new `test_session` phase in `contrib/dockerswarm`
  (14 cases): a reservation actually withholding its nodes from a general job, a
  request relayed from a non-master daemon, both nodes' procs stopping and
  resuming, a signal reaching the session's jobs on every node they occupy, a
  session created to run apps being reclaimed when they end, and a standing
  reservation persisting until explicitly terminated.
  **Full suite: 395 passed, 0 failed, 2 skipped** (both skips pre-existing PMIx
  capability gates, unrelated).

The multi-node run is what found items 1–3 above, plus a self-deadlock of my own
making: `_send_alloc_resp` releases the request *twice* — explicitly, and again
through its caddy's destructor — so a new caller has to hand it over holding the
extra `PMIX_RETAIN` the allocation branch already takes, or the last release runs
the destructor while the object lock is held. That path also has to be
thread-shifted out of the RML receive before it drives the PLM, as the allocation
branch does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
