### PR TITLE
hwloc: report cpu numbers in the basis we claim, reset NUMA placement counters, honor a qualifier-only --bind-to

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -341,8 +341,23 @@ docker cp prte-node1:/tmp/vg-hnp.txt .
 A daemon can be traced the same way by pointing `prte_launch_agent` at a
 wrapper script that execs `valgrind prted`. Note this is deliberately **not**
 part of `run-tests.sh`: a valgrind run is many times slower than the suite it
-would be embedded in. Compare totals before and after a change rather than
-chasing an absolute number — PMIx and hwloc contribute their own.
+would be embedded in.
+
+**For `definitely lost` the number to expect is zero**, and that command above
+is the one to check it with. Read `still reachable` differently — PMIx, hwloc
+and libevent all keep live state at exit, so compare totals before and after
+rather than chasing an absolute there.
+
+Two things this found that are easy to reintroduce:
+
+- A record with **direct bytes but zero indirect bytes** means a container was
+  dropped after its payload was moved out — someone unloaded a
+  `pmix_data_buffer_t` and never released the shell. That was every
+  inter-daemon reliable message (`prte_relm_start_msg`).
+- The leak you are looking for may only be on an **error** path, so run a
+  command line that *fails*, not just one that works. `prterun -n 1 --display
+  map --display cpus hostname` is refused for the repeated option, and that
+  return leaked the parser's argv until it was fixed.
 
 ## 6. What "success" looks like
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2786,7 +2786,7 @@ test_util() {
 }
 
 test_hwloc() {
-    local out rc n c bad_cores
+    local out rc n c bad_cores cpus back
 
     # src/hwloc is a library of pure functions over a topology, so nearly all
     # of it is pinned down by test/unit/hwloc against synthetic topologies.
@@ -3014,6 +3014,61 @@ test_hwloc() {
     n=$(echo "$out" | grep -c 'Process rank: 0 Bound: package')
     [ "$n" = 3 ] && ok "all 3 numa:limit jobs bound in one DVM" \
                  || bad "$n/3 numa:limit jobs bound - a per-NUMA counter leaked between jobs: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+    cleanup_swarm
+
+    banner "hwloc: the cpu numbers PRRTE prints are the ones it accepts"
+    # Every renderer here used to short-cut whenever the bits "already were"
+    # cores (npus == ncores, which is exactly these containers) and print the
+    # raw cpuset bits - PU OS indices - under a "core:L" label. --cpu-set
+    # resolves its input LOGICALLY, so on any node whose OS and logical
+    # numbering differ, the numbers PRRTE printed were not numbers PRRTE
+    # would accept back. This asserts the round trip: whatever --display cpus
+    # reports for a node has to be selectable, and selecting it has to yield
+    # the same set.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:8 -n 1 --display cpus hostname' 2>&1)
+    cpus=$(echo "$out" | sed -n 's/^PKG\[0\]: \(.*\)$/\1/p' | head -1)
+    [ -n "$cpus" ] && ok "--display cpus reported package 0 as '$cpus'" \
+                   || bad "--display cpus reported nothing: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    if [ -n "$cpus" ]; then
+        out=$(RUN "timeout 90 prterun --prtemca hwloc_default_cpu_list '$cpus' \
+                       --host node2:8 -n 1 --display cpus hostname" 2>&1)
+        rc=$?
+        [ "$rc" = 0 ] && ok "the reported cpu list is accepted by --cpu-set (rc=0)" \
+                      || bad "--cpu-set rejected the list --display cpus just printed ('$cpus', rc=$rc)"
+        back=$(echo "$out" | sed -n 's/^PKG\[0\]: \(.*\)$/\1/p' | head -1)
+        [ "$back" = "$cpus" ] && ok "selecting those cpus reports the same set back ('$back')" \
+                              || bad "round trip changed the set: printed '$cpus', got back '$back'"
+    fi
+    cleanup_swarm
+
+    banner "hwloc: logical and physical binding reports agree on this node"
+    # --report-bindings renders through the same path with "physical" either
+    # set or not, and it used to be ignored outright whenever the short cut
+    # above fired - both spellings produced the OS indices. These containers
+    # number their cpus 0-7 either way, so this cannot catch a wrong BASIS;
+    # what it does catch is the label going missing or the two spellings
+    # rendering through different code again.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:2 -n 2 --bind-to core \
+                   --display map hostname' 2>&1)
+    echo "$out" | grep -q 'core:L' \
+        && ok "a logical binding is labelled core:L" \
+        || bad "no core:L label in the default binding report: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    out=$(RUN 'timeout 90 prterun --host node2:2 -n 2 --bind-to core \
+                   --display map:physical hostname' 2>&1)
+    echo "$out" | grep -q 'core:P' \
+        && ok "a physical binding is labelled core:P" \
+        || bad "--display map:physical did not reach the renderer: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # --display cpus goes through its own renderer, which ignored the
+    # qualifier entirely until both were routed through cpuset2ranges()
+    out=$(RUN 'timeout 90 prterun --host node2:8 -n 1 --display cpus:physical hostname' 2>&1)
+    rc=$?
+    [ "$rc" = 0 ] && ok "--display cpus:physical completed (rc=0)" \
+                  || bad "--display cpus:physical failed (rc=$rc): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    echo "$out" | grep -qE '^PKG\[0\]: [0-9]' \
+        && ok "--display cpus:physical reported a package" \
+        || bad "--display cpus:physical reported nothing: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
     cleanup_swarm
 }
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2990,6 +2990,31 @@ test_hwloc() {
         && ok "object cpusets were rendered" \
         || bad "no cpuset was rendered in the topology dump"
     cleanup_swarm
+
+    banner "hwloc: per-object binding limits do not carry over between jobs"
+    # prte_hwloc_base_reset_counters() clears the per-object "how many procs
+    # did I already place here" counters between jobs. It walked only the
+    # normal depth hierarchy, and hwloc 2.x keeps NUMA nodes OUT of that
+    # hierarchy - so a counter attached to a NUMA node by "--bind-to
+    # numa:limit=N" was never cleared. It survived for the life of the DVM,
+    # and the SECOND such job found every domain already at its limit and
+    # could not be bound at all.
+    #
+    # A persistent DVM is the only place this shows: prterun starts a fresh
+    # HNP each time and takes the stale counters down with it. One proc per
+    # job against limit=1, so a leaked counter is immediately fatal to the
+    # next job. These containers report a single NUMA node covering the
+    # machine, which is all this needs.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prte --daemonize --host node2:8 && sleep 2 &&
+               for i in 1 2 3; do
+                   echo "RUN$i";
+                   timeout 60 prun -n 1 --bind-to numa:limit=1 --display map hostname;
+               done; pterm' 2>&1)
+    n=$(echo "$out" | grep -c 'Process rank: 0 Bound: package')
+    [ "$n" = 3 ] && ok "all 3 numa:limit jobs bound in one DVM" \
+                 || bad "$n/3 numa:limit jobs bound - a per-NUMA counter leaked between jobs: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+    cleanup_swarm
 }
 
 # Absolute path, deliberately -- see the note above DS.

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3042,6 +3042,33 @@ test_hwloc() {
     fi
     cleanup_swarm
 
+    banner "hwloc: a qualifier with no policy keeps the default binding"
+    # "--bind-to :overload-allowed" means "the binding I would have got,
+    # but allow overload" - the same thing "--map-by :OVERSUBSCRIBE" has
+    # always meant. pmix_check_cli_option() compares only
+    # min(strlen(a),strlen(b)) characters, so the empty policy word matched
+    # the first option tested against it, which is "none": binding was
+    # silently disabled, and the default MAPPING policy fell from BYCORE to
+    # BYSLOT along with it. Nothing was printed to say so.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:4 -n 2 --bind-to :overload-allowed \
+                   --display map hostname' 2>&1)
+    echo "$out" | grep -q 'Binding policy: CORE' \
+        && ok "a qualifier-only --bind-to keeps the default CORE policy" \
+        || bad "qualifier-only --bind-to changed the policy: $(echo "$out" | grep -i 'policy' | tr '\n' ' ')"
+    echo "$out" | grep -q 'OVERLOAD-ALLOWED' \
+        && ok "the qualifier itself survived" \
+        || bad "the qualifier was lost: $(echo "$out" | grep -i 'policy' | tr '\n' ' ')"
+    n=$(echo "$out" | grep -c 'Bound: package')
+    [ "$n" = 2 ] && ok "both ranks were still bound" \
+                 || bad "$n/2 ranks bound under a qualifier-only --bind-to"
+    # and the mapping policy has to be untouched too - it is chosen from the
+    # binding, so "none" dragged it down with it
+    echo "$out" | grep -q 'Mapping policy: BYCORE' \
+        && ok "the mapping policy is unchanged" \
+        || bad "the mapping policy moved: $(echo "$out" | grep -i 'Mapping policy' | tr '\n' ' ')"
+    cleanup_swarm
+
     banner "hwloc: logical and physical binding reports agree on this node"
     # --report-bindings renders through the same path with "physical" either
     # set or not, and it used to be ignored outright whenever the short cut

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -33,7 +33,7 @@ is the property to preserve.
 | `ess/hnp`, `plm/base` | `prte_hwloc_base_get_topology()`, `_filter_cpus()`, `_setup_summary()` — acquiring the local topology and receiving remote ones |
 | `rmaps/*` | `_get_nbobjs_by_type()`, `_get_obj_by_type()`, `_get_npus()`, `_generate_cpuset()`, `_cpu_list_parse()`, `_reset_counters()`, `prte_hwloc_obj_data_t` |
 | `odls/base` | `prte_hwloc_base_map` / `_mbfa` (the memory-policy globals) and `_cset2str()` |
-| `runtime/data_type_support`, `ras/base` | `_cset2str()`, `prte_hwloc_get_binding_info()`, `prte_hwloc_print()`, `prte_hwloc_build_map()` — every `--display` variant |
+| `runtime/data_type_support`, `ras/base` | `_cset2str()`, `_cpuset2ranges()`, `prte_hwloc_get_binding_info()`, `prte_hwloc_print()` — every `--display` variant |
 | `schizo`, `tools` | `_set_binding_policy()`, `_print_binding()` |
 
 ---
@@ -180,18 +180,55 @@ a value that does not fit has to be rejected rather than truncated.
 
 ---
 
-## Rendering a binding: three functions, three buffer contracts
+## GOLDEN RULE: a cpuset's bits are PU OS indices; a cpu *number* is not
 
-This is where the sharp edges are, because the output is built into
-fixed-size buffers whose size the *caller* chooses.
+Every rendering in PRRTE starts from an `hwloc_cpuset_t`, and the bits of
+one are always **PU OS indices** — the kernel's cpu numbers. What PRRTE
+shows a user is a list of **cores** (or of hwthreads, when the job treats
+hwthreads as cpus), and every PRRTE grammar that *accepts* such a list —
+`--cpu-set`, the rankfile slot lists — resolves it as an hwloc **logical**
+index. Those three numbering schemes coincide only by luck.
 
-| Function | Output | Buffer |
-|----------|--------|--------|
-| `prte_hwloc_base_cset2str()` | `package[0][core:L0,2-3]` | allocates and returns; internally builds through a 2048-byte scratch |
-| `prte_hwloc_get_binding_info()` | one `<core>N</core>` element per bound core, plus the package number | **caller's** buffer and size |
-| `prte_hwloc_print()` | the whole topology as indented text | allocates and returns |
+So: **resolve each bit to the object it belongs to and take that object's
+index.** `prte_hwloc_base_cpuset2ranges()` is the one place that does it,
+and everything that renders cpu numbers goes through it:
 
-Rules that were all being broken:
+| Function | Output |
+|----------|--------|
+| `prte_hwloc_base_cpuset2ranges()` | `0,2-3` — the primitive; allocates and returns |
+| `prte_hwloc_base_cset2str()` | `package[0][core:L0,2-3]` — one element per package; allocates |
+| `prte_hwloc_get_binding_info()` | one `<core>N</core>` element per site, plus the package number, into the **caller's** buffer |
+| `prte_hwloc_print()` | the whole topology as indented text; allocates |
+
+Three renderers used to short-cut this whenever the bits "already were
+cores" (`npus == ncores`) or the job was in hwthreads, and print the raw
+bit numbers under a `core:L`/`hwt:L` label. That is wrong on exactly the
+machines where it matters — any SMT node viewed in hwthreads, and any node
+whose firmware interleaves cpu numbers across packages — and it is worse
+than cosmetic, because the user reads the number back out and hands it to
+`--cpu-set`. The `physical` flag was also simply ignored on those paths.
+`--display cpus` in both `ras/base` and `runtime/data_type_support` carried
+its own copy of the same three-branch short cut; both now call
+`cpuset2ranges()`.
+
+There is no `bits_as_cores` special case left. Do not reintroduce one:
+`cpuset2ranges()` produces the identical answer when the indices happen to
+agree, and the correct one when they do not.
+
+The rule reaches past the display code. A **diagnostic** that names cpu
+numbers is subject to it too, and three mappers were breaking it in the
+same message: `rmaps/seq`, `rmaps/rank_file` and `rmaps/lsf` print
+"requested / available / overlapping" cpu sets when a slot list collides
+with cpus already in use, and rendered them straight off the bitmap while
+quoting the user's own logical slot list beside them — three numbering
+schemes in one message. They call `cpuset2ranges()` now.
+
+The one place a raw `hwloc_bitmap_list_asprintf()` is **correct** is
+`prte_proc_t.cpuset`: that is a wire format, read back with
+`hwloc_bitmap_list_sscanf()`, and it must stay in OS indices. Never show
+it to a user unrendered.
+
+Other rules here, all of which were being broken:
 
 - **Charge every byte written against the remaining room.** The XML element
   writer advanced its cursor through a run of set bits without reducing the
@@ -306,9 +343,18 @@ summary-not-yet-built case), `_get_npus()` in core and hwthread terms,
 `_cpu_list_parse()` grammar including every id that does not exist,
 `_cset2str()` range collapsing, `prte_hwloc_get_binding_info()` against a
 **guarded** buffer (a canary past `sz` — this is how the element-writer
-overflow is pinned), `prte_hwloc_build_map()`, the print-buffer ring, the
-`--bind-to` parser, and userdata release across the normal hierarchy *and*
-the special NUMA depth.
+overflow is pinned), `_cpuset2ranges()`, the print-buffer ring, the
+`--bind-to` parser, userdata release across the normal hierarchy *and* the
+special NUMA depth, and `_reset_counters()` at both of those places.
+
+One case cannot be built synthetically: hwloc's synthetic generator always
+makes `os_index` and `logical_index` agree, so **the logical-vs-physical
+divergence is driven from a hand-written XML topology embedded in the test**
+(`interleaved_xml`: two packages whose PU OS indices interleave, 0/2/4/6 and
+1/3/5/7). That is the only way to prove a renderer reports the basis it
+claims. If you write more XML there, note that hwloc's importer segfaults —
+it does not diagnose — on an object missing `complete_cpuset`/`nodeset`/
+`complete_nodeset`; copy the attribute set from an existing object.
 
 Add to it rather than around it. If a change here is not reachable from a
 synthetic topology plus a string, say why in the test file.
@@ -326,7 +372,11 @@ buffer — those containers are 8 cores, one package, no SMT, no sysfs NUMA
 node, which is exactly the shape that trips it), `--map-by numa` against
 topologies the HNP never sensed, a DVM cpu-set applied to every node rather
 than just the first, a malformed cpu-set being refused without taking the
-HNP down, and `--display topo` over several topologies at once.
+HNP down, `--display topo` over several topologies at once, the
+print-then-accept round trip (`--display cpus` → `--cpu-set` → the same set
+back), both spellings of the index basis, and — the one case that needs a
+**persistent** DVM, because `prterun` takes the stale state down with its
+HNP — three successive `--bind-to numa:limit=1` jobs all binding.
 
 **Not covered anywhere:** `prte_hwloc_base_get_topology()`'s sensing path
 (it reads the real machine), and `prte_hwloc_print()` against a machine wide
@@ -356,8 +406,28 @@ enough to fill its cpuset buffer — a few thousand PUs.
   `_check_on_coprocessor()`), along with the topology-signature builder,
   `_single_cpu()`, `_get_obj_idx()` and `_topology_export_xmlbuffer()` —
   none had callers.
+- **`prte_hwloc_build_map()` is gone**, and with it the "the bits already
+  are cores" short cut its three callers wrapped it in. It produced a
+  *bitmap* of core indices, which is a lossy shape for the job — a caller
+  then printed that bitmap with `hwloc_bitmap_list_snprintf()`, mixing two
+  index bases in one string. `prte_hwloc_base_cpuset2ranges()` replaces it
+  and answers the question the callers were actually asking.
 - **`prte_hwloc_get_binding_info()`'s output is undefined for a process
   bound across more than one package.** It renders the last matching package
   and reports that package's number. The caller wraps the result in a single
   `<package>` element, so the shape of the fix is an API change, not a
   one-liner.
+- **`_cset2str()` and `_get_binding_info()` iterate packages, so a topology
+  with no `HWLOC_OBJ_PACKAGE` level renders as nothing at all** (`cset2str`
+  returns NULL, and its callers print `UNBOUND`). Every real machine has
+  packages; the shape that would not is the same museum piece that has no
+  cores. `_cpuset2ranges()` does not have this problem — reach for it if you
+  need a rendering that does not presuppose packages. Fixing the other two
+  means changing the `package[N][...]` output form and the `<package>`
+  element its caller wraps around it.
+- **A topology with PUs but no cores is rendered in hwthreads**, and says
+  so (`hwt:L` rather than `core:L`). hwloc does not find cores on every
+  platform — PPC64 on old Linux kernels reported only NUMA nodes and PUs —
+  and `prte_hwloc_base_get_pu()` has always allowed for it. The renderers
+  did not: a core-based lookup resolved nothing and every binding on such a
+  machine came back `UNBOUND`.

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -307,6 +307,12 @@ wraps it and is what produces `prte_node_t.available`.
 user input too, and every lookup can legitimately fail — `--cpu-set P99`
 used to be a segfault.
 
+**A core id in `package:core` notation is relative to that package**, so
+resolve it with `hwloc_get_obj_inside_cpuset_by_type()` against the
+package's cpuset. It used to be turned into a global index by adding
+"objects per package × package id", which names an object in the wrong
+package as soon as two packages hold different numbers of them.
+
 ---
 
 ## The print-buffer ring

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -126,6 +126,14 @@ hwloc does not know these pointers are ours, so:
   reinterpreting it as a counter would scribble on `numa_cutoff`. Release
   code can treat both uniformly (`PMIX_RELEASE` is correct for either), but
   anything that *reads a field* cannot.
+- **`prte_hwloc_base_reset_counters()` must sweep the special NUMA depth
+  too, for the same reason `release_userdata()` does.** It walked only
+  `1..get_depth()` and carried a `HWLOC_OBJ_NUMANODE != type` test that
+  could never fire, so a counter attached to a NUMA node was never cleared:
+  `--bind-to numa:limit=N` accumulated `nprocs` for the life of the DVM and
+  the *second* such job found every domain already at its limit and could
+  not be bound. Any new sweep over "the objects binding touches" has to
+  visit both places.
 - `prte_hwloc_base_reset_counters()` walks `prte_node_topologies`, which is
   NULL until `prte_init()`.
 

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -178,6 +178,24 @@ index past a qualifier's name to find its `=value`** — use
 `pmix_cli_qualifier_value()`. `limit=N` lands in a `uint16_t` attribute, so
 a value that does not fit has to be rejected rather than truncated.
 
+Two ordering rules the parser now encodes:
+
+- **`pmix_check_cli_option()` compares only `min(strlen(a), strlen(b))`
+  characters, so an empty string matches whatever it is tested against
+  first.** The policy word is empty for the `--bind-to :qualifier` form,
+  and that form used to fall straight into the first arm of the chain —
+  `none` — silently disabling binding *and* dragging the default mapping
+  policy from `BYCORE` down to `BYSLOT` with it. A qualifier with no policy
+  means "the binding I would otherwise have got, plus this qualifier",
+  exactly as `--map-by :OVERSUBSCRIBE` does; leave the policy bits at zero
+  so `PRTE_SET_DEFAULT_BINDING_POLICY` can fill them in around the
+  qualifiers later. Any new empty-string-versus-option test here needs the
+  same guard.
+- **Resolve the policy word before applying any qualifier**, because
+  `report` and `limit=N` write to `jdata->attributes`. Parsed the other way
+  round, `--bind-to sockets:report` recorded report-bindings on the job and
+  *then* rejected the request.
+
 ---
 
 ## GOLDEN RULE: a cpuset's bits are PU OS indices; a cpu *number* is not

--- a/src/hwloc/help-prte-hwloc-base.txt
+++ b/src/hwloc/help-prte-hwloc-base.txt
@@ -60,11 +60,6 @@ to obtain a processor unit object:
 There will be no impact to your application, so we will continue
 but will not be able to output the binding locations.
 #
-[too-many-sites]
-At least one process in your application is bound to too many sites
-for us to report in a string. There will be no impact to your application
-so we will continue but will not be able to output the binding locations.
-#
 [unfound-cpu]
 The CPU list provided on your cmd line contains at least one entry that
 could not be resolved:

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -221,8 +221,27 @@ PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
 
 PRTE_EXPORT void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
                                              bool use_hwthread_cpus,
+                                             bool physical,
                                              hwloc_topology_t topo, int *pkgnum,
                                              char *cores, int sz);
+
+/**
+ * Render the set bits of a cpuset as a comma-separated list of index
+ * ranges - "0-3,7" - in terms of cores, or of hwthreads when
+ * "use_hwthread_cpus" is set. Indices are hwloc logical indices unless
+ * "physical" is set, in which case they are OS indices.
+ *
+ * This is the only correct way to turn a cpuset into a list of cpu numbers
+ * for a user to read: the bits themselves are PU OS indices, so printing
+ * them raw mislabels every topology whose logical and OS numbering differ.
+ *
+ * Returns an allocated string the caller must free, or NULL if the set is
+ * empty or a bit could not be resolved.
+ */
+PRTE_EXPORT char *prte_hwloc_base_cpuset2ranges(hwloc_topology_t topo,
+                                                hwloc_const_cpuset_t bitmap,
+                                                bool use_hwthread_cpus,
+                                                bool physical);
 
 /* get the hwloc object that corresponds to the given processor id  and type */
 PRTE_EXPORT hwloc_obj_t prte_hwloc_base_get_pu(hwloc_topology_t topo, bool use_hwthread_cpus,
@@ -232,11 +251,6 @@ PRTE_EXPORT int prte_hwloc_base_open(void);
 PRTE_EXPORT void prte_hwloc_base_close(void);
 PRTE_EXPORT int prte_hwloc_base_register(void);
 PRTE_EXPORT int prte_hwloc_print(char **output, char *prefix, hwloc_topology_t src);
-
-PRTE_EXPORT void prte_hwloc_build_map(hwloc_topology_t topo,
-                                      hwloc_cpuset_t avail,
-                                      bool use_hwthread_cpus,
-                                      hwloc_bitmap_t coreset);
 
 PRTE_EXPORT bool prte_hwloc_base_core_cpus(hwloc_topology_t topo);
 

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -213,9 +213,16 @@ int prte_hwloc_base_register(void)
 
 
     if (NULL != default_cpu_list) {
-        if (NULL != (ptr = strrchr(default_cpu_list, ':'))) {
+        /* The MCA layer owns this string and reports the parameter's value
+         * through it, so parse a copy: splitting the modifier off in place
+         * makes prte_info and every later reader see a truncated value the
+         * user never set. */
+        prte_hwloc_default_cpu_list = strdup(default_cpu_list);
+        if (NULL == prte_hwloc_default_cpu_list) {
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        if (NULL != (ptr = strrchr(prte_hwloc_default_cpu_list, ':'))) {
             *ptr = '\0';
-            prte_hwloc_default_cpu_list = strdup(default_cpu_list);
             ++ptr;
             if (0 == strcasecmp(ptr, "HWTCPUS")) {
                 prte_hwloc_default_use_hwthread_cpus = true;
@@ -224,10 +231,10 @@ int prte_hwloc_base_register(void)
             } else {
                 pmix_show_help("help-prte-hwloc-base.txt", "bad-processor-type", true,
                                default_cpu_list, ptr);
+                free(prte_hwloc_default_cpu_list);
+                prte_hwloc_default_cpu_list = NULL;
                 return PRTE_ERR_BAD_PARAM;
             }
-        } else {
-            prte_hwloc_default_cpu_list = strdup(default_cpu_list);
         }
     }
 

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -518,6 +518,64 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
     if (NULL != ptr) {
         *ptr = '\0';
         ++ptr;
+    }
+
+    /* Resolve the policy word FIRST, before any qualifier can record itself
+     * on the job: a spec whose policy does not parse must leave the job
+     * exactly as it found it.
+     *
+     * An empty policy word - the ":qualifier" form, with no policy at all -
+     * means "keep whatever binding policy would otherwise apply, but with
+     * these qualifiers". That is what "--map-by :OVERSUBSCRIBE" has always
+     * meant on the mapping side, and it has to mean the same here. It did
+     * not: pmix_check_cli_option() compares only min(strlen(a), strlen(b))
+     * characters, so an empty string matches the first option it is tested
+     * against - which is "none". "--bind-to :overload-allowed" therefore
+     * disabled binding outright, silently, and took the default mapping
+     * policy down with it. Leaving the policy bits at zero here means
+     * PRTE_BINDING_POLICY_IS_SET() still answers "no" and
+     * PRTE_SET_DEFAULT_BINDING_POLICY() later fills the policy in while
+     * preserving the qualifier half of the word. */
+    if ('\0' != myspec[0]) {
+        if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NONE)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NONE);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_HWT)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_CORE)) {
+            /* honor the user's "core" unless the topology has no cores at all;
+             * a core that holds a single hwthread is still a core to bind to */
+            if (!prte_rmaps_base.have_cores) {
+                PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
+            } else {
+                PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_CORE);
+            }
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L1CACHE)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L1CACHE);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L2CACHE)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L2CACHE);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L3CACHE)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L3CACHE);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NUMA)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NUMA);
+
+        } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_PACKAGE)) {
+            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
+
+        } else {
+            pmix_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
+                           spec);
+            free(myspec);
+            return PRTE_ERR_BAD_PARAM;
+        }
+    }
+
+    if (NULL != ptr) {
         quals = PMIx_Argv_split(ptr, ':');
         for (i = 0; NULL != quals[i]; i++) {
             if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_IF_SUPP)) {
@@ -589,43 +647,6 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
             }
         }
         PMIx_Argv_free(quals);
-    }
-
-    if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NONE)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NONE);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_HWT)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_CORE)) {
-        /* honor the user's "core" unless the topology has no cores at all;
-         * a core that holds a single hwthread is still a core to bind to */
-        if (!prte_rmaps_base.have_cores) {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_HWTHREAD);
-        } else {
-            PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_CORE);
-        }
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L1CACHE)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L1CACHE);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L2CACHE)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L2CACHE);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_L3CACHE)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_L3CACHE);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_NUMA)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_NUMA);
-
-    } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_PACKAGE)) {
-        PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
-
-    } else {
-        pmix_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
-                       spec);
-        free(myspec);
-        return PRTE_ERR_BAD_PARAM;
     }
     free(myspec);
 

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -74,6 +74,12 @@ bool prte_hwloc_base_core_cpus(hwloc_topology_t topo)
     }
     /* see if the cpuset of a core match that of a PU */
     pu = hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, 0);
+    if (NULL == pu) {
+        /* a topology with cores but no PUs answers no question we can
+         * usefully ask here, and dereferencing the missing PU took the
+         * caller down */
+        return false;
+    }
     /* if the two are equal, then we really don't have
      * cores in this topology */
     if (hwloc_bitmap_isequal(obj->cpuset, pu->cpuset)) {
@@ -155,7 +161,7 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
 {
     hwloc_cpuset_t avail = NULL, pucpus, res;
     char **ranges = NULL, **range = NULL;
-    int idx, cpu, start, end;
+    int idx, cpu, start, end, nranges;
     hwloc_obj_t pu;
     char **cache = NULL;
     char tmp[256];
@@ -163,11 +169,12 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
 
     /* find the specified logical cpus */
     ranges = PMIx_Argv_split(*cpulist, ',');
+    nranges = PMIx_Argv_count(ranges);
     avail = hwloc_bitmap_alloc();
     hwloc_bitmap_zero(avail);
     res = hwloc_bitmap_alloc();
     pucpus = hwloc_bitmap_alloc();
-    for (idx = 0; idx < PMIx_Argv_count(ranges); idx++) {
+    for (idx = 0; idx < nranges; idx++) {
         range = PMIx_Argv_split(ranges[idx], '-');
         bad = false;
         switch (PMIx_Argv_count(range)) {
@@ -477,12 +484,11 @@ int prte_hwloc_base_get_topology(void)
     * that aren't really of interest
     */
     obj = hwloc_get_root_obj(prte_hwloc_topology);
-    for (i = 0; i < obj->infos_count; i++) {
-        if (NULL == obj->infos[i].name || NULL == obj->infos[i].value) {
-            continue;
-        }
-        if (0 == strncmp(obj->infos[i].name, "HostName", strlen("HostName")) ||
-            0 == strncmp(obj->infos[i].name, "ProcessName", strlen("ProcessName"))) {
+    i = 0;
+    while (i < obj->infos_count) {
+        if (NULL != obj->infos[i].name && NULL != obj->infos[i].value &&
+            (0 == strcmp(obj->infos[i].name, "HostName") ||
+             0 == strcmp(obj->infos[i].name, "ProcessName"))) {
             free(obj->infos[i].name);
             free(obj->infos[i].value);
             /* left justify the array */
@@ -492,7 +498,12 @@ int prte_hwloc_base_get_topology(void)
             obj->infos[obj->infos_count - 1].name = NULL;
             obj->infos[obj->infos_count - 1].value = NULL;
             obj->infos_count--;
+            /* the entry that just shifted into slot i has not been examined
+             * yet, so do not advance - two removable entries side by side
+             * used to leave the second one behind */
+            continue;
         }
+        i++;
     }
 
     /* fill prte_cache_line_size global with the smallest L2 cache
@@ -760,8 +771,6 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
     int package_id, core_id;
     hwloc_obj_t package, core;
     hwloc_obj_type_t obj_type = HWLOC_OBJ_CORE;
-    unsigned int npus;
-    bool hwthreadcpus = false;
 
     package_core = PMIx_Argv_split(package_core_list, ':');
     if (NULL == package_core || !parse_cpu_id(package_core[0], &package_id)) {
@@ -782,10 +791,7 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
      */
     if (NULL == prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0)) {
         obj_type = HWLOC_OBJ_PU;
-        hwthreadcpus = true;
     }
-    npus = prte_hwloc_base_get_npus(topo, hwthreadcpus, NULL, package);
-    npus = npus * package_id;
 
     for (i = 1; NULL != package_core[i]; i++) {
         if ('C' == package_core[i][0] || 'c' == package_core[i][0]) {
@@ -812,9 +818,14 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
                         rc = PRTE_ERR_BAD_PARAM;
                         break;
                     }
-                    core_id += npus;
-                    /* get that object */
-                    core = prte_hwloc_base_get_obj_by_type(topo, obj_type, core_id);
+                    /* The id is relative to this package. Ask hwloc for the
+                     * nth object *inside* the package's cpuset rather than
+                     * offsetting into the global index by "cores per package
+                     * times package id" - that arithmetic silently names an
+                     * object in the wrong package the moment two packages
+                     * do not hold the same number of them. */
+                    core = hwloc_get_obj_inside_cpuset_by_type(topo, package->cpuset,
+                                                               obj_type, core_id);
                     if (NULL == core) {
                         rc = PRTE_ERR_NOT_FOUND;
                         break;
@@ -835,10 +846,10 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
                     return PRTE_ERR_BAD_PARAM;
                 }
                 for (j = lower_range; j <= upper_range; j++) {
-                    /* get the indexed core from this package */
-                    core_id = j + npus;
-                    /* get that object */
-                    core = prte_hwloc_base_get_obj_by_type(topo, obj_type, core_id);
+                    /* the indexed object within this package - see the note
+                     * on the single-id case above */
+                    core = hwloc_get_obj_inside_cpuset_by_type(topo, package->cpuset,
+                                                               obj_type, j);
                     if (NULL == core) {
                         rc = PRTE_ERR_NOT_FOUND;
                         break;
@@ -1457,8 +1468,18 @@ int prte_hwloc_print(char **output, char *prefix, hwloc_topology_t src)
     hwloc_obj_t obj;
     char *tmp = NULL;
 
+    /* every caller hands us a topology out of prte_node_topologies and
+     * prints the result unconditionally, so answer rather than crash if the
+     * node's topology has not arrived */
+    *output = NULL;
+    if (NULL == src) {
+        return PRTE_ERR_NOT_FOUND;
+    }
     /* get root object */
     obj = hwloc_get_root_obj(src);
+    if (NULL == obj) {
+        return PRTE_ERR_NOT_FOUND;
+    }
     /* print it */
     print_hwloc_obj(&tmp, prefix, src, obj);
     *output = tmp;

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1559,14 +1559,31 @@ int prte_hwloc_print(char **output, char *prefix, hwloc_topology_t src)
     return PRTE_SUCCESS;
 }
 
+/* zero the placement counters hanging off every object at one level of a
+ * topology. Only ever called for a level below the root: depth 0 carries a
+ * prte_hwloc_topo_data_t, and reinterpreting that as a counter would
+ * scribble on numa_cutoff. */
+static void reset_level_counters(hwloc_topology_t topo, int depth)
+{
+    hwloc_obj_t obj;
+    prte_hwloc_obj_data_t *objcnt;
+    unsigned width, w;
+
+    width = hwloc_get_nbobjs_by_depth(topo, depth);
+    for (w = 0; w < width; w++) {
+        obj = hwloc_get_obj_by_depth(topo, depth, w);
+        if (NULL != obj && NULL != obj->userdata) {
+            objcnt = (prte_hwloc_obj_data_t *) obj->userdata;
+            objcnt->nprocs = 0;
+        }
+    }
+}
+
 void prte_hwloc_base_reset_counters(void)
 {
     prte_topology_t *ptopo;
     hwloc_topology_t topo;
     hwloc_obj_type_t type;
-    hwloc_obj_t obj;
-    prte_hwloc_obj_data_t *objcnt;
-    unsigned width, w;
     unsigned depth, d;
     int n;
 
@@ -1597,31 +1614,23 @@ void prte_hwloc_base_reset_counters(void)
         for (d = 1; d < depth; d++) {
             /* get the object type at this depth */
             type = hwloc_get_depth_type(topo, d);
-            /* if it isn't one of interest, then ignore it */
-            if (HWLOC_OBJ_NUMANODE != type && HWLOC_OBJ_PACKAGE != type &&
+            /* if it isn't one of interest, then ignore it. NUMA nodes are
+             * deliberately absent from this list - they cannot appear at a
+             * normal depth in hwloc 2.x, and are swept separately below. */
+            if (HWLOC_OBJ_PACKAGE != type &&
                 HWLOC_OBJ_L1CACHE != type && HWLOC_OBJ_L2CACHE != type && HWLOC_OBJ_L3CACHE != type &&
                 HWLOC_OBJ_CORE != type && HWLOC_OBJ_PU != type) {
                 continue;
             }
-
-            /* get the width of the topology at this depth */
-            width = hwloc_get_nbobjs_by_depth(topo, d);
-            if (0 == width) {
-                continue;
-            }
-
-            /* scan all objects at this depth to see if
-             * the location overlaps with them
-             */
-            for (w = 0; w < width; w++) {
-                /* get the object at this depth/index */
-                obj = hwloc_get_obj_by_depth(topo, d, w);
-                if (NULL != obj->userdata) {
-                    objcnt = (prte_hwloc_obj_data_t*)obj->userdata;
-                    objcnt->nprocs = 0;
-                }
-            }
+            reset_level_counters(topo, d);
         }
+        /* NUMA nodes live at a special depth of their own, so a walk over
+         * 0..get_depth() never visits one. Binding attaches a counter to a
+         * NUMA node exactly as it does to a package (--bind-to numa), and
+         * missing them here left those counters accumulating across every
+         * job in the life of a DVM: the second "--bind-to numa:limit=N" job
+         * found every domain already at its limit and could not be bound. */
+        reset_level_counters(topo, HWLOC_TYPE_DEPTH_NUMANODE);
     }
 }
 

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1050,173 +1050,6 @@ char *prte_hwloc_base_print_binding(prte_binding_policy_t binding)
     return ret;
 }
 
-void prte_hwloc_build_map(hwloc_topology_t topo,
-                          hwloc_cpuset_t avail,
-                          bool use_hwthread_cpus,
-                          hwloc_bitmap_t coreset)
-{
-    unsigned k, obj_index, core_index;
-    hwloc_obj_t pu, core;
-
-    /* the bits in the cpuset _always_ represent hwthreads, so
-     * we have to manually determine which core each bit is under
-     * so we can report the cpus in terms of "cores" */
-    /* start with the first set bit */
-    hwloc_bitmap_zero(coreset);
-    k = hwloc_bitmap_first(avail);
-    obj_index = 0;
-    while (k != (unsigned) -1) {
-        if (use_hwthread_cpus) {
-            /* mark this thread as occupied */
-            hwloc_bitmap_set(coreset, k);
-        } else {
-            /* Go upward and find the core this PU belongs to */
-            pu = hwloc_get_obj_inside_cpuset_by_type(topo, avail, HWLOC_OBJ_PU, obj_index);
-            core = pu;
-            while (NULL != core && core->type != HWLOC_OBJ_CORE) {
-                core = core->parent;
-            }
-            core_index = 0;
-            if (NULL != core) {
-                core_index = core->logical_index;
-            }
-            /* mark everything since the last place as
-             * being empty */
-            hwloc_bitmap_set(coreset, core_index);
-        }
-        /* move to the next set bit */
-        k = hwloc_bitmap_next(avail, k);
-        ++obj_index;
-    }
-}
-
-/* Render the set bits of a bitmap as one XML element per bit.
- *
- * Returns the number of bytes that *would* have been written (snprintf
- * semantics), so a return >= buflen means the output was truncated. The
- * previous version advanced the write pointer inside a range without also
- * charging the bytes against the remaining budget, so a bitmap holding a
- * run of bits walked straight off the end of the caller's buffer.
- */
-static int bitmap_list_snprintf_exp(char *__hwloc_restrict buf, size_t buflen,
-                                    const struct hwloc_bitmap_s *__hwloc_restrict set,
-                                    char *type)
-{
-    size_t total = 0;
-    int prev = -1;
-    int begin, end, i, res;
-
-    /* mark the end in case we do nothing later */
-    if (0 < buflen) {
-        buf[0] = '\0';
-    }
-
-    while (1) {
-        begin = hwloc_bitmap_next(set, prev);
-        if (-1 == begin) {
-            break;
-        }
-        end = hwloc_bitmap_next_unset(set, begin);
-        /* an infinite run has no next unset bit - emit the one bit we know
-         * about rather than looping forever */
-        if (-1 == end) {
-            end = begin + 1;
-        }
-
-        for (i = begin; i < end; i++) {
-            /* Always hand snprintf the *remaining* room. total can exceed
-             * buflen once we truncate, so clamp rather than subtract. */
-            char *at = (total < buflen) ? buf + total : NULL;
-            size_t room = (total < buflen) ? buflen - total : 0;
-
-            res = snprintf(at, room, "%*c<%s>%d</%s>\n", 20, ' ', type, i, type);
-            if (0 > res) {
-                return -1;
-            }
-            total += (size_t) res;
-        }
-
-        prev = end - 1;
-    }
-    return (int) total;
-}
-
-/*
- * Render a process' binding as XML elements, and report the package it
- * lies in. Output is undefined if a rank is bound to more than 1 package.
- *
- * "cores" always comes back NUL-terminated and "*pkgnum" always comes back
- * set: the caller wraps both in one <package> element, and every caller
- * leaves pkgnum uninitialized on the way in.
- */
-void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
-                               bool use_hwthread_cpus, hwloc_topology_t topo,
-                               int *pkgnum, char *cores, int sz)
-{
-    int n, npkgs, npus, ncores;
-    hwloc_cpuset_t avail, coreset = NULL;
-    hwloc_obj_t pkg;
-    bool bits_as_cores = false;
-
-    *pkgnum = -1;
-    if (0 < sz) {
-        cores[0] = '\0';
-    }
-
-    /* if the cpuset is all zero, then something is wrong. Say so and stop -
-     * the scan below would otherwise find nothing and leave the message in
-     * place only by accident */
-    if (hwloc_bitmap_iszero(cpuset)) {
-        snprintf(cores, sz, "\n%*c<EMPTY CPUSET/>\n", 20, ' ');
-        return;
-    }
-
-    /* get the number of packages in the topology */
-    npkgs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PACKAGE);
-    avail = hwloc_bitmap_alloc();
-    npus = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
-    ncores = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
-
-    if (npus == ncores && !use_hwthread_cpus) {
-        /* the bits in this bitmap represent cores */
-        bits_as_cores = true;
-    }
-    if (!use_hwthread_cpus && !bits_as_cores) {
-        coreset = hwloc_bitmap_alloc();
-    }
-
-    /* binding happens within a package and not across packages */
-    for (n = 0; n < npkgs; n++) {
-        pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, n);
-        if (NULL == pkg || NULL == pkg->cpuset) {
-            continue;
-        }
-        /* see if we have any here */
-        hwloc_bitmap_and(avail, cpuset, pkg->cpuset);
-
-        if (hwloc_bitmap_iszero(avail)) {
-            continue;
-        }
-
-        if (bits_as_cores) {
-            /* can just use the hwloc fn directly */
-            bitmap_list_snprintf_exp(cores, sz, avail, "core");
-        } else if (use_hwthread_cpus) {
-            /* can just use the hwloc fn directly */
-            bitmap_list_snprintf_exp(cores, sz, avail, "hwt");
-        } else {
-            prte_hwloc_build_map(topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
-            /* now print out the string */
-            bitmap_list_snprintf_exp(cores, sz, coreset, "core");
-        }
-        *pkgnum = n;
-    }
-    hwloc_bitmap_free(avail);
-    if (NULL != coreset) {
-        hwloc_bitmap_free(coreset);
-    }
-}
-
 static int compare_unsigned(const void *a, const void *b)
 {
     unsigned x = *(const unsigned *) a;
@@ -1233,128 +1066,240 @@ static int compare_unsigned(const void *a, const void *b)
     return 0;
 }
 
-#define PRTE_HWLOC_MAX_SITES 2048
-
-/* Append to a bounded buffer, tracking the offset. Returns false once the
- * buffer is full so the caller can stop instead of writing past the end -
- * the original open-coded memcpy() chain here charged nothing against the
- * caller's size and would run off a 2048-byte buffer given a scattered
- * binding wide enough to need more. */
-static bool append_str(char *buf, size_t size, size_t *pos, const char *str)
+/* Resolve the set bits of a cpuset to the objects that own them.
+ *
+ * The bits of an hwloc cpuset are always PU *OS* indices. What PRRTE reports
+ * to a user is a list of cores - or of hwthreads, when the job is treating
+ * hwthreads as cpus - and every PRRTE grammar that accepts such a list
+ * (--cpu-set, the rankfile slot lists) is expressed in hwloc *logical*
+ * indices. So a rendering has to walk each bit up to the object it is being
+ * reported in terms of and take that object's index, logical unless the
+ * caller asked for physical.
+ *
+ * Printing the raw bit numbers instead is right only by coincidence - when
+ * a PU's logical and OS indices happen to agree - and it is wrong on
+ * precisely the machines where the answer matters: any SMT node rendered in
+ * hwthreads (PU 1 of core 0 is OS index 24 on a 24-core part), and any node
+ * whose firmware interleaves cpu numbers across packages. Reporting a core
+ * that way is worse than cosmetic: the user reads the number back out and
+ * hands it to --cpu-set, which resolves it logically.
+ *
+ * On success writes a malloc'd, sorted, duplicate-free array of indices to
+ * *sites and returns how many there are. Returns -1 if a bit could not be
+ * resolved (already reported through show_help) or on allocation failure.
+ */
+static int collect_sites(hwloc_topology_t topo, hwloc_const_cpuset_t bitmap,
+                         bool as_hwthreads, bool physical,
+                         unsigned **sites)
 {
-    size_t len = strlen(str);
+    hwloc_obj_type_t leaf = as_hwthreads ? HWLOC_OBJ_PU : HWLOC_OBJ_CORE;
+    unsigned *indices, val;
+    int nsites = 0, n, weight, id;
+    hwloc_obj_t obj;
+    bool unique;
 
-    if (*pos + len + 1 > size) {
-        return false;
+    *sites = NULL;
+    weight = hwloc_bitmap_weight(bitmap);
+    if (0 >= weight) {
+        /* weight() is -1 for an infinitely-set bitmap, which no topology
+         * produces, and 0 for an empty one - neither has any sites */
+        return 0;
     }
-    memcpy(&buf[*pos], str, len);
-    *pos += len;
-    buf[*pos] = '\0';
-    return true;
-}
-
-/* generate a logical string output of a hwloc_cpuset_t */
-static int build_map(char *answer, size_t size,
-                     hwloc_const_cpuset_t bitmap,
-                     bool physical, char *prefix,
-                     hwloc_topology_t topo)
-{
-    unsigned indices[PRTE_HWLOC_MAX_SITES], id;
-    int nsites = 0, n, start, end;
-    size_t pos;
-    hwloc_obj_t pu;
-    char tmp[128];
-    bool first, unique;
-    unsigned val;
-
-    if (0 == size) {
-        return PRTE_ERR_BAD_PARAM;
+    /* each set bit contributes at most one site, so this is an exact bound */
+    indices = (unsigned *) malloc(weight * sizeof(unsigned));
+    if (NULL == indices) {
+        return -1;
     }
-    answer[0] = '\0';
 
-    for (id = hwloc_bitmap_first(bitmap);
-         id != (unsigned)-1;
-         id = hwloc_bitmap_next(bitmap, id)) {
-        // the id's are for threads, but we want cores
-        pu = hwloc_get_pu_obj_by_os_index(topo, id);
-
-        // go upward to find the core that contains this pu
-        while (NULL != pu && pu->type != HWLOC_OBJ_CORE) {
-            pu = pu->parent;
+    for (id = hwloc_bitmap_first(bitmap); -1 != id; id = hwloc_bitmap_next(bitmap, id)) {
+        obj = hwloc_get_pu_obj_by_os_index(topo, (unsigned) id);
+        /* a PU is its own leaf; a core is the first CORE ancestor */
+        while (NULL != obj && leaf != obj->type) {
+            obj = obj->parent;
         }
-        if (NULL == pu) {
-            pmix_show_help("help-prte-hwloc-base.txt", "pu-not-found", true, id);
-            return PRTE_ERR_SILENT;
+        if (NULL == obj) {
+            pmix_show_help("help-prte-hwloc-base.txt", "pu-not-found", true, (unsigned) id);
+            free(indices);
+            return -1;
         }
-        if (physical) {
-            // record the physical site
-            val = pu->os_index;
-        } else {
-            // record the logical site
-            val = pu->logical_index;
+        val = physical ? obj->os_index : obj->logical_index;
+        if (HWLOC_UNKNOWN_INDEX == val) {
+            /* XML written by hand, or by an hwloc old enough not to record
+             * OS indices, carries no physical index. The logical one always
+             * exists, so report that rather than (unsigned)-1. */
+            val = obj->logical_index;
         }
-        // add it uniquely to the array of indices - it could be a duplicate
+        /* several PUs can sit under one core, so the same site comes up
+         * once per hwthread */
         unique = true;
-        for (n=0; n < nsites; n++) {
+        for (n = 0; n < nsites; n++) {
             if (indices[n] == val) {
                 unique = false;
                 break;
             }
         }
         if (unique) {
-            if (PRTE_HWLOC_MAX_SITES == nsites) {
-                pmix_show_help("help-prte-hwloc-base.txt", "too-many-sites", true);
-                return PRTE_ERR_SILENT;
-            }
             indices[nsites] = val;
             ++nsites;
         }
     }
 
-    /* this should never happen as it would mean that the bitmap was
-     * empty, which is something we checked before calling this function */
-    if (0 == nsites) {
-        return PRTE_ERR_NOT_FOUND;
-    }
-
-    // sort them
     qsort(indices, nsites, sizeof(unsigned), compare_unsigned);
+    *sites = indices;
+    return nsites;
+}
 
-    pos = 0;
-    if (!append_str(answer, size, &pos, prefix)) {
-        return PRTE_ERR_SILENT;
+/* Are we reporting this topology in hwthreads? Either because the job asked
+ * for it, or because the topology has no cores to report - hwloc does not
+ * find cores on every platform (PPC64 on old Linux kernels reports only NUMA
+ * nodes and PUs), and on such a machine a core-based rendering resolves
+ * nothing and every binding comes out "UNBOUND". */
+static bool report_as_hwthreads(hwloc_topology_t topo, bool use_hwthread_cpus)
+{
+    return (use_hwthread_cpus || !prte_hwloc_base_has_cores(topo));
+}
+
+char *prte_hwloc_base_cpuset2ranges(hwloc_topology_t topo,
+                                    hwloc_const_cpuset_t bitmap,
+                                    bool use_hwthread_cpus,
+                                    bool physical)
+{
+    unsigned *sites = NULL, start, end;
+    int nsites, n;
+    char **output = NULL, *result;
+    char tmp[64];
+
+    nsites = collect_sites(topo, bitmap, report_as_hwthreads(topo, use_hwthread_cpus),
+                           physical, &sites);
+    if (0 >= nsites) {
+        free(sites);
+        return NULL;
     }
 
     /* Walk the sorted indices, collapsing consecutive runs into "lo-hi".
-     * [start,end] is the run we are currently accumulating; it is emitted
-     * as soon as the next index does not extend it, and once more at the
-     * end for the run left dangling. */
-    start = indices[0];
-    end = indices[0];
-    first = true;
+     * [start,end] is the run currently being accumulated; it is emitted as
+     * soon as the next index does not extend it, and once more at the end
+     * for the run left dangling. */
+    start = sites[0];
+    end = sites[0];
     for (n = 1; n <= nsites; n++) {
-        if (n < nsites && indices[n] == (unsigned)(end + 1)) {
-            end = indices[n];
+        if (n < nsites && sites[n] == end + 1) {
+            end = sites[n];
             continue;
         }
         if (start == end) {
-            snprintf(tmp, sizeof(tmp), "%s%u", first ? "" : ",", start);
+            snprintf(tmp, sizeof(tmp), "%u", start);
         } else {
-            snprintf(tmp, sizeof(tmp), "%s%u-%u", first ? "" : ",", start, end);
+            snprintf(tmp, sizeof(tmp), "%u-%u", start, end);
         }
-        if (!append_str(answer, size, &pos, tmp)) {
-            /* the caller renders this into a fixed-size element, so a
-             * truncated site list is worse than none */
-            pmix_show_help("help-prte-hwloc-base.txt", "too-many-sites", true);
-            return PRTE_ERR_SILENT;
-        }
-        first = false;
+        PMIx_Argv_append_nosize(&output, tmp);
         if (n < nsites) {
-            start = indices[n];
-            end = indices[n];
+            start = sites[n];
+            end = sites[n];
         }
     }
-    return PRTE_SUCCESS;
+    free(sites);
+
+    result = PMIx_Argv_join(output, ',');
+    PMIx_Argv_free(output);
+    return result;
+}
+
+/* Render a list of site indices as one XML element apiece.
+ *
+ * Returns the number of bytes that *would* have been written (snprintf
+ * semantics), so a return >= buflen means the output was truncated. An
+ * earlier version advanced the write pointer through a run of bits without
+ * also charging the bytes against the remaining budget, so a process bound
+ * to more than a few cores walked straight off the end of the caller's
+ * buffer - in the HNP, which holds every node's topology.
+ */
+static int sites_snprintf_exp(char *buf, size_t buflen,
+                              const unsigned *sites, int nsites,
+                              const char *type)
+{
+    size_t total = 0;
+    int n, res;
+
+    /* mark the end in case we do nothing below */
+    if (0 < buflen) {
+        buf[0] = '\0';
+    }
+
+    for (n = 0; n < nsites; n++) {
+        /* Always hand snprintf the *remaining* room. total can exceed
+         * buflen once we truncate, so clamp rather than subtract. */
+        char *at = (total < buflen) ? buf + total : NULL;
+        size_t room = (total < buflen) ? buflen - total : 0;
+
+        res = snprintf(at, room, "%*c<%s>%u</%s>\n", 20, ' ', type, sites[n], type);
+        if (0 > res) {
+            return -1;
+        }
+        total += (size_t) res;
+    }
+    return (int) total;
+}
+
+/*
+ * Render a process' binding as XML elements, and report the package it
+ * lies in. Output is undefined if a rank is bound to more than 1 package.
+ *
+ * "cores" always comes back NUL-terminated and "*pkgnum" always comes back
+ * set: the caller wraps both in one <package> element, and every caller
+ * leaves pkgnum uninitialized on the way in.
+ */
+void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
+                                 bool use_hwthread_cpus, bool physical,
+                                 hwloc_topology_t topo,
+                                 int *pkgnum, char *cores, int sz)
+{
+    int n, npkgs, nsites;
+    hwloc_cpuset_t avail;
+    hwloc_obj_t pkg;
+    unsigned *sites = NULL;
+    bool as_hwt;
+
+    *pkgnum = -1;
+    if (NULL == cores || 0 >= sz) {
+        return;
+    }
+    cores[0] = '\0';
+
+    /* if the cpuset is all zero, then something is wrong. Say so and stop -
+     * the scan below would otherwise find nothing and leave the message in
+     * place only by accident */
+    if (hwloc_bitmap_iszero(cpuset)) {
+        snprintf(cores, (size_t) sz, "\n%*c<EMPTY CPUSET/>\n", 20, ' ');
+        return;
+    }
+
+    /* get the number of packages in the topology */
+    npkgs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PACKAGE);
+    avail = hwloc_bitmap_alloc();
+    as_hwt = report_as_hwthreads(topo, use_hwthread_cpus);
+
+    /* binding happens within a package and not across packages */
+    for (n = 0; n < npkgs; n++) {
+        pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, n);
+        if (NULL == pkg || NULL == pkg->cpuset) {
+            continue;
+        }
+        /* see if we have any here */
+        hwloc_bitmap_and(avail, cpuset, pkg->cpuset);
+        if (hwloc_bitmap_iszero(avail)) {
+            continue;
+        }
+        nsites = collect_sites(topo, avail, as_hwt, physical, &sites);
+        if (0 < nsites) {
+            sites_snprintf_exp(cores, (size_t) sz, sites, nsites,
+                               as_hwt ? "hwt" : "core");
+        }
+        free(sites);
+        sites = NULL;
+        *pkgnum = n;
+    }
+    hwloc_bitmap_free(avail);
 }
 
 /*
@@ -1365,14 +1310,11 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
                                bool physical,
                                hwloc_topology_t topo)
 {
-    int n, npkgs, npus, ncores;
-    char tmp[2048], ans[4096];
-    hwloc_cpuset_t avail, coreset = NULL;
-    char **output = NULL, *result;
+    int n, npkgs;
+    hwloc_cpuset_t avail;
+    char **output = NULL, *result, *ranges, *ans;
     hwloc_obj_t pkg;
-    bool bits_as_cores = false;
-    int complete;
-    char *prefix;
+    const char *prefix;
 
     /* if the cpuset is all zero, then something is wrong */
     if (hwloc_bitmap_iszero(cpuset)) {
@@ -1388,36 +1330,17 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
      * proc carries no cpuset at all - so the test is gone rather than
      * repaired, which would have changed --display bind output. */
 
+    if (report_as_hwthreads(topo, use_hwthread_cpus)) {
+        prefix = physical ? "hwt:P" : "hwt:L";
+    } else {
+        prefix = physical ? "core:P" : "core:L";
+    }
+
     /* get the number of packages in the topology */
     npkgs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PACKAGE);
     avail = hwloc_bitmap_alloc();
 
-    npus = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PU);
-    ncores = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE);
-    if (npus == ncores && !use_hwthread_cpus) {
-        /* the bits in this bitmap represent cores */
-        bits_as_cores = true;
-    }
-    if (!use_hwthread_cpus && !bits_as_cores) {
-        coreset = hwloc_bitmap_alloc();
-    }
-    if (bits_as_cores || !use_hwthread_cpus) {
-        if (physical) {
-            prefix = "core:P";
-        } else {
-            prefix = "core:L";
-        }
-    } else {
-        if (physical) {
-            prefix = "hwt:P";
-        } else {
-            prefix = "hwt:L";
-        }
-    }
-
     for (n = 0; n < npkgs; n++) {
-        memset(tmp, 0, sizeof(tmp));
-        memset(ans, 0, sizeof(ans));
         pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, n);
         if (NULL == pkg || NULL == pkg->cpuset) {
             continue;
@@ -1427,30 +1350,16 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
         if (hwloc_bitmap_iszero(avail)) {
             continue;
         }
-        if (bits_as_cores) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, sizeof(tmp), avail);
-            snprintf(ans, sizeof(ans), "package[%d][%s%s]", n, prefix, tmp);
-        } else if (use_hwthread_cpus) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, sizeof(tmp), avail);
-            snprintf(ans, sizeof(ans), "package[%d][%s%s]", n, prefix, tmp);
-        } else {
-            // build the map for this cpuset
-            complete = build_map(tmp, sizeof(tmp), avail,
-                                 physical, prefix, topo);
-            if (PRTE_SUCCESS == complete) {
-                snprintf(ans, sizeof(ans), "package[%d][%s]", n, tmp);
-            } else {
-                PMIx_Argv_free(output);
-                hwloc_bitmap_free(avail);
-                if (NULL != coreset) {
-                    hwloc_bitmap_free(coreset);
-                }
-                return NULL;
-            }
+        ranges = prte_hwloc_base_cpuset2ranges(topo, avail, use_hwthread_cpus, physical);
+        if (NULL == ranges) {
+            PMIx_Argv_free(output);
+            hwloc_bitmap_free(avail);
+            return NULL;
         }
+        pmix_asprintf(&ans, "package[%d][%s%s]", n, prefix, ranges);
+        free(ranges);
         PMIx_Argv_append_nosize(&output, ans);
+        free(ans);
     }
 
     if (NULL != output) {
@@ -1460,9 +1369,6 @@ char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
         result = NULL;
     }
     hwloc_bitmap_free(avail);
-    if (NULL != coreset) {
-        hwloc_bitmap_free(coreset);
-    }
     return result;
 }
 

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -365,9 +365,10 @@ static int rte_init(int argc, char **argv)
     if (15 < pmix_output_get_verbosity(prte_ess_base_framework.framework_output)) {
         char *output = NULL;
         pmix_output(0, "%s Topology Info:", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        prte_hwloc_print(&output, "\t", prte_hwloc_topology);
-        pmix_output(0, "%s", output);
-        free(output);
+        if (PRTE_SUCCESS == prte_hwloc_print(&output, "\t", prte_hwloc_topology)) {
+            pmix_output(0, "%s", output);
+            free(output);
+        }
     }
 
     /* Open/select the odls */

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -188,28 +188,19 @@ static void display_cpus(prte_topology_t *t,
                          prte_job_t *jdata,
                          char *node)
 {
-    char tmp[2048];
+    char *tmp;
     unsigned pkg, npkgs;
-    bool bits_as_cores = false, use_hwthread_cpus = prte_hwloc_default_use_hwthread_cpus;
-    unsigned npus, ncores;
+    bool use_hwthread_cpus, physical;
     hwloc_obj_t obj;
     hwloc_cpuset_t avail = NULL;
     hwloc_cpuset_t allowed;
-    hwloc_cpuset_t coreset = NULL;
     bool parsable;
 
     parsable = prte_get_attribute(&jdata->attributes, PRTE_JOB_DISPLAY_PARSEABLE_OUTPUT, NULL, PMIX_BOOL);
 
-    npus = prte_hwloc_base_get_nbobjs_by_type(t->topo, HWLOC_OBJ_PU);
-    ncores = prte_hwloc_base_get_nbobjs_by_type(t->topo, HWLOC_OBJ_CORE);
-    if (npus == ncores && !use_hwthread_cpus) {
-        /* the bits in this bitmap represent cores */
-        bits_as_cores = true;
-    }
     use_hwthread_cpus = prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL);
-    if (!use_hwthread_cpus && !bits_as_cores) {
-        coreset = hwloc_bitmap_alloc();
-    }
+    physical = prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_PHYSICAL_CPUS, NULL,
+                                  PMIX_BOOL);
     avail = hwloc_bitmap_alloc();
 
     if (parsable) {
@@ -231,37 +222,19 @@ static void display_cpus(prte_topology_t *t,
             }
             continue;
         }
-        if (bits_as_cores) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, 2048, avail);
-             if (parsable) {
-                pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg, tmp);
-            } else {
-                pmix_output(prte_clean_output, "PKG[%d]: %s", pkg, tmp);
-            }
-        } else if (use_hwthread_cpus) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, 2048, avail);
-             if (parsable) {
-                pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg, tmp);
-            } else {
-                pmix_output(prte_clean_output, "PKG[%d]: %s", pkg, tmp);
-            }
+        /* the bits are PU OS indices; what the user needs to read back out
+         * (and hand to --cpu-set) is the list of cores, or of hwthreads if
+         * that is what this job is using as cpus */
+        tmp = prte_hwloc_base_cpuset2ranges(t->topo, avail, use_hwthread_cpus, physical);
+        if (parsable) {
+            pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg,
+                        (NULL == tmp) ? "NONE" : tmp);
         } else {
-            prte_hwloc_build_map(t->topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
-            /* now print out the string */
-            hwloc_bitmap_list_snprintf(tmp, 2048, coreset);
-             if (parsable) {
-                pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg, tmp);
-            } else {
-                pmix_output(prte_clean_output, "PKG[%d]: %s", pkg, tmp);
-            }
+            pmix_output(prte_clean_output, "PKG[%d]: %s", pkg, (NULL == tmp) ? "NONE" : tmp);
         }
+        free(tmp);
     }
     hwloc_bitmap_free(avail);
-    if (NULL != coreset) {
-        hwloc_bitmap_free(coreset);
-    }
     if (parsable) {
         pmix_output(prte_clean_output, "</processors>\n");
     } else {

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -493,9 +493,12 @@ DISPLAY:
                 pmix_output(prte_clean_output,
                             "=================================================================\n");
                 pmix_output(prte_clean_output, "TOPOLOGY FOR NODE %s", node->name);
-                prte_hwloc_print(&ptr, NULL, node->topology->topo);
-                pmix_output(prte_clean_output, "%s", ptr);
-                free(ptr);
+                if (PRTE_SUCCESS == prte_hwloc_print(&ptr, NULL, node->topology->topo)) {
+                    pmix_output(prte_clean_output, "%s", ptr);
+                    free(ptr);
+                } else {
+                    pmix_output(prte_clean_output, "TOPOLOGY NOT AVAILABLE");
+                }
                 pmix_output(prte_clean_output,
                             "=================================================================\n");
             }
@@ -509,9 +512,12 @@ DISPLAY:
                 pmix_output(prte_clean_output,
                             "=================================================================\n");
                 pmix_output(prte_clean_output, "TOPOLOGY FOR NODE %s", node->name);
-                prte_hwloc_print(&ptr, NULL, node->topology->topo);
-                pmix_output(prte_clean_output, "%s", ptr);
-                free(ptr);
+                if (PRTE_SUCCESS == prte_hwloc_print(&ptr, NULL, node->topology->topo)) {
+                    pmix_output(prte_clean_output, "%s", ptr);
+                    free(ptr);
+                } else {
+                    pmix_output(prte_clean_output, "TOPOLOGY NOT AVAILABLE");
+                }
                 pmix_output(prte_clean_output,
                             "=================================================================\n");
             }

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -454,9 +454,23 @@ node→session deviation.
   spelling turned `--map-by core:P=2` into pes-per-proc **0** (and then a
   misleading "out of resource") and `seq:F=path` into an attempt to open the
   path five characters in. `qualifier_value()` in `rmaps_base_frame.c` is the
-  one way to get a qualifier's value. **The same pattern still exists outside
-  this framework** — `src/hwloc/hwloc.c` reads the job-level `--bind-to`
-  `LIMIT=` value at `&quals[i][6]`.
+  one way to get a qualifier's value. (`src/hwloc/hwloc.c` had the same bug in
+  the job-level `--bind-to` `LIMIT=` value and now uses
+  `pmix_cli_qualifier_value()`.) A related trap in the same family: an
+  **empty** string matches whatever `PMIX_CHECK_CLI_OPTION` tests it against
+  first, because the comparison is only `min(strlen(a), strlen(b))` long —
+  which is why the `--map-by :QUALIFIER` form needs its own explicit branch,
+  and why `--bind-to :overload-allowed` used to resolve to `none`.
+- **A cpu number shown to a user goes through
+  `prte_hwloc_base_cpuset2ranges()`.** The bits of a cpuset are PU *OS*
+  indices; every grammar this framework accepts — slot lists, rankfile
+  entries, `--cpu-set` — is in hwloc *logical* indices. `seq`, `rank_file`
+  and `lsf` each printed a raw bitmap as the "available" and "overlapping"
+  cpus of a collision message while quoting the user's logical slot list
+  beside it. `prte_proc_t.cpuset` is the one deliberate exception: it is a
+  wire format, read back with `hwloc_bitmap_list_sscanf()`, and must stay in
+  OS indices — so never show *it* to a user either. See
+  [`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md).
 - **Module-static state outlives the job.** `rank_file` and `lsf` both keep
   their parsed rank map and rank count in file statics. Reset them at the
   start of every map and reclaim them on *every* exit, success or failure —

--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -97,6 +97,7 @@ static int lsf_map(prte_job_t *jdata,
     char *cpu_bitmap;
     char *avail_bitmap = NULL;
     char *overlap_bitmap = NULL;
+    char *req_bitmap = NULL;
     bool physical;
 
     /* only handle initial launch of rf job */
@@ -412,17 +413,36 @@ static int lsf_map(prte_job_t *jdata,
                 /* Check to see if these slots are available on this node */
                 if (!hwloc_bitmap_isincluded(proc_bitmap, node->available) && !options->overload) {
                     bitmap = hwloc_bitmap_alloc();
-                    hwloc_bitmap_list_asprintf(&avail_bitmap, node->available);
-
                     hwloc_bitmap_andnot(bitmap, proc_bitmap, node->available);
-                    hwloc_bitmap_list_asprintf(&overlap_bitmap, bitmap);
+
+                    /* The user wrote the slot list in logical cpu ids, so
+                     * every set we show back has to be in the same terms.
+                     * proc->cpuset and a raw bitmap render are PU *OS*
+                     * indices - the wire format - which is a different
+                     * numbering on any node whose firmware does not number
+                     * its cpus in hwloc's order. */
+                    req_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, proc_bitmap,
+                                                               options->use_hwthreads, false);
+                    avail_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo,
+                                                                 node->available,
+                                                                 options->use_hwthreads, false);
+                    overlap_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, bitmap,
+                                                                   options->use_hwthreads, false);
 
                     pmix_show_help("help-rmaps_lsf.txt", "rmaps:proc-slots-overloaded", true,
                                    PRTE_NAME_PRINT(&proc->name),
                                    node->name,
-                                   proc->cpuset,
-                                   avail_bitmap,
-                                   overlap_bitmap);
+                                   (NULL == req_bitmap) ? "NONE" : req_bitmap,
+                                   (NULL == avail_bitmap) ? "NONE" : avail_bitmap,
+                                   (NULL == overlap_bitmap) ? "NONE" : overlap_bitmap);
+                    /* these three were never released - the error label
+                     * below does not know about them */
+                    free(req_bitmap);
+                    req_bitmap = NULL;
+                    free(avail_bitmap);
+                    avail_bitmap = NULL;
+                    free(overlap_bitmap);
+                    overlap_bitmap = NULL;
 
                     hwloc_bitmap_free(bitmap);
                     hwloc_bitmap_free(proc_bitmap);

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -100,6 +100,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
     char *cpu_bitmap;
     char *avail_bitmap = NULL;
     char *overlap_bitmap = NULL;
+    char *req_bitmap = NULL;
     bool physical;
 
     /* only handle initial launch of rf job */
@@ -439,17 +440,36 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 /* Check to see if these slots are available on this node */
                 if (!hwloc_bitmap_isincluded(proc_bitmap, node->available) && !options->overload) {
                     bitmap = hwloc_bitmap_alloc();
-                    hwloc_bitmap_list_asprintf(&avail_bitmap, node->available);
-
                     hwloc_bitmap_andnot(bitmap, proc_bitmap, node->available);
-                    hwloc_bitmap_list_asprintf(&overlap_bitmap, bitmap);
+
+                    /* The user wrote the slot list in logical cpu ids, so
+                     * every set we show back has to be in the same terms.
+                     * proc->cpuset and a raw bitmap render are PU *OS*
+                     * indices - the wire format - which is a different
+                     * numbering on any node whose firmware does not number
+                     * its cpus in hwloc's order. */
+                    req_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, proc_bitmap,
+                                                               options->use_hwthreads, false);
+                    avail_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo,
+                                                                 node->available,
+                                                                 options->use_hwthreads, false);
+                    overlap_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, bitmap,
+                                                                   options->use_hwthreads, false);
 
                     pmix_show_help("help-rmaps_rank_file.txt", "rmaps:proc-slots-overloaded", true,
                                    PRTE_NAME_PRINT(&proc->name),
                                    node->name,
-                                   proc->cpuset,
-                                   avail_bitmap,
-                                   overlap_bitmap);
+                                   (NULL == req_bitmap) ? "NONE" : req_bitmap,
+                                   (NULL == avail_bitmap) ? "NONE" : avail_bitmap,
+                                   (NULL == overlap_bitmap) ? "NONE" : overlap_bitmap);
+                    /* these three were never released - the error label
+                     * below does not know about them */
+                    free(req_bitmap);
+                    req_bitmap = NULL;
+                    free(avail_bitmap);
+                    avail_bitmap = NULL;
+                    free(overlap_bitmap);
+                    overlap_bitmap = NULL;
 
                     hwloc_bitmap_free(bitmap);
                     hwloc_bitmap_free(proc_bitmap);

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -135,10 +135,20 @@ static int bind_to_entry_cpuset(prte_job_t *jdata, prte_proc_t *proc,
     if (!options->overload && !hwloc_bitmap_isincluded(bits, node->available)) {
         missing = hwloc_bitmap_alloc();
         hwloc_bitmap_andnot(missing, bits, node->available);
-        hwloc_bitmap_list_asprintf(&avail, node->available);
-        hwloc_bitmap_list_asprintf(&overlap, missing);
+        /* The user wrote "cpuset" in logical cpu ids - that is what
+         * prte_hwloc_base_cpu_list_parse() accepts - so the two sets we
+         * show alongside it have to be in the same terms. Rendering the
+         * bitmaps directly prints PU *OS* indices, which put three
+         * different numbering schemes in one message on any node whose
+         * firmware does not number its cpus in hwloc's order. */
+        avail = prte_hwloc_base_cpuset2ranges(node->topology->topo, node->available,
+                                              options->use_hwthreads, false);
+        overlap = prte_hwloc_base_cpuset2ranges(node->topology->topo, missing,
+                                                options->use_hwthreads, false);
         pmix_show_help("help-prte-rmaps-seq.txt", "seq:cpuset-not-available", true,
-                       PRTE_NAME_PRINT(&proc->name), node->name, cpuset, avail, overlap);
+                       PRTE_NAME_PRINT(&proc->name), node->name, cpuset,
+                       (NULL == avail) ? "NONE" : avail,
+                       (NULL == overlap) ? "NONE" : overlap);
         free(avail);
         free(overlap);
         hwloc_bitmap_free(missing);

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -263,6 +263,14 @@ prefix keys. Written on any later app it stays with that app, and the apps
 that gave none fall back to the defaults: saying nothing is not the same as
 agreeing.
 
+**Every exit from `prte_parse_locals()` owns `temp_argv` and `env`.** It has
+three: the `create_app()` failure inside the segment loop, the one after it
+for the trailing segment, and the success path. Only the last released both,
+so any command line whose *final* segment fails to parse leaked them —
+`--display map --display cpus` is enough, because a repeated option is
+refused right there. `env` is filled in by `create_app()` and belongs to us
+whether or not it then failed.
+
 `prun_common()` is the tool body: `PMIx_tool_init` (with whatever DVM
 search directive the user gave), register event handlers for job
 termination and debugger events, `PMIx_Spawn_nb`, push stdin, wait, then

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -840,8 +840,10 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                                 hostfiles, hosts, jobdata);
                 if (PRTE_SUCCESS != rc) {
                     /* Assume that the error message has already been
-                     printed; */
+                     printed; create_app may still have filled in "env"
+                     before it failed, and it belongs to us either way */
                     PMIx_Argv_free(temp_argv);
+                    PMIx_Argv_free(env);
                     return rc;
                 }
                 if (made_app) {
@@ -863,6 +865,12 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
         rc = create_app(schizo, temp_argv, &app, &made_app, &env,
                         hostfiles, hosts, jobdata);
         if (PRTE_SUCCESS != rc) {
+            /* this return used to skip the two frees below entirely, so
+             * any command line that fails its final segment leaked both -
+             * "--display map --display cpus" is enough, since a repeated
+             * option is refused here */
+            PMIx_Argv_free(temp_argv);
+            PMIx_Argv_free(env);
             return rc;
         }
         if (made_app) {

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -74,6 +74,17 @@ new neighbors so in-flight messages resume over the repaired tree.
   evicted; cached data is dropped by timer (`relm_base_cache_ms`) or when the
   cache exceeds `relm_base_cache_max_count`. Don't assume `msg->data.bytes` is
   non-NULL.
+- **`prte_relm_start_msg()` owns the caller's buffer once it succeeds, and
+  unloading a buffer is not releasing it.** This is the same contract
+  `prte_rml_send_buffer_nb()` follows — every `PRTE_RML_RELIABLE_SEND` caller
+  hands the buffer over on success and releases it itself on an error return.
+  `start_msg` consumed the buffer's *payload* with `PMIx_Data_unload()` into a
+  fresh RELM-framed buffer and then dropped the emptied container on the
+  floor: a `pmix_data_buffer_t` leaked **per inter-daemon reliable message**,
+  for the life of the DVM. The signature to recognize is a valgrind record
+  with direct bytes but *zero* indirect ones — the payload was moved out and
+  freed, only the shell survived. If you add another framing step here,
+  release what you unloaded.
 - **Every lookup helper can answer NULL.** `prte_relm_find_rank`,
   `find_msg`, `get_rank`, `get_msg`, `find_prev_msg`, `get_prev_msg` all return
   NULL for a bad signature, an out-of-range rank, or a hash-table failure. They

--- a/src/rml/relm/state_machine.c
+++ b/src/rml/relm/state_machine.c
@@ -231,9 +231,19 @@ int prte_relm_start_msg(
     PMIx_Byte_object_destruct(&bo);
     if(PMIX_SUCCESS != ret){
         PMIx_Data_buffer_release(data);
+        /* "buf" is the caller's on every error return, exactly as it is for
+         * prte_rml_send_buffer_nb() - so leave it alone here even though the
+         * unload above may already have emptied it. Releasing an emptied
+         * buffer is what the caller then does, and it is harmless. */
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         return ret;
     }
+    /* We took ownership of "buf" by succeeding, and the unload above moved
+     * its payload out into "data" - but that leaves the container itself,
+     * and nothing was releasing it. Every reliable send between daemons
+     * came through here, so this was not a one-off 40 bytes: it was 40
+     * bytes per inter-daemon message, for the life of the DVM. */
+    PMIx_Data_buffer_release(buf);
 
     start_msg_caddy_t* msg_cd = PMIX_NEW(start_msg_caddy_t);
     msg_cd->dst = dst;

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -46,28 +46,19 @@ static void display_cpus(prte_topology_t *t,
                          prte_job_t *jdata,
                          char *node, char**output)
 {
-    char tmp[2048];
+    char *tmp;
     unsigned pkg, npkgs;
-    bool bits_as_cores = false, use_hwthread_cpus = prte_hwloc_default_use_hwthread_cpus;
-    unsigned npus, ncores;
+    bool use_hwthread_cpus, physical;
     hwloc_obj_t obj;
     hwloc_cpuset_t avail = NULL;
     hwloc_cpuset_t allowed;
-    hwloc_cpuset_t coreset = NULL;
     PRTE_HIDE_UNUSED_PARAMS(node);
 
     char *tmp1, *tmp2;
 
-    npus = prte_hwloc_base_get_nbobjs_by_type(t->topo, HWLOC_OBJ_PU);
-    ncores = prte_hwloc_base_get_nbobjs_by_type(t->topo, HWLOC_OBJ_CORE);
-    if (npus == ncores && !use_hwthread_cpus) {
-        /* the bits in this bitmap represent cores */
-        bits_as_cores = true;
-    }
     use_hwthread_cpus = prte_get_attribute(&jdata->attributes, PRTE_JOB_HWT_CPUS, NULL, PMIX_BOOL);
-    if (!use_hwthread_cpus && !bits_as_cores) {
-        coreset = hwloc_bitmap_alloc();
-    }
+    physical = prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_PHYSICAL_CPUS, NULL,
+                                  PMIX_BOOL);
     avail = hwloc_bitmap_alloc();
     pmix_asprintf(&tmp1, "        <processors>\n");
     npkgs = prte_hwloc_base_get_nbobjs_by_type(t->topo, HWLOC_OBJ_PACKAGE);
@@ -85,28 +76,18 @@ static void display_cpus(prte_topology_t *t,
             tmp2 = NULL;
             continue;
         }
-        if (bits_as_cores) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, 2048, avail);
-            pmix_asprintf(&tmp2, "%s            <package id=\"%d\" cpus=\"%s\"/>\n", tmp1, pkg, tmp);
-        } else if (use_hwthread_cpus) {
-            /* can just use the hwloc fn directly */
-            hwloc_bitmap_list_snprintf(tmp, 2048, avail);
-            pmix_asprintf(&tmp2, "%s            <package id=\"%d\" cpus=\"%s\"/>\n", tmp1, pkg, tmp);
-        } else {
-            prte_hwloc_build_map(t->topo, avail, use_hwthread_cpus | bits_as_cores, coreset);
-            /* now print out the string */
-            hwloc_bitmap_list_snprintf(tmp, 2048, coreset);
-            pmix_asprintf(&tmp2, "%s            <package id=\"%d\" cpus=\"%s\"/>\n", tmp1, pkg, tmp);
-        }
+        /* the bits are PU OS indices; what the user needs to read back out
+         * (and hand to --cpu-set) is the list of cores, or of hwthreads if
+         * that is what this job is using as cpus */
+        tmp = prte_hwloc_base_cpuset2ranges(t->topo, avail, use_hwthread_cpus, physical);
+        pmix_asprintf(&tmp2, "%s            <package id=\"%d\" cpus=\"%s\"/>\n", tmp1, pkg,
+                      (NULL == tmp) ? "NONE" : tmp);
+        free(tmp);
         free(tmp1);
         tmp1 = tmp2;
         tmp2 = NULL;
     }
     hwloc_bitmap_free(avail);
-    if (NULL != coreset) {
-        hwloc_bitmap_free(coreset);
-    }
 
     pmix_asprintf(output, "%s        </processors>\n", tmp1);
     free(tmp1);
@@ -375,7 +356,7 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
                 *output = tmp;
                 return;
             }
-            prte_hwloc_get_binding_info(mycpus, use_hwthread_cpus,
+            prte_hwloc_get_binding_info(mycpus, use_hwthread_cpus, physical,
                                         src->node->topology->topo, &pkgnum, cores, sz);
 
             hwloc_bitmap_free(mycpus);

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -1010,11 +1010,50 @@ static int test_binding_policy(void)
     CHECK("a zero limit is refused",
           PRTE_SUCCESS != prte_hwloc_base_set_binding_policy(jdata, "core:limit=0"));
 
+    /* A qualifier with NO policy means "whatever binding would otherwise
+     * apply, plus this qualifier" - the same thing "--map-by :OVERSUBSCRIBE"
+     * has always meant. pmix_check_cli_option() compares only
+     * min(strlen(a),strlen(b)) characters, so an empty policy word matched
+     * the first option tested against it, which is "none": "--bind-to
+     * :overload-allowed" silently disabled binding altogether. The policy
+     * bits must stay unset so the default chooser can still fill them in,
+     * and the qualifier must survive into the word. */
+    jdata->map->binding = 0;
+    CHECK("a qualifier-only spec parses",
+          PRTE_SUCCESS == prte_hwloc_base_set_binding_policy(jdata, ":overload-allowed"));
+    CHECK("a qualifier-only spec does not choose a policy",
+          !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding));
+    CHECK("a qualifier-only spec did not silently select none",
+          PRTE_BIND_TO_NONE != PRTE_GET_BINDING_POLICY(jdata->map->binding));
+    CHECK("a qualifier-only spec keeps its qualifier",
+          PRTE_BIND_OVERLOAD_ALLOWED(jdata->map->binding));
+    /* ...and the default chooser then fills the policy in around it */
+    PRTE_SET_DEFAULT_BINDING_POLICY(jdata->map->binding, PRTE_BIND_TO_CORE);
+    CHECK("the default policy lands on top of the qualifier",
+          PRTE_BIND_TO_CORE == PRTE_GET_BINDING_POLICY(jdata->map->binding));
+    CHECK("the qualifier survived the default policy",
+          PRTE_BIND_OVERLOAD_ALLOWED(jdata->map->binding));
+
+    /* the same form is legal as a DVM default */
+    CHECK("a qualifier-only default parses",
+          PRTE_SUCCESS == prte_hwloc_base_set_binding_policy(NULL, ":if-supported"));
+    CHECK("a qualifier-only default does not choose a policy",
+          !PRTE_BINDING_POLICY_IS_SET(prte_hwloc_default_binding_policy));
+
     /* bad input */
     CHECK("an unknown policy is refused",
           PRTE_SUCCESS != prte_hwloc_base_set_binding_policy(jdata, "sockets"));
     CHECK("an unknown qualifier is refused",
           PRTE_SUCCESS != prte_hwloc_base_set_binding_policy(jdata, "core:frobnicate"));
+
+    /* A spec that does not parse must leave the job exactly as it was. The
+     * qualifiers used to be applied first, so "sockets:report" recorded
+     * report-bindings on the job and then rejected the request. */
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_REPORT_BINDINGS);
+    CHECK("a bad policy carrying a good qualifier is refused",
+          PRTE_SUCCESS != prte_hwloc_base_set_binding_policy(jdata, "sockets:report"));
+    CHECK("a refused spec records nothing on the job",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL));
 
     /* the job-only qualifiers are refused on the DVM default, where there is
      * no job to record them against */

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -1000,6 +1000,17 @@ static int test_reset_counters(void)
         CHECK("core counter is reset",
               0 == ((prte_hwloc_obj_data_t *) core->userdata)->nprocs);
     }
+    /* The NUMA counter is the one that used to survive. hwloc 2.x keeps NUMA
+     * nodes out of the depth hierarchy, so a walk over 0..get_depth() never
+     * visits one - and "--bind-to numa:limit=N" attaches its per-object
+     * counter there. Missing the reset left those counters accumulating for
+     * the life of the DVM, so the second such job found every domain already
+     * at its limit and could not be bound at all. */
+    CHECK("a numa node resolves", NULL != numa);
+    if (NULL != numa && NULL != numa->userdata) {
+        CHECK("numa counter is reset",
+              0 == ((prte_hwloc_obj_data_t *) numa->userdata)->nprocs);
+    }
     /* The root's summary is NOT an obj_data_t. reset_counters must not walk
      * depth 0, or it would reinterpret the summary as a counter and scribble
      * on numa_cutoff. */

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -350,6 +350,7 @@ static int test_cpu_list_parse(void)
     int failures = 0;
     hwloc_topology_t topo;
     hwloc_cpuset_t mask;
+    hwloc_obj_t pkg;
     int rc;
 
     topo = make_topo("package:2 core:4 pu:2");
@@ -392,9 +393,36 @@ static int test_cpu_list_parse(void)
     CHECK("package wildcard parses", PRTE_SUCCESS == rc);
     CHECK("package wildcard covers the package", 8 == hwloc_bitmap_weight(mask));
 
+    /* A core id in "package:core" notation is relative to that package. The
+     * lookup used to reach it by adding "cores per package times package id"
+     * to a GLOBAL index, which names a core in the wrong package as soon as
+     * two packages hold different numbers of them - so assert not just how
+     * many cpus came back but that they lie inside the package asked for. */
     rc = prte_hwloc_base_cpu_list_parse("P1:0", topo, false, mask);
     CHECK("package:core parses", PRTE_SUCCESS == rc);
     CHECK("package:core covers one core", 2 == hwloc_bitmap_weight(mask));
+    pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, 1);
+    CHECK("package 1 resolves", NULL != pkg);
+    if (NULL != pkg) {
+        CHECK("package:core stays inside the package named",
+              hwloc_bitmap_isincluded(mask, pkg->cpuset));
+    }
+
+    rc = prte_hwloc_base_cpu_list_parse("P1:0-2", topo, false, mask);
+    CHECK("package:core-range parses", PRTE_SUCCESS == rc);
+    CHECK("package:core-range covers three cores", 6 == hwloc_bitmap_weight(mask));
+    if (NULL != pkg) {
+        CHECK("package:core-range stays inside the package named",
+              hwloc_bitmap_isincluded(mask, pkg->cpuset));
+    }
+
+    rc = prte_hwloc_base_cpu_list_parse("P1:0,2", topo, false, mask);
+    CHECK("package:core-list parses", PRTE_SUCCESS == rc);
+    CHECK("package:core-list covers two cores", 4 == hwloc_bitmap_weight(mask));
+    if (NULL != pkg) {
+        CHECK("package:core-list stays inside the package named",
+              hwloc_bitmap_isincluded(mask, pkg->cpuset));
+    }
 
     /* Everything below is a user-supplied name for something that does not
      * exist. Each of these used to reach an unchecked dereference of the

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -34,17 +34,25 @@
  *    dereferenced the result of a package lookup without checking it: a
  *    cpu-set naming a package that does not exist was a segfault.
  *
- *  - bitmap_list_snprintf_exp() (reached through
- *    prte_hwloc_get_binding_info()) advanced its write pointer inside a run
- *    of set bits without charging those bytes against the remaining buffer,
- *    so a wide binding wrote past the end of the caller's buffer. The caller
- *    sizes that buffer at 20 bytes per PU while each element needs ~34.
+ *  - the XML element writer (reached through prte_hwloc_get_binding_info())
+ *    advanced its write pointer inside a run of set bits without charging
+ *    those bytes against the remaining buffer, so a wide binding wrote past
+ *    the end of the caller's buffer. The caller sizes that buffer at 20
+ *    bytes per PU while each element needs ~34.
  *
  *  - prte_hwloc_get_binding_info() never set *pkgnum when the cpuset matched
  *    no package, and its only caller prints it uninitialized.
  *
- *  - build_map() (reached through prte_hwloc_base_cset2str()) appended to
- *    the caller's buffer with memcpy() and no bound at all.
+ *  - the range builder behind prte_hwloc_base_cset2str() appended to the
+ *    caller's buffer with memcpy() and no bound at all.
+ *
+ *  - every renderer short-cut to printing the raw cpuset bits -- PU *OS*
+ *    indices -- whenever npus == ncores or the job used hwthreads, while
+ *    labelling them logical, and ignored "physical" outright. --cpu-set
+ *    resolves logically, so the numbers PRRTE printed were not numbers it
+ *    would accept back. This is what test_index_basis() pins, and it needs a
+ *    hand-written XML topology: hwloc's synthetic generator always makes
+ *    os_index and logical_index agree.
  *
  *  - prte_hwloc_base_print_binding() handed back a pointer into a ring of
  *    per-thread buffers but never advanced the ring, so two calls in one
@@ -457,7 +465,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("empty cpuset says so", NULL != strstr(buf, "EMPTY CPUSET"));
     CHECK("empty cpuset reports no package", -1 == pkgnum);
     CHECK("empty cpuset stays in bounds", guard_intact(buf, sz));
@@ -470,7 +478,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("cpuset outside every package reports no package", -1 == pkgnum);
     CHECK("cpuset outside every package stays in bounds", guard_intact(buf, sz));
     free(buf);
@@ -482,7 +490,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("single core reports its package", 0 == pkgnum);
     CHECK("single core is rendered", NULL != strstr(buf, "<core>0</core>"));
     CHECK("single core stays in bounds", guard_intact(buf, sz));
@@ -500,7 +508,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("wide binding reports its package", 0 == pkgnum);
     CHECK("wide binding stays in bounds", guard_intact(buf, sz));
     CHECK("wide binding is NUL terminated", sz > (int) strlen(buf));
@@ -511,7 +519,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("wide binding renders the first core", NULL != strstr(buf, "<core>0</core>"));
     CHECK("wide binding renders a middle core", NULL != strstr(buf, "<core>17</core>"));
     CHECK("wide binding renders the last core", NULL != strstr(buf, "<core>31</core>"));
@@ -523,7 +531,7 @@ static int test_binding_info(void)
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
     pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
     CHECK("tiny buffer stays in bounds", guard_intact(buf, sz));
     free(buf);
 
@@ -628,48 +636,231 @@ static int test_cset2str(void)
 }
 
 /* ------------------------------------------------------------------ */
-/* build_map (core vs hwthread coresets)                              */
+/* cpuset2ranges (the one place bits become cpu numbers)              */
 /* ------------------------------------------------------------------ */
 
-static int test_build_map(void)
+static int test_cpuset2ranges(void)
 {
     int failures = 0;
     hwloc_topology_t topo;
-    hwloc_cpuset_t avail, coreset;
+    hwloc_cpuset_t avail;
+    char *str;
 
     topo = make_topo("package:1 core:4 pu:2");
     if (NULL == topo) {
-        fprintf(stdout, "  SKIP build-map (no synthetic topology support)\n");
+        fprintf(stdout, "  SKIP cpuset2ranges (no synthetic topology support)\n");
         return 0;
     }
     avail = hwloc_bitmap_alloc();
-    coreset = hwloc_bitmap_alloc();
 
     /* both hwthreads of cores 0 and 1 */
     hwloc_bitmap_set_range(avail, 0, 3);
-    prte_hwloc_build_map(topo, avail, false, coreset);
-    CHECK("two cores map to two core bits", 2 == hwloc_bitmap_weight(coreset));
-    CHECK("core 0 is marked", hwloc_bitmap_isset(coreset, 0));
-    CHECK("core 1 is marked", hwloc_bitmap_isset(coreset, 1));
+    str = prte_hwloc_base_cpuset2ranges(topo, avail, false, false);
+    CHECK("two whole cores collapse into a range", NULL != str && 0 == strcmp(str, "0-1"));
+    free(str);
 
-    /* the same cpuset in hwthread terms keeps all four bits */
-    prte_hwloc_build_map(topo, avail, true, coreset);
-    CHECK("hwthread terms keep every bit", 4 == hwloc_bitmap_weight(coreset));
+    /* the same cpuset in hwthread terms names all four hwthreads */
+    str = prte_hwloc_base_cpuset2ranges(topo, avail, true, false);
+    CHECK("hwthread terms keep every bit", NULL != str && 0 == strcmp(str, "0-3"));
+    free(str);
 
-    /* one hwthread of one core still marks that core */
+    /* one hwthread of one core still names that core, exactly once */
     hwloc_bitmap_zero(avail);
     hwloc_bitmap_set(avail, 5);
-    prte_hwloc_build_map(topo, avail, false, coreset);
-    CHECK("a single hwthread marks its core", 1 == hwloc_bitmap_weight(coreset));
-    CHECK("that core is core 2", hwloc_bitmap_isset(coreset, 2));
+    str = prte_hwloc_base_cpuset2ranges(topo, avail, false, false);
+    CHECK("a single hwthread names its core", NULL != str && 0 == strcmp(str, "2"));
+    free(str);
 
-    /* an empty input yields an empty coreset, not the previous contents */
+    /* a scattered set lists individually and collapses what it can */
     hwloc_bitmap_zero(avail);
-    prte_hwloc_build_map(topo, avail, false, coreset);
-    CHECK("an empty cpuset yields an empty coreset", hwloc_bitmap_iszero(coreset));
+    hwloc_bitmap_set(avail, 0); /* core 0 */
+    hwloc_bitmap_set(avail, 4); /* core 2 */
+    hwloc_bitmap_set(avail, 6); /* core 3 */
+    str = prte_hwloc_base_cpuset2ranges(topo, avail, false, false);
+    CHECK("a scattered set lists and collapses", NULL != str && 0 == strcmp(str, "0,2-3"));
+    free(str);
+
+    /* an empty input has no sites at all */
+    hwloc_bitmap_zero(avail);
+    str = prte_hwloc_base_cpuset2ranges(topo, avail, false, false);
+    CHECK("an empty cpuset has no ranges", NULL == str);
+    free(str);
 
     hwloc_bitmap_free(avail);
-    hwloc_bitmap_free(coreset);
+    free_topo(topo);
+
+    /* hwloc does not find cores on every platform - PPC64 on old Linux
+     * kernels reported only NUMA nodes and PUs. A core-based rendering
+     * resolves nothing there, so every binding came back NULL and every
+     * caller printed "UNBOUND". Fall back to hwthreads, and say so. */
+    topo = make_topo("package:1 pu:4");
+    if (NULL != topo) {
+        CHECK("a core-less topology really has no cores",
+              0 == prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE));
+        avail = hwloc_bitmap_alloc();
+        hwloc_bitmap_set_range(avail, 1, 2);
+        str = prte_hwloc_base_cpuset2ranges(topo, avail, false, false);
+        CHECK("a core-less topology still renders", NULL != str && 0 == strcmp(str, "1-2"));
+        free(str);
+        str = prte_hwloc_base_cset2str(avail, false, false, topo);
+        CHECK("a core-less topology says it is reporting hwthreads",
+              NULL != str && NULL != strstr(str, "hwt:L"));
+        free(str);
+        hwloc_bitmap_free(avail);
+        free_topo(topo);
+    }
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
+/* logical vs physical index basis                                    */
+/* ------------------------------------------------------------------ */
+
+/* A topology whose PU OS indices are interleaved across its two packages -
+ * the ordinary shape of a machine whose firmware round-robins cpu numbers,
+ * and of any SMT machine viewed in hwthreads. hwloc's synthetic generator
+ * always makes os_index and logical_index agree, so the divergence that
+ * matters here can only be built from XML.
+ *
+ * Package 0 owns PUs 0,2,4,6 (logical 0-3); package 1 owns PUs 1,3,5,7
+ * (logical 4-7). One PU per core, so npus == ncores: this is exactly the
+ * "the bits already are cores" shape that the renderers used to short-cut
+ * by printing the raw bit numbers.
+ */
+static const char *interleaved_xml =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<!DOCTYPE topology SYSTEM \"hwloc2.dtd\">\n"
+    "<topology version=\"2.0\">\n"
+    "  <object type=\"Machine\" os_index=\"0\" cpuset=\"0x000000ff\" complete_cpuset=\"0x000000ff\" allowed_cpuset=\"0x000000ff\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" allowed_nodeset=\"0x00000001\" gp_index=\"1\">\n"
+    "    <object type=\"NUMANode\" os_index=\"0\" cpuset=\"0x000000ff\" complete_cpuset=\"0x000000ff\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"2\" local_memory=\"1073741824\"/>\n"
+    "    <object type=\"Package\" os_index=\"0\" cpuset=\"0x00000055\" complete_cpuset=\"0x00000055\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"3\">\n"
+    "      <object type=\"Core\" os_index=\"0\" cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"10\">\n"
+    "        <object type=\"PU\" os_index=\"0\" cpuset=\"0x00000001\" complete_cpuset=\"0x00000001\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"11\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"2\" cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"12\">\n"
+    "        <object type=\"PU\" os_index=\"2\" cpuset=\"0x00000004\" complete_cpuset=\"0x00000004\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"13\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"4\" cpuset=\"0x00000010\" complete_cpuset=\"0x00000010\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"14\">\n"
+    "        <object type=\"PU\" os_index=\"4\" cpuset=\"0x00000010\" complete_cpuset=\"0x00000010\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"15\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"6\" cpuset=\"0x00000040\" complete_cpuset=\"0x00000040\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"16\">\n"
+    "        <object type=\"PU\" os_index=\"6\" cpuset=\"0x00000040\" complete_cpuset=\"0x00000040\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"17\"/>\n"
+    "      </object>\n"
+    "    </object>\n"
+    "    <object type=\"Package\" os_index=\"1\" cpuset=\"0x000000aa\" complete_cpuset=\"0x000000aa\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"4\">\n"
+    "      <object type=\"Core\" os_index=\"1\" cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"18\">\n"
+    "        <object type=\"PU\" os_index=\"1\" cpuset=\"0x00000002\" complete_cpuset=\"0x00000002\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"19\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"3\" cpuset=\"0x00000008\" complete_cpuset=\"0x00000008\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"20\">\n"
+    "        <object type=\"PU\" os_index=\"3\" cpuset=\"0x00000008\" complete_cpuset=\"0x00000008\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"21\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"5\" cpuset=\"0x00000020\" complete_cpuset=\"0x00000020\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"22\">\n"
+    "        <object type=\"PU\" os_index=\"5\" cpuset=\"0x00000020\" complete_cpuset=\"0x00000020\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"23\"/>\n"
+    "      </object>\n"
+    "      <object type=\"Core\" os_index=\"7\" cpuset=\"0x00000080\" complete_cpuset=\"0x00000080\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"24\">\n"
+    "        <object type=\"PU\" os_index=\"7\" cpuset=\"0x00000080\" complete_cpuset=\"0x00000080\" nodeset=\"0x00000001\" complete_nodeset=\"0x00000001\" gp_index=\"25\"/>\n"
+    "      </object>\n"
+    "    </object>\n"
+    "  </object>\n"
+    "</topology>\n";
+
+static int test_index_basis(void)
+{
+    int failures = 0;
+    hwloc_topology_t topo;
+    hwloc_cpuset_t cpuset;
+    hwloc_obj_t pkg;
+    char *str, *buf;
+    int pkgnum, sz;
+
+    if (0 != hwloc_topology_init(&topo)) {
+        fprintf(stdout, "  SKIP index-basis (topology_init failed)\n");
+        return 0;
+    }
+    if (0 != hwloc_topology_set_xmlbuffer(topo, interleaved_xml, (int) strlen(interleaved_xml) + 1)
+        || 0 != hwloc_topology_load(topo)) {
+        fprintf(stdout, "  SKIP index-basis (no XML topology support)\n");
+        hwloc_topology_destroy(topo);
+        return 0;
+    }
+
+    /* sanity: this is the topology the rest of the test assumes */
+    CHECK("interleaved topology has 8 PUs",
+          8 == prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PU));
+    CHECK("interleaved topology has 8 cores",
+          8 == prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE));
+    CHECK("interleaved topology has 2 packages",
+          2 == prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PACKAGE));
+
+    pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, 0);
+    CHECK("package 0 resolves", NULL != pkg);
+    if (NULL == pkg) {
+        hwloc_topology_destroy(topo);
+        return failures;
+    }
+
+    cpuset = hwloc_bitmap_dup(pkg->cpuset);
+
+    /* THE bug. Package 0's cpus are OS indices 0,2,4,6 and logical cores
+     * 0-3. Because npus == ncores, every renderer here used to take the
+     * "the bits already are cores" short cut and print the raw bit numbers
+     * while labelling them logical - so --display cpus reported "0,2,4,6"
+     * for a package whose logical cores are 0-3, and a user who fed those
+     * numbers back to --cpu-set (which resolves logically) selected cpus
+     * spread across both packages. */
+    str = prte_hwloc_base_cpuset2ranges(topo, cpuset, false, false);
+    CHECK("logical cores are logical", NULL != str && 0 == strcmp(str, "0-3"));
+    free(str);
+
+    str = prte_hwloc_base_cpuset2ranges(topo, cpuset, false, true);
+    CHECK("physical cores are the OS indices", NULL != str && 0 == strcmp(str, "0,2,4,6"));
+    free(str);
+
+    /* the same divergence in hwthread terms */
+    str = prte_hwloc_base_cpuset2ranges(topo, cpuset, true, false);
+    CHECK("logical hwthreads are logical", NULL != str && 0 == strcmp(str, "0-3"));
+    free(str);
+
+    str = prte_hwloc_base_cpuset2ranges(topo, cpuset, true, true);
+    CHECK("physical hwthreads are the OS indices", NULL != str && 0 == strcmp(str, "0,2,4,6"));
+    free(str);
+
+    /* package 1's logical cores continue where package 0's left off */
+    pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, 1);
+    if (NULL != pkg) {
+        str = prte_hwloc_base_cpuset2ranges(topo, pkg->cpuset, false, false);
+        CHECK("package 1's logical cores are 4-7", NULL != str && 0 == strcmp(str, "4-7"));
+        free(str);
+    }
+
+    /* cset2str carries the same basis, and says which one it used */
+    str = prte_hwloc_base_cset2str(cpuset, false, false, topo);
+    CHECK("cset2str renders logical cores",
+          NULL != str && 0 == strcmp(str, "package[0][core:L0-3]"));
+    free(str);
+
+    str = prte_hwloc_base_cset2str(cpuset, false, true, topo);
+    CHECK("cset2str renders physical cores",
+          NULL != str && 0 == strcmp(str, "package[0][core:P0,2,4,6]"));
+    free(str);
+
+    /* and so does the parseable XML rendering, which used to ignore
+     * "physical" outright */
+    sz = 4096;
+    buf = malloc(sz);
+    pkgnum = 12345;
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
+    CHECK("binding info reports package 0", 0 == pkgnum);
+    CHECK("binding info renders logical core 3", NULL != strstr(buf, "<core>3</core>"));
+    CHECK("binding info does not leak an OS index",
+          NULL == strstr(buf, "<core>6</core>"));
+
+    prte_hwloc_get_binding_info(cpuset, false, true, topo, &pkgnum, buf, sz);
+    CHECK("binding info honors physical", NULL != strstr(buf, "<core>6</core>"));
+    free(buf);
+
+    hwloc_bitmap_free(cpuset);
     free_topo(topo);
     return failures;
 }
@@ -1042,7 +1233,8 @@ int main(void)
     failures += test_cpu_list_parse();
     failures += test_binding_info();
     failures += test_cset2str();
-    failures += test_build_map();
+    failures += test_cpuset2ranges();
+    failures += test_index_basis();
     failures += test_print_binding();
     failures += test_binding_policy();
     failures += test_userdata();


### PR DESCRIPTION
A second review pass over `src/hwloc`, following #2578. Three substantive
defects, three small ones, and two memory leaks the review turned up
elsewhere. Six commits, each standalone and bisectable.

## The cpu numbers we print are not the ones we accept

The bits of an hwloc cpuset are always PU **OS** indices — the kernel's cpu
numbers. What PRRTE shows a user is a list of *cores* (or of hwthreads, when
the job treats hwthreads as cpus), and every PRRTE grammar that *accepts*
such a list — `--cpu-set`, the rankfile and sequence-file slot lists —
resolves it as an hwloc **logical** index. Those three numbering schemes
coincide only by luck.

Three renderers short-cut whenever the bits "already were" cores
(`npus == ncores`) or the job was in hwthreads: they printed the raw bitmap
under a `core:L`/`hwt:L` label, and ignored `physical` outright. So on any
SMT node viewed in hwthreads, or any node whose firmware interleaves cpu
numbers across packages, `--display cpus` reported numbers that `--cpu-set`
would resolve to a different set of cpus.

Everything now resolves each set bit to the object that owns it, through one
new primitive, `prte_hwloc_base_cpuset2ranges()`. `prte_hwloc_build_map()` is
gone with the short cut — it produced a *bitmap* of core indices, which a
caller then printed with `hwloc_bitmap_list_snprintf()`, mixing two index
bases in one string. `prte_proc_t.cpuset` deliberately stays raw: it is a
wire format read back with `hwloc_bitmap_list_sscanf()`.

The same defect was in the collision messages of `rmaps/seq`,
`rmaps/rank_file` and `rmaps/lsf`, which printed a raw bitmap as the
"available" and "overlapping" cpus beside the user's own logical slot list.
Fixed there too.

## `--bind-to numa:limit=N` works once per DVM

`prte_hwloc_base_reset_counters()` clears the per-object placement counters
between jobs. It walked only the normal depth hierarchy — and hwloc 2.x keeps
NUMA nodes *out* of that hierarchy, at `HWLOC_TYPE_DEPTH_NUMANODE`. Its
`HWLOC_OBJ_NUMANODE != type` guard could never fire, so a counter attached to
a NUMA node was never reset. In a persistent DVM it accumulated for the life
of the DVM, and the **second** `--bind-to numa:limit=N` job found every
domain already at its limit and could not be bound. `prterun` hides it by
starting a fresh HNP each time.

## `--bind-to :overload-allowed` silently meant `--bind-to none`

`pmix_check_cli_option()` compares only `min(strlen(a), strlen(b))`
characters, so the empty policy word of the `:qualifier` form matched the
first option it was tested against — `none`. Binding was disabled, and
because the default mapping policy is derived from the binding, `BYCORE`
became `BYSLOT` along with it. Nothing was printed to say so.
`--map-by :OVERSUBSCRIBE` has always worked correctly; these now agree.

## Two leaks

Found with valgrind while checking the above; both pre-existing and outside
`src/hwloc`, so they are the first two commits.

- **`prte_relm_start_msg()`** unloaded the caller's `pmix_data_buffer_t` into
  a fresh RELM-framed one and never released the emptied container. It owns
  the buffer once it succeeds — the contract `prte_rml_send_buffer_nb()`
  follows and every `PRTE_RML_RELIABLE_SEND` caller depends on. This was one
  leaked buffer **per inter-daemon reliable message**, for the life of the
  DVM, not the one-off the first reproducer suggested.
- **`prte_parse_locals()`** has three exits and only the success path
  released `temp_argv`/`env`. Any command line whose final segment fails to
  parse leaked both — `--display map --display cpus` is enough, since a
  repeated option is refused right there.

## Smaller things

A core-less topology (PPC64 on old kernels reports only NUMA nodes and PUs)
now renders in hwthreads and says so, instead of resolving nothing and coming
back `UNBOUND`. A `package:core` id resolves *inside* its package rather than
by "objects-per-package × package id". `prte_hwloc_print()` and its three
callers handle a node whose topology has not arrived. The
`hwloc_default_cpu_list` MCA value is no longer truncated in place. Plus a
NULL PU deref and an info-array removal loop that skipped the entry shifted
into the vacated slot.

## Testing

- `make check` — `test/unit/hwloc` extended; the logical-vs-physical case
  needs a **hand-written XML topology**, because hwloc's synthetic generator
  always makes `os_index` and `logical_index` agree. (Note for anyone
  extending it: hwloc's XML importer *segfaults* rather than diagnoses on an
  object missing `complete_cpuset`/`nodeset`/`complete_nodeset`.)
- `make -C test/offline check-offline` — 1180/1180.
- `contrib/dockerswarm` — `test_hwloc` grew from 23 to 35 cases, including
  the one that needs a **persistent** DVM (three successive `numa:limit=1`
  jobs) and the print-then-accept round trip. Full suite: **407 passed, 0
  failed, 2 skipped** (both skips pre-existing PMIx-capability gates).
- valgrind on the rendering and launch paths: `definitely lost: 0`.

Each commit builds warning-free on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
