### PR TITLE
Complete a group construct on the survivors when a daemon is lost

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -1133,7 +1133,7 @@ The probe is `groupcon`, compiled by `build.sh` the same way as
 `elastic`/`dataserver`/`proctable`:
 
 ```sh
-groupcon <groupID> [secs]
+groupcon [--ft] [--delay <s>] <groupID> [secs]
 ```
 
 Every rank contributes `PMIX_GROUP_LOCAL_CID` = 1234 + rank as
@@ -1158,6 +1158,66 @@ single-host test wearing a hat), and three back-to-back constructs
 followed by a plain job must all succeed — a caddy leak or a tracker that
 is never deleted shows up as drift across runs rather than as one bad
 one.
+
+### Losing a daemon mid-construct (`test_grpcomm_ft`)
+
+The second half of the phase kills a real `prted` while a construct is in
+flight. It is gated on `pmix_cap PMIX_CAP_GROUP_FT` and skips without it,
+since the whole feature compiles out.
+
+**`--delay <s>` is what makes these cases real.** Without a stagger the
+construct is over microseconds after `prun` starts and the kill lands on
+a DVM with nothing in flight — every assertion still passes, and nothing
+has been tested. The ranks sleep before calling construct; the kill goes
+in during that window. If you change the timing, check the capture file
+still shows `DELAYING` lines before the daemon dies.
+
+**`--rtos recoverable` is not optional, and this is the thing that will
+waste your afternoon.** Killing the daemon that hosts a rank does not
+merely remove a group member — by default the errmgr treats the loss of
+any proc as fatal to its whole job and terminates the survivors too, so
+they never reach the construct at all. The capture then contains nothing
+but `DELAYING` lines and *"We cannot recover from this failure, and
+therefore will terminate the job"*, and every assertion fails with an
+empty string, which reads like the feature is broken when it is the test
+that is. The survivors have to be told to survive: `recoverable` (or
+`continuous`) is what flips `errmgr/dvm` from abort-the-job to
+notify-and-continue. That is also the honest usage — an application
+asking for a fault-tolerant group collective is by definition one that
+expects to outlive a lost member.
+
+Note the *"will terminate the job"* text is emitted unconditionally by
+the daemon-loss path, so it still appears in a recoverable run that goes
+on to complete perfectly. Do not read it as a failure, and do not assert
+on its absence.
+
+Four cases:
+
+1. **With `--ft`, the construct completes on the survivors.** Three
+   survivors must each report `CONSTRUCT PMIX_SUCCESS`, agree on
+   `MEMBERS 3`, and receive a `MEMBER-FAILED` event naming the process
+   that went away. The event is the part worth having: the construct
+   returning success only says the group formed, not that the membership
+   is smaller than what was asked for.
+2. **Without `--ft`, the same loss aborts** with
+   `PMIX_GROUP_CONSTRUCT_ABORT`, and the DVM survives. This is the
+   regression guard on the pre-existing behavior, and it is the case that
+   fails if the flag stops being plumbed. Note `groupcon` jumps to its
+   exit on a failed construct, so there is **no** `DESTRUCT` line here —
+   assert on the construct status.
+3. **Losing a relay-only daemon does not stall the construct.** Run at
+   `--prtemca rml_base_radix 2` so the tree is deep enough to have an
+   interior daemon at all; at the default radix every daemon is a child of
+   the controller and the case cannot exist. Membership must be
+   **unchanged** — nothing was lost, only a message path.
+4. **Further constructs still work afterwards**, which is where a leaked
+   tracker, memo entry or caddy shows up.
+
+A note if you extend this. Do not assert on the *absence* of a failure
+marker — a run whose job never started has no marker either. Every case
+here counts positive evidence (`CONSTRUCT`, `MEMBERS`, `MEMBER-FAILED`
+lines) and guards the setup separately by checking the target daemon is
+actually up before killing it.
 
 ## 16. The event base and the constants (`test_event`, `test_include`)
 

--- a/contrib/dockerswarm/groupcon.c
+++ b/contrib/dockerswarm/groupcon.c
@@ -11,18 +11,26 @@
  * groupcon -- a minimal PMIx client that drives PMIx_Group_construct /
  * PMIx_Group_destruct across a real, multi-node DVM.
  *
- *   groupcon <groupID> [seconds]
+ *   groupcon [--ft] [--delay <s>] <groupID> [seconds]
  *       Every rank contributes a PMIX_GROUP_LOCAL_CID of its own
  *       (1234 + rank) as PMIX_GROUP_INFO, asks for a context id, and
  *       constructs the group.  As soon as construct returns -- with NO
  *       fence in between -- each rank reads back EVERY rank's local cid
  *       and checks the value.  Then it destructs the group.
  *
+ *       --ft         ask for PMIX_GROUP_FT_COLLECTIVE, so the construct
+ *                    completes on the survivors if a member is lost
+ *       --delay <s>  sleep this long before calling construct.  Staggering
+ *                    the ranks is what makes the collective still be in
+ *                    flight when a daemon is killed; without it the
+ *                    construct is over long before the kill lands.
+ *
  * Output lines, one per rank, all prefixed GRP so the harness can grep:
  *
  *   GRP <rank> HOST <hostname>
  *   GRP <rank> CONSTRUCT <status> CID <cid> ASSIGNED <T|F>
  *   GRP <rank> MEMBERS <n>
+ *   GRP <rank> MEMBER-FAILED <nspace>:<rank>
  *   GRP <rank> CID-OK <n>            (read back n peers' local cids)
  *   GRP <rank> CID-FAIL <peer> <status>
  *   GRP <rank> DESTRUCT <status>
@@ -74,12 +82,51 @@
 
 static pmix_proc_t myproc;
 
+#ifdef PMIX_GROUP_MEMBER_FAILED
+/* A member of the group was lost with its daemon. The DVM raises this at the
+ * survivors of a fault-tolerant construct, so it is the visible half of the
+ * degraded-mode behavior - the construct returning success only says the group
+ * formed, not that anything went missing. */
+static void member_failed_handler(size_t evhdlr_registration_id, pmix_status_t status,
+                                  const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                                  pmix_info_t results[], size_t nresults,
+                                  pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    size_t n;
+    (void) evhdlr_registration_id;
+    (void) status;
+    (void) source;
+    (void) results;
+    (void) nresults;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
+            printf("GRP %u MEMBER-FAILED %s:%u\n", myproc.rank,
+                   info[n].value.data.proc->nspace,
+                   (unsigned) info[n].value.data.proc->rank);
+            fflush(stdout);
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void reg_handler(pmix_status_t status, size_t refid, void *cbdata)
+{
+    (void) status;
+    (void) refid;
+    (void) cbdata;
+}
+#endif
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc, ret;
     pmix_value_t *val = NULL;
     pmix_value_t value;
-    pmix_proc_t proc, *procs = NULL;
+    pmix_proc_t proc, *procs = NULL, *members = NULL;
+    size_t nmembers = 0;
     pmix_info_t *results = NULL, *info = NULL;
     pmix_info_t tinfo[2];
     pmix_data_array_t darray;
@@ -90,17 +137,41 @@ int main(int argc, char **argv)
     char hostname[256];
     const char *grpid;
     int seconds = 0;
+    int delay = 0;
     int failures = 0;
+    int i, npos = 0;
     bool idassigned = false;
+    bool ft = false;
+#ifdef PMIX_GROUP_MEMBER_FAILED
+    pmix_status_t evcode = PMIX_GROUP_MEMBER_FAILED;
+#endif
 
-    if (2 > argc) {
-        fprintf(stderr, "usage: %s <groupID> [seconds]\n", argv[0]);
+    /* flags may appear anywhere; the positional arguments keep their old
+     * meaning so existing cases in the harness are unaffected */
+    grpid = NULL;
+    for (i = 1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--ft")) {
+            ft = true;
+        } else if (0 == strcmp(argv[i], "--delay") && (i + 1) < argc) {
+            delay = atoi(argv[++i]);
+        } else if (0 == npos) {
+            grpid = argv[i];
+            ++npos;
+        } else if (1 == npos) {
+            seconds = atoi(argv[i]);
+            ++npos;
+        }
+    }
+    if (NULL == grpid) {
+        fprintf(stderr, "usage: %s [--ft] [--delay <s>] <groupID> [seconds]\n", argv[0]);
         return 2;
     }
-    grpid = argv[1];
-    if (3 <= argc) {
-        seconds = atoi(argv[2]);
+#ifndef PMIX_GROUP_FT_COLLECTIVE
+    if (ft) {
+        fprintf(stderr, "ERROR --ft: this PMIx has no PMIX_GROUP_FT_COLLECTIVE\n");
+        return 2;
     }
+#endif
 
     gethostname(hostname, sizeof(hostname));
     hostname[sizeof(hostname) - 1] = '\0';
@@ -112,6 +183,13 @@ int main(int argc, char **argv)
     }
     printf("GRP %u HOST %s\n", myproc.rank, hostname);
     fflush(stdout);
+
+#ifdef PMIX_GROUP_MEMBER_FAILED
+    /* register before constructing - the notification can arrive with the
+     * construct's own completion */
+    PMIx_Register_event_handler(&evcode, 1, NULL, 0, member_failed_handler,
+                                reg_handler, NULL);
+#endif
 
     /* how many of us are there? */
     PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
@@ -151,6 +229,15 @@ int main(int argc, char **argv)
         fprintf(stderr, "ERROR list_add ctxid: %s\n", PMIx_Error_string(rc));
         goto done;
     }
+#ifdef PMIX_GROUP_FT_COLLECTIVE
+    if (ft) {
+        rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_FT_COLLECTIVE, NULL, PMIX_BOOL);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "ERROR list_add ftcoll: %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+#endif
     list = PMIx_Info_list_start();
     lcid = GROUPCON_BASE_CID + (size_t) myproc.rank;
     rc = PMIx_Info_list_add(list, PMIX_GROUP_LOCAL_CID, &lcid, PMIX_SIZE);
@@ -180,6 +267,14 @@ int main(int argc, char **argv)
     ninfo = darray.size;
     PMIx_Info_list_release(grpinfo);
 
+    /* hold here if asked, so the collective is still in flight when whatever
+     * the test is doing to the DVM happens */
+    if (0 < delay) {
+        printf("GRP %u DELAYING %d\n", myproc.rank, delay);
+        fflush(stdout);
+        sleep(delay);
+    }
+
     rc = PMIx_Group_construct(grpid, procs, nprocs, info, ninfo, &results, &nresults);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     if (PMIX_SUCCESS != rc) {
@@ -196,6 +291,14 @@ int main(int argc, char **argv)
             if (PMIX_DATA_ARRAY == results[m].value.type && NULL != results[m].value.data.darray) {
                 printf("GRP %u MEMBERS %u\n", myproc.rank,
                        (unsigned) results[m].value.data.darray->size);
+                /* keep the membership: it is what we read back below. After a
+                 * fault-tolerant construct it is SMALLER than the job, and
+                 * asking a departed rank for its contribution is a guaranteed
+                 * not-found rather than a real failure. */
+                nmembers = results[m].value.data.darray->size;
+                PMIX_PROC_CREATE(members, nmembers);
+                memcpy(members, results[m].value.data.darray->array,
+                       nmembers * sizeof(pmix_proc_t));
             }
         }
     }
@@ -216,17 +319,24 @@ int main(int argc, char **argv)
     PMIX_INFO_CONSTRUCT(&tinfo[1]);
     PMIX_INFO_LOAD(&tinfo[1], PMIX_TIMEOUT, &get_timeout, PMIX_UINT32);
 
-    for (n = 0; n < nprocs; n++) {
-        PMIX_LOAD_PROCID(&proc, myproc.nspace, n);
-        rc = PMIx_Get(&proc, PMIX_GROUP_LOCAL_CID, tinfo, 2, &val);
+    /* read back the members the group actually ended up with, not every rank
+     * the job started with */
+    for (n = 0; n < nmembers; n++) {
+        if (PMIX_RANK_WILDCARD == members[n].rank) {
+            continue;
+        }
+        rc = PMIx_Get(&members[n], PMIX_GROUP_LOCAL_CID, tinfo, 2, &val);
         if (PMIX_SUCCESS != rc) {
-            printf("GRP %u CID-FAIL %u %s\n", myproc.rank, n, PMIx_Error_string(rc));
+            printf("GRP %u CID-FAIL %u %s\n", myproc.rank,
+                   (unsigned) members[n].rank, PMIx_Error_string(rc));
             fflush(stdout);
             failures++;
             continue;
         }
-        if (PMIX_SIZE != val->type || (GROUPCON_BASE_CID + (size_t) n) != val->data.size) {
-            printf("GRP %u CID-FAIL %u BADVALUE\n", myproc.rank, n);
+        if (PMIX_SIZE != val->type
+            || (GROUPCON_BASE_CID + (size_t) members[n].rank) != val->data.size) {
+            printf("GRP %u CID-FAIL %u BADVALUE\n", myproc.rank,
+                   (unsigned) members[n].rank);
             fflush(stdout);
             failures++;
             PMIX_VALUE_RELEASE(val);
@@ -250,6 +360,9 @@ int main(int argc, char **argv)
 done:
     if (NULL != procs) {
         PMIX_PROC_FREE(procs, nprocs);
+    }
+    if (NULL != members) {
+        PMIX_PROC_FREE(members, nmembers);
     }
     if (0 < seconds) {
         sleep(seconds);

--- a/contrib/dockerswarm/groupcon.c
+++ b/contrib/dockerswarm/groupcon.c
@@ -11,7 +11,7 @@
  * groupcon -- a minimal PMIx client that drives PMIx_Group_construct /
  * PMIx_Group_destruct across a real, multi-node DVM.
  *
- *   groupcon [--ft] [--delay <s>] <groupID> [seconds]
+ *   groupcon [--ft] [--fence] [--delay <s>] <groupID> [seconds]
  *       Every rank contributes a PMIX_GROUP_LOCAL_CID of its own
  *       (1234 + rank) as PMIX_GROUP_INFO, asks for a context id, and
  *       constructs the group.  As soon as construct returns -- with NO
@@ -20,7 +20,12 @@
  *
  *       --ft         ask for PMIX_GROUP_FT_COLLECTIVE, so the construct
  *                    completes on the survivors if a member is lost
- *       --delay <s>  sleep this long before calling construct.  Staggering
+ *       --fence      run a PMIx_Fence over the whole job instead of a
+ *                    group construct.  Here --delay applies to the LAST
+ *                    rank only, so everyone else blocks inside the fence
+ *                    for that long and a daemon can be killed while the
+ *                    allgather is genuinely in flight
+ *       --delay <s>  sleep this long before calling construct (or fence).  Staggering
  *                    the ranks is what makes the collective still be in
  *                    flight when a daemon is killed; without it the
  *                    construct is over long before the kill lands.
@@ -142,6 +147,7 @@ int main(int argc, char **argv)
     int i, npos = 0;
     bool idassigned = false;
     bool ft = false;
+    bool dofence = false;
 #ifdef PMIX_GROUP_MEMBER_FAILED
     pmix_status_t evcode = PMIX_GROUP_MEMBER_FAILED;
 #endif
@@ -152,6 +158,8 @@ int main(int argc, char **argv)
     for (i = 1; i < argc; i++) {
         if (0 == strcmp(argv[i], "--ft")) {
             ft = true;
+        } else if (0 == strcmp(argv[i], "--fence")) {
+            dofence = true;
         } else if (0 == strcmp(argv[i], "--delay") && (i + 1) < argc) {
             delay = atoi(argv[++i]);
         } else if (0 == npos) {
@@ -163,7 +171,8 @@ int main(int argc, char **argv)
         }
     }
     if (NULL == grpid) {
-        fprintf(stderr, "usage: %s [--ft] [--delay <s>] <groupID> [seconds]\n", argv[0]);
+        fprintf(stderr, "usage: %s [--ft] [--fence] [--delay <s>] <groupID> [seconds]\n",
+                argv[0]);
         return 2;
     }
 #ifndef PMIX_GROUP_FT_COLLECTIVE
@@ -220,6 +229,40 @@ int main(int argc, char **argv)
     PMIX_PROC_CREATE(procs, nprocs);
     for (n = 0; n < nprocs; n++) {
         PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+    }
+
+    /* --fence: exercise the allgather rather than the group collective. The
+     * point of the mode is what happens when a daemon dies while one is in
+     * flight, which nothing else here can hold open long enough to test. */
+    if (dofence) {
+        /* Only the LAST rank waits. Everyone else enters the allgather at
+         * once and blocks there, so the fence is genuinely in flight for the
+         * length of the delay - which is the state a test needs in order to
+         * kill a daemon during one. A uniform delay would not do: every rank
+         * would enter after the kill, and the fence would simply run to
+         * completion over whatever was left. */
+        if (0 < delay && myproc.rank == (nprocs - 1)) {
+            printf("GRP %u DELAYING %d\n", myproc.rank, delay);
+            fflush(stdout);
+            sleep(delay);
+        }
+        printf("GRP %u FENCING\n", myproc.rank);
+        fflush(stdout);
+        PMIX_INFO_CREATE(info, 1);
+        ninfo = 1;
+        /* collect the data each rank put, so this is a real allgather and
+         * not just a barrier */
+        PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &dofence, PMIX_BOOL);
+        rc = PMIx_Fence(procs, nprocs, info, ninfo);
+        PMIX_INFO_FREE(info, ninfo);
+        info = NULL;
+        ninfo = 0;
+        printf("GRP %u FENCE %s\n", myproc.rank, PMIx_Error_string(rc));
+        fflush(stdout);
+        if (PMIX_SUCCESS != rc) {
+            failures++;
+        }
+        goto done;
     }
 
     /* ask for a context id, and contribute our own local cid as group info */

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3209,6 +3209,174 @@ test_grpcomm() {
 
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
+
+    test_grpcomm_ft
+}
+
+# Losing a whole daemon mid-construct.  This is the daemon-death analog of the
+# client-death handling the PMIx server library already does, and it is the
+# reason grpcomm carries a recovery epoch at all: the rollup's expected counts
+# come from the routing tree, so a failure invalidates every one of them and
+# the collective has to be restarted rather than merely waited on.
+#
+# Every case here kills a real daemon under a live construct, so they need the
+# stagger that --delay gives: without it the construct is long over before the
+# kill lands and the case passes without testing anything.
+test_grpcomm_ft() {
+    local out n g
+
+    if ! pmix_cap PMIX_CAP_GROUP_FT; then
+        skp "grpcomm FT: the installed PMIx has no PMIX_CAP_GROUP_FT"
+        return
+    fi
+
+    banner "grpcomm: an FT construct survives losing a participating daemon"
+    # With PMIX_GROUP_FT_COLLECTIVE the construct must complete on the
+    # survivors with a reduced membership, and each survivor must be told
+    # which processes went away.  Ranks are one per node so killing node4
+    # removes exactly one member.
+    cleanup_swarm
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        PRUN_BG /tmp/grp-ft.out "--rtos recoverable,notifyerrors --host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $GC --ft --delay 12 ftgrp"
+        sleep 4
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill -- the job did not land where expected"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 60 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            out=$(RUN 'tr -d "\\000" < /tmp/grp-ft.out' 2>&1)
+            # three survivors, each of which must have completed the construct
+            n=$(echo "$out" | grep -c 'CONSTRUCT PMIX_SUCCESS')
+            [ "$n" = 3 ] \
+                && ok "all 3 surviving ranks completed the construct" \
+                || bad "$n of 3 survivors completed the construct: $(echo "$out" | grep CONSTRUCT | tr '\n' ' ' | tail -c 300)"
+            # the membership must have shrunk to the survivors
+            n=$(echo "$out" | grep -c 'MEMBERS 3')
+            [ "$n" = 3 ] \
+                && ok "...on the reduced membership of 3" \
+                || bad "survivors did not agree on a membership of 3: $(echo "$out" | grep MEMBERS | tr '\n' ' ' | tail -c 200)"
+            # and they must have been told who was lost
+            n=$(echo "$out" | grep -c 'MEMBER-FAILED')
+            [ "$n" -ge 3 ] \
+                && ok "...and every survivor was told which member failed" \
+                || bad "only $n MEMBER-FAILED events reached the survivors (want >= 3)"
+            # the reduced group must still be usable: each survivor reads back
+            # every remaining member's contribution and reports no failures
+            n=$(echo "$out" | grep -c 'DONE 0')
+            [ "$n" = 3 ] \
+                && ok "...and the reduced group was intact and usable" \
+                || bad "$n of 3 survivors finished cleanly: $(echo "$out" | grep -E 'CID-FAIL|DONE' | tr '\n' ' ' | tail -c 250)"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "the HNP survived the loss" \
+                || bad "the HNP died along with the lost daemon"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the FT group test"
+    fi
+    cleanup_swarm
+
+    banner "grpcomm: without FT_COLLECTIVE the same loss aborts the construct"
+    # The regression guard on the pre-existing behavior.  Note groupcon jumps
+    # straight to its exit on a failed construct, so there is no DESTRUCT line
+    # on this path -- assert on the CONSTRUCT status and on the DVM surviving.
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        PRUN_BG /tmp/grp-noft.out "--rtos recoverable,notifyerrors --host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $GC --delay 12 noftgrp"
+        sleep 4
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill -- the job did not land where expected"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 60 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            out=$(RUN 'tr -d "\\000" < /tmp/grp-noft.out' 2>&1)
+            n=$(echo "$out" | grep -c 'CONSTRUCT PMIX_GROUP_CONSTRUCT_ABORT')
+            [ "$n" = 3 ] \
+                && ok "all 3 survivors were told the construct aborted" \
+                || bad "$n of 3 survivors reported an abort: $(echo "$out" | grep CONSTRUCT | tr '\n' ' ' | tail -c 300)"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "...and the DVM survived the abort" \
+                || bad "the HNP died rather than aborting the construct"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the non-FT group test"
+    fi
+    cleanup_swarm
+
+    banner "grpcomm: losing a relay-only daemon does not stall a construct"
+    # A daemon that hosts no member but sits between the controller and one
+    # that does.  Nothing about the membership changes, so the construct must
+    # simply complete -- with or without --ft.  Before the rollup learned to
+    # recompute what it expects, this was the silent case: the operation was
+    # not "affected", so it was never aborted either, and it hung on a count
+    # that could never be reached.
+    #
+    # radix 2 is what makes the tree deep enough to have an interior node at
+    # all; at the default radix every daemon is a child of the controller.
+    if prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1' \
+                           '--prtemca rml_base_radix 2'; then
+        # members on node1 and node7 only; node3 relays for node7's side of
+        # the radix-2 tree and hosts nobody
+        PRUN_BG /tmp/grp-relay.out "--host node1:1,node7:1 -n 2 --map-by node $GC --ft --delay 12 relaygrp"
+        sleep 4
+        if ! ON 3 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node3 has no daemon to kill"
+        else
+            ON 3 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 60 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            out=$(RUN 'tr -d "\\000" < /tmp/grp-relay.out' 2>&1)
+            n=$(echo "$out" | grep -c 'CONSTRUCT PMIX_SUCCESS')
+            [ "$n" = 2 ] \
+                && ok "both members completed the construct despite the lost relay" \
+                || bad "$n of 2 members completed: $(echo "$out" | grep -E 'CONSTRUCT|DELAYING' | tr '\n' ' ' | tail -c 300)"
+            n=$(echo "$out" | grep -c 'MEMBERS 2')
+            [ "$n" = 2 ] \
+                && ok "...with the membership intact -- no member was lost" \
+                || bad "the membership changed when only a relay died: $(echo "$out" | grep MEMBERS | tr '\n' ' ' | tail -c 200)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a radix-2 DVM for the relay-loss test"
+    fi
+    cleanup_swarm
+
+    banner "grpcomm: the DVM still runs group constructs after a loss"
+    # A recovery that leaves a tracker, a memo entry or a caddy behind shows
+    # up as drift on the next operation rather than as a bad run of its own.
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        PRUN_BG /tmp/grp-after.out "--rtos recoverable,notifyerrors --host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $GC --ft --delay 12 killgrp"
+        sleep 4
+        ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+        n=0
+        while [ "$n" -lt 60 ]; do
+            RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+            sleep 1; n=$((n+1))
+        done
+        n=0
+        for g in a1 a2; do
+            out=$(PRUN "--host node1:1,node2:1,node3:1 -n 3 --map-by node $GC --ft $g" 2>&1)
+            [ "$(echo "$out" | grep -c 'CID-OK 3')" = 3 ] && n=$((n+1))
+        done
+        [ "$n" = 2 ] \
+            && ok "two further group constructs completed on the reduced DVM" \
+            || bad "only $n of 2 group constructs completed after the loss"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the post-loss group test"
+    fi
+    cleanup_swarm
 }
 
 test_rml() {

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3352,6 +3352,77 @@ test_grpcomm_ft() {
     fi
     cleanup_swarm
 
+    banner "grpcomm: a daemon loss elsewhere does not disturb a live fence"
+    # The bystander case, and the reason the fence handler was changed. It
+    # used to kill the job whenever ANY daemon failed while ANY fence was in
+    # flight, without asking whether the two were related - and fences run
+    # constantly, so an unrelated failure anywhere was fatal. Here the fence
+    # spans node1 and node2 only, and the daemon that dies hosts none of it.
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        PRUN_BG /tmp/grp-fence1.out "--host node1:1,node2:1 -n 2 --map-by node $GC --fence --delay 12 fen1"
+        sleep 4
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 60 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            out=$(RUN 'tr -d "\000" < /tmp/grp-fence1.out' 2>&1)
+            n=$(echo "$out" | grep -c 'FENCE PMIX_SUCCESS')
+            [ "$n" = 2 ] \
+                && ok "both ranks completed the fence despite an unrelated daemon dying" \
+                || bad "$n of 2 ranks completed the fence: $(echo "$out" | grep -E 'FENCE|FENCING' | tr '\n' ' ' | tail -c 250)"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "...and the HNP survived" \
+                || bad "the HNP died over a fence it had no part in"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the fence bystander test"
+    fi
+    cleanup_swarm
+
+    banner "grpcomm: a fence that loses a participant fails, and only it"
+    # An allgather has no opt-in to running degraded - its answer is every
+    # participant's contribution - so a fence that really lost one cannot
+    # complete. It must say so to its own participants rather than activating
+    # a DVM-wide comm failure, which is what it used to do.
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        PRUN_BG /tmp/grp-fence2.out "--rtos recoverable,notifyerrors --host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $GC --fence --delay 12 fen2"
+        sleep 4
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 60 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            out=$(RUN 'tr -d "\000" < /tmp/grp-fence2.out' 2>&1)
+            # the three survivors must each be told the fence failed, rather
+            # than being left blocked in it
+            n=$(echo "$out" | grep -c '^GRP [0-2] FENCE ')
+            [ "$n" = 3 ] \
+                && ok "all 3 survivors were released from the fence" \
+                || bad "$n of 3 survivors got a fence result: $(echo "$out" | grep -E 'FENCE' | tr '\n' ' ' | tail -c 250)"
+            n=$(echo "$out" | grep -c 'FENCE PMIX_SUCCESS')
+            [ "$n" = 0 ] \
+                && ok "...and none of them was told the allgather succeeded" \
+                || bad "$n survivors were told a fence missing a participant had succeeded"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "...and the DVM survived" \
+                || bad "the HNP died rather than failing the fence"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the fence participant-loss test"
+    fi
+    cleanup_swarm
+
     banner "grpcomm: the DVM still runs group constructs after a loss"
     # A recovery that leaves a tracker, a memo entry or a caddy behind shows
     # up as drift on the next operation rather than as a bad run of its own.

--- a/docs/plans/ft_group.rst
+++ b/docs/plans/ft_group.rst
@@ -1,0 +1,335 @@
+Degraded-mode survival of a group construct on daemon loss
+==========================================================
+
+Tracking issue: `#2510 <https://github.com/openpmix/prrte/issues/2510>`_.
+
+Context
+-------
+
+A PMIx group collective can lose a participant two ways, and PRRTE handled
+them asymmetrically.
+
+**Client death** is handled inside the PMIx server library.
+``grp_ft_collective()`` gates it: when ``PMIX_GROUP_FT_COLLECTIVE`` was
+requested the construct completes on the survivors and each is told who was
+lost via ``PMIX_GROUP_MEMBER_FAILED``; otherwise ``abort_construct()`` fires
+``PMIX_GROUP_CONSTRUCT_ABORT``.
+
+**Daemon death** — a whole ``prted`` and its entire subtree of clients — is
+handled by ``prte_grpcomm_direct_group_fault_handler``, which aborted every
+affected operation *regardless* of the flag, because the flag was neither
+parsed nor stored at this layer. ``PMIX_GROUP_FT_COLLECTIVE`` appeared exactly
+once in the whole tree: in a comment explaining that it was not honored.
+Closing that asymmetry is the issue.
+
+The hard part is not the policy — it is re-converging an up-tree rollup over a
+routing tree that just changed shape. ``coll->nexpected`` was computed once, at
+tracker creation, and is invalidated by the fault.
+
+Reading the code turned up four further problems the fix depends on:
+
+* **An interior relay death silently hung a construct.** A tracker whose
+  participants all survive but whose relaying child died was not "affected" by
+  the handler's test, which only inspected ``coll->dmns``, so it was never
+  aborted — and its stale ``nexpected`` never completed.
+* **``nreported`` was an identity-free counter**, safe only while each child
+  contributes exactly once. Recovery makes duplicates normal, and two messages
+  from one child plus zero from another satisfy ``nreported == nexpected`` just
+  as well as one from each.
+* **Nothing bounded a group operation in time.** ``coll->timeout`` was parsed,
+  max-merged and forwarded to the parent — and never armed. The unconditional
+  abort was the de-facto liveness guarantee.
+* **``create_dmns`` failure was a silent hang path.** Recovery must not depend
+  on resolving a process whose node is being torn down.
+
+Corrections to earlier premises
+-------------------------------
+
+Three assumptions that an earlier draft of this plan got wrong, recorded
+because each one changes the design:
+
+#. **A global notice fires the handler twice on each daemon.**
+   ``prte_rml_repair_routing_tree(.., global=true)`` recurses into the LOCAL
+   pass and then falls through to the GLOBAL pass. The GLOBAL pass carries the
+   *full* rank list and always reports no topology change, because the topology
+   work is skipped — so the tree is already repaired and
+   ``prte_rml_get_num_contributors()`` is immediately usable there.
+
+#. **The xcast ordering argument must not be stated as "process before
+   forward".** ``PRTE_RML_TAG_DAEMON_DIED`` *is* in xcast's ``process_first``
+   set, but ``process_msg()`` only *queues* the local delivery, and
+   ``forward_op()`` then reads the children synchronously. The ordering this
+   design needs still holds, for a different reason: a daemon makes its own
+   delivery event active before it can read any reply from a child, and
+   libevent dispatches active events before the next I/O poll. The design
+   handles a newer stamp anyway rather than assuming it away.
+
+#. **``prte_grpcomm.xcast()`` copies its buffer.** Three callers dropped the
+   pointer afterwards and leaked the entire release payload on every group and
+   fence operation.
+
+Desired behavior
+----------------
+
+Evaluated at the controller, per in-flight operation:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 24 16 46
+
+   * - Operation
+     - Participating daemon lost?
+     - ``FT_COLLECTIVE``
+     - Result
+   * - construct
+     - no (only relays changed)
+     - —
+     - **completes normally** (fixes the hang above)
+   * - construct
+     - yes
+     - set
+     - **completes on survivors**, reduced membership, one
+       ``PMIX_GROUP_MEMBER_FAILED`` per departed process
+   * - construct
+     - yes
+     - unset
+     - aborts ``PMIX_GROUP_CONSTRUCT_ABORT`` (prior behavior)
+   * - destruct
+     - yes
+     - —
+     - completes ``PMIX_SUCCESS`` (prior behavior)
+   * - any
+     - surviving membership empty
+     - —
+     - aborts ``PMIX_GROUP_CONSTRUCT_ABORT``
+   * - bootstrap
+     - any
+     - —
+     - aborts (see `Out of scope`_)
+
+Design: one global epoch, not a per-link round
+----------------------------------------------
+
+The instinct is to copy ``prte_grpcomm_direct_xcast_fault_handler`` — ack
+rounds chosen by the parent and echoed by the child. **That model does not
+transfer.** In xcast the payload flows *down*, so the parent always holds the
+operation and can re-poll. In a group rollup the payload flows *up*, so the
+parent is exactly the party that may hold nothing: a pass-through daemon's
+tracker is created lazily, on the first arriving contribution. A parent-driven
+re-poll cannot reach a promoted orphan whose new parent has no tracker, and a
+round cannot invalidate a contribution the parent has *already absorbed* — that
+invalidation has to travel up, and rounds travel down.
+
+Instead, use the synchronization the RML already provides: the **GLOBAL fault
+scope**. It is DVM-wide, ordered identically on every daemon, and arrives after
+the tree is repaired. That gives a simultaneous restart for free — no new RML
+tag, no re-poll protocol, no promoted-orphan special case, and the topology
+deltas are not needed at all.
+
+**The mechanism.** One ``uint32_t group_epoch`` per daemon, advanced in the
+GLOBAL-scope group fault handler on **every** daemon. On advance, every
+in-flight non-bootstrap tracker:
+
+#. resets — clears ``reported_slots``/``self_reported``/``converged``, releases
+   and reopens ``grpinfo``/``endpts``, resets the sticky ``status``;
+#. recomputes ``nexpected`` from the repaired tree. ``coll->dmns`` stays the
+   **full pre-fault set**: ``prte_rml_get_num_contributors()`` skips
+   ``prte_rml_base.failed_dmns`` internally, so the count is automatically
+   fault-aware while ``dmns`` remains the record of who was *supposed* to take
+   part;
+#. re-injects its own saved contribution to itself, stamped with the new epoch.
+   A daemon with nothing of its own — a pure relay — simply calls
+   ``check_complete()``, which fires immediately if ``nexpected`` is now zero.
+   That is the interior-relay fix.
+
+::
+
+    HNP xcast DAEMON_DIED
+             |
+             v
+    each daemon: repair_routing_tree(global)
+             |
+             +--> LOCAL pass: tree repaired, xcast handler re-forwards
+             |
+             v
+    GLOBAL pass: group fault handler, on EVERY daemon
+             |
+             +-- master && operation cannot survive?
+             |     (bootstrap, or construct + lost participant + no FT)
+             |        -> abort_group_op(); mark aborting; skip the reset
+             |
+             v
+    advance_group_epoch(E+1)
+             |
+             +--> reset tracker, recompute nexpected
+             +--> re-inject my_contribution to self @ epoch E+1
+                       |
+                       v
+             grp_recv: per-slot dedup, drop stale epochs
+                       |
+              +--------+---------+
+              |                  |
+          non-HNP              HNP
+        roll up to          FT gate: departed set,
+        parent @ E+1        reduced membership
+              |                  |
+              +------------------+
+                       |
+                       v
+             xcast GROUP_RELEASE + departed list
+                       |
+                       v
+             grp_release: complete clients,
+             then GROUP_MEMBER_FAILED events
+
+**Epoch stamping.** The epoch is *not* part of the signature. ``group()``
+builds the contribution body, saves ``coll->my_contribution`` as a copy of it,
+then sends ``[epoch][body]``. The rollup to the parent does the same. Replay is
+``[new epoch][my_contribution]``. ``grp_recv`` unpacks the epoch first:
+
+* ``stamp < group_epoch`` — stale; drop before any merge.
+* ``stamp > group_epoch`` — we are behind. Call ``advance_group_epoch(stamp)``,
+  which is exactly what the fault handler would have done a moment later and is
+  idempotent with it, then process normally. No hold queue, no dropped
+  contribution. ``PRTE_ERROR_LOG`` it so the ordering assumption stays
+  testable.
+
+**Per-slot accounting** replaces the bare counter.
+``prte_rml_get_subtree_index()`` returns an index computed by the same radix
+math ``get_num_contributors`` uses, so the two agree by construction.
+``grp_recv`` already receives ``sender``. A contribution whose slot bit is
+already set is dropped **whole**, before the info-list accumulation, which
+appends with no key de-duplication. Completion becomes "every expected slot
+present", idempotent under replay. This applies to the **non-bootstrap** branch
+only — bootstrap contributions go straight to the controller from arbitrary
+daemons, so a subtree index is meaningless for them.
+
+**The FT policy lives at controller completion, not in the fault handler.**
+That is the one point with full information, it runs exactly once, and it
+covers the case where the controller had no tracker when the fault landed. The
+fault handler's job is mechanical re-convergence plus one optimization:
+aborting immediately what provably cannot survive.
+
+Commits
+-------
+
+One branch, one PR against ``master``.
+
+Drive-by fixes (1–5)
+~~~~~~~~~~~~~~~~~~~~
+
+Each stands alone and is independently revertable.
+
+#. The wildcard-preservation writes in ``get_tracker`` index the *incoming*
+   loop variable into the *tracker's* array. Out-of-bounds write whenever the
+   arrays differ in length or order.
+#. ``get_tracker``'s creation path never copies ``bootstrap``, ``follower`` or
+   ``final_order`` into the accumulated signature. A single-leader bootstrap
+   therefore has ``nleaders == 0`` and can never complete; the release describes
+   the operation wrongly; and a final order supplied by whichever daemon happens
+   to create the tracker is silently discarded.
+#. The signature destructor never freed ``final_order``.
+#. Three release buffers leak after ``xcast``, which copies.
+#. ``find_delete_tracker`` matched on ``groupID`` only while ``get_tracker``
+   matches ``groupID`` **and** operation.
+
+Rollup accounting (6)
+~~~~~~~~~~~~~~~~~~~~~
+
+No behavior change; every part is correct on its own merits. Per-slot reporting
+bitmap; a ``converged`` latch so a straggler cannot drive a second release
+broadcast or a second rollup; a bounded memo of released operations so a
+straggler cannot recreate a tracker nothing will delete; ``check_complete()``
+factored out so a fault handler can re-test a tracker with no message in hand;
+and ``coll->timeout`` finally armed on the controller — only when a participant
+actually asked for one, so a tree with no timeout directive behaves as before.
+Three dead tracker fields go with the struct surgery.
+
+The FT feature (7)
+~~~~~~~~~~~~~~~~~~
+
+``ft_collective`` on the signature, parsed under ``#if
+PRTE_PMIX_HAVE_GROUP_FT`` but packed and unpacked **unguarded** so the wire
+format is uniform regardless of the capability. Sticky-OR on merge, which means
+"any **surviving** participant asked for it" — a participant that requested it
+and died before rolling up is not visible, and that deviation is documented at
+the code. It is also a deliberate superset of the PMIx server's first-match-wins
+rule.
+
+Then: the saved contribution, the epoch machinery, the fault-handler rewrite,
+``create_dmns`` tolerance for a torn-down node, the controller's completion
+gate, the departed list carried in the release, and the
+``PMIX_GROUP_MEMBER_FAILED`` events. The events use ``PMIX_RANGE_CUSTOM`` over
+the group's local members rather than ``PMIX_RANGE_LOCAL``, which would reach
+every client on the node including unrelated jobs, and they carry the
+mandatory ``prte.notify.donotloop`` marker — without it PMIx hands the event
+back to our own upcall, which thread-shifts onto the progress thread we are
+blocking on, and the daemon deadlocks.
+
+Tests and docs (8–9)
+~~~~~~~~~~~~~~~~~~~~
+
+``test/unit/grpcomm`` gains the new constructor defaults and drives
+``prte_grpcomm_direct_group_member_departed()`` against a synthetic failed-daemon
+set — the only genuinely unit-testable part, and where policy bugs will live.
+
+``contrib/dockerswarm`` is where the feature is actually proven. ``groupcon``
+gains ``--ft``, ``--delay`` and a ``PMIX_GROUP_MEMBER_FAILED`` handler, keeping
+its positional interface so existing cases are unaffected. Four new cases, all
+gated on ``pmix_cap PMIX_CAP_GROUP_FT``: an FT construct surviving the loss of a
+participating daemon; the same loss without ``--ft`` aborting cleanly; the loss
+of a relay-only daemon not stalling anything; and further constructs still
+working afterwards. ``--delay`` is load-bearing — without the stagger the
+construct is over before the kill lands and every assertion passes without
+testing anything.
+
+Out of scope
+------------
+
+* **Bootstrap operations.** They have no resolved daemon set, and ``nleaders``
+  is a count with no identities, so the controller cannot work out how much of
+  one died. Keep the unconditional abort; recording leader identities is the
+  enabling change for a follow-up.
+* **Revival/unheal during an in-flight operation.** Aborted.
+  ``PRTE_RML_TAG_DAEMON_REVIVED`` is deliberately forward-first in the xcast, so
+  it cannot give the parent-before-child ordering an epoch advance needs. This
+  path previously did nothing at all, i.e. hung, so aborting is an improvement
+  rather than a fix.
+* **``prte_grpcomm_direct_fence_fault_handler`` has no scope guard at all**, so
+  it activates ``PRTE_JOB_STATE_COMM_FAILED`` twice per fault *and once on every
+  revival* — killing a job on a legitimate unheal. A real bug, but not this
+  one; report it separately rather than widening this work.
+* The inherent race where the controller completes a construct microseconds
+  before learning a member's daemon died. That member is an ordinary
+  post-construct member failure, not a departed entry.
+
+Verification
+------------
+
+.. code-block:: sh
+
+   mkdir -p build/debug && cd build/debug
+   ../../configure --enable-debug --with-pmix=<pmix> --with-hwloc=<hwloc> \
+       --with-libevent=<libevent>
+   make -j$(nproc)      # --enable-debug implies warnings-as-errors
+   make check
+
+``grep PMIX_CAP_GROUP_FT <pmix>/include/pmix_version.h`` before trusting any
+result — without it the feature compiles out and a green build proves nothing.
+Build both with and without a capable PMIx if time allows, or the ``#else`` arm
+of the completion gate is never compiled.
+
+Then a single-host smoke test to prove the ordinary path is untouched
+(``prte --daemonize`` → ``prun -n 4 hostname`` → ``pterm``), and the harness,
+which is the only layer that proves the feature — a daemon that merely
+*receives* the release does not exist on one host:
+
+.. code-block:: sh
+
+   cd contrib/dockerswarm
+   ./build.sh
+   docker compose up -d
+   ./run-tests.sh linux
+
+``make -C test/offline check-offline`` is not needed; nothing here touches the
+mapper.

--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -10,3 +10,4 @@ Detailed implementation plans for in-progress and upcoming features.
    node_reservation/index.rst
    elastic_dvm/index.rst
    bootstrap/index.rst
+   ft_group.rst

--- a/src/mca/errmgr/base/help-errmgr-base.txt
+++ b/src/mca/errmgr/base/help-errmgr-base.txt
@@ -66,8 +66,12 @@ PRTE has lost communication with a remote daemon.
 
 This is usually due to either a failure of the TCP network
 connection to the node, or possibly an internal failure of
-the daemon itself. We cannot recover from this failure, and
-therefore will terminate the job.
+the daemon itself.
+
+Any processes that were running on that node have been lost.
+A job that loses a process is terminated unless it asked to
+survive that - see the "recoverable" and "continuous" runtime
+options, for example "--rtos recoverable".
 #
 [simple-message]
 An internal error has occurred in PRTE:

--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -85,7 +85,7 @@ component fills it in. Every function pointer **MUST** be provided.
 |-------|-----------|---------------------------|
 | `init` | `int (*)(void)` | Called once on the winning module right after selection. Set up trackers, register RML receives. Returns `PRTE_SUCCESS`. |
 | `finalize` | `void (*)(void)` | Tear down trackers and cancel RML receives. Called by the framework close. |
-| `fault_handler` | `void (*)(const prte_rml_recovery_status_t *status)` | Invoked by the RML/routed layer (`src/rml/routed_radix.c`) when the routing tree changes — a daemon died, revived, or the local node was re-parented/promoted. Repair or abort in-flight collectives. |
+| `fault_handler` | `void (*)(const prte_rml_recovery_status_t *status)` | Invoked **on every daemon** by the RML/routed layer (`src/rml/routed_radix.c`) when the routing tree changes — a daemon died, revived, or the local node was re-parented/promoted. Repair or abort in-flight collectives. Called twice per death (LOCAL then GLOBAL scope); which one a collective keys on depends on what it needs, so read `direct/AGENTS.md` before adding a third. |
 | `xcast` | `int (*)(prte_rml_tag_t tag, pmix_data_buffer_t *msg)` | Scalably broadcast `msg` to **every** daemon in the DVM, to be delivered at `tag`. Non-destructive to `msg` (caller still owns it). Returns `PRTE_SUCCESS` when the broadcast has been *accepted*, not when it completes. |
 | `xcast_nb` | `int (*)(prte_rml_tag_t tag, pmix_data_buffer_t *msg, prte_grpcomm_xcast_complete_fn_t cbfunc, void *cbdata)` | Same as `xcast`, but when `cbfunc != NULL` it fires on the **master** once the whole DVM has confirmed receipt (all ACKs have rolled back up the tree). `cbfunc`/`cbdata` are ignored on non-master daemons. `xcast` is just `xcast_nb(tag, msg, NULL, NULL)`. |
 | `fence` | `int (*)(const pmix_proc_t procs[], size_t nprocs, const pmix_info_t info[], size_t ninfo, char *data, size_t ndata, pmix_modex_cbfunc_t cbfunc, void *cbdata)` | Non-blocking allgather/barrier across the daemons hosting `procs`. Barrier == NULL data. `cbfunc` is invoked with the gathered buffer on completion. Returns `PRTE_SUCCESS` once queued. |
@@ -215,13 +215,20 @@ the framework makes sense:
 - **Non-destructive to the caller's buffer.** `xcast`/`fence` copy the
   payload; the caller keeps ownership of the `pmix_data_buffer_t` it
   passed.
-- **Capability-guarded FT code.** Group fault-tolerance (the
-  `PMIX_GROUP_CANCEL` operation and cancel routing) is compiled only when
-  `#if PRTE_PMIX_HAVE_GROUP_FT`. That macro is defined by
-  `config/prte_setup_pmix.m4` via `PRTE_CHECK_PMIX_CAP([GROUP_FT], …)`,
-  which succeeds when the installed PMIx advertises `PMIX_CAP_GROUP_FT`.
-  Any new group-FT code must live behind that guard, and you must build
-  against a new-enough PMIx (and re-run `autogen.pl`) to exercise it.
+- **Capability-guarded FT code.** Group fault-tolerance — the
+  `PMIX_GROUP_CANCEL` operation and cancel routing, the
+  `PMIX_GROUP_FT_COLLECTIVE` directive, the controller's decision about a
+  construct that lost a member, and the `PMIX_GROUP_MEMBER_FAILED` events —
+  is compiled only when `#if PRTE_PMIX_HAVE_GROUP_FT`. That macro is
+  defined by `config/prte_setup_pmix.m4` via
+  `PRTE_CHECK_PMIX_CAP([GROUP_FT], …)`, which succeeds when the installed
+  PMIx advertises `PMIX_CAP_GROUP_FT`. Any new group-FT code must live
+  behind that guard, and you must build against a new-enough PMIx (and
+  re-run `autogen.pl`) to exercise it.
+  **The wire format is the exception**: the signature's `ft_collective`
+  field is packed and unpacked unguarded, so every daemon in a DVM agrees
+  on the message layout no matter what its PMIx advertised. Guard the
+  *behavior*, never the bytes.
 - **Every entry-point handler owns its caddy/op — release it on *all*
   paths.** `fence`/`group`/`xcast_nb` each allocate a heap object
   (`prte_pmix_fence_caddy_t`, `prte_pmix_grp_caddy_t`, or the xcast `op_t`),

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -324,19 +324,93 @@ Guarded by `PRTE_PMIX_HAVE_GROUP_FT` (from
   The HNP's `grp_recv` (before `get_tracker`, so it never creates a
   spurious cancel tracker) calls `find_construct_op(groupID)` and, if the
   construct is still in flight, `abort_group_op(coll, PMIX_GROUP_CONSTRUCT_ABORT)`.
-- **Participant failure.** `prte_grpcomm_direct_group_fault_handler` runs
-  **only on the HNP, only in the GLOBAL-scope pass** (the global
-  notification carries the consistent `failed_ranks` on every rank). It
-  aborts every in-flight group op that a failed daemon participated in
-  (constructs get `PMIX_GROUP_CONSTRUCT_ABORT`, destructs get
-  `PMIX_SUCCESS` since they are tearing down anyway). An op whose daemon set
-  was never resolved (e.g. a bootstrap) is aborted defensively.
+- **Daemon failure.** See *Surviving a daemon failure* below.
 
 `abort_group_op()` broadcasts a `PRTE_RML_TAG_GROUP_RELEASE` carrying only
 the signature + a completion status; the normal `grp_release` non-success
 path then completes each daemon's local participants with that status and
 deletes the tracker — so a cancel/abort tears down the collective cleanly
 **without tearing down the DVM**, which is the whole point of this work.
+It also sets `coll->aborting`, because the tracker is not deleted until
+that broadcast comes back around.
+
+### Surviving a daemon failure
+
+A daemon failure invalidates every in-flight rollup: `nexpected` is derived
+from the routing tree, and the tree just changed shape. Recovery is a
+**restart**, not a repair — each daemon discards what it has gathered,
+recomputes what the repaired tree owes it, and re-offers the contribution
+it originally made (`coll->my_contribution`, kept for exactly this).
+
+**The epoch.** A file-static `group_epoch` per daemon, stamped on every
+message on `PRTE_RML_TAG_GROUP` as `[epoch][body]`, tells one round from
+the next; a contribution stamped older than the receiver's epoch belongs to
+a round that no longer exists and is dropped before it is merged.
+
+**Why a per-link round does not work here, and why one epoch does.** The
+obvious model is xcast's — `ack_id_down` chosen by the parent, echoed by the
+child. It does not transfer. xcast's payload flows *down*, so the parent
+always holds the op and can re-poll; a group rollup flows *up*, so the
+parent is the party that may hold nothing at all (a pass-through daemon's
+tracker is created lazily, on the first arriving contribution). A round
+cannot invalidate a contribution the parent has **already absorbed** —
+that invalidation has to travel up, and rounds travel down.
+
+What makes a single epoch work is that the restart is *simultaneous*. The
+GLOBAL fault scope reaches every daemon from one broadcast, in the same
+order everywhere, after the tree is repaired. `PRTE_RML_TAG_DAEMON_DIED` is
+in xcast's `process_first` set, so a daemon hands the notice to its own
+delivery before forwarding it, and libevent runs that active event before
+its next round of socket reads — so a daemon has advanced its epoch before
+it can read a contribution from a child that advanced first. A **newer**
+stamp should therefore be unreachable. `grp_recv` handles one anyway, by
+adopting the epoch (which is what the fault notice would have done a moment
+later) and logging it, so the ordering argument stays falsifiable.
+
+**A partial restart is the failure mode to fear**, not a hang: a daemon
+that resets and re-sends into a parent that did not would have its subtree
+counted twice and another subtree not at all — a quietly wrong membership.
+That is why `advance_group_epoch()` walks *every* tracker.
+
+**The policy lives at completion, not in the fault handler.**
+`check_complete()` on the controller decides what a construct that lost a
+member does: complete on the survivors if `sig->ft_collective`, else
+`PMIX_GROUP_CONSTRUCT_ABORT`; abort either way if nothing is left. That is
+the one place with the whole picture, it runs exactly once, and it covers
+an operation whose first contribution had not yet reached the controller
+when the failure landed. The fault handler keeps an early abort purely so
+participants of a doomed construct are not made to wait out a
+re-convergence that can only end that way.
+
+**`ft_collective` means "some *surviving* participant asked for it."** It
+is accumulated by sticky-OR as contributions merge, so a participant that
+requested it and then died before rolling up is not visible. Note this is a
+deliberate superset of PMIx's own rule, which takes the first
+`PMIX_GROUP_FT_COLLECTIVE` in the aggregated block info and ignores the
+rest — do not "fix" it to match.
+
+**Losing a pure relay** — a daemon hosting no member but sitting between
+the controller and one that does — now completes rather than stalling. Its
+`nexpected` falls to zero on the recompute and `check_complete()` fires at
+once. Previously such an op was not "affected" by the handler's test, so it
+was never aborted either, and hung on a count that could never be reached.
+
+**Still aborted, deliberately:** bootstrap operations (no resolved daemon
+set, and `nleaders` is a count with no identities, so there is no way to
+work out how much of one died) and anything in flight across a **revival**
+(`PRTE_RML_TAG_DAEMON_REVIVED` is forward-first by design, so it cannot
+give the ordering an epoch advance needs). The revival path is discriminated
+by LOCAL scope with an empty `failed_ranks`.
+
+Two supporting pieces are worth knowing about. `nreported` is backed by
+`reported_slots`, a bitmap keyed on `prte_rml_get_subtree_index()` of the
+sender, so a replayed contribution is idempotent rather than double-counted
+— the info-list accumulation appends with no key matching, so a
+double-count is also a duplicated payload. And `completed_group_ops` is a
+bounded memo of operations already released, consulted by `grp_recv` so a
+straggler cannot build a tracker nothing will ever complete or delete;
+`group()` clears the matching entry, because a local client starting an
+operation is proof the previous one of that name is over.
 
 ---
 

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -41,8 +41,10 @@ prte_grpcomm_base_module_t prte_grpcomm_direct_module = {
 (`xcast_ops`, `fence_ops`, `group_ops`) and registers **six** persistent
 RML receives: `XCAST`, `XCAST_ACK`, `FENCE`, `FENCE_RELEASE`, `GROUP`,
 `GROUP_RELEASE`. `finalize()` destructs the trackers and cancels the
-receives. `fault_handler()` simply fans the recovery notice out to the
-xcast, fence, and group fault handlers in turn.
+receives. `fault_handler()` fans the recovery notice out to the xcast,
+fence, and group fault handlers in turn — each ends what it cannot
+recover — and then, on the global-scope pass, advances the shared
+`recovery_epoch` once, which restarts everything still in flight.
 
 ---
 
@@ -50,7 +52,9 @@ xcast, fence, and group fault handlers in turn.
 
 - **`prte_grpcomm_direct_component_t`** — the component. Holds
   `xcast_ops` (a `prte_grpcomm_xcast_t`), `fence_ops` (list of
-  `prte_grpcomm_fence_t`), and `group_ops` (list of `prte_grpcomm_group_t`).
+  `prte_grpcomm_fence_t`), `group_ops` (list of `prte_grpcomm_group_t`), a
+  bounded `completed_group_ops` memo, and the `recovery_epoch` that fence
+  and group share.
 - **`prte_grpcomm_xcast_t`** — global xcast state: the `ops` list of
   in-flight broadcasts, a `pending_completions` FIFO of completion
   callbacks awaiting relay-back, and three sequence counters
@@ -192,9 +196,18 @@ Message flow:
 participant. The tracker lives on `component.fence_ops`, keyed by exact
 proc-signature match.
 
-The fence `fault_handler` is currently **not resilient**: a TODO. If any
-fence op is in flight when a daemon fails it activates
-`PRTE_JOB_STATE_COMM_FAILED` (kills the job) rather than repairing.
+The fence `fault_handler` restarts what it can and ends what it cannot.
+A fence whose participants all survive lost only a message path and
+re-converges over the repaired tree at the new recovery epoch — so the
+loss of a pure relay is invisible to it. A fence that genuinely lost a
+participant cannot produce its answer, because an allgather has no
+opt-in to running degraded, so the controller ends that fence with
+`PMIX_ERR_LOST_CONNECTION` via `abort_fence_op()`. Note the difference
+from a group construct, which *can* complete on the survivors when asked:
+a fence has no equivalent of `PMIX_GROUP_FT_COLLECTIVE`.
+
+It shares the recovery epoch and the restart machinery with `group` —
+see *Surviving a daemon failure* below, which describes both.
 
 ---
 
@@ -336,14 +349,18 @@ that broadcast comes back around.
 
 ### Surviving a daemon failure
 
+This applies to **both** fence and group; where they differ is only in what
+they do about a collective that genuinely lost a participant.
+
 A daemon failure invalidates every in-flight rollup: `nexpected` is derived
 from the routing tree, and the tree just changed shape. Recovery is a
 **restart**, not a repair — each daemon discards what it has gathered,
 recomputes what the repaired tree owes it, and re-offers the contribution
 it originally made (`coll->my_contribution`, kept for exactly this).
 
-**The epoch.** A file-static `group_epoch` per daemon, stamped on every
-message on `PRTE_RML_TAG_GROUP` as `[epoch][body]`, tells one round from
+**The epoch.** One `recovery_epoch` per daemon, on the component and shared
+by both collectives, stamped on every message on `PRTE_RML_TAG_GROUP` and
+`PRTE_RML_TAG_FENCE` as `[epoch][body]`, tells one round from
 the next; a contribution stamped older than the receiver's epoch belongs to
 a round that no longer exists and is dropped before it is merged.
 
@@ -442,10 +459,14 @@ operation is proof the previous one of that name is over.
   Note the fault-handler abort loop itself is *unguarded* (it uses only
   status fields and `abort_group_op`), but the `PMIX_GROUP_CANCEL` handling
   is guarded — preserve that split.
-- **The fence fault handler is a known gap.** It kills the job on any
-  in-flight fence when a daemon fails (TODO to make it resilient). If you
-  are adding fence resilience, that is the place — do not weaken it into a
-  silent no-op.
+- **Fence and group share one recovery epoch, advanced in one place.**
+  It lives on the component and is bumped by the framework's own
+  `fault_handler` in `grpcomm_direct.c`, which then restarts both. Do not
+  give a collective its own counter: the restart is only safe because it
+  is simultaneous across the DVM, and two counters racing to advance would
+  break exactly that. A per-collective handler decides what it cannot
+  recover and marks those trackers `aborting`; the shared restart skips
+  them.
 - **Free every allocation the handler still owns before it returns.** The
   entry-point handlers (`begin_xcast`, `fence`, `group`) own the caddy/op
   they were thread-shifted; the recv handlers own the info arrays / darrays

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -209,6 +209,16 @@ a fence has no equivalent of `PMIX_GROUP_FT_COLLECTIVE`.
 It shares the recovery epoch and the restart machinery with `group` —
 see *Surviving a daemon failure* below, which describes both.
 
+**Only a fence that was in flight when the failure landed is ended.** A
+fence *started afterwards* completes among the survivors, because
+`prte_rml_get_num_contributors()` skips the failed daemons when the
+tracker is built. That is deliberate, and it is the opposite of where the
+group policy sits (at completion, in `check_complete`). The reason is
+that the failed-daemon set is permanent: applying the test at completion
+would make every later fence naming that namespace fail for the life of
+the DVM, which would leave a recoverable job unable to fence at all after
+its first loss. If you move this check, that is the regression to expect.
+
 ---
 
 ## `group` — PMIx group operations (`grpcomm_direct_group.c`)

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -107,9 +107,103 @@ static void finalize(void)
     return;
 }
 
+bool prte_grpcomm_direct_proc_departed(const pmix_proc_t *proc)
+{
+    prte_job_t *jdata;
+    prte_proc_t *p;
+
+    if (PMIX_RANK_WILDCARD == proc->rank || PMIX_RANK_INVALID == proc->rank) {
+        return false;
+    }
+    if (pmix_bitmap_is_clear(&prte_rml_base.failed_dmns)) {
+        /* nothing has failed, so nothing can have departed - and this keeps
+         * the common, fault-free path from walking the job map at all */
+        return false;
+    }
+    jdata = prte_get_job_data_object(proc->nspace);
+    if (NULL == jdata) {
+        return true;
+    }
+    p = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, proc->rank);
+    if (NULL == p || NULL == p->node || NULL == p->node->daemon) {
+        /* we cannot place it any more, which is what a node being torn down
+         * looks like - treat it as gone rather than as an error */
+        return true;
+    }
+    return pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns,
+                                  p->node->daemon->name.rank);
+}
+
+bool prte_grpcomm_direct_procs_lost(const pmix_proc_t *procs, size_t nprocs)
+{
+    prte_job_t *jdata;
+    prte_proc_t *p;
+    size_t n;
+    int i;
+
+    if (pmix_bitmap_is_clear(&prte_rml_base.failed_dmns)) {
+        return false;
+    }
+    for (n = 0; n < nprocs; n++) {
+        if (PMIX_RANK_WILDCARD != procs[n].rank) {
+            if (prte_grpcomm_direct_proc_departed(&procs[n])) {
+                return true;
+            }
+            continue;
+        }
+        /* a wildcard names the whole namespace, so ask whether any of it was
+         * on a failed daemon. Skipping these would quietly excuse a
+         * collective whose membership is written as a namespace - which is
+         * the common spelling - from noticing it lost anyone at all. */
+        jdata = prte_get_job_data_object(procs[n].nspace);
+        if (NULL == jdata) {
+            return true;
+        }
+        for (i = 0; i < jdata->procs->size; i++) {
+            p = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, i);
+            if (NULL == p || NULL == p->node || NULL == p->node->daemon) {
+                continue;
+            }
+            if (pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns,
+                                       p->node->daemon->name.rank)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void prte_grpcomm_direct_advance_epoch(uint32_t to)
+{
+    if (to <= prte_mca_grpcomm_direct_component.recovery_epoch) {
+        return;
+    }
+    prte_mca_grpcomm_direct_component.recovery_epoch = to;
+
+    pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                        "%s grpcomm:direct restarting collectives at epoch %u",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) to);
+
+    prte_grpcomm_direct_fence_restart();
+    prte_grpcomm_direct_group_restart();
+}
+
 static void fault_handler(const prte_rml_recovery_status_t* status)
 {
     prte_grpcomm_direct_xcast_fault_handler(status);
+    /* Each collective first decides what it cannot recover and fails that
+     * outright, marking those trackers so the restart below leaves them
+     * alone... */
     prte_grpcomm_direct_fence_fault_handler(status);
     prte_grpcomm_direct_group_fault_handler(status);
+    /* ...then everything still in flight restarts together. The restart has
+     * to be DVM-wide and simultaneous: a daemon that resets and re-sends into
+     * a parent that did not would have its subtree counted twice and another
+     * not at all, which is a quietly wrong result rather than a hang. The
+     * global scope is what provides that - one broadcast, same order
+     * everywhere, after the routing tree has been repaired. */
+    if (PRTE_RML_FAULT_SCOPE_GLOBAL == status->scope) {
+        prte_grpcomm_direct_advance_epoch(
+            prte_mca_grpcomm_direct_component.recovery_epoch + 1);
+    }
 }

--- a/src/mca/grpcomm/direct/grpcomm_direct.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct.c
@@ -64,6 +64,7 @@ static int init(void)
                    prte_grpcomm_xcast_t);
     PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
     PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.group_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.completed_group_ops, pmix_list_t);
 
     /* xcast receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST,
@@ -95,6 +96,7 @@ static void finalize(void)
     PMIX_DESTRUCT(&prte_mca_grpcomm_direct_component.xcast_ops);
     PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.fence_ops);
     PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.group_ops);
+    PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.completed_group_ops);
 
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST_ACK);

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -60,6 +60,14 @@ typedef struct {
     // as the first contribution to a brand-new operation and build a tracker
     // that nothing will ever complete or delete.
     pmix_list_t completed_group_ops;
+    // The collective recovery epoch for this daemon. A daemon failure
+    // invalidates every in-flight rollup, because how many contributions each
+    // daemon expects is derived from the routing tree. Recovery is a
+    // simultaneous restart across the DVM, and this counter is what tells one
+    // round from the next, so a contribution still in flight from before the
+    // failure can be recognized as stale. Shared by fence and group: one
+    // failure, one restart, one epoch.
+    uint32_t recovery_epoch;
 } prte_grpcomm_direct_component_t;
 
 #define PRTE_GRPCOMM_GROUP_MEMO_MAX 64
@@ -71,9 +79,25 @@ typedef struct {
 } prte_grpcomm_group_memo_t;
 PMIX_CLASS_DECLARATION(prte_grpcomm_group_memo_t);
 
-/* Exported for the unit test: was this member hosted by a daemon that has
- * since failed? */
-PRTE_MODULE_EXPORT bool prte_grpcomm_direct_group_member_departed(const pmix_proc_t *member);
+/* Was this process hosted by a daemon that has since failed? A wildcard rank
+ * names a whole namespace rather than one process and so is never answered
+ * here - use prte_grpcomm_direct_procs_lost() for a set that may contain one.
+ * Exported so the unit test can drive it against a synthetic failed set. */
+PRTE_MODULE_EXPORT bool prte_grpcomm_direct_proc_departed(const pmix_proc_t *proc);
+
+/* Did this set of participants lose anyone to a failed daemon? Unlike the
+ * single-process test, a wildcard entry is expanded through the job map, so
+ * a collective whose membership is written as a whole namespace is answered
+ * correctly. */
+PRTE_MODULE_EXPORT bool prte_grpcomm_direct_procs_lost(const pmix_proc_t *procs, size_t nprocs);
+
+/* Advance the recovery epoch and restart every in-flight collective at it.
+ * Idempotent: an epoch at or below the current one does nothing. */
+PRTE_MODULE_EXPORT void prte_grpcomm_direct_advance_epoch(uint32_t to);
+
+/* Per-collective halves of the restart, called only by the above. */
+void prte_grpcomm_direct_group_restart(void);
+void prte_grpcomm_direct_fence_restart(void);
 
 PRTE_MODULE_EXPORT extern prte_grpcomm_direct_component_t prte_mca_grpcomm_direct_component;
 extern prte_grpcomm_base_module_t prte_grpcomm_direct_module;
@@ -134,6 +158,15 @@ typedef struct {
     size_t nexpected;
     /* number reported in */
     size_t nreported;
+    // Which child subtrees have reported, keyed the same way the group
+    // tracker does it - see the note there. A fence replays its
+    // contributions on a fault too, so the same duplicate-proofing applies.
+    pmix_bitmap_t reported_slots;
+    bool self_reported;
+    bool converged;
+    bool aborting;
+    // this daemon's own contribution, saved so a fault can replay it
+    pmix_data_buffer_t *my_contribution;
     /* controls values */
     int timeout;
     /* callback function */

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -71,6 +71,10 @@ typedef struct {
 } prte_grpcomm_group_memo_t;
 PMIX_CLASS_DECLARATION(prte_grpcomm_group_memo_t);
 
+/* Exported for the unit test: was this member hosted by a daemon that has
+ * since failed? */
+PRTE_MODULE_EXPORT bool prte_grpcomm_direct_group_member_departed(const pmix_proc_t *member);
+
 PRTE_MODULE_EXPORT extern prte_grpcomm_direct_component_t prte_mca_grpcomm_direct_component;
 extern prte_grpcomm_base_module_t prte_grpcomm_direct_module;
 
@@ -102,6 +106,12 @@ typedef struct {
     size_t naddmembers;
     pmix_proc_t *final_order;
     size_t nfinal;
+    // Set when a participant asked for PMIX_GROUP_FT_COLLECTIVE: a construct
+    // that loses a member should complete on the survivors rather than abort.
+    // Accumulated by sticky-OR as contributions merge, so it means "some
+    // surviving participant asked for it" - a participant that requested it
+    // and then died before its contribution rolled up cannot be seen here.
+    bool ft_collective;
 } prte_grpcomm_direct_group_signature_t;
 PRTE_MODULE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_direct_group_signature_t);
 
@@ -189,6 +199,15 @@ typedef struct {
     // its participants instead of hanging them
     prte_event_t tev;
     bool tev_active;
+    // This daemon's own contribution, kept so a fault can replay it: recovery
+    // resets every tracker and each daemon re-injects what it originally
+    // contributed. NULL on a daemon that is only relaying for its subtree.
+    pmix_data_buffer_t *my_contribution;
+    // Members lost with a failed daemon, filled in by the controller when a
+    // fault-tolerant construct completes on the survivors, and carried in the
+    // release so each daemon can tell its own clients who went missing.
+    pmix_proc_t *departed;
+    size_t ndeparted;
     void *grpinfo;  // info list of group info
     void *endpts;   // info list of endpts
     /* callback function */

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -18,6 +18,8 @@
 
 #include "prte_config.h"
 
+#include "src/class/pmix_bitmap.h"
+
 #include "src/mca/grpcomm/grpcomm.h"
 
 BEGIN_C_DECLS
@@ -51,7 +53,23 @@ typedef struct {
     pmix_list_t fence_ops;
     // track ongoiong group operations - list of prte_grpcomm_group_t
     pmix_list_t group_ops;
+    // A short memory of group operations we have already released - list of
+    // prte_grpcomm_group_memo_t, capped at PRTE_GRPCOMM_GROUP_MEMO_MAX. A
+    // contribution can arrive after the release that retired its tracker has
+    // already been processed here; without this, get_tracker() would take it
+    // as the first contribution to a brand-new operation and build a tracker
+    // that nothing will ever complete or delete.
+    pmix_list_t completed_group_ops;
 } prte_grpcomm_direct_component_t;
+
+#define PRTE_GRPCOMM_GROUP_MEMO_MAX 64
+
+typedef struct {
+    pmix_list_item_t super;
+    char *groupID;
+    pmix_group_operation_t op;
+} prte_grpcomm_group_memo_t;
+PMIX_CLASS_DECLARATION(prte_grpcomm_group_memo_t);
 
 PRTE_MODULE_EXPORT extern prte_grpcomm_direct_component_t prte_mca_grpcomm_direct_component;
 extern prte_grpcomm_base_module_t prte_grpcomm_direct_module;
@@ -126,14 +144,28 @@ typedef struct {
     pmix_rank_t *dmns;
     /** number of participating daemons */
     size_t ndmns;
-    /** my index in the dmns array */
-    unsigned long my_rank;
     /* type of collective */
     bool bootstrap;
 
     /*** NON-BOOTSTRAP TRACKERS ***/
     size_t nexpected;  // number of buckets expected
     size_t nreported;  // number reported in
+    // A contribution is identified by which of our routing-tree child
+    // subtrees it arrived from, not merely counted: a bare counter cannot
+    // tell two messages from one child apart from one message from each of
+    // two, which is exactly what a replay after a fault produces. The slot
+    // index is prte_rml_get_subtree_index() of the sender, the same mapping
+    // prte_rml_get_num_contributors() uses to compute nexpected, so the two
+    // agree by construction. Our own contribution has no subtree index and
+    // is tracked separately.
+    pmix_bitmap_t reported_slots;
+    bool self_reported;
+    // set once the rollup has been answered (released by the controller, or
+    // rolled up to our parent) so a straggler cannot drive it a second time
+    bool converged;
+    // set when an abort has been broadcast for this op but the tracker has
+    // not yet been deleted by the returning release
+    bool aborting;
 
     /*** BOOTSTRAP TRACKERS ***/
     // "leaders" are group members reporting as
@@ -151,9 +183,12 @@ typedef struct {
     size_t nfollowers_reported;  // number reported in
 
     /* controls values */
-    bool assignID;
     int timeout;
-    size_t memsize;
+    // the controller arms a timer for "timeout" seconds once a participant
+    // has asked for one, so a collective that can no longer converge fails
+    // its participants instead of hanging them
+    prte_event_t tev;
+    bool tev_active;
     void *grpinfo;  // info list of group info
     void *endpts;   // info list of endpts
     /* callback function */

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -85,6 +85,7 @@ static void sgcon(prte_grpcomm_direct_group_signature_t *p)
     p->naddmembers = 0;
     p->final_order = NULL;
     p->nfinal = 0;
+    p->ft_collective = false;
 }
 static void sgdes(prte_grpcomm_direct_group_signature_t *p)
 {
@@ -155,6 +156,9 @@ static void gccon(prte_grpcomm_group_t *p)
     p->aborting = false;
     p->timeout = 0;
     p->tev_active = false;
+    p->my_contribution = NULL;
+    p->departed = NULL;
+    p->ndeparted = 0;
     p->grpinfo = PMIx_Info_list_start();
     p->endpts = PMIx_Info_list_start();
     p->cbfunc = NULL;
@@ -167,6 +171,12 @@ static void gcdes(prte_grpcomm_group_t *p)
         p->tev_active = false;
     }
     PMIX_DESTRUCT(&p->reported_slots);
+    if (NULL != p->my_contribution) {
+        PMIX_DATA_BUFFER_RELEASE(p->my_contribution);
+    }
+    if (NULL != p->departed) {
+        PMIX_PROC_FREE(p->departed, p->ndeparted);
+    }
     if (NULL != p->sig) {
         PMIX_RELEASE(p->sig);
     }

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -115,6 +115,12 @@ static void ccon(prte_grpcomm_fence_t *p)
     p->ndmns = 0;
     p->nexpected = 0;
     p->nreported = 0;
+    PMIX_CONSTRUCT(&p->reported_slots, pmix_bitmap_t);
+    pmix_bitmap_init(&p->reported_slots, 1);
+    p->self_reported = false;
+    p->converged = false;
+    p->aborting = false;
+    p->my_contribution = NULL;
     p->timeout = 0;
     p->cbfunc = NULL;
     p->cbdata = NULL;
@@ -123,6 +129,10 @@ static void cdes(prte_grpcomm_fence_t *p)
 {
     if (NULL != p->sig) {
         PMIX_RELEASE(p->sig);
+    }
+    PMIX_DESTRUCT(&p->reported_slots);
+    if (NULL != p->my_contribution) {
+        PMIX_DATA_BUFFER_RELEASE(p->my_contribution);
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->bucket);
     if (NULL != p->dmns) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -146,9 +146,15 @@ static void gccon(prte_grpcomm_group_t *p)
     p->nleaders_reported = 0;
     p->nfollowers = 0;
     p->nfollowers_reported = 0;
-    p->assignID = false;
+    /* the bitmap grows on demand as slots are set, so size it minimally
+     * here - a tracker can be constructed with no routing tree in place */
+    PMIX_CONSTRUCT(&p->reported_slots, pmix_bitmap_t);
+    pmix_bitmap_init(&p->reported_slots, 1);
+    p->self_reported = false;
+    p->converged = false;
+    p->aborting = false;
     p->timeout = 0;
-    p->memsize = 0;
+    p->tev_active = false;
     p->grpinfo = PMIx_Info_list_start();
     p->endpts = PMIx_Info_list_start();
     p->cbfunc = NULL;
@@ -156,6 +162,11 @@ static void gccon(prte_grpcomm_group_t *p)
 }
 static void gcdes(prte_grpcomm_group_t *p)
 {
+    if (p->tev_active) {
+        prte_event_del(&p->tev);
+        p->tev_active = false;
+    }
+    PMIX_DESTRUCT(&p->reported_slots);
     if (NULL != p->sig) {
         PMIX_RELEASE(p->sig);
     }
@@ -168,6 +179,21 @@ static void gcdes(prte_grpcomm_group_t *p)
 PMIX_CLASS_INSTANCE(prte_grpcomm_group_t,
                     pmix_list_item_t,
                     gccon, gcdes);
+
+static void memocon(prte_grpcomm_group_memo_t *p)
+{
+    p->groupID = NULL;
+    p->op = PMIX_GROUP_NONE;
+}
+static void memodes(prte_grpcomm_group_memo_t *p)
+{
+    if (NULL != p->groupID) {
+        free(p->groupID);
+    }
+}
+PMIX_CLASS_INSTANCE(prte_grpcomm_group_memo_t,
+                    pmix_list_item_t,
+                    memocon, memodes);
 
 static void mdcon(prte_pmix_fence_caddy_t *p)
 {

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -97,6 +97,9 @@ static void sgdes(prte_grpcomm_direct_group_signature_t *p)
     if (NULL != p->addmembers) {
         free(p->addmembers);
     }
+    if (NULL != p->final_order) {
+        PMIX_PROC_FREE(p->final_order, p->nfinal);
+    }
 }
 PMIX_CLASS_INSTANCE(prte_grpcomm_direct_group_signature_t,
                     pmix_object_t,

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -321,8 +321,10 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
                 return;
             }
 
-            /* send the release via xcast */
+            /* send the release via xcast - it copies the payload, so the
+             * buffer is still ours to free */
             (void) prte_grpcomm.xcast(PRTE_RML_TAG_FENCE_RELEASE, reply);
+            PMIX_DATA_BUFFER_RELEASE(reply);
         } else {
             PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                                  "%s grpcomm:direct fence rollup complete - sending to %s",

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -783,6 +783,13 @@ static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
     size_t nds = 0;
     pmix_rank_t *dns = NULL;
     int rc = PRTE_SUCCESS;
+    /* Once the DVM has known failures, a participant we cannot resolve is
+     * most likely one whose node is being torn down. Refusing to resolve the
+     * whole set would strand the fence, because the caller drops the
+     * contribution with no completion path - so skip what we cannot place and
+     * carry on. With nothing failed, an unresolvable participant is still a
+     * genuine error and still fatal. */
+    bool tolerate = !pmix_bitmap_is_clear(&prte_rml_base.failed_dmns);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct:fence:create_dmns called with %s signature size %" PRIsize_t "",
@@ -828,6 +835,9 @@ static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
                     continue;
                 }
                 if (NULL == node->daemon) {
+                    if (tolerate) {
+                        continue;
+                    }
                     PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                     rc = PRTE_ERR_NOT_FOUND;
                     goto done;
@@ -859,11 +869,17 @@ static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
             proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs,
                                                                sig->signature[n].rank);
             if (NULL == proc) {
+                if (tolerate) {
+                    continue;
+                }
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                 rc = PRTE_ERR_NOT_FOUND;
                 goto done;
             }
             if (NULL == proc->node || NULL == proc->node->daemon) {
+                if (tolerate) {
+                    continue;
+                }
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                 rc = PRTE_ERR_NOT_FOUND;
                 goto done;

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -47,6 +47,7 @@ static int fence_sig_pack(pmix_data_buffer_t *bkt,
                           prte_grpcomm_direct_fence_signature_t *sig);
 static int fence_sig_unpack(pmix_data_buffer_t *buffer,
                             prte_grpcomm_direct_fence_signature_t **sig);
+static void check_complete(prte_grpcomm_fence_t *coll);
 
 int prte_grpcomm_direct_fence(const pmix_proc_t procs[], size_t nprocs,
                               const pmix_info_t info[], size_t ninfo, char *data,
@@ -81,17 +82,171 @@ int prte_grpcomm_direct_fence(const pmix_proc_t procs[], size_t nprocs,
     return PRTE_SUCCESS;
 }
 
+/* Frame a contribution with the current recovery epoch. The body is copied,
+ * not consumed, so the caller keeps ownership of it. */
+static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Data_pack(NULL, framed,
+                        &prte_mca_grpcomm_direct_component.recovery_epoch, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    rc = PMIx_Data_copy_payload(framed, body);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    return PRTE_SUCCESS;
+}
+
+/* End an in-flight fence that cannot complete correctly, without taking
+ * anything else down with it. Only the controller calls this: it broadcasts a
+ * release carrying the signature and a status but no gathered data, which the
+ * normal release path hands to each daemon's local participants. */
+static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st)
+{
+    pmix_data_buffer_t *reply;
+    pmix_status_t rc;
+
+    PMIX_DATA_BUFFER_CREATE(reply);
+    rc = fence_sig_pack(reply, coll->sig);
+    if (PMIX_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    /* xcast copies the payload, so the buffer is still ours to free */
+    (void) prte_grpcomm.xcast(PRTE_RML_TAG_FENCE_RELEASE, reply);
+    PMIX_DATA_BUFFER_RELEASE(reply);
+    /* the tracker goes when that release comes back around */
+    coll->aborting = true;
+}
+
+void prte_grpcomm_direct_fence_restart(void)
+{
+    prte_grpcomm_fence_t *coll, *nxt;
+    pmix_data_buffer_t *framed;
+    size_t n;
+    int rc;
+
+    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
+                           prte_grpcomm_fence_t) {
+        if (coll->aborting) {
+            continue;
+        }
+
+        /* throw away everything gathered under the old tree */
+        pmix_bitmap_clear_all_bits(&coll->reported_slots);
+        coll->self_reported = false;
+        coll->nreported = 0;
+        coll->converged = false;
+        PMIX_DATA_BUFFER_DESTRUCT(&coll->bucket);
+        PMIX_DATA_BUFFER_CONSTRUCT(&coll->bucket);
+
+        /* recompute what the repaired tree owes us - dmns stays the full
+         * pre-fault set, and get_num_contributors() already skips the daemons
+         * now known to have failed */
+        coll->nexpected = prte_rml_get_num_contributors(coll->dmns, coll->ndmns);
+        for (n = 0; n < coll->ndmns; n++) {
+            if (coll->dmns[n] == PRTE_PROC_MY_NAME->rank) {
+                coll->nexpected++;
+                break;
+            }
+        }
+
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct:fence restarting at epoch %u, "
+                             "nexpected now %d",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             (unsigned) prte_mca_grpcomm_direct_component.recovery_epoch,
+                             (int) coll->nexpected));
+
+        if (NULL == coll->my_contribution) {
+            /* nothing of our own to re-offer - we are relaying for our
+             * subtree. If that subtree has just gone, nexpected is now zero
+             * and this completes on the spot, which is what stops the loss of
+             * a pure relay from stalling the fence */
+            check_complete(coll);
+            continue;
+        }
+
+        PMIX_DATA_BUFFER_CREATE(framed);
+        rc = pack_epoch_frame(framed, coll->my_contribution);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            continue;
+        }
+        PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed, PRTE_RML_TAG_FENCE);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(framed);
+        }
+    }
+}
+
+/* A fence is an allgather with no opt-in to running degraded: its result is
+ * every participant's contribution, so losing one means the answer cannot be
+ * produced. That is why this differs from the group handler, which can
+ * complete on the survivors when asked to.
+ *
+ * What it must not do is what it used to: kill the job on *any* daemon loss
+ * while *any* fence was in flight, without even asking whether the two had
+ * anything to do with each other. Fences run constantly, so that made an
+ * unrelated daemon failure fatal to bystanders - and because it had no scope
+ * guard it also fired twice per failure and once on every revival, taking a
+ * job down over a daemon that had just come back. */
 void prte_grpcomm_direct_fence_fault_handler(const prte_rml_recovery_status_t* status)
 {
-    PRTE_HIDE_UNUSED_PARAMS(status);
-    /* TODO: make this actually resilient
-     * For now, we'll just kill the job if any ops are active */
-    if(0 < pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops)){
-        PMIX_OUTPUT_VERBOSE((0, prte_grpcomm_base_framework.framework_output,
-                             "%s grpcomm:direct:fence daemon failed during"
-                             " active fence operation(s)",
+    prte_grpcomm_fence_t *coll, *nxt;
+
+    if (0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops)) {
+        return;
+    }
+
+    if (PRTE_RML_FAULT_SCOPE_GLOBAL != status->scope) {
+        /* A revival arrives here: local scope with no failed ranks, since a
+         * death's local pass returns early when it has nothing new. A revival
+         * reshapes the tree as a death does, but it rides a forward-first
+         * broadcast, so it cannot give the parent-before-child ordering a
+         * restart depends on - end the fences instead. */
+        if (PRTE_PROC_IS_MASTER && 0 == status->failed_ranks.size) {
+            PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
+                                   prte_grpcomm_fence_t) {
+                if (!coll->aborting) {
+                    abort_fence_op(coll, PMIX_ERR_LOST_CONNECTION);
+                }
+            }
+        }
+        return;
+    }
+
+    if (!PRTE_PROC_IS_MASTER) {
+        return;
+    }
+    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
+                           prte_grpcomm_fence_t) {
+        if (coll->aborting) {
+            continue;
+        }
+        if (!prte_grpcomm_direct_procs_lost(coll->sig->signature, coll->sig->sz)) {
+            /* only the paths between us changed - the restart driven by the
+             * component's epoch advance re-converges this one */
+            continue;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct:fence ending a fence that lost a "
+                             "participant to a failed daemon",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
+        abort_fence_op(coll, PMIX_ERR_LOST_CONNECTION);
     }
 }
 
@@ -101,7 +256,7 @@ static void fence(int sd, short args, void *cbdata)
     prte_grpcomm_direct_fence_signature_t sig;
     prte_grpcomm_fence_t *coll;
     int rc;
-    pmix_data_buffer_t *relay, bkt;
+    pmix_data_buffer_t *relay, *framed, bkt;
     pmix_byte_object_t bo;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -173,12 +328,39 @@ static void fence(int sd, short args, void *cbdata)
         return;
     }
 
+    /* Keep our own contribution so a fault can replay it: recovery resets
+     * every tracker and has each daemon re-offer what it originally gave.
+     * PRTE_RML_SEND takes ownership of what we hand it, so this is a copy. */
+    if (NULL != coll->my_contribution) {
+        PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
+    }
+    PMIX_DATA_BUFFER_CREATE(coll->my_contribution);
+    rc = PMIx_Data_copy_payload(coll->my_contribution, relay);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
+        coll->my_contribution = NULL;
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    /* stamp it with the current epoch and send that */
+    PMIX_DATA_BUFFER_CREATE(framed);
+    rc = pack_epoch_frame(framed, relay);
+    PMIX_DATA_BUFFER_RELEASE(relay);
+    if (PRTE_SUCCESS != rc) {
+        PMIX_DATA_BUFFER_RELEASE(framed);
+        PMIX_RELEASE(cd);
+        return;
+    }
+
     /* send this to ourselves for processing */
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct:fence sending to ourself",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
-    PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, relay,
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed,
                   PRTE_RML_TAG_FENCE);
     PMIX_RELEASE(cd);
     return;
@@ -189,12 +371,12 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
                                     prte_rml_tag_t tag, void *cbdata)
 {
     int32_t cnt;
-    int rc, timeout;
+    int rc, timeout, slot;
+    uint32_t stamp;
     size_t n, ninfo;
     pmix_status_t st;
     pmix_info_t *info = NULL;
     prte_grpcomm_direct_fence_signature_t *sig = NULL;
-    pmix_data_buffer_t *reply;
     prte_grpcomm_fence_t *coll;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
@@ -202,6 +384,30 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
                          "%s grpcomm:direct fence recvd from %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          PRTE_NAME_PRINT(sender)));
+
+    /* every message on this tag opens with the sender's recovery epoch */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &stamp, &cnt, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (stamp < prte_mca_grpcomm_direct_component.recovery_epoch) {
+        /* sent before a failure this daemon has already recovered from, so it
+         * belongs to a round that no longer exists */
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct fence stale epoch %u (at %u) - dropping",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) stamp,
+                             (unsigned) prte_mca_grpcomm_direct_component.recovery_epoch));
+        return;
+    }
+    if (stamp > prte_mca_grpcomm_direct_component.recovery_epoch) {
+        /* should be unreachable - see the recovery_epoch commentary in
+         * grpcomm_direct.h - but adopting it is what our own fault notice
+         * would do a moment later, so do that rather than lose the message */
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_ORDER_MSG);
+        prte_grpcomm_direct_advance_epoch(stamp);
+    }
 
     /* unpack the signature */
     rc = fence_sig_unpack(buffer, &sig);
@@ -218,6 +424,30 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
         return;
     }
     PMIX_RELEASE(sig);
+
+    /* Account for this contribution by which child subtree it came from, and
+     * drop it whole if that subtree has already been heard from - see the
+     * matching note in the group path. This has to happen before the bucket
+     * is merged, because a contribution counted twice is data merged twice. */
+    if (sender->rank == PRTE_PROC_MY_NAME->rank) {
+        if (coll->self_reported) {
+            return;
+        }
+        coll->self_reported = true;
+    } else {
+        slot = prte_rml_get_subtree_index(sender->rank);
+        if (0 > slot) {
+            /* not in any of our subtrees - we are not this daemon's parent,
+             * so this contribution is not ours to aggregate */
+            PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            return;
+        }
+        if (pmix_bitmap_is_set_bit(&coll->reported_slots, slot)) {
+            return;
+        }
+        pmix_bitmap_set_bit(&coll->reported_slots, slot);
+    }
+    coll->nreported++;
 
     // unpack the info structs
     cnt = 1;
@@ -270,116 +500,148 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
         }
     }
 
-    /* increment nprocs reported for collective */
-    coll->nreported++;
-
-    // transfer any data
+    /* transfer any data */
     rc = PMIx_Data_copy_payload(&coll->bucket, buffer);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_INFO_FREE(info, ninfo);
         return;
     }
+    PMIX_INFO_FREE(info, ninfo);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct fence recv nexpected %d nrep %d",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) coll->nexpected,
                          (int) coll->nreported));
 
-    /* see if everyone has reported */
-    if (coll->nreported == coll->nexpected) {
-        if (PRTE_PROC_IS_MASTER) {
-            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                                 "%s grpcomm:direct fence HNP reports complete",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            /* the allgather is complete - send the xcast */
-            PMIX_DATA_BUFFER_CREATE(reply);
+    check_complete(coll);
+}
 
-            /* pack the signature */
-            rc = fence_sig_pack(reply, coll->sig);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_INFO_FREE(info, ninfo);
-                return;
-            }
-            /* pack the status */
-            rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_INT32);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_INFO_FREE(info, ninfo);
-                return;
-            }
+/* Test whether this fence's rollup is complete and, if so, answer it: the
+ * controller broadcasts the release, everyone else rolls their bucket up to
+ * their parent. Factored out of fence_recv() because a contribution arriving
+ * is no longer the only thing that can complete a fence - a fault can lower
+ * what we are waiting for, and the tracker has to be re-tested with no
+ * message in hand.
+ *
+ * The info array forwarded upward is rebuilt from the tracker's own merged
+ * state rather than echoed from whichever contribution happened to arrive
+ * last. Only the timeout and the local collective status are ever read out of
+ * it, and both are accumulated on the tracker, so this says the same thing
+ * without depending on a message being present. */
+static void check_complete(prte_grpcomm_fence_t *coll)
+{
+    pmix_data_buffer_t *reply, *framed;
+    pmix_info_t *info = NULL;
+    size_t ninfo = 0;
+    int rc;
 
-            /* transfer the collected bucket */
-            rc = PMIx_Data_copy_payload(reply, &coll->bucket);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_INFO_FREE(info, ninfo);
-                return;
-            }
+    if (coll->converged || coll->aborting) {
+        return;
+    }
+    if (coll->nreported < coll->nexpected) {
+        return;
+    }
+    coll->converged = true;
 
-            /* send the release via xcast - it copies the payload, so the
-             * buffer is still ours to free */
-            (void) prte_grpcomm.xcast(PRTE_RML_TAG_FENCE_RELEASE, reply);
+    if (PRTE_PROC_IS_MASTER) {
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct fence HNP reports complete",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        PMIX_DATA_BUFFER_CREATE(reply);
+        rc = fence_sig_pack(reply, coll->sig);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
-        } else {
-            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                                 "%s grpcomm:direct fence rollup complete - sending to %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_PARENT)));
-            PMIX_DATA_BUFFER_CREATE(reply);
-            /* pack the signature */
-            rc = fence_sig_pack(reply, coll->sig);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_INFO_FREE(info, ninfo);
-                return;
-            }
+            return;
+        }
+        rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_INT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+        rc = PMIx_Data_copy_payload(reply, &coll->bucket);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+        /* xcast copies the payload, so the buffer is still ours to free */
+        (void) prte_grpcomm.xcast(PRTE_RML_TAG_FENCE_RELEASE, reply);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
 
-            // pack the info structs
-            rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_INFO_FREE(info, ninfo);
-                return;
-            }
-            if (0 < ninfo) {
-                rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_INFO_FREE(info, ninfo);
-                    return;
-                }
-            }
-            PMIX_INFO_FREE(info, ninfo);
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                         "%s grpcomm:direct fence rollup complete - sending to %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_PARENT)));
 
-            /* transfer the collected bucket */
-            rc = PMIx_Data_copy_payload(reply, &coll->bucket);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
-            }
-            /* send the info to our parent */
-            PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, reply,
-                          PRTE_RML_TAG_FENCE);
-            if (PRTE_SUCCESS != rc) {
-                PRTE_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
-            }
+    PMIX_DATA_BUFFER_CREATE(reply);
+    rc = fence_sig_pack(reply, coll->sig);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+
+    /* rebuild the directives we accumulated */
+    if (0 < coll->timeout) {
+        ++ninfo;
+    }
+    if (PMIX_SUCCESS != coll->status) {
+        ++ninfo;
+    }
+    if (0 < ninfo) {
+        size_t idx = 0;
+        PMIX_INFO_CREATE(info, ninfo);
+        if (0 < coll->timeout) {
+            PMIX_INFO_LOAD(&info[idx++], PMIX_TIMEOUT, &coll->timeout, PMIX_INT);
+        }
+        if (PMIX_SUCCESS != coll->status) {
+            PMIX_INFO_LOAD(&info[idx++], PMIX_LOCAL_COLLECTIVE_STATUS,
+                           &coll->status, PMIX_STATUS);
         }
     }
-    /* free the unpacked info.  The non-HNP rollup path above already freed and
-     * NULLed it before forwarding; on the HNP-complete path and on every
-     * intermediate (not-yet-complete) contribution it is still live here.
-     * PMIX_INFO_FREE is a no-op on a NULL pointer, so this covers all of them
-     * without double-freeing. */
-    PMIX_INFO_FREE(info, ninfo);
+    rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_INFO_FREE(info, ninfo);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    if (0 < ninfo) {
+        rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+        PMIX_INFO_FREE(info, ninfo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+    }
+
+    rc = PMIx_Data_copy_payload(reply, &coll->bucket);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+
+    /* stamp it with the epoch it belongs to, so a parent that has already
+     * recovered past it can tell it is stale */
+    PMIX_DATA_BUFFER_CREATE(framed);
+    rc = pack_epoch_frame(framed, reply);
+    PMIX_DATA_BUFFER_RELEASE(reply);
+    if (PRTE_SUCCESS != rc) {
+        PMIX_DATA_BUFFER_RELEASE(framed);
+        return;
+    }
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, framed, PRTE_RML_TAG_FENCE);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(framed);
+    }
 }
 
 static void relcb(void *cbdata)
@@ -430,10 +692,12 @@ void prte_grpcomm_direct_fence_release(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* unload the buffer */
+    /* unload the buffer. An aborted fence carries no gathered data, so an
+     * empty or unreadable payload is expected there - do not let that
+     * overwrite the status the controller sent, which is the whole message. */
     PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
     rc = PMIx_Data_unload(buffer, &bo);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_SUCCESS != rc && PMIX_SUCCESS == ret) {
         ret = rc;
     }
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -425,15 +425,16 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
     }
     PMIX_RELEASE(sig);
 
-    /* Account for this contribution by which child subtree it came from, and
-     * drop it whole if that subtree has already been heard from - see the
-     * matching note in the group path. This has to happen before the bucket
-     * is merged, because a contribution counted twice is data merged twice. */
+    /* Identify which child subtree this came from, and drop it whole if that
+     * subtree has already been heard from - see the matching note in the group
+     * path. Only the *test* happens here: the accounting is committed below,
+     * once the message has parsed, so a truncated one cannot leave a subtree
+     * counted with none of its data merged. */
+    slot = -1;
     if (sender->rank == PRTE_PROC_MY_NAME->rank) {
         if (coll->self_reported) {
             return;
         }
-        coll->self_reported = true;
     } else {
         slot = prte_rml_get_subtree_index(sender->rank);
         if (0 > slot) {
@@ -445,9 +446,7 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
         if (pmix_bitmap_is_set_bit(&coll->reported_slots, slot)) {
             return;
         }
-        pmix_bitmap_set_bit(&coll->reported_slots, slot);
     }
-    coll->nreported++;
 
     // unpack the info structs
     cnt = 1;
@@ -508,6 +507,14 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
         return;
     }
     PMIX_INFO_FREE(info, ninfo);
+
+    /* the contribution is in - now commit the accounting for it */
+    if (0 > slot) {
+        coll->self_reported = true;
+    } else {
+        pmix_bitmap_set_bit(&coll->reported_slots, slot);
+    }
+    coll->nreported++;
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct fence recv nexpected %d nrep %d",

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -43,39 +43,17 @@ static void check_complete(prte_grpcomm_group_t *coll);
 static void group_timeout(int sd, short args, void *cbdata);
 static bool group_op_completed(prte_grpcomm_direct_group_signature_t *sig);
 static void group_op_forget(prte_grpcomm_direct_group_signature_t *sig);
-static void advance_group_epoch(uint32_t to);
 #if PRTE_PMIX_HAVE_GROUP_FT
 static void collect_departed(prte_grpcomm_group_t *coll);
 #endif
 
-/* The group recovery epoch for this daemon.
- *
- * A daemon failure invalidates every in-flight group rollup: the number of
- * contributions each daemon should expect is derived from the routing tree,
- * and the tree just changed shape.  Recovery is a simultaneous restart -
- * every daemon resets its trackers, recomputes what it expects from the
- * repaired tree, and re-injects the contribution it originally made - and the
- * epoch is what tells the restarts apart, so a contribution still in flight
- * from before the failure is recognizable as stale and discarded rather than
- * counted against the new round.
- *
- * It is per-daemon rather than per-tracker deliberately.  Trackers are created
- * lazily and destroyed on release, so a counter living on one cannot survive
- * the gap; a daemon-wide counter also covers a tracker that did not yet exist
- * when the failure landed.
- *
- * What makes a simultaneous restart possible without a protocol of its own is
- * the global fault scope: it is delivered to every daemon by one broadcast,
- * in the same order everywhere, after the routing tree has been repaired.
- * DAEMON_DIED is in the xcast "process first" set, so a daemon hands the
- * notice to its own delivery before forwarding it, and libevent runs that
- * active event before the next round of socket reads - so a daemon has
- * advanced its epoch before it can read any contribution a child sent after
- * advancing its own.  A contribution stamped newer than our epoch should
- * therefore be impossible; we handle one anyway by adopting the epoch, which
- * is exactly what the fault handler would have done a moment later.
+/* The recovery epoch lives on the component and is shared with fence: one
+ * failure means one restart of every collective in flight, so there is one
+ * counter. See the commentary on recovery_epoch in grpcomm_direct.h for why a
+ * daemon-wide counter rather than a per-tracker one, and for the ordering
+ * argument that makes a simultaneous restart possible without a protocol of
+ * its own.
  */
-static uint32_t group_epoch = 0;
 
 /* Frame a contribution with the current epoch. The body is copied, not
  * consumed, so the caller keeps ownership of it. */
@@ -83,7 +61,7 @@ static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body
 {
     pmix_status_t rc;
 
-    rc = PMIx_Data_pack(NULL, framed, &group_epoch, 1, PMIX_UINT32);
+    rc = PMIx_Data_pack(NULL, framed, &prte_mca_grpcomm_direct_component.recovery_epoch, 1, PMIX_UINT32);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return prte_pmix_convert_status(rc);
@@ -234,7 +212,7 @@ static void request_group_cancel(prte_pmix_grp_caddy_t *cd)
     /* every message on the GROUP tag opens with the epoch, so the receiver
      * can read it before it knows what kind of message this is - a cancel
      * carries one even though nothing filters it against the epoch */
-    rc = PMIx_Data_pack(NULL, relay, &group_epoch, 1, PMIX_UINT32);
+    rc = PMIx_Data_pack(NULL, relay, &prte_mca_grpcomm_direct_component.recovery_epoch, 1, PMIX_UINT32);
     if (PMIX_SUCCESS == rc) {
         rc = pack_signature(relay, &sig);
     }
@@ -268,19 +246,8 @@ ack:
  * derived state that a torn-down node can make unresolvable. */
 static bool group_lost_member(prte_grpcomm_group_t *coll)
 {
-    size_t n;
-
-    for (n = 0; n < coll->sig->nmembers; n++) {
-        if (prte_grpcomm_direct_group_member_departed(&coll->sig->members[n])) {
-            return true;
-        }
-    }
-    for (n = 0; n < coll->sig->naddmembers; n++) {
-        if (prte_grpcomm_direct_group_member_departed(&coll->sig->addmembers[n])) {
-            return true;
-        }
-    }
-    return false;
+    return prte_grpcomm_direct_procs_lost(coll->sig->members, coll->sig->nmembers)
+           || prte_grpcomm_direct_procs_lost(coll->sig->addmembers, coll->sig->naddmembers);
 }
 
 /* Is this entry one of the members we have determined to be lost? Used to keep
@@ -303,21 +270,18 @@ static bool member_is_departed(prte_grpcomm_group_t *coll, const pmix_proc_t *me
     return false;
 }
 
-/* Restart every in-flight rollup at a new epoch. Every daemon does this, for
- * every tracker, on the same broadcast - a partial restart, where one daemon
- * re-sends into a parent that did not reset, would double-count that subtree
- * and complete the collective with another one missing. */
-static void advance_group_epoch(uint32_t to)
+/* Restart every in-flight group rollup at the epoch the component has just
+ * moved to. The caller is prte_grpcomm_direct_advance_epoch(), which is what
+ * guarantees every daemon does this on the same broadcast - a partial restart,
+ * where one daemon re-sends into a parent that did not reset, would
+ * double-count that subtree and complete the collective with another one
+ * missing. */
+void prte_grpcomm_direct_group_restart(void)
 {
     prte_grpcomm_group_t *coll, *nxt;
     pmix_data_buffer_t *framed;
     size_t n;
     int rc;
-
-    if (to <= group_epoch) {
-        return;
-    }
-    group_epoch = to;
 
     PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
                            prte_grpcomm_group_t) {
@@ -354,7 +318,7 @@ static void advance_group_epoch(uint32_t to)
                             "%s grpcomm:direct:group restarting \"%s\" at epoch %u, "
                             "nexpected now %d",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID,
-                            (unsigned) group_epoch, (int) coll->nexpected);
+                            (unsigned) prte_mca_grpcomm_direct_component.recovery_epoch, (int) coll->nexpected);
 
         if (NULL == coll->my_contribution) {
             /* nothing of our own to re-offer - we are relaying for our
@@ -457,7 +421,6 @@ void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* s
         }
     }
 
-    advance_group_epoch(group_epoch + 1);
 }
 
 
@@ -810,23 +773,23 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
      * are exempt: they bypass the rollup tree entirely, so a tree repair does
      * not invalidate them and there is nothing to restart. */
     if (0 == sig->bootstrap && !sig->follower) {
-        if (stamp < group_epoch) {
+        if (stamp < prte_mca_grpcomm_direct_component.recovery_epoch) {
             /* sent before the failure this daemon has already recovered from,
              * so it belongs to a round that no longer exists */
             pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
                                 "%s grpcomm:direct group recv stale epoch %u (at %u) - dropping",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                (unsigned) stamp, (unsigned) group_epoch);
+                                (unsigned) stamp, (unsigned) prte_mca_grpcomm_direct_component.recovery_epoch);
             PMIX_RELEASE(sig);
             return;
         }
-        if (stamp > group_epoch) {
-            /* Should be unreachable - see the group_epoch commentary. Adopt
+        if (stamp > prte_mca_grpcomm_direct_component.recovery_epoch) {
+            /* Should be unreachable - see the recovery_epoch commentary in grpcomm_direct.h. Adopt
              * it rather than dropping the contribution: that is precisely
              * what our own fault notice would do, just sooner. Log it so the
              * ordering assumption stays falsifiable. */
             PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_ORDER_MSG);
-            advance_group_epoch(stamp);
+            prte_grpcomm_direct_advance_epoch(stamp);
         }
     }
 
@@ -2270,41 +2233,6 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
     return coll;
 }
 
-/* Was this member hosted by a daemon that has since failed?
- *
- * A wildcard member names a whole namespace rather than one process, so it
- * cannot be answered proc-by-proc; the caller enumerates the job map for those
- * instead. A member we cannot resolve at all is treated as departed rather
- * than as an error: the usual reason to lose the mapping is that the node it
- * lived on is being torn down, which is exactly the case we are trying to
- * describe.
- *
- * Exported so the unit test can drive it against a synthetic failed set. */
-bool prte_grpcomm_direct_group_member_departed(const pmix_proc_t *member)
-{
-    prte_job_t *jdata;
-    prte_proc_t *proc;
-
-    if (PMIX_RANK_WILDCARD == member->rank || PMIX_RANK_INVALID == member->rank) {
-        return false;
-    }
-    if (pmix_bitmap_is_clear(&prte_rml_base.failed_dmns)) {
-        /* nothing has failed, so nothing can have departed - and this keeps
-         * the common path from walking the job map at all */
-        return false;
-    }
-    jdata = prte_get_job_data_object(member->nspace);
-    if (NULL == jdata) {
-        return true;
-    }
-    proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, member->rank);
-    if (NULL == proc || NULL == proc->node || NULL == proc->node->daemon) {
-        return true;
-    }
-    return pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns,
-                                  proc->node->daemon->name.rank);
-}
-
 /* Collect the members lost with a failed daemon. Wildcard members are expanded
  * through the job map here, because the final membership keeps the wildcard
  * entry as-is - we cannot prune a namespace proc-by-proc - but the clients
@@ -2329,7 +2257,7 @@ static void collect_departed(prte_grpcomm_group_t *coll)
     for (k = 0; k < 2; k++) {
         for (n = 0; n < nset[k]; n++) {
             if (PMIX_RANK_WILDCARD != set[k][n].rank) {
-                if (prte_grpcomm_direct_group_member_departed(&set[k][n])) {
+                if (prte_grpcomm_direct_proc_departed(&set[k][n])) {
                     nm = PMIX_NEW(prte_namelist_t);
                     memcpy(&nm->name, &set[k][n], sizeof(pmix_proc_t));
                     pmix_list_append(&dl, &nm->super);

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -109,8 +109,10 @@ static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
-    /* send the release via xcast to all daemons (ourselves included) */
+    /* send the release via xcast to all daemons (ourselves included).
+     * xcast copies the payload, so the buffer is still ours to free */
     (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
+    PMIX_DATA_BUFFER_RELEASE(reply);
 }
 
 #if PRTE_PMIX_HAVE_GROUP_FT
@@ -868,8 +870,10 @@ answer:
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
             }
 
-            /* send the release via xcast */
+            /* send the release via xcast - it copies the payload, so the
+             * buffer is still ours to free */
             (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
+            PMIX_DATA_BUFFER_RELEASE(reply);
 
         } else {
             PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1082,8 +1082,13 @@ static void find_delete_tracker(prte_grpcomm_direct_group_signature_t *sig)
     prte_grpcomm_group_t *coll;
 
     PMIX_LIST_FOREACH(coll, &prte_mca_grpcomm_direct_component.group_ops, prte_grpcomm_group_t) {
-        // must match groupID's
-        if (0 == strcmp(sig->groupID, coll->sig->groupID)) {
+        // must match both groupID and operation - the same key get_tracker
+        // uses. A groupID alone does not identify a tracker: a construct and
+        // a destruct of the same group are distinct operations, and matching
+        // on the name alone lets one operation's release delete the other's
+        // tracker.
+        if (0 == strcmp(sig->groupID, coll->sig->groupID) &&
+            sig->op == coll->sig->op) {
             pmix_list_remove_item(&prte_mca_grpcomm_direct_component.group_ops, &coll->super);
             PMIX_RELEASE(coll);
             return;

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1598,7 +1598,19 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
         coll->sig->addmembers = (pmix_proc_t *) malloc(coll->sig->naddmembers * sizeof(pmix_proc_t));
         memcpy(coll->sig->addmembers, sig->addmembers, coll->sig->naddmembers * sizeof(pmix_proc_t));
     }
+    // save any final membership order that was given - the match path
+    // above caches it, so failing to do so here would silently discard an
+    // order supplied by whichever daemon happens to create the tracker
+    if (NULL != sig->final_order) {
+        PMIX_PROC_CREATE(coll->sig->final_order, sig->nfinal);
+        memcpy(coll->sig->final_order, sig->final_order, sig->nfinal * sizeof(pmix_proc_t));
+        coll->sig->nfinal = sig->nfinal;
+    }
     coll->nfollowers = coll->sig->naddmembers;
+    // the accumulated signature is what we later pack onto the wire, so it
+    // has to carry the bootstrap description too
+    coll->sig->bootstrap = sig->bootstrap;
+    coll->sig->follower = sig->follower;
     // need to know the bootstrap in case one is ongoing
     coll->nleaders = coll->sig->bootstrap;
     if (0 < sig->bootstrap || sig->follower) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1453,9 +1453,13 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
                         if (PMIX_CHECK_PROCID(&sig->members[n], &coll->sig->members[nmb])) {
                             // yes, we do
                             found = true;
-                            // check for wildcard as that needs to be retained
+                            // check for wildcard as that needs to be retained.
+                            // note that "n" indexes the incoming signature while
+                            // "nmb" indexes the tracker's - the retention must be
+                            // applied to the entry we matched, not to whatever
+                            // happens to sit at the same offset over here
                             if (PMIX_RANK_WILDCARD == sig->members[n].rank) {
-                                coll->sig->members[n].rank = PMIX_RANK_WILDCARD;
+                                coll->sig->members[nmb].rank = PMIX_RANK_WILDCARD;
                             }
                             break;
                         }
@@ -1502,9 +1506,11 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
                         if (PMIX_CHECK_PROCID(&sig->addmembers[n], &coll->sig->addmembers[nmb])) {
                             // yes, we do
                             found = true;
-                            // check for wildcard as that needs to be retained
+                            // check for wildcard as that needs to be retained -
+                            // see the note above on the members loop: "nmb" is
+                            // the index into the tracker's array
                             if (PMIX_RANK_WILDCARD == sig->addmembers[n].rank) {
-                                coll->sig->addmembers[n].rank = PMIX_RANK_WILDCARD;
+                                coll->sig->addmembers[nmb].rank = PMIX_RANK_WILDCARD;
                             }
                             break;
                         }

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1051,97 +1051,134 @@ static void check_complete(prte_grpcomm_group_t *coll)
         coll->tev_active = false;
     }
 
-    {
-        if (PRTE_PROC_IS_MASTER) {
-            pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
-                                 "%s grpcomm:direct group HNP reports complete for %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID);
+    if (PRTE_PROC_IS_MASTER) {
+        pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct group HNP reports complete for %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID);
 
-            /* the allgather is complete - send the xcast */
-            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
-                /* Decide what a construct that lost a member should do. This
-                 * is the one place with the whole picture, it runs exactly
-                 * once, and unlike the fault handler it also covers an
-                 * operation the controller held no tracker for when the
-                 * failure landed. */
-                if (group_lost_member(coll)) {
+        /* the allgather is complete - send the xcast */
+        if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
+            /* Decide what a construct that lost a member should do. This
+             * is the one place with the whole picture, it runs exactly
+             * once, and unlike the fault handler it also covers an
+             * operation the controller held no tracker for when the
+             * failure landed. */
+            if (group_lost_member(coll)) {
 #if PRTE_PMIX_HAVE_GROUP_FT
-                    if (!coll->sig->ft_collective) {
-                        coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
-                        goto answer;
-                    }
-                    collect_departed(coll);
-                    pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
-                                        "%s grpcomm:direct:group \"%s\" completing on the "
-                                        "survivors - %d member(s) lost",
-                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        coll->sig->groupID, (int) coll->ndeparted);
-#else
-                    /* built against a PMIx with no notion of a fault-tolerant
-                     * group collective, so there is no way to have asked for
-                     * one - the loss of a member ends the construct */
+                if (!coll->sig->ft_collective) {
                     coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
                     goto answer;
+                }
+                collect_departed(coll);
+                pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                                    "%s grpcomm:direct:group \"%s\" completing on the "
+                                    "survivors - %d member(s) lost",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    coll->sig->groupID, (int) coll->ndeparted);
+#else
+                /* built against a PMIx with no notion of a fault-tolerant
+                 * group collective, so there is no way to have asked for
+                 * one - the loss of a member ends the construct */
+                coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
+                goto answer;
 #endif
-                }
-                /* if we were asked to provide a context id, do so */
-                if (coll->sig->assignID) {
-                    coll->sig->ctxid = prte_grpcomm_base.context_id;
-                    --prte_grpcomm_base.context_id;
-                    coll->sig->ctxid_assigned = true;
-                }
+            }
+            /* if we were asked to provide a context id, do so */
+            if (coll->sig->assignID) {
+                coll->sig->ctxid = prte_grpcomm_base.context_id;
+                --prte_grpcomm_base.context_id;
+                coll->sig->ctxid_assigned = true;
+            }
 
-                // construct the final membership
+            // construct the final membership
+            PMIX_CONSTRUCT(&nmlist, pmix_list_t);
+            // sadly, an exhaustive search
+            for (m=0; m < coll->sig->nmembers; m++) {
+                if (member_is_departed(coll, &coll->sig->members[m])) {
+                    continue;
+                }
+                found = false;
+                PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
+                    if (PMIX_CHECK_PROCID(&coll->sig->members[m], &nm->name)) {
+                        // if the new one is rank=WILDCARD, then ensure
+                        // we keep it as wildcard
+                        if (PMIX_RANK_WILDCARD == coll->sig->members[m].rank) {
+                            nm->name.rank = PMIX_RANK_WILDCARD;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    nm = PMIX_NEW(prte_namelist_t);
+                    memcpy(&nm->name, &coll->sig->members[m], sizeof(pmix_proc_t));
+                    pmix_list_append(&nmlist, &nm->super);
+                }
+            }
+            // now check any added members
+            for (m=0; m < coll->sig->naddmembers; m++) {
+                if (member_is_departed(coll, &coll->sig->addmembers[m])) {
+                    continue;
+                }
+                found = false;
+                PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
+                    if (PMIX_CHECK_PROCID(&coll->sig->addmembers[m], &nm->name)) {
+                        // if the new one is rank=WILDCARD, then ensure
+                        // we keep it as wildcard
+                        if (PMIX_RANK_WILDCARD == coll->sig->addmembers[m].rank) {
+                            nm->name.rank = PMIX_RANK_WILDCARD;
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    nm = PMIX_NEW(prte_namelist_t);
+                    memcpy(&nm->name, &coll->sig->addmembers[m], sizeof(pmix_proc_t));
+                    pmix_list_append(&nmlist, &nm->super);
+                }
+            }
+            // create the full membership array
+            nfinal = pmix_list_get_size(&nmlist);
+            PMIX_PROC_CREATE(finalmembership, nfinal);
+            m = 0;
+            PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
+                memcpy(&finalmembership[m], &nm->name, sizeof(pmix_proc_t));
+                ++m;
+            }
+            PMIX_LIST_DESTRUCT(&nmlist);
+
+            // if they gave us a final order, then sort the final membership
+            // accordingly. Note that order entries that consist of nspace,wildcard
+            // indicate that all participants from the given nspace should be
+            // included in the final membership at that point - it does NOT mean
+            // that all procs from that nspace are included in the final membership
+            if (NULL != coll->sig->final_order) {
                 PMIX_CONSTRUCT(&nmlist, pmix_list_t);
-                // sadly, an exhaustive search
-                for (m=0; m < coll->sig->nmembers; m++) {
-                    if (member_is_departed(coll, &coll->sig->members[m])) {
-                        continue;
-                    }
-                    found = false;
-                    PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
-                        if (PMIX_CHECK_PROCID(&coll->sig->members[m], &nm->name)) {
-                            // if the new one is rank=WILDCARD, then ensure
-                            // we keep it as wildcard
-                            if (PMIX_RANK_WILDCARD == coll->sig->members[m].rank) {
-                                nm->name.rank = PMIX_RANK_WILDCARD;
+                for (m=0; m < coll->sig->nfinal; m++) {
+                    // search the array of final members to capture those that match
+                    for (n=0; n < nfinal; n++) {
+                        if (PMIX_CHECK_PROCID(&coll->sig->final_order[m], &finalmembership[n])) {
+                            // add this proc to the final list
+                            nm = PMIX_NEW(prte_namelist_t);
+                            memcpy(&nm->name, &finalmembership[n], sizeof(pmix_proc_t));
+                            pmix_list_append(&nmlist, &nm->super);
+                            // the final order may have included rank=wildcard - if so,
+                            // then we have to continue
+                            if (PMIX_RANK_WILDCARD != coll->sig->final_order[m].rank) {
+                                // nope - can only match once
+                                break;
                             }
-                            found = true;
-                            break;
                         }
                     }
-                    if (!found) {
-                        nm = PMIX_NEW(prte_namelist_t);
-                        memcpy(&nm->name, &coll->sig->members[m], sizeof(pmix_proc_t));
-                        pmix_list_append(&nmlist, &nm->super);
-                    }
                 }
-                // now check any added members
-                for (m=0; m < coll->sig->naddmembers; m++) {
-                    if (member_is_departed(coll, &coll->sig->addmembers[m])) {
-                        continue;
-                    }
-                    found = false;
-                    PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
-                        if (PMIX_CHECK_PROCID(&coll->sig->addmembers[m], &nm->name)) {
-                            // if the new one is rank=WILDCARD, then ensure
-                            // we keep it as wildcard
-                            if (PMIX_RANK_WILDCARD == coll->sig->addmembers[m].rank) {
-                                nm->name.rank = PMIX_RANK_WILDCARD;
-                            }
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-                        nm = PMIX_NEW(prte_namelist_t);
-                        memcpy(&nm->name, &coll->sig->addmembers[m], sizeof(pmix_proc_t));
-                        pmix_list_append(&nmlist, &nm->super);
-                    }
+                // did we lose anyone?
+                if (nfinal != pmix_list_get_size(&nmlist)) {
+                    pmix_show_help("help-prte-runtime.txt", "bad-final-order", true);
+                    coll->status = PMIX_ERR_BAD_PARAM;
+                    goto answer;
                 }
-                // create the full membership array
-                nfinal = pmix_list_get_size(&nmlist);
-                PMIX_PROC_CREATE(finalmembership, nfinal);
+                // just overwrite the final array
                 m = 0;
                 PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
                     memcpy(&finalmembership[m], &nm->name, sizeof(pmix_proc_t));
@@ -1149,259 +1186,220 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 }
                 PMIX_LIST_DESTRUCT(&nmlist);
 
-                // if they gave us a final order, then sort the final membership
-                // accordingly. Note that order entries that consist of nspace,wildcard
-                // indicate that all participants from the given nspace should be
-                // included in the final membership at that point - it does NOT mean
-                // that all procs from that nspace are included in the final membership
-                if (NULL != coll->sig->final_order) {
-                    PMIX_CONSTRUCT(&nmlist, pmix_list_t);
-                    for (m=0; m < coll->sig->nfinal; m++) {
-                        // search the array of final members to capture those that match
-                        for (n=0; n < nfinal; n++) {
-                            if (PMIX_CHECK_PROCID(&coll->sig->final_order[m], &finalmembership[n])) {
-                                // add this proc to the final list
-                                nm = PMIX_NEW(prte_namelist_t);
-                                memcpy(&nm->name, &finalmembership[n], sizeof(pmix_proc_t));
-                                pmix_list_append(&nmlist, &nm->super);
-                                // the final order may have included rank=wildcard - if so,
-                                // then we have to continue
-                                if (PMIX_RANK_WILDCARD != coll->sig->final_order[m].rank) {
-                                    // nope - can only match once
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    // did we lose anyone?
-                    if (nfinal != pmix_list_get_size(&nmlist)) {
-                        pmix_show_help("help-prte-runtime.txt", "bad-final-order", true);
-                        coll->status = PMIX_ERR_BAD_PARAM;
-                        goto answer;
-                    }
-                    // just overwrite the final array
-                    m = 0;
-                    PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
-                        memcpy(&finalmembership[m], &nm->name, sizeof(pmix_proc_t));
-                        ++m;
-                    }
-                    PMIX_LIST_DESTRUCT(&nmlist);
+                // zero out the final order cache - no need to send it around
+                PMIX_PROC_FREE(coll->sig->final_order, coll->sig->nfinal);
+                coll->sig->final_order = NULL;
+                coll->sig->nfinal = 0;
 
-                    // zero out the final order cache - no need to send it around
-                    PMIX_PROC_FREE(coll->sig->final_order, coll->sig->nfinal);
-                    coll->sig->final_order = NULL;
-                    coll->sig->nfinal = 0;
-
-                } else {
-                     /* sort the procs so everyone gets the same order */
-                    qsort(finalmembership, nfinal, sizeof(pmix_proc_t), pmix_util_compare_proc);
-                }
-                /* a group of nobody is not a group - if the failure took every
-                 * member, there is nothing left to construct */
-                if (0 == nfinal) {
-                    coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
-                    goto answer;
-                }
+            } else {
+                 /* sort the procs so everyone gets the same order */
+                qsort(finalmembership, nfinal, sizeof(pmix_proc_t), pmix_util_compare_proc);
             }
+            /* a group of nobody is not a group - if the failure took every
+             * member, there is nothing left to construct */
+            if (0 == nfinal) {
+                coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
+                goto answer;
+            }
+        }
 
 answer:
-            // CONSTRUCT THE RELEASE MESSAGE
-            PMIX_DATA_BUFFER_CREATE(reply);
+        // CONSTRUCT THE RELEASE MESSAGE
+        PMIX_DATA_BUFFER_CREATE(reply);
 
-            /* pack the signature */
-            rc = pack_signature(reply, coll->sig);
+        /* pack the signature */
+        rc = pack_signature(reply, coll->sig);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            PMIX_PROC_FREE(finalmembership, nfinal);
+            return;
+        }
+        /* pack the status */
+        rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_STATUS);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            PMIX_PROC_FREE(finalmembership, nfinal);
+            return;
+        }
+
+        if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
+            // pack the final membership
+            rc = PMIx_Data_pack(NULL, reply, &nfinal, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
                 PMIX_PROC_FREE(finalmembership, nfinal);
                 return;
             }
-            /* pack the status */
-            rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_STATUS);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
+            if (0 < nfinal) {
+                rc = PMIx_Data_pack(NULL, reply, finalmembership, nfinal, PMIX_PROC);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    PMIX_PROC_FREE(finalmembership, nfinal);
+                    return;
+                }
                 PMIX_PROC_FREE(finalmembership, nfinal);
+            }
+
+            /* pack the members lost to a failed daemon, so each daemon can
+             * tell its own clients who is missing from the membership */
+            rc = PMIx_Data_pack(NULL, reply, &coll->ndeparted, 1, PMIX_SIZE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
                 return;
             }
-
-            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
-                // pack the final membership
-                rc = PMIx_Data_pack(NULL, reply, &nfinal, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_PROC_FREE(finalmembership, nfinal);
-                    return;
-                }
-                if (0 < nfinal) {
-                    rc = PMIx_Data_pack(NULL, reply, finalmembership, nfinal, PMIX_PROC);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_PROC_FREE(finalmembership, nfinal);
-                        return;
-                    }
-                    PMIX_PROC_FREE(finalmembership, nfinal);
-                }
-
-                /* pack the members lost to a failed daemon, so each daemon can
-                 * tell its own clients who is missing from the membership */
-                rc = PMIx_Data_pack(NULL, reply, &coll->ndeparted, 1, PMIX_SIZE);
+            if (0 < coll->ndeparted) {
+                rc = PMIx_Data_pack(NULL, reply, coll->departed,
+                                    coll->ndeparted, PMIX_PROC);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
                     return;
                 }
-                if (0 < coll->ndeparted) {
-                    rc = PMIx_Data_pack(NULL, reply, coll->departed,
-                                        coll->ndeparted, PMIX_PROC);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        return;
-                    }
-                }
-
-                // pack any group info
-                PMIx_Info_list_convert(coll->grpinfo, &darray);
-                info = (pmix_info_t*)darray.array;
-                ninfo = darray.size;
-                rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    return;
-                }
-                if (0 < ninfo) {
-                   rc =  PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        return;
-                    }
-                }
-                PMIX_DATA_ARRAY_DESTRUCT(&darray);
-
-                // pack any endpts
-                PMIx_Info_list_convert(coll->endpts, &darray);
-                info = (pmix_info_t*)darray.array;
-                ninfo = darray.size;
-                rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    return;
-                }
-                if (0 < ninfo) {
-                    rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        return;
-                    }
-                }
-                PMIX_DATA_ARRAY_DESTRUCT(&darray);
             }
 
-            /* send the release via xcast - it copies the payload, so the
-             * buffer is still ours to free */
-            (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
+            // pack any group info
+            PMIx_Info_list_convert(coll->grpinfo, &darray);
+            info = (pmix_info_t*)darray.array;
+            ninfo = darray.size;
+            rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
+            if (0 < ninfo) {
+               rc =  PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    return;
+                }
+            }
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+            // pack any endpts
+            PMIx_Info_list_convert(coll->endpts, &darray);
+            info = (pmix_info_t*)darray.array;
+            ninfo = darray.size;
+            rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
+            if (0 < ninfo) {
+                rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    return;
+                }
+            }
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        }
+
+        /* send the release via xcast - it copies the payload, so the
+         * buffer is still ours to free */
+        (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+
+    } else {
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                             "%s grpcomm:direct allgather rollup complete - sending to %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_PARENT)));
+
+        // setup to relay our rollup results
+        PMIX_DATA_BUFFER_CREATE(reply);
+
+        /* pack the signature */
+        rc = pack_signature(reply, coll->sig);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
 
-        } else {
-            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
-                                 "%s grpcomm:direct allgather rollup complete - sending to %s",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_PARENT)));
-
-            // setup to relay our rollup results
-            PMIX_DATA_BUFFER_CREATE(reply);
-
-            /* pack the signature */
-            rc = pack_signature(reply, coll->sig);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
-            }
-
-            // pack the local collective status
-            rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_STATUS);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
-            }
-
-            // pack any timeout directive
-            rc = PMIx_Data_pack(NULL, reply, &coll->timeout, 1, PMIX_INT);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
-            }
-
-            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
-                // pack any group info
-                PMIx_Info_list_convert(coll->grpinfo, &darray);
-                info = (pmix_info_t*)darray.array;
-                ninfo = darray.size;
-                rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    return;
-                }
-                if (0 < ninfo) {
-                    rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        return;
-                    }
-                }
-                PMIX_DATA_ARRAY_DESTRUCT(&darray);
-
-                // pack any endpts
-                PMIx_Info_list_convert(coll->endpts, &darray);
-                info = (pmix_info_t*)darray.array;
-                ninfo = darray.size;
-                rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DATA_BUFFER_RELEASE(reply);
-                    return;
-                }
-                if (0 < ninfo) {
-                    rc =PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
-                    if (PMIX_SUCCESS != rc) {
-                        PMIX_ERROR_LOG(rc);
-                        PMIX_DATA_BUFFER_RELEASE(reply);
-                        return;
-                    }
-                }
-                PMIX_DATA_ARRAY_DESTRUCT(&darray);
-            }
-
-            /* stamp our aggregate with the epoch it belongs to, so a parent
-             * that has already recovered past it can tell it is stale */
-            PMIX_DATA_BUFFER_CREATE(framed);
-            rc = pack_epoch_frame(framed, reply);
+        // pack the local collective status
+        rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_STATUS);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
-            if (PRTE_SUCCESS != rc) {
-                PMIX_DATA_BUFFER_RELEASE(framed);
-                return;
-            }
+            return;
+        }
 
-            /* send the info to our parent */
-            PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, framed,
-                          PRTE_RML_TAG_GROUP);
-            if (PRTE_SUCCESS != rc) {
-                PRTE_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(framed);
+        // pack any timeout directive
+        rc = PMIx_Data_pack(NULL, reply, &coll->timeout, 1, PMIX_INT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+
+        if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
+            // pack any group info
+            PMIx_Info_list_convert(coll->grpinfo, &darray);
+            info = (pmix_info_t*)darray.array;
+            ninfo = darray.size;
+            rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
                 return;
             }
+            if (0 < ninfo) {
+                rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    return;
+                }
+            }
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+            // pack any endpts
+            PMIx_Info_list_convert(coll->endpts, &darray);
+            info = (pmix_info_t*)darray.array;
+            ninfo = darray.size;
+            rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
+            if (0 < ninfo) {
+                rc =PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    return;
+                }
+            }
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        }
+
+        /* stamp our aggregate with the epoch it belongs to, so a parent
+         * that has already recovered past it can tell it is stale */
+        PMIX_DATA_BUFFER_CREATE(framed);
+        rc = pack_epoch_frame(framed, reply);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            return;
+        }
+
+        /* send the info to our parent */
+        PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, framed,
+                      PRTE_RML_TAG_GROUP);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            return;
         }
     }
 }

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -39,6 +39,10 @@
 #include "src/mca/grpcomm/base/base.h"
 
 static void group(int sd, short args, void *cbdata);
+static void check_complete(prte_grpcomm_group_t *coll);
+static void group_timeout(int sd, short args, void *cbdata);
+static bool group_op_completed(prte_grpcomm_direct_group_signature_t *sig);
+static void group_op_forget(prte_grpcomm_direct_group_signature_t *sig);
 
 static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *sig, bool create);
 
@@ -113,6 +117,31 @@ static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
      * xcast copies the payload, so the buffer is still ours to free */
     (void) prte_grpcomm.xcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
     PMIX_DATA_BUFFER_RELEASE(reply);
+    /* the tracker is not deleted here - it goes when the release we just
+     * broadcast comes back around - so mark it, both to keep the rollup from
+     * being driven any further and to keep a second abort from broadcasting */
+    coll->aborting = true;
+}
+
+/* The controller's guard timer for a collective a participant put a deadline
+ * on. Firing it completes every participant with PMIX_ERR_TIMEOUT rather than
+ * leaving them blocked in PMIx_Group_construct forever. */
+static void group_timeout(int sd, short args, void *cbdata)
+{
+    prte_grpcomm_group_t *coll = (prte_grpcomm_group_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(coll);
+    coll->tev_active = false;
+    if (coll->converged || coll->aborting) {
+        return;
+    }
+    pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                        "%s grpcomm:direct:group timeout on \"%s\" after %d seconds",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID,
+                        coll->timeout);
+    coll->status = PMIX_ERR_TIMEOUT;
+    abort_group_op(coll, PMIX_ERR_TIMEOUT);
 }
 
 #if PRTE_PMIX_HAVE_GROUP_FT
@@ -337,6 +366,11 @@ static void group(int sd, short args, void *cbdata)
         }
     }
 
+    /* a local client is starting this operation, which is proof that any
+     * earlier operation of the same name and type is finished with - drop it
+     * from the completed memo so this one is not mistaken for a straggler */
+    group_op_forget(&sig);
+
     /* create a tracker for this operation */
     if (NULL == (coll = get_tracker(&sig, true))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
@@ -489,17 +523,12 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
                                   prte_rml_tag_t tag, void *cbdata)
 {
     int32_t cnt;
-    int rc, timeout;
-    size_t m, n, ninfo, nfinal = 0, nendpts, ngrpinfo;
-    pmix_proc_t *finalmembership = NULL;
-    bool found;
-    pmix_list_t nmlist;
-    prte_namelist_t *nm;
-    pmix_data_array_t darray;
+    int rc, timeout, slot;
+    struct timeval tv;
+    size_t n, nendpts, ngrpinfo;
     pmix_status_t st;
-    pmix_info_t *info = NULL, *endpts, *grpinfo = NULL;
+    pmix_info_t *endpts, *grpinfo = NULL;
     prte_grpcomm_direct_group_signature_t *sig = NULL;
-    pmix_data_buffer_t *reply;
     prte_grpcomm_group_t *coll;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
@@ -541,11 +570,58 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     }
 #endif
 
+    /* if we have already released this operation, then this is a straggler
+     * that lost the race with the release - creating a tracker for it would
+     * strand one nothing will ever complete */
+    if (group_op_completed(sig)) {
+        pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                            "%s grpcomm:direct group recv for completed op \"%s\" - ignoring",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), sig->groupID);
+        PMIX_RELEASE(sig);
+        return;
+    }
+
     /* check for the tracker and create it if not found */
     if (NULL == (coll = get_tracker(sig, true))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         PMIX_RELEASE(sig);
         return;
+    }
+
+    /* Account for this contribution by *which* child subtree it came from
+     * rather than simply counting it, and drop it whole if that subtree has
+     * already been heard from. This has to happen before anything is merged
+     * into the tracker: the group-info and endpoint accumulation below appends
+     * with no key de-duplication, so a contribution counted twice is also a
+     * payload duplicated twice.
+     *
+     * Bootstrap contributions are exempt - they are sent straight to the
+     * controller from arbitrary daemons rather than up the routing tree, so a
+     * subtree index is meaningless for them and they keep the leader/follower
+     * counters. */
+    if (!coll->bootstrap) {
+        if (sender->rank == PRTE_PROC_MY_NAME->rank) {
+            if (coll->self_reported) {
+                PMIX_RELEASE(sig);
+                return;
+            }
+            coll->self_reported = true;
+        } else {
+            slot = prte_rml_get_subtree_index(sender->rank);
+            if (0 > slot) {
+                /* not in any of our subtrees - we are not this daemon's
+                 * parent, so this contribution is not ours to aggregate */
+                PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+                PMIX_RELEASE(sig);
+                return;
+            }
+            if (pmix_bitmap_is_set_bit(&coll->reported_slots, slot)) {
+                PMIX_RELEASE(sig);
+                return;
+            }
+            pmix_bitmap_set_bit(&coll->reported_slots, slot);
+        }
+        coll->nreported++;
     }
 
     // unpack the local collective status
@@ -571,6 +647,20 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     }
     if (coll->timeout < timeout) {
         coll->timeout = timeout;
+    }
+    /* A group op has never been bounded in time: the timeout directive is
+     * collected and relayed but nothing ever armed it, so an op that can no
+     * longer converge hangs its participants indefinitely. Arm it here, on the
+     * controller, which is the one daemon every rollup reaches. Only when a
+     * participant actually asked for a timeout - with no directive there is no
+     * deadline to impose, and the behavior is exactly as before. */
+    if (PRTE_PROC_IS_MASTER && !coll->tev_active && 0 < coll->timeout) {
+        prte_event_evtimer_set(prte_event_base, &coll->tev, group_timeout, coll);
+        tv.tv_sec = coll->timeout;
+        tv.tv_usec = 0;
+        coll->tev_active = true;
+        PMIX_POST_OBJECT(coll);
+        prte_event_evtimer_add(&coll->tev, &tv);
     }
 
 
@@ -652,27 +742,69 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) coll->nfollowers_reported,
                              (int) coll->nfollowers);
     } else {
-        // group collective op
-        coll->nreported++;
+        // group collective op - nreported was already bumped by the per-slot
+        // accounting above, which is what makes it duplicate-proof
         pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
                              "%s grpcomm:direct group recv nexpected %d nrep %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) coll->nexpected,
                              (int) coll->nreported);
     }
 
+    check_complete(coll);
+    PMIX_RELEASE(sig);
+}
+
+/* Test whether this tracker's rollup is complete and, if so, answer it: the
+ * controller broadcasts the release, everyone else rolls their aggregate up
+ * to their parent. Factored out of grp_recv() because a contribution arriving
+ * is no longer the only thing that can complete a collective - a fault can
+ * lower the number of contributions we are waiting for, and the tracker has
+ * to be re-tested against the new count with no message in hand.
+ *
+ * The completion test is ">=", not "==", precisely because nexpected can now
+ * shrink underneath a tracker that has already counted more than it ends up
+ * needing. The "converged" latch is what keeps that safe: without it a
+ * straggler arriving after completion would drive a second release broadcast,
+ * consuming another context id, or a second rollup to our parent. */
+static void check_complete(prte_grpcomm_group_t *coll)
+{
+    int rc;
+    size_t m, n, ninfo, nfinal = 0;
+    pmix_proc_t *finalmembership = NULL;
+    bool found;
+    pmix_list_t nmlist;
+    prte_namelist_t *nm;
+    pmix_data_array_t darray;
+    pmix_info_t *info = NULL;
+    pmix_data_buffer_t *reply;
+
+    /* an op we have already answered, or one an abort is tearing down, must
+     * not be driven again */
+    if (coll->converged || coll->aborting) {
+        return;
+    }
 
     /* see if everyone has reported */
-    if ((coll->bootstrap && (coll->nleaders_reported == coll->nleaders &&
-                             coll->nfollowers_reported == coll->nfollowers)) ||
-        (!coll->bootstrap && coll->nreported == coll->nexpected)) {
+    if (!((coll->bootstrap && (coll->nleaders_reported >= coll->nleaders &&
+                               coll->nfollowers_reported >= coll->nfollowers)) ||
+          (!coll->bootstrap && coll->nreported >= coll->nexpected))) {
+        return;
+    }
+    coll->converged = true;
+    /* the collective resolved, so the guard timer has done its job */
+    if (coll->tev_active) {
+        prte_event_del(&coll->tev);
+        coll->tev_active = false;
+    }
 
+    {
         if (PRTE_PROC_IS_MASTER) {
             pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
                                  "%s grpcomm:direct group HNP reports complete for %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID);
 
             /* the allgather is complete - send the xcast */
-            if (PMIX_GROUP_CONSTRUCT == sig->op) {
+            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
                 /* if we were asked to provide a context id, do so */
                 if (coll->sig->assignID) {
                     coll->sig->ctxid = prte_grpcomm_base.context_id;
@@ -790,7 +922,6 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 PMIX_PROC_FREE(finalmembership, nfinal);
                 return;
             }
@@ -799,18 +930,16 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 PMIX_PROC_FREE(finalmembership, nfinal);
                 return;
             }
 
-            if (PMIX_GROUP_CONSTRUCT == sig->op) {
+            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
                 // pack the final membership
                 rc = PMIx_Data_pack(NULL, reply, &nfinal, 1, PMIX_SIZE);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_RELEASE(sig);
                     PMIX_PROC_FREE(finalmembership, nfinal);
                     return;
                 }
@@ -819,7 +948,6 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_RELEASE(sig);
                         return;
                     }
                     PMIX_PROC_FREE(finalmembership, nfinal);
@@ -833,7 +961,6 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_RELEASE(sig);
                     return;
                 }
                 if (0 < ninfo) {
@@ -841,7 +968,6 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_RELEASE(sig);
                         return;
                     }
                 }
@@ -855,7 +981,6 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_RELEASE(sig);
                     return;
                 }
                 if (0 < ninfo) {
@@ -863,7 +988,6 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_RELEASE(sig);
                         return;
                     }
                 }
@@ -889,7 +1013,6 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 return;
             }
 
@@ -898,7 +1021,6 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 return;
             }
 
@@ -907,11 +1029,10 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 return;
             }
 
-            if (PMIX_GROUP_CONSTRUCT == sig->op) {
+            if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
                 // pack any group info
                 PMIx_Info_list_convert(coll->grpinfo, &darray);
                 info = (pmix_info_t*)darray.array;
@@ -920,7 +1041,6 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_RELEASE(sig);
                     return;
                 }
                 if (0 < ninfo) {
@@ -928,7 +1048,6 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_RELEASE(sig);
                         return;
                     }
                 }
@@ -942,7 +1061,6 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_RELEASE(sig);
                     return;
                 }
                 if (0 < ninfo) {
@@ -950,7 +1068,6 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
-                        PMIX_RELEASE(sig);
                         return;
                     }
                 }
@@ -963,12 +1080,10 @@ answer:
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_RELEASE(sig);
                 return;
             }
         }
     }
-    PMIX_RELEASE(sig);
 }
 
 static void relcb(void *cbdata)
@@ -1077,9 +1192,63 @@ static void grp_release_regcbfunc(pmix_status_t status, void *cbdata)
     PRTE_PMIX_THREADSHIFT(cd, prte_event_base, grp_release_resume);
 }
 
+/* Has this operation already been released here? */
+static bool group_op_completed(prte_grpcomm_direct_group_signature_t *sig)
+{
+    prte_grpcomm_group_memo_t *memo;
+
+    PMIX_LIST_FOREACH(memo, &prte_mca_grpcomm_direct_component.completed_group_ops,
+                      prte_grpcomm_group_memo_t) {
+        if (sig->op == memo->op && 0 == strcmp(sig->groupID, memo->groupID)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Forget any record of this operation, so a fresh one of the same name and
+ * type can run. Called when a local client starts one: the client asking is
+ * proof that the previous operation of that name is over and done with. */
+static void group_op_forget(prte_grpcomm_direct_group_signature_t *sig)
+{
+    prte_grpcomm_group_memo_t *memo, *nxt;
+
+    PMIX_LIST_FOREACH_SAFE(memo, nxt, &prte_mca_grpcomm_direct_component.completed_group_ops,
+                           prte_grpcomm_group_memo_t) {
+        if (sig->op == memo->op && 0 == strcmp(sig->groupID, memo->groupID)) {
+            pmix_list_remove_item(&prte_mca_grpcomm_direct_component.completed_group_ops,
+                                  &memo->super);
+            PMIX_RELEASE(memo);
+        }
+    }
+}
+
+/* Record that we released this operation, evicting the oldest entry once the
+ * memo is full - it only has to outlive messages still in flight. */
+static void group_op_remember(prte_grpcomm_direct_group_signature_t *sig)
+{
+    prte_grpcomm_group_memo_t *memo;
+
+    if (group_op_completed(sig)) {
+        return;
+    }
+    while (PRTE_GRPCOMM_GROUP_MEMO_MAX <=
+           pmix_list_get_size(&prte_mca_grpcomm_direct_component.completed_group_ops)) {
+        memo = (prte_grpcomm_group_memo_t *)
+            pmix_list_remove_first(&prte_mca_grpcomm_direct_component.completed_group_ops);
+        PMIX_RELEASE(memo);
+    }
+    memo = PMIX_NEW(prte_grpcomm_group_memo_t);
+    memo->groupID = strdup(sig->groupID);
+    memo->op = sig->op;
+    pmix_list_append(&prte_mca_grpcomm_direct_component.completed_group_ops, &memo->super);
+}
+
 static void find_delete_tracker(prte_grpcomm_direct_group_signature_t *sig)
 {
     prte_grpcomm_group_t *coll;
+
+    group_op_remember(sig);
 
     PMIX_LIST_FOREACH(coll, &prte_mca_grpcomm_direct_component.group_ops, prte_grpcomm_group_t) {
         // must match both groupID and operation - the same key get_tracker

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -44,7 +44,9 @@ static void group_timeout(int sd, short args, void *cbdata);
 static bool group_op_completed(prte_grpcomm_direct_group_signature_t *sig);
 static void group_op_forget(prte_grpcomm_direct_group_signature_t *sig);
 static void advance_group_epoch(uint32_t to);
+#if PRTE_PMIX_HAVE_GROUP_FT
 static void collect_departed(prte_grpcomm_group_t *coll);
+#endif
 
 /* The group recovery epoch for this daemon.
  *
@@ -2303,6 +2305,7 @@ bool prte_grpcomm_direct_group_member_departed(const pmix_proc_t *member)
  * through the job map here, because the final membership keeps the wildcard
  * entry as-is - we cannot prune a namespace proc-by-proc - but the clients
  * still deserve to be told which specific processes went away. */
+#if PRTE_PMIX_HAVE_GROUP_FT
 static void collect_departed(prte_grpcomm_group_t *coll)
 {
     pmix_list_t dl;
@@ -2361,6 +2364,7 @@ static void collect_departed(prte_grpcomm_group_t *coll)
     }
     PMIX_LIST_DESTRUCT(&dl);
 }
+#endif /* PRTE_PMIX_HAVE_GROUP_FT */
 
 static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
                        pmix_rank_t **dmns, size_t *ndmns)

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -665,6 +665,12 @@ static void group(int sd, short args, void *cbdata)
      * every tracker and has each daemon re-inject what it originally
      * contributed; without a copy here there would be nothing to re-inject,
      * since PRTE_RML_SEND takes ownership of the buffer we hand it. */
+    /* a daemon can enter here more than once for the same tracker - several
+     * bootstrap leaders, or a leader and a follower - so let go of any
+     * earlier copy rather than stranding it */
+    if (NULL != coll->my_contribution) {
+        PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
+    }
     PMIX_DATA_BUFFER_CREATE(coll->my_contribution);
     rc = PMIx_Data_copy_payload(coll->my_contribution, relay);
     if (PMIX_SUCCESS != rc) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -822,13 +822,13 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
      * controller from arbitrary daemons rather than up the routing tree, so a
      * subtree index is meaningless for them and they keep the leader/follower
      * counters. */
+    slot = -1;
     if (!coll->bootstrap) {
         if (sender->rank == PRTE_PROC_MY_NAME->rank) {
             if (coll->self_reported) {
                 PMIX_RELEASE(sig);
                 return;
             }
-            coll->self_reported = true;
         } else {
             slot = prte_rml_get_subtree_index(sender->rank);
             if (0 > slot) {
@@ -842,9 +842,7 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
                 PMIX_RELEASE(sig);
                 return;
             }
-            pmix_bitmap_set_bit(&coll->reported_slots, slot);
         }
-        coll->nreported++;
     }
 
     // unpack the local collective status
@@ -965,8 +963,16 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) coll->nfollowers_reported,
                              (int) coll->nfollowers);
     } else {
-        // group collective op - nreported was already bumped by the per-slot
-        // accounting above, which is what makes it duplicate-proof
+        /* the contribution is in - now commit the per-slot accounting for it.
+         * Doing it here rather than at the test above means a message that
+         * failed to parse cannot leave a subtree counted with none of its
+         * data merged. */
+        if (0 > slot) {
+            coll->self_reported = true;
+        } else {
+            pmix_bitmap_set_bit(&coll->reported_slots, slot);
+        }
+        coll->nreported++;
         pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
                              "%s grpcomm:direct group recv nexpected %d nrep %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) coll->nexpected,

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -43,6 +43,56 @@ static void check_complete(prte_grpcomm_group_t *coll);
 static void group_timeout(int sd, short args, void *cbdata);
 static bool group_op_completed(prte_grpcomm_direct_group_signature_t *sig);
 static void group_op_forget(prte_grpcomm_direct_group_signature_t *sig);
+static void advance_group_epoch(uint32_t to);
+static void collect_departed(prte_grpcomm_group_t *coll);
+
+/* The group recovery epoch for this daemon.
+ *
+ * A daemon failure invalidates every in-flight group rollup: the number of
+ * contributions each daemon should expect is derived from the routing tree,
+ * and the tree just changed shape.  Recovery is a simultaneous restart -
+ * every daemon resets its trackers, recomputes what it expects from the
+ * repaired tree, and re-injects the contribution it originally made - and the
+ * epoch is what tells the restarts apart, so a contribution still in flight
+ * from before the failure is recognizable as stale and discarded rather than
+ * counted against the new round.
+ *
+ * It is per-daemon rather than per-tracker deliberately.  Trackers are created
+ * lazily and destroyed on release, so a counter living on one cannot survive
+ * the gap; a daemon-wide counter also covers a tracker that did not yet exist
+ * when the failure landed.
+ *
+ * What makes a simultaneous restart possible without a protocol of its own is
+ * the global fault scope: it is delivered to every daemon by one broadcast,
+ * in the same order everywhere, after the routing tree has been repaired.
+ * DAEMON_DIED is in the xcast "process first" set, so a daemon hands the
+ * notice to its own delivery before forwarding it, and libevent runs that
+ * active event before the next round of socket reads - so a daemon has
+ * advanced its epoch before it can read any contribution a child sent after
+ * advancing its own.  A contribution stamped newer than our epoch should
+ * therefore be impossible; we handle one anyway by adopting the epoch, which
+ * is exactly what the fault handler would have done a moment later.
+ */
+static uint32_t group_epoch = 0;
+
+/* Frame a contribution with the current epoch. The body is copied, not
+ * consumed, so the caller keeps ownership of it. */
+static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Data_pack(NULL, framed, &group_epoch, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    rc = PMIx_Data_copy_payload(framed, body);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    return PRTE_SUCCESS;
+}
 
 static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *sig, bool create);
 
@@ -179,7 +229,13 @@ static void request_group_cancel(prte_pmix_grp_caddy_t *cd)
     sig.groupID = strdup(cd->grpid);
 
     PMIX_DATA_BUFFER_CREATE(relay);
-    rc = pack_signature(relay, &sig);
+    /* every message on the GROUP tag opens with the epoch, so the receiver
+     * can read it before it knows what kind of message this is - a cancel
+     * carries one even though nothing filters it against the epoch */
+    rc = PMIx_Data_pack(NULL, relay, &group_epoch, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS == rc) {
+        rc = pack_signature(relay, &sig);
+    }
     PMIX_DESTRUCT(&sig);
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
@@ -204,69 +260,202 @@ ack:
 }
 #endif /* PRTE_PMIX_HAVE_GROUP_FT */
 
+/* Is any daemon hosting a member of this operation known to have failed? Keyed
+ * on the membership rather than on the resolved daemon set, because the
+ * membership is stable and present on every daemon while the daemon set is
+ * derived state that a torn-down node can make unresolvable. */
+static bool group_lost_member(prte_grpcomm_group_t *coll)
+{
+    size_t n;
+
+    for (n = 0; n < coll->sig->nmembers; n++) {
+        if (prte_grpcomm_direct_group_member_departed(&coll->sig->members[n])) {
+            return true;
+        }
+    }
+    for (n = 0; n < coll->sig->naddmembers; n++) {
+        if (prte_grpcomm_direct_group_member_departed(&coll->sig->addmembers[n])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Is this entry one of the members we have determined to be lost? Used to keep
+ * them out of the final membership. A wildcard entry never matches: it names a
+ * whole namespace, so it stays in the membership even when some of that
+ * namespace has gone, and expanding it here would change what the caller
+ * asked for. */
+static bool member_is_departed(prte_grpcomm_group_t *coll, const pmix_proc_t *member)
+{
+    size_t n;
+
+    if (0 == coll->ndeparted || PMIX_RANK_WILDCARD == member->rank) {
+        return false;
+    }
+    for (n = 0; n < coll->ndeparted; n++) {
+        if (PMIX_CHECK_PROCID(member, &coll->departed[n])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Restart every in-flight rollup at a new epoch. Every daemon does this, for
+ * every tracker, on the same broadcast - a partial restart, where one daemon
+ * re-sends into a parent that did not reset, would double-count that subtree
+ * and complete the collective with another one missing. */
+static void advance_group_epoch(uint32_t to)
+{
+    prte_grpcomm_group_t *coll, *nxt;
+    pmix_data_buffer_t *framed;
+    size_t n;
+    int rc;
+
+    if (to <= group_epoch) {
+        return;
+    }
+    group_epoch = to;
+
+    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
+                           prte_grpcomm_group_t) {
+        /* a bootstrap has no rollup to restart, and an operation already being
+         * torn down by an abort is not going to converge either way */
+        if (coll->bootstrap || coll->aborting) {
+            continue;
+        }
+
+        /* discard everything gathered under the old tree */
+        pmix_bitmap_clear_all_bits(&coll->reported_slots);
+        coll->self_reported = false;
+        coll->nreported = 0;
+        coll->converged = false;
+        coll->status = PMIX_SUCCESS;
+        PMIx_Info_list_release(coll->grpinfo);
+        PMIx_Info_list_release(coll->endpts);
+        coll->grpinfo = PMIx_Info_list_start();
+        coll->endpts = PMIx_Info_list_start();
+
+        /* recompute what the repaired tree owes us. dmns deliberately stays
+         * the full pre-fault set - it is the record of who was supposed to
+         * take part, and prte_rml_get_num_contributors() already skips the
+         * daemons now known to have failed */
+        coll->nexpected = prte_rml_get_num_contributors(coll->dmns, coll->ndmns);
+        for (n = 0; n < coll->ndmns; n++) {
+            if (coll->dmns[n] == PRTE_PROC_MY_NAME->rank) {
+                coll->nexpected++;
+                break;
+            }
+        }
+
+        pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                            "%s grpcomm:direct:group restarting \"%s\" at epoch %u, "
+                            "nexpected now %d",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID,
+                            (unsigned) group_epoch, (int) coll->nexpected);
+
+        if (NULL == coll->my_contribution) {
+            /* nothing of our own to re-offer - we are relaying for our
+             * subtree. If that subtree just went away, nexpected is now zero
+             * and this completes the operation on the spot, which is what
+             * keeps the loss of a pure relay from stalling the collective */
+            check_complete(coll);
+            continue;
+        }
+
+        /* re-offer our own contribution at the new epoch. Sending to ourselves
+         * defers to the event loop, so we never re-enter grp_recv while
+         * walking the tracker list */
+        PMIX_DATA_BUFFER_CREATE(framed);
+        rc = pack_epoch_frame(framed, coll->my_contribution);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            continue;
+        }
+        PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed, PRTE_RML_TAG_GROUP);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(framed);
+        }
+    }
+}
+
 void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* status)
 {
     prte_grpcomm_group_t *coll, *nxt;
-    const pmix_rank_t *failed;
-    size_t i, j;
-    bool affected;
-    pmix_status_t st;
 
-    /* Drive group-collective recovery exactly once, from the HNP, during the
-     * global-scope pass. The HNP is the master of every group op and the sole
-     * xcast source, and the global pass reports the same failed_ranks on every
-     * rank in a consistent order; other daemons complete their local
-     * participants when the HNP's abort release arrives. (The tree-topology
-     * fields are cleared in the global pass, but failed_ranks - the identity of
-     * the failure - is exactly what the global notification carries.) */
-    if (PRTE_RML_FAULT_SCOPE_GLOBAL != status->scope) {
-        return;
-    }
-    if (!PRTE_PROC_IS_MASTER) {
-        return;
-    }
     if (0 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.group_ops)) {
         return;
     }
 
-    failed = (const pmix_rank_t *) status->failed_ranks.array;
-
-    /* Abort every in-flight group op that a failed daemon participated in. This
-     * is the resilient replacement for tearing down the whole DVM. Completing a
-     * construct on the survivors (degraded, reduced membership) when
-     * PMIX_GROUP_FT_COLLECTIVE was requested is a larger distributed-recovery
-     * effort tracked separately; for now the loss of a participating daemon
-     * aborts the affected construct regardless of that flag. A destruct is
-     * tearing the group down anyway, so it is simply completed. */
-    PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops, prte_grpcomm_group_t) {
-        affected = false;
-        if (NULL == coll->dmns || 0 == coll->ndmns) {
-            /* the daemon set was never resolved (e.g. a bootstrap op), so we
-             * cannot prove this op is unaffected - abort it to be safe rather
-             * than risk leaving its participants blocked forever */
-            affected = true;
-        } else {
-            for (i = 0; i < status->failed_ranks.size && !affected; i++) {
-                for (j = 0; j < coll->ndmns; j++) {
-                    if (coll->dmns[j] == failed[i]) {
-                        affected = true;
-                        break;
-                    }
+    if (PRTE_RML_FAULT_SCOPE_GLOBAL != status->scope) {
+        /* A revival reaches us here: it leaves the scope at its local default
+         * and carries no failed ranks, whereas a death's local pass returns
+         * early when it has nothing new to report, so an empty rank list is an
+         * unambiguous discriminator.
+         *
+         * A revival reshapes the tree and invalidates the expected counts just
+         * as a death does, but it cannot be recovered the same way: it is
+         * driven by DAEMON_REVIVED, which is deliberately forward-first in the
+         * xcast, so a daemon can forward the notice to a child before acting on
+         * it and the simultaneous restart an epoch advance depends on is not
+         * available. Abort instead. Today this path does nothing at all, which
+         * means a group operation in flight across an unheal simply hangs, so
+         * failing it cleanly is the better of the two. */
+        if (PRTE_PROC_IS_MASTER && 0 == status->failed_ranks.size) {
+            PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
+                                   prte_grpcomm_group_t) {
+                if (coll->aborting) {
+                    continue;
                 }
+                pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                                    "%s grpcomm:direct:group aborting \"%s\" - a daemon "
+                                    "returned and reshaped the tree",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID);
+                abort_group_op(coll,
+                               (PMIX_GROUP_CONSTRUCT == coll->sig->op)
+                                   ? PMIX_GROUP_CONSTRUCT_ABORT : PMIX_SUCCESS);
             }
         }
-        if (!affected) {
-            continue;
-        }
-        st = (PMIX_GROUP_CONSTRUCT == coll->sig->op) ? PMIX_GROUP_CONSTRUCT_ABORT
-                                                     : PMIX_SUCCESS;
-        PMIX_OUTPUT_VERBOSE((0, prte_grpcomm_base_framework.framework_output,
-                             "%s grpcomm:direct:group aborting op \"%s\" - a "
-                             "participating daemon failed",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                             coll->sig->groupID));
-        abort_group_op(coll, st);
+        return;
     }
+
+    /* Global scope: the tree is repaired, and this notice reached every daemon
+     * from a single broadcast in the same order, which is what lets all of
+     * them restart their rollups together. */
+    if (PRTE_PROC_IS_MASTER) {
+        /* Fail fast the operations that provably cannot survive, so their
+         * participants are not made to wait out a re-convergence whose only
+         * possible outcome is the abort below. This is an optimization: the
+         * controller applies the same policy when the rollup completes, which
+         * is what covers an operation it holds no tracker for yet. */
+        PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
+                               prte_grpcomm_group_t) {
+            if (coll->aborting) {
+                continue;
+            }
+            if (coll->bootstrap) {
+                /* A bootstrap has no resolved daemon set to test, and its
+                 * leader count is a number with no identities attached, so
+                 * there is no way to work out how much of it died. */
+                abort_group_op(coll,
+                               (PMIX_GROUP_CONSTRUCT == coll->sig->op)
+                                   ? PMIX_GROUP_CONSTRUCT_ABORT : PMIX_SUCCESS);
+                continue;
+            }
+            if (PMIX_GROUP_CONSTRUCT == coll->sig->op &&
+                !coll->sig->ft_collective &&
+                group_lost_member(coll)) {
+                pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                                    "%s grpcomm:direct:group aborting \"%s\" - a member's "
+                                    "daemon failed and the group is not fault tolerant",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->sig->groupID);
+                abort_group_op(coll, PMIX_GROUP_CONSTRUCT_ABORT);
+            }
+        }
+    }
+
+    advance_group_epoch(group_epoch + 1);
 }
 
 
@@ -276,7 +465,7 @@ static void group(int sd, short args, void *cbdata)
     prte_grpcomm_direct_group_signature_t sig;
     prte_grpcomm_group_t *coll;
     size_t i;
-    pmix_data_buffer_t *relay;
+    pmix_data_buffer_t *relay, *framed;
     pmix_status_t rc, st = PMIX_SUCCESS;
     int timeout = 0;
     void *endpts, *grpinfo;
@@ -363,6 +552,10 @@ static void group(int sd, short args, void *cbdata)
         } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_FINAL_MEMBERSHIP_ORDER)) {
             sig.final_order = (pmix_proc_t*)cd->directives[i].value.data.darray->array;
             sig.nfinal = cd->directives[i].value.data.darray->size;
+#if PRTE_PMIX_HAVE_GROUP_FT
+        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_FT_COLLECTIVE)) {
+            sig.ft_collective = PMIX_INFO_TRUE(&cd->directives[i]);
+#endif
         }
     }
 
@@ -466,6 +659,32 @@ static void group(int sd, short args, void *cbdata)
     grpinfo = NULL;
     endpts = NULL;
 
+    /* Keep our own contribution so a fault can replay it. Recovery resets
+     * every tracker and has each daemon re-inject what it originally
+     * contributed; without a copy here there would be nothing to re-inject,
+     * since PRTE_RML_SEND takes ownership of the buffer we hand it. */
+    PMIX_DATA_BUFFER_CREATE(coll->my_contribution);
+    rc = PMIx_Data_copy_payload(coll->my_contribution, relay);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
+        coll->my_contribution = NULL;
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        PMIX_DESTRUCT(&sig);
+        goto error;
+    }
+
+    /* stamp it with the current epoch and send that */
+    PMIX_DATA_BUFFER_CREATE(framed);
+    rc = pack_epoch_frame(framed, relay);
+    PMIX_DATA_BUFFER_RELEASE(relay);
+    if (PRTE_SUCCESS != rc) {
+        PMIX_DATA_BUFFER_RELEASE(framed);
+        PMIX_DESTRUCT(&sig);
+        goto error;
+    }
+    relay = framed;
+
     /* if this is a bootstrap operation, send it directly to the HNP */
     if (coll->bootstrap) {
         PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
@@ -524,6 +743,7 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
 {
     int32_t cnt;
     int rc, timeout, slot;
+    uint32_t stamp;
     struct timeval tv;
     size_t n, nendpts, ngrpinfo;
     pmix_status_t st;
@@ -539,6 +759,14 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
     // empty buffer indicates lost connection
     if (NULL == buffer || NULL == buffer->unpack_ptr) {
         PMIX_ERROR_LOG(PMIX_ERR_EMPTY);
+        return;
+    }
+
+    /* every message on this tag opens with the sender's recovery epoch */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &stamp, &cnt, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         return;
     }
 
@@ -569,6 +797,30 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
         return;
     }
 #endif
+
+    /* Reconcile the sender's recovery epoch with ours. Bootstrap operations
+     * are exempt: they bypass the rollup tree entirely, so a tree repair does
+     * not invalidate them and there is nothing to restart. */
+    if (0 == sig->bootstrap && !sig->follower) {
+        if (stamp < group_epoch) {
+            /* sent before the failure this daemon has already recovered from,
+             * so it belongs to a round that no longer exists */
+            pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                                "%s grpcomm:direct group recv stale epoch %u (at %u) - dropping",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                (unsigned) stamp, (unsigned) group_epoch);
+            PMIX_RELEASE(sig);
+            return;
+        }
+        if (stamp > group_epoch) {
+            /* Should be unreachable - see the group_epoch commentary. Adopt
+             * it rather than dropping the contribution: that is precisely
+             * what our own fault notice would do, just sooner. Log it so the
+             * ordering assumption stays falsifiable. */
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_ORDER_MSG);
+            advance_group_epoch(stamp);
+        }
+    }
 
     /* if we have already released this operation, then this is a straggler
      * that lost the race with the release - creating a tracker for it would
@@ -776,7 +1028,7 @@ static void check_complete(prte_grpcomm_group_t *coll)
     prte_namelist_t *nm;
     pmix_data_array_t darray;
     pmix_info_t *info = NULL;
-    pmix_data_buffer_t *reply;
+    pmix_data_buffer_t *reply, *framed;
 
     /* an op we have already answered, or one an abort is tearing down, must
      * not be driven again */
@@ -805,6 +1057,31 @@ static void check_complete(prte_grpcomm_group_t *coll)
 
             /* the allgather is complete - send the xcast */
             if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
+                /* Decide what a construct that lost a member should do. This
+                 * is the one place with the whole picture, it runs exactly
+                 * once, and unlike the fault handler it also covers an
+                 * operation the controller held no tracker for when the
+                 * failure landed. */
+                if (group_lost_member(coll)) {
+#if PRTE_PMIX_HAVE_GROUP_FT
+                    if (!coll->sig->ft_collective) {
+                        coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
+                        goto answer;
+                    }
+                    collect_departed(coll);
+                    pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
+                                        "%s grpcomm:direct:group \"%s\" completing on the "
+                                        "survivors - %d member(s) lost",
+                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                        coll->sig->groupID, (int) coll->ndeparted);
+#else
+                    /* built against a PMIx with no notion of a fault-tolerant
+                     * group collective, so there is no way to have asked for
+                     * one - the loss of a member ends the construct */
+                    coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
+                    goto answer;
+#endif
+                }
                 /* if we were asked to provide a context id, do so */
                 if (coll->sig->assignID) {
                     coll->sig->ctxid = prte_grpcomm_base.context_id;
@@ -816,6 +1093,9 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 PMIX_CONSTRUCT(&nmlist, pmix_list_t);
                 // sadly, an exhaustive search
                 for (m=0; m < coll->sig->nmembers; m++) {
+                    if (member_is_departed(coll, &coll->sig->members[m])) {
+                        continue;
+                    }
                     found = false;
                     PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
                         if (PMIX_CHECK_PROCID(&coll->sig->members[m], &nm->name)) {
@@ -836,6 +1116,9 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 }
                 // now check any added members
                 for (m=0; m < coll->sig->naddmembers; m++) {
+                    if (member_is_departed(coll, &coll->sig->addmembers[m])) {
+                        continue;
+                    }
                     found = false;
                     PMIX_LIST_FOREACH(nm, &nmlist, prte_namelist_t) {
                         if (PMIX_CHECK_PROCID(&coll->sig->addmembers[m], &nm->name)) {
@@ -911,6 +1194,12 @@ static void check_complete(prte_grpcomm_group_t *coll)
                      /* sort the procs so everyone gets the same order */
                     qsort(finalmembership, nfinal, sizeof(pmix_proc_t), pmix_util_compare_proc);
                 }
+                /* a group of nobody is not a group - if the failure took every
+                 * member, there is nothing left to construct */
+                if (0 == nfinal) {
+                    coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
+                    goto answer;
+                }
             }
 
 answer:
@@ -948,9 +1237,28 @@ answer:
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DATA_BUFFER_RELEASE(reply);
+                        PMIX_PROC_FREE(finalmembership, nfinal);
                         return;
                     }
                     PMIX_PROC_FREE(finalmembership, nfinal);
+                }
+
+                /* pack the members lost to a failed daemon, so each daemon can
+                 * tell its own clients who is missing from the membership */
+                rc = PMIx_Data_pack(NULL, reply, &coll->ndeparted, 1, PMIX_SIZE);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DATA_BUFFER_RELEASE(reply);
+                    return;
+                }
+                if (0 < coll->ndeparted) {
+                    rc = PMIx_Data_pack(NULL, reply, coll->departed,
+                                        coll->ndeparted, PMIX_PROC);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_DATA_BUFFER_RELEASE(reply);
+                        return;
+                    }
                 }
 
                 // pack any group info
@@ -1074,12 +1382,22 @@ answer:
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
             }
 
+            /* stamp our aggregate with the epoch it belongs to, so a parent
+             * that has already recovered past it can tell it is stale */
+            PMIX_DATA_BUFFER_CREATE(framed);
+            rc = pack_epoch_frame(framed, reply);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            if (PRTE_SUCCESS != rc) {
+                PMIX_DATA_BUFFER_RELEASE(framed);
+                return;
+            }
+
             /* send the info to our parent */
-            PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, reply,
+            PRTE_RML_SEND(rc, PRTE_PROC_MY_PARENT->rank, framed,
                           PRTE_RML_TAG_GROUP);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
-                PMIX_DATA_BUFFER_RELEASE(reply);
+                PMIX_DATA_BUFFER_RELEASE(framed);
                 return;
             }
         }
@@ -1119,6 +1437,8 @@ typedef struct {
     size_t ninfo;
     pmix_proc_t *finalmembership;
     size_t nfinal;
+    pmix_proc_t *departed;
+    size_t ndeparted;
     pmix_info_t *grpinfo;
     size_t ngrpinfo;
     pmix_info_t *endpts;
@@ -1133,6 +1453,8 @@ static void rlcon(prte_grpcomm_release_caddy_t *p)
     p->info = NULL;
     p->ninfo = 0;
     p->finalmembership = NULL;
+    p->departed = NULL;
+    p->ndeparted = 0;
     p->nfinal = 0;
     p->grpinfo = NULL;
     p->ngrpinfo = 0;
@@ -1152,6 +1474,9 @@ static void rldes(prte_grpcomm_release_caddy_t *p)
     }
     if (NULL != p->finalmembership) {
         PMIX_PROC_FREE(p->finalmembership, p->nfinal);
+    }
+    if (NULL != p->departed) {
+        PMIX_PROC_FREE(p->departed, p->ndeparted);
     }
     if (NULL != p->nlist) {
         PMIX_INFO_LIST_RELEASE(p->nlist);
@@ -1393,6 +1718,28 @@ void prte_grpcomm_direct_grp_release(int status, pmix_proc_t *sender,
         }
     }
 
+    /* unpack the members lost to a failed daemon, if any */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &cd->ndeparted, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        cd->st = rc;
+        cd->ndeparted = 0;
+        PMIX_INFO_LIST_RELEASE(ilist);
+        goto notify;
+    }
+    if (0 < cd->ndeparted) {
+        PMIX_PROC_CREATE(cd->departed, cd->ndeparted);
+        cnt = cd->ndeparted;
+        rc = PMIx_Data_unpack(NULL, buffer, cd->departed, &cnt, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            cd->st = rc;
+            PMIX_INFO_LIST_RELEASE(ilist);
+            goto notify;
+        }
+    }
+
     // unpack group info
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &cd->ngrpinfo, &cnt, PMIX_SIZE);
@@ -1518,6 +1865,70 @@ notify:
     grp_release_complete(cd);
 }
 
+#if PRTE_PMIX_HAVE_GROUP_FT
+/* Raise PMIX_GROUP_MEMBER_FAILED, once per lost member, to this node's members
+ * of the group.
+ *
+ * The range is custom rather than local: PMIX_RANGE_LOCAL would reach every
+ * client on the node, including those belonging to jobs with no interest in
+ * this group. Build the target list from the final membership, keeping the
+ * procs that are actually running here.
+ *
+ * "prte.notify.donotloop" is required, not optional: without it PMIx hands the
+ * event back to our own notify_event upcall, which thread-shifts onto the
+ * progress thread - the thread we are on and are blocking inside
+ * PMIx_Notify_event - and the daemon deadlocks. */
+static void notify_members_lost(prte_grpcomm_release_caddy_t *cd)
+{
+    pmix_proc_t *targets;
+    size_t ntargets = 0, n;
+    prte_proc_t *p;
+    pmix_data_array_t darray;
+    pmix_info_t info[4];
+    pmix_status_t rc;
+
+    if (0 == cd->nfinal) {
+        return;
+    }
+    PMIX_PROC_CREATE(targets, cd->nfinal);
+    for (n = 0; n < cd->nfinal; n++) {
+        if (PMIX_RANK_WILDCARD == cd->finalmembership[n].rank) {
+            continue;
+        }
+        p = prte_get_proc_object(&cd->finalmembership[n]);
+        if (NULL == p || !PRTE_FLAG_TEST(p, PRTE_PROC_FLAG_LOCAL)) {
+            continue;
+        }
+        memcpy(&targets[ntargets], &cd->finalmembership[n], sizeof(pmix_proc_t));
+        ++ntargets;
+    }
+    if (0 == ntargets) {
+        PMIX_PROC_FREE(targets, cd->nfinal);
+        return;
+    }
+
+    for (n = 0; n < cd->ndeparted; n++) {
+        darray.type = PMIX_PROC;
+        darray.array = targets;
+        darray.size = ntargets;
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, &cd->departed[n], PMIX_PROC);
+        PMIX_INFO_LOAD(&info[1], PMIX_GROUP_ID, cd->sig->groupID, PMIX_STRING);
+        PMIX_INFO_LOAD(&info[2], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+        PMIX_INFO_LOAD(&info[3], "prte.notify.donotloop", NULL, PMIX_BOOL);
+        rc = PMIx_Notify_event(PMIX_GROUP_MEMBER_FAILED, &prte_process_info.myproc,
+                               PMIX_RANGE_CUSTOM, info, 4, NULL, NULL);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        PMIX_INFO_DESTRUCT(&info[2]);
+        PMIX_INFO_DESTRUCT(&info[3]);
+    }
+    PMIX_PROC_FREE(targets, cd->nfinal);
+}
+#endif /* PRTE_PMIX_HAVE_GROUP_FT */
+
 /* The remainder of grp_release, run once the group's resources are in our
  * local PMIx server.  Always executes on the PRRTE progress thread. */
 static void grp_release_complete(prte_grpcomm_release_caddy_t *cd)
@@ -1573,6 +1984,23 @@ static void grp_release_complete(prte_grpcomm_release_caddy_t *cd)
         /* return to the PMIx server library for relay to
          * local procs in the operation */
         coll->cbfunc(cd->st, ccd->info, ccd->ninfo, coll->cbdata, relcb, (void*)ccd);
+
+        /* Tell our own participants who they lost. This is done after the
+         * construct's completion has been dispatched, so a client sees
+         * PMIx_Group_construct return before it hears about the casualties,
+         * and only on a daemon that actually has participants - grp_release
+         * runs on every daemon in the DVM, and an untargeted notification
+         * would reach clients of unrelated jobs.
+         *
+         * PMIx cannot do this for us: its own equivalent walks the block's
+         * list of departed members, which is filled in from local client
+         * connections dropping, and a surviving server never learns anything
+         * about a process on a daemon that died. */
+#if PRTE_PMIX_HAVE_GROUP_FT
+        if (PMIX_SUCCESS == cd->st && 0 < cd->ndeparted) {
+            notify_members_lost(cd);
+        }
+#endif
     }
 
     // remove this collective from our tracker
@@ -1746,6 +2174,15 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
             if (!coll->sig->assignID && sig->assignID) {
                 coll->sig->assignID = true;
             }
+            /* Sticky-OR: one participant asking for a fault-tolerant
+             * collective makes the whole operation one. Note this is a
+             * deliberate superset of the PMIx server's own rule, which takes
+             * the first PMIX_GROUP_FT_COLLECTIVE it finds in the aggregated
+             * block info and ignores the rest - accumulating is the more
+             * predictable of the two when participants disagree. */
+            if (!coll->sig->ft_collective && sig->ft_collective) {
+                coll->sig->ft_collective = true;
+            }
             return coll;
         }
     }
@@ -1789,6 +2226,7 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
     // has to carry the bootstrap description too
     coll->sig->bootstrap = sig->bootstrap;
     coll->sig->follower = sig->follower;
+    coll->sig->ft_collective = sig->ft_collective;
     // need to know the bootstrap in case one is ongoing
     coll->nleaders = coll->sig->bootstrap;
     if (0 < sig->bootstrap || sig->follower) {
@@ -1826,6 +2264,104 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
     return coll;
 }
 
+/* Was this member hosted by a daemon that has since failed?
+ *
+ * A wildcard member names a whole namespace rather than one process, so it
+ * cannot be answered proc-by-proc; the caller enumerates the job map for those
+ * instead. A member we cannot resolve at all is treated as departed rather
+ * than as an error: the usual reason to lose the mapping is that the node it
+ * lived on is being torn down, which is exactly the case we are trying to
+ * describe.
+ *
+ * Exported so the unit test can drive it against a synthetic failed set. */
+bool prte_grpcomm_direct_group_member_departed(const pmix_proc_t *member)
+{
+    prte_job_t *jdata;
+    prte_proc_t *proc;
+
+    if (PMIX_RANK_WILDCARD == member->rank || PMIX_RANK_INVALID == member->rank) {
+        return false;
+    }
+    if (pmix_bitmap_is_clear(&prte_rml_base.failed_dmns)) {
+        /* nothing has failed, so nothing can have departed - and this keeps
+         * the common path from walking the job map at all */
+        return false;
+    }
+    jdata = prte_get_job_data_object(member->nspace);
+    if (NULL == jdata) {
+        return true;
+    }
+    proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, member->rank);
+    if (NULL == proc || NULL == proc->node || NULL == proc->node->daemon) {
+        return true;
+    }
+    return pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns,
+                                  proc->node->daemon->name.rank);
+}
+
+/* Collect the members lost with a failed daemon. Wildcard members are expanded
+ * through the job map here, because the final membership keeps the wildcard
+ * entry as-is - we cannot prune a namespace proc-by-proc - but the clients
+ * still deserve to be told which specific processes went away. */
+static void collect_departed(prte_grpcomm_group_t *coll)
+{
+    pmix_list_t dl;
+    prte_namelist_t *nm;
+    prte_job_t *jdata;
+    prte_proc_t *proc;
+    pmix_proc_t *set[2];
+    size_t nset[2], k, n, m;
+    int i;
+
+    PMIX_CONSTRUCT(&dl, pmix_list_t);
+    set[0] = coll->sig->members;
+    nset[0] = coll->sig->nmembers;
+    set[1] = coll->sig->addmembers;
+    nset[1] = coll->sig->naddmembers;
+
+    for (k = 0; k < 2; k++) {
+        for (n = 0; n < nset[k]; n++) {
+            if (PMIX_RANK_WILDCARD != set[k][n].rank) {
+                if (prte_grpcomm_direct_group_member_departed(&set[k][n])) {
+                    nm = PMIX_NEW(prte_namelist_t);
+                    memcpy(&nm->name, &set[k][n], sizeof(pmix_proc_t));
+                    pmix_list_append(&dl, &nm->super);
+                }
+                continue;
+            }
+            /* a wildcard - walk the namespace for procs on failed daemons */
+            jdata = prte_get_job_data_object(set[k][n].nspace);
+            if (NULL == jdata) {
+                continue;
+            }
+            for (i = 0; i < jdata->procs->size; i++) {
+                proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, i);
+                if (NULL == proc || NULL == proc->node || NULL == proc->node->daemon) {
+                    continue;
+                }
+                if (!pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns,
+                                            proc->node->daemon->name.rank)) {
+                    continue;
+                }
+                nm = PMIX_NEW(prte_namelist_t);
+                PMIX_LOAD_PROCID(&nm->name, set[k][n].nspace, proc->name.rank);
+                pmix_list_append(&dl, &nm->super);
+            }
+        }
+    }
+
+    coll->ndeparted = pmix_list_get_size(&dl);
+    if (0 < coll->ndeparted) {
+        PMIX_PROC_CREATE(coll->departed, coll->ndeparted);
+        m = 0;
+        PMIX_LIST_FOREACH(nm, &dl, prte_namelist_t) {
+            memcpy(&coll->departed[m], &nm->name, sizeof(pmix_proc_t));
+            ++m;
+        }
+    }
+    PMIX_LIST_DESTRUCT(&dl);
+}
+
 static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
                        pmix_rank_t **dmns, size_t *ndmns)
 {
@@ -1842,6 +2378,13 @@ static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
     size_t nds = 0;
     pmix_rank_t *dns = NULL;
     int rc = PRTE_SUCCESS;
+    /* Once the DVM has known failures, a member we cannot resolve is most
+     * likely one whose node is being torn down, and refusing to resolve the
+     * whole set would strand the collective: the caller drops the
+     * contribution with no completion path. Skip what we cannot resolve and
+     * carry on with the survivors. With no failures on record an
+     * unresolvable member is still a genuine error, and still fatal. */
+    bool tolerate = !pmix_bitmap_is_clear(&prte_rml_base.failed_dmns);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                          "%s grpcomm:direct:group:create_dmns called with %s signature size %" PRIsize_t "",
@@ -1879,6 +2422,9 @@ static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
                     continue;
                 }
                 if (NULL == node->daemon) {
+                    if (tolerate) {
+                        continue;
+                    }
                     PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                     rc = PRTE_ERR_NOT_FOUND;
                     goto done;
@@ -1910,11 +2456,17 @@ static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
             proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs,
                                                                sig->members[n].rank);
             if (NULL == proc) {
+                if (tolerate) {
+                    continue;
+                }
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                 rc = PRTE_ERR_NOT_FOUND;
                 goto done;
             }
             if (NULL == proc->node || NULL == proc->node->daemon) {
+                if (tolerate) {
+                    continue;
+                }
                 PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
                 rc = PRTE_ERR_NOT_FOUND;
                 goto done;
@@ -2034,6 +2586,15 @@ static int pack_signature(pmix_data_buffer_t *bkt,
             PMIX_ERROR_LOG(rc);
             return prte_pmix_convert_status(rc);
         }
+    }
+
+    /* pack the fault-tolerant-collective flag. Deliberately not guarded by
+     * PRTE_PMIX_HAVE_GROUP_FT: the wire format has to be identical across the
+     * DVM regardless of what the PMIx we built against advertises */
+    rc = PMIx_Data_pack(NULL, bkt, &sig->ft_collective, 1, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
     }
 
     // pack final order, if given
@@ -2161,6 +2722,15 @@ static int unpack_signature(pmix_data_buffer_t *buffer,
             PMIX_RELEASE(s);
             return prte_pmix_convert_status(rc);
         }
+    }
+
+    // unpack the fault-tolerant-collective flag - see pack_signature()
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &s->ft_collective, &cnt, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(s);
+        return prte_pmix_convert_status(rc);
     }
 
     // unpack the final order

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -52,6 +52,10 @@
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 
+#include "src/class/pmix_bitmap.h"
+#include "src/rml/rml.h"
+#include "src/runtime/prte_globals.h"
+
 #include "src/mca/grpcomm/grpcomm.h"
 #include "src/mca/grpcomm/base/base.h"
 #include "src/mca/grpcomm/direct/grpcomm_direct.h"
@@ -232,12 +236,17 @@ static int test_classes(void)
     CHECK("grp sig naddmembers 0", 0 == gsig->naddmembers);
     CHECK("grp sig final_order NULL", NULL == gsig->final_order);
     CHECK("grp sig nfinal 0", 0 == gsig->nfinal);
-    /* exercise the destructor's free(groupID)/free(members)/free(addmembers) */
+    /* a group is not fault tolerant unless somebody asks for it */
+    CHECK("grp sig ft_collective false", !gsig->ft_collective);
+    /* exercise the destructor's free of groupID/members/addmembers and the
+     * final order, which the destructor used to leak */
     gsig->groupID = strdup("test-group");
     gsig->nmembers = 1;
     gsig->members = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
     gsig->naddmembers = 1;
     gsig->addmembers = (pmix_proc_t *) malloc(sizeof(pmix_proc_t));
+    gsig->nfinal = 1;
+    PMIX_PROC_CREATE(gsig->final_order, gsig->nfinal);
     PMIX_RELEASE(gsig);
 
     /* fence tracker: clean rollup counters, constructed bucket */
@@ -310,6 +319,78 @@ static int test_classes(void)
     return failures;
 }
 
+/* The departed-member predicate decides whether a construct that lost a
+ * daemon may complete on the survivors, so it is worth pinning down away from
+ * a live DVM.  It reads only the failed-daemon set and the job data, both of
+ * which can be stood up by hand here. */
+static int test_member_departed(void)
+{
+    int failures = 0;
+    pmix_proc_t member;
+    prte_job_t *jdata;
+    prte_proc_t *proc;
+    prte_node_t *node;
+    prte_proc_t *dmn;
+
+    /* prte_init_util() opens neither the RML nor the job pool, so the two
+     * globals this predicate reads are still raw static storage - stand them
+     * up by hand, as the ras and runtime unit tests do */
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, 8);
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT_MAX, 8);
+    }
+
+    /* with nothing failed, nobody has departed - and this is the path every
+     * fault-free collective takes, so it must not even consult the job map */
+    PMIX_LOAD_PROCID(&member, "no-such-nspace", 0);
+    CHECK("departed: clean failed set says no",
+          !prte_grpcomm_direct_group_member_departed(&member));
+
+    /* mark daemon 1 as failed and hang a job off daemons 0 and 1 */
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 1);
+
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "ft-test-nspace");
+    prte_set_job_data_object(jdata);
+
+    for (pmix_rank_t r = 0; r < 2; r++) {
+        node = PMIX_NEW(prte_node_t);
+        dmn = PMIX_NEW(prte_proc_t);
+        PMIX_LOAD_PROCID(&dmn->name, PRTE_PROC_MY_NAME->nspace, r);
+        node->daemon = dmn;
+        proc = PMIX_NEW(prte_proc_t);
+        PMIX_LOAD_PROCID(&proc->name, jdata->nspace, r);
+        proc->node = node;
+        pmix_pointer_array_set_item(jdata->procs, r, proc);
+    }
+    jdata->num_procs = 2;
+
+    /* rank 0 lives on the surviving daemon, rank 1 on the failed one */
+    PMIX_LOAD_PROCID(&member, jdata->nspace, 0);
+    CHECK("departed: member on a live daemon survives",
+          !prte_grpcomm_direct_group_member_departed(&member));
+    PMIX_LOAD_PROCID(&member, jdata->nspace, 1);
+    CHECK("departed: member on a failed daemon departed",
+          prte_grpcomm_direct_group_member_departed(&member));
+
+    /* a wildcard names a namespace, not a process, so it is never resolvable
+     * to a single daemon and must not be reported as departed */
+    PMIX_LOAD_PROCID(&member, jdata->nspace, PMIX_RANK_WILDCARD);
+    CHECK("departed: wildcard is not a departed member",
+          !prte_grpcomm_direct_group_member_departed(&member));
+
+    /* an unresolvable member is treated as departed rather than as an error -
+     * losing the mapping is what a node being torn down looks like */
+    PMIX_LOAD_PROCID(&member, "ft-test-missing", 0);
+    CHECK("departed: unresolvable member counts as departed",
+          prte_grpcomm_direct_group_member_departed(&member));
+
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -334,6 +415,9 @@ int main(void)
     failures += test_component_identity();
     failures += test_base_context_id();
     failures += test_classes();
+#if PRTE_TEST_GRPCOMM_DIRECT
+    failures += test_member_departed();
+#endif
 
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
     prte_finalize();

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -265,9 +265,19 @@ static int test_classes(void)
     CHECK("grp trk nleaders_reported 0", 0 == gc->nleaders_reported);
     CHECK("grp trk nfollowers 0", 0 == gc->nfollowers);
     CHECK("grp trk nfollowers_reported 0", 0 == gc->nfollowers_reported);
-    CHECK("grp trk assignID false", !gc->assignID);
     CHECK("grp trk grpinfo opened", NULL != gc->grpinfo);
     CHECK("grp trk endpts opened", NULL != gc->endpts);
+    /* the rollup must start with nothing reported from anywhere: a set slot
+     * bit or a raised self_reported would silently subtract a contribution
+     * from what the collective waits for */
+    CHECK("grp trk no slots reported",
+          0 == pmix_bitmap_num_set_bits(&gc->reported_slots,
+                                        pmix_bitmap_size(&gc->reported_slots)));
+    CHECK("grp trk self_reported false", !gc->self_reported);
+    CHECK("grp trk converged false", !gc->converged);
+    CHECK("grp trk aborting false", !gc->aborting);
+    CHECK("grp trk timeout 0", 0 == gc->timeout);
+    CHECK("grp trk tev inactive", !gc->tev_active);
     PMIX_RELEASE(gc);
 
     /* fence caddy: all borrowed pointers NULL, sizes zero */

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -346,7 +346,7 @@ static int test_member_departed(void)
      * fault-free collective takes, so it must not even consult the job map */
     PMIX_LOAD_PROCID(&member, "no-such-nspace", 0);
     CHECK("departed: clean failed set says no",
-          !prte_grpcomm_direct_group_member_departed(&member));
+          !prte_grpcomm_direct_proc_departed(&member));
 
     /* mark daemon 1 as failed and hang a job off daemons 0 and 1 */
     pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 1);
@@ -370,22 +370,22 @@ static int test_member_departed(void)
     /* rank 0 lives on the surviving daemon, rank 1 on the failed one */
     PMIX_LOAD_PROCID(&member, jdata->nspace, 0);
     CHECK("departed: member on a live daemon survives",
-          !prte_grpcomm_direct_group_member_departed(&member));
+          !prte_grpcomm_direct_proc_departed(&member));
     PMIX_LOAD_PROCID(&member, jdata->nspace, 1);
     CHECK("departed: member on a failed daemon departed",
-          prte_grpcomm_direct_group_member_departed(&member));
+          prte_grpcomm_direct_proc_departed(&member));
 
     /* a wildcard names a namespace, not a process, so it is never resolvable
      * to a single daemon and must not be reported as departed */
     PMIX_LOAD_PROCID(&member, jdata->nspace, PMIX_RANK_WILDCARD);
     CHECK("departed: wildcard is not a departed member",
-          !prte_grpcomm_direct_group_member_departed(&member));
+          !prte_grpcomm_direct_proc_departed(&member));
 
     /* an unresolvable member is treated as departed rather than as an error -
      * losing the mapping is what a node being torn down looks like */
     PMIX_LOAD_PROCID(&member, "ft-test-missing", 0);
     CHECK("departed: unresolvable member counts as departed",
-          prte_grpcomm_direct_group_member_departed(&member));
+          prte_grpcomm_direct_proc_departed(&member));
 
     PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
     return failures;


### PR DESCRIPTION
Fixes #2510.

## The asymmetry

A group collective can lose a participant two ways. When a **client** dies, the PMIx server library honors `PMIX_GROUP_FT_COLLECTIVE`: the construct completes on the survivors and each is told who was lost. When an entire **daemon** dies, taking its whole subtree of clients, PRRTE aborted the construct regardless of that request — the directive appeared exactly once in the tree, in a comment saying it was not honored.

Now it is honored. A construct whose participants asked for a fault-tolerant collective completes on the reduced membership and raises `PMIX_GROUP_MEMBER_FAILED` at each survivor. Without the flag, behavior is unchanged.

## Why an epoch and not xcast's ack rounds

The instinct is to copy `xcast_fault_handler` — rounds chosen by the parent, echoed by the child. That model does not transfer. In xcast the payload flows *down*, so the parent always holds the op and can re-poll. In a rollup it flows *up*, so the parent is exactly the party that may hold nothing: a pass-through daemon's tracker is created lazily, on the first arriving contribution. A round also cannot invalidate a contribution the parent has *already absorbed* — that invalidation has to travel up, and rounds travel down.

Instead each daemon carries a `recovery_epoch`, advanced from the **global fault scope**: one broadcast, identically ordered everywhere, after the routing tree is repaired. Every daemon discards what it gathered, recomputes what the repaired tree owes it, and re-offers its own saved contribution. The failure mode this guards is not a hang but a *partial* restart — one daemon re-sending into a parent that did not reset would have its subtree counted twice and another not at all, which is a quietly wrong membership.

The FT policy itself lives at controller completion rather than in the fault handler, which is what covers an operation whose first contribution had not yet arrived when the failure landed.

## Fence

The fence handler killed the job whenever *any* daemon failed while *any* fence was in flight, never asking whether the two were related — and fences run constantly, so an unrelated failure anywhere was fatal to bystanders. It had no scope guard either, so it ran twice per failure and once on every daemon *revival*: a daemon coming back killed a job.

Fence now shares the same machinery. A fence whose participants all survive re-converges; the loss of a pure relay is invisible to it. A fence that genuinely lost a participant cannot produce its answer — an allgather has no opt-in to running degraded, which is what separates it from a group construct — so it ends, completing its own participants with `PMIX_ERR_LOST_CONNECTION` rather than activating a DVM-wide comm failure.

One deliberate asymmetry, recorded at the code: the fence check sits at fault time, the group's at completion. `failed_dmns` is permanent, so a completion-time fence check would fail every later fence naming that namespace for the life of the DVM, leaving a recoverable job unable to fence at all after one loss.

## Drive-by fixes

Found while reading, each its own commit:

- an out-of-bounds write in `get_tracker`'s wildcard merge — it indexed the incoming array into the tracker's
- `get_tracker`'s create path never copied `bootstrap`/`follower`/`final_order`, so a single-leader bootstrap could never complete and a final order was honored or discarded depending on message arrival order
- the signature destructor leaked `final_order`
- three release buffers leaked after `xcast`, which copies — on the controller for **every** group and fence operation
- `find_delete_tracker` matched on groupID alone while `get_tracker` matches groupID and operation
- `create_dmns` refused to resolve a participant set if any one member could not be placed, which is what a node being torn down looks like — the caller then dropped the contribution with no completion path
- the daemon-loss notice claimed it "will terminate the job", which is untrue for a recoverable one, and named no option; it now says what is known and points at `--rtos recoverable`

Along the way the rollup accounting moved from a bare counter to per-subtree marks, with a convergence latch and a bounded memo of released operations. A counter cannot tell two messages from one child apart from one message from each, which is exactly what replay produces.

## Testing

`test/unit/grpcomm` covers the departed-member predicates against a synthetic failed-daemon set — the only genuinely unit-testable part, and where policy bugs live.

The rest needs real daemons. `groupcon` gains `--ft`, `--fence` and `--delay`, and six cases in `contrib/dockerswarm` kill a real `prted` under a live collective. Two things make them real rather than decorative, both documented at the harness:

- `--delay` staggers the ranks so the collective is genuinely in flight when the kill lands. In `--fence` mode it applies to the last rank alone, so the others block inside the allgather; a uniform delay would have every rank enter *after* the kill and test nothing.
- the job must be launched `--rtos recoverable`. By default the loss of a proc is fatal to its whole job, so the survivors are killed before they can survive anything, and the case fails in a way that looks like the feature is broken rather than the test.

**Verification run:** warning-free debug build with `PMIX_CAP_GROUP_FT` present **and forced off** (that second build is what caught an unguarded static); `make check` 21/21; Sphinx `-W` clean; single-host DVM smoke test; full dockerswarm suite **422 passed / 0 failed / 2 skipped** (the 2 skips are pre-existing and unrelated), against a 412 baseline.

The bystander fence case was checked for teeth by restoring the pre-fix handler and re-running: **0 of 2 ranks survived**, so it catches the old behavior rather than passing vacuously.

## Out of scope, deliberately

- **Bootstrap operations** still abort. They have no resolved daemon set, and the leader count is a number with no identities attached, so the controller cannot work out how much of one died. Recording leader identities is the enabling change for a follow-up.
- **A collective in flight across a revival** is ended rather than restarted. `PRTE_RML_TAG_DAEMON_REVIVED` is deliberately forward-first in the xcast, so it cannot give the parent-before-child ordering a restart needs. This path previously did nothing at all, i.e. hung, so ending it is an improvement rather than a fix.
- The race where the controller completes a construct microseconds before learning a member's daemon died — that member is an ordinary post-construct failure, not a departed entry.
