### PR TITLE
plm/slurm: don't mistake a daemonizing prted's srun exit for death

### DIFF
--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -109,9 +109,18 @@ meaningless (it's srun's, not the failed proc's). The callback:
 - Refuses to proceed against an `ancient` SLURM (`ancient-version`).
 - On non-zero exit → `srun-failed` help + activate
   `DAEMONS_TERMINATED`.
-- On clean exit of the **primary** srun → fire `DAEMONS_TERMINATED` (set
-  `num_terminated = num_procs` first to avoid a bogus error message) so
-  `prun`/the HNP can exit.
+- On clean exit of the **primary** srun, whether that means the DVM is
+  gone depends on whether the `prted`s daemonized. By default a `prted`
+  forks and detaches (see `src/tools/prted/AGENTS.md`), and its parent —
+  the process srun actually tracks as the task — exits as soon as the
+  real daemon signals it is up, long before the daemon itself does. So a
+  clean exit here is normally just that hand-off, not termination: it is
+  ignored, and real daemon loss is instead caught when the daemon's RML
+  connection to the HNP drops. Only with `--debug-daemons` or
+  `--leave-session-attached` (no forking, `prted` stays attached) does
+  srun genuinely track the daemon's own lifetime, so only then does a
+  clean exit fire `DAEMONS_TERMINATED` (set `num_terminated = num_procs`
+  first to avoid a bogus error message) so `prun`/the HNP can exit.
 
 `plm_slurm_terminate_prteds` similarly special-cases the "we never
 launched additional daemons" case (`primary_pid_set == false`) by firing

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -678,15 +678,31 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
     } else {
         /* otherwise, check to see if this is the primary pid */
         if (primary_srun_pid == proc->pid) {
-            /* in this case, we just want to fire the proper trigger so
-             * mpirun can exit
-             */
-            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                                 "%s plm:slurm: primary daemons complete!",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            /* need to set the #terminated value to avoid an incorrect error msg */
-            jdata->num_terminated = jdata->num_procs;
-            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+            if (prte_debug_daemons_flag || prte_leave_session_attached) {
+                /* the prted stayed attached instead of forking off and
+                 * daemonizing, so the process srun is tracking really is
+                 * the persistent daemon - its clean exit means the DVM
+                 * is genuinely gone. Fire the proper trigger so mpirun
+                 * can exit.
+                 */
+                PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                     "%s plm:slurm: primary daemons complete!",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+                /* need to set the #terminated value to avoid an incorrect error msg */
+                jdata->num_terminated = jdata->num_procs;
+                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+            } else {
+                /* the prted forked and daemonized (the default): srun was
+                 * only ever tracking the fork's parent, which exits as
+                 * soon as the real daemon signals it is up and running.
+                 * A clean exit here is that hand-off, not termination -
+                 * daemon loss is instead caught when its RML connection
+                 * to the HNP actually drops. */
+                PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                     "%s plm:slurm: primary srun exited after "
+                                     "daemon hand-off",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+            }
         }
     }
 


### PR DESCRIPTION
@rhc54 I ran into this issue when running the Slurm-DVM coordination example; I've tested it on my system but please check that the diagnosis and remedy make sense. 

## Summary
- On Slurm, launching a DVM across more than one node (`prterun`/`prte`) could tear itself down immediately after every daemon had already reported in successfully — nothing had failed, but the whole DVM exited anyway. A single-node allocation never showed it, since no `srun` call is needed when there are no remote daemons to launch.
- Root cause: `srun_wait_cb` in `plm/slurm` treats any clean exit of the "primary" `srun` as proof that all daemons have terminated, on the assumption that `srun` stays attached to the job step for the daemon's entire lifetime. By default `prted` forks and daemonizes (`src/util/daemon_init.c`): the parent — the process `srun` actually tracks as the task — exits as soon as the real daemon signals it's ready, well before the daemon itself is done. `srun` sees that as task completion and returns, and `plm/slurm` misreads it as the whole DVM having died.
- This bug had been latent for a long time but was masked by a separate, unrelated bug until `fcd60b9bbc` ("prted: release the daemonize parent once up and running"). Before that commit, nothing ever wrote the daemon's readiness byte, so the fork's parent blocked forever instead — leaking a stale `prted` process per node and holding the launcher's `ssh` session open for the daemon's whole life. That bug's side effect was to accidentally keep the process `srun` tracks alive for the daemon's whole lifetime, which is exactly what `srun_wait_cb` needed to be true. Once `fcd60b9bbc` correctly fixed the readiness-pipe leak, the parent started exiting early as designed, and `plm/slurm`'s pre-existing bad assumption was finally exposed.
- Fix: only treat a clean exit of the primary `srun` as daemon death when `prted` was launched *without* daemonizing (`--debug-daemons` or `--leave-session-attached`), where `srun` genuinely does track the daemon's own lifetime. Otherwise, rely on the daemon's RML connection to the HNP dropping to catch a real failure — the same mechanism already used elsewhere for this.

Credits: AccelCom @ Barcelona Supercomputing Center