### PR TITLE
ras/slurm: don't spell a release refusal as NOT_SUPPORTED

### DIFF
--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -618,10 +618,12 @@ int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
+    /* Not NOT_SUPPORTED: the modify driver reads that as "ask the next
+     * module", and ras/hosts would then serve the release anyway. */
     if (!prte_elastic_mode) {
         pmix_output(0, "ras:slurm:modify: release requests require elastic DVM mode. "
                        "Set the prte_elastic_mode MCA parameter to 1.");
-        return PRTE_ERR_NOT_SUPPORTED;
+        return PRTE_ERR_NOT_AVAILABLE;
     }
 
     int err = PRTE_SUCCESS;
@@ -1095,7 +1097,7 @@ static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, c
         pmix_output(0, "ras:slurm:remove_allocation_by_id: refusing to terminate job %s "
                        "because it was not dynamically added by PRRTE",
                     alloc_id);
-        return PRTE_ERR_NOT_SUPPORTED;
+        return PRTE_ERR_BAD_PARAM;
     }
 
     if (session_item->nodes_in_session >= prte_num_allocated_nodes) {


### PR DESCRIPTION
`ras/slurm` refuses a `PMIX_ALLOC_RELEASE` outside elastic mode, and for an
alloc id naming a job PRRTE did not create. Both returned
`PRTE_ERR_NOT_SUPPORTED` — the modify driver's "ask the next module" code. The
next module is `ras/hosts`, the priority-1 catch-all, which serves any
`PMIX_ALLOC_RELEASE` it is handed. So the refusal refused nothing: the daemon
was removed fire-and-forget, the Slurm job never resized, and the requester
answered `PMIX_SUCCESS` — the refusal printed and then contradicted, followed
by "PRTE has lost communication with a remote daemon".

Credits: AccelCom @ Barcelona Supercomputing Center