### PR TITLE
Rebind every node to its daemon on each nidmap decode (#2616)

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5846,6 +5846,54 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "elastic DVM: a job spanning a surviving daemon runs after grow/shrink/grow"
+    # The daemon that was already up when the DVM grew has to learn the new
+    # daemon's vpid, because odls walks EVERY proc of a job -- not just its own
+    # -- to wire each one to its node, and one unresolvable parent throws away
+    # the whole child list, including the process that daemon was about to fork.
+    # prte_util_decode_nidmap() used to record the node->daemon binding only
+    # when it created a new node-pool entry, so on every wireup after its first
+    # a surviving daemon skipped the binding entirely and never heard of the new
+    # daemon; it launched nothing and the HNP, which had no such gap, waited
+    # forever (openpmix/prrte#2616). It also keyed the pool by packing position
+    # while the sender skips daemon-less nodes, so a shrink slid every later
+    # node onto the wrong slot -- which is why the grow does NOT have to reuse
+    # the node that was shrunk out for this to break.
+    #
+    # Only a job that SPANS the survivor shows this: the tests above launch
+    # "prun -n 1", which lands on the HNP alone and passes with the DVM in
+    # exactly this state. Grow, shrink a node, grow a different node, then run
+    # one proc per node and require every node to report.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'timeout 90 elastic grow node2:2,node3:2' >/dev/null 2>&1
+        RUN 'timeout 90 elastic shrink node3' >/dev/null 2>&1; sleep 3
+        out=$(RUN 'timeout 90 elastic grow node4:2' 2>&1); sleep 3
+        echo "$out" | grep -q PMIX_DVM_IS_READY && ok "grow after the shrink completed" \
+                                               || bad "grow after the shrink did not complete"
+        # node2 survived both DVM changes; node4 arrived in the second grow
+        out=$(RUN 'timeout 60 prun -n 3 --map-by ppr:1:node hostname' 2>&1)
+        for n in node1 node2 node4; do
+            echo "$out" | grep -qw "$n" && ok "$n ran its proc after grow/shrink/grow" \
+                                        || bad "$n launched nothing after grow/shrink/grow (nidmap rebind)"
+        done
+        # Now re-grow the node that was shrunk OUT. It keeps the pool slot it
+        # always had, so this is the case that a slot-keyed decode cannot fix
+        # by placement alone: the survivor has the node, and only the daemon on
+        # it has changed. Nothing is rebound unless every decode rebinds.
+        RUN 'timeout 90 elastic grow node3:2' >/dev/null 2>&1; sleep 3
+        out=$(RUN 'timeout 60 prun -n 4 --map-by ppr:1:node hostname' 2>&1)
+        for n in node1 node2 node3 node4; do
+            echo "$out" | grep -qw "$n" && ok "$n ran its proc after the shrunk node was re-grown" \
+                                        || bad "$n launched nothing after the re-grow (nidmap rebind)"
+        done
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the spanning-launch test"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: a grow launches ONLY on the nodes it was given"
     # An allocation request naming node4 must start a daemon on node4 and
     # nowhere else. Shrink node2 first so the DVM holds a node that is in the

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -284,6 +284,13 @@ static void job_errors(int fd, short args, void *cbdata)
 
     switch (jobstate) {
     case PRTE_JOB_STATE_FAILED_TO_START:
+    case PRTE_JOB_STATE_NEVER_LAUNCHED:
+        /* NEVER_LAUNCHED is what odls activates when it could not build this
+         * node's child list at all. The procs it marked failed have no pid
+         * and never will, so they are retired here exactly as a failed start
+         * is - otherwise they sit in prte_local_children forever, and the
+         * daemon's own termination accounting waits on procs that do not
+         * exist. The report below goes out either way. */
         failed_start(jdata);
         break;
     case PRTE_JOB_STATE_COMM_FAILED:

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -989,12 +989,44 @@ REPORT_ERROR:
      * were told to launch) or that job - never one of the prior jobs
      * decoded above, which use their own variable. A NULL here is
      * survivable: the prted errmgr falls back to the daemon job. */
-    /* we have to report an error back to the HNP so we don't just
-     * hang. Although there shouldn't be any errors once this is
-     * all debugged, it is still good practice to have a way
-     * for it to happen - especially so developers don't have to
-     * deal with the hang!
-     */
+    /* We have to report an error back to the HNP so we don't just hang.
+     * Activating the job state is not enough on its own: what the errmgr
+     * sends the HNP is the state of this daemon's local children of that
+     * job, and a child list we failed to build has none - or has them in
+     * whatever state they were unpacked in, which the HNP reads as "nothing
+     * wrong here". The job then never completes and the tool that asked for
+     * it waits forever with nothing logged anywhere (that is what made
+     * #2616 present as a silent hang). So first fail every proc that was
+     * ours to launch, which is what gives the HNP something to act on.
+     * The master reports to nobody and already holds the authoritative
+     * job object, so this is for the daemons only. */
+    if (!PRTE_PROC_IS_MASTER && NULL != jdata && NULL != jdata->procs) {
+        int32_t nlocal = 0;
+        for (n = 0; n < jdata->procs->size; n++) {
+            pptr = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, n);
+            if (NULL == pptr || pptr->parent != PRTE_PROC_MY_NAME->rank) {
+                continue;
+            }
+            pptr->state = PRTE_PROC_STATE_FAILED_TO_START;
+            pptr->exit_code = rc;
+            /* nothing was forked and no stdio was ever opened for it, so the
+             * two things the lifecycle waits on are complete by definition */
+            PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_IOF_COMPLETE);
+            PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_WAITPID);
+            if (!PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_LOCAL)) {
+                /* the report walks prte_local_children, so a proc we never
+                 * got as far as adding would otherwise go unmentioned */
+                PMIX_RETAIN(pptr);
+                PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_LOCAL);
+                pmix_pointer_array_add(prte_local_children, pptr);
+            }
+            ++nlocal;
+        }
+        /* keep the count that the termination accounting compares against in
+         * step with the list we just completed - we abandoned the loop that
+         * normally maintains it */
+        jdata->num_local_procs = nlocal;
+    }
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
     return rc;
 }

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -851,9 +851,9 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     int rc;
     uint32_t u32;
     uint16_t u16;
-    prte_job_t *jdata;
+    prte_job_t *jdata, *dmns;
     prte_app_context_t *app;
-    prte_proc_t *proc;
+    prte_proc_t *proc, *dproc;
     prte_node_t *node;
     void *ilist, *joblist;
     pmix_data_array_t darray;
@@ -893,8 +893,20 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     proc->pid = cd->pid;
     proc->state = PRTE_PROC_STATE_RUNNING;
     pmix_pointer_array_set_item(jdata->procs, 0, proc);
-    // find the node it is on
-    node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, prte_process_info.myproc.rank);
+    // find the node it is on - the tool is on our node, and our node is
+    // whichever one carries our own daemon proc. Our vpid is not a subscript
+    // into the node pool: the pool is indexed by node identity, and in a DVM
+    // that has shrunk the two diverge (a departed daemon's vpid is retired,
+    // its node's pool slot is not).
+    node = NULL;
+    dmns = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL != dmns) {
+        dproc = (prte_proc_t *) pmix_pointer_array_get_item(dmns->procs,
+                                                            PRTE_PROC_MY_NAME->rank);
+        if (NULL != dproc) {
+            node = dproc->node;
+        }
+    }
     if (NULL == node) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         return PRTE_ERR_NOT_FOUND;

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -163,6 +163,36 @@ up and PRRTE must not.
 
 ---
 
+## The nidmap
+
+`prte_util_nidmap_create()` packs, and `prte_util_decode_nidmap()` unpacks,
+four lockstep lists — node name, aliases, daemon vpid, and the node's slot in
+the sender's `prte_node_pool` — plus the *span* of the daemon vpid space. It
+is sent to every daemon whenever the DVM's membership changes, so a daemon
+decodes it **many times**, and each decode has to leave the daemon's view
+equal to the master's:
+
+- **The pool slot travels on the wire because it is the node's identity.**
+  It is the `PMIX_NODEID` a daemon hands its local clients, and the subscript
+  the `PMIX_SERVER_URI` query resolves a nodeid through. It is *not* the
+  position in the packed list: the sender skips nodes that have no daemon, so
+  after a shrink the packed sequence is compacted while the pool is not, and
+  a receiver that used the packed position renamed one node's entry into
+  another's and gave two machines one nodeid. It is not the daemon's vpid
+  either — a shrink retires a vpid permanently but leaves the node's slot.
+- **Every decode rebinds, it does not just fill gaps.** A node's daemon
+  changes (grow, shrink, re-grow), so `nd->daemon` and
+  `daemons->procs[vpid]` are (re)established on every pass, releasing the
+  reference the node held. Binding only newly-created entries made every
+  decode after the first a no-op, which is how a daemon that predated a grow
+  never learned the new daemon existed — and `odls` resolves the parent of
+  *every* proc in a job, not just its own, so that daemon launched nothing
+  and the master, which had no such gap, waited forever (#2616).
+- **A node the sender did not name has lost its daemon** and its backpointer
+  is cleared, mirroring what the master did to its own pool on the shrink.
+
+---
+
 ## `prte_process_info`
 
 A single global, filled in by `prte_setup_hostname()` and `prte_proc_info()`.
@@ -198,6 +228,11 @@ the modex match the names found locally.
 Not unit-testable, and deliberately left to the live smoke test: `session_dir`
 (creates directories under the real `$TMPDIR`), `stacktrace` (installs signal
 handlers), `daemon_init` (forks), and `nidmap` (needs a populated DVM).
+
+`nidmap` in particular needs a DVM that has **changed size**, and a job that
+**spans a daemon which predates the change** — a one-proc job lands on the
+master, whose copy of the map is authoritative and never decoded. That is the
+elastic grow/shrink/grow case in `contrib/dockerswarm/run-tests.sh`.
 
 ---
 

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -36,6 +36,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
 {
     char *raw = NULL;
     pmix_rank_t *vpids = NULL;
+    int32_t *ndidx = NULL;
     uint8_t u8;
     int n, m, ndaemons, nbytes;
     pmix_rank_t span;
@@ -107,6 +108,21 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
+    /* Every node also carries the index of the slot it occupies in *our* node
+     * pool.  That index is the node's identity across the DVM - it is the
+     * PMIX_NODEID every daemon hands its local clients, and the subscript the
+     * PMIX_SERVER_URI query resolves a nodeid through - so the receiver has to
+     * place the node in the same slot we hold it in.  It cannot derive that
+     * from the packing order: a node whose daemon has departed stays in our
+     * pool with no daemon and is skipped below, so the packed sequence is
+     * compacted while the pool is not.  Each node has exactly one daemon here,
+     * so this list is no longer than the vpid list. */
+    ndidx = (int32_t *) malloc(span * sizeof(int32_t));
+    if (NULL == ndidx) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        free(vpids);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
 
     ndaemons = 0;
     for (n = 0; n < pool->size; n++) {
@@ -135,8 +151,9 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         } else {
             PMIx_Argv_append_nosize(&aliases, "PRTENONE");
         }
-        /* store the vpid */
+        /* store the vpid and the pool slot this node occupies */
         vpids[ndaemons] = nptr->daemon->name.rank;
+        ndidx[ndaemons] = nptr->index;
         ++ndaemons;
     }
 
@@ -144,6 +161,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     if (NULL == names || NULL == aliases) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         free(vpids);
+        free(ndidx);
         return PRTE_ERR_NOT_FOUND;
     }
 
@@ -167,6 +185,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         PMIX_ERROR_LOG(rc);
         free(bo.bytes);
         free(vpids);
+        free(ndidx);
         return rc;
     }
     /* add the object */
@@ -175,6 +194,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         PMIX_ERROR_LOG(rc);
         free(bo.bytes);
         free(vpids);
+        free(ndidx);
         return rc;
     }
     free(bo.bytes);
@@ -200,6 +220,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         PMIX_ERROR_LOG(rc);
         free(bo.bytes);
         free(vpids);
+        free(ndidx);
         return rc;
     }
     /* add the object */
@@ -208,6 +229,7 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
         PMIX_ERROR_LOG(rc);
         free(bo.bytes);
         free(vpids);
+        free(ndidx);
         return rc;
     }
     free(bo.bytes);
@@ -237,6 +259,38 @@ int prte_util_nidmap_create(pmix_pointer_array_t *pool, pmix_data_buffer_t *buff
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         free(bo.bytes);
+        free(ndidx);
+        return rc;
+    }
+    /* add the object */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &bo, 1, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        free(bo.bytes);
+        free(ndidx);
+        return rc;
+    }
+    free(bo.bytes);
+    bo.bytes = NULL;
+
+    /* compress the pool indices - again only the entries we filled */
+    nbytes = ndaemons * sizeof(int32_t);
+    if (PMIx_Data_compress((uint8_t *) ndidx, nbytes, (uint8_t **) &bo.bytes, &sz)) {
+        /* mark that this was compressed */
+        compressed = true;
+        bo.size = sz;
+        free(ndidx);
+    } else {
+        /* mark that this was not compressed */
+        compressed = false;
+        bo.bytes = (char *) ndidx;
+        bo.size = nbytes;
+    }
+    /* indicate compression */
+    rc = PMIx_Data_pack(PRTE_PROC_MY_NAME, buffer, &compressed, 1, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        free(bo.bytes);
         return rc;
     }
     /* add the object */
@@ -256,11 +310,13 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     uint8_t u8;
     pmix_rank_t *vpid = NULL;
     pmix_rank_t ndmns = 0;
-    int cnt, n;
+    int32_t *ndidx = NULL;
+    int cnt, n, nnodes;
     bool compressed;
-    size_t sz;
+    size_t sz, isz;
     pmix_byte_object_t pbo;
     char *raw = NULL, **names = NULL, **aliases = NULL;
+    char *seen = NULL;
     prte_node_t *nd;
     prte_job_t *daemons;
     prte_proc_t *proc;
@@ -387,6 +443,38 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
     }
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
 
+    /* unpack compression flag for the node pool indices */
+    cnt = 1;
+    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buf, &compressed, &cnt, PMIX_BOOL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    /* unpack the pool index object */
+    cnt = 1;
+    rc = PMIx_Data_unpack(PRTE_PROC_MY_NAME, buf, &pbo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    /* if compressed, decompress */
+    if (compressed) {
+        if (!PMIx_Data_decompress((uint8_t *) pbo.bytes, pbo.size, (uint8_t **) &ndidx, &isz)) {
+            PRTE_ERROR_LOG(PRTE_ERROR);
+            PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+            rc = PRTE_ERROR;
+            goto cleanup;
+        }
+    } else {
+        ndidx = (int32_t *) pbo.bytes;
+        isz = pbo.size;
+        pbo.bytes = NULL;
+        pbo.size = 0;
+    }
+    PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+
     /* if we are the HNP, we don't need any of this stuff */
     if (PRTE_PROC_IS_MASTER) {
         rc = PRTE_SUCCESS;
@@ -402,12 +490,14 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         goto cleanup;
     }
 
-    /* the three arrays are built in lockstep by nidmap_create, so anything
+    /* the four arrays are built in lockstep by nidmap_create, so anything
      * shorter than the node-name list means the message is not one of ours -
-     * and the loop below indexes all three by the same subscript */
-    if (NULL == names || NULL == aliases || NULL == vpid
-        || PMIx_Argv_count(names) > PMIx_Argv_count(aliases)
-        || (size_t) PMIx_Argv_count(names) > sz / sizeof(pmix_rank_t)) {
+     * and the loop below indexes all four by the same subscript */
+    nnodes = (NULL == names) ? 0 : PMIx_Argv_count(names);
+    if (NULL == names || NULL == aliases || NULL == vpid || NULL == ndidx
+        || nnodes > PMIx_Argv_count(aliases)
+        || (size_t) nnodes > sz / sizeof(pmix_rank_t)
+        || (size_t) nnodes > isz / sizeof(int32_t)) {
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
         rc = PRTE_ERR_BAD_PARAM;
         goto cleanup;
@@ -421,39 +511,53 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         rc = PRTE_ERR_NOT_FOUND;
         goto cleanup;
     }
-    /* create the node pool array - this will include
-     * _all_ nodes known to the allocation */
-    for (n = 0; NULL != names[n]; n++) {
-        /* do we already have this node? */
-        nd = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, n);
-        if (NULL != nd) {
-            /* check the name */
-            if (0 != strcmp(nd->name, names[n])) {
-                free(nd->name);
-                nd->name = strdup(names[n]);
-            }
-            if (0 != strcmp(aliases[n], "PRTENONE")) {
-                if (NULL != nd->aliases) {
-                    PMIx_Argv_free(nd->aliases);
-                }
-                nd->aliases = PMIx_Argv_split(aliases[n], ',');
-            }
-            continue;
+    /* Rebuild the node pool - this will include _all_ nodes known to the
+     * allocation.  Every node goes in the slot the sender holds it in, and
+     * every node is (re)bound to the daemon the sender says is on it: a DVM
+     * that has grown, shrunk, or both hands us this map more than once, and
+     * neither the node's slot nor its daemon is what it was the first time.
+     * Doing the binding only for a slot we did not already have - which is
+     * what this loop used to do - meant that after the first decode populated
+     * the pool, every later decode was very nearly a no-op: a daemon that
+     * predated a grow never learned the new daemon's vpid at all, so
+     * daemons->procs had a hole where odls looks up the parent of every proc
+     * in a job, and that daemon launched nothing (#2616). */
+    for (n = 0; n < nnodes; n++) {
+        if (0 > ndidx[n]) {
+            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+            rc = PRTE_ERR_BAD_PARAM;
+            goto cleanup;
         }
-        /* add this name to the pool */
-        nd = PMIX_NEW(prte_node_t);
-        nd->name = strdup(names[n]);
-        nd->index = n;
-        pmix_pointer_array_set_item(prte_node_pool, n, nd);
-        /* add any aliases */
+        nd = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, ndidx[n]);
+        if (NULL == nd) {
+            /* add this node to the pool, in the sender's slot */
+            nd = PMIX_NEW(prte_node_t);
+            nd->name = strdup(names[n]);
+            nd->index = ndidx[n];
+            pmix_pointer_array_set_item(prte_node_pool, ndidx[n], nd);
+            /* set the topology - always default to homogeneous
+             * as that is the most common scenario. Retain it: the node holds a
+             * counted reference so the topology cannot go away underneath it */
+            PMIX_RETAIN(t);
+            nd->topology = t;
+        } else if (0 != strcmp(nd->name, names[n])) {
+            /* the sender has put a different machine in this slot - the old
+             * name's aliases are not this one's, so they go too rather than
+             * surviving into a node that never claimed them */
+            free(nd->name);
+            nd->name = strdup(names[n]);
+            if (NULL != nd->aliases) {
+                PMIx_Argv_free(nd->aliases);
+                nd->aliases = NULL;
+            }
+        }
+        /* refresh the aliases */
         if (0 != strcmp(aliases[n], "PRTENONE")) {
+            if (NULL != nd->aliases) {
+                PMIx_Argv_free(nd->aliases);
+            }
             nd->aliases = PMIx_Argv_split(aliases[n], ',');
         }
-        /* set the topology - always default to homogeneous
-         * as that is the most common scenario. Retain it: the node holds a
-         * counted reference so the topology cannot go away underneath it */
-        PMIX_RETAIN(t);
-        nd->topology = t;
         /* record the daemon on it */
         proc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, vpid[n]);
         if (NULL == proc) {
@@ -467,8 +571,42 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
         /* the node backpointer is borrowed, not retained (see
          * prte_proc_destruct) */
         proc->node = nd;
-        PMIX_RETAIN(proc);
-        nd->daemon = proc;
+        if (nd->daemon != proc) {
+            /* the node holds a counted reference on its daemon, so a rebind
+             * has to drop the one it was holding */
+            if (NULL != nd->daemon) {
+                PMIX_RELEASE(nd->daemon);
+            }
+            PMIX_RETAIN(proc);
+            nd->daemon = proc;
+        }
+    }
+
+    /* A node the sender did not name has no daemon on it any more - it was
+     * shrunk out of the DVM, or its grow was rolled back.  The sender cleared
+     * its own backpointer when that happened, and we have to do the same:
+     * anything that reaches a daemon through the node pool (the
+     * PMIX_SERVER_URI query does exactly that) would otherwise be handed a
+     * proc for a vpid this DVM has permanently retired. */
+    seen = (char *) calloc(prte_node_pool->size, sizeof(char));
+    if (NULL == seen) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        rc = PRTE_ERR_OUT_OF_RESOURCE;
+        goto cleanup;
+    }
+    for (n = 0; n < nnodes; n++) {
+        seen[ndidx[n]] = 1;
+    }
+    for (n = 0; n < prte_node_pool->size; n++) {
+        if (seen[n]) {
+            continue;
+        }
+        nd = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, n);
+        if (NULL == nd || NULL == nd->daemon) {
+            continue;
+        }
+        PMIX_RELEASE(nd->daemon);
+        nd->daemon = NULL;
     }
 
     /* Record any vpid holes as departed ranks. The DVM spans [0, ndmns) daemon
@@ -511,6 +649,12 @@ int prte_util_decode_nidmap(pmix_data_buffer_t *buf)
 cleanup:
     if (NULL != vpid) {
         free(vpid);
+    }
+    if (NULL != ndidx) {
+        free(ndidx);
+    }
+    if (NULL != seen) {
+        free(seen);
     }
     if (NULL != names) {
         PMIx_Argv_free(names);


### PR DESCRIPTION
Fixes #2616.

## The problem

An elastic DVM re-sends the nidmap whenever its membership changes, and a daemon that is already up decodes it again. `prte_util_decode_nidmap()` recorded the node→daemon binding **only when it created a new node-pool entry**, so after a daemon's first wireup every later decode bound nothing. A daemon that predated a grow never learned the new daemon's vpid, and `daemons->procs` had a hole at exactly the rank `odls` uses to wire each proc to its node.

`odls` resolves the parent of *every* proc in a job, not just its own, so one missing entry threw away the entire child list — the daemon launched nothing, including the process it had already queued for itself, while the master (which never decodes) believed the job had launched. Any job spanning a surviving daemon after `grow → shrink → grow` hung indefinitely.

The same branch was keyed on the node's **position in the packed list**, which is not its identity: the sender skips daemon-less nodes, so a shrink compacts the packed sequence while the pool stays sparse. Every node past the hole landed in another machine's slot and was renamed in place, keeping its predecessor's retired daemon. That slot is also the `PMIX_NODEID` a daemon hands its clients and the subscript the `PMIX_SERVER_URI` query resolves a nodeid through, so master and daemons disagreed about which node a nodeid named.

## The fix

- The nidmap now carries each node's **pool slot**, and the receiver places the node there.
- Every decode **(re)binds** `nd->daemon` / `daemons->procs[vpid]`, releasing the reference the node held.
- A node the sender no longer names has its daemon backpointer cleared, mirroring what the master does on a shrink.

Two adjacent defects of the same kind:

- `prte_pmix_server_register_tool()` found "our node" as `prte_node_pool[our vpid]`, true only while node slots and daemon vpids are numbered alike. It now resolves through our own daemon proc.
- A daemon that could not build a child list reported nothing the master could act on — which is why the failure was a silent hang rather than an error naming the node. It now fails the procs that were its to launch and retires them through the failed-start path.

## Testing

- `contrib/dockerswarm`: reproduced the hang, then verified the fix, for both a grow onto a fresh node and a re-grow of the node that was shrunk out (the latter keeps its slot, so only the rebind saves it). Added as a regression case — the existing grow/shrink tests all confirm the DVM with `prun -n 1`, which lands on the master alone and passes with a daemon in exactly the broken state.
- Full Linux swarm suite: **573 passed, 0 failed, 3 skipped**.
- `make check` clean; warning-free `--enable-debug` build.
- The odls reporting change was verified by injecting the original fault back into the decode: the launch now ends in seconds with `Error name: Not found, Node: node2` and the DVM keeps running, where before it hung forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)