### PR TITLE
Pin down what a lost daemon does to a fence in flight

### DIFF
--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -266,6 +266,15 @@ constructs with the documented defaults (all rollup counters zero, the
 group tracker's info-lists opened) and destructs without leaking or
 crashing. Extend it when you add a class or change a constructor default.
 
+It also covers the **daemon-failure decisions**, which need no tree even
+though acting on them does: the departed-member predicate, and the fence
+fault handler's choice between re-converging a fence that merely lost a
+message path and ending one that lost a participant. Both read only the
+failed-daemon set and the job map, so the test stands those up by hand and
+stubs `prte_grpcomm.xcast` to capture the release the controller would
+broadcast. That is where to pin a change to the *policy*; the recovery
+itself still needs the dockerswarm harness.
+
 The live collectives are covered by the
 [dockerswarm harness](../../../contrib/dockerswarm/AGENTS.md): `xcast`
 and `fence` fall out of nearly every phase, and `test_grpcomm` drives

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -40,6 +41,14 @@
  *      every counter must start at zero so a rollup cannot complete
  *      early), and their destructors must free their owned members --
  *      including the NULL case -- without crashing.
+ *
+ *   5. The daemon-failure decisions.  Recovering a collective needs the
+ *      routing tree, but *deciding* what to recover does not: it reads
+ *      only the failed-daemon set and the job map, both of which can be
+ *      stood up by hand here.  So the departed-member predicate and the
+ *      fence fault handler's choice -- re-converge a fence that merely
+ *      lost a message path, end one that lost a participant -- are pinned
+ *      down away from a live DVM, with the release broadcast stubbed.
  */
 
 #include "prte_config.h"
@@ -49,6 +58,7 @@
 
 #include "constants.h"
 #include "src/mca/base/pmix_base.h"
+#include "src/pmix/pmix-internal.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
 
@@ -391,13 +401,238 @@ static int test_member_departed(void)
     return failures;
 }
 
+#if PRTE_TEST_GRPCOMM_DIRECT
+/* Stands in for the down-tree release the controller broadcasts to end a
+ * fence.  There is no routing tree here to broadcast over, and the abort is
+ * defined by what it puts on the wire anyway: the signature of the fence
+ * being ended, and the status its participants are to be completed with. */
+static int fence_xcast_calls;
+static prte_rml_tag_t fence_xcast_tag;
+static pmix_status_t fence_xcast_status;
+static char fence_xcast_nspace[PMIX_MAX_NSLEN + 1];
+
+static int stub_xcast(prte_rml_tag_t tag, pmix_data_buffer_t *msg)
+{
+    size_t sz = 0;
+    pmix_proc_t *procs = NULL;
+    pmix_status_t st = PMIX_SUCCESS;
+    int32_t cnt;
+
+    fence_xcast_calls++;
+    fence_xcast_tag = tag;
+    fence_xcast_status = PMIX_SUCCESS;
+    fence_xcast_nspace[0] = '\0';
+
+    /* read it back the way fence_release() does - signature, then status */
+    cnt = 1;
+    if (PMIX_SUCCESS != PMIx_Data_unpack(NULL, msg, &sz, &cnt, PMIX_SIZE)) {
+        return PRTE_SUCCESS;
+    }
+    if (0 < sz) {
+        PMIX_PROC_CREATE(procs, sz);
+        cnt = (int32_t) sz;
+        if (PMIX_SUCCESS == PMIx_Data_unpack(NULL, msg, procs, &cnt, PMIX_PROC)) {
+            PMIX_LOAD_NSPACE(fence_xcast_nspace, procs[0].nspace);
+        }
+        PMIX_PROC_FREE(procs, sz);
+    }
+    cnt = 1;
+    if (PMIX_SUCCESS == PMIx_Data_unpack(NULL, msg, &st, &cnt, PMIX_INT32)) {
+        fence_xcast_status = st;
+    }
+    return PRTE_SUCCESS;
+}
+
+/* Hang a job of nprocs off daemons 0..nprocs-1, one rank apiece, so a
+ * signature naming this namespace resolves through the job map. */
+static void build_job(const char *nspace, pmix_rank_t nprocs)
+{
+    prte_job_t *jdata;
+    prte_node_t *node;
+    prte_proc_t *proc, *dmn;
+    pmix_rank_t r;
+
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
+    prte_set_job_data_object(jdata);
+
+    for (r = 0; r < nprocs; r++) {
+        node = PMIX_NEW(prte_node_t);
+        dmn = PMIX_NEW(prte_proc_t);
+        PMIX_LOAD_PROCID(&dmn->name, PRTE_PROC_MY_NAME->nspace, r);
+        node->daemon = dmn;
+        proc = PMIX_NEW(prte_proc_t);
+        PMIX_LOAD_PROCID(&proc->name, jdata->nspace, r);
+        proc->node = node;
+        pmix_pointer_array_set_item(jdata->procs, r, proc);
+    }
+    jdata->num_procs = nprocs;
+}
+
+/* Append a tracker standing in for a fence rolling up right now over the
+ * whole of nspace -- the wildcard is how a fence signature is usually
+ * spelled, and expanding it is part of what is under test here. */
+static prte_grpcomm_fence_t *add_fence_op(const char *nspace)
+{
+    prte_grpcomm_fence_t *coll = PMIX_NEW(prte_grpcomm_fence_t);
+
+    coll->sig = PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
+    coll->sig->sz = 1;
+    PMIX_PROC_CREATE(coll->sig->signature, 1);
+    PMIX_LOAD_PROCID(&coll->sig->signature[0], nspace, PMIX_RANK_WILDCARD);
+    coll->nexpected = 2;
+    coll->nreported = 1;
+    pmix_list_append(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);
+    return coll;
+}
+#endif
+
+/*
+ * A daemon failure used to end every fence in flight, and a fence ends its
+ * participants -- so the loss of a daemon anywhere was fatal to whatever
+ * else happened to be fencing at the time, and fences run constantly.  The
+ * handler must now ask whether the two had anything to do with each other:
+ * a fence whose participants all survive lost only a message path and
+ * re-converges over the repaired tree at the new recovery epoch, while one
+ * that genuinely lost a participant cannot produce its answer and ends --
+ * itself, with PMIX_ERR_LOST_CONNECTION, leaving the DVM standing.
+ *
+ * The decision is the controller's, made once on the global-scope pass; a
+ * revival is the exception, ending everything in flight because its
+ * broadcast is forward-first and so cannot order a restart.
+ */
+static int test_fence_fault_handler(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_DIRECT
+    prte_rml_recovery_status_t status;
+    prte_grpcomm_fence_t *bystander, *doomed;
+    prte_proc_type_t save_type;
+
+    /* init() is what constructs the tracker list, and it takes a selected
+     * module and a live RML - stand the list up by hand instead */
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, 8);
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT_MAX, 8);
+    }
+    prte_grpcomm.xcast = stub_xcast;
+    fence_xcast_calls = 0;
+
+    /* daemon 1 has failed; one job lives entirely on the survivor, the
+     * other straddles both */
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 1);
+    build_job("fence-live-nspace", 1);
+    build_job("fence-lost-nspace", 2);
+
+    /* nothing in flight: the handler must not reach for anything */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("fault: no ops, nothing broadcast", 0 == fence_xcast_calls);
+
+    bystander = add_fence_op("fence-live-nspace");
+    doomed = add_fence_op("fence-lost-nspace");
+
+    /* the local pass of a death belongs to the RML's own tree repair - the
+     * collectives act on the global notice, which reaches every daemon in
+     * one order, so acting here would end a fence on the daemons nearest
+     * the failure while their peers waited out a re-convergence */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_LOCAL;
+    PMIx_Data_array_construct(&status.failed_ranks, 1, PMIX_PROC_RANK);
+    ((pmix_rank_t *) status.failed_ranks.array)[0] = 1;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("fault: local pass of a death broadcasts nothing", 0 == fence_xcast_calls);
+    CHECK("fault: local pass leaves the doomed fence alone", !doomed->aborting);
+
+    /* only the controller decides: a fence's participants are completed by
+     * the release it broadcasts, so a daemon acting on its own would end
+     * its own clients and leave everyone else's blocked */
+    save_type = prte_process_info.proc_type;
+    prte_process_info.proc_type = PRTE_PROC_DAEMON;
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    prte_process_info.proc_type = save_type;
+    CHECK("fault: a non-controller broadcasts nothing", 0 == fence_xcast_calls);
+    CHECK("fault: a non-controller ends nothing", !doomed->aborting);
+
+    /* the controller's global pass: exactly the fence that lost a
+     * participant is ended, and the bystander is left to re-converge */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("fault: exactly one release broadcast", 1 == fence_xcast_calls);
+    CHECK("fault: released on the fence-release tag",
+          PRTE_RML_TAG_FENCE_RELEASE == fence_xcast_tag);
+    CHECK("fault: the fence that lost a participant is the one ended",
+          0 == strcmp("fence-lost-nspace", fence_xcast_nspace));
+    CHECK("fault: ended with a lost connection",
+          PMIX_ERR_LOST_CONNECTION == fence_xcast_status);
+    CHECK("fault: the doomed fence is marked aborting", doomed->aborting);
+    CHECK("fault: the bystander fence is untouched", !bystander->aborting);
+    /* the tracker is not dropped here - it goes when its own release comes
+     * back around, which is also what completes the local participants */
+    CHECK("fault: both trackers still in flight",
+          2 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+
+    /* a second failure must not re-broadcast a release already sent */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("fault: an aborting fence is not ended twice", 1 == fence_xcast_calls);
+
+    /* a revival: local scope with nothing newly failed.  It reshapes the
+     * tree as a death does, but rides a forward-first broadcast, so it
+     * cannot order a restart - everything in flight ends, bystander
+     * included */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_LOCAL;
+    prte_grpcomm_direct_fence_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("fault: a revival ends the bystander too", 2 == fence_xcast_calls);
+    CHECK("fault: revival released the bystander",
+          0 == strcmp("fence-live-nspace", fence_xcast_nspace));
+    CHECK("fault: bystander now aborting", bystander->aborting);
+
+    prte_grpcomm.xcast = NULL;
+    PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.fence_ops);
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fence_fault_handler\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
+    pmix_status_t prc;
 
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
         fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+
+    /* the fence abort under test packs a release buffer, and PMIx_Data_pack
+     * refuses to run until PMIx itself is up.  A daemon reaches that state
+     * through PMIx_server_init, so do the same */
+    prc = PMIx_server_init(NULL, NULL, 0);
+    if (PMIX_SUCCESS != prc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(prc));
+        prte_finalize();
         return 1;
     }
 
@@ -418,8 +653,10 @@ int main(void)
 #if PRTE_TEST_GRPCOMM_DIRECT
     failures += test_member_departed();
 #endif
+    failures += test_fence_fault_handler();
 
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);
+    PMIx_server_finalize();
     prte_finalize();
 
     if (0 == failures) {


### PR DESCRIPTION
The fence fault handler decides, for every fence in flight, whether the daemon that just died had anything to do with it: one whose participants all survive re-converges over the repaired tree, one that genuinely lost a participant is ended. Getting that question wrong is what made an unrelated daemon failure fatal to bystanders — and fences run constantly, so a regression there costs the whole DVM. Until now the only thing guarding it was the dockerswarm harness, which needs four containers to run.

The decision needs no routing tree even though acting on it does: it reads only the failed-daemon set and the job map. So this drives `prte_grpcomm_direct_fence_fault_handler()` directly against a synthetic pair of fences — one over a namespace living entirely on the survivor, one straddling the failed daemon — with `prte_grpcomm.xcast` stubbed to capture the release the controller would have broadcast.

Covered: the bystander case, the controller-only and global-scope gates, the local pass of a death, the tag/signature/status the abort puts on the wire, that an already-aborting tracker is not ended twice, and the revival (which ends everything in flight, its broadcast being forward-first).

Verified non-vacuous: reverting the `procs_lost` gate to the old abort-everything behavior fails four of the checks.

The abort packs a release buffer and `PMIx_Data_pack` refuses to run before PMIx is up, so `main()` now reaches the state a daemon reaches through `PMIx_server_init` — as `test/unit/runtime` already does for its wire tests.

`make check` passes across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)