### PR TITLE
Deep review of src/include

### DIFF
--- a/config/prte_check_attributes.m4
+++ b/config/prte_check_attributes.m4
@@ -137,7 +137,6 @@ AC_DEFUN([PRTE_CHECK_ATTRIBUTES], [
     prte_cv___attribute__cold=0
     prte_cv___attribute__const=0
     prte_cv___attribute__deprecated=0
-    prte_cv___attribute__deprecated_argument=0
     prte_cv___attribute__format=0
     prte_cv___attribute__format_funcptr=0
     prte_cv___attribute__hot=0
@@ -193,14 +192,6 @@ AC_DEFUN([PRTE_CHECK_ATTRIBUTES], [
     _PRTE_CHECK_SPECIFIC_ATTRIBUTE([deprecated],
         [
          int foo(int arg1, int arg2) __attribute__ ((__deprecated__));
-         int foo(int arg1, int arg2) { return arg1 * arg2 + arg1; }
-        ],
-        [],
-        [])
-
-    _PRTE_CHECK_SPECIFIC_ATTRIBUTE([deprecated_argument],
-        [
-         int foo(int arg1, int arg2) __attribute__ ((__deprecated__("compiler allows argument")));
          int foo(int arg1, int arg2) { return arg1 * arg2 + arg1; }
         ],
         [],
@@ -522,8 +513,6 @@ AC_DEFUN([PRTE_CHECK_ATTRIBUTES], [
                      [Whether your compiler has __attribute__ const or not])
   AC_DEFINE_UNQUOTED(PRTE_HAVE_ATTRIBUTE_DEPRECATED, [$prte_cv___attribute__deprecated],
                      [Whether your compiler has __attribute__ deprecated or not])
-  AC_DEFINE_UNQUOTED(PRTE_HAVE_ATTRIBUTE_DEPRECATED_ARGUMENT, [$prte_cv___attribute__deprecated_argument],
-                     [Whether your compiler has __attribute__ deprecated with optional argument])
   AC_DEFINE_UNQUOTED(PRTE_HAVE_ATTRIBUTE_FORMAT, [$prte_cv___attribute__format],
                      [Whether your compiler has __attribute__ format or not])
   AC_DEFINE_UNQUOTED(PRTE_HAVE_ATTRIBUTE_FORMAT_FUNCPTR, [$prte_cv___attribute__format_funcptr],

--- a/config/prte_configure_options.m4
+++ b/config/prte_configure_options.m4
@@ -134,20 +134,23 @@ AC_DEFINE_UNQUOTED(PRTE_MEMORY_SANITIZERS, $WANT_MEMORY_SANITIZERS,
                    [Whether or not we are using memory sanitizers])
 
 #
-# Do we want to install the internal devel headers?
+# There was a --with-devel-headers option here, installing PRRTE's internal
+# headers under $(includedir)/prte for "authors doing deeper integration".
+# It is gone, because there is nothing those headers can be compiled
+# against: PRRTE ships no linkable library at all -- it is a set of
+# executables -- so an installed header set has no consumer.  The option is
+# an inheritance from ORTE, which lived inside Open MPI and did have one.
 #
-AC_MSG_CHECKING([if want to install project-internal header files])
-AC_ARG_WITH(devel-headers,
-    AS_HELP_STRING([--with-devel-headers],
-                   [Normal PRTE users/applications do not need this.  Developer headers are only necessary for authors doing deeper integration (default: disabled).]))
-if test "$with_devel_headers" = "yes"; then
-    AC_MSG_RESULT([yes])
-    WANT_INSTALL_HEADERS=1
-else
-    AC_MSG_RESULT([no])
-    WANT_INSTALL_HEADERS=0
-fi
-AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
+# It had also stopped working.  The generated headers (prte_config.h and
+# version.h) were collected into a nodist_headers variable that no _HEADERS
+# variable referenced, so they were never installed -- while
+# prte_config_top.h and prte_config_bottom.h, which each #error unless
+# PRTE_CONFIG_H is already defined, were.  Since every PRRTE header opens
+# with #include "prte_config.h", nothing in the installed tree could be
+# compiled.  Separately, the mca framework Makefile.am files set
+# nobase_prte_HEADERS *outside* the conditional, so their headers installed
+# on every build whether the option was given or not.
+#
 
 #
 # Do we want the pretty-print stack trace feature?

--- a/configure.ac
+++ b/configure.ac
@@ -426,7 +426,7 @@ AC_CHECK_HEADERS([arpa/inet.h dirent.h \
                   sys/types.h sys/uio.h sys/un.h net/uio.h sys/utsname.h sys/wait.h syslog.h \
                   termios.h unistd.h util.h malloc.h \
                   paths.h \
-                  ioLib.h sockLib.h hostLib.h stdatomic.h])
+                  stdatomic.h])
 
 # Needed to work around Darwin requiring sys/socket.h for
 # net/if.h
@@ -595,8 +595,6 @@ AC_CHECK_FUNC([htonl], [prte_have_htonl=yes], [prte_have_htonl=no])
 AS_IF([test "$prte_cv_htonl_define" = "yes" || test "$prte_have_htonl" = "yes"],
     [AC_DEFINE_UNQUOTED([HAVE_UNIX_BYTESWAP], [1],
         [whether unix byteswap routines -- htonl, htons, nothl, ntohs -- are available])])
-
-AC_CHECK_DECLS(__func__)
 
 # checkpoint results
 AC_CACHE_SAVE

--- a/configure.ac
+++ b/configure.ac
@@ -999,10 +999,12 @@ esac
 
 prtedatadir='${datadir}/prte'
 prtelibdir='${libdir}/prte'
-prteincludedir='${includedir}/prte'
 AC_SUBST(prtedatadir)
 AC_SUBST(prtelibdir)
-AC_SUBST(prteincludedir)
+dnl There was a prteincludedir here, the install root for the headers that
+dnl --with-devel-headers used to install.  Both are gone -- PRRTE ships no
+dnl linkable library, so an installed header set has nothing to be compiled
+dnl against.  See config/prte_configure_options.m4.
 
 prte_want_prd=0
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4111,6 +4111,15 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     echo "$out" | grep -q 'already' \
         && ok "collision reported to the user" \
         || bad "collision produced no diagnostic: $(echo "$out" | tr '\n' ' ')"
+    # PRTE_ERR_PRELOAD_CONFLICT is the last code in constants.h, and this is
+    # the only place in the suite that provokes it. That matters beyond
+    # filem: the string sweep in test/unit/util ran to a bound written out by
+    # hand, and when this code was appended the bound was not moved, so the
+    # newest code was precisely the one nothing checked. Assert here that it
+    # still reaches the user as a sentence rather than as "Unknown error".
+    echo "$out" | grep -qi 'unknown error' \
+        && bad "the collision came back as \"Unknown error\": $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+        || ok "the collision was named, not reported as \"Unknown error\""
     c=$(prted_settle 10 1 2 3 4 5 6 7 8 9 10)
     [ "$c" = 0 ] && ok "no daemons linger after the refused preload" || bad "$c stray prted after refused preload"
     for n in 1 2 3; do docker exec "$NODE$n" sh -c 'rm -f /root/pf.dat' >/dev/null 2>&1; done

--- a/contrib/platform/embedded/debug
+++ b/contrib/platform/embedded/debug
@@ -18,7 +18,6 @@ enable_ft_thread=no
 enable_per_user_config_files=no
 enable_mca_no_build=crs,carto,maffinity,paffinity,pstat,filem,grpcomm-basic,grpcomm-hier,rmaps-rank_file,rmaps-seq,rmaps-topo,routed-binomial,routed-linear,routed-radix,routed-slave,snapc
 enable_contrib_no_build=libnbc
-with_devel_headers=yes
 with_alps=no
 with_ftb=no
 with_sge=no

--- a/contrib/platform/embedded/optimized
+++ b/contrib/platform/embedded/optimized
@@ -18,7 +18,6 @@ enable_ft_thread=no
 enable_per_user_config_files=no
 enable_mca_no_build=crs,carto,maffinity,paffinity,pstat,filem,grpcomm-basic,grpcomm-hier,rmaps-rank_file,rmaps-seq,rmaps-topo,routed-binomial,routed-linear,routed-radix,routed-slave,snapc
 enable_contrib_no_build=libnbc
-with_devel_headers=yes
 with_alps=no
 with_ftb=no
 with_sge=no

--- a/contrib/platform/intel/bend/ext
+++ b/contrib/platform/intel/bend/ext
@@ -20,7 +20,6 @@ enable_io_romio=no
 enable_contrib_no_build=libnbc
 with_memory_manager=no
 with_tm=no
-with_devel_headers=yes
 with_portals=no
 with_valgrind=no
 if [ -n "$SLURMHOME" ] ; then

--- a/contrib/platform/intel/bend/gadget
+++ b/contrib/platform/intel/bend/gadget
@@ -25,6 +25,5 @@ enable_mca_direct=pml-ob1
 with_memory_manager=no
 with_tm=no
 with_verbs=no
-with_devel_headers=yes
 with_portals=no
 with_valgrind=no

--- a/contrib/platform/intel/bend/gadget-optimized
+++ b/contrib/platform/intel/bend/gadget-optimized
@@ -22,6 +22,5 @@ enable_contrib_no_build=libnbc
 with_memory_manager=no
 with_tm=no
 with_verbs=no
-with_devel_headers=yes
 with_portals=no
 with_valgrind=no

--- a/contrib/platform/intel/bend/linux
+++ b/contrib/platform/intel/bend/linux
@@ -23,7 +23,6 @@ with_memory_manager=no
 with_tm=no
 with_psm=no
 with_psm2=no
-with_devel_headers=yes
 with_libfabric=no
 with_portals=no
 with_valgrind=no

--- a/contrib/platform/intel/bend/linux-optimized
+++ b/contrib/platform/intel/bend/linux-optimized
@@ -22,7 +22,6 @@ enable_mca_no_build=crs,memchecker,snapc,rml-ftrm,filem-rsh
 enable_contrib_no_build=libnbc
 with_memory_manager=no
 with_tm=no
-with_devel_headers=yes
 with_portals=no
 with_valgrind=no
 with_mpi_param_check=no

--- a/contrib/platform/intel/bend/mac
+++ b/contrib/platform/intel/bend/mac
@@ -6,5 +6,4 @@ enable_debug=yes
 enable_shared=yes
 enable_static=no
 enable_ipv6=no
-with_devel_headers=yes
 enable_prte_prefix_by_default=yes

--- a/contrib/platform/intel/bend/mac-optimized
+++ b/contrib/platform/intel/bend/mac-optimized
@@ -19,7 +19,6 @@ enable_memchecker=no
 enable_mca_no_build=crs,memchecker,snapc,rml-ftrm,filem-rsh
 enable_contrib_no_build=libnbc
 with_memory_manager=no
-with_devel_headers=yes
 with_xgrid=no
 with_slurm=no
 with_jdk_bindir=/usr/bin

--- a/contrib/platform/intel/bend/pi
+++ b/contrib/platform/intel/bend/pi
@@ -14,4 +14,3 @@ enable_ipv6=no
 enable_install_libpmix=yes
 with_memory_manager=no
 with_tm=no
-with_devel_headers=yes

--- a/contrib/platform/intel/bend/ubuntu
+++ b/contrib/platform/intel/bend/ubuntu
@@ -23,7 +23,6 @@ with_memory_manager=no
 with_tm=no
 with_psm=no
 with_psm2=no
-with_devel_headers=yes
 with_libfabric=no
 with_portals=no
 with_valgrind=no

--- a/contrib/platform/mellanox/optimized
+++ b/contrib/platform/mellanox/optimized
@@ -2,7 +2,6 @@ enable_mca_no_build=coll-ml,btl-uct
 enable_debug_symbols=yes
 enable_prterun_prefix_by_default=yes
 with_verbs=no
-with_devel_headers=yes
 enable_oshmem=yes
 enable_oshmem_fortran=yes
 disable_wrapper_rpath=yes

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,19 +56,19 @@ libprrte_la_DEPENDENCIES = \
 libprrte_la_LDFLAGS = -version-info $(libprrte_so_version)
 libprrte_la_CPPFLAGS =
 
-# included subdirectory Makefile.am's and appended-to variables
+# included subdirectory Makefile.am's and appended-to variables.
+#
+# PRRTE's headers are not installed anywhere -- see
+# config/prte_configure_options.m4 for why --with-devel-headers is gone.
+# $(headers) stays because listing it in libprrte_la_SOURCES is what gets
+# these files into the tarball and tracked as build dependencies.  There was
+# also a $(nodist_headers), holding prte_config.h and version.h; with the
+# install gone nothing reads it, and those two are already handled by
+# AC_CONFIG_HEADERS and AC_CONFIG_FILES.
 headers =
-nodist_headers =
 noinst_LTLIBRARIES =
 EXTRA_DIST =
 libprrte_la_SOURCES += $(headers)
-
-# Conditionally install the header files
-
-if WANT_INSTALL_HEADERS
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-endif
 
 include include/Makefile.am
 include runtime/Makefile.am

--- a/src/include/AGENTS.md
+++ b/src/include/AGENTS.md
@@ -25,7 +25,7 @@ up as strange behavior in whatever subsystem happened to use it.
 | `types.h` | Rank/app-index typedefs, `prte_socklen_t`, the 64-bit byte-order helpers. | no |
 | `prte_config_top.h` | Undefs the autoconf `PACKAGE_*` macros. Included at the *top* of `prte_config.h`. | no |
 | `prte_config_bottom.h` | The portability layer: the `__prte_attribute_*__` wrappers, `PRTE_EXPORT`, `PRTE_PATH_MAX`, the `sockaddr`/`AF_*` fallbacks. Included at the *bottom* of `prte_config.h`. | no |
-| `prte_stdint.h` | Fixed-width types and `PRIsize_t` where the system's are inadequate. | no |
+| `prte_stdint.h` | Pointer-sized integer fallbacks and `PRIsize_t`. | no |
 | `prte_stdatomic.h` | `prte_atomic_bool_t`. That is the whole file. | no |
 | `prte_socket_errno.h` | `#define prte_socket_errno errno`. | no |
 | `prte_portable_platform.h`, `_real.h` | Compiler-identification macros, also read by `config/prte_check_compiler_version.m4`. | vendored — do not edit |
@@ -48,7 +48,8 @@ place before anything else is parsed.
 ```
 PRTE_ERR_BASE  PMIX_EXTERNAL_ERR_BASE  (-3000)
                  offsets   1 ..  72  ->  -3001 .. -3072   mirrored from PMIx
-                 offsets 101 .. 155  ->  -3101 .. -3155   PRRTE's own
+                 offsets 101 .. 156  ->  -3101 .. -3156   PRRTE's own
+PRTE_ERR_MAX                  offset 157  ->  -3157       not a code: the bound
 ```
 
 `PRTE_SUCCESS` is `0` and is the only code that is not an offset. Everything
@@ -82,10 +83,41 @@ were flattened into `src/` in 2019. So the whole lower group became
 **positive** error codes (+99 down to +43), and a `PRTE_ERR_MAX` defined as
 `(PRTE_ERR_SPLIT - 100)` was `0` — the value of `PRTE_SUCCESS`. OPAL and
 ORTE have been one code base since that merge, so the second base is gone
-too: one enum in one file does not need two. `PRTE_ERR_MAX` is gone rather
-than corrected — nothing in the tree ever used it, and a bound with no
-consumer is a bound nobody maintains. If you need one, the range is
-`PRTE_ERR_BASE` downwards and the test that cares defines its own span.
+too: one enum in one file does not need two.
+
+### `PRTE_ERR_MAX` — the bound, and why it is back
+
+`PRTE_ERR_MAX` is the last member of the enum and is **not a code**. Nothing
+returns it, nothing tests for it, and `prte_strerror()` deliberately has no
+case for it. It is one past the last assigned offset, and it exists so that
+code sweeping the list has a bound it does not have to guess.
+
+It was removed once, on the reasoning that nothing consumed it and *a bound
+with no consumer is a bound nobody maintains* — leaving each test that
+needed one to define its own span. That was the wrong shape. Two of them
+(`test/unit/include` and `test/unit/util`) wrote out the last offset as a
+literal `155`, and **both went stale on the very first code appended after
+they were written**. The consequence was worse in `test/unit/util`, whose
+sweep exists precisely to catch a code added without a `prte_strerror()`
+string: it stopped one short of the newest code — the code most likely to be
+missing one.
+
+So the bound is back, with the two things that were missing the first time:
+
+- **It lives next to the append site.** Bump it in the same edit that adds a
+  code. It sits at the bottom of the enum, immediately below where you are
+  appending, for exactly that reason.
+- **A stale bound is a test failure, not a silent loss of coverage.**
+  `test_error_bound()` in `test/unit/util` uses `prte_strerror()` as the
+  oracle: the offset just inside `PRTE_ERR_MAX` must be a real named code,
+  and `PRTE_ERR_MAX` itself must not be. That catches both directions —
+  appending a code without bumping the bound, and bumping the bound past the
+  last code.
+
+`test/unit/pmix` keeps a span of its own (`PRTE_CODE_SPAN`, 200) on purpose.
+It is a deliberately loose range test — "is this value plausibly a PRRTE
+code rather than a raw PMIx status?" — and wants headroom rather than the
+exact end of the list.
 
 Nothing in the tree ever tested a PRRTE code by sign, which is why the
 inversion went unnoticed for so long: the house idiom is `PRTE_SUCCESS != rc`,
@@ -95,15 +127,21 @@ form that stays correct when the base moves.
 
 ### Adding a code
 
-Append it at the end of its group with the next unused offset (or at the very
-end — the two groups are a convention for readers, not arithmetic), leave the
-hole between offsets 72 and 101 alone, and **add its string to
-[`src/util/error.c`](../util/error.c)**. `test/unit/util` sweeps the whole
-range and fails on a code with no string, because `PRTE_ERROR_LOG()` prints
-nothing else and the user would see "Unknown error". `test/unit/include`
-checks the range arithmetic. Uniqueness needs no test: `prte_strerror()`
-switches on every code, so a repeated value is a duplicate-`case` error at
-build time.
+Three steps, all in the same edit:
+
+1. Append it at the end of its group with the next unused offset (or at the
+   very end — the two groups are a convention for readers, not arithmetic),
+   leaving the hole between offsets 72 and 101 alone.
+2. **Bump `PRTE_ERR_MAX`** to one past your new offset. It is the next line
+   down; you cannot miss it, and if you do, `test/unit/util` fails.
+3. **Add its string to [`src/util/error.c`](../util/error.c).**
+   `test/unit/util` sweeps the whole range and fails on a code with no
+   string, because `PRTE_ERROR_LOG()` prints nothing else and the user would
+   see "Unknown error".
+
+`test/unit/include` checks the range arithmetic. Uniqueness needs no test:
+`prte_strerror()` switches on every code, so a repeated value is a
+duplicate-`case` error at build time.
 
 Job and process states are numbered similarly but live somewhere else:
 [`src/mca/plm/plm_types.h`](../mca/plm/plm_types.h). They have **not** been
@@ -134,6 +172,36 @@ project's usual `#if FOO` rule, which applies to the `AC_DEFINE_UNQUOTED`
 0-or-1 symbols. Where it is absent, `prte_config_bottom.h` supplies identity
 `htonl`/`htons` stubs and these follow suit.
 
+---
+
+## `prte_stdint.h`
+
+Fixed-width and pointer-sized integer types, plus `PRIsize_t`. Two notes:
+
+- **`PRIsize_t` is unconditionally `"zu"`.** C11 is a hard requirement, so
+  `"z"` is always available and is the only spelling correct by *definition*
+  rather than by a size coincidence. It used to be a ladder whose `"zu"` arm
+  was guarded on `ACCEPT_C99` — a symbol PRRTE's configure has never defined
+  — so every build fell through to comparing `SIZEOF_SIZE_T` against
+  `SIZEOF_LONG` and `SIZEOF_LONG_LONG`, landing on a working answer for the
+  usual data models and on plain `"u"` for any where it did not.
+- **The `intptr_t`/`uintptr_t` ladder is live** and ends in an `#error`, so
+  it is one of the few things here that fails loudly. It only fires where
+  the system's `<stdint.h>` does not supply the types (configure probes with
+  `HAVE_INTPTR_T`/`HAVE_UINTPTR_T`), which C11 does not require it to.
+
+There was also a 128-bit block here — `prte_int128_t`, `prte_uint128_t` and
+`HAVE_PRTE_INT128_T`, selected from `HAVE_INT128_T` or `HAVE___INT128`. It
+came from OPAL, whose atomics needed a 128-bit type. **Neither configure
+symbol has ever been probed by PRRTE's configure**, so the types were never
+declared and `HAVE_PRTE_INT128_T` was always `0` — and nothing in the tree
+names any of the three. It is gone. If PRRTE ever needs one, probe for it in
+`configure.ac` in the same change.
+
+---
+
+## What `types.h` no longer carries
+
 `types.h` used to also carry `prte_ptr_t`, `prte_iov_base_ptr_t`,
 `prte_ptr_ptol`/`ltop` and a set of `prte_swap_bytes*` functions. Nothing
 used any of them.
@@ -142,7 +210,7 @@ used any of them.
 
 ## `prte_config_bottom.h`
 
-The portability layer. Two things to know:
+The portability layer. Three things to know:
 
 - **The `__prte_attribute_*__` macros are the only correct way to write a
   compiler attribute** in this tree (`__prte_attribute_unused__`,
@@ -158,6 +226,59 @@ The portability layer. Two things to know:
   narrowing exists for — and `--enable-devel-check` makes that an error.
   This is the one place in the tree that legitimately `#undef`s a logical
   macro.
+- **The printf fallbacks all come from PMIx.** Where the platform's libc is
+  missing `asprintf`/`snprintf`/`vasprintf`/`vsnprintf`, this header maps the
+  name onto `pmix_asprintf`/`pmix_snprintf`/`pmix_vasprintf`/`pmix_vsnprintf`
+  from `src/util/pmix_printf.h`. **PRRTE has no printf replacements of its
+  own and never had** — if you find yourself writing `prte_` here, that is
+  the mistake. It was already made once: the `vsnprintf` arm named
+  `prte_vsnprintf`, a symbol in neither tree, so a platform without
+  `vsnprintf()` would have failed to build every tool — and not merely at
+  link time. `pmix_printf.h` pulls in PMIx's own `pmix_config_bottom.h`,
+  which maps `vsnprintf` to `pmix_vsnprintf` under the identical guard, so
+  PRRTE's line would have redefined a live macro with a different body:
+  `-Wmacro-redefined`, which `--enable-devel-check` makes an error. Nothing
+  caught it because the whole block only compiles where the libc function is
+  absent, which is nowhere anyone builds. `test/unit/include` now takes the
+  address of all four, so at least the names have to exist.
+
+Two blocks that used to live here are gone, both unreachable by
+construction rather than merely unused:
+
+- A `__func__` fallback defining it to `__FILE__`, guarded on
+  `AC_CHECK_DECLS(__func__)`. C11 mandates `__func__` (6.4.2.2) and PRRTE
+  requires C11.
+- A VxWorks block including `<ioLib.h>`, `<sockLib.h>` and `<hostLib.h>`,
+  guarded on `MCS_VXWORKS` — a symbol that appears nowhere else in the tree
+  and that nothing under `config/` has ever defined.
+
+The configure checks that existed only to feed them (`AC_CHECK_DECLS`
+for `__func__`, and the three `AC_CHECK_HEADERS` entries) went with them.
+When you delete a guard here, delete its probe too — an emitted symbol with
+no reader is the state that made both of these survive this long. On the
+same principle, `PRTE_HAVE_ATTRIBUTE_DEPRECATED_ARGUMENT` and its
+`_PRTE_CHECK_SPECIFIC_ATTRIBUTE` probe are gone from
+`config/prte_check_attributes.m4`: `prte_config_bottom.h` never grew a
+`__prte_attribute_deprecated_argument__` wrapper for it, so the configure
+result had nowhere to go. (PMIx emits the same symbol and likewise has
+neither a wrapper nor a use — so "parity with PMIx" would only have meant
+keeping the same dead check in two places.)
+
+**And the whole file used to sit inside `#if OMPI_BUILDING`.** That is an
+Open MPI inheritance: there, `mpi.h` set `OMPI_BUILDING` to `0` before
+pulling in the config header, so none of the portability layer —
+`#define snprintf pmix_snprintf`, `#define sockaddr_in6 sockaddr_in`,
+`#define sin6_addr sin_addr`, the `static inline htonl` definitions, the
+redefinition of Apple's `__PRI_64_LENGTH_MODIFIER__` — landed in an MPI
+application's namespace, and an `#else` arm stripped the `PACKAGE_*` macros
+back out for it. The fence earns its keep in Open MPI. In PRRTE it had no
+"outside": there is no `mpi.h`, nothing ever set it to `0`, and with
+`--with-devel-headers` gone PRRTE installs no header an external consumer
+could include at all. So the block always compiled, the `#else` arm was
+unreachable, and an `OMPI_`-prefixed symbol sat in PRRTE's most-included
+header against the project's own symbol-prefix rule. Removing it changes
+nothing: the preprocessed output of `prte_config.h` is byte-identical
+before and after.
 
 ---
 
@@ -218,18 +339,66 @@ does not have, add it to PMIx and require the PMIx that has it via
 adding a framework or a `config/*.m4` change means re-running `./autogen.pl`
 and reconfiguring — a plain `make` will not do it and can wedge the tree.
 
+### PRRTE's headers are not installed, anywhere
+
+`Makefile.am` here appends its files to `headers`, which
+[`src/Makefile.am`](../Makefile.am) feeds to `libprrte_la_SOURCES`. That is
+what puts them in the tarball and makes them tracked build dependencies —
+**not** an install rule. There is no install rule. Do not add one.
+
+`prte_config.h` and `version.h` are deliberately not in that list either:
+they are generated into the build tree and `AC_CONFIG_HEADERS` /
+`AC_CONFIG_FILES` already own them.
+
+There used to be a `--with-devel-headers` option ("for authors doing deeper
+integration") that installed all of it under `$(includedir)/prte`. It has
+been removed, for the reason that settles the question: **PRRTE ships no
+linkable library.** It is a set of executables. There is nothing an
+installed header set could be compiled *against*, so there was never a
+consumer. The option is an ORTE-era inheritance, from when ORTE lived
+inside Open MPI and did have one.
+
+It had also long since stopped working, in two independent ways worth
+knowing about because both are easy to reintroduce:
+
+- The generated headers went into a `nodist_headers` variable that **no
+  `_HEADERS` variable ever referenced**, so `prte_config.h` was never
+  installed — while `prte_config_top.h` and `prte_config_bottom.h`, which
+  each `#error` unless `PRTE_CONFIG_H` is already defined, were. Since every
+  PRRTE header opens with `#include "prte_config.h"`, nothing in the
+  installed tree compiled at all.
+- The `mca` framework `Makefile.am` files set `nobase_prte_HEADERS`
+  *outside* the `WANT_INSTALL_HEADERS` conditional, so their headers
+  installed on every build whether the option was given or not.
+
+And even with the first repaired, it did not work: most `Makefile.am`
+fragments never append to `headers`, so `src/event/`, `src/pmix/` and much
+of `src/util/` were absent while installed headers included them by path.
+Measured before removal: 96 headers installed, 73 of 93 failed to compile
+standalone.
+
 ---
 
 ## Testing
 
 **Unit tests — `test/unit/include/test_include.c`, run by `make check`.**
 Covers the error-code band arithmetic (no code is `PRTE_SUCCESS`, the two
-bands cannot collide, and there is headroom to grow), the rank types and
-their sentinels including the parenthesization trap, `prte_hton64`/`ntoh64`
-round-trip *and* their actual big-endian byte layout — a pair of no-op
-functions round-trips perfectly and still puts the wrong bytes on the wire —
-`PRIsize_t`, the `PRTE_PATH_MAX`/`PRTE_MAXHOSTNAMELEN` fallbacks, and the
-`PRTE_ENABLE_IPV6` narrowing.
+bands cannot collide, there is headroom to grow, and `PRTE_ERR_MAX` really
+is one past the end), the rank types and their sentinels including the
+parenthesization trap, `prte_hton64`/`ntoh64` round-trip *and* their actual
+big-endian byte layout — a pair of no-op functions round-trips perfectly and
+still puts the wrong bytes on the wire — `PRIsize_t`, the pointer-sized
+integer ladder, the `PRTE_PATH_MAX`/`PRTE_MAXHOSTNAMELEN` fallbacks, the
+`PRTE_ENABLE_IPV6` narrowing, and the existence of the four PMIx printf
+replacements.
+
+**The other half of the error-code coverage is in `test/unit/util`**, because
+it needs `prte_strerror()`: `test_error_strings()` sweeps every offset and
+fails on a code with no string, and `test_error_bound()` checks that
+`PRTE_ERR_MAX` — the bound that sweep runs to — has not gone stale in either
+direction. Keeping the bound in `constants.h` and the staleness check next
+to the oracle is deliberate; see the `PRTE_ERR_MAX` section above for what
+happened when each test kept its own copy.
 
 That test deliberately does **not** call `prte_init_util()`. Everything here
 has to be correct before any of PRRTE is running — `prte_init_util` is

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -36,9 +36,14 @@ headers += \
         include/prte_stdatomic.h \
         include/prte_socket_errno.h
 
-nodist_headers += \
-        include/prte_config.h \
-        include/version.h
+# prte_config.h and version.h are deliberately absent from the list above.
+# They are generated into the build tree, and AC_CONFIG_HEADERS /
+# AC_CONFIG_FILES already own them.  They used to be collected into a
+# nodist_headers variable that no _HEADERS variable ever referenced -- so
+# they were never installed, which is one of the reasons the
+# --with-devel-headers option that would have installed them produced a
+# tree that could not be compiled.  That option is gone; see
+# config/prte_configure_options.m4.
 
 libprrte_la_SOURCES += \
         $(headers) \

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -221,7 +221,29 @@ enum {
     PRTE_ERR_SLURM_SUBMIT_FAILURE = (PRTE_ERR_BASE - 153),
     PRTE_ERR_SLURM_CANCEL_FAILURE = (PRTE_ERR_BASE - 154),
     PRTE_ERR_SLURM_SHRINK_FAILURE = (PRTE_ERR_BASE - 155),
-    PRTE_ERR_PRELOAD_CONFLICT = (PRTE_ERR_BASE - 156)
+    PRTE_ERR_PRELOAD_CONFLICT = (PRTE_ERR_BASE - 156),
+
+    /* Not an error code.  Nothing returns it, nothing tests for it, and
+     * prte_strerror() deliberately has no case for it: it is one past the
+     * last assigned offset, and it exists so that the code that sweeps this
+     * list has a bound it does not have to guess.
+     *
+     * Bump it in the same edit that appends a code above.  It sits here,
+     * adjacent to where you are appending, for exactly that reason -- the
+     * two copies of this bound that used to live in test/unit/include and
+     * test/unit/util both went stale on the first code added after they
+     * were written, which silently stopped the string sweep one code short
+     * of the end.  Forgetting is now a test failure rather than a quiet
+     * loss of coverage: test/unit/util checks that PRTE_ERR_MAX itself has
+     * no string and that the code just above it does, so a bound that is
+     * either too low or too high is caught.
+     *
+     * There was an earlier PRTE_ERR_MAX, removed because nothing consumed
+     * it -- and because, computed from a base whose sign had been dropped,
+     * it evaluated to PRTE_SUCCESS.  This one has consumers, and a test
+     * that notices when it lies.
+     */
+    PRTE_ERR_MAX = (PRTE_ERR_BASE - 157)
 };
 
 END_C_DECLS

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -160,10 +160,15 @@ enum {
     PRTE_PMIX_LAUNCHER_READY = (PRTE_ERR_BASE - 71),
     PRTE_OPERATION_SUCCEEDED = (PRTE_ERR_BASE - 72),
 
-    /* error codes specific to PRTE - don't forget to update
-        src/util/error_strings.c when adding new error codes!!
-        Otherwise, the error reporting system will potentially crash,
-        or at the least not be able to report the new error correctly.
+    /* Error codes specific to PRRTE.
+     *
+     * Whichever group you append to, give the new code a string in
+     * prte_strerror(), which lives in src/util/error.c -- NOT in
+     * src/util/error_strings.c, which this comment used to name.  That file
+     * holds the *state* strings (prte_job_state_to_str() and friends), so
+     * following the old instruction put the string somewhere prte_strerror()
+     * never looks and left the user reading "Unknown error" -- precisely the
+     * failure the instruction exists to prevent.  test/unit/util catches it.
      */
 
     PRTE_ERR_RECV_LESS_THAN_POSTED = (PRTE_ERR_BASE - 101),

--- a/src/include/prte_config_bottom.h
+++ b/src/include/prte_config_bottom.h
@@ -365,16 +365,12 @@ static inline uint16_t ntohs(uint16_t netvar)
 }
 #    endif
 
-/*
- * Define __func__-preprocessor directive if the compiler does not
- * already define it.  Define it to __FILE__ so that we at least have
- * a clue where the developer is trying to indicate where the error is
- * coming from (assuming that __func__ is typically used for
- * printf-style debugging).
- */
-#    if defined(HAVE_DECL___FUNC__) && !HAVE_DECL___FUNC__
-#        define __func__ __FILE__
-#    endif
+/* There was a fallback here defining __func__ to __FILE__ where the
+ * compiler did not supply __func__, guarded on AC_CHECK_DECLS(__func__).
+ * C11 mandates __func__ (6.4.2.2) and PRRTE requires a C11 compiler --
+ * config/prte_setup_cc.m4 aborts configure otherwise -- so the fallback was
+ * unreachable, and the configure check that fed it has been dropped with
+ * it. */
 
 /* ensure the bool type is defined as it is used everywhere */
 #    include <stdbool.h>
@@ -444,23 +440,13 @@ static inline uint16_t ntohs(uint16_t netvar)
 #        endif
 #    endif
 
-#    ifdef MCS_VXWORKS
-/* VXWorks puts some common functions in oddly named headers.  Rather
-   than update all the places the functions are used, which would be a
-   maintenance disatster, just update here... */
-#        ifdef HAVE_IOLIB_H
-/* pipe(), ioctl() */
-#            include <ioLib.h>
-#        endif
-#        ifdef HAVE_SOCKLIB_H
-/* socket() */
-#            include <sockLib.h>
-#        endif
-#        ifdef HAVE_HOSTLIB_H
-/* gethostname() */
-#            include <hostLib.h>
-#        endif
-#    endif
+/* There was a VxWorks block here, pulling in <ioLib.h>, <sockLib.h> and
+ * <hostLib.h> for pipe()/ioctl(), socket() and gethostname().  It was
+ * guarded on MCS_VXWORKS -- a symbol that appears nowhere else in the tree
+ * and that neither configure.ac nor any macro under config/ has ever
+ * defined, so it could not be reached however PRRTE was configured.  The
+ * three AC_CHECK_HEADERS entries that existed only to feed it have been
+ * dropped with it. */
 
 /* If we're in C++, then just undefine restrict and then define it to
    nothing.  "restrict" is not part of the C++ language, and we don't

--- a/src/include/prte_config_bottom.h
+++ b/src/include/prte_config_bottom.h
@@ -37,25 +37,6 @@
 #endif
 
 /*
- * If we build a static library, Visual C define the _LIB symbol. In the
- * case of a shared library _USERDLL get defined.
- *
- * OMPI_BUILDING and _LIB define how prte_config.h
- * handles configuring all of PRTE's "compatibility" code.  Both
- * constants will always be defined by the end of prte_config.h.
- *
- * OMPI_BUILDING affects how much compatibility code is included by
- * prte_config.h.  It will always be 1 or 0.  The user can set the
- * value before including either mpi.h or prte_config.h and it will be
- * respected.  If prte_config.h is included before mpi.h, it will
- * default to 1.  If mpi.h is included before prte_config.h, it will
- * default to 0.
- */
-#ifndef OMPI_BUILDING
-#    define OMPI_BUILDING 1
-#endif
-
-/*
  * Flex is trying to include the unistd.h file. As there is no configure
  * option or this, the flex generated files will try to include the file
  * even on platforms without unistd.h. Therefore, if we
@@ -67,8 +48,7 @@
 
 /***********************************************************************
  *
- * code that should be in ompi_config_bottom.h regardless of build
- * status
+ * The C-linkage and compiler-attribute wrappers.
  *
  **********************************************************************/
 
@@ -269,75 +249,87 @@
 
 /***********************************************************************
  *
- * Code that is only for when building PRTE or utilities that are
- * using the internals of PRTE.  It should not be included when
- * building MPI applications
+ * The portability layer proper.
+ *
+ * This used to sit inside "#if OMPI_BUILDING", an Open MPI inheritance.
+ * There, mpi.h set OMPI_BUILDING to 0 before pulling in the config header
+ * so that none of what follows -- the printf and sockaddr renames, the
+ * static inline htonl definitions, the redefinition of Apple's
+ * __PRI_64_LENGTH_MODIFIER__ -- landed in an MPI application's namespace,
+ * and an #else arm stripped the PACKAGE_* macros back out for it.
+ *
+ * PRRTE has no mpi.h, nothing ever set OMPI_BUILDING to 0, and since the
+ * removal of --with-devel-headers PRRTE installs no header that an outside
+ * consumer could include at all.  So the fence had no "outside": the block
+ * always compiled and the #else arm was unreachable.  It also put an OMPI_
+ * prefixed symbol in PRRTE's most-included header, against the project's
+ * own symbol-prefix rule.
  *
  **********************************************************************/
-#if OMPI_BUILDING
+
 
 /*
  * Maximum size of a filename path.
  */
-#    include <limits.h>
-#    ifdef HAVE_SYS_PARAM_H
-#        include <sys/param.h>
-#    endif
-#    if defined(PATH_MAX)
-#        define PRTE_PATH_MAX (PATH_MAX + 1)
-#    elif defined(_POSIX_PATH_MAX)
-#        define PRTE_PATH_MAX (_POSIX_PATH_MAX + 1)
-#    else
-#        define PRTE_PATH_MAX 256
-#    endif
+#include <limits.h>
+#ifdef HAVE_SYS_PARAM_H
+#    include <sys/param.h>
+#endif
+#if defined(PATH_MAX)
+#    define PRTE_PATH_MAX (PATH_MAX + 1)
+#elif defined(_POSIX_PATH_MAX)
+#    define PRTE_PATH_MAX (_POSIX_PATH_MAX + 1)
+#else
+#    define PRTE_PATH_MAX 256
+#endif
 
 /*
  * Set the compile-time path-separator on this system
  */
-#    define PRTE_PATH_SEP "/"
+#define PRTE_PATH_SEP "/"
 
-#    if defined(MAXHOSTNAMELEN)
-#        define PRTE_MAXHOSTNAMELEN (MAXHOSTNAMELEN + 1)
-#    elif defined(HOST_NAME_MAX)
-#        define PRTE_MAXHOSTNAMELEN (HOST_NAME_MAX + 1)
-#    else
+#if defined(MAXHOSTNAMELEN)
+#    define PRTE_MAXHOSTNAMELEN (MAXHOSTNAMELEN + 1)
+#elif defined(HOST_NAME_MAX)
+#    define PRTE_MAXHOSTNAMELEN (HOST_NAME_MAX + 1)
+#else
 /* SUSv2 guarantees that "Host names are limited to 255 bytes". */
-#        define PRTE_MAXHOSTNAMELEN (255 + 1)
-#    endif
+#    define PRTE_MAXHOSTNAMELEN (255 + 1)
+#endif
 
 /*
  * printf functions for portability (only when building PRTE)
  */
-#    if !defined(HAVE_VASPRINTF) || !defined(HAVE_VSNPRINTF)
-#        include <stdarg.h>
-#        include <stdlib.h>
-#    endif
+#if !defined(HAVE_VASPRINTF) || !defined(HAVE_VSNPRINTF)
+#    include <stdarg.h>
+#    include <stdlib.h>
+#endif
 
-#    if !defined(HAVE_ASPRINTF) || !defined(HAVE_SNPRINTF) || !defined(HAVE_VASPRINTF) \
+#if !defined(HAVE_ASPRINTF) || !defined(HAVE_SNPRINTF) || !defined(HAVE_VASPRINTF) \
         || !defined(HAVE_VSNPRINTF)
-#        include "src/util/pmix_printf.h"
-#    endif
+#    include "src/util/pmix_printf.h"
+#endif
 
-#    ifndef HAVE_ASPRINTF
-#        define asprintf pmix_asprintf
-#    endif
+#ifndef HAVE_ASPRINTF
+#    define asprintf pmix_asprintf
+#endif
 
-#    ifndef HAVE_SNPRINTF
-#        define snprintf pmix_snprintf
-#    endif
+#ifndef HAVE_SNPRINTF
+#    define snprintf pmix_snprintf
+#endif
 
-#    ifndef HAVE_VASPRINTF
-#        define vasprintf pmix_vasprintf
-#    endif
+#ifndef HAVE_VASPRINTF
+#    define vasprintf pmix_vasprintf
+#endif
 
-#    ifndef HAVE_VSNPRINTF
+#ifndef HAVE_VSNPRINTF
 /* pmix_vsnprintf, not prte_vsnprintf: PRRTE has no printf replacements of
  * its own, and never had -- all four of these come from PMIx's
  * src/util/pmix_printf.h, included just above.  This one named a symbol
  * that exists nowhere in either tree, so a platform without vsnprintf()
  * would have failed to link every tool. */
-#        define vsnprintf pmix_vsnprintf
-#    endif
+#    define vsnprintf pmix_vsnprintf
+#endif
 
 /*
  * On some homogenous big-iron machines (Sandia's Red Storm), there
@@ -346,7 +338,7 @@
  * and would want to talk to the outside world... On other platforms
  * we fail to detect them correctly.
  */
-#    if !defined(HAVE_UNIX_BYTESWAP)
+#if !defined(HAVE_UNIX_BYTESWAP)
 static inline uint32_t htonl(uint32_t hostvar)
 {
     return hostvar;
@@ -363,7 +355,7 @@ static inline uint16_t ntohs(uint16_t netvar)
 {
     return netvar;
 }
-#    endif
+#endif
 
 /* There was a fallback here defining __func__ to __FILE__ where the
  * compiler did not supply __func__, guarded on AC_CHECK_DECLS(__func__).
@@ -373,7 +365,7 @@ static inline uint16_t ntohs(uint16_t netvar)
  * it. */
 
 /* ensure the bool type is defined as it is used everywhere */
-#    include <stdbool.h>
+#include <stdbool.h>
 
 /**
  * Top level define to check 2 things: a) if we want ipv6 support, and
@@ -388,40 +380,40 @@ static inline uint16_t ntohs(uint16_t netvar)
  * makes the compiler emit -Wmacro-redefined on exactly the platform the
  * narrowing exists for, which under --enable-devel-check is a build error.
  */
-#    if PRTE_ENABLE_IPV6 && !defined(HAVE_STRUCT_SOCKADDR_IN6)
-#        undef PRTE_ENABLE_IPV6
-#        define PRTE_ENABLE_IPV6 0
-#    endif
+#if PRTE_ENABLE_IPV6 && !defined(HAVE_STRUCT_SOCKADDR_IN6)
+#    undef PRTE_ENABLE_IPV6
+#    define PRTE_ENABLE_IPV6 0
+#endif
 
-#    if !defined(HAVE_STRUCT_SOCKADDR_STORAGE) && defined(HAVE_STRUCT_SOCKADDR_IN)
-#        define sockaddr_storage sockaddr
-#        define ss_family        sa_family
-#    endif
+#if !defined(HAVE_STRUCT_SOCKADDR_STORAGE) && defined(HAVE_STRUCT_SOCKADDR_IN)
+#    define sockaddr_storage sockaddr
+#    define ss_family        sa_family
+#endif
 
 /* Compatibility structure so that we don't have to have as many
    #if checks in the code base */
-#    if !defined(HAVE_STRUCT_SOCKADDR_IN6) && defined(HAVE_STRUCT_SOCKADDR_IN)
-#        define sockaddr_in6 sockaddr_in
-#        define sin6_len     sin_len
-#        define sin6_family  sin_family
-#        define sin6_port    sin_port
-#        define sin6_addr    sin_addr
-#    endif
+#if !defined(HAVE_STRUCT_SOCKADDR_IN6) && defined(HAVE_STRUCT_SOCKADDR_IN)
+#    define sockaddr_in6 sockaddr_in
+#    define sin6_len     sin_len
+#    define sin6_family  sin_family
+#    define sin6_port    sin_port
+#    define sin6_addr    sin_addr
+#endif
 
-#    if !HAVE_DECL_AF_UNSPEC
-#        define AF_UNSPEC 0
-#    endif
-#    if !HAVE_DECL_PF_UNSPEC
-#        define PF_UNSPEC 0
-#    endif
-#    if !HAVE_DECL_AF_INET6
-#        define AF_INET6 AF_UNSPEC
-#    endif
-#    if !HAVE_DECL_PF_INET6
-#        define PF_INET6 PF_UNSPEC
-#    endif
+#if !HAVE_DECL_AF_UNSPEC
+#    define AF_UNSPEC 0
+#endif
+#if !HAVE_DECL_PF_UNSPEC
+#    define PF_UNSPEC 0
+#endif
+#if !HAVE_DECL_AF_INET6
+#    define AF_INET6 AF_UNSPEC
+#endif
+#if !HAVE_DECL_PF_INET6
+#    define PF_INET6 PF_UNSPEC
+#endif
 
-#    if defined(__APPLE__) && defined(HAVE_INTTYPES_H)
+#if defined(__APPLE__) && defined(HAVE_INTTYPES_H)
 /* Prior to Mac OS X 10.3, the length modifier "ll" wasn't
    supported, but "q" was for long long.  This isn't ANSI
    C and causes a warning when using PRI?64 macros.  We
@@ -429,16 +421,16 @@ static inline uint16_t ntohs(uint16_t netvar)
    need such backward compatibility.  Instead, redefine
    the macros to be "ll", which is ANSI C and doesn't
    cause a compiler warning. */
-#        include <inttypes.h>
-#        if defined(__PRI_64_LENGTH_MODIFIER__)
-#            undef __PRI_64_LENGTH_MODIFIER__
-#            define __PRI_64_LENGTH_MODIFIER__ "ll"
-#        endif
-#        if defined(__SCN_64_LENGTH_MODIFIER__)
-#            undef __SCN_64_LENGTH_MODIFIER__
-#            define __SCN_64_LENGTH_MODIFIER__ "ll"
-#        endif
+#    include <inttypes.h>
+#    if defined(__PRI_64_LENGTH_MODIFIER__)
+#        undef __PRI_64_LENGTH_MODIFIER__
+#        define __PRI_64_LENGTH_MODIFIER__ "ll"
 #    endif
+#    if defined(__SCN_64_LENGTH_MODIFIER__)
+#        undef __SCN_64_LENGTH_MODIFIER__
+#        define __SCN_64_LENGTH_MODIFIER__ "ll"
+#    endif
+#endif
 
 /* There was a VxWorks block here, pulling in <ioLib.h>, <sockLib.h> and
  * <hostLib.h> for pipe()/ioctl(), socket() and gethostname().  It was
@@ -452,28 +444,8 @@ static inline uint16_t ntohs(uint16_t netvar)
    nothing.  "restrict" is not part of the C++ language, and we don't
    have a corresponding AC_CXX_RESTRICT to figure out what the C++
    compiler supports. */
-#    if defined(c_plusplus) || defined(__cplusplus)
-#        undef restrict
-#        define restrict
-#    endif
+#if defined(c_plusplus) || defined(__cplusplus)
+#    undef restrict
+#    define restrict
+#endif
 
-#else
-
-/* For a similar reason to what is listed in prte_config_top.h, we
-   want to protect others from the autoconf/automake-generated
-   PACKAGE_<foo> macros in prte_config.h.  We can't put these undef's
-   directly in prte_config.h because they'll be turned into #defines'
-   via autoconf.
-
-   So put them here in case any only else includes OMPI/PRTE's
-   config.h files. */
-
-#    undef PACKAGE_BUGREPORT
-#    undef PACKAGE_NAME
-#    undef PACKAGE_STRING
-#    undef PACKAGE_TARNAME
-#    undef PACKAGE_VERSION
-#    undef PACKAGE_URL
-#    undef HAVE_CONFIG_H
-
-#endif /* OMPI_BUILDING */

--- a/src/include/prte_config_bottom.h
+++ b/src/include/prte_config_bottom.h
@@ -331,7 +331,12 @@
 #    endif
 
 #    ifndef HAVE_VSNPRINTF
-#        define vsnprintf prte_vsnprintf
+/* pmix_vsnprintf, not prte_vsnprintf: PRRTE has no printf replacements of
+ * its own, and never had -- all four of these come from PMIx's
+ * src/util/pmix_printf.h, included just above.  This one named a symbol
+ * that exists nowhere in either tree, so a platform without vsnprintf()
+ * would have failed to link every tool. */
+#        define vsnprintf pmix_vsnprintf
 #    endif
 
 /*

--- a/src/include/prte_stdatomic.h
+++ b/src/include/prte_stdatomic.h
@@ -32,8 +32,10 @@
  * same way, and the two projects share a threading model.  There used to be
  * a `volatile`-typed fallback selected by PRTE_ATOMIC_C11 == 0; `volatile`
  * is not an atomic type, so that arm was a way to build something that
- * could not be correct.  PRTE_CONFIG_ASM (config/prte_config_asm.m4) now
- * fails configure outright when the compiler cannot supply C11 atomics.
+ * could not be correct.  PRTE_SETUP_CC (config/prte_setup_cc.m4) now fails
+ * configure outright when the compiler cannot supply C11 atomics, right
+ * after the compiler checks that answer the question rather than several
+ * hundred checks later.
  */
 #    include <stdatomic.h>
 

--- a/src/include/prte_stdint.h
+++ b/src/include/prte_stdint.h
@@ -43,38 +43,13 @@
 #    include <sys/types.h>
 #endif
 
-/* 128-bit */
-
-#ifdef HAVE_INT128_T
-
-typedef int128_t prte_int128_t;
-typedef uint128_t prte_uint128_t;
-
-#    define HAVE_PRTE_INT128_T 1
-
-#elif defined(HAVE___INT128)
-
-/* suppress warning about __int128 type */
-#    pragma GCC diagnostic push
-/* Clang won't quietly accept "-pedantic", but GCC versions older than ~4.8
- * won't quietly accept "-Wpedanic".  The whole "#pragma GCC diagnostic ..."
- * facility only was added to GCC as of version 4.6. */
-#    if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 6)
-#        pragma GCC diagnostic ignored "-Wpedantic"
-#    else
-#        pragma GCC diagnostic ignored "-pedantic"
-#    endif
-typedef __int128 prte_int128_t;
-typedef unsigned __int128 prte_uint128_t;
-#    pragma GCC diagnostic pop
-
-#    define HAVE_PRTE_INT128_T 1
-
-#else
-
-#    define HAVE_PRTE_INT128_T 0
-
-#endif
+/* There was a 128-bit block here, selecting prte_int128_t/prte_uint128_t
+ * from HAVE_INT128_T or HAVE___INT128 and setting HAVE_PRTE_INT128_T.  It
+ * was inherited from OPAL, where the atomics needed a 128-bit type.  Neither
+ * of those two configure symbols has ever been probed by PRRTE's configure,
+ * so the types were never declared and HAVE_PRTE_INT128_T was always 0 --
+ * and nothing in the tree names any of the three.  If PRRTE ever needs one,
+ * probe for it in configure.ac at the same time. */
 
 /* Pointers */
 
@@ -116,16 +91,17 @@ typedef unsigned long long uintptr_t;
 /* inttypes.h printf specifiers */
 #include <inttypes.h>
 
+/* PRRTE requires a C11 compiler (config/prte_setup_cc.m4 aborts otherwise),
+ * so "z" is available and is the only spelling that is correct by
+ * definition rather than by a size coincidence.
+ *
+ * This used to be a ladder guarded on ACCEPT_C99 -- a symbol PRRTE's
+ * configure has never defined -- so the "zu" arm was unreachable and every
+ * build fell through to comparing SIZEOF_SIZE_T against SIZEOF_LONG and
+ * SIZEOF_LONG_LONG.  That happens to land on a working answer for the usual
+ * data models and silently lands on "u" for any where it does not. */
 #ifndef PRIsize_t
-#    if defined(ACCEPT_C99)
-#        define PRIsize_t "zu"
-#    elif SIZEOF_SIZE_T == SIZEOF_LONG
-#        define PRIsize_t "lu"
-#    elif SIZEOF_SIZE_T == SIZEOF_LONG_LONG
-#        define PRIsize_t "llu"
-#    else
-#        define PRIsize_t "u"
-#    endif
+#    define PRIsize_t "zu"
 #endif
 
 #endif /* PRTE_STDINT_H */

--- a/src/mca/errmgr/Makefile.am
+++ b/src/mca/errmgr/Makefile.am
@@ -30,10 +30,6 @@ libprtemca_errmgr_la_SOURCES += $(headers)
 # pkgdata setup
 EXTRA_DIST =
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/ess/Makefile.am
+++ b/src/mca/ess/Makefile.am
@@ -32,10 +32,6 @@ EXTRA_DIST =
 headers = ess.h
 libprtemca_ess_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/filem/Makefile.am
+++ b/src/mca/filem/Makefile.am
@@ -28,10 +28,6 @@ libprtemca_filem_la_SOURCES =
 headers = filem.h
 libprtemca_filem_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/grpcomm/Makefile.am
+++ b/src/mca/grpcomm/Makefile.am
@@ -28,10 +28,6 @@ headers = grpcomm.h
 
 libprtemca_grpcomm_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/iof/Makefile.am
+++ b/src/mca/iof/Makefile.am
@@ -30,10 +30,6 @@ libprtemca_iof_la_SOURCES =
 headers = iof.h iof_types.h
 libprtemca_iof_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/odls/Makefile.am
+++ b/src/mca/odls/Makefile.am
@@ -30,10 +30,6 @@ EXTRA_DIST =
 headers = odls.h odls_types.h
 libprtemca_odls_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/plm/Makefile.am
+++ b/src/mca/plm/Makefile.am
@@ -30,10 +30,6 @@ EXTRA_DIST =
 headers = plm.h plm_types.h
 libprtemca_plm_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/prtebacktrace/Makefile.am
+++ b/src/mca/prtebacktrace/Makefile.am
@@ -27,10 +27,6 @@ libprtemca_prtebacktrace_la_SOURCES =
 headers = prtebacktrace.h
 libprtemca_prtebacktrace_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/prteinstalldirs/Makefile.am
+++ b/src/mca/prteinstalldirs/Makefile.am
@@ -19,10 +19,6 @@ libprtemca_prteinstalldirs_la_SOURCES =
 headers = prteinstalldirs.h
 libprtemca_prteinstalldirs_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/prtereachable/Makefile.am
+++ b/src/mca/prtereachable/Makefile.am
@@ -22,10 +22,6 @@ EXTRA_DIST =
 headers = prtereachable.h
 libprtemca_prtereachable_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/ras/Makefile.am
+++ b/src/mca/ras/Makefile.am
@@ -32,10 +32,6 @@ EXTRA_DIST =
 headers = ras.h
 libprtemca_ras_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/rmaps/Makefile.am
+++ b/src/mca/rmaps/Makefile.am
@@ -30,10 +30,6 @@ EXTRA_DIST =
 headers = rmaps.h rmaps_types.h
 libprtemca_rmaps_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/schizo/Makefile.am
+++ b/src/mca/schizo/Makefile.am
@@ -20,10 +20,6 @@ EXTRA_DIST =
 headers = schizo.h
 libprtemca_schizo_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/mca/state/Makefile.am
+++ b/src/mca/state/Makefile.am
@@ -22,10 +22,6 @@ EXTRA_DIST =
 headers = state.h state_types.h
 libprtemca_state_la_SOURCES += $(headers)
 
-# Conditionally install the header files
-prtedir = $(prteincludedir)/$(subdir)
-nobase_prte_HEADERS = $(headers)
-
 include base/Makefile.am
 
 distclean-local:

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -108,13 +108,6 @@ check-local:
 		--cppflags="$(CPPFLAGS)" \
 		--check-only
 
-# Conditionally install the header files
-
-if WANT_INSTALL_HEADERS
-prtedir = $(prteincludedir)/$(subdir)
-prte_HEADERS = $(headers)
-endif
-
 clean-local:
 	rm -f prte_show_help_content.c prte_show_help_content.lo
 

--- a/test/unit/include/test_include.c
+++ b/test/unit/include/test_include.c
@@ -91,12 +91,18 @@
         }                                                     \
     } while (0)
 
-/* Where the two documentation groups in constants.h start and end. Kept up
- * to date by hand -- but unlike a table of code *names*, going stale here
- * only weakens the sweep, it cannot make it wrong. */
+/* Where the two documentation groups in constants.h start and end. The
+ * group boundaries are a convention for readers and are stated by hand; the
+ * *end* of the list is not, because a hand-written end goes stale silently.
+ * This one used to read "155 / PRTE_ERR_SLURM_SHRINK_FAILURE" and stayed
+ * that way when PRTE_ERR_PRELOAD_CONFLICT was appended at offset 156, so the
+ * sweep below stopped one short of the newest code -- the code most likely
+ * to be wrong. It now comes from PRTE_ERR_MAX, which lives in constants.h
+ * next to the append site and which test/unit/util fails on if it is
+ * stale. */
 #define GROUP1_LAST  72  /* PRTE_OPERATION_SUCCEEDED */
 #define GROUP2_FIRST 101 /* PRTE_ERR_RECV_LESS_THAN_POSTED */
-#define GROUP2_LAST  155 /* PRTE_ERR_SLURM_SHRINK_FAILURE */
+#define GROUP2_LAST  (PRTE_ERR_BASE - PRTE_ERR_MAX - 1)
 
 /* ------------------------------------------------------------------ */
 /* error code numbering                                               */
@@ -137,10 +143,15 @@ static int test_error_code_numbering(void)
     CHECK("the last code is negative", (PRTE_ERR_BASE - GROUP2_LAST) < 0);
 
     CHECK("PRTE_ERROR is the first code", (PRTE_ERR_BASE - 1) == PRTE_ERROR);
-    CHECK("the last code is where the header says",
-          (PRTE_ERR_BASE - GROUP2_LAST) == PRTE_ERR_SLURM_SHRINK_FAILURE);
     CHECK("the second group starts where the header says",
           (PRTE_ERR_BASE - GROUP2_FIRST) == PRTE_ERR_RECV_LESS_THAN_POSTED);
+
+    /* PRTE_ERR_MAX is one past the end, so it must sit below every code and
+     * must not itself be one. The check that it is not stale -- that the
+     * offset just inside it is a real, named code -- needs prte_strerror()
+     * and lives in test/unit/util; here we only pin the arithmetic. */
+    CHECK("the bound is below the last code", PRTE_ERR_MAX < PRTE_ERR_PRELOAD_CONFLICT);
+    CHECK("the bound is one past the end", (PRTE_ERR_MAX + 1) == PRTE_ERR_PRELOAD_CONFLICT);
 
     /* PRTE_ERROR must NOT be PMIX_ERROR any more. They were both -1, which
      * made a PRRTE code handed to PMIx unconverted invisible in the one

--- a/test/unit/include/test_include.c
+++ b/test/unit/include/test_include.c
@@ -80,6 +80,11 @@
 #include "constants.h"
 #include "types.h"
 
+/* PMIx's printf replacements -- the four names prte_config_bottom.h maps a
+ * missing libc printf onto. prte_config_bottom.h includes this itself, but
+ * only on a platform that needs it. */
+#include "src/util/pmix_printf.h"
+
 #include "src/include/prte_stdatomic.h"
 #include "src/runtime/runtime.h"
 
@@ -314,6 +319,46 @@ static int test_config_bottom(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* the printf fallbacks                                               */
+/* ------------------------------------------------------------------ */
+
+/* prte_config_bottom.h maps asprintf/snprintf/vasprintf/vsnprintf onto PMIx
+ * replacements on any platform whose libc is missing one. PRRTE has no
+ * printf replacements of its own and never had -- all four come from PMIx's
+ * src/util/pmix_printf.h.
+ *
+ * One of the four named prte_vsnprintf, a symbol that exists in neither
+ * tree, so a platform without vsnprintf() would have failed to link every
+ * tool. Nothing caught it because the mapping is compiled only where the
+ * libc function is absent, which is nowhere anyone builds.
+ *
+ * Be honest about what this proves: it cannot exercise the mapping itself
+ * on a platform that does not need it. What it does do is take the address
+ * of each of the four names the mapping resolves to, so they have to exist
+ * and be linkable here -- which catches both a typo of the kind above and
+ * PMIx dropping or renaming one out from under us. PRRTE builds against
+ * PMIx's *internal* headers, so the latter is a live risk, not a
+ * hypothetical.
+ */
+static int test_printf_fallbacks(void)
+{
+    int failures = 0;
+    const void *fns[4];
+
+    fns[0] = (const void *) (uintptr_t) pmix_asprintf;
+    fns[1] = (const void *) (uintptr_t) pmix_snprintf;
+    fns[2] = (const void *) (uintptr_t) pmix_vasprintf;
+    fns[3] = (const void *) (uintptr_t) pmix_vsnprintf;
+
+    CHECK("the asprintf replacement exists", NULL != fns[0]);
+    CHECK("the snprintf replacement exists", NULL != fns[1]);
+    CHECK("the vasprintf replacement exists", NULL != fns[2]);
+    CHECK("the vsnprintf replacement exists", NULL != fns[3]);
+
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 
 int main(void)
 {
@@ -328,6 +373,7 @@ int main(void)
     failures += test_rank_types();
     failures += test_byte_order();
     failures += test_config_bottom();
+    failures += test_printf_fallbacks();
 
     if (0 == failures) {
         fprintf(stdout, "PASSED all include unit tests\n");

--- a/test/unit/include/test_include.c
+++ b/test/unit/include/test_include.c
@@ -290,12 +290,27 @@ static int test_config_bottom(void)
     CHECK("PRTE_MAXHOSTNAMELEN is usable", PRTE_MAXHOSTNAMELEN > 64);
     CHECK("PRTE_PATH_SEP is a separator", 0 == strcmp("/", PRTE_PATH_SEP));
 
-    /* PRIsize_t is picked by comparing SIZEOF_SIZE_T against SIZEOF_LONG and
-     * SIZEOF_LONG_LONG. Get it wrong and every verbose message using it is
-     * undefined behavior rather than a compile error, because the format
-     * string is assembled by concatenation. */
+    /* PRIsize_t is used in verbose output across the tree. Get it wrong and
+     * every message using it is undefined behavior rather than a compile
+     * error, because the format string is assembled by concatenation.
+     *
+     * It is now unconditionally "zu" -- C11 is a hard requirement, so "z" is
+     * always available and is the only spelling correct by definition rather
+     * than by a size coincidence. It used to be a ladder whose "zu" arm was
+     * guarded on ACCEPT_C99, a symbol PRRTE's configure has never defined,
+     * so every build fell through to comparing SIZEOF_SIZE_T against
+     * SIZEOF_LONG and SIZEOF_LONG_LONG -- landing on a working answer for
+     * the usual data models and on "u" for any where it did not. */
     snprintf(buf, sizeof(buf), "%" PRIsize_t, val);
     CHECK("PRIsize_t formats a size_t", 0 == strcmp("1234567", buf));
+
+    /* prte_stdint.h picks intptr_t/uintptr_t by walking SIZEOF_VOID_P
+     * against SIZEOF_INT/LONG/LONG_LONG when the system does not supply
+     * them. The entire point of that ladder is that a pointer fits, and it
+     * is a #error if none of the three match -- but nothing checked the
+     * arm it lands on. */
+    CHECK("an intptr_t holds a pointer", sizeof(intptr_t) >= sizeof(void *));
+    CHECK("a uintptr_t holds a pointer", sizeof(uintptr_t) >= sizeof(void *));
 
     /* PRTE_ENABLE_IPV6 is narrowed in prte_config_bottom.h from what
      * configure asked for to what the platform can honor. It must come out

--- a/test/unit/util/test_util.c
+++ b/test/unit/util/test_util.c
@@ -273,7 +273,14 @@ static int test_name_printing(void)
  * assigned in between. */
 #define GROUP1_LAST  72  /* PRTE_OPERATION_SUCCEEDED */
 #define GROUP2_FIRST 101 /* PRTE_ERR_RECV_LESS_THAN_POSTED */
-#define GROUP2_LAST  155 /* PRTE_ERR_SLURM_SHRINK_FAILURE */
+/* The end of the list is NOT written out here. It used to be -- as "155 /
+ * PRTE_ERR_SLURM_SHRINK_FAILURE" -- and it stayed that way when
+ * PRTE_ERR_PRELOAD_CONFLICT was appended at offset 156, so this sweep, whose
+ * entire job is to catch a code that was added without a string, stopped one
+ * short of the code most likely to be missing one. It now derives from
+ * PRTE_ERR_MAX in constants.h, and test_error_bound() below fails if that
+ * bound has gone stale in either direction. */
+#define GROUP2_LAST  (PRTE_ERR_BASE - PRTE_ERR_MAX - 1)
 
 static int test_error_strings(void)
 {
@@ -304,6 +311,32 @@ static int test_error_strings(void)
     /* PRTE_ERR_SILENT must never be logged - PRTE_ERROR_LOG() suppresses it -
      * but it still needs a name for anything that prints it directly */
     CHECK("silent has a string", NULL != prte_strerror(PRTE_ERR_SILENT));
+
+    return failures;
+}
+
+/* The sweep above is only as good as the bound it runs to, and a bound is
+ * exactly the kind of thing that goes stale without anyone noticing -- this
+ * one did, the first time a code was appended after it was written, and the
+ * result was a sweep that quietly stopped short of the newest code.
+ *
+ * So check the bound itself. prte_strerror() is the oracle: PRTE_ERR_MAX is
+ * one past the end, so the offset just inside it must be a real named code
+ * and PRTE_ERR_MAX itself must not be. That catches both directions --
+ * appending a code and forgetting to bump the bound, and bumping the bound
+ * past the last code.
+ */
+static int test_error_bound(void)
+{
+    int failures = 0;
+
+    CHECK("the bound is not stale (a code was added without bumping it)",
+          0 != strcmp("Unknown error", prte_strerror(PRTE_ERR_MAX + 1)));
+    CHECK("the bound is not past the end (nothing is assigned at it)",
+          0 == strcmp("Unknown error", prte_strerror(PRTE_ERR_MAX)));
+
+    /* and it really is one past the end of the run the sweep walks */
+    CHECK("the bound agrees with the sweep", (PRTE_ERR_BASE - GROUP2_LAST) == (PRTE_ERR_MAX + 1));
 
     return failures;
 }
@@ -1017,6 +1050,7 @@ int main(void)
     failures += test_compare_name_fields();
     failures += test_name_printing();
     failures += test_error_strings();
+    failures += test_error_bound();
     failures += test_state_strings();
     failures += test_attr_key_names();
     failures += test_attr_round_trip();


### PR DESCRIPTION
A review pass over `src/include` — the return codes, the base typedefs and
the configure-driven portability layer. Nothing here has behavior of its
own, which is exactly what makes it worth reviewing: a defect is invisible
at the point of the mistake and surfaces in whatever subsystem happened to
use it.

Ten commits, each standalone and separately reviewable.

## The problems found

**The error-code sweeps had gone stale, silently.** `test/unit/include` and
`test/unit/util` each wrote out the last offset as a literal `155`.
`PRTE_ERR_PRELOAD_CONFLICT` was later appended at 156 and neither was
updated, so both sweeps stopped one short of the newest code. That matters
most in `test/unit/util`, whose sweep exists precisely to catch a code added
without a `prte_strerror()` string — the code most likely to be missing one
was the one it had stopped looking at.

`PRTE_ERR_MAX` had been removed on the reasoning that a bound with no
consumer is a bound nobody maintains. The consumers then reappeared as
literals in two files, which is worse. It is back, at the bottom of the enum
next to where codes get appended, and a stale value now fails a test rather
than quietly shrinking coverage: `test_error_bound()` uses `prte_strerror()`
as the oracle, so both forgetting to bump it and bumping it past the end are
caught. Verified by breaking it in both directions.

**`#define vsnprintf prte_vsnprintf`** named a symbol that exists in neither
PRRTE nor PMIx; its three siblings correctly name `pmix_*`. On a platform
lacking `vsnprintf` this is not just an undefined symbol — `pmix_printf.h`
drags in PMIx's `pmix_config_bottom.h`, which maps the same name to
`pmix_vsnprintf` under the identical guard, so PRRTE would have redefined a
live macro with a different body: `-Wmacro-redefined`, a build failure under
`--enable-devel-check`.

**`constants.h` pointed contributors at the wrong file** — it said to add
strings to `error_strings.c`, which holds the *state* strings; error-code
strings live in `error.c`. Following the instruction produced exactly the
"Unknown error" the instruction exists to prevent.

**`--with-devel-headers` installed a header set that could not be compiled.**
The generated headers went into a `nodist_headers` variable no `_HEADERS`
variable referenced, so `prte_config.h` was never installed — while
`prte_config_top.h`/`prte_config_bottom.h`, which each `#error` without it,
were. Separately, the `mca` framework `Makefile.am` files set
`nobase_prte_HEADERS` *outside* the conditional, so those installed
unconditionally. And most fragments never append to `headers` at all: with
the first two repaired, 96 headers installed and 73 of 93 still failed to
compile standalone. The option is removed rather than repaired — PRRTE ships
no linkable library, so an installed header set has no possible consumer.
`make install` now installs `prte.h` and `prte_version.h`, the genuine
public pair.

**Four things were unreachable by construction**, each keeping a configure
probe alive to feed it: the `__func__`→`__FILE__` fallback (C11 mandates
`__func__`, and PRRTE requires C11); the VxWorks block (`MCS_VXWORKS` is
defined nowhere, ever); `PRIsize_t`'s `"zu"` arm (guarded on `ACCEPT_C99`,
never defined, so every build fell through a SIZEOF ladder); and the 128-bit
types (`HAVE_INT128_T`/`HAVE___INT128` are never probed). Their probes go
with them — deleting a guard without its probe is what let these survive.

**`OMPI_BUILDING` fenced the whole portability layer.** In Open MPI that
fence earns its keep: `mpi.h` sets it to 0 so the layer's macro renames do
not land in an application's namespace. In PRRTE there is no `mpi.h`,
nothing set it to 0, and no header is installed for an external consumer to
include — so the block always compiled and the `#else` arm was unreachable,
while an `OMPI_`-prefixed symbol sat in the header every file includes
first. Removal is behaviour-neutral by construction and measurably so: the
preprocessed output of `prte_config.h` is byte-identical before and after.

## Testing

New coverage in `test/unit/include` for the bound arithmetic, the pointer-sized
integer ladder (the one ladder here that *is* live), and the existence of the
four PMIx printf replacements. `test_error_bound()` added to `test/unit/util`.
The dockerswarm preload-collision case — the only place that provokes the
newest error code — now also requires it to reach the user as a name.

Verified: warning-free `--enable-debug` build; `make check` 21/21;
`make -C test/offline check-offline` 1180/1180; live DVM smoke test; and the
dockerswarm multi-node suite at 428 passed / 0 failed / 2 skipped.

`src/include/AGENTS.md` is updated throughout — including a correction to
its own account of why `PRTE_ERR_MAX` had been removed, which read
convincingly and was wrong.