### PR TITLE
Third deep review of src/hwloc

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3037,6 +3037,19 @@ test_hwloc() {
     rc=$?
     [ "$rc" != 0 ] && ok "a job-only bindto qualifier is fatal at DVM scope (rc=$rc)" \
                    || bad "bindto=core:report was diagnosed and then ignored"
+    # every documented value that this node actually provides must map AND bind
+    for lvl in hwthread core package numa; do
+        out=$(RUN "timeout 60 prterun --prtemca bindto $lvl --host node2:4 -n 2 --display map hostname" 2>&1)
+        rc=$?
+        echo "$out" | grep -q 'lies above the mapping' \
+            && bad "bindto=$lvl was refused by the bind-upwards check" \
+            || ok "bindto=$lvl was not refused as binding above the map"
+        [ "$rc" = 0 ] && ok "bindto=$lvl ran the job" \
+                      || bad "bindto=$lvl failed (rc=$rc): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        n=$(echo "$out" | grep -c 'Bound: ')
+        [ "$n" = 2 ] && ok "bindto=$lvl bound both ranks" \
+                     || bad "bindto=$lvl bound $n/2 ranks: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    done
     cleanup_swarm
 
     banner "hwloc: per-object binding limits do not carry over between jobs"

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3164,6 +3164,34 @@ test_hwloc() {
         || bad "the mapping policy moved: $(echo "$out" | grep -i 'Mapping policy' | tr '\n' ' ')"
     cleanup_swarm
 
+    banner "hwloc: the REPORT binding qualifier is reachable"
+    # Three lists decide what a --bind-to qualifier is: the schizo whitelist
+    # (bndquals[]), the job-level parser in src/hwloc, and the per-app parser
+    # in rmaps/base. REPORT was implemented only in the job-level parser and
+    # was missing from the whitelist, so no command line could reach it -
+    # including the diagnostic that same arm emits when it is given as a
+    # DVM-wide default, which tells the user to give it per job instead.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:4 -n 2 --bind-to core:report hostname' 2>&1)
+    rc=$?
+    [ "$rc" = 0 ] && ok "--bind-to core:report is accepted for a job (rc=0)" \
+                  || bad "--bind-to core:report was refused (rc=$rc): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    echo "$out" | grep -qi 'unrecognized qualifier' \
+        && bad "--bind-to core:report is still refused as an unrecognized qualifier" \
+        || ok "the qualifier was not reported as unrecognized"
+    # ...and it describes the whole job, so a later MPMD segment has nowhere
+    # to record it. That has to be said by name - the same spelling is legal
+    # one segment earlier, so the generic "unrecognized qualifier" would be
+    # baffling.
+    out=$(RUN 'timeout 90 prterun --host node2:4 -n 1 hostname : -n 1 --bind-to core:report hostname' 2>&1)
+    rc=$?
+    [ "$rc" != 0 ] && ok "a per-app REPORT is refused (rc=$rc)" \
+                   || bad "a per-app REPORT was accepted, but there is nowhere to record it"
+    echo "$out" | grep -q 'describes the whole job' \
+        && ok "the per-app refusal explains itself" \
+        || bad "the per-app refusal was generic: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    cleanup_swarm
+
     banner "hwloc: logical and physical binding reports agree on this node"
     # --report-bindings renders through the same path with "physical" either
     # set or not, and it used to be ignored outright whenever the short cut

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3103,6 +3103,40 @@ test_hwloc() {
     fi
     cleanup_swarm
 
+    banner "hwloc: the parseable renderings actually parse"
+    # PRRTE writes the same fact two ways. "--display map:parseable" runs
+    # prte_hwloc_get_binding_info() and emits <package id="0"><core>N</core>
+    # ...</package>; "--display cpus:parseable" runs the ras/base copy and
+    # used to emit "<processors node=x>" wrapping "<pkg=0 cpus=0-7>" - an
+    # unquoted attribute value around something that is not an element at
+    # all. Neither could be read by an XML parser, which is the one thing
+    # the mode is named for. Both are checked here against a real parser
+    # rather than a grep, because a grep is exactly what let this stand.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:4 -n 2 --map-by core --bind-to core \
+                   --display map:parseable hostname' 2>&1)
+    echo "$out" | sed -n '/<map>/,/<\/map>/p' > /tmp/prte-map-parseable.$$
+    python3 -c "import sys,xml.etree.ElementTree as ET; ET.parse(sys.argv[1])" \
+        /tmp/prte-map-parseable.$$ 2>/dev/null \
+        && ok "--display map:parseable produces a well-formed document" \
+        || bad "--display map:parseable does not parse: $(head -c 300 /tmp/prte-map-parseable.$$ | tr '\n' ' ')"
+    grep -q '<package id=' /tmp/prte-map-parseable.$$ \
+        && ok "the map document names each package as an element attribute" \
+        || bad "no <package id=...> element in the map document"
+    rm -f /tmp/prte-map-parseable.$$
+
+    out=$(RUN 'timeout 90 prterun --host node2:4 -n 1 --display cpus:parseable hostname' 2>&1)
+    echo "$out" | sed -n '/<processors/,/<\/processors>/p' > /tmp/prte-cpus-parseable.$$
+    python3 -c "import sys,xml.etree.ElementTree as ET; ET.parse(sys.argv[1])" \
+        /tmp/prte-cpus-parseable.$$ 2>/dev/null \
+        && ok "--display cpus:parseable produces a well-formed document" \
+        || bad "--display cpus:parseable does not parse: $(head -c 300 /tmp/prte-cpus-parseable.$$ | tr '\n' ' ')"
+    grep -q '<package id=' /tmp/prte-cpus-parseable.$$ \
+        && ok "both parseable renderings spell a package the same way" \
+        || bad "--display cpus:parseable does not use the <package id=...> shape"
+    rm -f /tmp/prte-cpus-parseable.$$
+    cleanup_swarm
+
     banner "hwloc: a qualifier with no policy keeps the default binding"
     # "--bind-to :overload-allowed" means "the binding I would have got,
     # but allow overload" - the same thing "--map-by :OVERSUBSCRIBE" has

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2995,6 +2995,20 @@ test_hwloc() {
     echo "$out" | grep -q 'Cpuset:  0x' \
         && ok "object cpusets were rendered" \
         || bad "no cpuset was rendered in the topology dump"
+    # The dump has to contain the levels PRRTE maps and binds to. NUMA is the
+    # one that was missing: hwloc 2.x hangs NUMA nodes off memory_first_child,
+    # not off the children[] array the renderer walked, so a user who ran
+    # "--display topo" to work out what "--map-by numa" would do got a
+    # topology with no NUMA domains in it at all. hwloc always synthesizes at
+    # least one NUMA node covering the machine, so this holds even here where
+    # sysfs reports none.
+    for lvl in Package Core PU NUMANode; do
+        echo "$out" | grep -q "Type: $lvl" \
+            && ok "--display topo shows $lvl objects" \
+            || bad "--display topo omitted every $lvl object"
+    done
+    cleanup_swarm
+
     cleanup_swarm
 
     banner "hwloc: per-object binding limits do not carry over between jobs"

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3009,6 +3009,34 @@ test_hwloc() {
     done
     cleanup_swarm
 
+    banner "hwloc: the DVM-wide bindto parameter means what it says"
+    # "bindto" is the DVM-wide default binding policy, and it documents eight
+    # values. Five of them were unusable.
+    #
+    # 1. A value the parser refuses was diagnosed and then IGNORED:
+    #    prte_init() discarded prte_hwloc_base_open()'s return, so the DVM
+    #    came up with the default binding after telling the user their request
+    #    was not recognized. The command-line spelling of the same typo
+    #    ("--bind-to bogus") has always been fatal.
+    # 2. A value COARSER THAN A CORE was refused outright. Deriving the
+    #    default mapping reads jdata->map->binding, but the MCA default was
+    #    not copied onto the job until after the mapping had been settled -
+    #    so the job mapped BYCORE and the bind-upwards check then rejected
+    #    binding to a package. "--bind-to package" on the command line
+    #    mapped BYPACKAGE and worked.
+    cleanup_swarm
+    out=$(RUN 'timeout 60 prterun --prtemca bindto bogus --host node2:2 -n 1 hostname' 2>&1)
+    rc=$?
+    [ "$rc" != 0 ] && ok "an unrecognized DVM-wide bindto is fatal (rc=$rc)" \
+                   || bad "bindto=bogus was diagnosed and then ignored"
+    echo "$out" | grep -q 'not recognized' \
+        && ok "the refusal named the unrecognized policy" \
+        || bad "no diagnostic for the unrecognized bindto: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # a job-only qualifier at DVM scope is the same class of mistake
+    out=$(RUN 'timeout 60 prterun --prtemca bindto core:report --host node2:2 -n 1 hostname' 2>&1)
+    rc=$?
+    [ "$rc" != 0 ] && ok "a job-only bindto qualifier is fatal at DVM scope (rc=$rc)" \
+                   || bad "bindto=core:report was diagnosed and then ignored"
     cleanup_swarm
 
     banner "hwloc: per-object binding limits do not carry over between jobs"

--- a/src/docs/prrte-rst-content/cli-bind-to.rst
+++ b/src/docs/prrte-rst-content/cli-bind-to.rst
@@ -79,16 +79,26 @@ option:
 * ``OVERLOAD`` indicates that objects can have more
   processes bound to them than CPUs within them
 
+* ``NO-OVERLOAD`` indicates that they cannot. This is the default, so
+  the qualifier is only useful for overriding an ``OVERLOAD`` that a
+  DVM-wide default (the ``bindto`` MCA parameter) has already applied.
+
 * ``IF-SUPPORTED`` indicates that the job should continue to
   be launched and executed even if binding cannot be
   performed as requested.
 
 * ``LIMIT=n`` limits the number of processes bound to each eligible
   representative of the specified type to the given number. For
-  example, speifying "--bindto l3:limit=2" would direct PRRTE
+  example, specifying ``--bindto l3:limit=2`` would direct PRRTE
   to bind ranks to the L3caches, limiting the number of processes
   bound to each l3cache to two - i.e., bind 2 processes to a
   given l3cache, and then move on to the next.
+
+* ``REPORT`` reports each process' binding as it is applied, which is
+  the same thing ``--report-bindings`` does. It describes the job as a
+  whole: unlike the other qualifiers here it cannot be given per
+  application context, and it cannot be given as a DVM-wide default
+  through the ``bindto`` MCA parameter.
 
 .. note:: Directives and qualifiers are case-insensitive.
           ``OVERLOAD`` is the same as ``overload``.

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -231,6 +231,22 @@ Two ordering rules the parser now encodes:
   round, `--bind-to sockets:report` recorded report-bindings on the job and
   *then* rejected the request.
 
+### `bindto` is a real parameter, not a suggestion
+
+Two things had to be true before the DVM-wide `bindto` parameter meant what
+it documents, and neither was. Both are the same shape: the MCA spelling of
+a request was answered differently from the command-line spelling.
+
+- **A `bindto` value the parser refuses is fatal.** The whole point of
+  `prte_hwloc_base_open()` is to validate it, and `prte_init()` used to
+  discard the return — so `--prtemca bindto bogus` printed "the specified
+  binding policy is not recognized" and then launched the job anyway with
+  the default binding. `--bind-to bogus` has always been fatal. `open()`
+  converts its failure to `PRTE_ERR_SILENT` so `prte_init()` does not stack
+  a generic "internal failure" report on top of a diagnostic the parser has
+  already produced; the sibling parameters in `_register()`
+  (`mem_alloc_policy`, `mem_bind_failure_action`) already worked this way.
+
 ---
 
 ## GOLDEN RULE: a cpuset's bits are PU OS indices; a cpu *number* is not
@@ -387,6 +403,12 @@ same thread has cycled through the other 15 — never store one.
   what you want for "how many" and "exactly one".
 - **Comparing unsigneds by subtracting into an `int`** gets the order wrong
   for values far apart. `compare_unsigned()` learned this.
+- **A validator whose answer nobody reads is not a validator.**
+  `prte_hwloc_base_open()` exists to check the `bindto` parameter and
+  `prte_init()` threw its return away, so the check ran, printed, and
+  changed nothing. If you add a function here whose whole job is to say
+  "no", check that its one caller is listening — the failure mode is a
+  user who is told their request was refused and then watches it run.
 - **Warnings are errors.** Debug builds imply `--enable-devel-check`.
 
 ---

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -106,6 +106,41 @@ Consequences:
 
 ---
 
+## GOLDEN RULE: an hwloc object has four child lists, and `children[]` is one
+
+The same fact bites a second way, away from the counting wrappers. In
+hwloc 2.x an object's children are split across **four** separate lists:
+
+| List | Head | Count | Holds |
+|------|------|-------|-------|
+| normal | `obj->children[]` | `obj->arity` | packages, caches, cores, PUs, groups |
+| memory | `obj->memory_first_child` | `obj->memory_arity` | **NUMA nodes**, memcaches |
+| I/O | `obj->io_first_child` | `obj->io_arity` | bridges, PCI and OS devices |
+| Misc | `obj->misc_first_child` | `obj->misc_arity` | annotations |
+
+So **a recursive walk over `obj->children[0..arity)` visits no NUMA node
+and no device** — the same blind spot as a depth loop, wearing different
+clothes. `prte_hwloc_print()` — the whole of `--display topo` — was written
+that way, so it rendered a topology with no NUMA domains in it at all, on a
+runtime whose `--map-by numa` is usually the reason a user asked to see the
+topology in the first place. It also dropped every I/O object, which this
+directory goes out of its way to *keep* (`topology_set_flags()` asks hwloc
+for `HWLOC_TYPE_FILTER_KEEP_IMPORTANT`), so the network and GPU devices a
+user is looking for when they want to reason about locality were never
+shown either.
+
+**Use `hwloc_get_next_child()`** — it walks normal, then memory, then I/O,
+then Misc — and if you report a child *count*, sum all four arities:
+`obj->arity` alone makes a package holding a NUMA node read as though it
+held only its cores.
+
+Note that this is orthogonal to the `userdata` sweep below: nothing
+attaches PRRTE data to an I/O or Misc object, so
+`prte_hwloc_base_release_userdata()` is right to cover the normal depths
+plus `HWLOC_TYPE_DEPTH_NUMANODE` and no more.
+
+---
+
 ## Two kinds of `userdata`, hanging off the same pointer
 
 PRRTE stores two *different* PMIx objects on hwloc `userdata` pointers:

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -31,7 +31,8 @@ is the property to preserve.
 | Caller | What it wants |
 |--------|---------------|
 | `ess/hnp`, `plm/base` | `prte_hwloc_base_get_topology()`, `_filter_cpus()`, `_setup_summary()` — acquiring the local topology and receiving remote ones |
-| `rmaps/*` | `_get_nbobjs_by_type()`, `_get_obj_by_type()`, `_get_npus()`, `_generate_cpuset()`, `_cpu_list_parse()`, `_reset_counters()`, `prte_hwloc_obj_data_t` |
+| `rmaps/*` | `_get_nbobjs_by_type()`, `_get_obj_by_type()`, `_generate_cpuset()`, `_cpu_list_parse()`, `_reset_counters()`, `_has_cores()`/`_core_cpus()`, `prte_hwloc_obj_data_t` |
+| `ras/simulator` | `_get_npus()`, `_filter_cpus()` — the only caller of `_get_npus()`, which fabricates a node's slot count from a synthetic topology |
 | `odls/base` | `prte_hwloc_base_map` / `_mbfa` (the memory-policy globals) and `_cset2str()` |
 | `runtime/data_type_support`, `ras/base` | `_cset2str()`, `_cpuset2ranges()`, `prte_hwloc_get_binding_info()`, `prte_hwloc_print()` — every `--display` variant |
 | `schizo`, `tools` | `_set_binding_policy()`, `_print_binding()` |
@@ -103,6 +104,10 @@ Consequences:
   expressed in OS indices.
 - **`numa_cutoff` must never be left at `UINT_MAX`,** on any error path.
   The consumers scan `0..cutoff`.
+- **`prte_hwloc_base_setup_summary()` can fail to allocate the summary.**
+  Both lookups re-read the root's `userdata` after asking for it and cope
+  with a `NULL`; the builder itself has to as well, rather than
+  dereferencing what `PMIX_NEW` just failed to give it.
 
 ---
 
@@ -246,7 +251,11 @@ Two ordering rules the parser now encodes:
 - **Resolve the policy word before applying any qualifier**, because
   `report` and `limit=N` write to `jdata->attributes`. Parsed the other way
   round, `--bind-to sockets:report` recorded report-bindings on the job and
-  *then* rejected the request.
+  *then* rejected the request. The same rule reaches the `jdata->map ==
+  NULL` check, which is what says whether there is anywhere to *put* the
+  answer: it runs before the parse now, because running it last left
+  `PRTE_JOB_REPORT_BINDINGS` on a job whose binding was never set. **Any
+  new reason to refuse a spec belongs above the parsing, not below it.**
 
 ### `bindto` is a real parameter, not a suggestion
 

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -213,6 +213,23 @@ index past a qualifier's name to find its `=value`** — use
 `pmix_cli_qualifier_value()`. `limit=N` lands in a `uint16_t` attribute, so
 a value that does not fit has to be rejected rather than truncated.
 
+**Three lists have to agree about what a `--bind-to` qualifier is**, and
+they did not:
+
+| Where | What it is |
+|-------|------------|
+| `bndquals[]` in `schizo/base/schizo_base_frame.c` | the front-door whitelist — a name missing here never reaches a parser |
+| `prte_hwloc_base_set_binding_policy()` (here) | the job-level parser |
+| `prte_rmaps_base_set_app_binding_policy()` (`rmaps/base/rmaps_base_frame.c`) | the per-app parser |
+
+`report` was implemented only in the job-level parser and was missing from
+the whitelist, so no command line could reach it — including the `show_help`
+that same arm produces when it is given at DVM scope, which tells the user
+"you can provide this modifier on a per-job basis". It is in the whitelist
+now. It stays out of the per-app parser deliberately: the only attribute
+behind it is `PRTE_JOB_REPORT_BINDINGS`, and there is no per-app
+counterpart, so `report` describes the whole job or nothing.
+
 Two ordering rules the parser now encodes:
 
 - **`pmix_check_cli_option()` compares only `min(strlen(a), strlen(b))`

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -246,6 +246,18 @@ a request was answered differently from the command-line spelling.
   a generic "internal failure" report on top of a diagnostic the parser has
   already produced; the sibling parameters in `_register()`
   (`mem_alloc_policy`, `mem_bind_failure_action`) already worked this way.
+- **A `bindto` value coarser than a core has to reach the mapping
+  decision.** "Binding given, mapping not given" means *map by the binding
+  object* (`prte_rmaps_base_set_default_mapping()`), and that test reads
+  `jdata->map->binding` — which `rmaps_base_map_job.c` did not populate from
+  `prte_hwloc_default_binding_policy` until long after the mapping had been
+  settled. So `--prtemca bindto package` mapped `BYCORE` and was then
+  refused outright by the bind-upwards check, while `--bind-to package`
+  mapped `BYPACKAGE` and worked. Five of the eight values `bindto`
+  documents were unusable. The two *inheritance* arms (parent's binding,
+  MCA default) now run before the mapping is derived; deriving a binding
+  *from* the mapping necessarily still runs after it. If you add a third
+  source of a binding, ask which side of that line it belongs on.
 
 ---
 

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -427,6 +427,21 @@ same thread has cycled through the other 15 — never store one.
 - **A failure path that has destroyed the topology must NULL
   `prte_hwloc_topology`.** `prte_hwloc_base_close()` tests it for NULL and
   destroys it again otherwise.
+- **An imported topology reports no binding support, and
+  `hwloc_use_topo_file` has to say otherwise.** hwloc zeroes every bit of
+  `hwloc_topology_get_support()` for a topology it read from XML — it has no
+  way to know what the described machine can do — and
+  `prte_rmaps_base_check_support()` refuses any *explicitly requested*
+  binding when those bits are clear. So `--prtemca hwloc_use_topo_file X
+  --bind-to core` came back "at least one node does NOT support binding
+  processes to cpus" on a machine that supports it perfectly, leaving the
+  option usable only with `--bind-to none`. `set_topology()` asserts the
+  bits itself. **After `hwloc_topology_load()`, not before** — hwloc's own
+  header says the support structure "only contains valid information after"
+  the load, so the assertion that used to sit before it was filled in and
+  wiped by the load and had quietly never done anything.
+  `HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT` is a different question (what the
+  *exporting* machine could do) and was deliberately abandoned once before.
 - **`hwloc_bitmap_first()`/`_last()` return `-1` for an empty bitmap.**
   Do not feed that to `hwloc_bitmap_isset()`. `hwloc_bitmap_weight()` is
   what you want for "how many" and "exactly one".
@@ -488,11 +503,22 @@ topologies the HNP never sensed, a DVM cpu-set applied to every node rather
 than just the first, a malformed cpu-set being refused without taking the
 HNP down, `--display topo` over several topologies at once, the
 print-then-accept round trip (`--display cpus` → `--cpu-set` → the same set
-back), both spellings of the index basis, and — the one case that needs a
+back), both spellings of the index basis, that every value the DVM-wide
+`bindto` parameter documents both maps and binds rather than being refused
+as "binding above the map" (and that one it does *not* document is fatal
+rather than diagnosed-and-ignored), and — the one case that needs a
 **persistent** DVM, because `prterun` takes the stale state down with its
 HNP — three successive `--bind-to numa:limit=1` jobs all binding.
 
-**Not covered anywhere:** `prte_hwloc_base_get_topology()`'s sensing path
+The unit test also drives `prte_hwloc_base_get_topology()`'s **file** path
+(`hwloc_use_topo_file`), by writing the embedded XML to a temp file: that it
+loads, that a malformed file is refused without leaving a handle behind, and
+that the binding-support bits come back asserted. The offline harness runs
+that same path 1180 times, which is why a regression in it does not show up
+as a mapping failure — the harness passes `--rtos donotlaunch`, and
+`prte_rmaps_base_check_support()` is skipped for donotlaunch.
+
+**Not covered anywhere:** `prte_hwloc_base_get_topology()`'s *sensing* path
 (it reads the real machine), and `prte_hwloc_print()` against a machine wide
 enough to fill its cpuset buffer — a few thousand PUs.
 

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -453,6 +453,11 @@ same thread has cycled through the other 15 — never store one.
   changed nothing. If you add a function here whose whole job is to say
   "no", check that its one caller is listening — the failure mode is a
   user who is told their request was refused and then watches it run.
+- **Anything labelled "parseable" gets checked with a parser, not a grep.**
+  Both this directory's binding renderer and the `--display cpus` copy in
+  `ras/base` emitted documents that no XML reader would accept
+  (`<EMPTY CPUSET/>`, `<pkg=0 cpus=0-7>`), for years, under passing tests
+  that matched on substrings.
 - **Warnings are errors.** Debug builds imply `--enable-devel-check`.
 
 ---

--- a/src/hwloc/AGENTS.md
+++ b/src/hwloc/AGENTS.md
@@ -278,8 +278,23 @@ and everything that renders cpu numbers goes through it:
 |----------|--------|
 | `prte_hwloc_base_cpuset2ranges()` | `0,2-3` — the primitive; allocates and returns |
 | `prte_hwloc_base_cset2str()` | `package[0][core:L0,2-3]` — one element per package; allocates |
-| `prte_hwloc_get_binding_info()` | one `<core>N</core>` element per site, plus the package number, into the **caller's** buffer |
+| `prte_hwloc_get_binding_info()` | `<package id="N">` per package, each holding one `<core>N</core>` per site, into the **caller's** buffer |
 | `prte_hwloc_print()` | the whole topology as indented text; allocates |
+
+**The two binding renderers have to agree.** `_cset2str()` (the `--display
+map` short form) and `_get_binding_info()` (the `--display map:parseable`
+XML) describe the same `proc->cpuset`, and they must describe all of it.
+`_get_binding_info()` used to render only the *sites*, into a single
+`<package>` element its caller wrapped around them, and report the package
+number through an out parameter — so a process bound across two packages had
+each package overwrite the previous one from the top of the buffer, and came
+out naming the last package with every earlier one's cores dropped. That is
+not incomplete output, it is *wrong* output, and it is the machine-readable
+half of the pair. It is reachable, too: PRRTE refuses cross-package
+placement in the ordinary mappers and its own diagnostic points the user at
+the rankfile mapper, where a slot list of `P0:0;P1:0` produces exactly this.
+The renderer now emits the `<package>` elements itself and there is no
+`pkgnum`. If you add a third rendering, render every package.
 
 Three renderers used to short-cut this whenever the bits "already were
 cores" (`npus == ncores`) or the job was in hwthreads, and print the raw
@@ -316,16 +331,18 @@ Other rules here, all of which were being broken:
   budget it handed `snprintf`, so a process bound to more than a few cores
   wrote past the end of the caller's buffer — in the HNP, which is holding
   every node's topology, so the corruption surfaced as a crash somewhere
-  unrelated.
+  unrelated. `bounded_append()` is the one way to add to that buffer: it
+  clamps rather than subtracts, because the running total legitimately
+  exceeds the buffer length once anything has been truncated.
 - **A caller sizing a buffer per PU must use the real element size.** Each
-  element is 20 spaces of indent plus `<core>%d</core>\n` — about 34 bytes
-  for a single-digit index, more as indices grow. The one caller in
-  `runtime/data_type_support/prte_dt_print_fns.c` budgeted 20.
+  site element is 20 spaces of indent plus `<core>%d</core>\n` — about 34
+  bytes for a single-digit index, more as indices grow — and each package
+  costs an opening and a closing element on top. The one caller in
+  `runtime/data_type_support/prte_dt_print_fns.c` budgeted 20 per PU and
+  nothing per package.
 - **`hwloc_bitmap_snprintf()` gets `sizeof(buf)`, not a constant that
   happens to be nearby.** `print_hwloc_obj()` declared 1024 bytes and
   claimed 2048.
-- **`*pkgnum` is always set.** Its only caller declares it uninitialized
-  and prints it.
 - **`hwloc_bitmap_isfull()` is never true for a topology's cpuset.** It
   means "infinitely set". A dead `isequal(cpuset, avail) && isfull(avail)`
   "unbound" test lived in two of these functions for years. Deciding a
@@ -436,9 +453,13 @@ summary-not-yet-built case), `_get_npus()` in core and hwthread terms,
 `_cpu_list_parse()` grammar including every id that does not exist,
 `_cset2str()` range collapsing, `prte_hwloc_get_binding_info()` against a
 **guarded** buffer (a canary past `sz` — this is how the element-writer
-overflow is pinned), `_cpuset2ranges()`, the print-buffer ring, the
+overflow is pinned) including a cpuset spanning two packages,
+`_cpuset2ranges()`, the print-buffer ring, the
 `--bind-to` parser, userdata release across the normal hierarchy *and* the
-special NUMA depth, and `_reset_counters()` at both of those places.
+special NUMA depth, `_reset_counters()` at both of those places, and
+`prte_hwloc_print()` — which levels reach the output (NUMA nodes are the
+ones that used to be missing) and whether the child count it prints
+accounts for every child list.
 
 One case cannot be built synthetically: hwloc's synthetic generator always
 makes `os_index` and `logical_index` agree, so **the logical-vs-physical
@@ -505,11 +526,12 @@ enough to fill its cpuset buffer — a few thousand PUs.
   then printed that bitmap with `hwloc_bitmap_list_snprintf()`, mixing two
   index bases in one string. `prte_hwloc_base_cpuset2ranges()` replaces it
   and answers the question the callers were actually asking.
-- **`prte_hwloc_get_binding_info()`'s output is undefined for a process
-  bound across more than one package.** It renders the last matching package
-  and reports that package's number. The caller wraps the result in a single
-  `<package>` element, so the shape of the fix is an API change, not a
-  one-liner.
+- **`prte_hwloc_get_binding_info()` no longer has a `pkgnum` out
+  parameter**, and no longer produces undefined output for a process bound
+  across more than one package. It emits the `<package id="N">` elements
+  itself, one per package the cpuset touches. See "The two binding renderers
+  have to agree" above; the caller's job is now to emit the result verbatim
+  inside its `<binding>` element.
 - **`_cset2str()` and `_get_binding_info()` iterate packages, so a topology
   with no `HWLOC_OBJ_PACKAGE` level renders as nothing at all** (`cset2str`
   returns NULL, and its callers print `UNBOUND`). Every real machine has

--- a/src/hwloc/help-prte-hwloc-base.txt
+++ b/src/hwloc/help-prte-hwloc-base.txt
@@ -52,7 +52,7 @@ The specified binding lies above the mapping object type:
 Please correct the map/bind directives and try again.
 #
 [pu-not-found]
-Construction of the binding output string failed due to inabilty
+Construction of the binding output string failed due to inability
 to obtain a processor unit object:
 
   PU number: %u

--- a/src/hwloc/hwloc-internal.h
+++ b/src/hwloc/hwloc-internal.h
@@ -219,10 +219,15 @@ PRTE_EXPORT char *prte_hwloc_base_cset2str(hwloc_const_cpuset_t cpuset,
                                            bool physical,
                                            hwloc_topology_t topo);
 
+/**
+ * Render a binding as XML into the caller's buffer: one <package id="N">
+ * element per package the cpuset touches, each holding one <core>/<hwt>
+ * element per site. Writes at most "sz" bytes and always NUL-terminates.
+ */
 PRTE_EXPORT void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
                                              bool use_hwthread_cpus,
                                              bool physical,
-                                             hwloc_topology_t topo, int *pkgnum,
+                                             hwloc_topology_t topo,
                                              char *cores, int sz);
 
 /**

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -261,11 +261,23 @@ int prte_hwloc_base_open(void)
     }
     prte_hwloc_base_inited = true;
 
-    /* check the provided default binding policy for correctness - specifically want to ensure
-     * there are no disallowed qualifiers and setup the global param */
-    if (PRTE_SUCCESS
-        != (rc = prte_hwloc_base_set_binding_policy(NULL, prte_hwloc_base_binding_policy))) {
-        return rc;
+    /* Check the provided default binding policy for correctness - specifically want to ensure
+     * there are no disallowed qualifiers and setup the global param.
+     *
+     * A bad value here is fatal, exactly as a bad "mem_alloc_policy" or
+     * "mem_bind_failure_action" is in prte_hwloc_base_register() above. It
+     * did not used to be: prte_init() discarded this function's return, so
+     * "--prtemca bindto bogus" printed "the specified binding policy is not
+     * recognized" and then launched the job anyway with the default binding
+     * - having told the user their request was refused. The command-line
+     * spelling of the same mistake ("--bind-to bogus") has always been
+     * fatal, so the two were answering differently for one typo. */
+    rc = prte_hwloc_base_set_binding_policy(NULL, prte_hwloc_base_binding_policy);
+    if (PRTE_SUCCESS != rc) {
+        /* the parser has already said precisely what is wrong with the
+         * value, so keep prte_init() from wrapping that in a generic
+         * "internal failure" report on top of it */
+        return PRTE_ERR_SILENT;
     }
 
     return PRTE_SUCCESS;

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -530,6 +530,16 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
         return PRTE_SUCCESS;
     }
 
+    /* A job we cannot record the answer on has to be refused before we parse
+     * anything, not after: the "report" and "limit=N" qualifiers write to
+     * jdata->attributes as they are read, so failing this check at the end
+     * left them on a job whose binding was never set - the same ordering
+     * mistake the policy word above used to make. */
+    if (NULL != jdata && NULL == jdata->map) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
     myspec = strdup(spec); // protect the input
 
     /* check for qualifiers */
@@ -672,10 +682,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
     if (NULL == jdata) {
         prte_hwloc_default_binding_policy = tmp;
     } else {
-        if (NULL == jdata->map) {
-            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
-            return PRTE_ERR_BAD_PARAM;
-        }
+        /* jdata->map was checked on the way in */
         jdata->map->binding = tmp;
     }
     return PRTE_SUCCESS;

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1216,72 +1216,81 @@ char *prte_hwloc_base_cpuset2ranges(hwloc_topology_t topo,
     return result;
 }
 
-/* Render a list of site indices as one XML element apiece.
+/* Append one formatted item to a bounded buffer, snprintf-style.
  *
- * Returns the number of bytes that *would* have been written (snprintf
- * semantics), so a return >= buflen means the output was truncated. An
- * earlier version advanced the write pointer through a run of bits without
- * also charging the bytes against the remaining budget, so a process bound
- * to more than a few cores walked straight off the end of the caller's
- * buffer - in the HNP, which holds every node's topology.
+ * "total" is how many bytes the output would need so far, which can exceed
+ * "buflen" once we have truncated - so the room handed to vsnprintf is
+ * clamped rather than subtracted. Returns what this item would have needed;
+ * the caller adds it to its running total. An earlier version advanced the
+ * write pointer through a run of set bits without also charging the bytes
+ * against the remaining budget, so a process bound to more than a few cores
+ * walked straight off the end of the caller's buffer - in the HNP, which
+ * holds every node's topology, so the corruption surfaced somewhere else
+ * entirely.
  */
-static int sites_snprintf_exp(char *buf, size_t buflen,
-                              const unsigned *sites, int nsites,
-                              const char *type)
+static int bounded_append(char *buf, size_t buflen, size_t total,
+                          const char *fmt, ...)
+    __prte_attribute_format__(__printf__, 4, 5);
+
+static int bounded_append(char *buf, size_t buflen, size_t total,
+                          const char *fmt, ...)
 {
-    size_t total = 0;
-    int n, res;
+    char *at = (total < buflen) ? buf + total : NULL;
+    size_t room = (total < buflen) ? buflen - total : 0;
+    va_list ap;
+    int res;
 
-    /* mark the end in case we do nothing below */
-    if (0 < buflen) {
-        buf[0] = '\0';
-    }
-
-    for (n = 0; n < nsites; n++) {
-        /* Always hand snprintf the *remaining* room. total can exceed
-         * buflen once we truncate, so clamp rather than subtract. */
-        char *at = (total < buflen) ? buf + total : NULL;
-        size_t room = (total < buflen) ? buflen - total : 0;
-
-        res = snprintf(at, room, "%*c<%s>%u</%s>\n", 20, ' ', type, sites[n], type);
-        if (0 > res) {
-            return -1;
-        }
-        total += (size_t) res;
-    }
-    return (int) total;
+    va_start(ap, fmt);
+    res = vsnprintf(at, room, fmt, ap);
+    va_end(ap);
+    return res;
 }
 
 /*
- * Render a process' binding as XML elements, and report the package it
- * lies in. Output is undefined if a rank is bound to more than 1 package.
+ * Render a process' binding as XML: one <package> element per package the
+ * process has cpus in, each holding one <core>/<hwt> element per site.
  *
- * "cores" always comes back NUL-terminated and "*pkgnum" always comes back
- * set: the caller wraps both in one <package> element, and every caller
- * leaves pkgnum uninitialized on the way in.
+ * "cores" always comes back NUL-terminated, and the caller emits it verbatim
+ * inside its <binding> element.
+ *
+ * This used to render only the *sites*, into the caller's single <package>
+ * element, and report the package number through an out parameter - which
+ * made the output of a process bound across more than one package not merely
+ * incomplete but wrong: each package overwrote the previous one from the top
+ * of the buffer, so the rendering named the last package and dropped every
+ * earlier one's cores. The short form of the same binding
+ * (prte_hwloc_base_cset2str, "--display map") has always reported every
+ * package, so the two renderings of one binding disagreed - and the one that
+ * was wrong is the machine-readable one. It is reachable: PRRTE's own
+ * cross-package diagnostic points users at the rankfile mapper, and a
+ * rankfile slot list of "P0:0;P1:0" produces exactly this.
  */
 void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
                                  bool use_hwthread_cpus, bool physical,
                                  hwloc_topology_t topo,
-                                 int *pkgnum, char *cores, int sz)
+                                 char *cores, int sz)
 {
-    int n, npkgs, nsites;
+    int n, npkgs, nsites, i, res;
+    size_t total = 0, buflen;
     hwloc_cpuset_t avail;
     hwloc_obj_t pkg;
     unsigned *sites = NULL;
     bool as_hwt;
+    const char *type;
 
-    *pkgnum = -1;
     if (NULL == cores || 0 >= sz) {
         return;
     }
+    buflen = (size_t) sz;
     cores[0] = '\0';
 
-    /* if the cpuset is all zero, then something is wrong. Say so and stop -
+    /* If the cpuset is all zero, then something is wrong. Say so and stop -
      * the scan below would otherwise find nothing and leave the message in
-     * place only by accident */
+     * place only by accident. The element name carries no space: this goes
+     * into the document "--display map:parseable" produces, and an element
+     * whose name contains a space does not parse. */
     if (hwloc_bitmap_iszero(cpuset)) {
-        snprintf(cores, (size_t) sz, "\n%*c<EMPTY CPUSET/>\n", 20, ' ');
+        snprintf(cores, buflen, "%*c<empty_cpuset/>\n", 16, ' ');
         return;
     }
 
@@ -1289,8 +1298,8 @@ void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
     npkgs = prte_hwloc_base_get_nbobjs_by_type(topo, HWLOC_OBJ_PACKAGE);
     avail = hwloc_bitmap_alloc();
     as_hwt = report_as_hwthreads(topo, use_hwthread_cpus);
+    type = as_hwt ? "hwt" : "core";
 
-    /* binding happens within a package and not across packages */
     for (n = 0; n < npkgs; n++) {
         pkg = prte_hwloc_base_get_obj_by_type(topo, HWLOC_OBJ_PACKAGE, n);
         if (NULL == pkg || NULL == pkg->cpuset) {
@@ -1302,13 +1311,33 @@ void prte_hwloc_get_binding_info(hwloc_const_cpuset_t cpuset,
             continue;
         }
         nsites = collect_sites(topo, avail, as_hwt, physical, &sites);
-        if (0 < nsites) {
-            sites_snprintf_exp(cores, (size_t) sz, sites, nsites,
-                               as_hwt ? "hwt" : "core");
+        if (0 >= nsites) {
+            free(sites);
+            sites = NULL;
+            continue;
+        }
+        res = bounded_append(cores, buflen, total, "%*c<package id=\"%d\">\n",
+                             16, ' ', n);
+        if (0 > res) {
+            free(sites);
+            break;
+        }
+        total += (size_t) res;
+        for (i = 0; i < nsites; i++) {
+            res = bounded_append(cores, buflen, total, "%*c<%s>%u</%s>\n",
+                                 20, ' ', type, sites[i], type);
+            if (0 > res) {
+                break;
+            }
+            total += (size_t) res;
         }
         free(sites);
         sites = NULL;
-        *pkgnum = n;
+        res = bounded_append(cores, buflen, total, "%*c</package>\n", 16, ' ');
+        if (0 > res) {
+            break;
+        }
+        total += (size_t) res;
     }
     hwloc_bitmap_free(avail);
 }

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -1409,14 +1409,20 @@ static void print_hwloc_obj(char **output, char *prefix, hwloc_topology_t topo, 
 {
     hwloc_obj_t obj2;
     char string[PRTE_HWLOC_MAX_STRING], *tmp, *tmp2, *pfx;
-    unsigned i;
+    unsigned nchildren;
     struct hwloc_topology_support *support;
+
+    /* Count every child, not just the normal ones. In hwloc 2.x an object's
+     * children are split across four lists, and "arity" covers only the
+     * first of them - so reporting it alone understates the object for
+     * exactly the levels a user is most likely to be looking for. */
+    nchildren = obj->arity + obj->memory_arity + obj->io_arity + obj->misc_arity;
 
     /* print the object type */
     hwloc_obj_type_snprintf(string, sizeof(string), obj, 1);
     pmix_asprintf(&pfx, "\n%s\t", (NULL == prefix) ? "" : prefix);
     pmix_asprintf(&tmp, "%sType: %s Number of child objects: %u%sName=%s",
-                  (NULL == prefix) ? "" : prefix, string, obj->arity, pfx,
+                  (NULL == prefix) ? "" : prefix, string, nchildren, pfx,
                   (NULL == obj->name) ? "NULL" : obj->name);
     if (0 < hwloc_obj_attr_snprintf(string, sizeof(string), obj, pfx, 1)) {
         /* print the attributes */
@@ -1451,10 +1457,20 @@ static void print_hwloc_obj(char **output, char *prefix, hwloc_topology_t topo, 
     free(tmp);
     free(pfx);
     pmix_asprintf(&pfx, "%s\t", (NULL == prefix) ? "" : prefix);
-    for (i = 0; i < obj->arity; i++) {
-        obj2 = obj->children[i];
+    /* Walk *all* the children. "obj->children" is the normal-children array
+     * only: in hwloc 2.x NUMA nodes hang off memory_first_child, and the
+     * I/O objects this directory deliberately asks hwloc to keep
+     * (HWLOC_TYPE_FILTER_KEEP_IMPORTANT, see topology_set_flags) hang off
+     * io_first_child. Recursing through the array therefore printed a
+     * topology with no NUMA domains in it at all - on a runtime whose
+     * "--map-by numa" is the thing a user is most often trying to
+     * understand when they ask for the topology. hwloc_get_next_child()
+     * walks normal, then memory, then I/O, then Misc. */
+    obj2 = hwloc_get_next_child(topo, obj, NULL);
+    while (NULL != obj2) {
         /* print the object */
         print_hwloc_obj(&tmp2, pfx, topo, obj2);
+        obj2 = hwloc_get_next_child(topo, obj, obj2);
     }
     free(pfx);
     if (NULL != *output) {

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -285,6 +285,14 @@ void prte_hwloc_base_setup_summary(hwloc_topology_t topo)
         root->userdata = (void *) PMIX_NEW(prte_hwloc_topo_data_t);
     }
     sum = (prte_hwloc_topo_data_t *) root->userdata;
+    if (NULL == sum) {
+        /* the summary could not be allocated. Both callers re-read the
+         * root's userdata afterwards and cope with it still being NULL, so
+         * say nothing more than we can - dereferencing it here would turn
+         * an allocation failure into a segfault */
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return;
+    }
 
     /* only need to do this once */
     if (sum->computed) {
@@ -822,7 +830,14 @@ static int package_core_to_cpu_set(char *package_core_list, hwloc_topology_t top
         obj_type = HWLOC_OBJ_PU;
     }
 
-    for (i = 1; NULL != package_core[i]; i++) {
+    /* Every element below is user input, and the loop stops at the first one
+     * that does not resolve. It used to record the failure in "rc" and carry
+     * on, which had two consequences: bits from later elements went on
+     * accumulating into a mask the caller was going to discard, and a later
+     * "*" element assigned rc = PRTE_SUCCESS - so "--cpu-set P0:99:*" was
+     * accepted as "every cpu on package 0" with the nonexistent core 99
+     * silently forgiven. */
+    for (i = 1; PRTE_SUCCESS == rc && NULL != package_core[i]; i++) {
         if ('C' == package_core[i][0] || 'c' == package_core[i][0]) {
             corestr = &package_core[i][1];
         } else {

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -526,6 +526,7 @@ int prte_hwloc_base_get_topology(void)
 static int set_topology(char *topofile)
 {
     int rc;
+    struct hwloc_topology_support *support;
 
     PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output,
                         "hwloc:base:set_topology %s", topofile));
@@ -547,9 +548,8 @@ static int set_topology(char *topofile)
         return PRTE_ERR_NOT_SUPPORTED;
     }
 
-    /* since we are loading this from an external source, we have to
-     * explicitly set a flag so hwloc sets things up correctly
-     */
+    /* no extra topology flags for an imported description - the support
+     * bits it needs are asserted by hand below, after the load */
     rc = topology_set_flags(prte_hwloc_topology, 0, true);
     if (0 != rc) {
         hwloc_topology_destroy(prte_hwloc_topology);
@@ -562,6 +562,35 @@ static int set_topology(char *topofile)
         prte_hwloc_topology = NULL;
         PMIX_OUTPUT_VERBOSE((5, prte_hwloc_base_output, "hwloc:base:set_topology failed to load"));
         return PRTE_ERR_NOT_SUPPORTED;
+    }
+
+    /* hwloc zeroes every support bit of an imported topology - it has no way
+     * to know what the machine the XML describes can do, and says so:
+     * "binding is disabled by default ... also marked by putting zeroes in
+     * the corresponding supported feature bits". But this option means "this
+     * file describes the machine I am running on", and
+     * prte_rmaps_base_check_support() refuses any *explicitly requested*
+     * binding when those bits are clear - so "--prtemca hwloc_use_topo_file
+     * X --bind-to core" was answered with "at least one node does NOT support
+     * binding processes to cpus" on a machine that supports it perfectly,
+     * which leaves the option usable only with --bind-to none.
+     *
+     * So assert them, as this code has always meant to. Note the "always
+     * meant to": the assertion used to sit *before* hwloc_topology_load(),
+     * and hwloc's own header says the support structure "only contains valid
+     * information after" the load - the load filled the struct in and wiped
+     * it. It has to be here, after.
+     *
+     * HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT is not the answer: it reports what
+     * the *exporting* machine could do, which is a different question and,
+     * per the commit that took it back out, not a reliable one. */
+    support = (struct hwloc_topology_support *)
+              hwloc_topology_get_support(prte_hwloc_topology);
+    if (NULL != support) {
+        support->cpubind->set_thisproc_cpubind = true;
+        support->cpubind->set_thisthread_cpubind = true;
+        support->membind->set_thisproc_membind = true;
+        support->membind->set_thisthread_membind = true;
     }
 
     /* all done */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -266,6 +266,15 @@ input list.** Walk it carefully before touching allocation code:
   `SLOTS_GIVEN`, `NONUSABLE`) for that display.
 - `prte_ras_base_display_cpus(jdata, nodelist)` prints available
   processors per package for the requested nodes (`--display-cpus`).
+  **Its parseable form has to parse.** It used to emit
+  `<processors node=x>` — an unquoted attribute value — wrapping
+  `<pkg=0 cpus=0-7>`, which is not an element at all, while
+  `--display map:parseable` writes the identical fact as
+  `<package id="0" cpus="0-7"/>` in `prte_node_print()`. Two spellings of
+  one fact, and the one here could not be read by any XML parser. Keep the
+  two in step; the cpu list itself comes from
+  `prte_hwloc_base_cpuset2ranges()` for the reason given in
+  [`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md).
 
 ---
 

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -204,7 +204,14 @@ static void display_cpus(prte_topology_t *t,
     avail = hwloc_bitmap_alloc();
 
     if (parsable) {
-        pmix_output(prte_clean_output, "<processors node=%s>", node);
+        /* "parseable" has to actually parse. This element carried an
+         * unquoted attribute value and wrapped a "<pkg=0 cpus=0-7>" that is
+         * not an element at all, while the very same information inside
+         * "--display map:parseable" is written as
+         * <package id="0" cpus="0-7"/> - the two spellings of one fact, one
+         * of them unusable by any XML reader. Follow the map document's
+         * shape; see prte_node_print() in runtime/data_type_support. */
+        pmix_output(prte_clean_output, "<processors node=\"%s\">", node);
     } else {
         pmix_output(prte_clean_output,
                     "\n======================   AVAILABLE PROCESSORS [node: %s]   ======================\n\n", node);
@@ -216,7 +223,7 @@ static void display_cpus(prte_topology_t *t,
         hwloc_bitmap_and(avail, obj->cpuset, allowed);
         if (hwloc_bitmap_iszero(avail)) {
             if (parsable) {
-                pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg, "NONE");
+                pmix_output(prte_clean_output, "    <package id=\"%d\" cpus=\"%s\"/>", pkg, "NONE");
             } else {
                 pmix_output(prte_clean_output, "PKG[%d]: NONE", pkg);
             }
@@ -227,7 +234,7 @@ static void display_cpus(prte_topology_t *t,
          * that is what this job is using as cpus */
         tmp = prte_hwloc_base_cpuset2ranges(t->topo, avail, use_hwthread_cpus, physical);
         if (parsable) {
-            pmix_output(prte_clean_output, "    <pkg=%d cpus=%s>", pkg,
+            pmix_output(prte_clean_output, "    <package id=\"%d\" cpus=\"%s\"/>", pkg,
                         (NULL == tmp) ? "NONE" : tmp);
         } else {
             pmix_output(prte_clean_output, "PKG[%d]: %s", pkg, (NULL == tmp) ? "NONE" : tmp);

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -409,6 +409,20 @@ but **empty**, and the colocation path reaches binding without going
 through `get_target_nodes`, so the intersection falls back to the bare
 object when it would otherwise come up empty.
 
+**`--bind-to` is parsed in two places and gated in a third.** Per-app by
+`prte_rmaps_base_set_app_binding_policy()` here, job-level by
+`prte_hwloc_base_set_binding_policy()` in
+[`src/hwloc`](../../hwloc/AGENTS.md), and whitelisted before either of them
+by `bndquals[]` in `schizo/base/schizo_base_frame.c` — a qualifier missing
+from that list never reaches a parser at all, which is how `report` came to
+be implemented, refused, and undocumented at the same time. All three
+policies and all the qualifiers agree now, with one deliberate exception:
+`report` is **job-level only**, because the attribute behind it
+(`PRTE_JOB_REPORT_BINDINGS`) has no per-app counterpart — reporting is a
+property of the whole job. The per-app parser therefore refuses it *by
+name* (`job-only-modifier`) rather than as an unrecognized qualifier, since
+the same spelling is legal one app segment earlier.
+
 The `limit` qualifier is parsed **twice** — per-app by
 `prte_rmaps_base_set_app_binding_policy()` here, and job-level by
 `prte_hwloc_base_set_binding_policy()` in

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -193,6 +193,19 @@ framework. Understand its phases before touching anything:
    without a mapping policy → map by the binding object. Then resolve
    default ranking and binding the same way.
 
+   **Order matters here, in one direction only.** Deriving the mapping
+   reads `jdata->map->binding`, so any binding the *user* asked for has to
+   be on the job before that runs — including one inherited from the parent
+   job or from the DVM-wide `bindto` MCA parameter. Those two arms used to
+   run afterwards, so `--prtemca bindto package` derived `BYCORE` and was
+   then refused by the bind-upwards check below, while `--bind-to package`
+   on the command line derived `BYPACKAGE` and worked. Deriving a binding
+   *from* the mapping (`set_default_binding`) is the opposite dependency and
+   necessarily still runs after the mapping is known; `bind_inherited` is
+   what keeps the two from both firing. See
+   [`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md), "`bindto` is a real
+   parameter, not a suggestion".
+
 4. **Proc counts.** For mappers that don't compute their own counts,
    sum `app->num_procs` (calling `get_target_nodes` to learn slot counts
    when an app gave no explicit `-n`).

--- a/src/mca/rmaps/base/help-bindto.txt
+++ b/src/mca/rmaps/base/help-bindto.txt
@@ -85,15 +85,25 @@ combination of one or more of the following to the "--bindto" option:
 * "OVERLOAD" indicates that objects can have more processes bound to
   them than CPUs within them
 
+* "NO-OVERLOAD" indicates that they cannot. This is the default, so
+  the qualifier is only useful for overriding an "OVERLOAD" that a
+  DVM-wide default (the "bindto" MCA parameter) has already applied.
+
 * "IF-SUPPORTED" indicates that the job should continue to be launched
   and executed even if binding cannot be performed as requested.
 
 * "LIMIT=n" limits the number of processes bound to each eligible
   representative of the specified type to the given number. For
-  example, speifying "--bindto l3:limit=2" would direct PRRTE
+  example, specifying "--bindto l3:limit=2" would direct PRRTE
   to bind ranks to the L3caches, limiting the number of processes
   bound to each l3cache to two - i.e., bind 2 processes to a
   given l3cache, and then move on to the next.
+
+* "REPORT" reports each process' binding as it is applied, which is
+  the same thing "--report-bindings" does. It describes the job as a
+  whole: unlike the other qualifiers here it cannot be given per
+  application context, and it cannot be given as a DVM-wide default
+  through the "bindto" MCA parameter.
 
 Note:
 

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -374,6 +374,16 @@ Although we were able to map your job, we are unable to launch
 it at this time due to required resources being busy. Please
 try again later.
 #
+[job-only-modifier]
+A %s modifier was given for a single application context, but it
+describes the whole job:
+
+  Modifier:  %s
+
+There is no way to apply it to one application and not another, so it
+can only be given as a job-level directive - on the first application
+context of the command line, or on a command line with only one.
+#
 [unsupported-default-modifier]
 A %s modifier was provided that is not supported as a default value:
 

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -1278,6 +1278,19 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
             } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_NOOVERLOAD)) {
                 tmp = (tmp & ~PRTE_BIND_ALLOW_OVERLOAD);
                 tmp |= PRTE_BIND_OVERLOAD_GIVEN;
+            } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_REPORT)) {
+                /* The job-level parser in src/hwloc accepts this and records
+                 * PRTE_JOB_REPORT_BINDINGS. There is no per-app counterpart
+                 * to that attribute - reporting is a property of the whole
+                 * job - so say precisely that rather than falling into the
+                 * generic "unrecognized qualifier" below, which would be
+                 * baffling now that the schizo whitelist lets the same
+                 * spelling through on the job. */
+                pmix_show_help("help-prte-rmaps-base.txt", "job-only-modifier", true,
+                               "binding", quals[i]);
+                PMIx_Argv_free(quals);
+                free(myspec);
+                return PRTE_ERR_SILENT;
             } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_LIMIT)) {
                 p2 = pmix_cli_qualifier_value(quals[i]);
                 if (NULL == p2) {

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -549,6 +549,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     int rc = PRTE_SUCCESS;
     int n;
     bool did_map, pernode = false;
+    bool bind_inherited = false;
     prte_rmaps_base_selected_module_t *mod;
     prte_job_t *parent = NULL;
     prte_app_context_t *app;
@@ -790,6 +791,40 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                         PRTE_JOBID_PRINT(jdata->nspace),
                         inherit ? "TRUE" : "FALSE",
                         options.use_hwthreads ? "TRUE" : "FALSE");
+
+    /* Adopt an *explicitly given* inherited binding before the mapping
+     * policy is derived, because deriving the mapping reads it: a binding
+     * given with no mapping given means "map by the binding object" (see
+     * prte_rmaps_base_set_default_mapping), and that test looks at
+     * jdata->map->binding.
+     *
+     * A binding that came from the parent job or from the DVM-wide "bindto"
+     * MCA parameter was not copied onto the job until long after the mapping
+     * had been settled, so the test saw nothing and picked BYCORE. The
+     * bind-upwards sanity check further down then refused the job outright,
+     * because binding to a package while mapping by core is not allowed.
+     * That made five of the eight values "bindto" documents - l1cache,
+     * l2cache, l3cache, numa, package - unusable at DVM scope, while the
+     * command-line spelling of the same request ("--bind-to package") mapped
+     * BYPACKAGE and worked.
+     *
+     * Only the two arms that adopt a binding somebody actually *asked for*
+     * belong up here. Deriving a binding from the mapping stays below, where
+     * the mapping is known. */
+    bind_inherited = false;
+    if (!PRTE_BINDING_POLICY_IS_SET(jdata->map->binding) && inherit) {
+        if (NULL != parent) {
+            jdata->map->binding = parent->map->binding;
+            bind_inherited = true;
+        } else if (PRTE_BINDING_POLICY_IS_SET(prte_hwloc_default_binding_policy)) {
+            /* the user specified a default binding policy via MCA param, so
+             * we use it - this can include a directive to overload */
+            pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
+                                "mca:rmaps[%d] default binding policy given", __LINE__);
+            jdata->map->binding = prte_hwloc_default_binding_policy;
+            bind_inherited = true;
+        }
+    }
 
     /* set the default mapping policy IFF it wasn't provided */
     if (!PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
@@ -1260,36 +1295,24 @@ ranking:
      * and reset an unset (default) binding to BIND_TO_NONE for the affected
      * node(s) at that point. Forcing NONE here off the permission alone broke
      * binding for non-oversubscribed jobs whenever a default oversubscribe
-     * policy was in effect. */
-    if (!PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
-        did_map = false;
-        if (inherit) {
-            if (NULL != parent) {
-                jdata->map->binding = parent->map->binding;
-                did_map = true;
-            } else if (PRTE_BINDING_POLICY_IS_SET(prte_hwloc_default_binding_policy)) {
-                /* if the user specified a default binding policy via
-                 * MCA param, then we use it - this can include a directive
-                 * to overload */
-                pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
-                                    "mca:rmaps[%d] default binding policy given", __LINE__);
-                jdata->map->binding = prte_hwloc_default_binding_policy;
-                did_map = true;
-            }
+     * policy was in effect.
+     *
+     * The two inheritance arms that used to live here now run before the
+     * mapping policy is derived - see "bind_inherited" above - because that
+     * derivation reads the binding. What is left is the case that genuinely
+     * cannot move: deriving a binding *from* the mapping. */
+    if (!bind_inherited && !PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
+        // let the job's personality set the default binding behavior
+        if (NULL != schizo->set_default_binding) {
+            rc = schizo->set_default_binding(jdata, &options);
+        } else {
+            rc = prte_hwloc_base_set_default_binding(jdata, &options);
         }
-        if (!did_map) {
-            // let the job's personality set the default binding behavior
-            if (NULL != schizo->set_default_binding) {
-                rc = schizo->set_default_binding(jdata, &options);
-            } else {
-                rc = prte_hwloc_base_set_default_binding(jdata, &options);
-            }
-            if (PRTE_SUCCESS != rc) {
-                // the error message should have been printed
-                jdata->exit_code = rc;
-                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
-                goto cleanup;
-            }
+        if (PRTE_SUCCESS != rc) {
+            // the error message should have been printed
+            jdata->exit_code = rc;
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
+            goto cleanup;
         }
     }
     options.overload = PRTE_BIND_OVERLOAD_ALLOWED(jdata->map->binding);

--- a/src/mca/schizo/AGENTS.md
+++ b/src/mca/schizo/AGENTS.md
@@ -227,6 +227,19 @@ table.
 - **`prte_schizo_base_check_directives` / `_check_qualifiers`** — the
   reusable directive validators, including the special-cased
   `--map-by ppr:N:resource` pattern check.
+
+  **The `mappers[]`/`rankers[]`/`binders[]`/`*quals[]` tables in
+  `prte_schizo_base_sanity()` are the front door.** A name missing from one
+  of them is refused here and never reaches the parser that implements it,
+  and nothing anywhere reports the disagreement — the parser's arm simply
+  becomes unreachable. `bndquals[]` was missing `report`, so the job-level
+  arm for it in `prte_hwloc_base_set_binding_policy()` could not be reached
+  from any command line, including the diagnostic that arm emits at DVM
+  scope telling the user to give it per job instead. When you add a
+  qualifier to a parser, add it here, and check the *other* parser for the
+  same directive — `--bind-to` has two (job-level in
+  [`src/hwloc`](../../hwloc/AGENTS.md), per-app in
+  [`rmaps/base`](../rmaps/AGENTS.md)).
 - **`prte_schizo_base_parse_display` / `_parse_output`** — convert a
   parsed `--display` / `--output` option into `PMIX_INFO` list entries
   (`PMIX_DISPLAY_MAP`, `PMIX_IOF_TAG_OUTPUT`, `PMIX_IOF_OUTPUT_TO_FILE`,

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -773,11 +773,20 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_PACKAGE,
         NULL
     };
+    /* This list is the front door: a qualifier missing from it is refused
+     * here and never reaches the parser that implements it. REPORT was
+     * missing, so the job-level arm for it in
+     * prte_hwloc_base_set_binding_policy() was unreachable from any command
+     * line - including the show_help that arm produces at DVM scope, which
+     * tells the user "you can provide this modifier on a per-job basis".
+     * Keep this in step with both parsers (src/hwloc/hwloc.c for the job,
+     * rmaps_base_set_app_binding_policy() below for an app). */
     char *bndquals[] = {
         PRTE_CLI_OVERLOAD,
         PRTE_CLI_NOOVERLOAD,
         PRTE_CLI_IF_SUPP,
         PRTE_CLI_LIMIT,
+        PRTE_CLI_REPORT,
         NULL
     };
 

--- a/src/runtime/data_type_support/AGENTS.md
+++ b/src/runtime/data_type_support/AGENTS.md
@@ -117,13 +117,22 @@ none of the three checked `src->node` itself, which is NULL for an unmapped
 proc and for a proc that outlived its node.
 
 The XML arm sizes a buffer for `prte_hwloc_get_binding_info()` itself, and
-has to size it from the **element** it will hold, not from a round number:
-each is 20 spaces of indent plus `<core>%d</core>\n`, so ~34 bytes for a
-single-digit core index and more as indices grow. The estimate used to be 20
-bytes per PU, which silently truncated the site list for any process bound to
-more than about half the cores of a non-SMT node — and, before `src/hwloc`
-bounded its writes, overran the buffer outright. See
-[`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md), "Rendering a binding".
+has to size it from the **elements** it will hold, not from a round number:
+each site is 20 spaces of indent plus `<core>%d</core>\n`, so ~34 bytes for a
+single-digit core index and more as indices grow, and each package the
+process touches costs an opening and a closing element on top. The estimate
+used to be 20 bytes per PU and nothing per package, which silently truncated
+the site list for any process bound to more than about half the cores of a
+non-SMT node — and, before `src/hwloc` bounded its writes, overran the buffer
+outright. See [`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md), "a cpuset's
+bits are PU OS indices".
+
+**The `<package>` elements come from the renderer, not from here.** This arm
+used to wrap the returned site list in a single `<package id="%d">` built
+from a `pkgnum` out parameter, which meant a process bound across two
+packages was reported as belonging to one — the short form of the same
+binding (`prte_hwloc_base_cset2str`) named both. Emit what the renderer
+returns verbatim.
 
 The string building is `pmix_asprintf`-and-free chaining: `tmp` always owns
 the accumulated string, each step builds `tmp2` from it, frees `tmp`, and

--- a/src/runtime/data_type_support/prte_dt_print_fns.c
+++ b/src/runtime/data_type_support/prte_dt_print_fns.c
@@ -317,8 +317,8 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
     hwloc_cpuset_t mycpus;
     char *str;
     bool use_hwthread_cpus;
-    int pkgnum;
     int npus;
+    int npkgs;
     char *cores = NULL;
     char xmlsp = ' ';
     bool physical;
@@ -342,29 +342,36 @@ void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src)
             hwloc_bitmap_list_sscanf(mycpus, src->cpuset);
 
             npus = prte_hwloc_base_get_nbobjs_by_type(src->node->topology->topo, HWLOC_OBJ_PU);
+            npkgs = prte_hwloc_base_get_nbobjs_by_type(src->node->topology->topo,
+                                                       HWLOC_OBJ_PACKAGE);
             /* There can be one element per PU, and each is 20 spaces of
              * indent plus "<core>%d</core>\n" - 34 characters for a
              * single-digit index and more as the index grows. The estimate
              * used to be 20 per element, so a process bound to more than
              * about half the cores of a non-SMT node had its site list
              * silently truncated (and, before the writes were bounded,
-             * overran this buffer outright). */
-            int sz = sizeof(char) * (npus * 48 + 64);
+             * overran this buffer outright). Each package the process
+             * touches also costs an opening and a closing element, so budget
+             * for the whole topology's worth of them rather than one. */
+            int sz = sizeof(char) * (npus * 48 + npkgs * 64 + 64);
             cores = (char*)malloc(sz);
             if (NULL == cores) {
                 pmix_asprintf(&tmp, "\n%*c<MemoryError/>\n", 8, xmlsp);
                 *output = tmp;
                 return;
             }
+            /* the renderer emits the <package> elements itself: a process
+             * bound across two packages has two of them, and the shape this
+             * used to wrap around it could only ever name one */
             prte_hwloc_get_binding_info(mycpus, use_hwthread_cpus, physical,
-                                        src->node->topology->topo, &pkgnum, cores, sz);
+                                        src->node->topology->topo, cores, sz);
 
             hwloc_bitmap_free(mycpus);
 
             pmix_asprintf(&tmp, "\n%*c<rank id=\"%s\" appid=\"%ld\">\n%*c<binding>\n"
-                          "%*c<package id=\"%d\">\n%s\n%*c</package>\n%*c</binding>\n%*c</rank>\n",
+                          "%s%*c</binding>\n%*c</rank>\n",
                           8, xmlsp, PRTE_VPID_PRINT(src->name.rank), (long) src->app_idx, 12, xmlsp,
-                          16, xmlsp, pkgnum, cores, 16, xmlsp, 12, xmlsp, 8, xmlsp);
+                          cores, 12, xmlsp, 8, xmlsp);
 
             free (cores);
         } else {

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -450,8 +450,12 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
     /* let the pmix server register params */
     pmix_server_register_params();
 
-    /* open hwloc */
-    prte_hwloc_base_open();
+    /* open hwloc - this is where the DVM-wide "bindto" value is validated,
+     * so a bad one has to stop us here rather than be diagnosed and ignored */
+    if (PRTE_SUCCESS != (ret = prte_hwloc_base_open())) {
+        error = "prte_hwloc_base_open";
+        goto error;
+    }
 
     /* setup the global job and node arrays */
     prte_job_data = PMIX_NEW(pmix_pointer_array_t);

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -1283,6 +1283,67 @@ static int test_reset_counters(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* the topology renderer behind --display topo                        */
+/* ------------------------------------------------------------------ */
+
+static int test_hwloc_print(void)
+{
+    int failures = 0;
+    hwloc_topology_t topo;
+    char *output = NULL;
+    int rc;
+
+    /* two packages, each with its own NUMA domain */
+    topo = make_topo("pack:2 numa:1 core:2 pu:2");
+    if (NULL == topo) {
+        fprintf(stderr, "SKIP test_hwloc_print: no synthetic topology support\n");
+        return 0;
+    }
+
+    /* a NULL topology is answered, not dereferenced: every caller hands us
+     * one out of prte_node_topologies and prints the result unconditionally */
+    output = (char *) 0x1;
+    rc = prte_hwloc_print(&output, NULL, NULL);
+    CHECK("print of a NULL topology reports not-found", PRTE_ERR_NOT_FOUND == rc);
+    CHECK("print of a NULL topology clears the output", NULL == output);
+
+    output = NULL;
+    rc = prte_hwloc_print(&output, NULL, topo);
+    CHECK("print succeeds", PRTE_SUCCESS == rc && NULL != output);
+    if (NULL != output) {
+        /* The levels a user expects to see. NUMANode is the one that was
+         * missing: hwloc 2.x hangs NUMA nodes off memory_first_child, not
+         * off the children[] array the renderer walked, so --display topo
+         * showed a topology with no NUMA domains in it at all - on a runtime
+         * whose "--map-by numa" is usually why the user asked. */
+        CHECK("print includes the machine", NULL != strstr(output, "Type: Machine"));
+        CHECK("print includes packages", NULL != strstr(output, "Type: Package"));
+        CHECK("print includes cores", NULL != strstr(output, "Type: Core"));
+        CHECK("print includes PUs", NULL != strstr(output, "Type: PU"));
+        CHECK("print includes NUMA nodes", NULL != strstr(output, "Type: NUMANode"));
+        /* the child count has to cover every child list, or the object it
+         * names reads as childless right where a memory child hangs */
+        CHECK("machine reports both packages",
+              NULL != strstr(output, "Type: Machine Number of child objects: 2"));
+        CHECK("a package reports its core children and its NUMA child",
+              NULL != strstr(output, "Type: Package Number of child objects: 3"));
+        free(output);
+    }
+
+    /* a prefix is applied to every line of the dump */
+    output = NULL;
+    rc = prte_hwloc_print(&output, "XX", topo);
+    CHECK("prefixed print succeeds", PRTE_SUCCESS == rc && NULL != output);
+    if (NULL != output) {
+        CHECK("the prefix reaches the root", NULL != strstr(output, "XXType: Machine"));
+        free(output);
+    }
+
+    free_topo(topo);
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(void)
 {
@@ -1306,6 +1367,7 @@ int main(void)
     failures += test_binding_policy();
     failures += test_userdata();
     failures += test_reset_counters();
+    failures += test_hwloc_print();
 
     prte_finalize();
 

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -459,6 +459,20 @@ static int test_cpu_list_parse(void)
 #define GUARD_LEN 64
 #define GUARD_BYTE 0x5a
 
+/* how many times "needle" occurs in "hay" */
+static int count_substr(const char *hay, const char *needle)
+{
+    const char *p = hay;
+    size_t len = strlen(needle);
+    int n = 0;
+
+    while (NULL != (p = strstr(p, needle))) {
+        ++n;
+        p += len;
+    }
+    return n;
+}
+
 static bool guard_intact(const char *buf, int sz)
 {
     int i;
@@ -477,7 +491,7 @@ static int test_binding_info(void)
     hwloc_topology_t topo;
     hwloc_cpuset_t cpuset;
     char *buf;
-    int pkgnum, sz;
+    int sz;
 
     topo = make_topo("package:2 core:32 pu:1");
     if (NULL == topo) {
@@ -486,28 +500,29 @@ static int test_binding_info(void)
     }
     cpuset = hwloc_bitmap_alloc();
 
-    /* An empty cpuset says so, and leaves pkgnum at a value the caller can
-     * recognize. *pkgnum used to be left untouched here, and the only caller
-     * declares it uninitialized and prints it. */
+    /* An empty cpuset says so rather than rendering nothing at all. */
     sz = 256;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
-    CHECK("empty cpuset says so", NULL != strstr(buf, "EMPTY CPUSET"));
-    CHECK("empty cpuset reports no package", -1 == pkgnum);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    /* the element name carries no space - this lands in the document
+     * "--display map:parseable" produces, and "<EMPTY CPUSET/>" does not
+     * parse as one */
+    CHECK("empty cpuset says so", NULL != strstr(buf, "<empty_cpuset/>"));
     CHECK("empty cpuset stays in bounds", guard_intact(buf, sz));
     free(buf);
 
-    /* A cpuset that matches no package likewise has to leave pkgnum set. */
+    /* A cpuset that matches no package renders no package element - and
+     * still comes back NUL-terminated, because the caller emits it verbatim */
     hwloc_bitmap_zero(cpuset);
     hwloc_bitmap_set(cpuset, 4096);
     sz = 256;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
-    CHECK("cpuset outside every package reports no package", -1 == pkgnum);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    CHECK("cpuset outside every package renders no package",
+          NULL == strstr(buf, "<package"));
+    CHECK("cpuset outside every package is NUL terminated", sz > (int) strlen(buf));
     CHECK("cpuset outside every package stays in bounds", guard_intact(buf, sz));
     free(buf);
 
@@ -517,10 +532,10 @@ static int test_binding_info(void)
     sz = 256;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
-    CHECK("single core reports its package", 0 == pkgnum);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    CHECK("single core names its package", NULL != strstr(buf, "<package id=\"0\">"));
     CHECK("single core is rendered", NULL != strstr(buf, "<core>0</core>"));
+    CHECK("single core closes its package", NULL != strstr(buf, "</package>"));
     CHECK("single core stays in bounds", guard_intact(buf, sz));
     free(buf);
 
@@ -535,9 +550,8 @@ static int test_binding_info(void)
     sz = 32 * 20;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
-    CHECK("wide binding reports its package", 0 == pkgnum);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    CHECK("wide binding names its package", NULL != strstr(buf, "<package id=\"0\">"));
     CHECK("wide binding stays in bounds", guard_intact(buf, sz));
     CHECK("wide binding is NUL terminated", sz > (int) strlen(buf));
     free(buf);
@@ -546,21 +560,43 @@ static int test_binding_info(void)
     sz = 8192;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
     CHECK("wide binding renders the first core", NULL != strstr(buf, "<core>0</core>"));
     CHECK("wide binding renders a middle core", NULL != strstr(buf, "<core>17</core>"));
     CHECK("wide binding renders the last core", NULL != strstr(buf, "<core>31</core>"));
     CHECK("wide binding with room stays in bounds", guard_intact(buf, sz));
     free(buf);
 
+    /* A process bound across TWO packages. The old shape rendered the sites
+     * only, into the caller's single <package> element, and reported one
+     * package number - so each package overwrote the previous one from the
+     * top of the buffer and the result named the last package and dropped
+     * every earlier one's cores. That is not incomplete output, it is wrong
+     * output, and it disagreed with what _cset2str() reports for the same
+     * binding. A rankfile slot list of "P0:0;P1:0" produces exactly this. */
+    hwloc_bitmap_zero(cpuset);
+    hwloc_bitmap_set(cpuset, 0);   /* package 0, core 0 */
+    hwloc_bitmap_set(cpuset, 32);  /* package 1, core 32 */
+    sz = 8192;
+    buf = malloc(sz + GUARD_LEN);
+    memset(buf + sz, GUARD_BYTE, GUARD_LEN);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    CHECK("cross-package binding names package 0", NULL != strstr(buf, "<package id=\"0\">"));
+    CHECK("cross-package binding names package 1", NULL != strstr(buf, "<package id=\"1\">"));
+    CHECK("cross-package binding keeps package 0's core", NULL != strstr(buf, "<core>0</core>"));
+    CHECK("cross-package binding keeps package 1's core", NULL != strstr(buf, "<core>32</core>"));
+    CHECK("cross-package binding closes both packages",
+          2 == count_substr(buf, "</package>"));
+    CHECK("cross-package binding stays in bounds", guard_intact(buf, sz));
+    free(buf);
+
     /* a truly tiny buffer must still be safe */
     sz = 4;
     buf = malloc(sz + GUARD_LEN);
     memset(buf + sz, GUARD_BYTE, GUARD_LEN);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
     CHECK("tiny buffer stays in bounds", guard_intact(buf, sz));
+    CHECK("tiny buffer is NUL terminated", sz > (int) strlen(buf));
     free(buf);
 
     hwloc_bitmap_free(cpuset);
@@ -800,7 +836,7 @@ static int test_index_basis(void)
     hwloc_cpuset_t cpuset;
     hwloc_obj_t pkg;
     char *str, *buf;
-    int pkgnum, sz;
+    int sz;
 
     if (0 != hwloc_topology_init(&topo)) {
         fprintf(stdout, "  SKIP index-basis (topology_init failed)\n");
@@ -877,14 +913,13 @@ static int test_index_basis(void)
      * "physical" outright */
     sz = 4096;
     buf = malloc(sz);
-    pkgnum = 12345;
-    prte_hwloc_get_binding_info(cpuset, false, false, topo, &pkgnum, buf, sz);
-    CHECK("binding info reports package 0", 0 == pkgnum);
+    prte_hwloc_get_binding_info(cpuset, false, false, topo, buf, sz);
+    CHECK("binding info reports package 0", NULL != strstr(buf, "<package id=\"0\">"));
     CHECK("binding info renders logical core 3", NULL != strstr(buf, "<core>3</core>"));
     CHECK("binding info does not leak an OS index",
           NULL == strstr(buf, "<core>6</core>"));
 
-    prte_hwloc_get_binding_info(cpuset, false, true, topo, &pkgnum, buf, sz);
+    prte_hwloc_get_binding_info(cpuset, false, true, topo, buf, sz);
     CHECK("binding info honors physical", NULL != strstr(buf, "<core>6</core>"));
     free(buf);
 

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -40,8 +40,24 @@
  *    the end of the caller's buffer. The caller sizes that buffer at 20
  *    bytes per PU while each element needs ~34.
  *
- *  - prte_hwloc_get_binding_info() never set *pkgnum when the cpuset matched
- *    no package, and its only caller prints it uninitialized.
+ *  - prte_hwloc_get_binding_info() rendered only the *sites*, into a single
+ *    <package> element its caller wrapped around them, and reported the
+ *    package number through an out parameter. A process bound across two
+ *    packages therefore had each package overwrite the previous one from the
+ *    top of the buffer: the output named the last package and dropped every
+ *    earlier one's cores, disagreeing with what _cset2str() reports for the
+ *    same binding. It emits the <package> elements itself now.
+ *
+ *  - prte_hwloc_print() walked obj->children[] only, and hwloc 2.x keeps
+ *    NUMA nodes on a separate memory-child list - so "--display topo"
+ *    rendered a topology with no NUMA domains in it at all.
+ *
+ *  - prte_hwloc_base_set_default_binding()'s PPR arm has to reach a policy
+ *    for every object ppr_object() can produce; a hole leaves the binding
+ *    word at zero, which is not a value in the policy space.
+ *
+ *  - the package:core parser recorded a failed element in "rc" and carried
+ *    on, so a later "*" element assigned PRTE_SUCCESS over the top of it.
  *
  *  - the range builder behind prte_hwloc_base_cset2str() appended to the
  *    caller's buffer with memcpy() and no bound at all.
@@ -446,6 +462,21 @@ static int test_cpu_list_parse(void)
 
     rc = prte_hwloc_base_cpu_list_parse("999", topo, false, mask);
     CHECK("unknown bare core is an error", PRTE_SUCCESS != rc);
+
+    /* A bad element must not be forgiven by a good one after it. The
+     * package:core loop recorded the failure and kept going, so a later "*"
+     * element assigned PRTE_SUCCESS over the top of it and "P0:99:*" came
+     * back as "every cpu on package 0" - the nonexistent core silently
+     * dropped. The same shape with a plain core after the bad one kept
+     * accumulating bits into a mask the caller was about to throw away. */
+    rc = prte_hwloc_base_cpu_list_parse("P0:99:*", topo, false, mask);
+    CHECK("a wildcard after an unknown core does not excuse it", PRTE_SUCCESS != rc);
+
+    rc = prte_hwloc_base_cpu_list_parse("P0:99:0", topo, false, mask);
+    CHECK("a good core after an unknown one does not excuse it", PRTE_SUCCESS != rc);
+
+    rc = prte_hwloc_base_cpu_list_parse("P0:0:99", topo, false, mask);
+    CHECK("an unknown core after a good one is still an error", PRTE_SUCCESS != rc);
 
     hwloc_bitmap_free(mask);
     free_topo(topo);
@@ -1074,6 +1105,68 @@ static int test_topo_file(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* the default-binding chooser                                        */
+/* ------------------------------------------------------------------ */
+
+/* prte_hwloc_base_set_default_binding() derives a binding from the mapping
+ * when the user gave none. Every arm of it has to reach a policy: leaving
+ * jdata->map->binding at zero is not "bind to nothing", it is a value that
+ * is not in the policy space at all - PRTE_GET_BINDING_POLICY() yields 0,
+ * which is neither NONE nor any object - and the caller then feeds it to the
+ * bind-upwards check and to a switch that has no case for it. The PPR arm is
+ * the one with an object-by-object chain and hence the one that could
+ * acquire a hole; ppr_object() in rmaps_base_map_job.c produces exactly the
+ * eight types below, so those eight are what this arm has to cover. */
+static int test_default_binding(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    prte_rmaps_options_t options;
+    hwloc_obj_type_t ppr_types[] = {HWLOC_OBJ_MACHINE, HWLOC_OBJ_PACKAGE,
+                                    HWLOC_OBJ_NUMANODE, HWLOC_OBJ_L1CACHE,
+                                    HWLOC_OBJ_L2CACHE, HWLOC_OBJ_L3CACHE,
+                                    HWLOC_OBJ_CORE, HWLOC_OBJ_PU};
+    size_t t;
+    int rc;
+
+    for (t = 0; t < sizeof(ppr_types) / sizeof(ppr_types[0]); t++) {
+        jdata = PMIX_NEW(prte_job_t);
+        jdata->map = PMIX_NEW(prte_job_map_t);
+        PRTE_SET_MAPPING_POLICY(jdata->map->mapping, PRTE_MAPPING_PPR);
+
+        memset(&options, 0, sizeof(options));
+        /* a verbosity above the stream's threshold keeps the chooser quiet */
+        options.verbosity = 1000;
+        options.stream = 0;
+        options.maptype = ppr_types[t];
+        options.nprocs = 4;
+
+        rc = prte_hwloc_base_set_default_binding(jdata, &options);
+        CHECK("ppr default binding succeeds", PRTE_SUCCESS == rc);
+        CHECK("ppr default binding lands on a real policy",
+              0 != PRTE_GET_BINDING_POLICY(jdata->map->binding) &&
+              PRTE_BIND_TO_HWTHREAD >= PRTE_GET_BINDING_POLICY(jdata->map->binding));
+        PMIX_RELEASE(jdata);
+    }
+
+    /* a tool is never bound, and that answer is marked as given so nothing
+     * downstream re-derives one for it */
+    jdata = PMIX_NEW(prte_job_t);
+    jdata->map = PMIX_NEW(prte_job_map_t);
+    PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
+    memset(&options, 0, sizeof(options));
+    options.verbosity = 1000;
+    options.stream = 0;
+    rc = prte_hwloc_base_set_default_binding(jdata, &options);
+    CHECK("a tool's default binding succeeds", PRTE_SUCCESS == rc);
+    CHECK("a tool is not bound",
+          PRTE_BIND_TO_NONE == PRTE_GET_BINDING_POLICY(jdata->map->binding));
+    PMIX_RELEASE(jdata);
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 /* --bind-to parsing                                                  */
 /* ------------------------------------------------------------------ */
 
@@ -1092,6 +1185,19 @@ static int test_binding_policy(void)
 
     CHECK("a NULL spec is not an error",
           PRTE_SUCCESS == prte_hwloc_base_set_binding_policy(jdata, NULL));
+
+    /* A job with no map cannot hold the answer, so it is refused before any
+     * qualifier gets the chance to record itself on it. That check used to
+     * run last, so "--bind-to core:report" against a mapless job left
+     * REPORT_BINDINGS on the job and then failed. */
+    {
+        prte_job_t *nomap = PMIX_NEW(prte_job_t);
+        CHECK("a mapless job is refused",
+              PRTE_SUCCESS != prte_hwloc_base_set_binding_policy(nomap, "core:report"));
+        CHECK("a refused mapless job records nothing",
+              !prte_get_attribute(&nomap->attributes, PRTE_JOB_REPORT_BINDINGS, NULL, PMIX_BOOL));
+        PMIX_RELEASE(nomap);
+    }
 
     CHECK("none parses", PRTE_SUCCESS == prte_hwloc_base_set_binding_policy(jdata, "none"));
     CHECK("none is recorded", PRTE_BIND_TO_NONE == PRTE_GET_BINDING_POLICY(jdata->map->binding));
@@ -1485,6 +1591,7 @@ int main(void)
     failures += test_index_basis();
     failures += test_print_binding();
     failures += test_topo_file();
+    failures += test_default_binding();
     failures += test_binding_policy();
     failures += test_userdata();
     failures += test_reset_counters();

--- a/test/unit/hwloc/test_hwloc.c
+++ b/test/unit/hwloc/test_hwloc.c
@@ -78,6 +78,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "constants.h"
 #include "types.h"
@@ -989,6 +991,89 @@ static int test_print_binding(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* loading the local topology from a file                             */
+/* ------------------------------------------------------------------ */
+
+/* "hwloc_use_topo_file" means "this XML describes the machine I am running
+ * on". hwloc cannot know that, so it zeroes every support bit of an imported
+ * topology - and prte_rmaps_base_check_support() refuses any explicitly
+ * requested binding when those bits are clear, so the option was usable only
+ * with "--bind-to none". PRRTE asserts the bits itself; this pins that it
+ * happens, and that it happens *after* hwloc_topology_load(), which is the
+ * only place it sticks (hwloc's header: the support structure "only contains
+ * valid information after" the load). */
+static int test_topo_file(void)
+{
+    int failures = 0;
+    const struct hwloc_topology_support *support;
+    char path[] = "/tmp/prte_test_topoXXXXXX";
+    char *saved_file;
+    hwloc_topology_t saved_topo;
+    int fd, rc;
+    size_t len;
+    ssize_t wrote;
+
+    fd = mkstemp(path);
+    if (0 > fd) {
+        fprintf(stderr, "SKIP test_topo_file: could not create a temp file\n");
+        return 0;
+    }
+    len = strlen(interleaved_xml);
+    wrote = write(fd, interleaved_xml, len);
+    close(fd);
+    if ((ssize_t) len != wrote) {
+        fprintf(stderr, "SKIP test_topo_file: short write\n");
+        unlink(path);
+        return 0;
+    }
+
+    /* get_topology() reads these two globals and returns early if the
+     * topology is already set, so stand them up and put them back */
+    saved_file = prte_hwloc_base_topo_file;
+    saved_topo = prte_hwloc_topology;
+    prte_hwloc_base_topo_file = path;
+    prte_hwloc_topology = NULL;
+
+    rc = prte_hwloc_base_get_topology();
+    CHECK("a topology file loads", PRTE_SUCCESS == rc);
+    if (PRTE_SUCCESS == rc && NULL != prte_hwloc_topology) {
+        CHECK("the loaded topology has the file's packages",
+              2 == prte_hwloc_base_get_nbobjs_by_type(prte_hwloc_topology,
+                                                      HWLOC_OBJ_PACKAGE));
+        support = hwloc_topology_get_support(prte_hwloc_topology);
+        CHECK("the loaded topology reports support", NULL != support);
+        if (NULL != support) {
+            CHECK("cpubind is asserted for an imported topology",
+                  support->cpubind->set_thisproc_cpubind &&
+                  support->cpubind->set_thisthread_cpubind);
+            CHECK("membind is asserted for an imported topology",
+                  support->membind->set_thisproc_membind &&
+                  support->membind->set_thisthread_membind);
+        }
+        prte_hwloc_base_release_userdata(prte_hwloc_topology);
+        hwloc_topology_destroy(prte_hwloc_topology);
+    }
+
+    /* a file that is not a topology is refused, and leaves no handle behind
+     * for prte_hwloc_base_close() to destroy a second time */
+    prte_hwloc_topology = NULL;
+    fd = open(path, O_WRONLY | O_TRUNC);
+    if (0 <= fd) {
+        wrote = write(fd, "not a topology\n", 15);
+        (void) wrote;
+        close(fd);
+        rc = prte_hwloc_base_get_topology();
+        CHECK("a malformed topology file is refused", PRTE_SUCCESS != rc);
+        CHECK("a refused topology file leaves no handle", NULL == prte_hwloc_topology);
+    }
+
+    prte_hwloc_base_topo_file = saved_file;
+    prte_hwloc_topology = saved_topo;
+    unlink(path);
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 /* --bind-to parsing                                                  */
 /* ------------------------------------------------------------------ */
 
@@ -1399,6 +1484,7 @@ int main(void)
     failures += test_cpuset2ranges();
     failures += test_index_basis();
     failures += test_print_binding();
+    failures += test_topo_file();
     failures += test_binding_policy();
     failures += test_userdata();
     failures += test_reset_counters();


### PR DESCRIPTION
A third pass over `src/hwloc`, following #2578 and #2597. Nine review
rounds; seven defects that mattered, each reproduced before being fixed
and each now guarded by a test that fails without the fix. One commit per
defect.

### What was wrong

**`--display topo` showed no NUMA domains at all.** An hwloc object's
children live on four separate lists and `obj->children` is only the
first; NUMA nodes hang off `memory_first_child` and the I/O objects this
directory deliberately asks hwloc to *keep* off `io_first_child`. So a
user who ran `--display topo` to work out what `--map-by numa` would do
got a topology with no NUMA in it.

**`--prtemca bindto <bad>` printed "not recognized" and then ran the
job.** `prte_hwloc_base_open()` exists to validate that parameter and
`prte_init()` discarded its return. The command-line spelling of the same
typo has always been fatal, so one mistake got two answers.

**`bindto` was unusable for five of the eight values it documents.**
Deriving the default *mapping* reads `jdata->map->binding`, but an
inherited binding was not copied onto the job until after the mapping had
been settled — so `--prtemca bindto package` mapped `BYCORE` and was then
refused by the bind-upwards check, while `--bind-to package` mapped
`BYPACKAGE` and worked.

**`--display map:parseable` was wrong for a rank bound across two
packages** — each package overwrote the previous one, so the XML named
the last and dropped the rest, contradicting `--display map` for the same
binding. Reachable through the rankfile mapper, which PRRTE's own
cross-package diagnostic points users at.

**`hwloc_use_topo_file` plus any explicit `--bind-to` was refused.** hwloc
zeroes the support bits of an imported topology; the assertion meant to
supply them sat *before* `hwloc_topology_load()`, which fills that
structure in — so it had quietly never worked, and the option was usable
only with `--bind-to none`.

**The `REPORT` binding qualifier could not be reached from any command
line** — implemented in the job-level parser, missing from the schizo
whitelist, including the diagnostic telling users to give it per job.

**Two "parseable" outputs were not parseable** — `<EMPTY CPUSET/>` and
`--display cpus`' `<pkg=0 cpus=0-7>`, in modes named for being read by a
program.

Plus smaller hardening: a NULL-deref in `setup_summary()` on an
allocation failure, `--cpu-set P0:99:*` silently accepted as "all of
package 0", and a refusal that ran after the qualifiers had already
written to the job.

### Testing

`test/unit/hwloc` gains five groups, including the only automated cover
for the `hwloc_use_topo_file` path; `contrib/dockerswarm`'s `test_hwloc`
phase gains four, and checks the parseable documents **with a parser
rather than a grep** — a grep is exactly what let those two stand.

Validated on the tip: warning-free debug build, `make check` 0 failures,
`make -C test/offline check-offline` 1180/1180, the help/schizo
cross-check clean, the docs building clean under `-W`, and the full
dockerswarm suite at **454 passed / 0 failed / 2 skipped** (both skips are
pre-existing PMIx-capability gates in the baked image).

`src/hwloc/AGENTS.md` carries everything durable, including a new golden
rule about hwloc's four child lists and two lessons worth keeping: a
validator whose answer nobody reads is not a validator, and anything
labelled "parseable" gets checked with a parser.
