### PR TITLE
Add a test harness that runs PRRTE under an actual SLURM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -620,8 +620,22 @@ changes; `run-tests.sh` drives the multi-node suite (launch, IOF,
 preload, mapping/ranking across nodes, elastic grow/shrink, relay).  Do
 not invent an ad-hoc container flow — use the harness.
 
-For resource-manager integration (SLURM, PBS, LSF), test within an actual
-allocation on the relevant system.
+**Testing under a real SLURM.**  [`contrib/slurmswarm/`](contrib/slurmswarm/)
+is the same harness with an actual SLURM installation in the ten
+containers — a real `slurmctld`, ten `slurmd`s, real `salloc`/`srun`/
+`sbatch`/`scancel` — so `ras/slurm` and `plm/slurm` can be exercised
+against a scheduler that can say no.  It is the only place `plm/slurm`
+runs at all (the sibling harness's fake scheduler supplies the control
+plane, not the launcher), and the only place PRRTE's `scontrol show job
+--json` parser meets SLURM's own output.  See its
+[`AGENTS.md`](contrib/slurmswarm/AGENTS.md); note in particular that
+`ras/slurm`'s JSON parser requires **SLURM 24.05 or newer**, which is why
+that image builds SLURM from source rather than taking the distribution
+package.  Everything that is not about the scheduler belongs in
+`contrib/dockerswarm`, which is faster and needs no SLURM.
+
+For PBS and LSF integration, test within an actual allocation on the
+relevant system.
 
 **Never bend a test to accommodate a bug.** Do not weaken, skip, or
 rewrite an existing test — and do not craft a new one — merely to make

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -8,6 +8,16 @@ running node, stop: `build.sh` below already does the right thing
 (bind-mounts your live working tree into a builder and compiles it
 out-of-tree into the shared volume the nodes read).
 
+> **The one exception: a real scheduler.** The SLURM in this harness is
+> [`fake-slurm.py`](fake-slurm.py) (§12) — a stand-in control plane, which
+> can show that PRRTE issues the right commands and can never show that
+> SLURM accepts them. It also supplies no `srun`, so `plm/slurm` is not
+> exercised here at all. For that,
+> [`contrib/slurmswarm`](../slurmswarm/) is the same harness with an actual
+> SLURM installation in the ten containers. Keep the division: anything
+> without a `SLURM_` in it belongs *here*, because this harness is faster
+> and needs no scheduler.
+
 A small, self-contained harness for exercising PRRTE across several container
 "nodes" — a persistent DVM, one-shot `prterun`, and the **elastic DVM**
 (grow/shrink) plus multi-hop routing/relay — plus a native single-host build on

--- a/contrib/slurmswarm/.gitignore
+++ b/contrib/slurmswarm/.gitignore
@@ -1,0 +1,9 @@
+# Out-of-tree (VPATH) build directories.  This harness builds only into the
+# shared docker volume, so nothing of its own lands here -- but the sibling
+# harness's host build does, and both are driven from the same source tree.
+vpath-linux/
+vpath-macos/
+
+# Downloaded SLURM tarball, if you ever unpack one here to read the schema
+slurm-*.tar.bz2
+slurm-*/

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -1,0 +1,452 @@
+# AGENTS.md — the slurmswarm harness: PRRTE under a real SLURM
+
+Orientation for AI agents and human contributors who need to run PRRTE under
+an actual SLURM installation without a cluster.
+
+Ten `ubuntu:24.04` containers on one bridge network, running a real
+`slurmctld` and ten real `slurmd`s, with PRRTE built from your **live**
+working tree into a volume they all mount. `salloc` grants real allocations,
+`srun` launches the daemons, `sbatch` queues real jobs, and `scancel` really
+takes them away.
+
+It is the sibling of [`contrib/dockerswarm`](../dockerswarm/) and is
+deliberately the same harness in every respect but one: **the ten containers
+are running SLURM.** Same `build.sh`/`docker-compose.yml`/`run-tests.sh`
+shape, same shared-volume build of your live tree, same `node1..node10`
+hostnames, same conventions. If you know that harness you know this one; the
+differences are in §3, §9 and §10 and nowhere else.
+
+> **Read this first if you are here to add a test.** Almost nothing belongs
+> here. This suite covers what *only a real scheduler* can answer; everything
+> else about multi-node PRRTE — launch, IOF, collectives, elastic grow/shrink
+> by hostname, mapping, the lot — belongs in `contrib/dockerswarm`, which is
+> faster and does not need a scheduler at all. See §12.
+
+---
+
+## 1. What's here
+
+| File | Purpose |
+|------|---------|
+| `build.sh` | Builds PRRTE (and optionally PMIx) from your **live** tree via VPATH into the shared volume the cluster mounts. Start here. |
+| `run-tests.sh` | Runs the suite and reports PASS/FAIL. Five phases: the cluster itself, `ras/slurm` allocation semantics, `plm/slurm` launch, the elastic modify surface, and a launch smoke test. |
+| `Dockerfile` | Base image: toolchain, a baked PMIx, **SLURM built from source**, munge, SSH wiring. It does **not** contain PRRTE. |
+| `slurm.conf` | The cluster configuration, one copy baked into the image. Every container-specific choice is commented in the file; see §9. |
+| `cgroup.conf` | `CgroupPlugin=disabled`. Two lines, and the reason the containers can stay unprivileged; see §9. |
+| `slurm-alloc.py` | Creates and holds a real allocation across many `docker exec` calls, and replays the environment SLURM put in it. See §11. |
+| `docker-compose.yml` | The ten nodes `prteslurm-node1..prteslurm-node10`. Every name derives from `$PRTE_SLURM_SWARM`, so two clones can each run a cluster. |
+| *(no file here)* | The `elastic` test client is compiled from [`../dockerswarm/elastic.c`](../dockerswarm/elastic.c) rather than copied — it is the same program, and two copies would drift. |
+
+## 2. How it works
+
+```
+              your live PRRTE tree  (bind-mounted read-only)
+                        │
+                        ▼
+                 builder container
+             VPATH -> /opt/prte/vpath-linux
+             install -> /opt/prte  (shared volume)
+                        │
+                        ▼
+        ┌───────────────────────────────────────┐
+        │  node1        node2 ... node10        │
+        │  slurmctld    slurmd    slurmd        │
+        │  slurmd       prted     prted         │
+        │  prte (HNP)                           │
+        │  ── all mount /opt/prte:ro ──         │
+        └───────────────────────────────────────┘
+                        ▲
+                run-tests.sh drives node1
+```
+
+- **Never stale, no commit.** Change a file, rerun `build.sh`, and the cluster
+  runs your change (the build is incremental).
+- **One source tree, two harnesses.** This and `contrib/dockerswarm` build the
+  same tree into two different volumes with two different sets of configure
+  arguments. That is supported. What they must not share is an *in-tree*
+  build — see "When a distclean is actually needed" in the sibling's
+  [`AGENTS.md`](../dockerswarm/AGENTS.md), which applies verbatim here.
+
+## 3. Prerequisites
+
+- Docker (with `docker compose`) and `git`.
+- A working autotools toolchain on the host for `autogen.pl`.
+- **Network access during the first image build**: it clones PMIx and
+  downloads a SLURM release tarball from `download.schedmd.com`.
+- Time. The first image build compiles both PMIx and SLURM; budget ten to
+  twenty minutes. After that it is cached and `build.sh` only rebuilds PRRTE.
+
+Unlike the sibling harness there is no macOS mode: the subject is a scheduler
+that does not run on a Mac. For a native host build use
+`../dockerswarm/build.sh macos` — it builds the same source tree.
+
+## 4. Quick start
+
+```sh
+# from this directory (contrib/slurmswarm/)
+./build.sh                 # image (PMIx + SLURM), then PRRTE from your tree
+docker compose up -d       # start prteslurm-node1 .. prteslurm-node10
+./run-tests.sh             # the suite
+```
+
+Rebuild after editing PRRTE: just rerun `./build.sh` (incremental). No image
+rebuild, no `docker compose` restart — the nodes read the shared volume. To
+also test an openpmix change, add `PMIX_SRC=/path/to/openpmix`.
+
+### Two clones on one host: `PRTE_SLURM_SWARM`
+
+Every global name — the compose project, the ten container names, the build
+volume, the docker network — derives from `$PRTE_SLURM_SWARM` (default
+`prteslurm`):
+
+```sh
+export PRTE_SLURM_SWARM=alt      # for the WHOLE shell
+./build.sh && docker compose up -d && ./run-tests.sh
+```
+
+It is deliberately **not** `$PRTE_SWARM`, which is the sibling harness's
+variable. The two are meant to be drivable from one shell, and a shared
+variable would point both at the same ten container names.
+
+Both clusters contain a container whose **hostname is `node1`**, and that is
+fine: each user-defined bridge network runs its own embedded DNS, so `node2`
+inside a cluster can only ever mean that cluster's node2 — and, here, only
+that cluster's `slurmctld` is reachable at `node1:6817`.
+
+## 5. Driving it by hand
+
+```sh
+NODE=prteslurm-node1
+SA='docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 '$NODE' bash -lc'
+
+# look at the cluster
+docker exec $NODE sinfo
+docker exec $NODE squeue
+
+# take an allocation and hold it (see §11 for why this is not just `salloc`)
+docker exec $NODE slurm-alloc new --nodes 3 --tasks-per-node 2
+docker exec $NODE slurm-alloc env          # what SLURM actually set
+
+# start a DVM inside it -- prte_elastic_mode is REQUIRED for extend/release
+$SA '. /opt/prte/env.sh; eval "$(slurm-alloc env)";
+     nohup prte --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5 \
+           >/tmp/prte.out 2>&1 & sleep 8'
+
+$SA '. /opt/prte/env.sh; eval "$(slurm-alloc env)"; prun -n 3 --map-by node hostname'
+$SA '. /opt/prte/env.sh; eval "$(slurm-alloc env)"; elastic extend 2'
+$SA '. /opt/prte/env.sh; eval "$(slurm-alloc env)"; elastic release 2'
+$SA '. /opt/prte/env.sh; eval "$(slurm-alloc env)"; pterm'
+
+docker exec $NODE slurm-alloc free --all   # hand the nodes back
+```
+
+`eval "$(slurm-alloc env)"` is what puts the allocation in the shell. Without
+it, `ras/slurm` and `plm/slurm` do not even activate — `SLURM_JOBID` is the
+gate for both — and you get an ordinary ssh-launched DVM that looks fine and
+is testing nothing. That is the mistake this harness makes easy to make; the
+suite has a case for the other side of it (`plm/slurm: no allocation means no
+SLURM launcher`).
+
+> **The other flag that bites you.** As in the sibling harness, PRRTE gates
+> all of the grow/shrink completion machinery behind `prte_elastic_mode`
+> (default off). Without `--prtemca prte_elastic_mode 1`, a release returns
+> phase-1 SUCCESS and never completes; the client times out after 60s.
+
+## 6. What "success" looks like
+
+The five phases, and what each is really asserting.
+
+**`test_cluster`** — not a PRRTE test. A ten-node `srun`, an allocation held
+and handed back, `SLURM_JOBID` still being set (see §13), and the JSON schema
+check of §10. It runs first because every later phase blames PRRTE for what
+it finds, and a broken cluster would make all of them lie.
+
+**`test_ras_alloc`** — what an allocation *means* to the DVM. The DVM forms
+across the whole allocation with no `--host`; the slot count is SLURM's, not
+the core count; `--host` selects within the allocation and refuses outside
+it. Two cases here cannot exist anywhere else:
+
+- **SLURM's compressed node list.** The fake scheduler hands out comma
+  separated names; SLURM hands out `node[2,4,6]`, and `ras/slurm` has its own
+  parser for that notation. The allocation is deliberately non-contiguous: a
+  parser that reads `node[2,4,6]` as the range 2..6 gets five nodes, three of
+  which it was never given, and the case asserts that neither node3 nor node5
+  was invented.
+- **An allocation that excludes the head node.** `prte` runs on node1 while
+  SLURM allocated node2 and node3 only, which also means `srun` is issued
+  from a host that is not part of the job.
+
+**`test_plm`** — the launcher. This component is unreachable from the sibling
+harness at all: the fake scheduler supplies `sbatch`/`scontrol`/`scancel`, and
+`plm/slurm` shells out to **`srun`**, so every DVM over there goes out over
+ssh no matter what the ras was told. The cases assert that `plm/slurm` won
+selection, that the command really is `srun`, that it carried
+`--jobid=<the allocation>` (a launcher that omitted it would work on an idle
+cluster and queue a second job on a busy one), that PRRTE read the srun exit
+as a **hand-off** rather than a failure once `prted` daemonized, that SLURM
+is left with no dangling job step, that `pterm` does not cancel the user's
+allocation, and — the other side of the gate — that with no allocation in the
+environment the ssh launcher runs instead and creates no SLURM job.
+
+**`test_elastic`** — the phase this harness exists for. Every command goes to
+a scheduler that can say no: `sbatch` really queues a job, `scontrol show job
+--json` really emits SLURM's own schema, `scontrol update` really has to be a
+resize SLURM accepts **on a running job**, and `scancel` really removes an
+allocation. Note the request shapes differ from a plain elastic grow:
+`elastic grow <nodes>` is `PMIX_ALLOC_NEW` naming hosts, which the *base*
+serves without consulting the ras. `ras/slurm`'s `modify()` accepts only
+`PMIX_ALLOC_EXTEND`+`NUM_NODES`,
+`PMIX_ALLOC_RELEASE`+(`NODE_LIST`|`NUM_NODES`|`ALLOC_ID`) and
+`PMIX_ALLOC_REQ_CANCEL` — which nodes an extend lands on is the scheduler's
+choice. Hence `elastic extend|release|release-id|cancel`.
+
+Two cases are worth calling out:
+
+- **The in-place resize.** A partial release keeps the SLURM job and shrinks
+  it with `scontrol update job <id> ReqNodeList=<survivors>`. Whether SLURM
+  accepts that on a RUNNING job is precisely the assumption a fake scheduler
+  cannot check, and the case asserts the scheduler's own node count came
+  down — not merely that PRRTE issued a command.
+- **A pending extend, with no fault injection.** The sibling harness has to
+  *make* a job pend (`fake-slurm set pending_secs`). Here the case asks for
+  more nodes than the cluster has free and SLURM queues it PENDING by itself,
+  which is the state `PMIX_ALLOC_REQ_CANCEL` exists for.
+
+The tainted-hostname case is carried over from the sibling harness because
+the stakes are different here: the command that would be built is one a live
+`slurmctld` would act on.
+
+**`test_launch`** — a deliberately short smoke test. Ranks spread over the
+allocated nodes, output forwarded back, a failing job reported as failing,
+and a job larger than the allocation refused rather than quietly
+oversubscribing nodes the scheduler believes are someone else's.
+
+## 7. Cleanup hygiene
+
+`run-tests.sh` cleans between phases, and its sweep has **two** halves where
+the sibling harness has one:
+
+```sh
+# 1. the PRRTE half -- identical to contrib/dockerswarm
+for n in $(seq 1 10); do
+  docker exec prteslurm-node$n sh -c '
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* /tmp/pmix.*
+    find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} +
+    true'
+done
+
+# 2. the scheduler half -- give the nodes back
+docker exec prteslurm-node1 slurm-alloc free --all
+docker exec prteslurm-node1 sinfo          # wait for ten idle nodes
+```
+
+The second half is not optional and is easy to forget. A PRRTE **extend**
+holds its nodes through a SLURM job of its own, and a run that left those
+standing starves every later case of the pool it needs — reported, of course,
+as "the grow did not happen", several cases further on. `slurm-alloc free
+--all` cancels *every* job in the queue, deliberately: this is a dedicated
+single-purpose cluster and there is nothing in it that is not the harness.
+
+Two things about cgroups being off (§9): SLURM's process tracking is
+best-effort here, so a stray application process is SLURM's to lose — the
+per-node `pkill` sweep is what actually guarantees a clean slate — and
+`cleanup_cluster` **waits for the cluster to go idle** rather than assuming a
+cancelled job frees its nodes at once. A case that asks for nodes before
+slurmctld has reaped the last one does not fail, it *pends*, which reads as a
+hang.
+
+## 8. Rebuilding / resetting
+
+| Want to… | Do |
+|----------|----|
+| pick up a PRRTE source edit | `./build.sh` (incremental into the volume) |
+| pick up an openpmix edit | `PMIX_SRC=/path/to/openpmix ./build.sh` |
+| force a clean PRRTE rebuild | `docker volume rm prteslurm-build && ./build.sh` |
+| test another SLURM release | `docker build --build-arg SLURM_VERSION=25.05.3 -t prte-slurm-swarm:latest .` then wipe the volume's VPATH dirs and `docker compose up -d --force-recreate` |
+| tear down the cluster | `docker compose down` (the `prteslurm-build` volume persists) |
+| run a second, independent cluster | `export PRTE_SLURM_SWARM=alt` and repeat the quick start |
+
+**The containers persist, so a rebuilt image does not reach them.** Same trap
+as the sibling harness, and here it has a second face: the image is where
+*SLURM* lives, so a container older than its image is running a different
+scheduler than the one you just configured. `run-tests.sh`'s preflight
+compares each container's image ID against the tag and refuses to run when
+they differ. The fix is `docker compose up -d --force-recreate`.
+
+**And the image is where the baked PMIx lives.** Rebuilding the image for a
+new SLURM also rebuilds PMIx from master, so PRRTE in the volume was linked
+against the *previous* one. The configure arguments have not changed, so
+`build.sh` will not reconfigure and an incremental `make` will not relink —
+wipe the build directory:
+
+```sh
+docker run --rm -v prteslurm-build:/opt/prte prte-slurm-swarm:latest \
+    rm -rf /opt/prte/vpath-linux /opt/prte/prte /opt/prte/.build-stamp
+./build.sh
+```
+
+## 9. The SLURM configuration, and what a container costs
+
+Everything below lives in [`slurm.conf`](slurm.conf) and
+[`cgroup.conf`](cgroup.conf), commented in place. The four settings that are
+not ordinary cluster configuration:
+
+- **`SlurmdParameters=config_overrides`.** All ten "nodes" are containers on
+  one host, so every `slurmd` reports the same CPU count — whatever the docker
+  VM was given, which is not the 8 that `NodeName=` claims and differs per
+  developer machine. Without this, `slurmctld` compares each node's report
+  against the configuration, finds it short, and marks the node INVALID:
+  `sinfo` shows *drain* with reason "Low socket\*core\*thread count" on every
+  node and nothing can ever be allocated. The numbers here are a fiction we
+  have chosen, and the jobs are `hostname` and `sleep`.
+- **`CgroupPlugin=disabled`.** `slurmd` initializes a cgroup context at
+  startup *whatever* `ProctrackType` and `TaskPlugin` are set to, in order to
+  put `slurmstepd` in a scope of its own. A container has neither a systemd to
+  ask over D-Bus nor a writable `/sys/fs/cgroup`, so without this it dies at
+  startup and `sinfo` shows ten `unk*` nodes forever — which reads like a
+  networking or munge problem and is neither. This option arrived in SLURM
+  24.05, and is the second reason the image pins a modern release (§10).
+  Against an older one the alternatives are `cap_add: SYS_ADMIN` plus a
+  remount of `/sys/fs/cgroup` in the entrypoint, or `privileged: true`; both
+  were tried and both work, and neither is worth asking of a developer's
+  machine when the scheduler has a switch for it.
+- **`ProctrackType=proctrack/linuxproc`, `TaskPlugin=task/none`.** The cgroup
+  plugins want a cgroup hierarchy to own. `linuxproc` tracks a step by walking
+  `/proc` parentage, which needs nothing a container lacks. See §7 for the
+  consequence.
+- **`InactiveLimit=0`.** Load-bearing. The harness holds its allocations with
+  `salloc --no-shell`-style background jobs and runs steps into them minutes
+  later; a non-zero `InactiveLimit` kills an allocation with no active step,
+  which would delete the DVM's allocation out from under it mid-suite.
+
+`SelectType=select/cons_tres` with `CR_Core` is chosen so an allocation can
+hand out *part* of a node — PRRTE reads `SLURM_TASKS_PER_NODE` and the suite
+asserts the slot count it derives, and a linear select would give whole nodes
+only and the slot-count cases would be measuring nothing.
+
+**Authentication.** munge, with a key generated at image build time so all ten
+containers share one. A test cluster whose credential key sits in a local
+image is not a security posture — it is why this must only ever run on a
+private docker network.
+
+## 10. Why the SLURM version is pinned: the JSON schema
+
+The image builds SLURM from source, pinned by `--build-arg SLURM_VERSION`
+(default 24.11.6), rather than installing the distribution package. That is
+not about JSON *support* — Ubuntu 24.04's `slurm-wlm` does ship
+`serializer_json.so` and `scontrol show job --json` works. It is about the
+JSON **schema**, and it is the first thing this harness found.
+
+Ubuntu 24.04 carries SLURM 23.11, whose newest data parser is v0.0.40. In
+that schema a job's resources are:
+
+```json
+"job_resources": { "nodes": "node[1-3]", "allocated_nodes": [ ... ] }
+```
+
+`ras_slurm_jansson.c` reads the shape SLURM adopted in data parser **v0.0.41**,
+which ships in SLURM **24.05** and is the default output from 24.05 onward:
+
+```json
+"job_resources": { "nodes": { "count": 3, "list": "node[1-3]",
+                              "allocation": [ ... ] } }
+```
+
+Against 23.11, *every* extend fails immediately with
+
+```
+PRTE ERROR: Failed to parse input JSON in file .../ras_slurm_jansson.c at line 579
+```
+
+and the elastic surface has no coverage at all. So: **PRRTE's `ras/slurm`
+requires SLURM 24.05 or newer**, and nothing in the tree said so before this
+harness existed. `run-tests.sh` checks the *schema* at preflight rather than
+the version number, because what matters is what the scheduler emits, and it
+skips the elastic phase rather than failing it when the schema is wrong — a
+red suite there would read as "your tree is broken" when it is not.
+
+The fields the parser needs, all present in v0.0.41 through v0.0.43
+(SLURM 24.05, 24.11, 25.05):
+
+| PRRTE reads | SLURM emits |
+|-------------|-------------|
+| `job_resources.nodes.count` / `.list` | `nodes/count`, `nodes/list` |
+| `job_resources.nodes.allocation[]` | `nodes/allocation` |
+| `…allocation[].cpus.{count,used}` | `cpus/count`, `cpus/used` |
+| `…allocation[].sockets[].cores[].status` | core `status` (ALLOCATED/UNALLOCATED) |
+| `threads_per_core.{set,infinite,number}` | the standard SLURM numeric triple |
+
+## 11. Holding an allocation across `docker exec` (`slurm-alloc`)
+
+A person testing PRRTE under SLURM types `salloc -N3 bash` and works in that
+shell; everything they run inherits the allocation's environment. A suite
+driving containers from outside has no such shell — every case is its own
+`docker exec`, and an allocation created in one is gone by the next.
+
+[`slurm-alloc.py`](slurm-alloc.py) closes that gap in two halves:
+
+```sh
+slurm-alloc new --nodes 3 --tasks-per-node 2   # real salloc, held in the background
+slurm-alloc env                                # export lines to eval
+slurm-alloc nodes | jobid | pool | jobs
+slurm-alloc free [--all]
+```
+
+`new` runs a real `salloc` whose command is a shell that **dumps its own
+environment to a file** and then sleeps, holding the allocation; `env` prints
+that captured environment back.
+
+**The environment is captured, never reconstructed**, and that distinction is
+the point. A reconstruction would encode this author's belief about which
+variables SLURM sets, and the interesting failures are exactly where that
+belief is wrong. What `env` prints is what SLURM itself put in the
+environment of a process inside the allocation — including the compressed
+`SLURM_NODELIST` and the `2(x3)` form of `SLURM_TASKS_PER_NODE` that the
+`ras/slurm` parsers exist to handle.
+
+## 12. What this harness deliberately does not cover
+
+Everything that is not about the scheduler. Do not add it here.
+
+`contrib/dockerswarm` covers PRRTE across ten nodes — the launch paths, IOF
+and its flow control, `grpcomm` collectives and group construct, the data
+server, direct modex, `errmgr`, `odls` envars, `rml` routing, `hwloc`,
+sessions, the elastic grow/shrink surface driven by *hostname*, and the
+`ras/slurm` **fault injection** cases (malformed JSON, a failing `scancel`,
+an oversized error message) that a real scheduler will not produce on demand.
+It is faster, it needs no scheduler, and it is where a regression in any of
+that will be found.
+
+The division to hold to:
+
+| Question | Harness |
+|----------|---------|
+| Does PRRTE issue the right command? | `dockerswarm` (fake-slurm records the argv) |
+| Does SLURM accept that command? | **here** |
+| Does PRRTE parse what SLURM said? | **here** (against SLURM's real output) |
+| Does PRRTE do the right thing with the answer? | either — prefer `dockerswarm` |
+| Anything with no `SLURM_` in it | `dockerswarm` |
+
+## 13. Things a real scheduler taught this harness
+
+Kept as a list because each one cost an afternoon.
+
+- **`SLURM_JOBID` is what PRRTE gates on**, and it has been deprecated in
+  favour of `SLURM_JOB_ID` for years. SLURM 24.11 still sets both. If a
+  future release stops setting the old name, `ras/slurm` and `plm/slurm` both
+  stop activating and *every case in this suite quietly falls back to the ssh
+  launcher and passes*. `test_cluster` asserts the variable exists for that
+  reason, and it is the one assertion here that is about SLURM rather than
+  about PRRTE.
+- **The JSON schema moved in 24.05** — §10, the reason for the version pin.
+- **`slurmd` needs a cgroup context even when nothing is configured to use
+  one**, which is what makes SLURM-in-a-container a version question at all
+  (§9).
+- **An `srun` that exits is not a failed launch.** `prted` daemonizes, so the
+  step ends immediately and SLURM reaps it; PRRTE has to read that as a
+  hand-off. Nothing in the fake harness can produce that sequence, because
+  nothing in it runs `srun`.
+- **A cancelled job does not free its nodes at once.** Anything that cancels
+  and then immediately allocates must wait for the cluster to go idle, or it
+  pends — and a pending allocation looks exactly like a hang.

--- a/contrib/slurmswarm/CLAUDE.md
+++ b/contrib/slurmswarm/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/contrib/slurmswarm/Dockerfile
+++ b/contrib/slurmswarm/Dockerfile
@@ -1,0 +1,157 @@
+# Base image for the PRRTE real-SLURM test swarm (see AGENTS.md).
+#
+# This is contrib/dockerswarm's image plus an actual SLURM installation.  Like
+# that one it does NOT contain PRRTE: PRRTE (and, optionally, PMIx) is built at
+# run time from your *live* working tree, which build.sh bind-mounts into a
+# builder container and compiles out-of-tree (VPATH) into a shared volume
+# mounted at /opt/prte.  This image provides:
+#
+#   * the build toolchain (so the builder container can compile PRRTE/PMIx),
+#   * a baked PMIx in /usr/local as the default (overridden when you bind-mount
+#     an openpmix checkout via PMIX_SRC),
+#   * SLURM (slurmctld/slurmd/client) and munge, with a shared munge key and a
+#     slurm.conf naming all ten nodes,
+#   * passwordless SSH between the "nodes" -- plm/ssh is what launches when
+#     there is no allocation, and this harness covers both launchers, and
+#   * an entrypoint that starts munge and the SLURM daemons and makes the
+#     shared-volume libraries loadable.
+#
+# Build it with ./build.sh (which also drives the PRRTE build); a bare
+# `docker build` just produces this base.
+#
+# WHY SLURM IS BUILT FROM SOURCE HERE, AND NOT INSTALLED FROM THE DISTRIBUTION.
+# It is not about JSON *support*: Ubuntu 24.04's slurm-wlm does ship
+# serializer_json.so, and `scontrol show job --json` works.  It is about the
+# JSON *schema*.  Ubuntu 24.04 carries SLURM 23.11, whose newest data parser
+# is v0.0.40, and in that schema a job's resources look like
+#
+#     "job_resources": { "nodes": "node[1-3]", "allocated_nodes": [ ... ] }
+#
+# PRRTE's parser (ras_slurm_jansson.c) reads the shape SLURM adopted in
+# data_parser v0.0.41, which ships in SLURM 24.05 and is the default output
+# from 24.05 on:
+#
+#     "job_resources": { "nodes": { "count": 3, "list": "node[1-3]",
+#                                   "allocation": [ ... ] } }
+#
+# Against 23.11 every extend fails at once with "Failed to parse input JSON in
+# ras_slurm_jansson.c" and no coverage is obtained at all -- which is exactly
+# what this harness was built to find out, and which it did find out.  So the
+# version is pinned here, and it is a build-arg so that the suite can be run
+# against another one:
+#
+#     docker build --build-arg SLURM_VERSION=25.05.3 -t prte-slurm-swarm:latest .
+#
+# 24.05 is the floor.  run-tests.sh checks the schema at preflight rather than
+# the version number, because what matters is what the scheduler emits.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential gcc g++ make \
+        autoconf automake libtool m4 flex \
+        perl python3 git curl bzip2 \
+        libevent-dev libhwloc-dev zlib1g-dev \
+        libjansson-dev \
+        munge libmunge-dev libjson-c-dev libyaml-dev \
+        openssh-server openssh-client \
+        iproute2 iputils-ping procps less vim ca-certificates \
+        valgrind \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- SLURM, from source ----
+# --with-json is the argument that matters: without libjson-c the serializer
+# plugin is not built, `scontrol show job --json` fails outright, and
+# ras/slurm's entire modify surface has nothing to parse.  configure does not
+# fail when it is missing, it just quietly builds less, so the plugin is
+# checked for after install rather than assumed.
+ARG SLURM_VERSION=24.11.6
+ARG SLURM_URL=https://download.schedmd.com/slurm
+RUN groupadd -r slurm && useradd -r -g slurm -d /var/lib/slurm -s /usr/sbin/nologin slurm \
+    && curl -fsSL "$SLURM_URL/slurm-$SLURM_VERSION.tar.bz2" -o /tmp/slurm.tar.bz2 \
+    && mkdir -p /src/slurm && tar xjf /tmp/slurm.tar.bz2 -C /src/slurm --strip-components=1 \
+    && cd /src/slurm \
+    && ./configure --prefix=/usr/local --sysconfdir=/etc/slurm \
+                   --with-munge --with-json --without-hwloc \
+    && make -j"$(nproc)" \
+    && make install \
+    && ldconfig \
+    && test -f /usr/local/lib/slurm/serializer_json.so \
+    && rm -rf /src/slurm /tmp/slurm.tar.bz2
+
+# ---- baked PMIx (default) ----
+# NOTE the order: SLURM is configured and built ABOVE this, with no PMIx on
+# the system, so it builds no mpi/pmix plugin.  That is deliberate.  Nothing
+# here wants one -- PRRTE is launched by srun as a plain task
+# (MpiDefault=none) and brings its own PMIx -- and a SLURM plugin linked
+# against this image's PMIx would tie the scheduler's ABI to the library the
+# harness exists to vary.  Moving this block above the SLURM build would
+# silently create that coupling.
+# Cloned with submodules so autogen.pl runs normally.  PMIx master is the
+# default because the DVM size-change event codes (PMIX_DVM_IS_READY /
+# PMIX_ERR_DVM_MOD) the elastic client registers for may not be in a release
+# yet; override with --build-arg, or bind-mount your own via PMIX_SRC at run
+# time (see build.sh), in which case this baked copy is ignored.
+# Do NOT pass --with-libevent=/usr: it forces /usr/lib and misses the multiarch
+# dir; let configure find the system libevent-dev/hwloc-dev.
+ARG PMIX_REPO=https://github.com/openpmix/openpmix.git
+ARG PMIX_REF=master
+RUN git clone --recursive --depth=1 -b "$PMIX_REF" "$PMIX_REPO" /src/pmix \
+    && cd /src/pmix \
+    && ./autogen.pl \
+    && ./configure --prefix=/usr/local \
+    && make -j"$(nproc)" \
+    && make install \
+    && ldconfig
+
+# ---- munge: one key for the whole cluster ----
+# Every node runs the same image, so baking the key here is what makes the ten
+# containers members of one authentication domain.  It is generated at build
+# time rather than checked in, so two people's swarms do not share a
+# credential -- but it is still a key sitting in a local image, which is fine
+# for a private bridge network and is not fine anywhere else.
+RUN install -d -o munge -g munge -m 0700 /etc/munge /var/lib/munge /var/log/munge \
+    && dd if=/dev/urandom of=/etc/munge/munge.key bs=1024 count=1 2>/dev/null \
+    && chown munge:munge /etc/munge/munge.key \
+    && chmod 0400 /etc/munge/munge.key
+
+# ---- SLURM configuration ----
+# One file, identical on every node, which is what SLURM requires and what a
+# swarm of containers from one image gets for free.  See slurm.conf for why
+# each container-specific setting is there.
+COPY slurm.conf /etc/slurm/slurm.conf
+COPY cgroup.conf /etc/slurm/cgroup.conf
+RUN chmod 0644 /etc/slurm/slurm.conf /etc/slurm/cgroup.conf \
+    && install -d -o slurm -g slurm -m 0755 /var/spool/slurmctld /var/log/slurm \
+    && install -d -m 0755 /var/spool/slurmd /var/lib/slurm
+
+# ---- the allocation helper ----
+# Creates and describes real SLURM allocations, and prints the SLURM_* export
+# lines that a `salloc`-with-a-shell would have set.  The harness holds an
+# allocation across many `docker exec` invocations, so it cannot simply run
+# everything under one salloc.  See AGENTS.md section 11.
+COPY slurm-alloc.py /usr/local/bin/slurm-alloc
+RUN chmod 0755 /usr/local/bin/slurm-alloc
+
+# ---- passwordless SSH between the container "nodes" ----
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && ssh-keygen -t ed25519 -N "" -f /root/.ssh/id_ed25519 \
+    && cp /root/.ssh/id_ed25519.pub /root/.ssh/authorized_keys \
+    && printf 'Host *\n    StrictHostKeyChecking no\n    UserKnownHostsFile /dev/null\n    LogLevel ERROR\n' \
+         > /root/.ssh/config \
+    && chmod 600 /root/.ssh/* \
+    && sed -i 's/#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && printf '\nAcceptEnv *\n' >> /etc/ssh/sshd_config
+
+# make the run-time install discoverable for any login shell (build.sh writes
+# /opt/prte/env.sh with PATH/LD_LIBRARY_PATH once it knows the PMIx layout)
+RUN echo '[ -f /opt/prte/env.sh ] && . /opt/prte/env.sh' > /etc/profile.d/prte.sh
+
+# ---- node entrypoint ----
+COPY node-entrypoint.sh /usr/local/bin/node-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/node-entrypoint.sh
+
+EXPOSE 22 6817 6818
+CMD ["/usr/local/bin/node-entrypoint.sh"]

--- a/contrib/slurmswarm/build.sh
+++ b/contrib/slurmswarm/build.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Build PRRTE for the real-SLURM test cluster (AGENTS.md) from your *live*
+# working tree -- no commit required, never stale.
+#
+#   ./build.sh          # or 'linux': build in a container into the shared
+#                       #   /opt/prte volume that the cluster nodes mount
+#   ./build.sh image    # (re)build just the base container image
+#
+# This is contrib/dockerswarm/build.sh with a different image, a different
+# volume, and two extra configure arguments.  It has no 'macos' mode: the
+# whole subject here is a scheduler that does not run on a Mac.  For the
+# native host build, use the sibling harness -- `../dockerswarm/build.sh
+# macos` builds the same source tree, out of tree, into <repo>/vpath-macos.
+#
+# Two clones on one host: set PRTE_SLURM_SWARM (see below) in the whole shell,
+# and each gets its own containers, volume, and network.
+#
+# Distcleaning the source tree
+# ----------------------------
+# An out-of-tree build cannot share a source tree with an in-tree build: VPATH
+# configure refuses to run against one, and (worse) automake sets VPATH=srcdir,
+# so an incremental out-of-tree make will happily link objects it finds in the
+# SOURCE tree -- which for a Linux container reading a macOS host tree are not
+# even the same architecture.  So this script distcleans whenever it finds an
+# in-tree build, not just on the first run.  The full reasoning, including why
+# it cannot be narrowed to "only when configure has to run", is in
+# ../dockerswarm/AGENTS.md, "When a distclean is actually needed" -- it is one
+# source tree and the rule is identical for both harnesses.
+#
+#   --distclean      force it
+#   --no-distclean   skip it -- an assertion that the tree really is clean.
+#                    If it is not, this script STOPS rather than building a
+#                    tree it has just been told to poison.
+#
+# NOTE that this harness and contrib/dockerswarm build the SAME source tree
+# into two different volumes.  That is supported and is the point of building
+# out of tree -- but they each hold their own VPATH directory with its own
+# configure arguments, so running one after the other rebuilds nothing in the
+# other's volume.  What they must not do is fight over an in-tree build; see
+# above, and do not keep one.
+#
+# Optional: point PMIX_SRC at a local openpmix checkout to build PMIx from
+# source too (covering both code bases); otherwise the baked-in PMIx is used.
+#
+# Requires: docker, git, and a working autotools toolchain.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(git -C "$here" rev-parse --show-toplevel)"
+
+# Which cluster this is.  Every global name the harness claims -- the compose
+# project, the ten container names, the build volume, the docker network -- is
+# derived from it, so two clones on one host can each drive their own cluster
+# without touching the other's containers, install, or SLURM.  Unset, it is
+# "prteslurm".  Set it for the whole shell, because `docker compose`
+# interpolates docker-compose.yml itself:
+#
+#   export PRTE_SLURM_SWARM=alt
+#   ./build.sh && docker compose up -d && ./run-tests.sh
+#
+# Deliberately NOT $PRTE_SWARM: this harness and contrib/dockerswarm are meant
+# to be drivable from one shell, and sharing the variable would point both at
+# the same ten container names.  The image is deliberately not per-cluster
+# (see docker-compose.yml).
+PRTE_SLURM_SWARM="${PRTE_SLURM_SWARM:-prteslurm}"
+# Rejected here rather than left to docker.  Filtering through LC_ALL=C tr,
+# not a shell [a-z] range: in a UTF-8 locale that range follows collation
+# order and matches 'B', so the obvious form of this test accepts names
+# docker then refuses.  Same reason the leading-character check is a literal
+# set.
+case "$PRTE_SLURM_SWARM" in [_-]*) PRTE_SLURM_SWARM="" ;; esac
+if [ -z "$PRTE_SLURM_SWARM" ] || \
+   [ "$PRTE_SLURM_SWARM" != "$(printf '%s' "$PRTE_SLURM_SWARM" | LC_ALL=C tr -cd 'a-z0-9_-')" ]; then
+    echo "PRTE_SLURM_SWARM must be lowercase [a-z0-9_-] and start with a letter or digit" >&2
+    exit 2
+fi
+
+IMAGE="${IMAGE:-prte-slurm-swarm:latest}"
+VOLUME="${VOLUME:-$PRTE_SLURM_SWARM-build}"
+PMIX_REF="${PMIX_REF:-master}"          # baked-image PMIx branch
+PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
+PMIX_SRC="${PMIX_SRC:-}"                # optional openpmix checkout to build
+
+mode=linux
+distclean=auto                          # auto | always | never
+for arg in "$@"; do
+    case "$arg" in
+        linux|image)    mode="$arg" ;;
+        --distclean)    distclean=always ;;
+        --no-distclean) distclean=never ;;
+        *) echo "usage: $0 [linux|image] [--distclean|--no-distclean]" >&2; exit 2 ;;
+    esac
+done
+
+# Does the source tree hold an in-tree build?  config.status/Makefile are what
+# make a VPATH configure refuse to run, but the object files are the bigger
+# problem -- see prep_srcdir.
+srcdir_has_intree() {
+    [ -f "$root/config.status" ] || [ -f "$root/Makefile" ] || \
+    [ -n "$(find "$root/src" -name '*.lo' -print -quit 2>/dev/null)" ]
+}
+
+# --- generate the flex output the builder cannot generate itself ------------
+# In a pristine checkout a *.l has no companion *.c: automake produces it at
+# build time, and ylwrap writes it into the SOURCE directory next to the .l --
+# but the builder mounts both source trees READ-ONLY, so the build dies with
+#
+#     config/ylwrap: line 204: .../keyval_lex.c: Read-only file system
+#
+# A tree that has been built in place at least once already carries the file,
+# which is why this only ever bites a *fresh* clone -- precisely what PMIX_SRC
+# usually points at.  Generate it here on the host the way automake would; the
+# -P symbol prefix lives in the sibling Makefile.am AM_LFLAGS.
+gen_lex() {
+    local tree="$1" lfile cfile prefix
+    while IFS= read -r lfile; do
+        [ -n "$lfile" ] || continue
+        cfile="${lfile%.l}.c"
+        if [ -f "$cfile" ]; then
+            continue
+        fi
+        if ! command -v flex >/dev/null 2>&1; then
+            echo ">>> WARNING: $lfile has no generated .c and flex is not" \
+                 "installed; the read-only builder cannot make one"
+            return 0
+        fi
+        prefix="$(sed -n 's/^AM_LFLAGS *= *-P//p' "$(dirname "$lfile")/Makefile.am" \
+                  2>/dev/null | head -1)"
+        echo ">>> flex $lfile (the builder mounts this tree read-only)"
+        if [ -n "$prefix" ]; then
+            flex "-P$prefix" -o "$cfile" "$lfile"
+        else
+            flex -o "$cfile" "$lfile"
+        fi
+    done <<EOF
+$(find "$tree" -name '*.l' 2>/dev/null)
+EOF
+}
+
+# --- make the source tree VPATH-ready (idempotent) --------------------------
+prep_srcdir() {
+    if srcdir_has_intree && [ "$distclean" != never ]; then
+        echo ">>> make distclean -- the source tree holds an in-tree build," \
+             "which would poison the out-of-tree build via VPATH"
+        echo ">>> NOTE: this removes your in-tree build; reconfigure before" \
+             "'make check' or 'make -C test/offline check-offline'"
+        echo ">>>       (or build the host side out-of-tree: ../dockerswarm/build.sh macos)"
+        make -C "$root" distclean >/dev/null 2>&1 || true
+        find "$root/src" -name '*.lo' -delete 2>/dev/null || true
+        find "$root/src" -name '.libs' -type d -exec rm -rf {} + 2>/dev/null || true
+    elif srcdir_has_intree; then
+        # Refuse rather than warn: --no-distclean asserts "the tree really is
+        # clean", it is not, and proceeding builds exactly the poisoned tree
+        # the check exists to prevent.  The expensive failure is the one that
+        # SUCCEEDS -- same platform, different --with-pmix -- and quietly
+        # tests a library nobody chose.
+        echo ">>> ERROR: --no-distclean, but the source tree holds an in-tree" \
+             "build." >&2
+        echo ">>>        VPATH=srcdir means this build would link objects out" \
+             "of the SOURCE tree, and pick up its stale prte_config.h ahead of" \
+             "the one configure just wrote." >&2
+        echo ">>>        Drop --no-distclean, or clean the tree yourself" \
+             "(make distclean at $root)." >&2
+        exit 2
+    fi
+
+    if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then
+        echo ">>> autogen.pl"
+        ( cd "$root" && ./autogen.pl )
+    fi
+
+    gen_lex "$root"
+}
+
+# --- (re)build the base image if needed -------------------------------------
+build_image() {
+    if [ "${1:-}" = force ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        echo ">>> docker build $IMAGE (SLURM from the distribution, baked PMIx $PMIX_REF)"
+        docker build -t "$IMAGE" \
+            --build-arg PMIX_REPO="$PMIX_REPO" \
+            --build-arg PMIX_REF="$PMIX_REF" \
+            "$here"
+    else
+        echo ">>> using existing image $IMAGE (./build.sh image to rebuild)"
+    fi
+}
+
+# --- the build (in a builder container, into the shared volume) -------------
+build_linux() {
+    build_image
+    docker volume create "$VOLUME" >/dev/null
+    prep_srcdir
+
+    local pmix_mount=()
+    if [ -n "$PMIX_SRC" ]; then
+        gen_lex "$(cd "$PMIX_SRC" && pwd)"
+        pmix_mount=(-v "$(cd "$PMIX_SRC" && pwd)":/pmix-src:ro)
+    fi
+
+    echo ">>> building PRRTE (and PMIx if PMIX_SRC set) into volume $VOLUME"
+    docker run --rm \
+        -v "$root":/prrte-src:ro \
+        -v "$VOLUME":/opt/prte \
+        ${pmix_mount[@]+"${pmix_mount[@]}"} \
+        "$IMAGE" bash -euo pipefail -c '
+            jobs=$(nproc)
+
+            # These VPATH build dirs live in the volume and persist across
+            # runs, so "configure only if there is no config.status" quietly
+            # reuses the arguments of whatever run created them.  Three ways
+            # a persistent build dir goes stale: never configured; configured
+            # with different arguments (point PMIX_SRC at a checkout after a
+            # plain build and PRRTE otherwise keeps the baked PMIx, with
+            # nothing in the output to say so); or configured before the
+            # build system was regenerated, which sends an incremental make
+            # into maintainer-mode regeneration INSIDE the container and dies
+            # with "aclocal-N.NN: command not found".
+            #
+            # $1 = build dir, $2 = argument string, $3 = srcdir
+            reconfigure_needed() {
+                [ -f "$1/config.status" ] || return 0
+                [ -f "$1/.configure-args" ] || return 0
+                [ "$(cat "$1/.configure-args")" = "$2" ] || return 0
+                [ "$3/configure" -nt "$1/config.status" ] && return 0
+                return 1
+            }
+
+            if [ -d /pmix-src ]; then
+                PMIX_PREFIX=/opt/prte/pmix
+                echo ">>>> PMIx from bind-mounted /pmix-src -> $PMIX_PREFIX"
+                mkdir -p /opt/prte/vpath-linux-pmix && cd /opt/prte/vpath-linux-pmix
+                pmix_args="--prefix=$PMIX_PREFIX"
+                if reconfigure_needed . "$pmix_args" /pmix-src; then
+                    echo ">>>> (re)configuring PMIx: $pmix_args"
+                    /pmix-src/configure $pmix_args
+                    echo "$pmix_args" > .configure-args
+                fi
+                make -j"$jobs"
+                make install
+            else
+                PMIX_PREFIX=/usr/local
+                echo ">>>> PMIx: using baked $PMIX_PREFIX"
+            fi
+
+            # invalidate the freshness stamp up front: from here until the
+            # build finishes, whatever is installed is NOT this source tree
+            rm -f /opt/prte/.build-stamp
+
+            echo ">>>> PRRTE VPATH build -> /opt/prte/prte"
+            mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
+            # --with-slurm is redundant on Linux (the components build by
+            # default there) and is passed anyway so that a build for THIS
+            # harness fails loudly if slurm support is ever made conditional
+            # on something this image does not have -- a silently missing
+            # plm/slurm would leave the whole suite launching over ssh and
+            # passing.
+            #
+            # --with-jansson is not redundant: it is off by default, and
+            # without it ras/slurm compiles ras_slurm_jansson_stub.c instead
+            # of the real parser -- so the entire "scontrol show job --json"
+            # surface, which is what the elastic phases here exercise against
+            # a real scheduler, is not even compiled.
+            prte_args="--prefix=/opt/prte/prte --with-pmix=$PMIX_PREFIX --with-slurm --with-jansson --enable-debug"
+            if reconfigure_needed . "$prte_args" /prrte-src; then
+                echo ">>>> (re)configuring PRRTE: $prte_args"
+                /prrte-src/configure $prte_args
+                echo "$prte_args" > .configure-args
+            fi
+            # show_help GOLDEN RULE: prte_show_help_content.c embeds every
+            # help-*.txt in the tree, but its make rule depends only on the
+            # converter script -- so an edited help file is NOT picked up by
+            # an incremental build, and the daemons serve stale (or missing)
+            # text while the .txt looks correct.  This build dir persists in
+            # the volume across runs, so drop the generated file every time.
+            # The .deps entry has to go too: if the SOURCE tree held a copy
+            # when an earlier build ran, VPATH resolved it there and the
+            # recorded prerequisite is the srcdir path, which a later
+            # distclean removes.
+            rm -f src/util/prte_show_help_content.c src/util/prte_show_help_content.lo \
+                  src/util/.deps/prte_show_help_content.Plo
+            make -j"$jobs"
+            make install
+
+            # The elastic client, borrowed from the sibling harness rather
+            # than copied: it is the same program, and the alternative is two
+            # of them drifting apart.  It is the only probe this suite needs
+            # that PRRTE does not install -- everything else here is driven
+            # through prun/prte and the SLURM commands themselves.
+            #
+            # NOTE the -Wl,-rpath.  An application launched onto a NON-head
+            # node gets an EMPTY LD_LIBRARY_PATH -- the head node inherits
+            # the login shell that sourced env.sh, the others do not -- so
+            # without an rpath this binary loads the PMIx baked into the
+            # image (/usr/local/lib) instead of the one this script just
+            # built.  That is silent: same soname, same version, different
+            # code.
+            # NOTE: this whole block is inside bash -c ..., so an apostrophe
+            # anywhere in it (even in a comment) ends the script.
+            echo ">>>> elastic test client (from ../dockerswarm)"
+            gcc -O0 -g -o /opt/prte/prte/bin/elastic \
+                /prrte-src/contrib/dockerswarm/elastic.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
+            # runtime env for login shells (node-entrypoint handles ld.so)
+            printf "export PATH=/opt/prte/prte/bin:\$PATH\nexport LD_LIBRARY_PATH=/opt/prte/prte/lib:%s/lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\n" \
+                "$PMIX_PREFIX" > /opt/prte/env.sh
+
+            # Written LAST, and only on success.  The install lives in a
+            # volume that outlives any one build, so a build that fails
+            # part-way leaves the PREVIOUS install standing, and run-tests.sh
+            # would happily exercise it and report on code that was never
+            # built.  The stamp is what lets the suite refuse.
+            date -u +%Y-%m-%dT%H:%M:%SZ > /opt/prte/.build-stamp
+            echo ">>>> done: install in /opt/prte/prte"
+        '
+    echo ">>> build complete."
+    if [ "$PRTE_SLURM_SWARM" = prteslurm ]; then
+        echo ">>> next: docker compose up -d && ./run-tests.sh"
+    else
+        # Say it with the variable: compose reads PRTE_SLURM_SWARM from the
+        # environment of the compose command, and a `docker compose up -d`
+        # without it brings up the DEFAULT cluster against the default
+        # volume, leaving this build sitting in $VOLUME unused.
+        echo ">>> next: PRTE_SLURM_SWARM=$PRTE_SLURM_SWARM docker compose up -d &&" \
+             "PRTE_SLURM_SWARM=$PRTE_SLURM_SWARM ./run-tests.sh"
+        echo ">>>       (cluster '$PRTE_SLURM_SWARM': containers" \
+             "$PRTE_SLURM_SWARM-node1..10, volume $VOLUME)"
+    fi
+}
+
+case "$mode" in
+    linux) build_linux ;;
+    # the image is built from this directory alone and never reads the source
+    # tree, so it needs no distclean at all
+    image) build_image force ;;
+esac

--- a/contrib/slurmswarm/cgroup.conf
+++ b/contrib/slurmswarm/cgroup.conf
@@ -1,0 +1,34 @@
+# cgroup.conf for the PRRTE real-SLURM test swarm (see AGENTS.md).
+#
+# This file exists for one reason: slurmd initializes a cgroup context at
+# startup and EXITS if it cannot, no matter what ProctrackType and TaskPlugin
+# are set to.  slurm.conf asks for proctrack/linuxproc and task/none precisely
+# so that no cgroup is needed -- and slurmd sets one up anyway, to place
+# slurmstepd in a scope of its own.  In a container there is neither a systemd
+# to ask over D-Bus nor a writable /sys/fs/cgroup to fall back on, so slurmd
+# dies at startup with
+#
+#   slurmd: error: cgroup_dbus_attach_to_scope: cannot connect to dbus system
+#           daemon ...
+#   slurmd: error: cannot create cgroup context for cgroup/v2
+#   slurmd: error: slurmd initialization failed
+#
+# and sinfo then shows all ten nodes "unk*" forever, which reads like a
+# networking or munge problem and is neither.
+#
+# CgroupPlugin=disabled is the supported way to say "this node does not do
+# cgroups", and it is why the image pins SLURM 24.05 or newer for a second
+# reason beyond the JSON schema: the option does not exist in 23.11, where the
+# only ways out are to give the container CAP_SYS_ADMIN so the entrypoint can
+# remount /sys/fs/cgroup read-write, or to run it privileged.  Both were
+# tried and both work; neither is worth asking of a developer's machine when
+# the scheduler has a switch for it.
+#
+# What it costs: nothing this harness needs.  Cgroups would give per-step
+# resource confinement and reliable process cleanup, and neither is a subject
+# here -- SLURM's job in this cluster is to hand PRRTE an allocation and
+# launch prted, and PRRTE is what actually tracks the processes.  The one
+# consequence to know about is that a stray process is SLURM's to lose, which
+# is why run-tests.sh sweeps every node between phases rather than trusting
+# the scheduler to have reaped everything.
+CgroupPlugin=disabled

--- a/contrib/slurmswarm/docker-compose.yml
+++ b/contrib/slurmswarm/docker-compose.yml
@@ -1,0 +1,117 @@
+# A 10-"node" SLURM cluster on a private docker network, for running PRRTE
+# under a real scheduler.  node1 is the controller (slurmctld) and the head
+# node -- you start `prte` and run the tests there; node2..node10 run slurmd
+# only.  Every node, node1 included, is a compute node of the cluster, so an
+# allocation can include or exclude the head node.
+#
+# This is contrib/dockerswarm's compose file with SLURM added, and it behaves
+# the same way: PRRTE is NOT baked into the image.  build.sh compiles your
+# live working tree out-of-tree into the shared build volume, which every node
+# mounts read-only at /opt/prte.  So `docker compose up -d` must be preceded
+# by a `./build.sh`.  See AGENTS.md.
+#
+# ---------------------------------------------------------------------------
+# EVERY global name this harness claims is derived from $PRTE_SLURM_SWARM, so
+# that two clones on one host can each run their own cluster.  Unset, it is
+# "prteslurm".
+#
+#   PRTE_SLURM_SWARM=alt ./build.sh
+#   PRTE_SLURM_SWARM=alt docker compose up -d
+#   PRTE_SLURM_SWARM=alt ./run-tests.sh
+#
+# The variable has to be in the environment of the `docker compose` command
+# itself -- compose interpolates this file, the scripts do not.  Set it for
+# the whole shell (`export PRTE_SLURM_SWARM=alt`) and every step agrees.
+#
+# It is deliberately NOT the same variable contrib/dockerswarm uses
+# ($PRTE_SWARM).  The two harnesses are meant to be runnable from one shell,
+# and a shared variable would have exported one name to both -- two compose
+# projects claiming the same ten container names, which is the single most
+# confusing state either harness can be in.
+#
+# What is NOT per-cluster: the image.  It is read-only to a running cluster
+# and expensive to build, so both instances share it -- but `./build.sh image`
+# rebuilds it under the other cluster's feet, and that cluster's containers
+# then fail run-tests.sh's "containers are running the current image"
+# preflight until they are recreated.
+name: ${PRTE_SLURM_SWARM:-prteslurm}swarm
+
+x-node: &node
+  image: ${IMAGE:-prte-slurm-swarm:latest}
+  networks: [dvm]
+  tty: true
+  volumes:
+    - prte-build:/opt/prte:ro
+  # NOTE what is NOT here: no privileged flag, no added capability, no bind
+  # mount of the host's /sys/fs/cgroup.  slurmd insists on initializing a
+  # cgroup context at startup whatever the configured plugins are, and a
+  # container has neither a systemd to ask nor a writable cgroup filesystem --
+  # so this harness used to need CAP_SYS_ADMIN to remount that filesystem
+  # read-write.  `CgroupPlugin=disabled` (SLURM 24.05 and newer, see
+  # cgroup.conf) removes the need entirely, and these are ordinary
+  # unprivileged containers exactly like contrib/dockerswarm's.
+  #
+  # If you ever run this against an older SLURM, that is the wall you will
+  # hit, and the symptom is ten "unk*" nodes in sinfo with slurmd dead on
+  # every one of them.
+
+services:
+  node1:
+    <<: *node
+    hostname: node1
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node1
+  node2:
+    <<: *node
+    hostname: node2
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node2
+  node3:
+    <<: *node
+    hostname: node3
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node3
+  node4:
+    <<: *node
+    hostname: node4
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node4
+  node5:
+    <<: *node
+    hostname: node5
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node5
+  node6:
+    <<: *node
+    hostname: node6
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node6
+  node7:
+    <<: *node
+    hostname: node7
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node7
+  node8:
+    <<: *node
+    hostname: node8
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node8
+  node9:
+    <<: *node
+    hostname: node9
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node9
+  node10:
+    <<: *node
+    hostname: node10
+    container_name: ${PRTE_SLURM_SWARM:-prteslurm}-node10
+
+# Left to compose to name (it becomes <project>_dvm), which is what keeps two
+# clusters apart: every node sets hostname node<N>, so both contain a "node1".
+# Each user-defined bridge network has its own embedded DNS serving only the
+# containers attached to it, so "node2" from inside one cluster can only ever
+# mean that cluster's node2 -- and, here, only that cluster's slurmctld is
+# reachable at "node1:6817".
+networks:
+  dvm:
+    driver: bridge
+
+# Populated by build.sh (docker volume create) and shared, read-only, by every
+# node of THIS cluster.  Declared external so the builder container and these
+# services reference the exact same volume name (no compose prefix) -- which
+# also means the name has to carry the cluster identity itself.
+volumes:
+  prte-build:
+    name: ${PRTE_SLURM_SWARM:-prteslurm}-build
+    external: true

--- a/contrib/slurmswarm/node-entrypoint.sh
+++ b/contrib/slurmswarm/node-entrypoint.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Entrypoint for a node of the PRRTE real-SLURM swarm.
+#
+# Brings up, in order: munge (the credential service everything else
+# authenticates through), slurmctld (on the controller node only), slurmd
+# (everywhere), and finally sshd in the foreground as PID 1's child so the
+# container stays up.
+#
+# It also does what contrib/dockerswarm's entrypoint does: register the
+# shared-volume library directories with ld.so and symlink the install's
+# binaries onto the default PATH.  That second one is not cosmetic here --
+# SLURM launches `prted` through srun, in an environment that has none of the
+# login shell's PATH, so an unlinked prted is a launch that fails with
+# "prted: command not found" and no other diagnostic.
+
+set -u
+
+log() { printf '[entrypoint] %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# the PRRTE install in the shared volume
+# ---------------------------------------------------------------------------
+for d in /opt/prte/prte/lib /opt/prte/pmix/lib; do
+    [ -d "$d" ] && echo "$d" >> /etc/ld.so.conf.d/prte.conf
+done
+ldconfig
+for b in /opt/prte/prte/bin/*; do
+    [ -e "$b" ] && ln -sf "$b" /usr/local/bin/
+done 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# munge
+# ---------------------------------------------------------------------------
+# The key is baked into the image, so every node already agrees.  What does
+# NOT survive the image is the runtime state: /run is a fresh tmpfs in every
+# container, and munged refuses to start if it cannot create its socket
+# directory with the right ownership.
+mkdir -p /run/munge /var/log/munge /var/lib/munge
+chown -R munge:munge /run/munge /var/log/munge /var/lib/munge
+chmod 0755 /run/munge
+rm -f /run/munge/munge.socket.2
+log "starting munged"
+runuser -u munge -- /usr/sbin/munged --force
+
+# Do not proceed to the SLURM daemons until munge actually answers: a slurmd
+# that starts against a dead munged does not retry, it exits, and the node
+# then shows up as DOWN for the life of the swarm with nothing in the SLURM
+# logs pointing at the credential service.
+for _ in $(seq 20); do
+    munge -n >/dev/null 2>&1 && break
+    sleep 0.5
+done
+if ! munge -n >/dev/null 2>&1; then
+    log "ERROR: munged is not answering; SLURM cannot authenticate"
+fi
+
+# ---------------------------------------------------------------------------
+# SLURM
+# ---------------------------------------------------------------------------
+mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm
+chown slurm:slurm /var/spool/slurmctld /var/log/slurm
+
+# Which node is the controller is read out of slurm.conf rather than
+# hardcoded here, so changing SlurmctldHost is a one-file edit.
+ctld_host="$(sed -n 's/^SlurmctldHost=\([^ ]*\).*/\1/p' /etc/slurm/slurm.conf | head -1)"
+if [ "$(hostname -s)" = "$ctld_host" ]; then
+    log "starting slurmctld (this node is the controller)"
+    slurmctld
+fi
+
+# Every node runs a slurmd, controller included: the head node is part of the
+# cluster here, exactly as it is in the dockerswarm harness, so a DVM can be
+# allocated node1 and PRRTE's "allocation excludes the head node" case has
+# something to exclude.
+log "starting slurmd"
+slurmd
+
+# ---------------------------------------------------------------------------
+# sshd
+# ---------------------------------------------------------------------------
+# Kept even though SLURM is the launcher: plm/ssh is what runs when there is
+# no allocation, and the harness deliberately covers both (a DVM inside an
+# allocation goes out over srun; the same swarm with no SLURM_JOBID set goes
+# out over ssh).  It is also how a case reaches a node to look at it.
+exec /usr/sbin/sshd -D -e

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -1,0 +1,838 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# Run the PRRTE-under-real-SLURM test suite against a build produced by
+# build.sh.
+#
+#   ./build.sh && docker compose up -d && ./run-tests.sh
+#
+# Prints PASS/FAIL per test and a summary; exits non-zero if anything failed.
+#
+# What this suite is for, and what it is NOT for.  contrib/dockerswarm covers
+# PRRTE across ten nodes -- launch, IOF, collectives, elastic, the lot -- with
+# a fake SLURM control plane standing in for the scheduler.  That fake
+# implements exactly the four command forms PRRTE issues, which makes it a
+# good regression test for PRRTE's side of the conversation and no test at all
+# of the assumption underneath it: that those four forms are what SLURM
+# actually accepts, and that what SLURM says back is what the parser expects.
+# Every case here exists because it can only be answered by a real scheduler.
+# Everything that is not about SLURM belongs in the sibling harness and is
+# deliberately absent here.
+#
+# Two clones on one host can each run a cluster: set PRTE_SLURM_SWARM (below).
+
+set -uo pipefail
+
+pass=0 fail=0 skip=0
+# Which cluster to drive.  Must match the PRTE_SLURM_SWARM that build.sh and
+# `docker compose up -d` ran under -- see docker-compose.yml.
+PRTE_SLURM_SWARM="${PRTE_SLURM_SWARM:-prteslurm}"
+# Reject what docker would reject, before it turns into a confusing compose
+# error.  The filter runs through LC_ALL=C tr rather than a shell [a-z] range
+# because in a UTF-8 locale that range follows collation order and matches
+# 'B' quite happily.
+case "$PRTE_SLURM_SWARM" in [_-]*) PRTE_SLURM_SWARM="" ;; esac
+if [ -z "$PRTE_SLURM_SWARM" ] || \
+   [ "$PRTE_SLURM_SWARM" != "$(printf '%s' "$PRTE_SLURM_SWARM" | LC_ALL=C tr -cd 'a-z0-9_-')" ]; then
+    echo "PRTE_SLURM_SWARM must be lowercase [a-z0-9_-] and start with a letter or digit" >&2
+    exit 2
+fi
+NODE="$PRTE_SLURM_SWARM-node"           # container names: ${NODE}1 .. ${NODE}10
+SWARM_ENV=""
+[ "$PRTE_SLURM_SWARM" = prteslurm ] || SWARM_ENV="PRTE_SLURM_SWARM=$PRTE_SLURM_SWARM "
+IMAGE="${IMAGE:-prte-slurm-swarm:latest}"
+
+ok()   { pass=$((pass+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  \033[31mFAIL\033[0m %s\n' "$1"; }
+skp()  { skip=$((skip+1)); printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+banner() { printf '\n=== %s ===\n' "$1"; }
+
+########################################################################
+# talking to the cluster
+########################################################################
+
+# Run a command on the head node with the PRRTE install on PATH, but with NO
+# SLURM allocation in the environment.  This is how you reach the scheduler
+# itself (sinfo/squeue/scontrol/slurm-alloc) and how you get a DVM that is
+# NOT under SLURM -- both of which the suite needs.
+RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "${NODE}1" bash -lc ". /opt/prte/env.sh; $*"; }
+# ...and the same on any node.
+ON()  { docker exec "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+
+# Run a command INSIDE a SLURM allocation -- the environment SLURM itself put
+# in a process running under `salloc`, captured by slurm-alloc and replayed
+# here.  This is the shell every PRRTE tool in this suite runs in, because it
+# is the shell a person under SLURM would be typing into.
+#
+# $ALLOC_TAG selects which allocation; the suite mostly uses the default.
+ALLOC_TAG=dvm
+SA() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+           "${NODE}1" bash -lc ". /opt/prte/env.sh;
+                                eval \"\$(slurm-alloc env --tag $ALLOC_TAG)\"; $*"; }
+# Detached, capturing output to a file -- for the DVM itself and for any tool
+# that has to stay alive while a case pokes at it.
+SA_BG() {
+    local outf=$1; shift
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        "${NODE}1" bash -lc ". /opt/prte/env.sh;
+                             eval \"\$(slurm-alloc env --tag $ALLOC_TAG)\"; $* > $outf 2>&1"
+}
+
+# slurm-alloc, outside any allocation
+ALLOC() { docker exec "${NODE}1" slurm-alloc "$@" 2>&1; }
+# the scheduler's own view
+SQ()    { docker exec "${NODE}1" bash -lc "$*" 2>&1; }
+
+########################################################################
+# cleanup
+########################################################################
+
+# What must not survive into the next case, on one node.  Identical to the
+# sibling harness's sweep -- every tool has its OWN session-dir prefix
+# (prte.<pid>, prtrn.<pid>, prted.<pid>, prun.<pid>, ompi.<pid>) and each
+# holds a pmix.* rendezvous file, so one missed prefix makes the next tool
+# report "multiple possible servers" and fail to find the DVM.
+SWARM_CLEAN='
+    for t in prted prte prterun prun pterm; do pkill -9 -x $t 2>/dev/null; done
+    rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* \
+           /tmp/pmix.* 2>/dev/null
+    find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} + 2>/dev/null
+    true'
+
+# The extra half that only this harness needs: give the scheduler its nodes
+# back.  A PRRTE extend holds its nodes through a SLURM job of its own, and a
+# suite that left those standing would starve every later case of the pool it
+# needs -- reported, of course, as "the grow did not happen", several cases
+# further on.
+cleanup_cluster() {
+    for n in $(seq 1 10); do
+        docker exec "$NODE$n" sh -c "$SWARM_CLEAN" >/dev/null 2>&1
+    done
+    ALLOC free --all >/dev/null 2>&1
+    # A cancelled job does not free its nodes instantly -- slurmctld has to
+    # reap the step and put each node back to idle, and an allocation
+    # requested before that happens simply waits.  Wait for the cluster to
+    # settle instead, so a case that is about to ask for nodes fails for its
+    # own reasons.
+    for _ in $(seq 30); do
+        [ "$(cluster_idle_count)" = 10 ] && break
+        sleep 1
+    done
+}
+
+cluster_idle_count() {
+    docker exec "${NODE}1" sh -c "sinfo -h -N -o '%t' 2>/dev/null | grep -c '^idle'" \
+        2>/dev/null | tr -d ' \r'
+}
+
+# how many nodes of the given list are running a prted
+prted_count() { local c=0 n; for n in "$@"; do ON "$n" 'pgrep -x prted' >/dev/null 2>&1 && c=$((c+1)); done; echo "$c"; }
+# "node2,node4" -> "2 4"
+idx_of() { echo "$1" | tr ',' '\n' | sed 's/^node//' | tr '\n' ' '; }
+
+########################################################################
+# starting a DVM inside an allocation
+########################################################################
+
+# Start a DVM on node1 in the current allocation.  $* is appended to the prte
+# command line.
+#
+# The DVM runs in the FOREGROUND under `docker exec -d` rather than with
+# --daemonize because several cases assert on what the HNP printed -- a
+# scheduler error PRRTE captured and reported -- and a daemonized HNP has
+# detached from stdio.
+dvm_start() {
+    SA 'rm -f /tmp/prte.out' >/dev/null 2>&1
+    SA_BG /tmp/prte.out "cd /root && prte $*"
+    for _ in $(seq 25); do
+        SA 'pgrep -x prte >/dev/null' && break
+        sleep 1
+    done
+    # `prte` existing is not the same as the DVM being up: the daemons are
+    # launched by srun and have to check in.  Wait for a trivial job to run
+    # rather than sleeping a fixed amount, which is both slower and less
+    # reliable on a loaded laptop.  Bounded on both axes -- a DVM that never
+    # forms should cost one case a couple of minutes, not the suite an hour.
+    for _ in $(seq 20); do
+        SA 'timeout 15 prun -n 1 hostname' >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    return 1
+}
+
+dvm_stop() { SA 'timeout -k 5 30 pterm' >/dev/null 2>&1; }
+
+########################################################################
+# preflight
+########################################################################
+
+preflight() {
+    banner "preflight"
+    local n out
+
+    if ! docker ps --format '{{.Names}}' | grep -q "^${NODE}1$"; then
+        echo "  no ${NODE}1 container -- run: ${SWARM_ENV}docker compose up -d" >&2
+        exit 2
+    fi
+    n=$(docker ps --format '{{.Names}}' | grep -c "^${NODE}[0-9]*$")
+    [ "$n" = 10 ] && ok "all ten node containers are running" \
+                  || { bad "only $n/10 node containers are running"; exit 2; }
+
+    # The containers are long-lived while the image is rebuilt under them --
+    # and the image is where SLURM and the baked PMIx live, so a container
+    # older than its image is running a different cluster than the one you
+    # think you configured.
+    local cimg iimg
+    cimg=$(docker inspect "${NODE}1" --format '{{.Image}}' 2>/dev/null)
+    iimg=$(docker images --no-trunc --format '{{.ID}}' "$IMAGE" 2>/dev/null | head -1)
+    if [ -n "$iimg" ] && [ "$cimg" != "$iimg" ]; then
+        bad "containers predate $IMAGE -- run: ${SWARM_ENV}docker compose up -d --force-recreate"
+        exit 2
+    fi
+    ok "containers are running the current image"
+
+    # The install lives in a volume that outlives any one build, so a build
+    # that died part-way leaves the PREVIOUS install standing and every
+    # failure reported below would really be "you are testing something else".
+    out=$(ON 1 'cat /opt/prte/.build-stamp 2>/dev/null' | tr -d '\r')
+    [ -n "$out" ] && ok "build stamp in the volume: $out" \
+                  || { bad "no build stamp in the volume -- rerun ./build.sh and check its exit status"; exit 2; }
+    RUN 'command -v prte >/dev/null && command -v prun >/dev/null' \
+        && ok "prte/prun are on PATH" \
+        || { bad "PRRTE tools are not on PATH in the container"; exit 2; }
+
+    # --- the cluster itself ---
+    out=$(SQ 'sinfo --version' | tr -d '\r')
+    [ -n "$out" ] && ok "SLURM answers: $out" \
+                  || { bad "slurmctld is not answering on node1"; exit 2; }
+    n=$(cluster_idle_count)
+    [ "$n" = 10 ] && ok "all ten nodes are idle in SLURM" \
+                  || bad "only $n/10 SLURM nodes are idle: $(SQ 'sinfo -h -N -o "%N=%t"' | tr '\n' ' ')"
+
+    # PRRTE parses `scontrol show job --json`, which is a build-time option of
+    # SLURM's.  If this SLURM cannot serialize, the elastic phases are not
+    # testing the parser -- they are testing an error path -- so say so here
+    # rather than reporting eight confusing failures later.
+    if SQ 'scontrol show config --json >/dev/null 2>&1'; then
+        ok "this SLURM can emit JSON (scontrol --json)"
+        HAVE_JSON=1
+    else
+        skp "this SLURM has no JSON serializer -- the elastic phases will skip"
+        HAVE_JSON=0
+    fi
+
+    # Was PRRTE built with the JSON parser?  Without --with-jansson, ras/slurm
+    # compiles a stub and every extend is refused for a reason that has
+    # nothing to do with the scheduler.
+    if RUN 'grep -q "with-jansson" /opt/prte/vpath-linux/.configure-args 2>/dev/null'; then
+        ok "PRRTE was configured --with-jansson (the real ras/slurm parser)"
+    else
+        skp "PRRTE was built without jansson -- ras/slurm uses the stub parser"
+        HAVE_JSON=0
+    fi
+}
+
+########################################################################
+# 1. the cluster itself
+########################################################################
+#
+# Not a PRRTE test.  It runs first because every other phase here blames
+# PRRTE for whatever it finds, and a cluster that cannot launch a step of its
+# own would make all of them lie.  Keep it to things SLURM does without
+# PRRTE's involvement.
+test_cluster() {
+    local out n jid
+
+    banner "cluster: SLURM launches a step across every node"
+    cleanup_cluster
+    out=$(SQ 'srun -N10 --ntasks-per-node=1 hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^node[0-9]+$')
+    [ "$n" = 10 ] && ok "a 10-node srun step ran on all ten nodes" \
+                  || bad "srun reached $n/10 nodes: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    banner "cluster: an allocation can be held and handed back"
+    # This is the mechanism the whole suite runs on -- an allocation created
+    # in one `docker exec` and used by the next -- so it is asserted rather
+    # than assumed.  See slurm-alloc.py.
+    jid=$(ALLOC new --tag probe --nodes 3 --tasks-per-node 2 | tail -1)
+    if echo "$jid" | grep -qE '^[0-9]+$'; then
+        ok "salloc granted job $jid and the allocation is being held"
+    else
+        bad "could not create an allocation: $jid"
+        return
+    fi
+    out=$(ALLOC env --tag probe)
+    # SLURM_JOBID is the variable both ras/slurm and plm/slurm gate on -- it
+    # has been deprecated in favour of SLURM_JOB_ID for years, and if a
+    # future release stops setting it, PRRTE stops recognizing SLURM at all
+    # and every case here quietly falls back to the ssh launcher and passes.
+    echo "$out" | grep -q "^export SLURM_JOBID=" \
+        && ok "SLURM still sets SLURM_JOBID (what PRRTE gates on)" \
+        || bad "SLURM_JOBID is not set -- PRRTE will not detect this scheduler at all"
+    echo "$out" | grep -q "^export SLURM_TASKS_PER_NODE=" \
+        && ok "SLURM sets SLURM_TASKS_PER_NODE (the slot count PRRTE reads)" \
+        || bad "SLURM_TASKS_PER_NODE is not set: $(echo "$out" | tr '\n' ' ')"
+    ALLOC free --tag probe >/dev/null 2>&1
+    for _ in $(seq 20); do [ "$(cluster_idle_count)" = 10 ] && break; sleep 1; done
+    [ "$(cluster_idle_count)" = 10 ] \
+        && ok "cancelling the allocation returned every node to the pool" \
+        || bad "nodes did not return to idle: $(SQ 'sinfo -h -N -o "%N=%t"' | tr '\n' ' ')"
+
+    banner "cluster: the JSON schema PRRTE parses is the one this SLURM emits"
+    # The reason this harness pins a SLURM version.  ras_slurm_jansson.c
+    # reads job_resources.nodes.{count,list,allocation}, which is data_parser
+    # v0.0.41 and later (SLURM 24.05+).  Against 23.11 the same query returns
+    # job_resources.nodes as a plain STRING and every extend fails with
+    # "Failed to parse input JSON" -- a failure that says nothing about
+    # PRRTE, so it is worth naming here rather than eight cases later.
+    if [ "$HAVE_JSON" != 1 ]; then
+        skp "no JSON serializer -- schema check not possible"
+        return
+    fi
+    jid=$(ALLOC new --tag probe --nodes 2 --tasks-per-node 2 | tail -1)
+    # Piped into the CONTAINER's python3, not the host's: the host running
+    # this script is whatever the developer has, and the harness should not
+    # acquire a dependency on it just to read a JSON document.
+    out=$(SQ "scontrol show job $jid --json" 2>/dev/null)
+    if out=$(printf '%s' "$out" | docker exec -i "${NODE}1" python3 -c '
+import json,sys
+try:
+    jr = json.load(sys.stdin)["jobs"][0]["job_resources"]
+except Exception as e:
+    print("unreadable: %s" % e); sys.exit(1)
+n = jr.get("nodes")
+if not isinstance(n, dict):
+    print("job_resources.nodes is %s, not an object (SLURM older than 24.05)"
+          % type(n).__name__); sys.exit(1)
+for k in ("count", "list", "allocation"):
+    if k not in n:
+        print("job_resources.nodes has no %r" % k); sys.exit(1)
+a = n["allocation"][0]
+for k in ("name", "cpus", "sockets"):
+    if k not in a:
+        print("an allocation entry has no %r" % k); sys.exit(1)
+if "status" not in a["sockets"][0]["cores"][0]:
+    print("a core has no status (PRRTE counts ALLOCATED cores)"); sys.exit(1)
+sys.exit(0)' 2>&1); then
+        ok "scontrol --json emits the job_resources shape ras/slurm parses"
+    else
+        bad "JSON schema mismatch: $out"
+        HAVE_JSON=0
+    fi
+    ALLOC free --all >/dev/null 2>&1
+}
+
+########################################################################
+# 2. ras/slurm: what an allocation means to the DVM
+########################################################################
+#
+# The unit test covers the half of ras/slurm that only reads the environment,
+# with the environment hand-written.  What it cannot do is write that
+# environment the way SLURM writes it.  Every case below turns on a value
+# this harness did not invent: the node list in SLURM's own compressed
+# notation, the task count in SLURM's own "N(xM)" notation, and the fact that
+# the head node need not be in the allocation at all.
+test_ras_alloc() {
+    local out n
+
+    banner "ras/slurm: the allocation forms the whole DVM, with no --host"
+    cleanup_cluster
+    ALLOC new --tag dvm --nodes 3 --tasks-per-node 2 >/dev/null 2>&1
+    if ! dvm_start --prtemca ras_base_verbose 5; then
+        bad "no DVM came up in a 3-node allocation: $(SA 'tail -5 /tmp/prte.out' | tr '\n' ' ')"
+        cleanup_cluster; return
+    fi
+    # node1 runs the HNP, so the daemons to count are on the other two
+    [ "$(prted_count 2 3)" = 2 ] \
+        && ok "daemons launched on every allocated node, with no --host given" \
+        || bad "the allocation did not form the DVM ($(prted_count 2 3)/2 daemons)"
+    out=$(SA 'timeout 60 prun -n 3 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 3 ] && ok "a job maps across the whole allocation" \
+                 || bad "job did not spread over the allocation ($n/3 distinct): $(echo "$out" | tr '\n' ' ')"
+
+    banner "ras/slurm: the slot count SLURM gave is the slot count PRRTE uses"
+    # SLURM_TASKS_PER_NODE arrives as "2(x3)".  A node whose count came from
+    # the scheduler must not be re-sized from its core count -- these
+    # containers claim 8 cores, so the failure would turn 2 slots into 8 and
+    # hide every oversubscription.
+    out=$(SA 'timeout 30 prun --display allocation -n 1 hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^[[:space:]]*node[0-9]+:[[:space:]]+slots=2[[:space:]]')
+    [ "$n" = 3 ] && ok "all three nodes kept slots=2 from SLURM_TASKS_PER_NODE" \
+                 || bad "slot counts were recomputed ($n/3 kept): $(echo "$out" | grep -E 'node[0-9]+:' | tr '\n' ' ')"
+
+    banner "ras/slurm: --host selects within the allocation, and only within it"
+    out=$(SA 'timeout 30 prun --host node2 -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node2 ] \
+        && ok "--host picks an allocated node" \
+        || bad "--host node2 did not run there: $out"
+    out=$(SA 'timeout 30 prun --host node9 -n 1 hostname 2>&1 | tr -d "\0"')
+    echo "$out" | grep -q 'Missing requested host: node9' \
+        && ok "--host outside the allocation is refused, naming the host" \
+        || bad "--host node9 was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    dvm_stop
+    cleanup_cluster
+
+    banner "ras/slurm: SLURM's compressed node list expands to exactly those nodes"
+    # The one thing the fake scheduler structurally cannot test.  It hands out
+    # comma-separated names; SLURM hands out "node[2,4,6]", and ras/slurm has
+    # its own parser for that notation.  A non-contiguous list is used on
+    # purpose: a parser that reads "node[2,4,6]" as the range 2..6 gets five
+    # nodes, three of which it was never given.
+    ALLOC new --tag dvm --nodelist node2,node4,node6 --tasks-per-node 2 >/dev/null 2>&1
+    out=$(ALLOC env --tag dvm | sed -n "s/^export SLURM_NODELIST='\(.*\)'$/\1/p")
+    case "$out" in
+        *\[*) ok "SLURM handed PRRTE the compressed form: $out" ;;
+        *)    skp "SLURM did not compress this node list ($out) -- parser not exercised" ;;
+    esac
+    if dvm_start --prtemca ras_base_verbose 5; then
+        n=$(SA 'grep -c "discover: adding node" /tmp/prte.out' 2>/dev/null | tr -d ' \r')
+        [ "$n" = 3 ] && ok "the compressed list expanded to exactly 3 nodes" \
+                     || bad "expansion produced $n nodes: $(SA 'grep "adding node" /tmp/prte.out' | tr '\n' ' ')"
+        for want in node2 node4 node6; do
+            SA "grep -q 'adding node $want ' /tmp/prte.out" \
+                && ok "$want is in the DVM allocation" \
+                || bad "$want missing from the expanded allocation"
+        done
+        SA 'grep -q "adding node node3 \|adding node node5 " /tmp/prte.out' \
+            && bad "a node BETWEEN the named ones was invented by the parser" \
+            || ok "no node between the named ones was invented"
+        dvm_stop
+    else
+        bad "no DVM came up on a non-contiguous allocation"
+    fi
+    cleanup_cluster
+
+    banner "ras/slurm: an allocation that excludes the head node"
+    # prte runs on node1, but SLURM allocated node2 and node3 only.  The head
+    # node is in the pool -- it always is -- yet is not usable, so a job must
+    # map only onto the allocation and naming node1 must be an error rather
+    # than a quiet fall-back onto an unallocated machine.  Note this also
+    # exercises srun being issued from a host that is not part of the job.
+    ALLOC new --tag dvm --nodelist node2,node3 --tasks-per-node 2 >/dev/null 2>&1
+    if dvm_start; then
+        [ "$(prted_count 2 3)" = 2 ] \
+            && ok "daemons launched on the allocation, not on the head node" \
+            || bad "head-node-excluded allocation did not form ($(prted_count 2 3)/2)"
+        out=$(SA 'timeout 60 prun -n 2 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[23]$' | sort -u | wc -l | tr -d ' ')
+        { [ "$n" = 2 ] && ! echo "$out" | grep -qE '^node1$'; } \
+            && ok "the job ran only on allocated nodes" \
+            || bad "job leaked onto the unallocated head node: $(echo "$out" | tr '\n' ' ')"
+        out=$(SA 'timeout 30 prun --host node1 -n 1 hostname 2>&1 | tr -d "\0"')
+        echo "$out" | grep -q 'Missing requested host: node1' \
+            && ok "--host naming the unallocated head node is refused" \
+            || bad "the unallocated head node was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        dvm_stop
+    else
+        bad "no DVM came up on an allocation excluding the head node"
+    fi
+    cleanup_cluster
+}
+
+########################################################################
+# 3. plm/slurm: the daemons go out over srun
+########################################################################
+#
+# The fake scheduler cannot reach this component at all: it supplies
+# sbatch/scontrol/scancel, and plm/slurm shells out to *srun*, which is a
+# launcher, not a control-plane query.  Every DVM in the sibling harness is
+# therefore launched over ssh no matter what the ras is told.  These cases are
+# the only place PRRTE's SLURM launcher is exercised.
+test_plm() {
+    local out n
+
+    banner "plm/slurm: daemons are launched by srun, inside the SLURM job"
+    cleanup_cluster
+    ALLOC new --tag dvm --nodes 4 --tasks-per-node 2 >/dev/null 2>&1
+    local jid; jid=$(ALLOC jobid --tag dvm | tr -d ' \r')
+    if ! dvm_start --prtemca plm_base_verbose 5; then
+        bad "no DVM came up in a 4-node allocation: $(SA 'tail -5 /tmp/prte.out' | tr '\n' ' ')"
+        cleanup_cluster; return
+    fi
+    SA 'grep -q "plm:slurm: LAUNCH DAEMONS CALLED" /tmp/prte.out' \
+        && ok "plm/slurm won selection and ran the launch" \
+        || bad "plm/slurm did not launch the daemons -- selection fell back to another component"
+    out=$(SA 'grep -A2 "final top-level argv" /tmp/prte.out' 2>/dev/null | tr '\n' ' ')
+    echo "$out" | grep -q 'srun ' \
+        && ok "the launch command is srun" \
+        || bad "no srun in the launch command: $(echo "$out" | tail -c 200)"
+    # --jobid is what makes the daemon step join THIS allocation rather than
+    # queue a new job of its own.  A launcher that omitted it would appear to
+    # work on an idle cluster and deadlock on a busy one.
+    echo "$out" | grep -q -- "--jobid=$jid" \
+        && ok "srun was told to run inside the allocation (--jobid=$jid)" \
+        || bad "srun did not carry --jobid=$jid: $(echo "$out" | tail -c 200)"
+    [ "$(prted_count 2 3 4)" = 3 ] \
+        && ok "a daemon is running on each non-head allocated node" \
+        || bad "only $(prted_count 2 3 4)/3 daemons came up"
+
+    banner "plm/slurm: srun hands off and exits, and the daemons outlive it"
+    # prted daemonizes by default, so the srun that launched it completes as
+    # soon as the fork is done -- and PRRTE has to recognize that exit as a
+    # hand-off rather than as a launch failure.  On a real scheduler the step
+    # really does end, and SLURM really does reap it; nothing in the sibling
+    # harness can show either.
+    SA 'grep -q "primary srun exited after daemon hand-off" /tmp/prte.out' \
+        && ok "PRRTE recognized the srun exit as a hand-off, not a failure" \
+        || bad "no hand-off note from plm/slurm: $(SA 'grep -c srun /tmp/prte.out')"
+    SA 'pgrep -x srun >/dev/null' \
+        && bad "an srun is still running after the hand-off" \
+        || ok "no srun survives the hand-off"
+    n=$(SQ "squeue -h -s -j $jid -o '%i'" | grep -c . | tr -d ' ')
+    [ "$n" = 0 ] && ok "SLURM has no leftover job step for the daemons" \
+                 || bad "$n job step(s) still registered against job $jid"
+    out=$(SA 'timeout 60 prun -n 4 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 4 ] && ok "a job runs across the srun-launched DVM" \
+                 || bad "job reached $n/4 nodes: $(echo "$out" | tr '\n' ' ')"
+
+    banner "plm/slurm: pterm takes the DVM down and leaves SLURM clean"
+    dvm_stop
+    sleep 3
+    [ "$(prted_count 1 2 3 4)" = 0 ] \
+        && ok "pterm left no daemon behind" \
+        || bad "$(prted_count 1 2 3 4) daemon(s) survived pterm"
+    # The allocation is the harness's, not PRRTE's: taking the DVM down must
+    # not cancel it.  A launcher that killed the job would take the user's
+    # shell with it on a real cluster.
+    SQ "squeue -h -j $jid -o '%T'" | grep -q RUNNING \
+        && ok "the SLURM allocation survived the DVM shutdown" \
+        || bad "pterm took the SLURM allocation with it"
+    cleanup_cluster
+
+    banner "plm/slurm: no allocation means no SLURM launcher"
+    # The gate is SLURM_JOBID, and this is the other side of it: on the very
+    # same cluster, with no allocation in the environment, PRRTE must fall
+    # back to ssh rather than trying to srun into a job it does not have.
+    RUN 'rm -f /tmp/prte-nossh.out'
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        "${NODE}1" bash -lc '. /opt/prte/env.sh; cd /root &&
+            prte --host node1:2,node2:2,node3:2 --prtemca plm_base_verbose 5 \
+                 > /tmp/prte-nossh.out 2>&1'
+    for _ in $(seq 25); do
+        RUN 'timeout 20 prun -n 1 hostname' >/dev/null 2>&1 && break
+        sleep 1
+    done
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'grep -q "plm:ssh" /tmp/prte-nossh.out' \
+            && ok "without SLURM_JOBID the ssh launcher runs instead" \
+            || bad "no plm/ssh activity outside an allocation: $(RUN 'grep -m2 "plm:" /tmp/prte-nossh.out' | tr '\n' ' ')"
+        out=$(RUN 'timeout 60 prun -n 3 --map-by node hostname' 2>&1)
+        n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 3 ] && ok "the ssh-launched DVM works on the same cluster" \
+                     || bad "ssh-launched DVM reached $n/3 nodes: $(echo "$out" | tr '\n' ' ')"
+        # ...and it must not have quietly consumed scheduler resources
+        n=$(SQ "squeue -h -o '%i'" | grep -c . | tr -d ' ')
+        [ "$n" = 0 ] && ok "the out-of-band DVM created no SLURM job" \
+                     || bad "$n SLURM job(s) appeared for a DVM launched outside SLURM"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "no DVM came up outside an allocation: $(RUN 'tail -3 /tmp/prte-nossh.out' | tr '\n' ' ')"
+    fi
+    cleanup_cluster
+}
+
+########################################################################
+# 4. ras/slurm: the elastic modify surface, against the real scheduler
+########################################################################
+#
+# This is the phase the harness exists for.  Every command here goes to a
+# scheduler that can say no: sbatch really queues a job, "scontrol show job
+# --json" really emits SLURM's own schema (which is why the image pins 24.05
+# or newer -- see test_cluster), "scontrol update" really has to be a resize
+# SLURM accepts on a RUNNING job, and scancel really removes an allocation.
+#
+# The request shapes are not the same as a plain elastic grow.  `elastic grow
+# <nodes>` is PMIX_ALLOC_NEW naming hosts, which the base serves without ever
+# consulting the ras.  ras/slurm's modify() accepts only
+# PMIX_ALLOC_EXTEND+NUM_NODES, PMIX_ALLOC_RELEASE+(NODE_LIST|NUM_NODES|
+# ALLOC_ID) and PMIX_ALLOC_REQ_CANCEL -- which nodes an extend lands on is
+# the scheduler's choice.  Hence `elastic extend|release|release-id|cancel`.
+job_nodes() {   # $1 = slurm job id -> comma-separated hostnames
+    local nl; nl=$(SQ "squeue -h -j $1 -o '%N'" | tr -d ' \r')
+    [ -n "$nl" ] || return 1
+    SQ "scontrol show hostnames $nl" | tr -d '\r' | paste -sd, -
+}
+
+test_elastic() {
+    local out jid ajid nodes idx n
+
+    if [ "$HAVE_JSON" != 1 ]; then
+        banner "ras/slurm: elastic modify surface"
+        skp "no usable JSON path -- the whole extend/release surface is unreachable"
+        return
+    fi
+
+    banner "ras/slurm: PMIX_ALLOC_EXTEND submits a real job and absorbs it"
+    cleanup_cluster
+    ALLOC new --tag dvm --nodes 3 --tasks-per-node 2 >/dev/null 2>&1
+    jid=$(ALLOC jobid --tag dvm | tr -d ' \r')
+    if ! dvm_start --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5; then
+        bad "no DVM came up for the elastic phase: $(SA 'tail -5 /tmp/prte.out' | tr '\n' ' ')"
+        cleanup_cluster; return
+    fi
+    out=$(SA 'timeout 180 elastic extend 2' 2>&1)
+    ajid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    if [ -z "$ajid" ]; then
+        bad "extend was refused: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        printf '    HNP: %s\n' "$(SA 'grep -iE "json|error|slurm" /tmp/prte.out | tail -3' | tr '\n' ' ')"
+        dvm_stop; cleanup_cluster; return
+    fi
+    ok "extend accepted and reported PMIX_ALLOC_ID=$ajid"
+    SQ "squeue -h -j $ajid -o '%i'" | grep -q "$ajid" \
+        && ok "SLURM really has a job $ajid (sbatch reached the scheduler)" \
+        || bad "no SLURM job $ajid exists -- the id PRRTE reported is not a job"
+    nodes=$(job_nodes "$ajid"); idx=$(idx_of "$nodes")
+    sleep 8
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 2 ] \
+        && ok "daemons launched on the nodes SLURM granted ($nodes)" \
+        || bad "no daemons on the granted nodes ($nodes) -- the grow never reached them"
+    # An extend puts its nodes in the GENERAL pool -- ras/slurm deliberately
+    # leaves node->session NULL -- so a plain prun must reach them with no
+    # allocation directive at all.
+    out=$(SA 'timeout 60 prun -n 5 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 5 ] && ok "a plain prun maps onto the extended allocation (5 nodes)" \
+                 || bad "prun did not reach the extended nodes ($n/5 distinct): $(echo "$out" | tr '\n' ' ')"
+    # The slot count comes from counting cores whose status is ALLOCATED,
+    # capped by cpus.count.  Here SLURM itself decides that number, so this
+    # asserts the parser against real core statuses rather than against a
+    # fixture written to match it.
+    SA "grep -q 'add_modified_resources: discovered node ${nodes%%,*} with .* slots' /tmp/prte.out" \
+        && ok "slots for the granted nodes were derived from the job JSON" \
+        || bad "no slot derivation logged for ${nodes%%,*}: $(SA 'grep -m3 discovered.node /tmp/prte.out' | tr '\n' ' ')"
+
+    banner "ras/slurm: the parent job's attributes reach the sbatch SLURM ran"
+    # The fake scheduler could only show that the arguments were *written*.
+    # Here they have to be arguments sbatch accepts -- one it does not is a
+    # submission failure, not a mis-formatted string -- and the scheduler's
+    # own record of the new job is what is asserted.
+    out=$(SQ "scontrol show job $ajid -o" | tr -d '\r')
+    echo "$out" | grep -q 'NumNodes=2' \
+        && ok "the expander job was submitted for exactly 2 nodes" \
+        || bad "wrong node count on job $ajid: $(echo "$out" | tr ' ' '\n' | grep -m1 NumNodes)"
+    echo "$out" | grep -q 'Partition=debug' \
+        && ok "the parent job's partition was propagated" \
+        || bad "partition not propagated: $(echo "$out" | tr ' ' '\n' | grep -m1 Partition)"
+    # --exclusive is in the fixed part of the sbatch line, and SLURM records
+    # it as whole-node ownership.
+    # --exclusive is in the fixed part of the sbatch line, and what it buys is
+    # WHOLE nodes: without it SLURM would hand back one CPU per node under
+    # cons_tres, and PRRTE would then be sharing machines it believes it owns.
+    # Assert the cpu count rather than OverSubscribe=, which is NO by default
+    # in this partition and would pass with the flag removed.
+    n=$(echo "$out" | tr ' ' '\n' | sed -n 's/^NumCPUs=//p')
+    [ -n "$n" ] && [ "$n" -ge 16 ] \
+        && ok "the expander job owns whole nodes ($n cpus for 2 nodes -- --exclusive)" \
+        || bad "the granted job did not get whole nodes (NumCPUs=$n, want >= 16)"
+
+    banner "ras/slurm: releasing one node resizes the SLURM job in place"
+    # Removing SOME of a job's nodes keeps the job and resizes it with
+    # "scontrol update job <id> ReqNodeList=<survivors>".  Whether SLURM
+    # accepts that on a RUNNING job is exactly the assumption a fake
+    # scheduler cannot check, and it is the single most valuable assertion
+    # in this file.
+    out=$(SA "timeout 180 elastic shrink ${nodes##*,}" 2>&1)
+    sleep 6
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "partial release completed (PMIX_DVM_IS_READY)" \
+        || bad "partial release never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $(idx_of "${nodes##*,}"))" = 0 ] \
+        && ok "daemon gone from the released node (${nodes##*,})" \
+        || bad "daemon still running on the released node"
+    n=$(SQ "squeue -h -j $ajid -o '%D'" | tr -d ' \r')
+    [ "$n" = 1 ] \
+        && ok "SLURM resized job $ajid down to its surviving node" \
+        || bad "SLURM did not accept the in-place resize (job $ajid still has $n nodes): $(SA 'grep -iE "scontrol|resize|update" /tmp/prte.out | tail -2' | tr '\n' ' ')"
+    [ "$(job_nodes "$ajid")" = "${nodes%%,*}" ] \
+        && ok "the job kept exactly the node PRRTE named as survivor" \
+        || bad "job $ajid holds $(job_nodes "$ajid"), expected ${nodes%%,*}"
+    # SLURM writes slurm_job_<id>_resize.{sh,csh} into the caller's cwd on a
+    # successful shrink for the user to source; PRRTE deletes them.  Their
+    # absence only means anything because the resize above really happened.
+    [ -z "$(SA 'find / -maxdepth 2 -name "slurm_job_*_resize.*" 2>/dev/null')" ] \
+        && ok "the resize helper scripts SLURM left behind were cleaned up" \
+        || bad "slurm_job_*_resize.* left behind after a shrink"
+
+    banner "ras/slurm: releasing a whole allocation scancels its SLURM job"
+    out=$(SA "timeout 180 elastic release-id $ajid" 2>&1)
+    sleep 6
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "release by allocation id completed" \
+        || bad "release-id never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 0 ] && ok "the granted nodes left the DVM" \
+                                  || bad "a daemon survived the full release"
+    SQ "squeue -h -j $ajid -o '%i'" | grep -q "$ajid" \
+        && bad "SLURM job $ajid still exists after the release" \
+        || ok "SLURM job $ajid is gone from the queue"
+    # the DVM's own allocation must be untouched: it holds the node PRRTE is
+    # running on
+    SQ "squeue -h -j $jid -o '%T'" | grep -q RUNNING \
+        && ok "the DVM's own SLURM allocation was left alone" \
+        || bad "the release took out the base allocation"
+    out=$(SA 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node1 ] \
+        && ok "DVM still responsive after the release" \
+        || bad "DVM wedged after the release: $out"
+
+    banner "ras/slurm: release by node COUNT cancels the newest allocation"
+    out=$(SA 'timeout 180 elastic extend 2' 2>&1)
+    ajid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    if [ -n "$ajid" ]; then
+        nodes=$(job_nodes "$ajid"); idx=$(idx_of "$nodes")
+        sleep 8
+        # shellcheck disable=SC2086
+        [ "$(prted_count $idx)" = 2 ] \
+            && ok "re-extend brought two more nodes in ($nodes)" \
+            || bad "re-extend did not launch daemons on $nodes"
+        out=$(SA 'timeout 180 elastic release 2' 2>&1)
+        sleep 6
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "release by count completed" \
+            || bad "release by count never completed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        # shellcheck disable=SC2086
+        [ "$(prted_count $idx)" = 0 ] \
+            && ok "the counted release emptied the newest allocation" \
+            || bad "a daemon survived the counted release"
+        SQ "squeue -h -j $ajid -o '%i'" | grep -q "$ajid" \
+            && bad "count release did not cancel job $ajid" \
+            || ok "the whole SLURM job was cancelled rather than resized"
+    else
+        bad "could not re-extend: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    fi
+
+    banner "ras/slurm: an extend SLURM cannot satisfy pends, and can be cancelled"
+    # No fault injection needed: ask for more nodes than the cluster has free
+    # and SLURM queues the job as PENDING, which is the state the cancel path
+    # exists for.  PMIX_ALLOC_REQ_CANCEL is served while the extend's poll
+    # loop is still waiting, and must scancel the queued job and turn the
+    # waiting request into a failure rather than leaving it to time out.
+    n=$(cluster_idle_count)
+    SA "nohup timeout 240 elastic extend $((n + 2)) --req-id slow-req \
+            >/tmp/extend.out 2>&1 & sleep 2" >/dev/null 2>&1
+    sleep 8
+    ajid=$(SQ "squeue -h -t PENDING -o '%i'" | tr -d ' \r' | head -1)
+    if [ -n "$ajid" ]; then
+        ok "the oversized extend queued SLURM job $ajid as PENDING"
+        SA 'timeout 90 elastic cancel slow-req' >/dev/null 2>&1
+        sleep 8
+        SQ "squeue -h -j $ajid -o '%i'" | grep -q "$ajid" \
+            && bad "the cancelled request left its pending job queued" \
+            || ok "the cancelled request scancelled its pending SLURM job"
+        SA 'grep -q "REJECTED\|FAILURE" /tmp/extend.out' \
+            && ok "the waiting extend reported failure to its requester" \
+            || bad "the cancelled extend never answered: $(SA 'tr "\n" " " < /tmp/extend.out' | tail -c 200)"
+    else
+        bad "the oversized extend never queued a job: $(SA 'tr "\n" " " < /tmp/extend.out' | tail -c 200)"
+    fi
+    SA 'pgrep -x prte >/dev/null' && ok "HNP survived the cancellation" \
+                                  || bad "HNP died during the cancellation"
+
+    banner "ras/slurm: a node name that is not a hostname never reaches a shell"
+    # Every hostname bound for an scontrol/scancel command line goes through
+    # prte_ras_slurm_validate_hostname's allowlist first.  This one carries a
+    # command separator: it must be refused outright, and nothing may run.
+    # The stake is higher against a real scheduler -- the command that would
+    # be built here is one a live slurmctld would act on.
+    SA 'rm -f /tmp/pwned' >/dev/null 2>&1
+    out=$(SA "timeout 90 elastic shrink 'node9;touch /tmp/pwned'" 2>&1)
+    echo "$out" | grep -q 'REJECTED' \
+        && ok "a release naming a tainted hostname was refused" \
+        || bad "tainted hostname not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    SA 'test -e /tmp/pwned' \
+        && bad "the injected command RAN -- hostname validation is not holding" \
+        || ok "the injected command never ran"
+    SA 'pgrep -x prte >/dev/null' && ok "HNP survived the tainted request" \
+                                  || bad "HNP died on a tainted hostname"
+    dvm_stop
+    cleanup_cluster
+}
+
+########################################################################
+# 5. running work in the allocation
+########################################################################
+#
+# A short launch smoke test, deliberately short: everything about mapping,
+# IOF, collectives and the rest is the sibling harness's subject and is not
+# repeated here.  What these cases add is that the ordinary paths still work
+# when the DVM was built out of a scheduler allocation rather than a --host
+# list -- the node objects come from a different producer, and that is enough
+# to break placement and I/O without breaking startup.
+test_launch() {
+    local out n
+
+    banner "launch: work runs across an allocation-built DVM"
+    cleanup_cluster
+    ALLOC new --tag dvm --nodes 4 --tasks-per-node 2 >/dev/null 2>&1
+    if ! dvm_start; then
+        bad "no DVM came up for the launch phase"
+        cleanup_cluster; return
+    fi
+    out=$(SA 'timeout 60 prun -n 8 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^node[0-9]+$')
+    [ "$n" = 8 ] && ok "8 ranks across 4 allocated nodes all reported" \
+                 || bad "only $n/8 ranks reported: $(echo "$out" | tr '\n' ' ')"
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 4 ] && ok "the ranks were spread over all four nodes" \
+                 || bad "ranks landed on $n/4 nodes"
+
+    banner "launch: stdout comes back from every node, and status with it"
+    # IOF over the wire is the sibling harness's subject; what is asserted
+    # here is only that a job whose nodes came from SLURM still forwards.
+    out=$(SA 'timeout 60 prun -n 4 --map-by node bash -c "echo OUT-\$PMIX_RANK-\$(hostname)"' 2>&1)
+    n=$(echo "$out" | grep -c '^OUT-')
+    [ "$n" = 4 ] && ok "output from all four ranks was forwarded to the tool" \
+                 || bad "only $n/4 output lines came back: $(echo "$out" | tr '\n' ' ')"
+    SA 'timeout 60 prun -n 2 --map-by node false' >/dev/null 2>&1
+    [ $? != 0 ] && ok "a failing job returns non-zero to the submitter" \
+                 || bad "a job of /bin/false reported success"
+
+    banner "launch: oversubscribing the allocation is refused"
+    # The slot count is SLURM's (2 a node), and a request past it must be
+    # refused rather than quietly oversubscribing the scheduler's nodes --
+    # on a shared cluster that is somebody else's job losing its cores.
+    out=$(SA 'timeout 60 prun -n 40 hostname 2>&1 | tr -d "\0"')
+    echo "$out" | grep -qiE 'not enough|no available|already filled|Insufficient' \
+        && ok "a job larger than the allocation was refused" \
+        || bad "a 40-rank job on 8 slots was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+    dvm_stop
+    sleep 3
+    [ "$(prted_count 1 2 3 4)" = 0 ] \
+        && ok "pterm left no daemon behind" \
+        || bad "$(prted_count 1 2 3 4) daemon(s) survived pterm"
+    cleanup_cluster
+}
+
+########################################################################
+# main
+########################################################################
+
+HAVE_JSON=0
+preflight
+test_cluster
+test_ras_alloc
+test_plm
+test_elastic
+test_launch
+
+# Leave the cluster as we found it: no PRRTE processes, no allocations, every
+# node idle.  A suite that left an allocation standing would make the NEXT
+# run's first phase fail for want of nodes.
+cleanup_cluster
+
+printf '\n=== summary ===\n'
+printf '  passed: %d\n  failed: %d\n  skipped: %d\n' "$pass" "$fail" "$skip"
+[ "$fail" = 0 ] || exit 1
+exit 0

--- a/contrib/slurmswarm/slurm-alloc.py
+++ b/contrib/slurmswarm/slurm-alloc.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+"""slurm-alloc -- hold a real SLURM allocation across many `docker exec` calls.
+
+The problem this solves is entirely a property of the harness, not of SLURM.
+A person testing PRRTE under SLURM writes::
+
+    salloc -N 3 --ntasks-per-node=2 bash      # ... and works in that shell
+
+Every command they then run inherits the allocation's environment, which is
+what ``ras/slurm`` reads (``SLURM_JOBID``, ``SLURM_NODELIST``,
+``SLURM_TASKS_PER_NODE``) and what ``plm/slurm`` needs before ``srun`` will
+join the allocation rather than making a new one.  A test suite driving the
+swarm from outside has no such shell: every case is its own ``docker exec``,
+and an allocation created in one of them is gone by the next.
+
+So this script does the same thing in two halves.  ``new`` runs a real
+``salloc`` whose command is a shell that **dumps its own environment to a
+file** and then sleeps, holding the allocation; ``env`` prints that captured
+environment back as ``export`` lines for a later shell to eval.
+
+The environment is *captured, never reconstructed*.  That distinction is the
+whole point of this harness: a reconstruction would encode this author's
+belief about which variables SLURM sets, and the interesting failures are
+exactly where that belief is wrong.  (It already was: see AGENTS.md section
+13 on ``SLURM_JOBID``.)  What ``env`` prints is what SLURM itself put in the
+environment of a process running inside the allocation.
+
+Subcommands::
+
+    slurm-alloc new [--tag NAME] [--nodes N] [--nodelist LIST]
+                    [--tasks-per-node T] [--exclusive] [--time MINS]
+    slurm-alloc env [--tag NAME]        # export lines to eval
+    slurm-alloc jobid [--tag NAME]      # the SLURM job id
+    slurm-alloc nodes [--tag NAME]      # allocated nodes, comma separated
+    slurm-alloc free [--tag NAME|--all] # scancel it
+    slurm-alloc pool                    # nodes with nothing allocated on them
+    slurm-alloc jobs                    # every job SLURM currently knows
+    slurm-alloc wait <jobid> [secs]     # block until the job is RUNNING
+
+State (the captured environments) lives in $SLURM_HARNESS_STATE, default
+/tmp/slurm-harness.
+"""
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+STATE = os.environ.get("SLURM_HARNESS_STATE", "/tmp/slurm-harness")
+
+# What `env` will print back.  The filter is a prefix test rather than a list
+# of names for the same reason the environment is captured rather than
+# reconstructed: a variable SLURM adds in a later release should reach PRRTE
+# without anyone here having to know about it.  SLURM_CONF is excluded because
+# it points at a file, not at an allocation, and the containers all read the
+# same baked one anyway.
+ENV_PREFIXES = ("SLURM_", "SLURMD_")
+ENV_EXCLUDE = ("SLURM_CONF",)
+
+
+def die(msg, rc=1):
+    sys.stderr.write("slurm-alloc: %s\n" % msg)
+    sys.exit(rc)
+
+
+def state_path(tag, suffix):
+    return os.path.join(STATE, "%s.%s" % (tag, suffix))
+
+
+def run(argv, **kw):
+    """Run a command and return (rc, stdout+stderr)."""
+    try:
+        p = subprocess.run(argv, stdout=subprocess.PIPE,
+                           stderr=subprocess.STDOUT, **kw)
+    except OSError as e:
+        return 127, str(e)
+    return p.returncode, p.stdout.decode("utf-8", "replace")
+
+
+# --------------------------------------------------------------------------
+# new
+# --------------------------------------------------------------------------
+
+def cmd_new(args):
+    os.makedirs(STATE, exist_ok=True)
+    envf = state_path(args.tag, "env")
+    jobf = state_path(args.tag, "jobid")
+    logf = state_path(args.tag, "log")
+    for f in (envf, jobf, logf):
+        try:
+            os.unlink(f)
+        except OSError:
+            pass
+
+    salloc = ["salloc", "--no-bell", "--job-name=prte-%s" % args.tag]
+    if args.nodes:
+        salloc.append("--nodes=%d" % args.nodes)
+    if args.nodelist:
+        salloc.append("--nodelist=%s" % args.nodelist)
+    if args.tasks_per_node:
+        salloc.append("--ntasks-per-node=%d" % args.tasks_per_node)
+    if args.exclusive:
+        salloc.append("--exclusive")
+    if args.time:
+        salloc.append("--time=%d" % args.time)
+
+    # The held command.  It writes the environment SLURM gave it, then the job
+    # id (LAST, so a reader that sees the job id knows the environment file is
+    # already complete), and then sleeps forever holding the allocation.
+    #
+    # `exec sleep infinity` rather than a shell loop: the sleep replaces the
+    # shell, so the process tree under salloc is one process and a scancel
+    # takes the whole thing down with nothing left behind.
+    held = ("env > %s; echo $SLURM_JOB_ID > %s; exec sleep infinity"
+            % (shlex.quote(envf), shlex.quote(jobf)))
+
+    with open(logf, "wb") as log:
+        subprocess.Popen(salloc + ["bash", "-c", held],
+                         stdout=log, stderr=subprocess.STDOUT,
+                         stdin=subprocess.DEVNULL, start_new_session=True)
+
+    # Wait for the allocation to be granted.  A request SLURM cannot satisfy
+    # sits PENDING forever rather than failing, so this has to time out and
+    # say what salloc was told -- an allocation that never arrives otherwise
+    # surfaces as an unrelated failure several cases later.
+    deadline = time.time() + args.timeout
+    while time.time() < deadline:
+        if os.path.exists(jobf):
+            with open(jobf) as fp:
+                jid = fp.read().strip()
+            if jid:
+                print(jid)
+                return 0
+        time.sleep(0.25)
+
+    try:
+        with open(logf) as fp:
+            why = " ".join(fp.read().split())
+    except OSError:
+        why = "(no output from salloc)"
+    die("allocation not granted in %ds: %s" % (args.timeout, why))
+
+
+# --------------------------------------------------------------------------
+# reading an allocation back
+# --------------------------------------------------------------------------
+
+def read_env(tag):
+    try:
+        with open(state_path(tag, "env")) as fp:
+            lines = fp.read().splitlines()
+    except OSError:
+        die("no allocation tagged '%s' -- run 'slurm-alloc new' first" % tag)
+    out = {}
+    for line in lines:
+        if "=" not in line:
+            continue                      # a multi-line value's continuation
+        key, value = line.split("=", 1)
+        out[key] = value
+    return out
+
+
+def cmd_env(args):
+    env = read_env(args.tag)
+    for key in sorted(env):
+        if key in ENV_EXCLUDE or not key.startswith(ENV_PREFIXES):
+            continue
+        # Quoted, always: SLURM_TASKS_PER_NODE carries the compressed "2(x4)"
+        # form, which is a syntax error unquoted.
+        print("export %s=%s" % (key, shlex.quote(env[key])))
+    return 0
+
+
+def cmd_jobid(args):
+    env = read_env(args.tag)
+    jid = env.get("SLURM_JOB_ID") or env.get("SLURM_JOBID")
+    if not jid:
+        die("the captured environment for '%s' has no job id" % args.tag)
+    print(jid)
+    return 0
+
+
+def cmd_nodes(args):
+    env = read_env(args.tag)
+    nodelist = env.get("SLURM_JOB_NODELIST") or env.get("SLURM_NODELIST")
+    if not nodelist:
+        die("the captured environment for '%s' has no node list" % args.tag)
+    # SLURM hands out the compressed form ("node[1-3,7]"); expand it with
+    # SLURM's own tool rather than a regex here, because getting that wrong
+    # would make the harness disagree with the scheduler about what it holds.
+    rc, out = run(["scontrol", "show", "hostnames", nodelist])
+    if 0 != rc:
+        die("scontrol show hostnames %s failed: %s" % (nodelist, out.strip()))
+    print(",".join(out.split()))
+    return 0
+
+
+# --------------------------------------------------------------------------
+# releasing, and looking at the cluster
+# --------------------------------------------------------------------------
+
+def cmd_free(args):
+    if args.all:
+        # Every job, not just the ones this script created.  A PRRTE *extend*
+        # submits its own expander job through sbatch, and that job is what
+        # holds the grown nodes -- so a teardown that spared it would leave
+        # the pool short for every later case, which is the harness failure
+        # that is hardest to read.  This is a dedicated single-purpose
+        # cluster; there is nothing in its queue that is not the harness.
+        rc, out = run(["squeue", "-h", "-o", "%i"])
+        if 0 != rc:
+            die("squeue failed: %s" % out.strip())
+        for jid in out.split():
+            run(["scancel", jid])
+        # and drop every captured environment, so a later `env` cannot hand
+        # back an allocation that no longer exists
+        if os.path.isdir(STATE):
+            for name in os.listdir(STATE):
+                os.unlink(os.path.join(STATE, name))
+        return 0
+
+    try:
+        env = read_env(args.tag)
+    except SystemExit:
+        return 0                          # nothing to free is not an error
+    jid = env.get("SLURM_JOB_ID") or env.get("SLURM_JOBID")
+    if jid:
+        run(["scancel", jid])
+    for suffix in ("env", "jobid", "log"):
+        try:
+            os.unlink(state_path(args.tag, suffix))
+        except OSError:
+            pass
+    return 0
+
+
+def cmd_pool(args):
+    """Nodes with nothing allocated on them.
+
+    %t is the abbreviated node state; a node is free for a new allocation when
+    it is idle.  Reported one per line, in the order sinfo gives them.
+    """
+    rc, out = run(["sinfo", "-h", "-N", "-o", "%N %t"])
+    if 0 != rc:
+        die("sinfo failed: %s" % out.strip())
+    for line in out.splitlines():
+        parts = line.split()
+        if 2 == len(parts) and parts[1] in ("idle", "idle~"):
+            print(parts[0])
+    return 0
+
+
+def cmd_jobs(args):
+    rc, out = run(["squeue", "-h", "-o", "%i %j %T %N"])
+    if 0 != rc:
+        die("squeue failed: %s" % out.strip())
+    sys.stdout.write(out)
+    return 0
+
+
+def cmd_wait(args):
+    deadline = time.time() + args.secs
+    while time.time() < deadline:
+        rc, out = run(["squeue", "-h", "-j", args.jobid, "-o", "%T"])
+        if 0 == rc and out.strip() == "RUNNING":
+            return 0
+        time.sleep(0.5)
+    die("job %s was not RUNNING within %ds" % (args.jobid, args.secs))
+
+
+# --------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(prog="slurm-alloc", add_help=True,
+                                 description=__doc__.splitlines()[0])
+    sub = ap.add_subparsers(dest="cmd")
+
+    p = sub.add_parser("new")
+    p.add_argument("--tag", default="dvm")
+    p.add_argument("--nodes", type=int)
+    p.add_argument("--nodelist")
+    p.add_argument("--tasks-per-node", type=int)
+    p.add_argument("--exclusive", action="store_true")
+    p.add_argument("--time", type=int)
+    p.add_argument("--timeout", type=int, default=60)
+    p.set_defaults(fn=cmd_new)
+
+    for name, fn in (("env", cmd_env), ("jobid", cmd_jobid), ("nodes", cmd_nodes)):
+        p = sub.add_parser(name)
+        p.add_argument("--tag", default="dvm")
+        p.set_defaults(fn=fn)
+
+    p = sub.add_parser("free")
+    p.add_argument("--tag", default="dvm")
+    p.add_argument("--all", action="store_true")
+    p.set_defaults(fn=cmd_free)
+
+    for name, fn in (("pool", cmd_pool), ("jobs", cmd_jobs)):
+        p = sub.add_parser(name)
+        p.set_defaults(fn=fn)
+
+    p = sub.add_parser("wait")
+    p.add_argument("jobid")
+    p.add_argument("secs", nargs="?", type=int, default=30)
+    p.set_defaults(fn=cmd_wait)
+
+    args = ap.parse_args()
+    if not getattr(args, "fn", None):
+        ap.print_help()
+        return 2
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/slurmswarm/slurm.conf
+++ b/contrib/slurmswarm/slurm.conf
@@ -1,0 +1,96 @@
+# slurm.conf for the PRRTE real-SLURM test swarm (see AGENTS.md).
+#
+# Ten containers, hostnames node1..node10, one bridge network.  node1 runs
+# slurmctld; every node runs slurmd.  The file is baked into the image, so
+# every node reads an identical copy -- which is what SLURM requires, and is
+# the one thing a container swarm gets for free.
+#
+# Everything below that is not obvious is here because a container is not a
+# compute node.  The three that actually matter:
+#
+#   * SlurmdParameters=config_overrides.  Every "node" is a container on ONE
+#     host, so all ten slurmd's report the SAME cpu count -- whatever the
+#     docker VM was given, which is not 8 and differs per developer machine.
+#     Without this, slurmctld compares each node's reported configuration
+#     against NodeName= below, finds it short, and marks the node INVALID:
+#     sinfo says "drain" with reason "Low socket*core*thread count", every
+#     node, and nothing can ever be allocated.  config_overrides tells
+#     slurmctld to believe the configuration file instead of the daemon,
+#     which is exactly right here: the numbers are a fiction we have chosen,
+#     and the jobs are hostname/sleep, not FLOPs.
+#
+#   * ProctrackType=proctrack/linuxproc + TaskPlugin=task/none.  The cgroup
+#     plugins need to own a cgroup hierarchy, and an unprivileged container
+#     does not have one it can write.  linuxproc tracks a step by walking
+#     /proc parentage, which needs nothing from the kernel that a container
+#     lacks.  The cost is that process tracking is best-effort -- a process
+#     that escapes its parent can outlive the step -- which is why
+#     run-tests.sh sweeps every node between phases rather than trusting
+#     SLURM to have reaped everything.
+#
+#   * ReturnToService=2.  A node whose slurmd is restarted (a container
+#     restart, a `docker compose up -d --force-recreate`) otherwise stays
+#     DOWN until someone runs `scontrol update`.  In a harness that is
+#     brought up and torn down repeatedly, that is a bring-up failure with a
+#     confusing name.
+#
+# NOTE: NodeName below fixes the swarm at ten nodes.  Adding a service block
+# to docker-compose.yml is not enough -- the node has to be named here too,
+# and the image rebuilt.
+ClusterName=prteslurm
+SlurmctldHost=node1
+
+# --- identity and authentication ---
+# munge, with a key baked into the image so all ten nodes share it (see the
+# Dockerfile).  A test cluster whose credential key is in a public image is
+# not a security posture -- it is why this harness must never be run on a
+# machine whose docker network is reachable by anyone else.
+SlurmUser=slurm
+SlurmdUser=root
+AuthType=auth/munge
+CredType=cred/munge
+
+# --- paths ---
+SlurmctldPort=6817
+SlurmdPort=6818
+StateSaveLocation=/var/spool/slurmctld
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmctldPidFile=/run/slurmctld.pid
+SlurmdPidFile=/run/slurmd.pid
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdLogFile=/var/log/slurm/slurmd.log
+
+# --- what a container can actually do ---
+ProctrackType=proctrack/linuxproc
+TaskPlugin=task/none
+MpiDefault=none
+ReturnToService=2
+SlurmdParameters=config_overrides
+
+# --- scheduling ---
+# cons_tres/CR_Core rather than linear: PRRTE reads SLURM_TASKS_PER_NODE and
+# asserts the slot count it derives, so an allocation has to be able to hand
+# out part of a node.  A linear select would give whole nodes only and the
+# slot-count cases would be measuring nothing.
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core
+
+# --- timeouts ---
+# InactiveLimit=0 is load-bearing: the harness holds its allocations with
+# `salloc --no-shell` and runs job steps into them minutes later.  A non-zero
+# InactiveLimit kills an allocation with no active step, which would delete
+# the DVM's allocation out from under it mid-suite.
+SlurmctldTimeout=120
+SlurmdTimeout=300
+InactiveLimit=0
+KillWait=10
+Waittime=0
+MessageTimeout=30
+
+# --- the nodes ---
+# CPUs=8 is a fiction (see config_overrides above) chosen to match the shape
+# contrib/dockerswarm's cases assume: one package, 8 cores, no SMT.
+NodeName=node[1-10] CPUs=8 Boards=1 SocketsPerBoard=1 CoresPerSocket=8 \
+         ThreadsPerCore=1 RealMemory=2000 State=UNKNOWN
+PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -160,5 +160,16 @@ the daemons, not srun).
   connections and duplicates command-line settings.
 - Multi-node behavior that does not need SLURM (tree-spawn, throttling,
   the prted command line) is covered by
-  [`contrib/dockerswarm`](../../../../contrib/dockerswarm/); the
-  SLURM-specific paths still require an allocation.
+  [`contrib/dockerswarm`](../../../../contrib/dockerswarm/) — note that
+  its fake scheduler supplies the *control plane* (`sbatch`, `scontrol`,
+  `scancel`) and not `srun`, so no DVM over there is launched by this
+  component at all.
+- The SLURM-specific paths need an allocation, and
+  [`contrib/slurmswarm`](../../../../contrib/slurmswarm/) is one: ten
+  containers running a real SLURM, where the daemons really do go out over
+  `srun --jobid=<the allocation>`. It asserts the three things only a live
+  scheduler shows — that the step joins the caller's job rather than
+  queueing a second one, that the srun exit after `prted` daemonizes is
+  read as a hand-off and not a launch failure (and leaves SLURM no dangling
+  step), and that `pterm` does not take the user's allocation down with the
+  DVM.

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -137,7 +137,18 @@ coverage follows that seam.
 | Half | Covered by |
 |------|------------|
 | `query` + `allocate` (nodelist expansion, taint refusal, `PRTE_EXISTS` on re-discovery) | `test/unit/ras/test_ras.c` — no scheduler needed, since both read only the environment |
-| `modify` (extend/release/cancel, the JSON parser, `validate_hostname`, `drain_cmd_output`) | [`contrib/dockerswarm`](../../../../contrib/dockerswarm/) — it shells out and is inherently multi-node, and it is the only automated build that configures `--with-jansson`, so it is the only place `ras_slurm_jansson.c` is even compiled |
+| `modify` (extend/release/cancel, the JSON parser, `validate_hostname`, `drain_cmd_output`) | [`contrib/dockerswarm`](../../../../contrib/dockerswarm/) — it shells out and is inherently multi-node, and it is one of the two automated builds that configure `--with-jansson`, so `ras_slurm_jansson.c` is compiled nowhere else |
+| the same surface against a scheduler that can refuse it | [`contrib/slurmswarm`](../../../../contrib/slurmswarm/) — ten containers running a real SLURM, so `sbatch` really queues, `scontrol update ... ReqNodeList=` really has to be a resize SLURM accepts on a RUNNING job, and the JSON is SLURM's own |
+
+**The JSON parser requires SLURM 24.05 or newer.**
+`prte_ras_slurm_get_jobinfo_json` reads
+`job_resources.nodes.{count,list,allocation}`, which is the shape SLURM
+adopted in data parser **v0.0.41**. Through 23.11 the same query answers with
+`job_resources.nodes` as a plain *string* alongside a flat `allocated_nodes`
+array, and every extend fails at once with *"Failed to parse input JSON"*.
+That floor was found by `contrib/slurmswarm` and is why its image builds
+SLURM from source rather than taking the distribution package; there is
+currently no configure-time or run-time check for it.
 
 The harness fakes the scheduler with
 [`fake-slurm.py`](../../../../contrib/dockerswarm/fake-slurm.py), installed


### PR DESCRIPTION
## The problem

`contrib/dockerswarm` fakes the scheduler. [`fake-slurm.py`](https://github.com/openpmix/prrte/blob/master/contrib/dockerswarm/fake-slurm.py) implements exactly the four command forms `ras/slurm` issues, which makes it a good regression test for PRRTE's side of the conversation and no test at all of the assumption underneath it:

- that those four forms are what SLURM actually **accepts**, and
- that what SLURM says **back** is what `ras_slurm_jansson.c` expects.

It also supplies no `srun` — it is a control plane, not a launcher — so **`plm/slurm` has never run in an automated test anywhere.**

## What this adds

`contrib/slurmswarm`: the same harness, same ten containers, same live-working-tree build into a shared volume — except the containers run a real `slurmctld` and ten real `slurmd`s. `salloc` grants allocations, `srun` launches the daemons, `sbatch` queues jobs, `scancel` takes them away.

```sh
cd contrib/slurmswarm
./build.sh && docker compose up -d && ./run-tests.sh
```

Five phases, 76 assertions: the cluster itself, `ras/slurm` allocation semantics, `plm/slurm` launch, the elastic modify surface, and a short launch smoke test. Only questions a real scheduler can answer live here; everything else stays in the sibling harness, which is faster and needs no SLURM. `AGENTS.md` §12 has the division as a table.

Containers are unprivileged and namespaced by `$PRTE_SLURM_SWARM` (deliberately *not* `$PRTE_SWARM`), so both harnesses can be driven from one shell.

## Two things standing it up answered immediately

**1. `ras/slurm` requires SLURM 24.05 or newer, and nothing in the tree said so.** The parser reads `job_resources.nodes.{count,list,allocation}` — the shape SLURM adopted in data parser **v0.0.41**. Through 23.11, and so on every current Ubuntu, the same query answers with `job_resources.nodes` as a plain *string* beside a flat `allocated_nodes` array, and every extend fails at once with:

```
PRTE ERROR: Failed to parse input JSON in file .../ras_slurm_jansson.c at line 579
```

That is why the image builds SLURM from source rather than installing the distribution package, and why the suite checks the emitted **schema** at preflight and *skips* the elastic phase rather than failing it. The floor is now recorded in `src/mca/ras/slurm/AGENTS.md`; there is still no configure-time or run-time check for it, which may deserve a follow-up.

**2. The in-place resize works.** SLURM accepts `scontrol update job <id> ReqNodeList=<survivors>` on a *running* job, shrinks it, and leaves the `slurm_job_*_resize.*` helper scripts PRRTE then deletes. That assumption had never been checked against anything but the fake.

Also confirmed against the real thing:

- `plm/slurm` launches `prted` over `srun --jobid=<the allocation>`, reads the srun exit after `prted` daemonizes as a **hand-off** rather than a launch failure, leaves SLURM no dangling job step, and does not cancel the user's allocation on `pterm`.
- With no allocation in the environment, the same cluster falls back to `plm/ssh` and creates no SLURM job — the other side of the gate.
- `ras/slurm` expands SLURM's own compressed node list, tested with a **non-contiguous** allocation (`node[2,4,6]`) so a parser reading it as a range would be caught.
- A pending extend needs no fault injection here: ask for more nodes than the cluster has free and SLURM queues it `PENDING` by itself, which is the state `PMIX_ALLOC_REQ_CANCEL` exists for.

## Notes for review

- **`slurm-alloc.py`** runs a real `salloc` whose command captures the environment SLURM gave it and then sleeps, holding the allocation. A suite driving containers from outside has no allocation shell. The environment is captured rather than reconstructed on purpose: a reconstruction would encode a belief about which variables SLURM sets, and the interesting failures are exactly where that belief is wrong.
- **`SLURM_JOBID`** — what both components gate on — has been deprecated in favour of `SLURM_JOB_ID` for years. The suite asserts it is still set, because the day it is not, every case here would silently fall back to the ssh launcher and pass.
- **Two container-specific config choices**, commented where they live: `slurmd` initializes a cgroup context at startup whatever the configured plugins are, which `CgroupPlugin=disabled` (24.05+, again) turns off so the containers can stay unprivileged; and `SlurmdParameters=config_overrides` is what stops `slurmctld` draining every node for reporting a CPU count that does not match the fiction `slurm.conf` states.

## Testing

`./run-tests.sh` — **76 passed, 0 failed, 0 skipped**, on two consecutive full runs against SLURM 24.11.6 on a ten-container cluster. No source changes in this PR; `src/mca/{ras,plm}/slurm/AGENTS.md` and the two harness guides gain cross-references and the version floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
