### PR TITLE
grpcomm: ownership, leaks, and re-answered collectives

### DIFF
--- a/contrib/dockerswarm/groupcon.c
+++ b/contrib/dockerswarm/groupcon.c
@@ -20,6 +20,10 @@
  *
  *       --ft         ask for PMIX_GROUP_FT_COLLECTIVE, so the construct
  *                    completes on the survivors if a member is lost
+ *       --order      supply PMIX_GROUP_FINAL_MEMBERSHIP_ORDER, listing the
+ *                    ranks in reverse, so the group comes back in an order
+ *                    the DVM had to impose rather than the one it would
+ *                    have sorted into by itself
  *       --fence      run a PMIx_Fence over the whole job instead of a
  *                    group construct.  Here --delay applies to the LAST
  *                    rank only, so everyone else blocks inside the fence
@@ -35,6 +39,7 @@
  *   GRP <rank> HOST <hostname>
  *   GRP <rank> CONSTRUCT <status> CID <cid> ASSIGNED <T|F>
  *   GRP <rank> MEMBERS <n>
+ *   GRP <rank> ORDER <r>,<r>,...
  *   GRP <rank> MEMBER-FAILED <nspace>:<rank>
  *   GRP <rank> CID-OK <n>            (read back n peers' local cids)
  *   GRP <rank> CID-FAIL <peer> <status>
@@ -148,6 +153,7 @@ int main(int argc, char **argv)
     bool idassigned = false;
     bool ft = false;
     bool dofence = false;
+    bool doorder = false;
 #ifdef PMIX_GROUP_MEMBER_FAILED
     pmix_status_t evcode = PMIX_GROUP_MEMBER_FAILED;
 #endif
@@ -158,6 +164,8 @@ int main(int argc, char **argv)
     for (i = 1; i < argc; i++) {
         if (0 == strcmp(argv[i], "--ft")) {
             ft = true;
+        } else if (0 == strcmp(argv[i], "--order")) {
+            doorder = true;
         } else if (0 == strcmp(argv[i], "--fence")) {
             dofence = true;
         } else if (0 == strcmp(argv[i], "--delay") && (i + 1) < argc) {
@@ -171,7 +179,8 @@ int main(int argc, char **argv)
         }
     }
     if (NULL == grpid) {
-        fprintf(stderr, "usage: %s [--ft] [--fence] [--delay <s>] <groupID> [seconds]\n",
+        fprintf(stderr,
+                "usage: %s [--ft] [--fence] [--order] [--delay <s>] <groupID> [seconds]\n",
                 argv[0]);
         return 2;
     }
@@ -301,6 +310,30 @@ int main(int argc, char **argv)
     PMIx_Info_list_release(list);
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
 
+    /* Ask for a specific final membership order - the ranks in reverse.
+     *
+     * This is the one directive that hands the DVM an array of procs to keep
+     * for the length of the operation, and the array belongs to the PMIx
+     * server that delivers it: the DVM must copy it, not point at it, or it
+     * frees what PMIx frees again.  Reversing is what makes the result
+     * checkable: the DVM sorts the membership itself when no order is given,
+     * so a directive that was quietly dropped looks exactly like the default.
+     */
+    if (doorder) {
+        PMIX_DATA_ARRAY_CONSTRUCT(&darray, nprocs, PMIX_PROC);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&((pmix_proc_t *) darray.array)[n], myproc.nspace,
+                           nprocs - 1 - n);
+        }
+        rc = PMIx_Info_list_add(grpinfo, PMIX_GROUP_FINAL_MEMBERSHIP_ORDER,
+                                &darray, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "ERROR list_add order: %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+
     rc = PMIx_Info_list_convert(grpinfo, &darray);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "ERROR list_convert grpinfo: %s\n", PMIx_Error_string(rc));
@@ -348,6 +381,16 @@ int main(int argc, char **argv)
     printf("GRP %u CONSTRUCT %s CID %lu ASSIGNED %s\n", myproc.rank,
            PMIx_Error_string(PMIX_SUCCESS), (unsigned long) cid, idassigned ? "T" : "F");
     fflush(stdout);
+    if (doorder && 0 < nmembers) {
+        /* report the membership in the order we were handed it, so the
+         * caller can see whether the order it asked for was applied */
+        printf("GRP %u ORDER", myproc.rank);
+        for (m = 0; m < nmembers; m++) {
+            printf("%s%u", (0 == m) ? " " : ",", (unsigned) members[m].rank);
+        }
+        printf("\n");
+        fflush(stdout);
+    }
     if (NULL != results) {
         PMIX_INFO_FREE(results, nresults);
         results = NULL;

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3330,6 +3330,45 @@ test_grpcomm() {
         && ok "...and the DVM still launches an ordinary job afterwards" \
         || bad "the DVM did not run a plain job after the group tests ($n of 3)"
 
+    banner "grpcomm: a requested membership order is applied on every daemon"
+    # PMIX_GROUP_FINAL_MEMBERSHIP_ORDER is one of two construct directives
+    # that hand the DVM an array of procs, and that array belongs to the PMIx
+    # server which delivered the upcall -- PMIx frees it, arrays and all, once
+    # the operation completes.  The daemon has to COPY it into the group
+    # signature, whose destructor frees what it holds; pointing at it instead
+    # is a double free of live heap on every daemon that had a local
+    # participant.  So this case is as much about the DVM being alive
+    # afterwards as it is about the order.
+    #
+    # The order asked for is the ranks reversed, because that is the one
+    # answer the DVM cannot arrive at by accident: with no order given it
+    # sorts the membership itself, so a directive that was dropped on the
+    # floor is indistinguishable from the default unless the order is a
+    # permutation the sort would never produce.
+    out=$(PRUN "--host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node $GC --order g5" 2>&1)
+    n=$(echo "$out" | grep -c 'CONSTRUCT PMIX_SUCCESS')
+    [ "$n" = 8 ] \
+        && ok "all 8 ranks constructed a group with a final order" \
+        || bad "$n of 8 ranks constructed the ordered group: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    n=$(echo "$out" | awk '$1=="GRP" && $3=="ORDER" {print $4}' | sort -u | wc -l | tr -d ' ')
+    g=$(echo "$out" | awk '$1=="GRP" && $3=="ORDER" {print $4; exit}')
+    if [ "$n" != 1 ]; then
+        bad "daemons returned $n different membership orders"
+    elif [ "$g" = "7,6,5,4,3,2,1,0" ]; then
+        ok "...and every daemon returned the reversed order that was asked for"
+    else
+        bad "the requested order was not applied (got '${g:-nothing}')"
+    fi
+    ranks=$(echo "$out" | grep -c 'CID-OK 8')
+    [ "$ranks" = 8 ] \
+        && ok "...with the whole membership still readable from each rank" \
+        || bad "only $ranks of 8 ranks read back a full set after ordering"
+    out=$(PRUN "--host node1:1,node2:1,node3:1 -n 3 --map-by node hostname" 2>&1)
+    n=$(echo "$out" | grep -c '^node')
+    [ "$n" = 3 ] \
+        && ok "...and every daemon that carried the order is still running" \
+        || bad "the DVM lost a daemon to the ordered construct ($n of 3)"
+
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 

--- a/src/mca/grpcomm/AGENTS.md
+++ b/src/mca/grpcomm/AGENTS.md
@@ -229,6 +229,16 @@ the framework makes sense:
   field is packed and unpacked unguarded, so every daemon in a DVM agrees
   on the message layout no matter what its PMIx advertised. Guard the
   *behavior*, never the bytes.
+- **A collective's own state is copied, never borrowed.** The arrays a
+  caller hands an entry point — the fence's `procs`, the group's
+  `directives` and the proc arrays inside them — belong to the PMIx server
+  that delivered the upcall, which keeps them alive until the completion
+  callback fires and then frees them itself. The caddy may point at them
+  for the length of the handler, but anything that outlives it (a
+  signature, a tracker) has to hold a copy, because *those* free what they
+  hold. Both halves of that rule have been broken: a group signature
+  pointed at a directive's array and freed it under PMIx, and the fence's
+  signature copied the procs but was itself never freed.
 - **Every entry-point handler owns its caddy/op — release it on *all*
   paths.** `fence`/`group`/`xcast_nb` each allocate a heap object
   (`prte_pmix_fence_caddy_t`, `prte_pmix_grp_caddy_t`, or the xcast `op_t`),
@@ -266,7 +276,20 @@ constructs with the documented defaults (all rollup counters zero, the
 group tracker's info-lists opened) and destructs without leaking or
 crashing. Extend it when you add a class or change a constructor default.
 
-It also covers the **daemon-failure decisions**, which need no tree even
+It also covers the two decisions a collective makes before any message
+moves. **Building a fence tracker**: what a signature naming the daemon
+job, a signature naming nobody, and a signature that cannot be resolved
+each produce — the last of which must leave *nothing* on the tracker list,
+because a half-built tracker is found by the next fence of that signature.
+And **parsing a group's directives**: that the signature ends up owning
+copies of the proc arrays the directives carried, so the caller's arrays
+survive the signature's destructor intact (the test asserts on the
+pointers, which is the only way to see the difference before something
+double-frees). Both drive the real functions, exported for the purpose.
+Note that the deliberate-failure cases log `PRTE_ERROR_LOG` output as they
+run; that noise is expected.
+
+And it covers the **daemon-failure decisions**, which need no tree even
 though acting on them does: the departed-member predicate, and the fence
 fault handler's choice between re-converging a fence that merely lost a
 message path and ending one that lost a participant. Both read only the

--- a/src/mca/grpcomm/base/grpcomm_base_select.c
+++ b/src/mca/grpcomm/base/grpcomm_base_select.c
@@ -37,6 +37,7 @@ int prte_grpcomm_base_select(void)
     prte_grpcomm_base_component_t *best_component = NULL;
     prte_grpcomm_base_module_t *best_module = NULL;
     pmix_status_t rc;
+    int ret;
 
     /*
      * Select the best component
@@ -52,9 +53,14 @@ int prte_grpcomm_base_select(void)
 
     /* Save the winner */
     prte_grpcomm = *best_module;
-    /* give it a chance to initialize */
+    /* give it a chance to initialize. A module that cannot initialize has
+     * no trackers and no RML receives, so every collective from here on
+     * would quietly do nothing - say so instead of reporting success */
     if (NULL != prte_grpcomm.init) {
-        prte_grpcomm.init();
+        ret = prte_grpcomm.init();
+        if (PRTE_SUCCESS != ret) {
+            return ret;
+        }
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -193,8 +193,39 @@ Message flow:
 
 `nexpected` counts routing-tree child contributors
 (`prte_rml_get_num_contributors`) plus one if this daemon is itself a
-participant. The tracker lives on `component.fence_ops`, keyed by exact
+participant — `set_nexpected()`, which is also what the recovery restart
+re-runs. The tracker lives on `component.fence_ops`, keyed by exact
 proc-signature match.
+
+**`create_dmns()`'s answer is a pair, and NULL means two different
+things.** A signature naming the daemon job is "every daemon in the DVM",
+reported as a count with a **NULL array** — there is no array to walk, and
+`set_nexpected()` answers it as `n_children + 1`. A NULL array with a
+**zero** count is the opposite statement, "nothing resolved". Both readers
+used to index the array regardless, which dereferenced NULL for any fence
+naming the daemon job.
+
+**A signature that cannot be read is refused, and refusal leaves nothing
+behind.** `create_dmns()` returns `PRTE_ERR_BAD_PARAM` for an empty
+signature or one whose first entry has no nspace — both of which are what
+a truncated RML message unpacks to, and the second of which is worse than
+it looks, because `PMIX_CHECK_NSPACE` answers *yes* for an empty nspace
+against anything, so it would be taken for a daemon-job fence and sized to
+expect the whole DVM. `get_tracker()` then removes the half-built tracker
+from `fence_ops` before returning NULL. That removal is not tidiness: a
+tracker with no daemon set can never complete, and the next fence with the
+same signature would *find* it, see a rollup expecting nothing, and answer
+immediately with data it never gathered.
+
+**Every exit from the `fence()` handler destructs the signature it built
+and completes the caller.** The signature is a stack object with a malloc'd
+proc array that `get_tracker()` copies rather than adopts, so walking away
+from it leaks it once per `PMIx_Fence` — which was the state of the success
+path. And a failure there is invisible to everyone else: the entry point
+answered `PRTE_SUCCESS` the moment the request was queued, and the
+contribution never entered the rollup, so no release is coming. The handler
+completes its own participants with the reason, after clearing the
+tracker's `cbfunc` so a later abort cannot complete them twice.
 
 The fence `fault_handler` restarts what it can and ends what it cannot.
 A fence whose participants all survive lost only a message path and
@@ -236,10 +267,25 @@ much richer signature and payload.
   to the HNP via `request_group_cancel()` and returns.
 - Otherwise it builds the group signature from `grpid` + `procs` (a NULL
   `procs` marks a bootstrap **follower**), scans the directives
-  (`PMIX_GROUP_ASSIGN_CONTEXT_ID`, `PMIX_GROUP_BOOTSTRAP`, `PMIX_TIMEOUT`,
+  (`prte_grpcomm_direct_group_parse_directives()`:
+  `PMIX_GROUP_ASSIGN_CONTEXT_ID`, `PMIX_GROUP_BOOTSTRAP`, `PMIX_TIMEOUT`,
   `PMIX_GROUP_ADD_MEMBERS`, `PMIX_GROUP_INFO`, `PMIX_PROC_DATA` endpoints,
   `PMIX_GROUP_FINAL_MEMBERSHIP_ORDER`, `PMIX_LOCAL_COLLECTIVE_STATUS`),
   gets-or-creates the tracker, and relays.
+
+  **A signature owns its arrays — always.** Two directives carry a proc
+  array (`PMIX_GROUP_ADD_MEMBERS`, `PMIX_GROUP_FINAL_MEMBERSHIP_ORDER`),
+  and the array inside a directive belongs to the **PMIx server** that
+  delivered the upcall: PMIx frees the directives, arrays and all, once the
+  operation completes. The signature's destructor frees what the signature
+  holds, so the parse takes a *copy* of each. Pointing at the caller's
+  array instead is a double free of live heap, and it is not a theoretical
+  one — the destructor grew its `final_order` free before the third
+  populator was noticed, and the add-members pointer was being cleared only
+  after the pack, which covers no failure before it. If you add a directive
+  that carries an array, copy it in `copy_directive_procs()` like the other
+  two; do not add a "clear it again before the destructor runs" step
+  anywhere.
 - **Bootstrap** ops send **directly to the HNP** (there is no rollup tree —
   each daemon reports straight to the controller); non-bootstrap ops send
   to self on `PRTE_RML_TAG_GROUP`, entering the same up-tree rollup as
@@ -331,7 +377,12 @@ the *previous* assignment had put there, which on the ilist path was the
 `PMIx_server_register_resources` as `pmix_info_t` and then freed twice.
 
 Coverage is `test_grpcomm` in the dockerswarm harness — one host cannot
-exercise a daemon that merely *received* the release.
+exercise a daemon that merely *received* the release. That phase also runs
+the construct with a `PMIX_GROUP_FINAL_MEMBERSHIP_ORDER` directive
+(`groupcon --order`, the ranks reversed), which is the end-to-end check on
+the array-ownership rule above: the order it asks for is one the DVM would
+never arrive at by sorting, and a daemon that freed the caller's array
+dies of a double free rather than merely returning the wrong order.
 
 ### Group fault tolerance (`#if PRTE_PMIX_HAVE_GROUP_FT`)
 

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -501,6 +501,17 @@ work out how much of one died) and anything in flight across a **revival**
 give the ordering an epoch advance needs). The revival path is discriminated
 by LOCAL scope with an empty `failed_ranks`.
 
+**A converged collective is finished, on the controller.** Neither the
+restart nor the fault handler touches a tracker the controller has already
+answered: the release is on the wire, ordered ahead of anything a restart
+could send, and every daemon retires its tracker when it lands. Re-running
+the rollup there answers twice — a second release, a second context id
+consumed, the same group registered twice on every daemon. The test is
+*only* valid on the controller: `converged` on any other daemon means it
+rolled its aggregate up to its parent, and re-sending that aggregate is
+precisely what recovery is for, since the failure may be what swallowed
+it.
+
 Two supporting pieces are worth knowing about. `nreported` is backed by
 `reported_slots`, a bitmap keyed on `prte_rml_get_subtree_index()` of the
 sender, so a replayed contribution is idempotent rather than double-counted
@@ -549,6 +560,12 @@ operation is proof the previous one of that name is over.
   break exactly that. A per-collective handler decides what it cannot
   recover and marks those trackers `aborting`; the shared restart skips
   them.
+- **One allocator per array.** The proc arrays on a signature are built
+  with `PMIX_PROC_CREATE` and freed with `PMIX_PROC_FREE` everywhere —
+  those allocate and free *inside the PMIx library*, so a plain `free()`
+  on one crosses the library boundary. It works today because both sides
+  land on the same libc; it would not survive a PMIx that accounts for its
+  own allocations.
 - **Free every allocation the handler still owns before it returns.** The
   entry-point handlers (`begin_xcast`, `fence`, `group`) own the caddy/op
   they were thread-shifted; the recv handlers own the info arrays / darrays

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -227,6 +227,27 @@ contribution never entered the rollup, so no release is coming. The handler
 completes its own participants with the reason, after clearing the
 tracker's `cbfunc` so a later abort cannot complete them twice.
 
+**The fence's deadline is the DVM's to keep.** A participant can put a
+`PMIX_TIMEOUT` on a fence, and the controller arms a timer for it on the
+first contribution that carries one (largest offered wins), disarming on
+convergence and ending the fence with `PMIX_ERR_TIMEOUT` through
+`abort_fence_op()` if it fires. Nothing else is watching: the PMIx server
+library arms a timeout of its own while it gathers the *local*
+contributions, then deletes it the instant the request is handed to the
+host — deliberately, so a late host answer cannot reach a tracker it
+already released. From that hand-off on, the deadline exists only here.
+The harness cannot reproduce a firing: a fence that stalls for a reason
+the fault handler already covers is aborted by the fault handler instead,
+and one that stalls before the local contributions are complete is timed
+out by PMIx before the DVM ever sees it.
+
+**A release with no local callback still has data to free.** `fence_release`
+unloads the broadcast into a byte object and hands it to `coll->cbfunc`,
+which frees it via `relcb` when the PMIx server is done. A daemon that
+holds a tracker only because it relayed for its subtree has no `cbfunc`,
+and that is the common case on any interior daemon — so that branch has to
+free the payload itself.
+
 The fence `fault_handler` restarts what it can and ends what it cannot.
 A fence whose participants all survive lost only a message path and
 re-converges over the repaired tree at the new recovery epoch — so the

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -152,8 +152,6 @@ typedef struct {
     pmix_rank_t *dmns;
     /** number of participating daemons */
     size_t ndmns;
-    /** my index in the dmns array */
-    unsigned long my_rank;
     /* number of buckets expected */
     size_t nexpected;
     /* number reported in */

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -310,6 +310,14 @@ void prte_grpcomm_direct_fence_release(int status, pmix_proc_t *sender,
 PRTE_MODULE_EXPORT extern
 void prte_grpcomm_direct_fence_fault_handler(const prte_rml_recovery_status_t* status);
 
+/* Find the tracker for this fence signature, optionally creating it. A new
+ * tracker resolves the signature to its participating daemons and sizes the
+ * rollup accordingly, and comes back NULL - with nothing left on the tracker
+ * list - if that cannot be done. Exported so the unit test can drive it. */
+PRTE_MODULE_EXPORT
+prte_grpcomm_fence_t *prte_grpcomm_direct_fence_get_tracker(prte_grpcomm_direct_fence_signature_t *sig,
+                                                            bool create);
+
 /* group functions */
 PRTE_MODULE_EXPORT extern
 int prte_grpcomm_direct_group(pmix_group_operation_t op, char *grpid,

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -169,6 +169,12 @@ typedef struct {
     pmix_data_buffer_t *my_contribution;
     /* controls values */
     int timeout;
+    // the controller arms a timer for "timeout" seconds once a participant
+    // has asked for one. Nothing else bounds a fence: the PMIx server library
+    // deletes its own timeout the moment it hands the request to us, so that
+    // a late answer cannot come back to a tracker it already released.
+    prte_event_t tev;
+    bool tev_active;
     /* callback function */
     pmix_modex_cbfunc_t cbfunc;
     /* user-provided callback data */

--- a/src/mca/grpcomm/direct/grpcomm_direct.h
+++ b/src/mca/grpcomm/direct/grpcomm_direct.h
@@ -320,6 +320,17 @@ int prte_grpcomm_direct_group(pmix_group_operation_t op, char *grpid,
 PRTE_MODULE_EXPORT extern
 void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* status);
 
+/* Fill in a group signature from the directives a participant supplied,
+ * along with the timeout, local status, group info and endpoint data that
+ * ride alongside it. The signature takes a COPY of every array a directive
+ * carries - the directives belong to the PMIx server that handed them to us.
+ * Exported so the unit test can drive it against a synthetic directive set. */
+PRTE_MODULE_EXPORT
+pmix_status_t prte_grpcomm_direct_group_parse_directives(prte_grpcomm_direct_group_signature_t *sig,
+                                                         const pmix_info_t *directives, size_t ndirs,
+                                                         int *timeout, pmix_status_t *st,
+                                                         void *grpinfo, void *endpts);
+
 PRTE_MODULE_EXPORT extern
 void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
                                   pmix_data_buffer_t *buffer,

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -62,8 +62,10 @@ static void scon(prte_grpcomm_direct_fence_signature_t *p)
 }
 static void sdes(prte_grpcomm_direct_fence_signature_t *p)
 {
+    /* PMIX_PROC_FREE, not free(): every populator of this array builds it
+     * with PMIX_PROC_CREATE, which allocates inside the PMIx library */
     if (NULL != p->signature) {
-        free(p->signature);
+        PMIX_PROC_FREE(p->signature, p->sz);
     }
 }
 PMIX_CLASS_INSTANCE(prte_grpcomm_direct_fence_signature_t,
@@ -92,11 +94,12 @@ static void sgdes(prte_grpcomm_direct_group_signature_t *p)
     if (NULL != p->groupID) {
         free(p->groupID);
     }
+    /* PMIX_PROC_FREE, not free(): see the note in sdes() above */
     if (NULL != p->members) {
-        free(p->members);
+        PMIX_PROC_FREE(p->members, p->nmembers);
     }
     if (NULL != p->addmembers) {
-        free(p->addmembers);
+        PMIX_PROC_FREE(p->addmembers, p->naddmembers);
     }
     if (NULL != p->final_order) {
         PMIX_PROC_FREE(p->final_order, p->nfinal);

--- a/src/mca/grpcomm/direct/grpcomm_direct_component.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_component.c
@@ -122,11 +122,16 @@ static void ccon(prte_grpcomm_fence_t *p)
     p->aborting = false;
     p->my_contribution = NULL;
     p->timeout = 0;
+    p->tev_active = false;
     p->cbfunc = NULL;
     p->cbdata = NULL;
 }
 static void cdes(prte_grpcomm_fence_t *p)
 {
+    if (p->tev_active) {
+        prte_event_del(&p->tev);
+        p->tev_active = false;
+    }
     if (NULL != p->sig) {
         PMIX_RELEASE(p->sig);
     }

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -203,6 +203,20 @@ void prte_grpcomm_direct_fence_restart(void)
         if (coll->aborting) {
             continue;
         }
+        /* A collective the controller has already answered is finished:
+         * its release is on the wire, ordered ahead of anything we could
+         * send now, and every daemon will retire its tracker when that
+         * release lands. Re-running the rollup here would answer it a
+         * second time - a second release broadcast, a second context id
+         * consumed, and a second registration of the same group on every
+         * daemon. Note this is a test only the controller can apply:
+         * "converged" on any other daemon means it rolled its aggregate up
+         * to its parent, and re-sending that aggregate is precisely what
+         * recovery is for, since the failure may have been what swallowed
+         * it. */
+        if (PRTE_PROC_IS_MASTER && coll->converged) {
+            continue;
+        }
 
         /* throw away everything gathered under the old tree */
         pmix_bitmap_clear_all_bits(&coll->reported_slots);
@@ -275,7 +289,7 @@ void prte_grpcomm_direct_fence_fault_handler(const prte_rml_recovery_status_t* s
         if (PRTE_PROC_IS_MASTER && 0 == status->failed_ranks.size) {
             PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
                                    prte_grpcomm_fence_t) {
-                if (!coll->aborting) {
+                if (!coll->aborting && !coll->converged) {
                     abort_fence_op(coll, PMIX_ERR_LOST_CONNECTION);
                 }
             }
@@ -288,7 +302,8 @@ void prte_grpcomm_direct_fence_fault_handler(const prte_rml_recovery_status_t* s
     }
     PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
                            prte_grpcomm_fence_t) {
-        if (coll->aborting) {
+        /* already answered, or already being torn down */
+        if (coll->aborting || coll->converged) {
             continue;
         }
         if (!prte_grpcomm_direct_procs_lost(coll->sig->signature, coll->sig->sz)) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -831,6 +831,15 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_direct_fence_signature_t *
     return coll;
 }
 
+/* Same, for a caller outside this file. Exported only so the unit test can
+ * build a tracker and inspect what the rollup was sized to expect, which is
+ * where a fence goes wrong long before any message moves. */
+prte_grpcomm_fence_t *prte_grpcomm_direct_fence_get_tracker(prte_grpcomm_direct_fence_signature_t *sig,
+                                                            bool create)
+{
+    return get_tracker(sig, create);
+}
+
 static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
                        pmix_rank_t **dmns, size_t *ndmns)
 {
@@ -860,14 +869,20 @@ static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (NULL == sig->signature) ? "NULL" : "NON-NULL", sig->sz));
 
-    /* a signature naming nobody has no daemons behind it. This is not
-     * reachable from a local client, but the signature also arrives off the
-     * wire, where a truncated message unpacks to exactly this - and the
-     * nspace test below would read signature[0] of an array that is NULL */
-    if (0 == sig->sz || NULL == sig->signature) {
+    /* A signature has to name somebody. This is not reachable from a local
+     * client - the PMIx server hands us the participants it aggregated - but
+     * the signature also arrives off the wire, where a truncated message
+     * unpacks to an empty one. The test below would then read signature[0]
+     * of an array that is NULL; and an entry with no nspace is worse than
+     * that, because PMIX_CHECK_NSPACE answers "yes" for an empty nspace
+     * against anything, so it would be taken for a fence over the daemon job
+     * and sized to expect the whole DVM. Refuse it: the caller drops the
+     * message, which is the right answer for one we cannot read. */
+    if (0 == sig->sz || NULL == sig->signature ||
+        PMIX_NSPACE_INVALID(sig->signature[0].nspace)) {
         *dmns = NULL;
         *ndmns = 0;
-        return PRTE_SUCCESS;
+        return PRTE_ERR_BAD_PARAM;
     }
 
     /* if the target jobid is our own,

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -277,9 +277,7 @@ static void fence(int sd, short args, void *cbdata)
      * for releasing it upon completion of the collective */
     coll = get_tracker(&sig, true);
     if (NULL == coll) {
-        PMIX_DESTRUCT(&sig);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
     coll->cbfunc = cd->cbfunc;
     coll->cbdata = cd->cbdata;
@@ -295,23 +293,20 @@ static void fence(int sd, short args, void *cbdata)
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
 
     // pack the info structs
     rc = PMIx_Data_pack(NULL, relay, &cd->ninfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(relay);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
     if (0 < cd->ninfo) {
         rc = PMIx_Data_pack(NULL, relay, cd->info, cd->ninfo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_DATA_BUFFER_RELEASE(relay);
-            PMIX_RELEASE(cd);
-            return;
+            goto done;
         }
     }
 
@@ -324,8 +319,7 @@ static void fence(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_DESTRUCT(&bkt);
     if (PMIX_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(relay);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
 
     /* Keep our own contribution so a fault can replay it: recovery resets
@@ -341,8 +335,7 @@ static void fence(int sd, short args, void *cbdata)
         PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
         coll->my_contribution = NULL;
         PMIX_DATA_BUFFER_RELEASE(relay);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
 
     /* stamp it with the current epoch and send that */
@@ -351,8 +344,7 @@ static void fence(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_RELEASE(relay);
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(framed);
-        PMIX_RELEASE(cd);
-        return;
+        goto done;
     }
 
     /* send this to ourselves for processing */
@@ -362,8 +354,12 @@ static void fence(int sd, short args, void *cbdata)
 
     PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed,
                   PRTE_RML_TAG_FENCE);
+
+done:
+    /* the signature we computed is ours - the tracker keeps a copy of its
+     * own - so it must go back on every path out of here */
+    PMIX_DESTRUCT(&sig);
     PMIX_RELEASE(cd);
-    return;
 }
 
 void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -166,6 +166,32 @@ static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st)
     coll->aborting = true;
 }
 
+/* The controller's guard timer for a fence a participant put a deadline on.
+ * Firing it completes every participant with PMIX_ERR_TIMEOUT rather than
+ * leaving them blocked in PMIx_Fence forever.
+ *
+ * Nothing else is watching. The PMIx server library arms a timeout of its own
+ * while it gathers the local contributions, but deletes it the moment the
+ * request is handed to us - deliberately, so that an answer arriving after it
+ * fired cannot reach a tracker it has already released. From that point the
+ * deadline the caller asked for exists only here. */
+static void fence_timeout(int sd, short args, void *cbdata)
+{
+    prte_grpcomm_fence_t *coll = (prte_grpcomm_fence_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(coll);
+    coll->tev_active = false;
+    if (coll->converged || coll->aborting) {
+        return;
+    }
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
+                         "%s grpcomm:direct:fence timeout after %d seconds",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), coll->timeout));
+    coll->status = PMIX_ERR_TIMEOUT;
+    abort_fence_op(coll, PMIX_ERR_TIMEOUT);
+}
+
 void prte_grpcomm_direct_fence_restart(void)
 {
     prte_grpcomm_fence_t *coll, *nxt;
@@ -433,6 +459,7 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
     int32_t cnt;
     int rc, timeout, slot;
     uint32_t stamp;
+    struct timeval tv;
     size_t n, ninfo;
     pmix_status_t st;
     pmix_info_t *info = NULL;
@@ -559,6 +586,19 @@ void prte_grpcomm_direct_fence_recv(int status, pmix_proc_t *sender,
         }
     }
 
+    /* Arm the deadline, if a participant asked for one. Only on the
+     * controller: it is the one daemon every rollup reaches, so it is the
+     * only one that can tell a fence that will never converge from one that
+     * simply has not yet. */
+    if (PRTE_PROC_IS_MASTER && !coll->tev_active && 0 < coll->timeout) {
+        prte_event_evtimer_set(prte_event_base, &coll->tev, fence_timeout, coll);
+        tv.tv_sec = coll->timeout;
+        tv.tv_usec = 0;
+        coll->tev_active = true;
+        PMIX_POST_OBJECT(coll);
+        prte_event_evtimer_add(&coll->tev, &tv);
+    }
+
     /* transfer any data */
     rc = PMIx_Data_copy_payload(&coll->bucket, buffer);
     if (PMIX_SUCCESS != rc) {
@@ -610,6 +650,11 @@ static void check_complete(prte_grpcomm_fence_t *coll)
         return;
     }
     coll->converged = true;
+    /* the fence resolved, so the guard timer has done its job */
+    if (coll->tev_active) {
+        prte_event_del(&coll->tev);
+        coll->tev_active = false;
+    }
 
     if (PRTE_PROC_IS_MASTER) {
         PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -341,8 +341,10 @@ static void fence(int sd, short args, void *cbdata)
     /* compute the signature of this collective */
     PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_fence_signature_t);
     sig.sz = cd->nprocs;
-    sig.signature = (pmix_proc_t *) malloc(sig.sz * sizeof(pmix_proc_t));
-    memcpy(sig.signature, cd->procs, sig.sz * sizeof(pmix_proc_t));
+    if (0 < sig.sz) {
+        PMIX_PROC_CREATE(sig.signature, sig.sz);
+        memcpy(sig.signature, cd->procs, sig.sz * sizeof(pmix_proc_t));
+    }
 
     /* retrieve an existing tracker, create it if not
      * already found. The fence module is responsible
@@ -875,7 +877,7 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_direct_fence_signature_t *
     coll->sig = PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
     coll->sig->sz = sig->sz;
     if (0 < coll->sig->sz) {
-        coll->sig->signature = (pmix_proc_t *) malloc(coll->sig->sz * sizeof(pmix_proc_t));
+        PMIX_PROC_CREATE(coll->sig->signature, coll->sig->sz);
         memcpy(coll->sig->signature, sig->signature, coll->sig->sz * sizeof(pmix_proc_t));
     }
     pmix_list_append(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -49,6 +49,41 @@ static int fence_sig_unpack(pmix_data_buffer_t *buffer,
                             prte_grpcomm_direct_fence_signature_t **sig);
 static void check_complete(prte_grpcomm_fence_t *coll);
 
+/* Work out how many contributions this daemon has to collect for a fence:
+ * one per child subtree holding a participant, plus our own if we are one.
+ *
+ * create_dmns() has one answer it gives without an array: a signature naming
+ * the daemon job itself is "every daemon in the DVM", reported as a count
+ * with a NULL array.  There is nothing to walk in that case, but the answer
+ * is known exactly - each of our children heads a subtree holding at least
+ * one daemon, and we are a participant ourselves.  A NULL array with a zero
+ * count is the opposite statement, "no daemons at all", and falls through to
+ * the general case, which reads it as zero.
+ *
+ * Called again on every recovery, because both terms move: a failure can
+ * take our children and can take participants. */
+static void set_nexpected(prte_grpcomm_fence_t *coll)
+{
+    size_t n;
+
+    if (NULL == coll->dmns && 0 < coll->ndmns) {
+        coll->nexpected = prte_rml_base.n_children + 1;
+        return;
+    }
+
+    coll->nexpected = prte_rml_get_num_contributors(coll->dmns, coll->ndmns);
+
+    /* see if I am in the array of participants - note that I may
+     * be in the rollup tree even though I'm not participating
+     * in the collective itself */
+    for (n = 0; n < coll->ndmns; n++) {
+        if (coll->dmns[n] == PRTE_PROC_MY_NAME->rank) {
+            coll->nexpected++;
+            break;
+        }
+    }
+}
+
 int prte_grpcomm_direct_fence(const pmix_proc_t procs[], size_t nprocs,
                               const pmix_info_t info[], size_t ninfo, char *data,
                               size_t ndata, pmix_modex_cbfunc_t cbfunc, void *cbdata)
@@ -135,7 +170,6 @@ void prte_grpcomm_direct_fence_restart(void)
 {
     prte_grpcomm_fence_t *coll, *nxt;
     pmix_data_buffer_t *framed;
-    size_t n;
     int rc;
 
     PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.fence_ops,
@@ -155,13 +189,7 @@ void prte_grpcomm_direct_fence_restart(void)
         /* recompute what the repaired tree owes us - dmns stays the full
          * pre-fault set, and get_num_contributors() already skips the daemons
          * now known to have failed */
-        coll->nexpected = prte_rml_get_num_contributors(coll->dmns, coll->ndmns);
-        for (n = 0; n < coll->ndmns; n++) {
-            if (coll->dmns[n] == PRTE_PROC_MY_NAME->rank) {
-                coll->nexpected++;
-                break;
-            }
-        }
+        set_nexpected(coll);
 
         PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_base_framework.framework_output,
                              "%s grpcomm:direct:fence restarting at epoch %u, "
@@ -717,7 +745,6 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_direct_fence_signature_t *
 {
     prte_grpcomm_fence_t *coll;
     int rc;
-    size_t n;
 
     /* search the existing tracker list to see if this already exists */
     PMIX_LIST_FOREACH(coll, &prte_mca_grpcomm_direct_component.fence_ops, prte_grpcomm_fence_t) {
@@ -744,28 +771,26 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_direct_fence_signature_t *
     // we have to know the participating procs
     coll->sig = PMIX_NEW(prte_grpcomm_direct_fence_signature_t);
     coll->sig->sz = sig->sz;
-    coll->sig->signature = (pmix_proc_t *) malloc(coll->sig->sz * sizeof(pmix_proc_t));
-    memcpy(coll->sig->signature, sig->signature, coll->sig->sz * sizeof(pmix_proc_t));
+    if (0 < coll->sig->sz) {
+        coll->sig->signature = (pmix_proc_t *) malloc(coll->sig->sz * sizeof(pmix_proc_t));
+        memcpy(coll->sig->signature, sig->signature, coll->sig->sz * sizeof(pmix_proc_t));
+    }
     pmix_list_append(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);
 
     /* now get the daemons involved */
     if (PRTE_SUCCESS != (rc = create_dmns(sig, &coll->dmns, &coll->ndmns))) {
         PRTE_ERROR_LOG(rc);
+        /* a tracker with no daemon set can never be completed, and leaving it
+         * on the list is worse than losing it: the next fence of the same
+         * signature would find this one, see a rollup that expects nothing,
+         * and answer with data it never gathered */
+        pmix_list_remove_item(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);
+        PMIX_RELEASE(coll);
         return NULL;
     }
 
     /* count the number of contributions we should get */
-    coll->nexpected = prte_rml_get_num_contributors(coll->dmns, coll->ndmns);
-
-    /* see if I am in the array of participants - note that I may
-     * be in the rollup tree even though I'm not participating
-     * in the collective itself */
-    for (n = 0; n < coll->ndmns; n++) {
-        if (coll->dmns[n] == PRTE_PROC_MY_NAME->rank) {
-            coll->nexpected++;
-            break;
-        }
-    }
+    set_nexpected(coll);
 
     return coll;
 }
@@ -798,6 +823,16 @@ static int create_dmns(prte_grpcomm_direct_fence_signature_t *sig,
                          "%s grpcomm:direct:fence:create_dmns called with %s signature size %" PRIsize_t "",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          (NULL == sig->signature) ? "NULL" : "NON-NULL", sig->sz));
+
+    /* a signature naming nobody has no daemons behind it. This is not
+     * reachable from a local client, but the signature also arrives off the
+     * wire, where a truncated message unpacks to exactly this - and the
+     * nspace test below would read signature[0] of an array that is NULL */
+    if (0 == sig->sz || NULL == sig->signature) {
+        *dmns = NULL;
+        *ndmns = 0;
+        return PRTE_SUCCESS;
+    }
 
     /* if the target jobid is our own,
      * then all daemons are participating */

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -771,6 +771,13 @@ void prte_grpcomm_direct_fence_release(int status, pmix_proc_t *sender,
     /* execute the callback */
     if (NULL != coll->cbfunc) {
         coll->cbfunc(ret, bo.bytes, bo.size, coll->cbdata, relcb, bo.bytes);
+    } else {
+        /* Nobody here was waiting on this fence: we hold a tracker because we
+         * relayed for our subtree, not because we had a participant of our
+         * own. The gathered data is still ours to free - relcb is the only
+         * other thing that frees it, and it only ever runs because the
+         * callback above was handed it. */
+        PMIX_BYTE_OBJECT_DESTRUCT(&bo);
     }
     pmix_list_remove_item(&prte_mca_grpcomm_direct_component.fence_ops, &coll->super);
     PMIX_RELEASE(coll);

--- a/src/mca/grpcomm/direct/grpcomm_direct_fence.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_fence.c
@@ -282,8 +282,11 @@ static void fence(int sd, short args, void *cbdata)
 {
     prte_pmix_fence_caddy_t *cd = (prte_pmix_fence_caddy_t *) cbdata;
     prte_grpcomm_direct_fence_signature_t sig;
-    prte_grpcomm_fence_t *coll;
+    prte_grpcomm_fence_t *coll = NULL;
     int rc;
+    /* what our own participants are told if this contribution never makes
+     * it into the rollup - PMIX_SUCCESS means it did */
+    pmix_status_t st = PMIX_SUCCESS;
     pmix_data_buffer_t *relay, *framed, bkt;
     pmix_byte_object_t bo;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
@@ -305,6 +308,7 @@ static void fence(int sd, short args, void *cbdata)
      * for releasing it upon completion of the collective */
     coll = get_tracker(&sig, true);
     if (NULL == coll) {
+        st = PMIX_ERR_NOT_FOUND;
         goto done;
     }
     coll->cbfunc = cd->cbfunc;
@@ -321,19 +325,24 @@ static void fence(int sd, short args, void *cbdata)
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
+        st = prte_pmix_convert_rc(rc);
         goto done;
     }
 
     // pack the info structs
     rc = PMIx_Data_pack(NULL, relay, &cd->ninfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
+        st = rc;
         goto done;
     }
     if (0 < cd->ninfo) {
         rc = PMIx_Data_pack(NULL, relay, cd->info, cd->ninfo, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(relay);
+            st = rc;
             goto done;
         }
     }
@@ -346,7 +355,9 @@ static void fence(int sd, short args, void *cbdata)
     rc = PMIx_Data_copy_payload(relay, &bkt);
     PMIX_DATA_BUFFER_DESTRUCT(&bkt);
     if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
+        st = rc;
         goto done;
     }
 
@@ -363,6 +374,7 @@ static void fence(int sd, short args, void *cbdata)
         PMIX_DATA_BUFFER_RELEASE(coll->my_contribution);
         coll->my_contribution = NULL;
         PMIX_DATA_BUFFER_RELEASE(relay);
+        st = rc;
         goto done;
     }
 
@@ -372,6 +384,7 @@ static void fence(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_RELEASE(relay);
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(framed);
+        st = prte_pmix_convert_rc(rc);
         goto done;
     }
 
@@ -382,11 +395,34 @@ static void fence(int sd, short args, void *cbdata)
 
     PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed,
                   PRTE_RML_TAG_FENCE);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(framed);
+        st = prte_pmix_convert_rc(rc);
+    }
 
 done:
     /* the signature we computed is ours - the tracker keeps a copy of its
      * own - so it must go back on every path out of here */
     PMIX_DESTRUCT(&sig);
+
+    if (PMIX_SUCCESS != st) {
+        /* Our contribution never entered the rollup, so no release is coming
+         * to complete the clients waiting in PMIx_Fence - and this daemon
+         * returned PRTE_SUCCESS from the entry point, so nothing upstream
+         * knows to fail them either. Complete them here with the reason, and
+         * take them off the tracker first so that a release arriving later
+         * (the controller can still abort the fence) cannot complete them a
+         * second time. The tracker itself is left in place: it is what any
+         * such release still has to find. */
+        if (NULL != coll) {
+            coll->cbfunc = NULL;
+            coll->cbdata = NULL;
+        }
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(st, NULL, 0, cd->cbdata, NULL, NULL);
+        }
+    }
     PMIX_RELEASE(cd);
 }
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -415,6 +415,20 @@ void prte_grpcomm_direct_group_restart(void)
         if (coll->bootstrap || coll->aborting) {
             continue;
         }
+        /* A collective the controller has already answered is finished:
+         * its release is on the wire, ordered ahead of anything we could
+         * send now, and every daemon will retire its tracker when that
+         * release lands. Re-running the rollup here would answer it a
+         * second time - a second release broadcast, a second context id
+         * consumed, and a second registration of the same group on every
+         * daemon. Note this is a test only the controller can apply:
+         * "converged" on any other daemon means it rolled its aggregate up
+         * to its parent, and re-sending that aggregate is precisely what
+         * recovery is for, since the failure may have been what swallowed
+         * it. */
+        if (PRTE_PROC_IS_MASTER && coll->converged) {
+            continue;
+        }
 
         /* discard everything gathered under the old tree */
         pmix_bitmap_clear_all_bits(&coll->reported_slots);
@@ -496,7 +510,7 @@ void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* s
         if (PRTE_PROC_IS_MASTER && 0 == status->failed_ranks.size) {
             PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
                                    prte_grpcomm_group_t) {
-                if (coll->aborting) {
+                if (coll->aborting || coll->converged) {
                     continue;
                 }
                 pmix_output_verbose(1, prte_grpcomm_base_framework.framework_output,
@@ -522,7 +536,8 @@ void prte_grpcomm_direct_group_fault_handler(const prte_rml_recovery_status_t* s
          * is what covers an operation it holds no tracker for yet. */
         PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_mca_grpcomm_direct_component.group_ops,
                                prte_grpcomm_group_t) {
-            if (coll->aborting) {
+            /* already answered, or already being torn down */
+            if (coll->aborting || coll->converged) {
                 continue;
             }
             if (coll->bootstrap) {

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -74,6 +74,115 @@ static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body
     return PRTE_SUCCESS;
 }
 
+/* Take a copy of a proc array a directive carried into the signature.
+ *
+ * The array belongs to the caller: the directives come straight from the
+ * PMIx server upcall, and PMIx frees them - the darray and the array inside
+ * it - once the operation completes. The signature's destructor frees
+ * whatever the signature holds, so pointing at the caller's array would have
+ * us free it out from under PMIx and have PMIx free it a second time. Every
+ * other populator of these fields (the tracker cache in get_tracker(), the
+ * unpack of an arriving signature) already allocates, so this keeps the
+ * ownership rule uniform: the signature owns its arrays, always. */
+static pmix_status_t copy_directive_procs(const pmix_info_t *dir,
+                                          pmix_proc_t **procs, size_t *nprocs)
+{
+    pmix_data_array_t *darray = dir->value.data.darray;
+
+    if (PMIX_DATA_ARRAY != dir->value.type || NULL == darray ||
+        NULL == darray->array || 0 == darray->size) {
+        /* nothing usable was given - not an error, just no members */
+        return PMIX_SUCCESS;
+    }
+    if (NULL != *procs) {
+        /* a second directive of the same key - the PMIx server aggregates
+         * these, so this should not happen, but do not strand the first */
+        PMIX_PROC_FREE(*procs, *nprocs);
+    }
+    PMIX_PROC_CREATE(*procs, darray->size);
+    if (NULL == *procs) {
+        *nprocs = 0;
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(*procs, darray->array, darray->size * sizeof(pmix_proc_t));
+    *nprocs = darray->size;
+    return PMIX_SUCCESS;
+}
+
+/* Scan the directives a participant gave us, filling in the signature and the
+ * values collected alongside it. Split out of group() so it can be exercised
+ * without a DVM - it reads nothing but its arguments. */
+pmix_status_t prte_grpcomm_direct_group_parse_directives(prte_grpcomm_direct_group_signature_t *sig,
+                                                         const pmix_info_t *directives, size_t ndirs,
+                                                         int *timeout, pmix_status_t *st,
+                                                         void *grpinfo, void *endpts)
+{
+    pmix_status_t rc;
+    size_t i;
+
+    for (i = 0; i < ndirs; i++) {
+        /* see if they want a context id assigned */
+        if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_ASSIGN_CONTEXT_ID)) {
+            sig->assignID = PMIX_INFO_TRUE(&directives[i]);
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_BOOTSTRAP)) {
+            PMIX_VALUE_GET_NUMBER(rc, &directives[i].value, sig->bootstrap, size_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_LOCAL_COLLECTIVE_STATUS)) {
+            PMIX_VALUE_GET_NUMBER(rc, &directives[i].value, *st, pmix_status_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_TIMEOUT)) {
+            PMIX_VALUE_GET_NUMBER(rc, &directives[i].value, *timeout, int);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_ADD_MEMBERS)) {
+            // there is only one of these as it is aggregated by the
+            // PMIx server library
+            rc = copy_directive_procs(&directives[i], &sig->addmembers, &sig->naddmembers);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_INFO)) {
+            rc = PMIx_Info_list_xfer(grpinfo, &directives[i]);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_PROC_DATA)) {
+            rc = PMIx_Info_list_xfer(endpts, &directives[i]);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_FINAL_MEMBERSHIP_ORDER)) {
+            rc = copy_directive_procs(&directives[i], &sig->final_order, &sig->nfinal);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+#if PRTE_PMIX_HAVE_GROUP_FT
+        } else if (PMIX_CHECK_KEY(&directives[i], PMIX_GROUP_FT_COLLECTIVE)) {
+            sig->ft_collective = PMIX_INFO_TRUE(&directives[i]);
+#endif
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
 static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *sig, bool create);
 
 static int create_dmns(prte_grpcomm_direct_group_signature_t *sig,
@@ -429,7 +538,6 @@ static void group(int sd, short args, void *cbdata)
     prte_pmix_grp_caddy_t *cd = (prte_pmix_grp_caddy_t*)cbdata;
     prte_grpcomm_direct_group_signature_t sig;
     prte_grpcomm_group_t *coll;
-    size_t i;
     pmix_data_buffer_t *relay, *framed;
     pmix_status_t rc, st = PMIX_SUCCESS;
     int timeout = 0;
@@ -467,61 +575,11 @@ static void group(int sd, short args, void *cbdata)
     grpinfo = PMIx_Info_list_start();
 
     /* check the directives */
-    for (i = 0; i < cd->ndirs; i++) {
-        /* see if they want a context id assigned */
-        if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_ASSIGN_CONTEXT_ID)) {
-            sig.assignID = PMIX_INFO_TRUE(&cd->directives[i]);
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_BOOTSTRAP)) {
-            PMIX_VALUE_GET_NUMBER(rc, &cd->directives[i].value, sig.bootstrap, size_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&sig);
-                goto error;
-            }
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_LOCAL_COLLECTIVE_STATUS)) {
-            PMIX_VALUE_GET_NUMBER(rc, &cd->directives[i].value, st, pmix_status_t);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&sig);
-                goto error;
-            }
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_TIMEOUT)) {
-            PMIX_VALUE_GET_NUMBER(rc, &cd->directives[i].value, timeout, int);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&sig);
-                goto error;
-            }
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_ADD_MEMBERS)) {
-            // there is only one of these as it is aggregated by the
-            // PMIx server library
-            sig.addmembers = (pmix_proc_t*)cd->directives[i].value.data.darray->array;
-            sig.naddmembers = cd->directives[i].value.data.darray->size;
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_INFO)) {
-            rc = PMIx_Info_list_xfer(grpinfo, &cd->directives[i]);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_PROC_DATA)) {
-            rc = PMIx_Info_list_xfer(endpts, &cd->directives[i]);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
-
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_FINAL_MEMBERSHIP_ORDER)) {
-            sig.final_order = (pmix_proc_t*)cd->directives[i].value.data.darray->array;
-            sig.nfinal = cd->directives[i].value.data.darray->size;
-#if PRTE_PMIX_HAVE_GROUP_FT
-        } else if (PMIX_CHECK_KEY(&cd->directives[i], PMIX_GROUP_FT_COLLECTIVE)) {
-            sig.ft_collective = PMIX_INFO_TRUE(&cd->directives[i]);
-#endif
-        }
+    rc = prte_grpcomm_direct_group_parse_directives(&sig, cd->directives, cd->ndirs,
+                                                    &timeout, &st, grpinfo, endpts);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&sig);
+        goto error;
     }
 
     /* a local client is starting this operation, which is proof that any
@@ -544,9 +602,6 @@ static void group(int sd, short args, void *cbdata)
 
     /* pack the signature */
     rc = pack_signature(relay, &sig);
-    // protect the inbound directives
-    sig.addmembers = NULL;
-    sig.naddmembers = 0;
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -2270,12 +2270,12 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_direct_group_signature_t *
     // save the participating procs
     coll->sig->nmembers = sig->nmembers;
     if (0 < sig->nmembers) {
-        coll->sig->members = (pmix_proc_t *) malloc(coll->sig->nmembers * sizeof(pmix_proc_t));
+        PMIX_PROC_CREATE(coll->sig->members, coll->sig->nmembers);
         memcpy(coll->sig->members, sig->members, coll->sig->nmembers * sizeof(pmix_proc_t));
     }
     coll->sig->naddmembers = sig->naddmembers;
     if (0 < sig->naddmembers) {
-        coll->sig->addmembers = (pmix_proc_t *) malloc(coll->sig->naddmembers * sizeof(pmix_proc_t));
+        PMIX_PROC_CREATE(coll->sig->addmembers, coll->sig->naddmembers);
         memcpy(coll->sig->addmembers, sig->addmembers, coll->sig->naddmembers * sizeof(pmix_proc_t));
     }
     // save any final membership order that was given - the match path

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -87,12 +87,23 @@ static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body
 static pmix_status_t copy_directive_procs(const pmix_info_t *dir,
                                           pmix_proc_t **procs, size_t *nprocs)
 {
-    pmix_data_array_t *darray = dir->value.data.darray;
+    pmix_data_array_t *darray;
 
-    if (PMIX_DATA_ARRAY != dir->value.type || NULL == darray ||
-        NULL == darray->array || 0 == darray->size) {
+    if (PMIX_DATA_ARRAY != dir->value.type) {
         /* nothing usable was given - not an error, just no members */
         return PMIX_SUCCESS;
+    }
+    darray = dir->value.data.darray;
+    if (NULL == darray || NULL == darray->array || 0 == darray->size) {
+        return PMIX_SUCCESS;
+    }
+    /* The element type has to be checked, not assumed: this array reaches us
+     * from a client's info array, and the copy below is sized in
+     * pmix_proc_t. An array of anything smaller would have us read past the
+     * end of it - by a factor, not by a few bytes. */
+    if (PMIX_PROC != darray->type) {
+        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+        return PMIX_ERR_TYPE_MISMATCH;
     }
     if (NULL != *procs) {
         /* a second directive of the same key - the PMIx server aggregates

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -323,7 +323,12 @@ static void request_group_cancel(prte_pmix_grp_caddy_t *cd)
      * carries one even though nothing filters it against the epoch */
     rc = PMIx_Data_pack(NULL, relay, &prte_mca_grpcomm_direct_component.recovery_epoch, 1, PMIX_UINT32);
     if (PMIX_SUCCESS == rc) {
+        /* note this one answers in PRTE codes, and we acknowledge in PMIx
+         * statuses - the two agree only on success */
         rc = pack_signature(relay, &sig);
+        if (PRTE_SUCCESS != rc) {
+            rc = prte_pmix_convert_rc(rc);
+        }
     }
     PMIX_DESTRUCT(&sig);
     if (PMIX_SUCCESS != rc) {
@@ -606,6 +611,9 @@ static void group(int sd, short args, void *cbdata)
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
         PMIX_DESTRUCT(&sig);
+        /* the error label answers our caller, which reads PMIx statuses -
+         * and this one is a PRTE code */
+        rc = prte_pmix_convert_rc(rc);
         goto error;
     }
 
@@ -707,6 +715,7 @@ static void group(int sd, short args, void *cbdata)
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(framed);
         PMIX_DESTRUCT(&sig);
+        rc = prte_pmix_convert_rc(rc);
         goto error;
     }
     relay = framed;

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1241,6 +1241,7 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 if (nfinal != pmix_list_get_size(&nmlist)) {
                     pmix_show_help("help-prte-runtime.txt", "bad-final-order", true);
                     coll->status = PMIX_ERR_BAD_PARAM;
+                    PMIX_LIST_DESTRUCT(&nmlist);
                     goto answer;
                 }
                 // just overwrite the final array
@@ -1335,6 +1336,7 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 return;
             }
             if (0 < ninfo) {
@@ -1342,6 +1344,7 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
+                    PMIX_DATA_ARRAY_DESTRUCT(&darray);
                     return;
                 }
             }
@@ -1355,6 +1358,7 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 return;
             }
             if (0 < ninfo) {
@@ -1362,6 +1366,7 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
+                    PMIX_DATA_ARRAY_DESTRUCT(&darray);
                     return;
                 }
             }
@@ -1415,6 +1420,7 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 return;
             }
             if (0 < ninfo) {
@@ -1422,6 +1428,7 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
+                    PMIX_DATA_ARRAY_DESTRUCT(&darray);
                     return;
                 }
             }
@@ -1435,6 +1442,7 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 return;
             }
             if (0 < ninfo) {
@@ -1442,6 +1450,7 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
+                    PMIX_DATA_ARRAY_DESTRUCT(&darray);
                     return;
                 }
             }

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -263,14 +263,12 @@ void prte_grpcomm_direct_xcast_recv(
     op_t* op = find_op(&sig);
     if(NULL == op){
         op = insert_forwarded_op(&sig);
-        if(PMIX_SUCCESS != unpack_msg(buffer, op)){
-            pmix_list_remove_item(&XCAST.ops, &op->super);
-            PMIX_RELEASE(op);
-            return;
-        }
         /* If we are the master and this is one of our own broadcasts, attach the
          * completion callback queued for it in begin_xcast (FIFO).  Remote-origin
-         * broadcasts queue nothing, so they never consume an entry. */
+         * broadcasts queue nothing, so they never consume an entry.  This has to
+         * happen before the unpack below can abandon the op: the FIFO is
+         * positional, so an entry left on it once its broadcast has been dropped
+         * would be handed to the next broadcast the master makes. */
         if(PRTE_PROC_IS_MASTER && NULL != sender &&
            sender->rank == PRTE_PROC_MY_NAME->rank &&
            !pmix_list_is_empty(&XCAST.pending_completions)){
@@ -279,6 +277,11 @@ void prte_grpcomm_direct_xcast_recv(
             op->cbfunc = pc->cbfunc;
             op->cbdata = pc->cbdata;
             PMIX_RELEASE(pc);
+        }
+        if(PMIX_SUCCESS != unpack_msg(buffer, op)){
+            pmix_list_remove_item(&XCAST.ops, &op->super);
+            PMIX_RELEASE(op);
+            return;
         }
     }
 

--- a/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_xcast.c
@@ -650,10 +650,18 @@ static op_t* insert_forwarded_op(signature_t* sig) {
 }
 
 static void forward_op(op_t* op){
+    /* The daemon job object can be gone by the time a broadcast is being
+     * forwarded - teardown retires it while the last xcasts (the halt, the
+     * job-end notifications) are still moving - so this cannot be an
+     * unchecked dereference. Its absence says nothing about whether to
+     * forward; only the do-not-launch attribute does, and without the job
+     * object nobody set it. */
     prte_job_t* daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
-    bool skip = prte_get_attribute(&daemons->attributes, PRTE_JOB_DO_NOT_LAUNCH,
-                                   NULL, PMIX_BOOL);
-    if(skip) return;
+    if(NULL != daemons &&
+       prte_get_attribute(&daemons->attributes, PRTE_JOB_DO_NOT_LAUNCH,
+                          NULL, PMIX_BOOL)){
+        return;
+    }
 
     op->replay_pending_parent = false;
     op->nexpected = prte_rml_base.n_children;

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1347,11 +1347,13 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     rc = prte_grpcomm.fence(procs, nprocs, info, ninfo,
                             cd->msg.unpack_ptr, cd->msg.bytes_used,
                             connect_release, cd);
-    if (PMIX_SUCCESS != rc) {
+    if (PRTE_SUCCESS != rc) {
         /* the release callback will never fire */
         PMIX_RELEASE(cd);
+        /* grpcomm answers in PRTE codes, our caller reads PMIx ones */
+        return prte_pmix_convert_rc(rc);
     }
-    return rc;
+    return PMIX_SUCCESS;
 }
 
 static void mdxcbfunc(pmix_status_t status,

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -66,7 +66,12 @@ pmix_status_t pmix_server_fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
     // just pass this along
     rc = prte_grpcomm.fence(procs, nprocs, info, ninfo,
                             data, ndata, cbfunc, cbdata);
-    return rc;
+    /* grpcomm answers in PRTE codes and our caller reads PMIx ones - the two
+     * agree only on success, so anything else has to be converted */
+    if (PRTE_SUCCESS != rc) {
+        return prte_pmix_convert_rc(rc);
+    }
+    return PMIX_SUCCESS;
 }
 
 

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -504,6 +504,28 @@ static int test_group_directives(void)
     PMIx_Info_list_release(grpinfo);
     PMIx_Info_list_release(endpts);
     PMIX_INFO_FREE(dirs, 1);
+
+    /* an array of the wrong element type is refused rather than copied. The
+     * copy is sized in pmix_proc_t, so an array of anything smaller would be
+     * read past its end by a factor - and this array is whatever a client
+     * chose to send */
+    PMIX_INFO_CREATE(dirs, 1);
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 4, PMIX_BYTE);
+    PMIX_INFO_LOAD(&dirs[0], PMIX_GROUP_ADD_MEMBERS, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
+    grpinfo = PMIx_Info_list_start();
+    endpts = PMIx_Info_list_start();
+    rc = prte_grpcomm_direct_group_parse_directives(&sig, dirs, 1,
+                                                    &timeout, &st, grpinfo, endpts);
+    CHECK("directives: an add-members array of the wrong type is refused",
+          PMIX_SUCCESS != rc);
+    CHECK("directives: ...and nothing was copied out of it",
+          NULL == sig.addmembers && 0 == sig.naddmembers);
+    PMIX_DESTRUCT(&sig);
+    PMIx_Info_list_release(grpinfo);
+    PMIx_Info_list_release(endpts);
+    PMIX_INFO_FREE(dirs, 1);
 #endif
 
     if (0 == failures) {

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -401,6 +401,216 @@ static int test_member_departed(void)
     return failures;
 }
 
+/*
+ * A group operation's directives belong to the PMIx server that handed
+ * them to us: it keeps them alive until the operation completes and then
+ * frees them, arrays and all.  The signature we build from them has the
+ * opposite ownership -- its destructor frees what it holds -- so every
+ * array a directive carries has to be copied into it.  A signature that
+ * merely pointed at the caller's array would free it out from under PMIx
+ * and leave PMIx to free it a second time, which is why this test asserts
+ * on the pointers and not just on the contents.
+ */
+static int test_group_directives(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_DIRECT
+    prte_grpcomm_direct_group_signature_t sig;
+    pmix_info_t *dirs;
+    pmix_data_array_t darray;
+    pmix_proc_t *p, *dirmembers, *dirorder;
+    void *grpinfo, *endpts;
+    pmix_status_t rc, st = PMIX_SUCCESS;
+    int timeout = 0;
+    size_t bootstrap = 3;
+    int tmo = 42;
+    size_t ndirs = 5;
+
+    PMIX_INFO_CREATE(dirs, ndirs);
+    PMIX_INFO_LOAD(&dirs[0], PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&dirs[1], PMIX_TIMEOUT, &tmo, PMIX_INT);
+    PMIX_INFO_LOAD(&dirs[2], PMIX_GROUP_BOOTSTRAP, &bootstrap, PMIX_SIZE);
+
+    /* PMIX_INFO_LOAD copies the array into the directive, so the directive
+     * ends up owning one of its own - exactly as it does off the wire */
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 2, PMIX_PROC);
+    p = (pmix_proc_t *) darray.array;
+    PMIX_LOAD_PROCID(&p[0], "grp-added", 0);
+    PMIX_LOAD_PROCID(&p[1], "grp-added", 1);
+    PMIX_INFO_LOAD(&dirs[3], PMIX_GROUP_ADD_MEMBERS, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    PMIX_DATA_ARRAY_CONSTRUCT(&darray, 1, PMIX_PROC);
+    p = (pmix_proc_t *) darray.array;
+    PMIX_LOAD_PROCID(&p[0], "grp-added", 1);
+    PMIX_INFO_LOAD(&dirs[4], PMIX_GROUP_FINAL_MEMBERSHIP_ORDER, &darray, PMIX_DATA_ARRAY);
+    PMIX_DATA_ARRAY_DESTRUCT(&darray);
+
+    dirmembers = (pmix_proc_t *) dirs[3].value.data.darray->array;
+    dirorder = (pmix_proc_t *) dirs[4].value.data.darray->array;
+
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
+    grpinfo = PMIx_Info_list_start();
+    endpts = PMIx_Info_list_start();
+    rc = prte_grpcomm_direct_group_parse_directives(&sig, dirs, ndirs,
+                                                    &timeout, &st, grpinfo, endpts);
+    CHECK("directives: parsed", PMIX_SUCCESS == rc);
+    CHECK("directives: context id requested", sig.assignID);
+    CHECK("directives: timeout collected", 42 == timeout);
+    CHECK("directives: bootstrap count", 3 == sig.bootstrap);
+
+    CHECK("directives: add-members counted", 2 == sig.naddmembers);
+    CHECK("directives: add-members copied, not borrowed",
+          NULL != sig.addmembers && sig.addmembers != dirmembers);
+    CHECK("directives: add-members content",
+          NULL != sig.addmembers &&
+          0 == memcmp(sig.addmembers, dirmembers, 2 * sizeof(pmix_proc_t)));
+
+    CHECK("directives: final order counted", 1 == sig.nfinal);
+    CHECK("directives: final order copied, not borrowed",
+          NULL != sig.final_order && sig.final_order != dirorder);
+    CHECK("directives: final order content",
+          NULL != sig.final_order &&
+          0 == memcmp(sig.final_order, dirorder, sizeof(pmix_proc_t)));
+
+    /* the destructor frees everything the signature owns. The directives
+     * must come through it untouched, because their owner frees them next -
+     * and would be freeing them a second time if we had borrowed */
+    PMIX_DESTRUCT(&sig);
+    CHECK("directives: add-member array survives the signature",
+          dirmembers == (pmix_proc_t *) dirs[3].value.data.darray->array &&
+          2 == dirs[3].value.data.darray->size &&
+          0 == strcmp("grp-added", dirmembers[0].nspace));
+    CHECK("directives: final-order array survives the signature",
+          dirorder == (pmix_proc_t *) dirs[4].value.data.darray->array &&
+          1 == dirs[4].value.data.darray->size);
+    PMIx_Info_list_release(grpinfo);
+    PMIx_Info_list_release(endpts);
+    PMIX_INFO_FREE(dirs, ndirs);
+
+    /* a directive whose array is missing describes no members rather than
+     * something to reach into - these arrive off the wire too */
+    PMIX_INFO_CREATE(dirs, 1);
+    PMIX_INFO_LOAD(&dirs[0], PMIX_GROUP_ADD_MEMBERS, NULL, PMIX_BOOL);
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_group_signature_t);
+    grpinfo = PMIx_Info_list_start();
+    endpts = PMIx_Info_list_start();
+    rc = prte_grpcomm_direct_group_parse_directives(&sig, dirs, 1,
+                                                    &timeout, &st, grpinfo, endpts);
+    CHECK("directives: an empty add-members is not an error", PMIX_SUCCESS == rc);
+    CHECK("directives: an empty add-members adds nobody",
+          NULL == sig.addmembers && 0 == sig.naddmembers);
+    PMIX_DESTRUCT(&sig);
+    PMIx_Info_list_release(grpinfo);
+    PMIx_Info_list_release(endpts);
+    PMIX_INFO_FREE(dirs, 1);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_group_directives\n");
+    }
+    return failures;
+}
+
+/*
+ * Building a fence tracker is where a fence goes wrong long before any
+ * message moves, because the tracker is what says how many contributions
+ * the rollup is waiting for.  Three answers have to be right:
+ *
+ *   - a signature naming the daemon job is "every daemon", which
+ *     create_dmns() reports as a count with no array at all.  Both readers
+ *     of that pair used to index the array anyway;
+ *   - a signature naming nobody -- which is what a truncated message
+ *     unpacks to -- resolves to no daemons, not to every daemon;
+ *   - a signature that cannot be resolved yields no tracker AND leaves
+ *     none behind.  A half-built one left on the list is worse than none,
+ *     because the next fence of that signature finds it and answers from a
+ *     rollup that expects nothing.
+ */
+static int test_fence_tracker(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_DIRECT
+    prte_grpcomm_direct_fence_signature_t sig;
+    prte_grpcomm_fence_t *coll, *again;
+    int32_t save_daemons;
+    pmix_nspace_t save_nspace;
+
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, 8);
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT_MAX, 8);
+    }
+    save_daemons = prte_process_info.num_daemons;
+    prte_process_info.num_daemons = 4;
+    /* "is this the daemon job?" is asked with PMIX_CHECK_NSPACE, which
+     * answers yes to anything when either side is empty - so this test says
+     * nothing at all unless we have a namespace of our own, as a daemon
+     * always does */
+    PMIX_LOAD_NSPACE(save_nspace, PRTE_PROC_MY_NAME->nspace);
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, "prte-unit-dvm");
+
+    /* a fence over the daemon job itself: every daemon takes part, and we
+     * are a leaf here, so our own contribution is the only one */
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_fence_signature_t);
+    sig.sz = 1;
+    PMIX_PROC_CREATE(sig.signature, 1);
+    PMIX_LOAD_PROCID(&sig.signature[0], PRTE_PROC_MY_NAME->nspace, PMIX_RANK_WILDCARD);
+    coll = prte_grpcomm_direct_fence_get_tracker(&sig, true);
+    CHECK("tracker: a daemon-job fence resolves", NULL != coll);
+    if (NULL != coll) {
+        CHECK("tracker: every daemon means all of them, with no array",
+              NULL == coll->dmns && 4 == coll->ndmns);
+        CHECK("tracker: expects our children plus ourselves",
+              (size_t) prte_rml_base.n_children + 1 == coll->nexpected);
+    }
+    /* the same signature must find that tracker rather than build a second */
+    again = prte_grpcomm_direct_fence_get_tracker(&sig, true);
+    CHECK("tracker: the same signature returns the same tracker", again == coll);
+    CHECK("tracker: and does not add another",
+          1 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    PMIX_DESTRUCT(&sig);
+
+    /* a signature naming nobody is refused rather than read as the "all
+     * daemons" case above, which is what an empty nspace would otherwise
+     * match */
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_fence_signature_t);
+    coll = prte_grpcomm_direct_fence_get_tracker(&sig, true);
+    CHECK("tracker: an empty signature is refused", NULL == coll);
+    CHECK("tracker: and builds nothing",
+          1 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    PMIX_DESTRUCT(&sig);
+
+    /* a signature we cannot resolve at all - no such job, and nothing has
+     * failed, so this is a genuine error rather than a torn-down node */
+    PMIX_CONSTRUCT(&sig, prte_grpcomm_direct_fence_signature_t);
+    sig.sz = 1;
+    PMIX_PROC_CREATE(sig.signature, 1);
+    PMIX_LOAD_PROCID(&sig.signature[0], "fence-nosuchjob", 0);
+    coll = prte_grpcomm_direct_fence_get_tracker(&sig, true);
+    CHECK("tracker: an unresolvable signature yields no tracker", NULL == coll);
+    CHECK("tracker: and leaves no wreckage on the list",
+          1 == pmix_list_get_size(&prte_mca_grpcomm_direct_component.fence_ops));
+    /* ...so asking again is a fresh attempt, not a hand-back of the wreck */
+    coll = prte_grpcomm_direct_fence_get_tracker(&sig, false);
+    CHECK("tracker: nothing to find on a second look", NULL == coll);
+    PMIX_DESTRUCT(&sig);
+
+    prte_process_info.num_daemons = save_daemons;
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, save_nspace);
+    PMIX_LIST_DESTRUCT(&prte_mca_grpcomm_direct_component.fence_ops);
+    PMIX_CONSTRUCT(&prte_mca_grpcomm_direct_component.fence_ops, pmix_list_t);
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fence_tracker\n");
+    }
+    return failures;
+}
+
 #if PRTE_TEST_GRPCOMM_DIRECT
 /* Stands in for the down-tree release the controller broadcasts to end a
  * fence.  There is no routing tree here to broadcast over, and the abort is
@@ -653,6 +863,8 @@ int main(void)
 #if PRTE_TEST_GRPCOMM_DIRECT
     failures += test_member_departed();
 #endif
+    failures += test_group_directives();
+    failures += test_fence_tracker();
     failures += test_fence_fault_handler();
 
     (void) pmix_mca_base_framework_close(&prte_grpcomm_base_framework);


### PR DESCRIPTION
A third deep review of `src/mca/grpcomm`, following #2529 (leaks and
NULL-derefs) and #2595 (fence fault resilience). Six review rounds; the
last two turned up nothing above LOW, which is where I stopped.

One logical change per commit, in rough severity order.

## The three that matter most

**A group signature freed arrays PMIx owns.** The signature's destructor
grew a `PMIX_PROC_FREE` of its final-order array recently, on the basis
that both places populating it allocate. There is a third: the stack
signature `group()` builds points straight at the array inside the
caller's directive, and those directives belong to the PMIx server that
delivered the upcall - PMIx frees them, arrays and all, when the
operation completes. So every construct carrying
`PMIX_GROUP_FINAL_MEMBERSHIP_ORDER` freed live heap and left PMIx to free
it again; add-members did the same on any error before the pack. Both
are copied now, so a signature owns its arrays no matter which of the
three paths built it.

**The fence leaked twice, both on paths every job takes.** `fence()`
computes the collective's signature on the stack and mallocs the proc
array inside it, and only the one error path destructed it - so every
`PMIx_Fence`, on every daemon, leaked it. And `fence_release` unloads the
gathered payload and hands it to the local participants' callback, which
frees it; where there is no callback the data was simply dropped, and
that is the common case, since a daemon holds a tracker because it
relayed for its subtree whether or not it hosted a participant.

**A fault re-answered collectives the controller had already answered.**
The release is broadcast the moment the rollup completes, and the tracker
lives until that broadcast comes back around. A daemon failure inside
that window had the controller run the whole thing again: for a group
construct, a second release that assigns a second context id and
registers the same group with every daemon's PMIx server a second time.
The skip is valid only on the controller - `converged` anywhere else
means that daemon rolled its aggregate up to its parent, and re-sending
that is exactly what recovery is for.

## The rest

- A fence over the daemon job dereferenced NULL: `create_dmns()` reports
  "every daemon" as a count with no array, and both readers indexed the
  array anyway. A truncated signature off the wire was read as the same
  case, because `PMIX_CHECK_NSPACE` answers yes for an empty nspace
  against anything.
- A failed `create_dmns()` left the half-built tracker on the list, where
  the next fence of that signature found it and answered from a rollup
  expecting nothing.
- Every error path in the fence handler returned without telling anyone.
  The entry point had already answered `PRTE_SUCCESS`, so the clients sat
  in `PMIx_Fence` forever.
- `PMIX_TIMEOUT` on a fence was collected, merged, relayed up the tree -
  and armed by nobody. The PMIx server library arms one while gathering
  the local contributions and deliberately deletes it at the hand-off to
  the host, so past that point the deadline existed nowhere. Now armed on
  the controller, the same shape the group collective already had.
- The two directives carrying a membership were copied out sized in
  `pmix_proc_t` without checking what the array held - it holds whatever
  the client sent.
- Five places handed a PRTE code to something reading PMIx statuses.
- Assorted: the daemon job object dereferenced unchecked while teardown
  is retiring it, `free()` on `PMIx_Proc_create` memory, error-path array
  leaks, a dead uninitialized tracker field, a discarded `init()` status,
  and a positional completion FIFO that could desync.

## Testing

`test/unit/grpcomm` gains coverage of the two decisions a collective
makes before any message moves, both driving the real functions:
building a fence tracker (all three answers `create_dmns()` can give,
including that a refusal leaves nothing behind), and parsing a group's
directives - asserting on the *pointers*, which is the only way to see
the ownership bug before something double-frees.

Across nodes, `groupcon` grows a `--order` flag and the swarm suite runs
a construct with it. The ranks reversed is the one order the DVM cannot
reach by accident, since with no directive it sorts the membership
itself; and it is the case that fails loudest if a daemon frees the
caller's array.

Validated: warning-free `--enable-debug` build, `make check` 20/20,
dockerswarm `test_grpcomm` 28/28 and the full suite 507 passed / 0
failed, and a live prte/prun/pterm run.

Both `AGENTS.md` files record the invariants that are not visible from
any one place in the code.