### PR TITLE
plm: second framework review - launch accounting, reservation ownership, and dead weight

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5290,6 +5290,50 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "plm: a second launch adds only the daemons that launch needs"
+    # setup_virtual_machine runs on EVERY launch, but the daemon job's map is
+    # persistent - it accumulates the DVM's nodes for the life of the session.
+    # num_new_daemons and daemon_vpid_start describe only the launch about to
+    # happen, so each pass has to recompute them from scratch; carried over,
+    # they make a launcher act on the previous launch's daemons. (ssh
+    # substitutes each node's own vpid per node, so the vpid half of that is
+    # only fatal under an RM launcher - see test/unit/plm - but the count is
+    # what every component keys its "anything to do?" test off.)
+    #
+    # So: form a DVM, then bring in a third node with --add-host and require
+    # that the second pass reports exactly ONE new daemon, not three.
+    # NOTE: the DVM runs in the FOREGROUND under RUN_BG rather than
+    # --daemonize, because a daemonized HNP detaches from its output and the
+    # trace this case reads would go nowhere.
+    cleanup_swarm
+    RUN_BG /tmp/prte.out 'prte --prtemca plm_base_verbose 5 --host node1:1,node2:1'
+    sleep 8
+    if RUN 'pgrep -x prte >/dev/null'; then
+        first=$(RUN 'grep -c "setup_vm add new daemon" /tmp/prte.out' | tr -d '\r')
+        [ "$first" = 1 ] && ok "DVM formation added one daemon (node2)" \
+                         || bad "DVM formation reported $first new daemons (expected 1)"
+        out=$(RUN 'timeout 90 prun --add-host node3:1 --host node1:1,node2:1,node3:1 \
+                     -n 3 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -cE '^node[1-3]$')
+        [ "$n" = 3 ] && ok "--add-host launch ran across all three nodes" \
+                     || bad "--add-host launch produced $n/3 procs: $(echo "$out" | tr '\n' ' ')"
+        [ "$(prted_count 3)" = 1 ] && ok "a daemon was started on the added node" \
+                                   || bad "no daemon on the added node"
+        total=$(RUN 'grep -c "setup_vm add new daemon" /tmp/prte.out' | tr -d '\r')
+        [ "$total" = 2 ] \
+            && ok "the second pass added exactly one daemon (count not carried over)" \
+            || bad "second pass brought the running total to $total new daemons (expected 2)"
+        # and the DVM still routes to everyone afterwards
+        out=$(RUN 'timeout 30 prun -n 3 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -cE '^node[1-3]$')
+        [ "$n" = 3 ] && ok "DVM still spans all three nodes after the grow" \
+                     || bad "post-grow job produced $n/3 procs: $(echo "$out" | tr '\n' ' ')"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the second-launch test"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: grow + shrink (radix 64, flat tree)"
     cleanup_swarm
     RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1993,7 +1993,11 @@ test_pmix() {
     else
         out=$(PRUN "--host node1:1 -n 1 $PT serveruri node2" 2>&1)
         u=$(echo "$out" | grep -m1 '^URI ' | awk '{print $2}' | tr -d '\r')
-        n2ip=$(docker exec prte-node2 hostname -i 2>/dev/null | awk '{print $1}' | tr -d '\r')
+        # ${NODE}2, not a hardcoded "prte-node2": every global name this
+        # harness claims is derived from $PRTE_SWARM (see docker-compose.yml),
+        # so a literal here asks a DIFFERENT swarm - or nothing at all - for
+        # the address, and the case fails against an unrelated container's IP
+        n2ip=$(docker exec "${NODE}2" hostname -i 2>/dev/null | awk '{print $1}' | tr -d '\r')
         if [ -z "$u" ]; then
             bad "no server URI for node2 with remote connections on: $(echo "$out" | grep -E '^ERR' | tr '\n' ' ' | tail -c 200)"
         elif echo "$u" | grep -q '127\.0\.0\.1'; then

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -61,7 +61,7 @@ Two very different flows share this framework:
 plm/
   plm.h                       # the module/component vtable (function-pointer struct)
   plm_types.h                 # **job / proc / node / app STATE codes** + PLM command codes (tree-wide!)
-  base/
+  base/                       # ...and its own AGENTS.md - read it before editing any of this
     base.h                    # public base API (state-machine handlers, spawn_response, ...)
     plm_private.h             # framework-internal API + prte_plm_globals_t + prted-cmd helpers
     plm_base_frame.c          # framework open/close/register; the DEFAULT "local-only" module
@@ -180,12 +180,11 @@ spine of launch:
 
 | Handler | State it services → what it does |
 |---------|----------------------------------|
-| `prte_plm_base_setup_job` | `INIT` → assign a jobid (`prte_plm_base_create_jobid`), arm spawn/job timeout timers, then `INIT_COMPLETE`. |
-| `prte_plm_base_setup_job_complete` | `INIT_COMPLETE` → `ALLOCATE`. |
+| `prte_plm_base_setup_job` | `INIT` → assign a jobid (`prte_plm_base_create_jobid`), record the job as an owner of the reservation(s) it targets (it has a namespace only now — see the command processor below), arm spawn/job timeout timers, then `INIT_COMPLETE`. |
 | `prte_plm_base_allocation_complete` | `ALLOCATION_COMPLETE` → `LAUNCH_DAEMONS` (the component's handler). Has a bootstrap-DVM special case that stands up the VM directly. |
 | `prte_plm_base_daemons_launched` | `DAEMONS_LAUNCHED` → **deliberately a no-op**; we wait for daemons to phone home rather than advancing. |
 | `prte_plm_base_daemons_reported` | `DAEMONS_REPORTED` → size any node whose slot count was not given (`PRTE_NODE_FLAG_SLOTS_GIVEN`), sum the job's session nodes into `total_slots_alloc`, then `VM_READY`. |
-| `prte_plm_base_vm_ready` | `VM_READY` → check topology limits, preposition files (`filem`), then `MAP`. |
+| *(VM_READY)* | handled by `state/dvm`'s own `vm_ready()` — WIREUP xcast, elastic grow drain, file prepositioning, then `MAP`. The unregistered copies of this and the `INIT_COMPLETE` handler that used to sit in `plm/base` are gone; edit the live ones. |
 | `prte_plm_base_mapping_complete` | `MAP_COMPLETE` → `SYSTEM_PREP`. |
 | `prte_plm_base_complete_setup` | `SYSTEM_PREP` → `LAUNCH_APPS`. |
 | `prte_plm_base_launch_apps` | `LAUNCH_APPS` → pack the `PRTE_DAEMON_ADD_LOCAL_PROCS` (or `DVM_ADD_PROCS` for a fixed DVM) command plus the `odls` add-procs payload into `jdata->launch_msg`. |
@@ -195,7 +194,15 @@ spine of launch:
 
 `prte_plm_base_spawn_response()` notifies the original spawn requestor
 (tool via PMIx event, or another daemon via `PRTE_RML_TAG_LAUNCH_RESP`)
-that the job launched.
+that the job launched. It is called with a **failure** status too —
+`errmgr/dvm` and `state/dvm` both answer a failed job through it, so a
+quick-failing job cannot leave its requestor unanswered. The
+`PMIX_LAUNCH_COMPLETE` event it raises for a tool-requested spawn is
+therefore emitted **only on success**: that event says the job is running
+and a tool may read it that way. A failure travels by the two routes that
+exist for it — the `PMIX_ERR_JOB_FAILED_TO_LAUNCH` event described below,
+and the error status carried by the response itself, which is what
+releases the requestor from `PMIx_Spawn`.
 
 It is also **the only chance to tell the requestor *why* a launch failed.**
 A response carrying an error status is what releases the requestor from
@@ -264,6 +271,16 @@ This is the crux of the whole framework. After a component starts a
    inherited rank 1's, so a daemon added by a later grow (which reports
    none of its own, not being rank 1) still inherits the right one.
 
+   **Diff ownership:** the node also owns whatever
+   `hwloc_topology_diff_build()` produced, and `prte_node_destruct` frees
+   it. hwloc allocates a diff list *whenever it has anything to say* —
+   including the `TOO_COMPLEX` entry it returns **1** with when the two
+   topologies genuinely differ, which is the usual outcome while walking
+   the recorded topologies looking for a match. Destroy every list you do
+   not adopt (a heterogeneous DVM otherwise leaks one per node per recorded
+   topology), and destroy the node's previous diff before storing a new
+   one, since a daemon can report in twice.
+
    **Topology ownership:** `node->topology` is a reference-counted
    pointer into the shared `prte_node_topologies` array, never a copy.
    Assigning one means `PMIX_RETAIN(t)` (and releasing whatever the node
@@ -320,6 +337,18 @@ thread-safe on the progress thread) and switches on
   child to its parent, processes `add-host`/`add-hostfile`, and finally
   calls `prte_plm.spawn(jdata)` (or caches the job if the DVM isn't ready
   yet).
+
+  Two things about this path are worth internalizing. **Every rejection
+  must happen before the job is added to `session->jobs`** — that array
+  borrows its entries and nothing ever removes one, so a job rejected
+  afterwards stays as a phantom for the life of the session. And **the job
+  has no namespace here**: the requester packs an unnamed job and the HNP
+  names it later, in `prte_plm_base_setup_job`. Anything keyed on the
+  job's own identity has to wait for that. The reservation-ownership grant
+  did not, and so recorded an *empty* namespace as an owner — which
+  `PMIx_Check_nspace` treats as a wildcard matching every namespace,
+  retiring the ownership gate on that reservation. The grant now happens
+  in `setup_job`, and `prte_session_add_owner` refuses an empty namespace.
 - **`PRTE_PLM_UPDATE_PROC_STATE`** — daemons report per-proc pid/state/
   exit-code; the handler activates the corresponding proc state.
 - **`PRTE_PLM_REGISTERED_CMD`** — procs registered for sync; advances to
@@ -371,8 +400,21 @@ Called first thing in every component's `launch_daemons`. It builds the
 **daemon job's map**: the set of nodes that need a *new* daemon. It
 handles a menagerie of cases — fixed DVM (nothing to do), extend/grow
 DVM, dynamic spawn (only "added" nodes), unmanaged allocation
-(`-host`/hostfile union), managed allocation (filter the node pool) —
-and for each node needing a daemon it:
+(`-host`/hostfile union), managed allocation (filter the node pool).
+
+**The daemon job's map is persistent; two of its fields are not.**
+`map->num_new_daemons` and `map->daemon_vpid_start` describe the launch
+about to happen, not the DVM, so `setup_virtual_machine` clears both once
+at the top — before any branch runs — and every branch recomputes them.
+That placement is the fix for a real defect: when each branch cleared them
+for itself, two of the four forgot, and a second launch that added a node
+(`--add-host`, an elastic grow) handed `slurm`/`lsf`/`pals` the *first*
+launch's start vpid, telling the new daemons to claim ranks that live
+daemons already owned. `ssh` is immune (it substitutes each node's own vpid
+per node), which is why it went unnoticed. Do not move the reset back into
+the branches.
+
+For each node needing a daemon it:
 
 - creates a `prte_proc_t` and assigns it a vpid — normally the **next
   available one** (`daemons->num_procs`), but in a **bootstrapped DVM**
@@ -506,6 +548,12 @@ placed daemons) or wireup stalls.
   `node->daemon` before reading `node->daemon->name.rank` — including in
   a tree-spawn "is this one of my children?" filter, which runs before
   the per-node launch checks.
+- **Do not advertise a knob nothing reads.** `plm_node_regex_threshold`
+  was registered and documented for years while the node regex travelled
+  in the launch message, not on the command line; `plm_ssh_delay` was
+  parsed and never applied. Both are gone. A dead knob is worse than no
+  knob — it makes a user's correct diagnosis look wrong. `prte_plm_globals_t`
+  is likewise down to the fields something actually reads.
 - **The version macro is `PRTE_PLM_BASE_VERSION_2_0_0`** (`plm` 2.0.0).
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on
   every block, `NULL ==`/constant-on-left comparisons, no new compiler
@@ -539,19 +587,29 @@ Launching daemons needs real nodes, so the coverage is split in three:
 
 | Layer | What it covers |
 |-------|----------------|
-| [`test/unit/plm/test_plm.c`](../../../test/unit/plm/) (`make check`) | Everything the launch path builds *before* it forks: `plm_types.h` state/command-code uniqueness and the UNTERMINATED/TERMINATED/ERROR boundaries, the module vtable contract (default + `ssh`), `prte_plm_base_wrap_args`, `prte_plm_base_setup_prted_cmd` (plain / wrapped / custom agent), the full `prte_plm_base_prted_append_basic_args` command line (vpid template slot, rmaps/ras/plm suppression, `=`-bearing MCA values, the `pass_environ_mca_params` opt-out), and `set_hnp_name`/`create_jobid` nspace assignment. |
+| [`test/unit/plm/test_plm.c`](../../../test/unit/plm/) (`make check`) | Everything the launch path builds *before* it forks: `plm_types.h` state/command-code uniqueness and the UNTERMINATED/TERMINATED/ERROR boundaries, the module vtable contract (default + `ssh`), `prte_plm_base_wrap_args`, `prte_plm_base_setup_prted_cmd` (plain / wrapped / custom agent), the full `prte_plm_base_prted_append_basic_args` command line (vpid template slot, rmaps/ras/plm suppression, `=`-bearing MCA values, the `pass_environ_mca_params` opt-out), `set_hnp_name`/`create_jobid` nspace assignment, the `UPDATE_PROC_STATE` round trip, and **`setup_virtual_machine`'s per-launch accounting** (`test_setup_vm`: each pass reports its own `num_new_daemons`/`daemon_vpid_start`, including the second launch that adds one node and the no-op third pass). It builds the global job/node pools by hand, as `test/unit/ras` does. |
 | [`test/offline`](../../../test/offline/) (`make -C test/offline check-offline`) | `setup_virtual_machine` on the `DO_NOT_LAUNCH` path, via the mapper matrix. |
-| [`contrib/dockerswarm`](../../../contrib/dockerswarm/) (`run-tests.sh linux`) | The real launch: radix-2 **tree-spawn** fan-out across 8 nodes (only a multi-level tree proves `remote_spawn` recursed), flat `no_tree_spawn` launch, `num_concurrent=1` throttled launch, an `=`-bearing MCA value surviving onto the prted cmd line, `pass_environ_mca_params 0`, and node-name/alias reconciliation (allocate by IP, then `--host` by both the reported name and the original address). |
+| [`contrib/dockerswarm`](../../../contrib/dockerswarm/) (`run-tests.sh linux`) | The real launch: radix-2 **tree-spawn** fan-out across 8 nodes (only a multi-level tree proves `remote_spawn` recursed), flat `no_tree_spawn` launch, `num_concurrent=1` throttled launch, an `=`-bearing MCA value surviving onto the prted cmd line, `pass_environ_mca_params 0`, node-name/alias reconciliation (allocate by IP, then `--host` by both the reported name and the original address), and a **second launch into a running DVM** (`--add-host`) adding exactly the one daemon it needs. |
 
 Add a new pure/structural check to the unit test; anything that needs a
 daemon to actually come up belongs in the dockerswarm suite.
+
+Note what the swarm **cannot** reach: it has only `ssh`, so anything
+specific to an RM launcher — `daemon_vpid_start`'s only consumers among
+them — is covered by the unit test and, ultimately, by a real allocation.
+There is no fake `srun`; `contrib/dockerswarm/fake-slurm.py` stands in for
+the SLURM *control plane* (`ras/slurm`), not for its launcher.
 
 ---
 
 ## Where to go next
 
-Each component directory has its own `AGENTS.md`:
+The base and each component directory have their own `AGENTS.md`:
 
+- [`base/AGENTS.md`](base/AGENTS.md) — the launch machinery itself:
+  `setup_virtual_machine`'s branches and its per-launch reset, the daemon
+  callback's ownership rules, the command processor's two invariants, and
+  what `prte_plm_globals_t` may hold.
 - [`ssh/AGENTS.md`](ssh/AGENTS.md) — the default/fallback; **read this
   second** — rsh/ssh tree-spawn is the reference implementation.
 - [`slurm/AGENTS.md`](slurm/AGENTS.md) — one `srun` launches all prteds.

--- a/src/mca/plm/base/AGENTS.md
+++ b/src/mca/plm/base/AGENTS.md
@@ -1,0 +1,250 @@
+# AGENTS.md — `plm/base` (the launch machinery itself)
+
+Guide to `src/mca/plm/base/`. Read the
+[framework guide](../AGENTS.md) first — it covers the module contract,
+component selection, and which component runs where. This file is about
+the code *underneath* the components: the state-machine handlers, the
+daemon callback, `setup_virtual_machine`, the command processor, and the
+elastic launch fence. A component is mostly glue; nearly every launch bug
+lives here.
+
+```
+base/
+  base.h                    # what other frameworks may call (state handlers, spawn_response,
+                            #   the UPDATE_PROC_STATE writers)
+  plm_private.h             # framework-internal API + prte_plm_globals_t
+  plm_base_frame.c          # open/close/register, the MCA alias, the DEFAULT local-only module
+  plm_base_select.c         # pick-ONE selection
+  plm_base_receive.c        # the HNP's inbound command processor + the state-update writers
+  plm_base_launch_support.c # 3000+ lines: everything else
+  plm_base_prted_cmds.c     # xcast terminate/kill/signal
+  plm_base_jobid.c          # HNP nspace + per-job nspace assignment
+  help-plm-base.txt         # user-facing text (mostly consumed by src/prted, not by plm)
+```
+
+---
+
+## `setup_virtual_machine` — the one function to understand
+
+Every component calls it first thing in `launch_daemons`. It answers:
+**which nodes need a new daemon, and what vpid does each get?**
+
+It is a switchyard of mutually exclusive branches, each selecting a
+different candidate node set, all converging on the `process:` loop that
+creates the daemon procs:
+
+| Branch | Selected when | Candidates |
+|--------|---------------|-----------|
+| fixed DVM | `PRTE_JOB_FIXED_DVM` | none — returns at once |
+| **grow** | `PRTE_JOB_EXTEND_DVM` | pool nodes marked `PRTE_NODE_STATE_ADDED`, and *only* those |
+| dynamic spawn | the job has an originator | first pass: the whole pool (singleton); later: `ADDED` nodes |
+| no-VM / multi-sim | `PRTE_JOB_NO_VM` or `PRTE_JOB_MULTI_DAEMON_SIM` | pool nodes carrying procs |
+| initial VM | otherwise | the whole pool, filtered through the app specs |
+
+### The per-launch reset (read this before adding a branch)
+
+The daemon job's **map is persistent** — it accumulates the DVM's nodes
+for the life of the session. Two of its fields are not cumulative:
+
+- **`map->num_new_daemons`** — what every component keys its "is there
+  anything to launch?" test off;
+- **`map->daemon_vpid_start`** — the base vpid `slurm`, `lsf` and `pals`
+  substitute into the prted command line, from which each daemon the RM
+  starts computes its own name.
+
+Both describe *this* launch, so `setup_virtual_machine` clears them once,
+at the top, before any branch runs. That is deliberate placement: when
+each branch cleared them for itself, two of the four forgot, and a second
+launch that added a node (`--add-host`, an elastic grow) handed an RM
+launcher the *first* launch's start vpid — telling the new daemons to
+claim ranks that live daemons already own. `ssh` never showed it, because
+it substitutes each node's own vpid per node. `test/unit/plm`'s
+`test_setup_vm` pins the invariant: each pass must report its own
+daemons.
+
+### vpid assignment
+
+Normally the next unused vpid (`daemons->num_procs`). In a **bootstrapped
+DVM** it is the node's canonical rank (`node->index`, recorded by
+`ras/bootstrap` from `prte.conf`) — not a preference: the daemon computed
+that same rank for itself before it ever contacted the HNP, and
+`prted_report_launch` looks a reporting daemon up *by the rank it claims*.
+
+`daemons->num_procs` is maintained as the vpid **span**, grown to cover
+the vpid just used rather than blindly incremented, so a canonical rank
+cannot leave it short of the highest daemon in the job (which would
+truncate the nidmap span).
+
+### Elastic bookkeeping
+
+In elastic mode the function also records a **grow campaign** and raises
+`prte_dvm_launch_fence`. Two details are load-bearing:
+
+- the campaign's target list is **collected as the vpids are assigned**,
+  not reconstructed afterwards as a run starting at `daemon_vpid_start`.
+  That reconstruction is right only while vpids come out consecutively,
+  which is not the rule in a bootstrapped DVM (there a daemon takes its
+  node's canonical rank), and a campaign naming ranks it did not launch
+  never drains its fence;
+- the requester is found by scanning **all** the targets' session
+  backpointers rather than trusting the first — see the framework guide
+  for the shrink-then-grow case that motivated it.
+
+---
+
+## The daemon callback — `prte_plm_base_daemon_callback`
+
+The recv on `PRTE_RML_TAG_PRTED_CALLBACK`; the framework guide walks the
+five steps. Two ownership rules that are easy to get wrong:
+
+- **`node->topology` is a counted reference** into `prte_node_topologies`.
+  Assigning one means retain-new/release-old.
+- **`node->topodiff` is owned by the node** and freed by
+  `prte_node_destruct`. `hwloc_topology_diff_build()` allocates a list
+  *whenever it has anything to say* — including the `TOO_COMPLEX` entry it
+  returns **1** with when the topologies genuinely differ, which is the
+  common outcome while walking the recorded topologies looking for a
+  match. Every list this code does not adopt has to be destroyed, or a
+  heterogeneous DVM leaks one diff per node per recorded topology; and the
+  node's previous diff has to be destroyed before a new one is stored,
+  because a daemon can report in more than once (the bootstrap unheal
+  path).
+
+The whole loop is written so a daemon may report **twice**: the URI is
+freed before being replaced, the topology reference is released before
+being re-taken, and a returning daemon that had been marked
+`COMM_FAILED` restores the daemon count.
+
+Everything the loop records lands on `daemon->node`, so it checks that
+the proc *has* a node before it starts. `setup_vm` links the two when it
+creates a daemon, so a report naming a rank with no node is a report from
+something we did not launch — a diagnostic, not a segfault in the HNP.
+
+---
+
+## `plm_base_receive.c` — the command processor
+
+`prte_plm_base_recv` handles `PRTE_RML_TAG_PLM` inside an event (so it is
+on the progress thread). Beyond the command dispatch described in the
+framework guide, two invariants govern `PRTE_PLM_LAUNCH_JOB_CMD`:
+
+**Ownership of the unpacked job.** `own_jdata` tracks whether the job
+object belongs to nobody but us. It is true from the unpack until the job
+is handed to a session; the `ANSWER_LAUNCH` error path releases it only
+while it is still ours. Anything that can reject the request must
+therefore run **before** the job is added to `session->jobs` — that array
+*borrows* its entries, so nothing ever removes or releases one, and a job
+rejected after being added stays there as a phantom for the life of the
+session.
+
+**A spawn request arrives with no namespace.** The requester packs a job
+object the HNP has not named yet; `prte_plm_base_setup_job` assigns the
+nspace (via `prte_plm_base_create_jobid`) when the job reaches `INIT`.
+Anything keyed on the job's identity therefore cannot be done here. That
+caught the reservation-ownership grant: the spawned job is supposed to
+become an owner of the reservation it targets (so it can spawn onto those
+nodes in turn), and recording it at request time wrote an **empty**
+namespace into the owner set. An empty namespace is not merely useless —
+`PMIx_Check_nspace` treats an empty side as a *wildcard*, so an empty
+owner entry matches every namespace and retires the reservation's
+ownership gate entirely. The grant now happens in `setup_job`, once the
+job has a name, and `prte_session_add_owner` refuses an empty namespace
+outright.
+
+The requester is still vetted here, before anything is granted:
+`prte_session_is_owned_by(session, requestor)`.
+
+### `TOOL_ATTACHED` — ask the daemon, don't index the pool
+
+A tool that connects through some daemon is reported to the master, which
+builds a job object for it. To record *where* the tool is, ask the
+reporting daemon: `daemons->procs[sender->rank]->node`. Indexing
+`prte_node_pool` by the daemon's rank — which this used to do — assumes
+vpids and pool indices run in step, and they need not: the pool holds
+every node the allocation named, including ones no daemon was ever
+launched on (excluded by a `-host`/hostfile spec, marked `DO_NOT_USE`,
+shrunk away), while vpids go only to nodes that get a daemon. And not
+knowing where a tool sits is no reason to bring the DVM down, which is
+what the old `NOT_FOUND` did by falling into the master's `CLEANUP`
+(→ `FORCED_EXIT`).
+
+### Two handlers that used to live here
+
+`prte_plm_base_vm_ready()` and `prte_plm_base_setup_job_complete()` are
+**gone**. The DVM state machine registers `state/dvm`'s `vm_ready()` and
+`init_complete()` on those states; the copies here were never registered
+by anything, so they drifted while looking authoritative — the live
+`vm_ready()` also builds the WIREUP xcast and drains the elastic grow
+campaigns, neither of which the copy knew about. If you are looking for
+the VM_READY behavior, it is in `state/dvm`.
+
+---
+
+## Telling the requester what happened
+
+`prte_plm_base_spawn_response(status, jdata)` is the single answer to a
+spawn request, and it is called with **failures** too (`errmgr/dvm` and
+`state/dvm` both route a failed job through it, so a quick-failing job
+cannot leave its requester unanswered). Three things travel, and they are
+not interchangeable:
+
+| What | To whom | When |
+|------|---------|------|
+| the diagnostic (`report_launch_failure`) | prterun: the job's stderr. A separate tool: a `PMIX_ERR_JOB_FAILED_TO_LAUNCH` event custom-ranged to it | failure only, once (`PRTE_JOB_FLAG_ERR_REPORTED`) |
+| `PMIX_LAUNCH_COMPLETE` | the launch proxy of a tool-requested (`PRTE_JOB_DVM_JOB`) spawn | **success only** — the event says the job is running, and a tool is entitled to read it that way |
+| the spawn response (status + nspace + room) | the originator, locally or over `PRTE_RML_TAG_LAUNCH_RESP` | always; this is what releases `PMIx_Spawn` |
+
+`PRTE_JOB_SPAWN_NOTIFIED` makes the whole thing single-shot on both the
+local and the relayed path.
+
+---
+
+## The `UPDATE_PROC_STATE` writers live here on purpose
+
+`prte_plm_base_pack_state_for_proc()` / `prte_plm_base_pack_state_update()`
+sit beside their only reader because the wire carries no version. There
+used to be three copies of the writer. `test/unit/plm` round-trips both
+shapes through an unpacker that repeats the receiver's sequence — that
+test *is* the format contract.
+
+Note the other three PLM message bodies (`REGISTERED`,
+`LOCAL_LAUNCH_COMP`, `READY_FOR_DEBUG`, all written by `state/prted`)
+have no shared writer and no terminator: their readers loop until the
+buffer runs out. If you add a field to one, change both ends in the same
+commit — see the top-level AGENTS.md on mixed-version DVMs.
+
+---
+
+## `prte_plm_globals_t` — keep it honest
+
+Three fields were removed from it in the 2026 review because nothing read
+them: `daemonlaunchstart`, `tree_spawn_cmd`, and `node_regex_threshold`.
+The last one was worse than dead: it was registered as the MCA parameter
+`plm_node_regex_threshold` and documented as controlling whether the node
+regex went on the prted command line, while the regex has travelled in the
+launch message for years. A knob that does nothing is worse than no knob —
+a user who hits a too-long command line sets it, sees nothing change, and
+cannot tell a wrong setting from a wrong diagnosis. (`plm_ssh_delay` was
+retired for the same reason.) The real remedy for an over-long command
+line is `plm_ssh_pass_environ_mca_params 0`, which `help-plm-ssh.txt`
+names.
+
+What remains: `base_nspace` (+ `next_jobid`), `daemon_nodes_assigned_at_launch`,
+and `pass_environ_mca_params`. If you add a field, make sure something
+reads it.
+
+---
+
+## Testing what is in here
+
+| Layer | What it reaches |
+|-------|-----------------|
+| [`test/unit/plm`](../../../../test/unit/plm/) | `plm_types.h` code uniqueness, the module vtable, `wrap_args`, `setup_prted_cmd`, the full `prted_append_basic_args` command line, `set_hnp_name`/`create_jobid`, the `UPDATE_PROC_STATE` round trip, and `setup_virtual_machine`'s per-launch accounting (`test_setup_vm`, which builds the global job/node pools by hand as `test/unit/ras` does) |
+| [`test/offline`](../../../../test/offline/) | `setup_virtual_machine` on the `DO_NOT_LAUNCH` path, across the mapper matrix |
+| [`contrib/dockerswarm`](../../../../contrib/dockerswarm/) | everything that needs daemons to actually come up: tree-spawn, throttling, the `=`-bearing MCA value, alias reconciliation, and a second launch adding a daemon to a running DVM |
+
+A pure/structural check belongs in the unit test. Anything that needs a
+daemon belongs in the swarm. Note that a change to `plm_private.h` changes
+the layout of `prte_plm_globals` — rebuild from the **top** of the build
+tree before running the unit test, or you will be testing a stale object
+against a new library.

--- a/src/mca/plm/base/CLAUDE.md
+++ b/src/mca/plm/base/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/mca/plm/base/base.h
+++ b/src/mca/plm/base/base.h
@@ -55,12 +55,13 @@ PRTE_EXPORT int prte_plm_base_select(void);
  */
 PRTE_EXPORT void prte_plm_base_set_slots(prte_node_t *node);
 PRTE_EXPORT void prte_plm_base_setup_job(int fd, short args, void *cbdata);
-PRTE_EXPORT void prte_plm_base_setup_job_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_complete_setup(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_daemons_reported(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_allocation_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_daemons_launched(int fd, short args, void *cbdata);
-PRTE_EXPORT void prte_plm_base_vm_ready(int fd, short args, void *cbdata);
+/* NOTE: the INIT_COMPLETE and VM_READY handlers are state/dvm's
+ * init_complete() and vm_ready(); the copies that used to be declared here
+ * were unregistered duplicates and are gone */
 PRTE_EXPORT void prte_plm_base_mapping_complete(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_launch_apps(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata);

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -56,11 +56,8 @@
 prte_plm_globals_t prte_plm_globals = {
     .base_nspace = NULL,
     .next_jobid = 0,
-    .daemonlaunchstart = {0, 0},
-    .tree_spawn_cmd = PMIX_DATA_BUFFER_STATIC_INIT,
     .daemon_nodes_assigned_at_launch = true,
-    .pass_environ_mca_params = true,
-    .node_regex_threshold = 0
+    .pass_environ_mca_params = true
 };
 
 /*
@@ -86,13 +83,16 @@ static int mca_plm_base_register(pmix_mca_base_register_flag_t flags)
 {
     PRTE_HIDE_UNUSED_PARAMS(flags);
 
-    prte_plm_globals.node_regex_threshold = 1024;
-    (void) pmix_mca_base_framework_var_register(&prte_plm_base_framework,
-                                                "node_regex_threshold",
-                                                "Only pass the node regex on the orted command line if smaller than this threshold",
-                                                PMIX_MCA_BASE_VAR_TYPE_SIZE_T,
-                                                &prte_plm_globals.node_regex_threshold);
-
+    /* NOTE: there is deliberately no "plm_node_regex_threshold" parameter
+     * here any more.  It was registered, documented as controlling whether
+     * the node regex went onto the prted command line, and read by nothing
+     * at all - the regex is passed through the launch message, not the
+     * command line, and has been for years.  A knob that does nothing is
+     * worse than no knob: a user who hits a too-long command line sets it,
+     * sees no change, and has no way to tell a broken setting from a wrong
+     * diagnosis.  (The same reasoning retired plm_ssh_delay.)  The real
+     * remedy for an over-long command line is
+     * plm_ssh_pass_environ_mca_params 0, which help-plm-ssh.txt names. */
     /* Note that we break abstraction rules here by listing a
      specific PLM here in the base.  This is necessary, however,
      due to extraordinary circumstances:
@@ -136,6 +136,9 @@ static int prte_plm_base_close(void)
 
     if (NULL != prte_plm_globals.base_nspace) {
         free(prte_plm_globals.base_nspace);
+        /* the tool-attach path in plm_base_receive reads this to mint a
+         * nspace, so leave a NULL rather than a freed pointer behind */
+        prte_plm_globals.base_nspace = NULL;
     }
 
     return pmix_mca_base_framework_components_close(&prte_plm_base_framework, NULL);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -762,6 +762,7 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
     prte_timer_t *timer = NULL;
     int time, *tp;
+    size_t n;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
     PMIX_ACQUIRE_OBJECT(caddy);
@@ -786,6 +787,27 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
             PMIX_RELEASE(caddy);
             return;
         }
+    }
+
+    /* Now - and only now - can the job be recorded as an owner of the
+     * reservation(s) it was cleared to run in.  That grant is what lets it
+     * spawn further jobs onto those nodes, and it belongs to the job's own
+     * namespace, which did not exist until the line above: a spawn request
+     * arrives with an empty nspace and the HNP names the job here.
+     *
+     * Granting it at request-vetting time therefore recorded an EMPTY
+     * namespace as an owner - and an empty namespace matches every other one
+     * (PMIx_Check_nspace treats it as a wildcard), so the first job spawned
+     * into a reservation quietly opened that reservation to every namespace
+     * in the DVM.  prte_session_add_owner now refuses an empty namespace
+     * outright; this is where the real one is recorded.  Both calls are
+     * no-ops for the default session, which everyone may use. */
+    if (NULL != caddy->jdata->target_sessions) {
+        for (n = 0; n < caddy->jdata->num_target_sessions; n++) {
+            prte_session_add_owner(caddy->jdata->target_sessions[n], caddy->jdata->nspace);
+        }
+    } else if (NULL != caddy->jdata->session) {
+        prte_session_add_owner(caddy->jdata->session, caddy->jdata->nspace);
     }
 
     /* if the spawn operation has a timeout assigned to it, setup the timer for it */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1235,9 +1235,20 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
         report_launch_failure(jdata);
     }
 
-    /* if the requestor was a tool, use PMIx to notify them of
-     * launch complete as they won't be listening on PRRTE oob */
-    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_DVM_JOB, NULL, PMIX_BOOL)) {
+    /* If the requestor was a tool, use PMIx to notify them of launch
+     * complete as they won't be listening on PRRTE oob.
+     *
+     * Only on SUCCESS, though.  PMIX_LAUNCH_COMPLETE says the job is running,
+     * and a tool is entitled to read it that way - so a job that never
+     * started must not raise it.  This path is reached with a failure status
+     * too (errmgr/dvm and state/dvm both answer a failed spawn through here,
+     * so a quick-failing job cannot leave its requestor unanswered), and the
+     * requestor learns of that failure by the two routes that exist for it:
+     * the PMIX_ERR_JOB_FAILED_TO_LAUNCH event raised just above, and the
+     * error status carried by the spawn response itself, which is what
+     * releases it from PMIx_Spawn. */
+    if (PMIX_SUCCESS == status &&
+        prte_get_attribute(&jdata->attributes, PRTE_JOB_DVM_JOB, NULL, PMIX_BOOL)) {
 
         /* dvm job => launch was requested by a TOOL, so we notify the launch proxy
          * and NOT the originator (as that would be us) */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -120,6 +120,7 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
     prte_topology_t *t;
     prte_node_t *node;
+    prte_session_t *session;
     int i;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -164,8 +165,20 @@ void prte_plm_base_daemons_reported(int fd, short args, void *cbdata)
      * even the nodes whose counts were given.
      */
     caddy->jdata->total_slots_alloc = 0;
-    for (i = 0; i < caddy->jdata->session->nodes->size; i++) {
-        node = (prte_node_t *) pmix_pointer_array_get_item(caddy->jdata->session->nodes, i);
+    /* every path that admits a job to the launch machinery gives it a session
+     * (the default one if nothing more specific), but this handler runs for
+     * the daemon job too and is reached from several states - so treat a
+     * missing session as "the default pool" rather than dereferencing NULL
+     * and taking the whole DVM down with it */
+    session = (NULL != caddy->jdata->session) ? caddy->jdata->session : prte_default_session;
+    if (NULL == session || NULL == session->nodes) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FAILED_TO_START);
+        PMIX_RELEASE(caddy);
+        return;
+    }
+    for (i = 0; i < session->nodes->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(session->nodes, i);
         if (NULL == node) {
             continue;
         }
@@ -1596,6 +1609,16 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             prted_failed_launch = true;
             goto CLEANUP;
         }
+        /* everything below records what this daemon reports ONTO ITS NODE -
+         * the name, the aliases, the topology, the launched flag. setup_vm
+         * links the two when it creates the daemon, so a missing node means
+         * this is not a daemon we launched; say so rather than dereferencing
+         * NULL and taking the HNP down with it */
+        if (NULL == daemon->node) {
+            PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            prted_failed_launch = true;
+            goto CLEANUP;
+        }
         /* A returning daemon (the bootstrap unheal path): its node rebooted and
          * it is reporting in again after we recorded it COMM_FAILED and
          * decremented num_daemons on its death. Restore the count so the nidmap
@@ -1939,6 +1962,14 @@ void prte_plm_base_daemon_failed(int st, pmix_proc_t *sender, pmix_data_buffer_t
 
     /* get the daemon job */
     jdatorted = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL == jdatorted) {
+        /* nothing to record the failure against - but a daemon has still
+         * failed, so fail the DVM rather than returning as if nothing
+         * happened */
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FAILED_TO_START);
+        return;
+    }
 
     /* unpack the daemon that failed */
     n = 1;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1837,6 +1837,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 prted_failed_launch = true;
+                PMIX_DATA_BUFFER_DESTRUCT(data);
                 goto CLEANUP;
             }
             /* cleanup */
@@ -1854,32 +1855,50 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                 if (NULL == t) {
                     continue;
                 }
-                /* compute the diff */
+                /* Compute the diff.  hwloc allocates a list whenever it has
+                 * anything to say - including the "too complex" entry it
+                 * returns 1 with when the two topologies are genuinely
+                 * different, which is the common case here: we are walking
+                 * every recorded topology looking for the one that matches.
+                 * That list is ours to free, so free the ones we do not adopt
+                 * or a heterogeneous DVM leaks a diff per node per recorded
+                 * topology. */
+                diff = NULL;
                 ret = hwloc_topology_diff_build(t->topo, ptopo.topology, 0, &diff);
-                if (0 == ret) {
-                    pmix_output_verbose(5, prte_plm_base_framework.framework_output,
-                                        "%s TOPOLOGY ALREADY RECORDED IN POSN %d - %s DIFFS FOUND",
-                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), i,
-                                        (NULL == diff) ? "NO" : "SOME");
-                    /* the node holds a counted reference to its topology -
-                     * a daemon can report in more than once (bootstrap
-                     * unheal), so release any prior reference first */
-                    if (NULL != daemon->node->topology) {
-                        PMIX_RELEASE(daemon->node->topology);
+                if (0 != ret) {
+                    if (NULL != diff) {
+                        hwloc_topology_diff_destroy(diff);
+                        diff = NULL;
                     }
-                    PMIX_RETAIN(t);
-                    daemon->node->topology = t;
-                    found = true;
-                    /* update the node's available processors */
-                    if (NULL != daemon->node->available) {
-                        hwloc_bitmap_free(daemon->node->available);
-                    }
-                    daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
-                    daemon->node->topodiff = diff;
-                    // release the unpacked topology
-                    PMIX_TOPOLOGY_DESTRUCT(&ptopo);
-                    break;
+                    continue;
                 }
+                pmix_output_verbose(5, prte_plm_base_framework.framework_output,
+                                    "%s TOPOLOGY ALREADY RECORDED IN POSN %d - %s DIFFS FOUND",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), i,
+                                    (NULL == diff) ? "NO" : "SOME");
+                /* the node holds a counted reference to its topology -
+                 * a daemon can report in more than once (bootstrap
+                 * unheal), so release any prior reference first */
+                if (NULL != daemon->node->topology) {
+                    PMIX_RELEASE(daemon->node->topology);
+                }
+                PMIX_RETAIN(t);
+                daemon->node->topology = t;
+                found = true;
+                /* update the node's available processors */
+                if (NULL != daemon->node->available) {
+                    hwloc_bitmap_free(daemon->node->available);
+                }
+                daemon->node->available = prte_hwloc_base_filter_cpus(t->topo);
+                /* likewise the diff: a repeat report would otherwise drop the
+                 * one recorded last time on the floor */
+                if (NULL != daemon->node->topodiff) {
+                    hwloc_topology_diff_destroy(daemon->node->topodiff);
+                }
+                daemon->node->topodiff = diff;
+                // release the unpacked topology
+                PMIX_TOPOLOGY_DESTRUCT(&ptopo);
+                break;
             }
             if (!found) {
                 // this is a new topology

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2244,6 +2244,10 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     pmix_rank_t vpid;
     pmix_proc_t grow_requester;
     char *grow_alloc_id = NULL, *grow_req_id = NULL;
+    /* the vpids THIS pass assigned, recorded as they are handed out (elastic
+     * mode only - they are what a grow campaign must name) */
+    pmix_rank_t *new_vpids = NULL;
+    int n_new_vpids = 0;
 
     PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
                          "%s plm:base:setup_vm",
@@ -2258,12 +2262,33 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     }
     map = daemons->map;
 
+    /* Reset the per-launch daemon accounting.  The daemon job's map is
+     * PERSISTENT - it accumulates the DVM's nodes across every launch - but
+     * these two fields describe only the launch we are about to compute, and
+     * every launcher reads them straight afterwards.  So they have to be
+     * cleared here, on every pass, rather than in the individual branches
+     * below (where two of the four forgot to, and the grow path had to
+     * rediscover the need for itself):
+     *
+     * - num_new_daemons is what tells a component whether to launch at all;
+     *   accumulated across passes it makes a launcher spawn daemons for nodes
+     *   an earlier launch already covered.
+     * - daemon_vpid_start is the base vpid slurm/lsf/pals substitute into the
+     *   prted command line - the RM starts N tasks and each computes its own
+     *   vpid by offsetting from it.  Left over from the initial DVM launch, a
+     *   later add-host launch would tell its new daemons to claim vpids that
+     *   already belong to live daemons.  ssh is immune (it substitutes each
+     *   node's real vpid per launch), which is why this went unnoticed.
+     */
+    map->num_new_daemons = 0;
+    map->daemon_vpid_start = PMIX_RANK_INVALID;
+
     /* if this job is being launched against a fixed DVM, then there is
      * nothing for us to do - the DVM will stand as is */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_FIXED_DVM, NULL, PMIX_BOOL)) {
-        /* mark that the daemons have reported so we can proceed */
+        /* mark that the daemons have reported so we can proceed - the
+         * accounting above already says "nothing to launch" */
         daemons->state = PRTE_JOB_STATE_DAEMONS_REPORTED;
-        map->num_new_daemons = 0;
         return PRTE_SUCCESS;
     }
 
@@ -2272,13 +2297,6 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM, NULL, PMIX_BOOL)) {
         // nodes have been added, so extend the DVM
         prte_remove_attribute(&jdata->attributes, PRTE_JOB_EXTEND_DVM);
-        /* Reset the per-launch daemon accounting. The initial-VM path zeroes
-         * these further below, but the grow path skips that code and would
-         * otherwise accumulate num_new_daemons across successive grows and
-         * reuse a stale daemon_vpid_start - corrupting the grow campaign's
-         * target list and suppressing its completion event (#2491). */
-        map->num_new_daemons = 0;
-        map->daemon_vpid_start = PMIX_RANK_INVALID;
         /* A grow launches daemons on the nodes THIS request added, and only
          * those: an allocation request naming node4 must start a daemon on
          * node4 alone. Every producer of a grow (the no-scheduler
@@ -2395,7 +2413,6 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
             /* reset the state so it can be used for mapping */
             node->state = PRTE_NODE_STATE_UP;
         }
-        map->num_new_daemons = 0;
         /* if we didn't get anything, then there is nothing else to
          * do as no other daemons are to be launched
          */
@@ -2505,11 +2522,6 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
         /* maintain accounting */
         PMIX_RETAIN(node);
     }
-
-    /* zero-out the number of new daemons as we will compute this
-     * each time we are called
-     */
-    map->num_new_daemons = 0;
 
     /* Construct the list of nodes this launch may use: everything in the
      * node pool, filtered through the union of the app specs.  The pool is
@@ -2774,6 +2786,25 @@ process:
         if (PMIX_RANK_INVALID == map->daemon_vpid_start) {
             map->daemon_vpid_start = proc->name.rank;
         }
+        /* An elastic grow campaign has to name the exact ranks it launched,
+         * so remember them as they are assigned rather than reconstructing
+         * them afterwards as a run starting at daemon_vpid_start.  That
+         * reconstruction is right only while vpids are handed out
+         * consecutively, which is not the rule in a bootstrapped DVM (there
+         * a daemon takes its node's canonical rank), and a campaign naming
+         * ranks it did not launch never drains its fence. */
+        if (prte_elastic_mode) {
+            pmix_rank_t *tmpv = (pmix_rank_t *) realloc(new_vpids,
+                                                        (n_new_vpids + 1) * sizeof(pmix_rank_t));
+            if (NULL == tmpv) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                free(new_vpids);
+                PMIX_LIST_DESTRUCT(&nodes);
+                return PRTE_ERR_OUT_OF_RESOURCE;
+            }
+            new_vpids = tmpv;
+            new_vpids[n_new_vpids++] = proc->name.rank;
+        }
         /* loop across all app procs on this node and update their parent */
         for (i = 0; i < node->procs->size; i++) {
             if (NULL != (pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, i))) {
@@ -2811,6 +2842,7 @@ process:
                                 NULL, PMIX_BOOL);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
+            free(new_vpids);
             return rc;
         }
     }
@@ -2826,6 +2858,7 @@ process:
             prte_plm_base_dvm_mod_notify(&grow_requester, grow_alloc_id,
                                          grow_req_id, true, PMIX_SUCCESS);
         }
+        free(new_vpids);
         return PRTE_SUCCESS;
     }
 
@@ -2835,23 +2868,21 @@ process:
      * normal daemon-failure handling, completely unchanged. */
     if (prte_elastic_mode && 0 < map->num_new_daemons) {
         prte_grow_campaign_t *gcamp;
-        pmix_rank_t gr;
-        int gk;
 
         /* Record this launch campaign so the launch fence can be resolved on
          * a per-daemon basis: each new daemon either reports home (success)
          * or its launch fails (comm-failure / failed-to-start), and only
          * those specific ranks affect this campaign.  This avoids an
          * unrelated daemon loss consuming the fence, and lets concurrent
-         * campaigns be tracked independently.  The new daemons were assigned
-         * consecutive vpids starting at map->daemon_vpid_start (see the
-         * daemon-creation loop above). */
+         * campaigns be tracked independently.  The targets are the vpids the
+         * daemon-creation loop above actually handed out, collected as it
+         * went - see the note there on why they are not reconstructed from
+         * map->daemon_vpid_start. */
         gcamp = PMIX_NEW(prte_grow_campaign_t);
-        gcamp->ntargets = map->num_new_daemons;
-        gcamp->targets = (pmix_rank_t *) malloc(gcamp->ntargets * sizeof(pmix_rank_t));
-        for (gk = 0, gr = map->daemon_vpid_start; gk < gcamp->ntargets; gk++, gr++) {
-            gcamp->targets[gk] = gr;
-        }
+        gcamp->ntargets = n_new_vpids;
+        gcamp->targets = new_vpids;
+        new_vpids = NULL;
+        n_new_vpids = 0;
         /* Record the requester for the spec's phase-two completion event.  The
          * RAS reservation machinery sets each reserved node's ->session
          * backpointer (add_nodes_to_session), and that session carries the
@@ -2887,7 +2918,8 @@ process:
             }
         }
         pmix_list_append(&prte_grow_campaigns, &gcamp->super);
-        prte_dvm_launch_fence += map->num_new_daemons;
+        /* raise the fence by exactly what this campaign will drain */
+        prte_dvm_launch_fence += gcamp->ntargets;
     }
 
     return PRTE_SUCCESS;

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -265,49 +265,13 @@ void prte_plm_base_daemons_launched(int fd, short args, void *cbdata)
     PMIX_RELEASE(caddy);
 }
 
-static void files_ready(int status, void *cbdata)
-{
-    prte_job_t *jdata = (prte_job_t *) cbdata;
-
-    if (PRTE_SUCCESS != status) {
-        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
-    } else {
-        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP);
-    }
-}
-
-void prte_plm_base_vm_ready(int fd, short args, void *cbdata)
-{
-    prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
-    prte_node_t *node;
-    PRTE_HIDE_UNUSED_PARAMS(fd, args);
-
-    PMIX_ACQUIRE_OBJECT(caddy);
-
-    /* progress the job */
-    caddy->jdata->state = PRTE_JOB_STATE_VM_READY;
-
-    /* check the first daemon's node for topology
-     * limitations - or the HNP's node if we didn't
-     * launch any daemons */
-    node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, 1);
-    if (NULL == node) {
-        node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, 0);
-    }
-    if (NULL != node && NULL != node->topology &&
-        NULL != node->topology->topo) {
-        prte_rmaps_base.require_hwtcpus = !prte_hwloc_base_core_cpus(node->topology->topo);
-        prte_rmaps_base.have_cores = prte_hwloc_base_has_cores(node->topology->topo);
-    }
-
-    /* position any required files */
-    if (PRTE_SUCCESS != prte_filem.preposition_files(caddy->jdata, files_ready, caddy->jdata)) {
-        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_FILES_POSN_FAILED);
-    }
-
-    /* cleanup */
-    PMIX_RELEASE(caddy);
-}
+/* NOTE: there is no prte_plm_base_vm_ready() here, and there must not be
+ * one.  The VM_READY handler the DVM actually runs is vm_ready() in
+ * state/dvm - it builds and xcasts the WIREUP message, drains the elastic
+ * grow campaigns, and prepositions files.  This file carried a second,
+ * unregistered copy that only did the topology check and the
+ * prepositioning; nothing in the tree ever called it, so it drifted while
+ * looking authoritative.  Edit the live one. */
 
 void prte_plm_base_mapping_complete(int fd, short args, void *cbdata)
 {
@@ -856,16 +820,8 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
     PMIX_RELEASE(caddy);
 }
 
-void prte_plm_base_setup_job_complete(int fd, short args, void *cbdata)
-{
-    prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(fd, args);
-
-    PMIX_ACQUIRE_OBJECT(caddy);
-    /* nothing to do here but move along */
-    PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_ALLOCATE);
-    PMIX_RELEASE(caddy);
-}
+/* Likewise no prte_plm_base_setup_job_complete(): state/dvm registers its
+ * own init_complete() on PRTE_JOB_STATE_INIT_COMPLETE. */
 
 void prte_plm_base_complete_setup(int fd, short args, void *cbdata)
 {

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -218,10 +218,13 @@ static int resolve_spawn_targets(prte_job_t *jdata, pmix_proc_t *requestor,
                 }
             }
         }
-        /* the spawned job becomes an owner of the reservation it targets, so
-         * it may in turn spawn further jobs onto those nodes (no-op for the
-         * default session) */
-        prte_session_add_owner(s, jdata->nspace);
+        /* The spawned job becomes an owner of the reservation it targets, so
+         * it may in turn spawn further jobs onto those nodes - but NOT here:
+         * the job has no namespace yet (the HNP assigns it in
+         * prte_plm_base_setup_job, which is also where the grant is now
+         * made). Recording it at this point wrote an EMPTY namespace into the
+         * owner set, and an empty namespace matches every other one, so the
+         * first job spawned into a reservation opened it to everybody. */
         start = p + 1;
     }
 
@@ -628,16 +631,17 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
         }
 
 moveon:
-        /* from here on the job is referenced by the session (and shortly by
-         * the parent's child list and the global job pool), so the error
-         * paths below must NOT free it out from under them */
-        own_jdata = false;
-        jdata->session = session;
-        pmix_pointer_array_add(jdata->session->jobs, jdata);
-
-        /* a job reaching a reservation through the legacy single-session
+        /* A job reaching a reservation through the legacy single-session
          * attributes (no spawn-target list) must still pass the ownership
-         * check and become an owner of that reservation */
+         * check.  Vet it BEFORE the job is handed to the session below: a
+         * rejected request that has already been added to session->jobs
+         * stays there for the life of the session (that array borrows its
+         * entries, so nothing ever removes or releases it), leaving a
+         * phantom job the session teardown will walk.
+         *
+         * The matching GRANT - the spawned job becoming an owner itself, so
+         * it can spawn onto those nodes in turn - happens in
+         * prte_plm_base_setup_job, once the job has a namespace to record. */
         if (NULL == jdata->target_sessions && NULL != session &&
             session != prte_default_session &&
             (PRTE_SESSION_FLAG_RESERVED & session->flags)) {
@@ -645,8 +649,14 @@ moveon:
                 rc = PRTE_ERR_PERM;
                 goto ANSWER_LAUNCH;
             }
-            prte_session_add_owner(session, jdata->nspace);
         }
+
+        /* from here on the job is referenced by the session (and shortly by
+         * the parent's child list and the global job pool), so the error
+         * paths below must NOT free it out from under them */
+        own_jdata = false;
+        jdata->session = session;
+        pmix_pointer_array_add(jdata->session->jobs, jdata);
 
         /* get the parent's job object */
         if (NULL != (parent = prte_get_job_data_object(nptr->nspace)) &&

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -295,14 +295,13 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     /* jdata MUST start NULL: the ANSWER_LAUNCH error path reads it, and we
      * can reach that path before (or without) it ever being assigned - e.g.,
      * when the job object fails to unpack */
-    prte_job_t *jdata = NULL, *parent;
+    prte_job_t *jdata = NULL, *parent, *daemons;
     /* true while the freshly unpacked job object belongs to nobody but us -
      * cleared once it has been handed to a session/parent/the job pool */
     bool own_jdata = false;
     pmix_data_buffer_t *answer;
     pmix_rank_t vpid;
-    prte_proc_t *proc;
-    prte_node_t *node;
+    prte_proc_t *proc, *dproc;
     prte_proc_state_t state;
     prte_exit_code_t exit_code;
     int32_t rc = PRTE_SUCCESS, ret;
@@ -431,6 +430,13 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             jdata->uid = tooluid;
             jdata->gid = toolgid;
             rc = prte_set_job_data_object(jdata);
+            if (PRTE_SUCCESS != rc) {
+                PRTE_ERROR_LOG(rc);
+                PMIX_RELEASE(jdata);
+                jdata = NULL;
+                free(tmp);
+                goto CLEANUP;
+            }
             app = PMIX_NEW(prte_app_context_t);
             if (NULL != tmp) {
                 app->argv = PMIx_Argv_split(tmp, ' ');
@@ -447,15 +453,35 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
             proc->pid = pid;
             proc->state = PRTE_PROC_STATE_RUNNING;
             pmix_pointer_array_set_item(jdata->procs, name.rank, proc);
-            // find the node it is on
-            node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, sender->rank);
-            if (NULL == node) {
-                PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-                rc = PRTE_ERR_NOT_FOUND;
-                goto CLEANUP;
+            /* Find the node the tool is on: it connected through the daemon
+             * that is reporting it, so ask that DAEMON where it is.
+             *
+             * This used to index prte_node_pool by the reporting daemon's
+             * rank, which is only right while daemon vpids and node-pool
+             * indices happen to run in step. They need not: the pool holds
+             * every node the allocation named, including ones no daemon was
+             * ever launched on (filtered out by a -host/hostfile spec, marked
+             * DO_NOT_USE, or shrunk away), while vpids are handed out only to
+             * nodes that get a daemon. One such node ahead of the reporter is
+             * enough to name the wrong node - or, past the end of the pool,
+             * none at all.
+             *
+             * Not knowing where a tool sits is also not a reason to bring the
+             * DVM down, which is what the old NOT_FOUND did: it fell through
+             * to the master's CLEANUP, which activates FORCED_EXIT. Record
+             * what we know and carry on. */
+            daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+            dproc = (NULL == daemons) ? NULL
+                  : (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, sender->rank);
+            if (NULL != dproc && NULL != dproc->node) {
+                /* the node backpointer is borrowed, not retained */
+                proc->node = dproc->node;
+            } else {
+                pmix_output_verbose(5, prte_plm_base_framework.framework_output,
+                                    "%s plm:base:receive tool %s attached via unknown daemon %s",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&name),
+                                    PRTE_NAME_PRINT(sender));
             }
-            /* the node backpointer is borrowed, not retained */
-            proc->node = node;
             jdata->num_procs = 1;
         }
         /* setup the response */

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -57,10 +57,6 @@ typedef struct {
     char *base_nspace;
     /* next jobid */
     uint32_t next_jobid;
-    /* time when daemons started launch */
-    struct timeval daemonlaunchstart;
-    /* tree spawn cmd */
-    pmix_data_buffer_t tree_spawn_cmd;
     /* daemon nodes assigned at launch */
     bool daemon_nodes_assigned_at_launch;
     /* include MCA params found in our environment on the prted cmd line.

--- a/src/mca/plm/lsf/AGENTS.md
+++ b/src/mca/plm/lsf/AGENTS.md
@@ -56,7 +56,9 @@ and the module. There is no version probing.
 3. Build the **`prted` argv**: strip stray `PMIX_LAUNCHER_*` env vars,
    `prte_plm_base_setup_prted_cmd`, then
    `prte_plm_base_prted_append_basic_args(..., "lsf", &proc_vpid_index)`,
-   substitute `map->daemon_vpid_start` into the vpid slot,
+   substitute `map->daemon_vpid_start` into the vpid slot (recomputed by
+   `setup_virtual_machine` on every launch - a stale base would tell the
+   daemons of a later add-host launch to claim ranks live daemons own),
    `prte_plm_base_wrap_args`.
 4. Build the **environment** (`env`): copy `prte_launch_environ` (already
    stripped of `PRTE_`/`PMIX_` vars), then rewrite `PATH`/

--- a/src/mca/plm/pals/AGENTS.md
+++ b/src/mca/plm/pals/AGENTS.md
@@ -56,7 +56,9 @@ is the default launcher.
    using the full allocation rather than an explicit host list.
 3. **Build the `prted` argv:** `prte_plm_base_setup_prted_cmd`, then
    `prte_plm_base_prted_append_basic_args(..., "pals", &proc_vpid_index)`,
-   substitute `map->daemon_vpid_start` into the vpid slot,
+   substitute `map->daemon_vpid_start` into the vpid slot (recomputed by
+   `setup_virtual_machine` on every launch - a stale base would tell the
+   daemons of a later add-host launch to claim ranks live daemons own),
    `prte_plm_base_wrap_args`.
 4. Copy `prte_launch_environ` (already stripped of `PRTE_`/`PMIX_`
    vars) as the child env; read the prefix(es) from the daemon job

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -76,7 +76,12 @@ If `srun` can't be run or the version can't be parsed, it declines.
    `prte_plm_base_prted_append_basic_args(..., "slurm", &proc_vpid_index)`.
    Substitute `map->daemon_vpid_start` into the vpid slot — SLURM starts
    the tasks and each daemon offsets from this base to compute its own
-   vpid. `prte_plm_base_wrap_args` quotes multi-word args (in case srun is
+   vpid. That base is recomputed by `setup_virtual_machine` on **every**
+   launch, and this component is one of the three reasons it must be: a
+   stale base (left over from DVM formation) tells the daemons of a later
+   `--add-host` launch to claim ranks that live daemons already own. `ssh`
+   never sees it, so the invariant is pinned in `test/unit/plm`, not in
+   the swarm. `prte_plm_base_wrap_args` quotes multi-word args (in case srun is
    wrapped by a script).
 4. Read the prefix(es) from the daemon job object and exec via
    `plm_slurm_start_proc`. Set state `DAEMONS_LAUNCHED`. On any error jump

--- a/src/mca/plm/slurm/plm_slurm_component.c
+++ b/src/mca/plm/slurm/plm_slurm_component.c
@@ -138,9 +138,14 @@ static int prte_mca_plm_slurm_component_query(pmix_mca_base_module_t **module, i
             return PRTE_ERROR;
         }
         ++ptr;
-        // parse on the dots
+        // parse on the dots. Step over the separator only if there IS one:
+        // "slurm 23" with no minor leaves ptr on the terminating NUL, and
+        // walking past that reads whatever the uninitialized tail of the
+        // fgets buffer happens to hold
         prte_mca_plm_slurm_component.major = strtol(ptr, &ptr, 10);
-        ++ptr;
+        if ('\0' != *ptr) {
+            ++ptr;
+        }
         prte_mca_plm_slurm_component.minor = strtol(ptr, NULL, 10);
 
         if (23 > prte_mca_plm_slurm_component.major) {

--- a/src/mca/plm/ssh/help-plm-ssh.txt
+++ b/src/mca/plm/ssh/help-plm-ssh.txt
@@ -55,3 +55,12 @@ The cmd line to launch remote daemons is too long:
 Consider setting -mca plm_ssh_pass_environ_mca_params 0 to
 avoid including any environmentally set MCA parameters on the
 command line.
+
+[no-launch-agent]
+The launch agent to be used for starting daemons was set to an empty
+value, so there is no command to run on the remote nodes:
+
+  prte_launch_agent: <empty>
+
+Set prte_launch_agent to the daemon command you want started (the
+default is "prted"), or leave it unset to use that default.

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -261,6 +261,10 @@ static int ssh_component_query(pmix_mca_base_module_t **module, int *priority)
             *module = NULL;
             return PRTE_ERROR;
         }
+        /* the MCA var system handed us a heap copy of the default and will
+         * free whatever pointer it finds here at deregistration, so release
+         * the one we are replacing rather than dropping it */
+        free(prte_mca_plm_ssh_component.agent);
         prte_mca_plm_ssh_component.agent = tmp;
         prte_mca_plm_ssh_component.using_qrsh = true;
         goto success;
@@ -278,6 +282,7 @@ static int ssh_component_query(pmix_mca_base_module_t **module, int *priority)
             *module = NULL;
             return PRTE_ERROR;
         }
+        free(prte_mca_plm_ssh_component.agent);
         prte_mca_plm_ssh_component.agent = strdup("llspawn");
         prte_mca_plm_ssh_component.using_llspawn = true;
         goto success;
@@ -289,6 +294,7 @@ static int ssh_component_query(pmix_mca_base_module_t **module, int *priority)
         NULL != getenv("PBS_JOBID")) {
         /* we already found the absolute path to pbs_tmrsh */
         PMIx_Argv_append_nosize(&prte_mca_plm_ssh_component.agent_argv , PRTE_PBSTRMSH_PATH);
+        free(prte_mca_plm_ssh_component.agent);
         prte_mca_plm_ssh_component.agent = strdup("pbs_tmrsh");
         prte_mca_plm_ssh_component.using_tmrsh = true;
         goto success;

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -698,6 +698,16 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     } else {
         full_orted_cmd = orted_cmd;
     }
+    if (NULL == full_orted_cmd) {
+        /* prte_launch_agent named nothing to run - an empty
+         * --prtemca prte_launch_agent "" gets here. There is no command to
+         * ssh, so say so rather than strdup(NULL) */
+        prte_show_help("help-plm-ssh.txt", "no-launch-agent", true);
+        free(orted_prefix);
+        PMIx_Argv_free(final_argv);
+        PMIx_Argv_free(argv);
+        return PRTE_ERR_SILENT;
+    }
     if (NULL != orted_prefix) {
         pmix_asprintf(&tmp, "%s %s", orted_prefix, full_orted_cmd);
         free(orted_prefix);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -1204,6 +1204,14 @@ void prte_session_add_owner(prte_session_t *session,
     if (NULL == session || session == prte_default_session) {
         return;
     }
+    /* An EMPTY namespace must never enter the owner set. PMIx_Check_nspace
+     * answers "true" whenever either side is empty - that is its wildcard
+     * rule - so an empty entry here makes prte_session_is_owned_by() say yes
+     * to every namespace that ever asks, silently retiring the reservation's
+     * ownership gate. A caller with nothing to record has nothing to grant. */
+    if (PMIX_NSPACE_INVALID(nspace)) {
+        return;
+    }
     if (NULL != session->owners) {
         for (n = 0; NULL != session->owners[n]; n++) {
             if (PMIX_CHECK_NSPACE(session->owners[n], nspace)) {

--- a/test/unit/plm/test_plm.c
+++ b/test/unit/plm/test_plm.c
@@ -62,6 +62,8 @@
 #include "src/util/pmix_environ.h"
 #include "src/util/proc_info.h"
 
+#include "src/mca/rmaps/rmaps_types.h"
+
 #include "src/mca/plm/base/base.h"
 #include "src/mca/plm/base/plm_private.h"
 #include "src/mca/plm/plm.h"
@@ -767,6 +769,191 @@ static int test_state_update_wire(void)
     return failures;
 }
 
+/*
+ * prte_init_util() stops short of building the global job/node arrays --
+ * that happens in prte_init(), which wants a live ESS, session directories
+ * and a network stack.  Stand up just the pieces setup_virtual_machine
+ * touches: the job pool with the daemon job in it, the node pool with the
+ * HNP's own node at index 0, and the topology array.
+ */
+/* create the array if this process has none yet, else empty the one it has -
+ * an earlier test in this binary may already have registered jobs, and they
+ * must not be visible to (or leaked by) this one */
+static void fresh_array(pmix_pointer_array_t **array)
+{
+    int i;
+    void *item;
+
+    if (NULL == *array) {
+        *array = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(*array, 8, INT_MAX, 8);
+        return;
+    }
+    for (i = 0; i < (*array)->size; i++) {
+        item = pmix_pointer_array_get_item(*array, i);
+        if (NULL != item) {
+            pmix_pointer_array_set_item(*array, i, NULL);
+            PMIX_RELEASE(item);
+        }
+    }
+}
+
+static int setup_vm_globals(const char *dvm_nspace)
+{
+    prte_job_t *djob;
+    prte_node_t *hnp;
+
+    fresh_array(&prte_job_data);
+    fresh_array(&prte_node_pool);
+    fresh_array(&prte_node_topologies);
+
+    djob = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(djob->nspace, dvm_nspace);
+    PMIX_LOAD_PROCID(PRTE_PROC_MY_NAME, dvm_nspace, 0);
+    /* the HNP is daemon 0 and is already "launched" */
+    djob->num_procs = 1;
+    prte_set_job_data_object(djob);
+
+    hnp = PMIX_NEW(prte_node_t);
+    hnp->name = strdup("plm-test-hnp");
+    hnp->state = PRTE_NODE_STATE_UP;
+    hnp->slots = 1;
+    hnp->index = pmix_pointer_array_add(prte_node_pool, hnp);
+    PRTE_FLAG_SET(hnp, PRTE_NODE_FLAG_DAEMON_LAUNCHED);
+
+    return (0 == hnp->index) ? PRTE_SUCCESS : PRTE_ERROR;
+}
+
+/* add a node to the pool in the given state */
+static prte_node_t *pool_node(const char *name, prte_node_state_t state)
+{
+    prte_node_t *nd = PMIX_NEW(prte_node_t);
+
+    nd->name = strdup(name);
+    nd->state = state;
+    nd->slots = 2;
+    nd->index = pmix_pointer_array_add(prte_node_pool, nd);
+    return nd;
+}
+
+/* a job that looks like a dynamic spawn: it has an originator, which is what
+ * routes setup_virtual_machine down the "only absorb nodes this request
+ * added" branch */
+static prte_job_t *spawn_job(const char *nspace)
+{
+    prte_job_t *jdata = PMIX_NEW(prte_job_t);
+
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
+    PMIX_LOAD_PROCID(&jdata->originator, "some-tool", 0);
+    return jdata;
+}
+
+/*
+ * prte_plm_base_setup_virtual_machine builds the DAEMON job's map, and that
+ * map is persistent: it accumulates the DVM's nodes across every launch.
+ * Two of its fields are not cumulative, though - they describe the launch
+ * about to happen, and every component reads them the moment setup_vm
+ * returns:
+ *
+ *   num_new_daemons    - whether to launch anything at all;
+ *   daemon_vpid_start  - the base vpid slurm/lsf/pals substitute into the
+ *                        prted command line, from which each daemon the RM
+ *                        starts computes its own name.
+ *
+ * A stale daemon_vpid_start is invisible under ssh (which substitutes each
+ * node's real vpid per node) and fatal under any RM launcher: the daemons of
+ * a later add-host launch are told to claim vpids that already belong to
+ * live daemons.  So check that each pass reports ITS OWN daemons.
+ */
+static int test_setup_vm(void)
+{
+    int failures = 0;
+    prte_job_t *daemons, *jdata;
+    prte_job_map_t *map;
+    prte_node_t *n1, *n2, *n3;
+    pmix_proc_t save_me;
+    pmix_rank_t first_start;
+
+    memcpy(&save_me, PRTE_PROC_MY_NAME, sizeof(pmix_proc_t));
+
+    if (PRTE_SUCCESS != setup_vm_globals("plm-test-dvm")) {
+        fprintf(stderr, "FAIL [setup_vm]: could not build globals\n");
+        memcpy(PRTE_PROC_MY_NAME, &save_me, sizeof(pmix_proc_t));
+        return 1;
+    }
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+
+    /* two more nodes in the allocation.  The first pass through a dynamic
+     * spawn has no map yet, so it absorbs the whole pool - the same shape as
+     * initial DVM formation */
+    n1 = pool_node("plm-test-n1", PRTE_NODE_STATE_UP);
+    n2 = pool_node("plm-test-n2", PRTE_NODE_STATE_UP);
+
+    jdata = spawn_job("plm-test-job1");
+    CHECK("setup_vm first pass succeeds", PRTE_SUCCESS == prte_plm_base_setup_virtual_machine(jdata));
+    map = daemons->map;
+    CHECK("first pass has a map", NULL != map);
+    if (NULL == map) {
+        goto done;
+    }
+    CHECK("first pass launches both nodes", 2 == map->num_new_daemons);
+    CHECK("first pass daemons got vpids", NULL != n1->daemon && NULL != n2->daemon);
+    first_start = map->daemon_vpid_start;
+    CHECK("first pass start vpid is the first new daemon",
+          NULL != n1->daemon && first_start == n1->daemon->name.rank);
+    CHECK("first pass start vpid is not INVALID", PMIX_RANK_INVALID != first_start);
+    CHECK("daemon job spans the new vpids", 3 == daemons->num_procs);
+    PMIX_RELEASE(jdata);
+
+    /* Now a SECOND launch that brings in one more node - the add-host /
+     * elastic-grow shape.  Its daemon takes the next free vpid, and that is
+     * what the launcher must be told.  Before this was fixed, the map still
+     * carried the first pass's start vpid and an RM launcher would have
+     * started the new daemon as vpid 1 - a rank a live daemon already owns. */
+    n3 = pool_node("plm-test-n3", PRTE_NODE_STATE_ADDED);
+    jdata = spawn_job("plm-test-job2");
+    CHECK("setup_vm second pass succeeds",
+          PRTE_SUCCESS == prte_plm_base_setup_virtual_machine(jdata));
+    CHECK("second pass launches only the added node", 1 == map->num_new_daemons);
+    CHECK("second pass gave the new node a daemon", NULL != n3->daemon);
+    CHECK("second pass start vpid is the NEW daemon",
+          NULL != n3->daemon && map->daemon_vpid_start == n3->daemon->name.rank);
+    CHECK("second pass start vpid is not the first pass's",
+          map->daemon_vpid_start != first_start);
+    CHECK("daemon job spans the new vpid", 4 == daemons->num_procs);
+    PMIX_RELEASE(jdata);
+
+    /* A third pass with nothing new: the fast path every component keys off.
+     * num_new_daemons must be zero AND the start vpid must not be left
+     * pointing at the previous launch's daemons. */
+    jdata = spawn_job("plm-test-job3");
+    CHECK("setup_vm third pass succeeds",
+          PRTE_SUCCESS == prte_plm_base_setup_virtual_machine(jdata));
+    CHECK("third pass launches nothing", 0 == map->num_new_daemons);
+    CHECK("third pass start vpid is cleared", PMIX_RANK_INVALID == map->daemon_vpid_start);
+    CHECK("third pass marks the daemons reported",
+          PRTE_JOB_STATE_DAEMONS_REPORTED == daemons->state);
+    PMIX_RELEASE(jdata);
+
+    /* a job pinned to a fixed DVM never launches a daemon, whatever the pool
+     * looks like */
+    pool_node("plm-test-n4", PRTE_NODE_STATE_ADDED);
+    jdata = spawn_job("plm-test-job4");
+    prte_set_attribute(&jdata->attributes, PRTE_JOB_FIXED_DVM, PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+    CHECK("setup_vm fixed-dvm succeeds",
+          PRTE_SUCCESS == prte_plm_base_setup_virtual_machine(jdata));
+    CHECK("fixed dvm launches nothing", 0 == map->num_new_daemons);
+    CHECK("fixed dvm start vpid is cleared", PMIX_RANK_INVALID == map->daemon_vpid_start);
+    PMIX_RELEASE(jdata);
+
+done:
+    memcpy(PRTE_PROC_MY_NAME, &save_me, sizeof(pmix_proc_t));
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_setup_vm\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -805,6 +992,8 @@ int main(void)
     failures += test_append_basic_args();
     failures += test_naming();
     failures += test_state_update_wire();
+    /* leaves the global job/node pools populated, so run it last */
+    failures += test_setup_vm();
 
     (void) pmix_mca_base_framework_close(&prte_plm_base_framework);
     PMIx_server_finalize();

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -275,7 +275,7 @@ static int test_session_registry(void)
 static int test_session_ownership(void)
 {
     int failures = 0;
-    prte_session_t *s;
+    prte_session_t *s, *s2;
     prte_session_t *saved_default;
 
     reset_globals();
@@ -310,6 +310,26 @@ static int test_session_ownership(void)
 
     /* a NULL session is the default pool */
     CHECK("owner: NULL session admits anyone", prte_session_is_owned_by(NULL, NS("nsZ")));
+
+    /* An EMPTY namespace must never be recorded as an owner, and the case
+     * that matters is a reservation whose owner list is still empty - with
+     * entries present, the wildcard below makes the empty one look like a
+     * duplicate and it is dropped by accident rather than on purpose.
+     *
+     * This is not hypothetical: a spawn request arrives with no namespace at
+     * all (the HNP names the job later, in prte_plm_base_setup_job), so the
+     * code that granted the spawned job ownership at request-vetting time
+     * handed in exactly this.  An empty entry does not merely fail to
+     * identify anybody - PMIx_Check_nspace treats an empty side as a
+     * wildcard, so it matches EVERY namespace and retires the reservation's
+     * ownership gate for good. */
+    s2 = PMIX_NEW(prte_session_t);
+    s2->session_id = 8;
+    CHECK("owner: second insert succeeds", PRTE_SUCCESS == prte_set_session_object(s2));
+    prte_session_add_owner(s2, NS(""));
+    CHECK("owner: an empty namespace is not recorded", 0 == PMIx_Argv_count(s2->owners));
+    CHECK("owner: an empty owner does not admit everybody",
+          !prte_session_is_owned_by(s2, NS("nsC")));
 
     reset_globals();
     return failures;


### PR DESCRIPTION
A second deep review of `src/mca/plm`, following #2548. Six review+fix rounds; the last found nothing of consequence. Each commit stands alone.

## The two that matter

**The per-launch daemon accounting was never reset.** The daemon job's map is persistent, but `num_new_daemons` and `daemon_vpid_start` describe only the launch being computed — and every launcher reads them the moment `setup_virtual_machine` returns. Each branch was left to clear them and two of the four did not, so a second launch that brings in a node (`--add-host`, an elastic grow) handed slurm/lsf/pals the *first* launch's base vpid: the new daemons are told to claim ranks that live daemons already own. `ssh` is immune — it substitutes each node's own vpid per node — which is why this survived so long. The reset is now done once, at the top, before any branch runs.

**A reservation's owner was recorded before the job had a name.** A spawn request arrives unnamed (the HNP names the job at `INIT`), so the grant wrote an *empty* namespace into the owner list. `PMIx_Check_nspace` treats an empty side as a wildcard, so such an entry matches every namespace and retires the reservation's ownership gate. What saved us in practice is the same rule one step earlier — the duplicate scan matched the existing owner and dropped the entry — which means the documented feature (a spawned job becoming an owner so it can spawn or extend onto those nodes) simply never worked. The grant moved to `setup_job`; `prte_session_add_owner` now refuses an empty namespace.

## The rest

- hwloc allocates a diff list whenever it has anything to say, including the `TOO_COMPLEX` entry it returns **1** with — the common outcome while scanning recorded topologies for a match. Only `0 ==` was handled, so a heterogeneous DVM leaked one diff per node per recorded topology.
- `PMIX_LAUNCH_COMPLETE` was raised for failed launches (`spawn_response` is deliberately called with failures). Success only now.
- A rejected spawn request was left in `session->jobs`, which borrows its entries and never removes one.
- `TOOL_ATTACHED` indexed the node pool by the reporting daemon's rank — only right while vpids and pool indices run in step — and a miss took the whole DVM down via `FORCED_EXIT`.
- `prte_plm_base_vm_ready()` and `prte_plm_base_setup_job_complete()` removed: unregistered duplicates of `state/dvm`'s live handlers, which the copies had drifted from (the real `vm_ready` also xcasts WIREUP and drains the grow campaigns).
- `plm_node_regex_threshold` retired — registered and documented, read by nothing; the regex has travelled in the launch message for years. Same reasoning as `plm_ssh_delay`.
- Assorted hardening: NULL guards in both daemon callbacks, a missing-session fallback, the `srun --version` parse walking past the NUL, an ssh agent-string leak, and an empty `prte_launch_agent` reaching `strdup(NULL)`.

## Tests

- `test/unit/plm` gains `test_setup_vm` (three launch passes plus a fixed-DVM job through `setup_virtual_machine`); it fails against the previous behavior.
- `test/unit/runtime` covers the empty-owner guard on a reservation with no owners yet — the case the wildcard otherwise hides.
- `contrib/dockerswarm` gains the end-to-end shape: form a DVM, bring in a third node with `--add-host`, require the second pass to add exactly one daemon. Also fixes a hardcoded container name that ignored `$PRTE_SWARM`.

Note what the swarm cannot reach: `daemon_vpid_start`'s only consumers are the RM launchers, and there is no fake `srun` — `fake-slurm.py` stands in for the SLURM control plane, not its launcher. That invariant is pinned by the unit test.

## Verification

Warning-free `--enable-debug` build; `make check` 21/21; `make -C test/offline check-offline` 1180/1180; live DVM cycle; dockerswarm **539 passed / 1 failed / 2 skipped**. The one failure ("N of 3 ranks survived a recoverable failure") is a harness output race, not a regression — the same build passes it 3/3 on re-run, and in the failing instance all three survivors had already printed their notification line; only one final `SURVIVED` print was lost at teardown.

## Left alone

#2546 (plm/slurm comparing a count against a pointer-array capacity) is untouched: benign today, and fixing it changes which nodes `srun` picks, so it wants a real SLURM allocation to re-test.