### PR TITLE
Wait for a bootstrap's leader count before converging

### DIFF
--- a/.github/workflows/group.yaml
+++ b/.github/workflows/group.yaml
@@ -94,3 +94,13 @@ jobs:
          prterun -n 2 ./openpmix/master/examples/multi_nspace_group >& /dev/null
       if:   ${{ true }}
       timeout-minutes: 5
+
+    - name: Run group bootstrap
+      run: |
+         export PATH=$RUNNER_TEMP/prteinstall/bin:${PATH}
+         export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+         log=$RUNNER_TEMP/group_bootstrap.log
+         prterun -n 6 ./openpmix/master/examples/group_bootstrap > "$log" 2>&1 || \
+             { rc=$?; echo "=== example failed with exit status $rc - output follows ==="; cat "$log"; exit $rc; }
+      if:   ${{ true }}
+      timeout-minutes: 5

--- a/src/mca/grpcomm/direct/AGENTS.md
+++ b/src/mca/grpcomm/direct/AGENTS.md
@@ -320,8 +320,14 @@ much richer signature and payload.
   into the tracker and bumps the appropriate counter: bootstrap **leaders**
   (`nleaders_reported`), bootstrap **followers** (`nfollowers_reported`),
   or ordinary participants (`nreported`). Completion is
-  `nleaders_reported == nleaders && nfollowers_reported == nfollowers` for
-  bootstrap, else `nreported == nexpected`.
+  `nleaders_reported >= nleaders && nfollowers_reported >= nfollowers` for
+  bootstrap, else `nreported >= nexpected` — `>=` rather than `==` because a
+  fault can lower `nexpected` under a tracker that has already counted more
+  than it now needs; the `converged` latch is what keeps that from answering
+  twice. A bootstrap additionally requires `0 < nleaders`: both of its counts
+  are zero until the first *leader* arrives to supply them, so without that
+  guard a tracker created by a follower would satisfy `>= 0` on its own and
+  converge on one contribution with an empty membership.
   - **HNP at completion:** for a construct it assigns the context id (if
     requested, from the decrementing `prte_grpcomm_base.context_id`),
     assembles the **final membership** (union of members + add-members,

--- a/src/mca/grpcomm/direct/grpcomm_direct_group.c
+++ b/src/mca/grpcomm/direct/grpcomm_direct_group.c
@@ -1084,7 +1084,19 @@ void prte_grpcomm_direct_grp_recv(int status, pmix_proc_t *sender,
  * shrink underneath a tracker that has already counted more than it ends up
  * needing. The "converged" latch is what keeps that safe: without it a
  * straggler arriving after completion would drive a second release broadcast,
- * consuming another context id, or a second rollup to our parent. */
+ * consuming another context id, or a second rollup to our parent.
+ *
+ * A bootstrap needs one more guard than that. Its two expected counts are not
+ * known when the tracker is created - they are filled in from the first
+ * *leader* to arrive, which is the only contribution that carries the leader
+ * count (PMIX_GROUP_BOOTSTRAP) and the add-members that set nfollowers. A
+ * tracker created by a follower therefore starts with both counts at zero, and
+ * a ">=" test against zero is satisfied by that single follower: the operation
+ * would converge on one contribution, before any leader has been heard from,
+ * and answer with the empty membership it has assembled so far. nleaders is
+ * the discriminator because a bootstrap always has at least one leader by
+ * definition, whereas nfollowers is legitimately zero for a bootstrap with no
+ * add-members. */
 static void check_complete(prte_grpcomm_group_t *coll)
 {
     int rc;
@@ -1104,8 +1116,9 @@ static void check_complete(prte_grpcomm_group_t *coll)
     }
 
     /* see if everyone has reported */
-    if (!((coll->bootstrap && (coll->nleaders_reported >= coll->nleaders &&
-                               coll->nfollowers_reported >= coll->nfollowers)) ||
+    if (!((coll->bootstrap && 0 < coll->nleaders &&
+           (coll->nleaders_reported >= coll->nleaders &&
+            coll->nfollowers_reported >= coll->nfollowers)) ||
           (!coll->bootstrap && coll->nreported >= coll->nexpected))) {
         return;
     }


### PR DESCRIPTION
## The problem

A group bootstrap can answer itself on a single contribution and abort,
leaving every participant's `PMIx_Group_construct` returning
`PMIX_GROUP_CONSTRUCT_ABORT` for no reason. It is intermittent — it depends
only on which contribution reaches the controller first — and has been
failing the openpmix `group_bootstrap` CI test at roughly one run in ten.

Captured from a failing run with `grpcomm_base_verbose 5`:

```
grpcomm:direct group recv follower nrep 1 of 0
grpcomm:direct group HNP reports complete for ourgroup
grpcomm:direct:xcast: with 40 bytes
...
grpcomm:direct group recv follower nrep 2 of 1
grpcomm:direct group recv leader nrep 1 of 2
grpcomm:direct group recv for completed op "ourgroup" - ignoring
```

`nrep 1 of 0` is one follower reported against `nfollowers == 0`. The next
line is the controller declaring the group complete, and the release xcast
is 40 bytes — no membership, because there was none. Both leaders and the
second follower then arrive and are discarded as stragglers.

## Why

A bootstrap tracker does not know its expected counts when it is created.
Both come from a leader: `nleaders` from that contribution's
`PMIX_GROUP_BOOTSTRAP` count, `nfollowers` from its add-members. A follower
carries neither, so a tracker a follower creates starts with both at zero,
and `check_complete`'s `nleaders_reported >= nleaders && nfollowers_reported
>= nfollowers` is satisfied by that lone follower against zero. It converges,
latches `converged`, and assembles a final membership from a signature that
holds no members — which trips

```c
/* a group of nobody is not a group ... */
if (0 == nfinal) {
    coll->status = PMIX_GROUP_CONSTRUCT_ABORT;
```

That guard is right about what it tests and wrong about why: it assumes an
empty membership means a failure took every member, so the real defect
arrives disguised as a plausible one. Nothing had failed.

## The fix

The `>=` is deliberate and stays — a fault can lower `nexpected` under a
tracker that has already counted past it. But that reasoning never applied
to the bootstrap counters, which are only ever assigned or grown, so `>=`
buys nothing on that branch and only exposes their zero-initialized state.
Require `0 < nleaders` before a bootstrap may converge.

`nleaders` is the right discriminator: a bootstrap has at least one leader
by definition, whereas `nfollowers` is legitimately zero for a bootstrap
with no add-members. This cannot hang an operation that genuinely lost its
leaders — `get_tracker` already rejects a leader count disagreeing with an
established one, and a fault taking out a bootstrap's daemons aborts it
outright in the group fault handler.

Also updates `src/mca/grpcomm/direct/AGENTS.md`, whose description of the
completion test still said `==` and so predated the `>=` change.

## Testing

Syntax-checked clean (`clang -fsyntax-only -Wall -Wextra`). Not yet built or
run end-to-end — the openpmix `group.yaml` CI job builds prrte master, so
the real confirmation is re-running that flake hunt once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)