### PR TITLE
Do not let a shrink start while the DVM is still growing

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -477,6 +477,60 @@ test_slurm() {
     FS jobs | grep -qx 1000 && ok "the DVM's own SLURM job was left alone" \
                             || bad "the release took out the base allocation"
 
+    banner "ras/slurm: a release issued while a grow is in flight does not wedge the DVM"
+    # Issue #2617.  Grow and shrink share one launch fence and one broadcast,
+    # and the shrink half had no notion of an in-flight grow: the shrink was
+    # xcast to every daemon INCLUDING ones still joining, which cannot be
+    # reached, so the campaign could neither complete nor abort.  It then sat
+    # on prte_shrink_campaigns forever and every later job parked at the
+    # LAUNCH_APPS hold -- a DVM wedged with no error reported to anyone.
+    #
+    # The interleaving is opportunistic, and deliberately so.  We start the
+    # extend in the background and issue the release without waiting for its
+    # daemons to join; if it happens to land outside the window the case still
+    # passes, correctly, having asserted a legal sequence.  When it lands
+    # inside -- which is the common outcome, since the fake scheduler answers
+    # in well under the time a daemon takes to report home -- an unfixed PRRTE
+    # wedges here and every assertion below fails.  Do not "stabilize" this by
+    # sleeping between the two requests: the sleep is the bug.
+    out=$(SL 'timeout 120 elastic extend 1' 2>&1)
+    settled=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    snode=$(FS "nodes $settled" | tr -d '\r')
+    sleep 10
+    # shellcheck disable=SC2086
+    [ -n "$snode" ] && [ "$(prted_count $(fs_idx "$snode"))" = 1 ] \
+        && ok "a settled node ($snode) is in place to be released" \
+        || bad "could not settle a node to release (job=$settled node=$snode)"
+    # now grow WITHOUT letting it settle, and release the settled node into
+    # that window.  The target is deliberately not one of the joining nodes --
+    # a per-target check would pass it, and the campaign would stall anyway on
+    # daemons the caller never selected.
+    SL 'nohup timeout 120 elastic extend 3 >/tmp/grow-race.out 2>&1 & sleep 1' \
+        >/dev/null 2>&1
+    out=$(SL "timeout 120 elastic shrink $snode" 2>&1)
+    sleep 20
+    echo "$out" | grep -q PMIX_DVM_IS_READY \
+        && ok "the release completed even though a grow was in flight" \
+        || bad "release never completed during a grow: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # shellcheck disable=SC2086
+    [ "$(prted_count $(fs_idx "$snode"))" = 0 ] \
+        && ok "the released node's daemon is gone" \
+        || bad "the daemon survived a release issued during a grow"
+    # the wedge's signature: every later job parks at LAUNCH_APPS and never
+    # launches, with no error reported anywhere
+    out=$(SL 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
+    [ "$(echo "$out" | tr -d '\r')" = node1 ] \
+        && ok "a later job still launches (the DVM is not wedged)" \
+        || bad "DVM wedged after a release during a grow: $out"
+    # and the grow itself must still have been honored
+    SL 'grep -q "SUCCESS\|ALLOC_ID" /tmp/grow-race.out' \
+        && ok "the concurrent grow was answered too" \
+        || bad "the grow was lost: $(SL 'tr "\n" " " < /tmp/grow-race.out' | tail -c 200)"
+    for j in $(FS jobs | grep -v '^1000$' | tr -d '\r'); do
+        SL "timeout 120 elastic release-id $j" >/dev/null 2>&1
+    done
+    sleep 5
+
     banner "ras/slurm: a pending extend can be cancelled by request id"
     # PMIX_ALLOC_REQ_CANCEL is served while the extend's poll loop is still
     # waiting on a PENDING SLURM job: cancelling drops the pending record and

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -176,6 +176,11 @@ static op_t* insert_forwarded_op(signature_t *sig);
 static void forward_op(op_t *op);
 // Forward to specific destination
 static void forward_op_to(op_t *op, pmix_rank_t dest);
+// Send-completion callback: a message to a child that never arrives means that
+// subtree's ack is never coming, so stop expecting it
+static void forward_lost(int status, pmix_proc_t *peer,
+                         pmix_data_buffer_t *buffer,
+                         prte_rml_tag_t tag, void *cbdata);
 // Locally process the message being broadcast, if not already done
 static void process_msg(op_t *op);
 // Ack that myself and my full subtree have received this message
@@ -807,7 +812,17 @@ static void send_ack_msg(
         return;
     }
 
-    PRTE_RML_SEND(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
+    if(is_request){
+        /* A re-poll aimed at a child we cannot reach says exactly what an
+         * undeliverable forward says - no ack is ever coming from that subtree
+         * - so it is tracked the same way.  The upward direction is not: a
+         * failure there is our lifeline, which is the fault machinery's
+         * business and not this op's. */
+        PRTE_RML_SEND_CB(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK,
+                         forward_lost, (void*)(intptr_t) sig->op_id);
+    } else {
+        PRTE_RML_SEND(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
+    }
     if(PMIX_SUCCESS != ret){
         PMIX_ERROR_LOG(ret);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
@@ -1742,6 +1757,69 @@ static void forward_op(op_t* op){
     mv->forward(op);
 }
 
+/* A forward that never arrives is an ack that never comes.
+ *
+ * PRTE_RML_SEND reports only that the message was *queued*: the OOB resolves
+ * the next hop on a later event, and an unreachable one is discovered there
+ * (prte_oob_base_send_nb sets PRTE_ERR_ADDRESSEE_UNKNOWN and completes the
+ * send through this callback).  So the rc check in forward_op_to cannot see
+ * it, and without this the op waits forever on a subtree it never reached.
+ *
+ * That is not a hypothetical.  The routing tree holds daemons that have not
+ * yet reported home - setup_virtual_machine recomputes it at launch
+ * *initiation*, and must, because plm/ssh tree-spawn is driven from it - so
+ * every broadcast issued during a DVM grow forwards to a child there is as yet
+ * no way to reach.  errmgr/dvm deliberately swallows that send failure (it is
+ * not a daemon death), which is right for the daemon and left the op stuck:
+ * the master's op_id_completed stopped advancing, every later broadcast tripped
+ * PRTE_ERR_OUT_OF_ORDER_MSG in finish_op, and anything waiting on the
+ * completion callback - the elastic shrink campaign - waited forever (#2617).
+ *
+ * Dropping the expectation is the answer rather than failing the broadcast,
+ * because a daemon that joins after op N was never going to see op N anyway:
+ * the late-joiner catch-up in insert_forwarded_op has it adopt ops 1..N-1 as
+ * complete when it arrives.  This only makes the sender agree with that.  A
+ * child that genuinely died is a separate story and still takes the fault
+ * handler's path, which recomputes nexpected and starts a fresh ack round. */
+static void forward_lost(int status, pmix_proc_t *peer,
+                         pmix_data_buffer_t *buffer,
+                         prte_rml_tag_t tag, void *cbdata)
+{
+    signature_t sig;
+    op_t *op;
+
+    sig.op_id = (size_t) (intptr_t) cbdata;
+
+    /* keep the RML's own reporting: what a failed send means for the *daemon*
+     * is the errmgr's call, and unchanged.  We only decide what it means for
+     * this op. */
+    prte_rml_send_callback(status, peer, buffer, tag, NULL);
+
+    if (PRTE_SUCCESS == status) {
+        return;
+    }
+
+    op = find_op(&sig);
+    if (NULL == op) {
+        /* the op finished (or was abandoned) while this send was in flight */
+        return;
+    }
+
+    PMIX_OUTPUT_VERBOSE((
+        1, prte_grpcomm_globals.output,
+        "%s grpcomm:xcast op %lu never reached %s (%s) - dropping its subtree "
+        "from the ack rollup",
+        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned long) sig.op_id,
+        (NULL == peer) ? "someone" : PRTE_NAME_PRINT(peer),
+        PRTE_ERROR_NAME(status)
+    ));
+
+    if (0 < op->nexpected) {
+        op->nexpected--;
+    }
+    drive_completions();
+}
+
 static void forward_op_to(op_t* op, pmix_rank_t dest){
     pmix_data_buffer_t* xcast_msg = PMIx_Data_buffer_create();
 
@@ -1760,7 +1838,11 @@ static void forward_op_to(op_t* op, pmix_rank_t dest){
         PRTE_VPID_PRINT(dest)
     ));
 
-    PRTE_RML_SEND(rc, dest, xcast_msg, PRTE_RML_TAG_XCAST);
+    /* The op-id is carried by value rather than by pointer: the send outlives
+     * the op on precisely the paths that matter, so the callback has to be
+     * able to look the op up and find it gone. */
+    PRTE_RML_SEND_CB(rc, dest, xcast_msg, PRTE_RML_TAG_XCAST,
+                     forward_lost, (void *) (intptr_t) op->sig.op_id);
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -3133,6 +3133,14 @@ void prte_plm_base_grow_drain(bool success)
         }
         PMIX_RELEASE(camp);
     }
+    /* The grow has resolved either way, so any release parked behind it can
+     * now run.  This is the resume point the deferral was written against:
+     * grow_drain is called from exactly the two safe places (vm_ready, after
+     * the WIREUP xcast, and the daemon-launch failure path) and is where
+     * prte_grow_campaigns is emptied - so a replayed release re-evaluates
+     * against a DVM that is no longer in flux. */
+    prte_ras_base_replay_deferred_releases();
+
     if (success) {
         /* admit the held jobs only once the *global* fence is clear — a
          * concurrent shrink may still hold it nonzero */

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -54,6 +54,10 @@ PRTE_EXPORT int prte_ras_base_select(void);
 typedef struct prte_ras_base_t {
     /* list of selected modules */
     pmix_list_t selected_modules;
+    /* PMIX_ALLOC_RELEASE requests parked because the DVM was still growing
+     * when they arrived, in arrival order. See prte_ras_base_dvm_is_growing()
+     * and prte_ras_base_replay_deferred_releases() below. */
+    pmix_list_t deferred_releases;
     int total_slots_alloc;
     int multiplier;
     bool launch_orted_on_hn;
@@ -87,6 +91,24 @@ PRTE_EXPORT void prte_ras_base_display_cpus(prte_job_t *jdata, char *nodelist);
 PRTE_EXPORT void prte_ras_base_allocate(int fd, short args, void *cbdata);
 
 PRTE_EXPORT void prte_ras_base_modify(int fd, short args, void *cbdata);
+
+/* Is any daemon still joining the DVM?  No shrink campaign may be created
+ * while one is: the shrink is broadcast DVM-wide and drains only when every
+ * daemon has received it, so a daemon that has not reported home leaves the
+ * campaign unable to either complete or abort.  See the definition for the
+ * three states of a growing DVM this has to answer for. */
+PRTE_EXPORT bool prte_ras_base_dvm_is_growing(void);
+
+/* Re-drive every PMIX_ALLOC_RELEASE that prte_ras_base_modify parked because
+ * the DVM was still growing when it arrived.  Called from
+ * prte_plm_base_grow_drain() on both of its outcomes: the requests are replayed
+ * from scratch, so a grow that failed simply lets them re-evaluate against the
+ * rolled-back DVM and fail through the ordinary error paths. */
+PRTE_EXPORT void prte_ras_base_replay_deferred_releases(void);
+
+/* Answer every parked release with the given status and drop it.  For teardown,
+ * where the grow that would have replayed them is never going to resolve. */
+PRTE_EXPORT void prte_ras_base_flush_deferred_releases(pmix_status_t status);
 
 /* Notify the active RAS modules that a shrink campaign has completed so they
  * can release the freed resources back to the scheduler. Cycles across every

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -585,12 +585,165 @@ void prte_ras_base_release_allocation(prte_session_t *session)
 }
 
 
+typedef struct {
+    pmix_list_item_t super;
+    prte_pmix_server_req_t *req;
+} deferred_release_t;
+static PMIX_CLASS_INSTANCE(deferred_release_t, pmix_list_item_t, NULL, NULL);
+
+/* Is any daemon still joining the DVM?
+ *
+ * A shrink cannot be started while one is.  The shrink is broadcast to the
+ * whole DVM and its campaign drains only when the broadcast has reached every
+ * daemon, and a daemon that has not reported home cannot be reached - so the
+ * campaign would neither complete nor abort, prte_shrink_campaigns would stay
+ * non-empty forever, and every later job would park at the LAUNCH_APPS hold
+ * (#2617).  The precondition is DVM-wide rather than per-target: what stalls
+ * the campaign is the reachability of daemons the caller never selected.
+ *
+ * Three terms, because the growing DVM passes through three states:
+ *
+ *  - PRTE_JOB_EXTEND_DVM on the daemon job covers the window between
+ *    prte_ras_base_activate_dvm_grow() - which only activates LAUNCH_DAEMONS -
+ *    and setup_virtual_machine actually running.  In that window there is no
+ *    campaign yet, and the new daemons have no proc objects to inspect.  The
+ *    attribute is consumed and removed inside setup_virtual_machine.
+ *  - a recorded grow campaign covers launch-in-progress, from
+ *    setup_virtual_machine to prte_plm_base_grow_drain() at VM_READY.  Only in
+ *    elastic mode, which is the only mode that records campaigns at all.
+ *  - a daemon we have recorded but never heard from is the exact statement of
+ *    the precondition, and catches any path that reaches neither of the above.
+ *    rml_uri is the right test and the only right one: it is written solely by
+ *    prte_plm_base_daemon_callback, i.e. only by the daemon itself reporting
+ *    in, whereas PRTE_PROC_FLAG_ALIVE and a RUNNING state are both set when the
+ *    launch is merely *recorded* (see the matching note in errmgr_dvm.c).  The
+ *    ALIVE test is still needed to exclude a daemon that failed to start, which
+ *    never reports a URI and must not park releases forever.
+ */
+bool prte_ras_base_dvm_is_growing(void)
+{
+    prte_job_t *daemons;
+    prte_proc_t *dproc;
+    int i;
+
+    if (!pmix_list_is_empty(&prte_grow_campaigns)) {
+        return true;
+    }
+
+    daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+    if (NULL == daemons) {
+        return false;
+    }
+    if (prte_get_attribute(&daemons->attributes, PRTE_JOB_EXTEND_DVM,
+                           NULL, PMIX_BOOL)) {
+        return true;
+    }
+    for (i = 0; i < daemons->procs->size; i++) {
+        dproc = (prte_proc_t *) pmix_pointer_array_get_item(daemons->procs, i);
+        if (NULL == dproc) {
+            continue;
+        }
+        if (PRTE_PROC_MY_NAME->rank == dproc->name.rank) {
+            continue;
+        }
+        if (PRTE_FLAG_TEST(dproc, PRTE_PROC_FLAG_ALIVE) &&
+            NULL == dproc->rml_uri) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_ras_base_replay_deferred_releases(void)
+{
+    deferred_release_t *dr;
+
+    /* Replay from scratch rather than resuming mid-flight: everything a
+     * deferred request had done before it was parked is in-memory target
+     * selection, and no scheduler command runs until a campaign drains.
+     * Re-running it also re-selects against the post-grow state, which is what
+     * the requester meant in the first place.
+     *
+     * This is called from both of grow_drain's outcomes.  On the failure path
+     * the rolled-back nodes have had node->daemon cleared by
+     * prte_plm_base_reset_dvm_node, so a replayed request simply re-evaluates
+     * and fails through the ordinary error paths - no separate handling.
+     *
+     * Guard on the framework's open count, as prte_ras_base_release_allocation
+     * does: this is called from plm, whose grow_drain has no way to know
+     * whether ras is still open, and the list is only constructed when it
+     * is. */
+    if (0 == prte_ras_base_framework.framework_refcnt) {
+        return;
+    }
+
+    while (NULL != (dr = (deferred_release_t *)
+                             pmix_list_remove_first(&prte_ras_base.deferred_releases))) {
+        prte_pmix_server_req_t *req = dr->req;
+        PMIX_RELEASE(dr);
+        prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE,
+                       prte_ras_base_modify, req);
+        PMIX_POST_OBJECT(req);
+        prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+    }
+}
+
+void prte_ras_base_flush_deferred_releases(pmix_status_t status)
+{
+    deferred_release_t *dr;
+
+    /* The DVM is going away with requests still parked.  Answer each one - a
+     * requester released nothing and must not be left waiting on an event that
+     * can no longer be raised. */
+    while (NULL != (dr = (deferred_release_t *)
+                             pmix_list_remove_first(&prte_ras_base.deferred_releases))) {
+        prte_pmix_server_req_t *req = dr->req;
+        PMIX_RELEASE(dr);
+        req->pstatus = status;
+        if (NULL != req->infocbfunc) {
+            req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
+                            prte_pmix_server_req_release, req);
+            continue;
+        }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                    req->local_index, NULL);
+        PMIX_RELEASE(req);
+    }
+}
+
 void prte_ras_base_modify(int fd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     prte_ras_base_selected_module_t *mod;
+    deferred_release_t *dr;
     pmix_status_t rc;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    /* Hold a release while the DVM is still growing, and replay it once the
+     * grow resolves.  Deferring beats rejecting: a caller has no way to know a
+     * grow is in flight - ras/slurm's extend acknowledges phase one as soon as
+     * the scheduler answers, long before its daemons join - and a target that
+     * is still joining becomes removable seconds later, so parking is what
+     * keeps the semantics the caller expects.
+     *
+     * The guard sits here, at the driver's entry, rather than beside campaign
+     * creation, so it covers both routes into the shrink machinery at once:
+     * the component path (ras/slurm's modify) and the base's own
+     * ras_base_complete_release_request, which runs downstream of this. */
+    if (PMIX_ALLOC_RELEASE == req->allocdir && prte_ras_base_dvm_is_growing()) {
+        PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
+                             "%s ras:base:modify deferring release - the DVM is"
+                             " still growing",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        dr = PMIX_NEW(deferred_release_t);
+        if (NULL == dr) {
+            req->pstatus = PMIX_ERR_NOMEM;
+            goto respond;
+        }
+        dr->req = req;
+        pmix_list_append(&prte_ras_base.deferred_releases, &dr->super);
+        return;
+    }
 
     // set the default response
     req->pstatus = PMIX_ERR_NOT_SUPPORTED;
@@ -631,6 +784,7 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
         prte_ras_base_complete_request(req);
     }
 
+respond:
     // execute the callback
     if (NULL != req->infocbfunc) {
         req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata, prte_pmix_server_req_release, req);

--- a/src/mca/ras/base/ras_base_frame.c
+++ b/src/mca/ras/base/ras_base_frame.c
@@ -51,6 +51,7 @@
  */
 prte_ras_base_t prte_ras_base = {
     .selected_modules = PMIX_LIST_STATIC_INIT,
+    .deferred_releases = PMIX_LIST_STATIC_INIT,
     .total_slots_alloc = 0,
     .multiplier = 0,
     .launch_orted_on_hn = false,
@@ -80,6 +81,11 @@ static int prte_ras_base_close(void)
 {
     prte_ras_base_selected_module_t *mod;
 
+    /* Answer anything still parked behind a grow that is never going to
+     * resolve now.  The requester released nothing, so it must be told rather
+     * than left waiting on a completion event the DVM can no longer raise. */
+    prte_ras_base_flush_deferred_releases(PMIX_ERR_UNREACH);
+
     /* Close selected components */
     PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t) {
         if (NULL != mod->module->finalize) {
@@ -87,6 +93,7 @@ static int prte_ras_base_close(void)
         }
     }
     PMIX_LIST_DESTRUCT(&prte_ras_base.selected_modules);
+    PMIX_LIST_DESTRUCT(&prte_ras_base.deferred_releases);
 
     return pmix_mca_base_framework_components_close(&prte_ras_base_framework, NULL);
 }
@@ -97,8 +104,11 @@ static int prte_ras_base_close(void)
  *    */
 static int prte_ras_base_open(pmix_mca_base_open_flag_t flags)
 {
-    /* init the globals */
+    /* init the globals.  The static initializers above leave each list's
+     * sentinel NULL-linked -- safe to read as empty, but NOT safe to append
+     * to -- so both have to be constructed here before anything uses them. */
     PMIX_CONSTRUCT(&prte_ras_base.selected_modules, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_ras_base.deferred_releases, pmix_list_t);
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&prte_ras_base_framework, flags);

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -17,7 +17,7 @@
  *                         and Technology (RIST). All rights reserved.
  *
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -78,6 +78,41 @@ PRTE_EXPORT int prte_rml_send_buffer_nb(pmix_rank_t rank,
                             PMIX_RANK_PRINT(r), t,              \
                             __FILE__, __func__, __LINE__);      \
         (_r) = prte_rml_send_buffer_nb(r, b, t);                \
+    } while(0)
+
+/**
+ * As prte_rml_send_buffer_nb, but tell the caller how the send ended.
+ *
+ * The return value of a plain send says only that the message was *queued*.
+ * The next hop is resolved on a later event, so an unreachable addressee, a
+ * peer that goes away mid-flight, or a connection that never completes are all
+ * discovered after the call has returned - and reported nowhere the caller can
+ * see.  A caller that is tracking whether the message arrived (a collective
+ * waiting on the subtree beneath this hop) needs to be told.
+ *
+ * cbfunc runs on the progress thread and OWNS the buffer, exactly as the
+ * default prte_rml_send_callback does - releasing it is the callback's job, and
+ * chaining to prte_rml_send_callback is the way to keep the RML's own failure
+ * reporting while adding to it.
+ *
+ * A message to *self* short-circuits into the local receive path and never
+ * reaches the OOB, so cbfunc does not fire for one (the receive owns the
+ * buffer).  There is nothing to report there - a self-send cannot fail - but a
+ * caller counting callbacks must not count on one.
+ */
+PRTE_EXPORT int prte_rml_send_buffer_cb_nb(pmix_rank_t rank,
+                                           pmix_data_buffer_t *buffer,
+                                           prte_rml_tag_t tag,
+                                           prte_rml_buffer_callback_fn_t cbfunc,
+                                           void *cbdata);
+
+#define PRTE_RML_SEND_CB(_r, r, b, t, cf, cd)                   \
+    do {                                                        \
+        pmix_output_verbose(2, prte_rml_base.rml_output,        \
+                            "RML-SEND-CB(%s:%d): %s:%s:%d",     \
+                            PMIX_RANK_PRINT(r), t,              \
+                            __FILE__, __func__, __LINE__);      \
+        (_r) = prte_rml_send_buffer_cb_nb(r, b, t, cf, cd);     \
     } while(0)
 
 /**

--- a/src/rml/rml_send.c
+++ b/src/rml/rml_send.c
@@ -14,7 +14,7 @@
  *                         reserved.
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -42,7 +42,9 @@
 static int send_buffer(pmix_rank_t rank,
                        pmix_data_buffer_t *buffer,
                        prte_rml_tag_t tag,
-                       bool direct)
+                       bool direct,
+                       prte_rml_buffer_callback_fn_t cbfunc,
+                       void *cbdata)
 {
     prte_rml_recv_t *rcv;
     prte_rml_send_t *snd;
@@ -93,6 +95,12 @@ static int send_buffer(pmix_rank_t rank,
     snd->tag = tag;
     snd->dbuf = buffer;
     snd->direct = direct;
+    /* the constructor installs prte_rml_send_callback; only override it when
+     * the caller actually asked to be told how the send ended */
+    if (NULL != cbfunc) {
+        snd->cbfunc = cbfunc;
+        snd->cbdata = cbdata;
+    }
 
     /* activate the OOB send state */
     PRTE_OOB_SEND(snd);
@@ -104,14 +112,23 @@ int prte_rml_send_buffer_nb(pmix_rank_t rank,
                             pmix_data_buffer_t *buffer,
                             prte_rml_tag_t tag)
 {
-    return send_buffer(rank, buffer, tag, false);
+    return send_buffer(rank, buffer, tag, false, NULL, NULL);
+}
+
+int prte_rml_send_buffer_cb_nb(pmix_rank_t rank,
+                               pmix_data_buffer_t *buffer,
+                               prte_rml_tag_t tag,
+                               prte_rml_buffer_callback_fn_t cbfunc,
+                               void *cbdata)
+{
+    return send_buffer(rank, buffer, tag, false, cbfunc, cbdata);
 }
 
 int prte_rml_send_buffer_direct_nb(pmix_rank_t rank,
                                    pmix_data_buffer_t *buffer,
                                    prte_rml_tag_t tag)
 {
-    return send_buffer(rank, buffer, tag, true);
+    return send_buffer(rank, buffer, tag, true, NULL, NULL);
 }
 
 int prte_rml_send_buffer_reliable_nb(pmix_rank_t rank,

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -164,6 +164,11 @@ static int setup_globals(void)
     prte_sessions = PMIX_NEW(pmix_pointer_array_t);
     pmix_pointer_array_init(prte_sessions, 8, INT_MAX, 8);
 
+    /* the elastic campaign lists -- constructed by prte_init(), which this
+     * test does not reach; prte_finalize() destructs them on the way out */
+    PMIX_CONSTRUCT(&prte_shrink_campaigns, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_grow_campaigns, pmix_list_t);
+
     /* the daemon job -- node_insert looks it up to test DO_NOT_LAUNCH */
     djob = PMIX_NEW(prte_job_t);
     PMIX_LOAD_NSPACE(djob->nspace, "prte-unit-test-dvm");
@@ -890,6 +895,82 @@ static int test_slurm_allocation(void)
     return failures;
 }
 
+/*
+ * prte_ras_base_dvm_is_growing() -- the precondition that decides whether a
+ * PMIX_ALLOC_RELEASE may start a shrink campaign now or has to be parked until
+ * the DVM settles (#2617). It is a pure function of the daemon job and the grow
+ * campaign list, so it is exactly the sort of decision this test can pin; what
+ * it guards -- an unreachable daemon stalling the shrink broadcast -- needs the
+ * dockerswarm harness.
+ *
+ * The three states of a growing DVM each get a case, and so does the one that
+ * must NOT read as growing: a daemon that failed to start never reports a URI,
+ * and if that counted it would park every later release for the life of the
+ * DVM.
+ */
+static int test_dvm_growing(void)
+{
+    int failures = 0;
+    prte_job_t *djob;
+    prte_proc_t *d1;
+    prte_grow_campaign_t *camp;
+
+    djob = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+
+    /* a settled DVM: one daemon besides us, and it has reported home */
+    d1 = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&d1->name, PRTE_PROC_MY_NAME->nspace, 1);
+    d1->rml_uri = strdup("1;tcp://127.0.0.1:1234");
+    PRTE_FLAG_SET(d1, PRTE_PROC_FLAG_ALIVE);
+    pmix_pointer_array_set_item(djob->procs, 1, d1);
+    CHECK("dvm_is_growing: a settled DVM is not growing",
+          !prte_ras_base_dvm_is_growing());
+
+    /* state 1: the grow has been requested but setup_virtual_machine has not
+     * run yet -- no campaign exists and the new daemons have no procs */
+    prte_set_attribute(&djob->attributes, PRTE_JOB_EXTEND_DVM,
+                       PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+    CHECK("dvm_is_growing: a requested-but-unstarted grow is growing",
+          prte_ras_base_dvm_is_growing());
+    prte_remove_attribute(&djob->attributes, PRTE_JOB_EXTEND_DVM);
+    CHECK("dvm_is_growing: settled again once the attribute is consumed",
+          !prte_ras_base_dvm_is_growing());
+
+    /* state 2: launch in progress -- a campaign is recorded */
+    camp = PMIX_NEW(prte_grow_campaign_t);
+    camp->ntargets = 1;
+    camp->targets = (pmix_rank_t *) malloc(sizeof(pmix_rank_t));
+    camp->targets[0] = 2;
+    pmix_list_append(&prte_grow_campaigns, &camp->super);
+    CHECK("dvm_is_growing: a recorded grow campaign is growing",
+          prte_ras_base_dvm_is_growing());
+    pmix_list_remove_item(&prte_grow_campaigns, &camp->super);
+    PMIX_RELEASE(camp);
+    CHECK("dvm_is_growing: settled again once the campaign drains",
+          !prte_ras_base_dvm_is_growing());
+
+    /* state 3: a daemon recorded as launched that has never reported in.
+     * rml_uri is the test, and only rml_uri: ALIVE and RUNNING are both set
+     * when the launch is merely recorded. */
+    free(d1->rml_uri);
+    d1->rml_uri = NULL;
+    d1->state = PRTE_PROC_STATE_RUNNING;
+    CHECK("dvm_is_growing: a daemon that has not reported home is growing",
+          prte_ras_base_dvm_is_growing());
+
+    /* ...but a daemon that failed to start is not still joining, and must not
+     * park releases forever */
+    PRTE_FLAG_UNSET(d1, PRTE_PROC_FLAG_ALIVE);
+    d1->state = PRTE_PROC_STATE_FAILED_TO_START;
+    CHECK("dvm_is_growing: a daemon that failed to start is not growing",
+          !prte_ras_base_dvm_is_growing());
+
+    pmix_pointer_array_set_item(djob->procs, 1, NULL);
+    PMIX_RELEASE(d1);
+
+    return failures;
+}
+
 
 int main(void)
 {
@@ -925,6 +1006,7 @@ int main(void)
     failures += test_preassigned_index();
     failures += test_hnp_dedup();
     failures += test_flag_string();
+    failures += test_dvm_growing();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */


### PR DESCRIPTION
Fixes #2617.

## The problem

A `PMIX_ALLOC_RELEASE` accepted while daemons from an earlier grow are still joining records a shrink campaign that can never finish. The shrink is broadcast DVM-wide and drains only once every daemon has it; a daemon that has not reported home cannot be reached. `prte_shrink_campaigns` then stays non-empty for the life of the session, so every later job parks at the `LAUNCH_APPS` hold and never launches — with no error reported to anyone, and with the scheduler work the release asked for never run, so the resources are not handed back either.

The issue lays out the shrink half thoroughly. Investigating it turned up two things it did not have, and they change what the fix has to be.

**The stall is silent because the send failure is asynchronous.** `forward_op_to()` does check the send and force-exits the DVM on failure, but that return value is only the queueing status. The unreachable addressee is discovered later, inside `prte_oob_base_send_nb()`, which sets `PRTE_ERR_ADDRESSEE_UNKNOWN` and *completes* the send through its callback. The xcast is never told, so there is no error path in grpcomm to reach.

**The hazard is not limited to elastic shrink.** The routing tree holds daemons that have not reported home — `setup_virtual_machine` recomputes it at launch *initiation*, and must, because `plm/ssh` tree-spawn is driven from it. So **any** xcast issued during a grow window forwards to a child there is as yet no way to reach, and its op stalls the same way. One stuck op on the HNP stops `XCAST.op_id_completed` advancing, so every later broadcast trips `PRTE_ERR_OUT_OF_ORDER_MSG` in `finish_op()` — which is exactly the diagnostic in the reporter's log. The `errmgr/dvm` swallow comment already names the general case in so many words ("the job's completion notice is xcast over a routing tree that already holds them… an `elastic extend` is the reliable way to see it"): that swallow was added deliberately for the *send*, and the stuck xcast op behind it was not noticed. A plain `--add-host` grow plus a concurrently terminating job reaches it with `prte_elastic_mode` off entirely. The shrink is the case where something is *waiting* on the completion callback, which is what turns a leak into a wedge.

## The fix, in two layers

**1. `rml`, `grpcomm` — stop a broadcast waiting on a subtree it never reached.**

Give the RML a send that reports how it *ended*, not just that it queued (`prte_rml_send_buffer_cb_nb` / `PRTE_RML_SEND_CB`), and have the xcast forward use it. A child we could not reach is a child whose ack is never coming, so it stops being expected and the broadcast completes on the daemons it did reach.

Dropping the expectation is right rather than failing the broadcast, because a daemon that joins after op N was never going to see op N anyway — the late-joiner catch-up has it adopt ops `1..N-1` as complete on arrival. This only makes the sender agree with that. A child that genuinely died still takes the fault handler's path, which recomputes `nexpected` and starts a fresh ack round.

An ack re-poll aimed at a child is tracked the same way, for the same reason. The upward direction is left alone: a failure there is our lifeline, which is the fault machinery's business and not the op's.

This is the layer that covers the non-elastic case above.

**2. `ras` — hold a release until the DVM has finished growing.**

Both existing target checks are too weak, and neither can be made strong enough: `setup_vm` assigns `node->daemon` at launch initiation, so "the node has a daemon" admits a node whose daemon is still starting — and more to the point the campaign stalls on the reachability of daemons the caller *never selected*, which no per-target check can see. `extend 1` (settle) → `extend 3` → `shrink 1` wedges the DVM even though the shrink's own target is long settled.

So the precondition belongs where the campaign is created, and it is DVM-wide. The guard sits at the modify driver's entry, covering the component route and the base's own release path at once, and it **parks** the request rather than refusing it: a caller has no way to know a grow is in flight (`ras/slurm` acknowledges an extend as soon as the scheduler answers, long before its daemons join), and a target that is still joining becomes removable seconds later. `prte_plm_base_grow_drain()` is the resume point, being the one place a grow resolves either way. Parked requests are replayed from scratch, so they re-select against the post-grow state, and a grow that failed simply lets them fail through the ordinary error paths.

"Still joining" is answered in three terms, because a growing DVM passes through three states:

- `PRTE_JOB_EXTEND_DVM` on the daemon job covers the window between `prte_ras_base_activate_dvm_grow()` — which only activates `LAUNCH_DAEMONS` — and `setup_virtual_machine` actually running. In that window there is no campaign yet, and the new daemons have no proc objects to inspect. (This term is not in the issue's suggested predicate; whether the gap is reachable depends on event ordering, but it costs one term to not care.)
- A recorded grow campaign covers the launch itself.
- A daemon recorded but never heard from covers anything reaching neither. That tests `rml_uri` and nothing else — `ALIVE` and `RUNNING` are both set when a launch is merely *recorded* — paired with `ALIVE` so a daemon that failed to start, which never reports a URI, cannot park releases forever.

## Testing

- `make check` — 21/21, including a new `test_dvm_growing` in `test/unit/ras` covering all three terms plus the failed-to-start case. Confirmed it has teeth by inverting an assertion and watching it fail.
- Clean `--enable-debug` build, no new warnings.
- Live smoke test (DVM up, jobs, `pterm`).
- `contrib/dockerswarm/run-tests.sh` gains a case that issues a release into a live grow and requires the DVM to still launch jobs afterwards. Its interleaving is opportunistic by design — the extend runs in the background and the release goes in without waiting, so a run that lands outside the window still passes correctly, and one that lands inside fails every assertion against unfixed PRRTE. Do not "stabilize" it with a sleep between the two requests; the sleep is the bug.

**Not yet run: the dockerswarm case.** It needs `run-tests.sh linux` and I had no swarm available. Given its opportunistic interleaving it deserves a couple of runs before this merges.

## Note for reviewers

`prte_ras_base.deferred_releases` is constructed in the framework `open` rather than static-initialized. `PMIX_LIST_STATIC_INIT` leaves the sentinel NULL-linked — safe to read as empty, but appending to it corrupts the list — which is why every such list in the tree is also `PMIX_CONSTRUCT`'d.
