### PR TITLE
ras/slurm: clean up an extend that is still in flight at finalize

### DIFF
--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -122,9 +122,37 @@ consequences, all in `prte_ras_slurm_exec_salloc`:
 --json` poll drives the extend from submission onwards, so the reap can fire
 either side of the request completing and shares no state with it.
 
-`init` allocates `prte_slurm_session_stack` and the pending-request
-tracker; `finalize` tears them down. A successful atomic modify returns
-`PMIX_OPERATION_SUCCEEDED` so the base completes the request.
+### Finalize cleans up in flight extends itself
+
+An incomplete extend owns a pending-request record, an armed poll timer and a
+live `salloc`. Nothing cleans those up after `finalize` returns: the event
+base is stopped, so neither the timer nor the SIGCHLD reaper fires again. So
+each half keeps a registry and empties it inline — cancel `scancel`s every
+job still listed, then extend deletes the timers and kills and reaps the
+children. Cancel goes first: `scancel` is what gives the resources back, and
+killing a child is not.
+
+Four rules for that teardown:
+
+- **Do not answer the requester.** `pmix_server_finalize()` has already run,
+  so the tracker holds the last reference to its request.
+- **Blocking is fine here, and only here.** `kill_job` uses `popen`; with the
+  loop stopped nothing can race `pclose`'s `waitpid`.
+- **Kill outright.** Nothing is left to ask for: the allocation is handled
+  elsewhere — by the cancel half, or by the session drain — and a submission
+  that failed was already signalled by `exec_salloc`. `salloc` does not
+  reliably act on a `SIGTERM` anyway.
+- **Reap.** PID 1 is not always something that reaps — under the `slurmd`
+  that is PID 1 in the test containers, an unreaped child is a zombie for the
+  life of the machine.
+
+A completed extend needs none of this: its job belongs to a session, and
+`prte_ras_slurm_drain_session_stack` scancels those.
+
+`init` allocates `prte_slurm_session_stack`, the pending-request tracker and
+the in-flight extend registries; `finalize` tears them down. A successful
+atomic modify returns `PMIX_OPERATION_SUCCEEDED` so the base completes the
+request.
 
 The JSON helpers (`ras_slurm_jansson.c`) are compiled only when the
 **extensions** are built — jansson available *and* a new enough SLURM, see

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -69,6 +69,8 @@ int prte_ras_slurm_modify_cancel_finalize(void);
 int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req);
 
 /* Features to serve extension requests */
+int prte_ras_slurm_modify_extend_init(void);
+int prte_ras_slurm_modify_extend_finalize(void);
 int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req);
 
 /* Features to serve release requests */

--- a/src/mca/ras/slurm/ras_slurm_modify_cancel.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_cancel.c
@@ -31,6 +31,7 @@ typedef struct {
 /* Local functions */
 static void prte_ras_slurm_pending_req_free(prte_ras_slurm_pending_req_t *pending_req);
 static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx);
+static void prte_ras_slurm_cancel_req_at(int idx);
 
 /**
  * @brief Process a PMIx pending resource cancellation request.
@@ -211,15 +212,29 @@ int prte_ras_slurm_cancel_pending_req(const char *request_id)
         return err;
     }
 
+    prte_ras_slurm_cancel_req_at(idx);
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Cancel and drop the pending request held at an array index.
+ *
+ * @param[in] idx Array index containing the request.
+ */
+static void prte_ras_slurm_cancel_req_at(int idx)
+{
     prte_ras_slurm_pending_req_t *pending_req =
         (prte_ras_slurm_pending_req_t *) pmix_pointer_array_get_item(&pending_reqs, idx);
+
+    if (NULL == pending_req) {
+        return;
+    }
 
     prte_ras_slurm_kill_job(pending_req->slurm_job_id, NULL, 0);
 
     prte_ras_slurm_pending_req_free(pending_req);
     pmix_pointer_array_set_item(&pending_reqs, idx, NULL);
-
-    return PRTE_SUCCESS;
 }
 
 /**
@@ -295,6 +310,9 @@ int prte_ras_slurm_modify_cancel_init(void)
 
 /**
  * @brief Destroy required data structures for record keeping.
+ *
+ * Anything still listed is an extend that never completed. Cancel rather than
+ * forget: a job left behind holds its nodes until its time limit.
  */
 int prte_ras_slurm_modify_cancel_finalize(void)
 {
@@ -303,11 +321,7 @@ int prte_ras_slurm_modify_cancel_finalize(void)
     }
 
     for (int i = 0; i < pending_reqs.size; i++) {
-        void *ptr = pmix_pointer_array_get_item(&pending_reqs, i);
-        if (NULL != ptr) {
-            prte_ras_slurm_pending_req_free((prte_ras_slurm_pending_req_t *) ptr);
-            pmix_pointer_array_set_item(&pending_reqs, i, NULL);
-        }
+        prte_ras_slurm_cancel_req_at(i);
     }
 
     PMIX_DESTRUCT(&pending_reqs);

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1214,7 +1214,12 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     complete:
 
-    if(PRTE_SUCCESS != err && PRTE_ERR_JOB_CANCELLED != err && !resources_added) {
+    if(PRTE_ERR_JOB_CANCELLED == err) {
+        /* Gone already, whether we asked or Slurm did. Drop the record rather
+         * than cancel it, or the job id outlives the job and is scancelled
+         * again later. */
+        prte_ras_slurm_remove_pending_req(request_id);
+    } else if(PRTE_SUCCESS != err && !resources_added) {
         prte_ras_slurm_cancel_pending_req(request_id);
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -14,11 +14,13 @@
 #include "types.h"
 
 #include <ctype.h>
+#include <limits.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <fcntl.h>
+#include <time.h>
 #include <unistd.h>
 #include <stdlib.h>
 
@@ -58,22 +60,35 @@ typedef struct {
     char *job_id;
     int err;
     uint64_t poll_delay_usec;
+    int tracker_index;
 } prte_slurm_wait_tracker_t;
 
 /* Everything the reap callback needs to finish with a salloc child. It is
  * deliberately disjoint from prte_slurm_wait_tracker_t: the child can exit
  * either side of the extend completing, so the two must not share state. */
 typedef struct {
+    pmix_list_item_t super;
     pid_t pid;
     int outfd;
     char *job_id;
 } prte_slurm_salloc_child_t;
+
+/* Bound on how long finalize waits for a killed salloc to become reapable */
+#define PRTE_SLURM_REAP_WAIT_USEC 1000000    /* 1 sec */
+#define PRTE_SLURM_REAP_POLL_USEC 10000      /* 10 ms */
+
+/* Extends still in flight, for finalize to clean up */
+static pmix_list_t prte_slurm_salloc_children;
+static pmix_pointer_array_t prte_slurm_wait_trackers;
+static bool extend_initialized = false;
 
 /*
  * Local functions
  */
 static void swt_con(prte_slurm_wait_tracker_t *p);
 static void swt_des(prte_slurm_wait_tracker_t *p);
+static void ssc_con(prte_slurm_salloc_child_t *p);
+static void ssc_des(prte_slurm_salloc_child_t *p);
 static void salloc_wait_cb(int fd, short args, void *cbdata);
 static int prte_ras_slurm_make_salloc_arg(pmix_hash_table_t *fields, const char *field_name, const char *field_format, bool obj_num, int *argc, char **argv);
 static int prte_ras_slurm_exec_salloc(char * const *argv, char *job_id);
@@ -88,6 +103,7 @@ static void prte_ras_slurm_rollback_session(const char *slurm_jobid);
 static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata);
 
 PMIX_CLASS_INSTANCE(prte_slurm_wait_tracker_t, pmix_object_t, swt_con, swt_des);
+PMIX_CLASS_INSTANCE(prte_slurm_salloc_child_t, pmix_list_item_t, ssc_con, ssc_des);
 
 /* String fields to read from "parent" Slurm job JSON */
 const char *const str_fields[STR_FIELD_COUNT] = {
@@ -143,6 +159,7 @@ static void swt_con(prte_slurm_wait_tracker_t *p)
     p->user_request_id_provided = false;
     p->job_id = NULL;
     p->err = PRTE_SUCCESS;
+    p->tracker_index = -1;
 }
 
 /*
@@ -161,6 +178,129 @@ static void swt_des(prte_slurm_wait_tracker_t *p)
     if (NULL != p->req) {
         PMIX_RELEASE(p->req);
     }
+}
+
+/*
+ * Constructor for prte_slurm_salloc_child_t
+ */
+static void ssc_con(prte_slurm_salloc_child_t *p)
+{
+    p->pid = -1;
+    p->outfd = -1;
+    p->job_id = NULL;
+}
+
+/*
+ * Destructor for prte_slurm_salloc_child_t
+ */
+static void ssc_des(prte_slurm_salloc_child_t *p)
+{
+    if (0 <= p->outfd) {
+        close(p->outfd);
+    }
+
+    if (NULL != p->job_id) {
+        free(p->job_id);
+    }
+}
+
+/*
+ * Set up the records of work in flight.
+ */
+int prte_ras_slurm_modify_extend_init(void)
+{
+    if (extend_initialized || !prte_ras_slurm_have_extensions()) {
+        return PRTE_SUCCESS;
+    }
+
+    int err;
+
+    PMIX_CONSTRUCT(&prte_slurm_salloc_children, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_slurm_wait_trackers, pmix_pointer_array_t);
+
+    err = pmix_pointer_array_init(&prte_slurm_wait_trackers, 0, INT_MAX, 16);
+
+    if (PMIX_SUCCESS != err) {
+        PMIX_DESTRUCT(&prte_slurm_wait_trackers);
+        PMIX_DESTRUCT(&prte_slurm_salloc_children);
+        return prte_pmix_convert_status(err);
+    }
+
+    extend_initialized = true;
+
+    return PRTE_SUCCESS;
+}
+
+/*
+ * Clean up any extend still in flight.
+ *
+ * Only the timers and the processes: the allocations behind them belong to
+ * the cancel half, which prte_ras_slurm_finalize runs first. Done inline
+ * because the event base has stopped - neither the poll timer nor the SIGCHLD
+ * that reaps a child will fire again.
+ */
+int prte_ras_slurm_modify_extend_finalize(void)
+{
+    if (!extend_initialized) {
+        return PRTE_SUCCESS;
+    }
+
+    prte_slurm_salloc_child_t *child;
+
+    for (int i = 0; i < prte_slurm_wait_trackers.size; i++) {
+        prte_slurm_wait_tracker_t *trk = (prte_slurm_wait_tracker_t *)
+            pmix_pointer_array_get_item(&prte_slurm_wait_trackers, i);
+
+        if (NULL == trk) {
+            continue;
+        }
+
+        /* The requester is not told, because the only caller runs after
+         * pmix_server_finalize(): the request has no other reference left and
+         * nothing to answer through. Finalizing this component with the DVM
+         * still up would have to complete these instead of dropping them. */
+        prte_event_evtimer_del(&trk->ev);
+        pmix_pointer_array_set_item(&prte_slurm_wait_trackers, i, NULL);
+        PMIX_RELEASE(trk);
+    }
+
+    while (NULL != (child = (prte_slurm_salloc_child_t *)
+                                pmix_list_remove_first(&prte_slurm_salloc_children))) {
+        /* No SIGTERM first: nothing is left to ask for. Its allocation is
+         * somebody else's to give back - the cancel half, or the session
+         * drain - and a submission that failed was already signalled by
+         * exec_salloc. salloc does not reliably act on one anyway. */
+        kill(child->pid, SIGKILL);
+
+        /* Reap it. PID 1 is not always something that reaps, and an orphan
+         * nobody waits on is a zombie for the life of the machine. */
+        for (uint64_t waited = 0; PRTE_SLURM_REAP_WAIT_USEC > waited;
+             waited += PRTE_SLURM_REAP_POLL_USEC) {
+            struct timespec tp = {0, PRTE_SLURM_REAP_POLL_USEC * 1000};
+            pid_t reaped = waitpid(child->pid, NULL, WNOHANG);
+
+            if (0 > reaped && EINTR == errno) {
+                continue;
+            }
+
+            /* Reaped, or never ours to wait for */
+            if (0 != reaped) {
+                break;
+            }
+
+            nanosleep(&tp, NULL);
+        }
+
+        /* This child's prte_wait_tracker_t is left holding a dangling cbdata,
+         * which is what salloc_wait_cb's finalized check is for. */
+        PMIX_RELEASE(child);
+    }
+
+    PMIX_DESTRUCT(&prte_slurm_wait_trackers);
+    PMIX_DESTRUCT(&prte_slurm_salloc_children);
+    extend_initialized = false;
+
+    return PRTE_SUCCESS;
 }
 
 /*
@@ -254,11 +394,22 @@ static int prte_ras_slurm_make_salloc_arg(pmix_hash_table_t *fields,
 static void salloc_wait_cb(int fd, short args, void *cbdata)
 {
     prte_wait_tracker_t *t2 = (prte_wait_tracker_t *) cbdata;
-    prte_slurm_salloc_child_t *child = (prte_slurm_salloc_child_t *) t2->cbdata;
+    prte_slurm_salloc_child_t *child;
     char tail[PRTE_SLURM_ALLOC_TAIL_MAX + 1];
     size_t n = 0;
     int status;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    /* Past finalize, cbdata names a child this component has already killed,
+     * reaped and freed. Reaching here would mean the event base was dispatched
+     * after the module closed, which does not happen - but the alternative to
+     * checking is a use-after-free on a shutdown path. */
+    if (!extend_initialized) {
+        PMIX_RELEASE(t2);
+        return;
+    }
+
+    child = (prte_slurm_salloc_child_t *) t2->cbdata;
 
     /* Collect whatever salloc had left to say. The child is gone and we hold
      * the only remaining descriptor, so this reads to EOF without blocking -
@@ -281,6 +432,7 @@ static void salloc_wait_cb(int fd, short args, void *cbdata)
 
     tail[n] = '\0';
     close(child->outfd);
+    child->outfd = -1;
 
     /* prte_wait.c records the raw waitpid status here */
     status = t2->child->exit_code;
@@ -302,10 +454,8 @@ static void salloc_wait_cb(int fd, short args, void *cbdata)
                              NULL == child->job_id ? "<unknown>" : child->job_id));
     }
 
-    if (NULL != child->job_id) {
-        free(child->job_id);
-    }
-    free(child);
+    pmix_list_remove_item(&prte_slurm_salloc_children, &child->super);
+    PMIX_RELEASE(child);
 
     /* The tracker owns the dummy proc; nothing owns cbdata but us */
     PMIX_RELEASE(t2);
@@ -397,17 +547,13 @@ static int prte_ras_slurm_exec_salloc(char * const *argv, char *job_id)
 
     /* Everything the reap needs is allocated up front: once the child exists
      * there must be no failure path that cannot hand it over. */
-    child = malloc(sizeof(*child));
+    child = PMIX_NEW(prte_slurm_salloc_child_t);
 
     if(NULL == child) {
         err = PRTE_ERR_OUT_OF_RESOURCE;
         PRTE_ERROR_LOG(err);
         goto cleanup;
     }
-
-    child->pid = -1;
-    child->outfd = -1;
-    child->job_id = NULL;
 
     dummy = PMIX_NEW(prte_proc_t);
 
@@ -494,6 +640,9 @@ static int prte_ras_slurm_exec_salloc(char * const *argv, char *job_id)
     pipefd[0] = -1;
     child_adopted = true;
 
+    /* The list owns our reference from here */
+    pmix_list_append(&prte_slurm_salloc_children, &child->super);
+
     dummy->pid = pid;
     /* be sure to mark it as alive so we don't instantly fire */
     PRTE_FLAG_SET(dummy, PRTE_PROC_FLAG_ALIVE);
@@ -568,7 +717,7 @@ static int prte_ras_slurm_exec_salloc(char * const *argv, char *job_id)
     }
 
     if(!child_adopted && NULL != child) {
-        free(child);
+        PMIX_RELEASE(child);
     }
 
     if(NULL != dummy) {
@@ -975,6 +1124,12 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     int err = trk->err;
 
+    /* The only place a tracker is released, so the only place it is dropped */
+    if (0 <= trk->tracker_index) {
+        pmix_pointer_array_set_item(&prte_slurm_wait_trackers, trk->tracker_index, NULL);
+        trk->tracker_index = -1;
+    }
+
     if(PRTE_SUCCESS != err) {
         goto complete;
     }
@@ -1340,6 +1495,16 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     };
 
     trk->poll_delay_usec = PRTE_SLURM_WAIT_MIN_USEC;
+
+    /* Before arming, since the poll callback drops it again */
+    trk->tracker_index = pmix_pointer_array_add(&prte_slurm_wait_trackers, trk);
+
+    if(0 > trk->tracker_index) {
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        PMIX_RELEASE(trk);
+        goto cleanup;
+    }
 
     prte_event_set(prte_event_base, &trk->ev, -1, 0, slurm_wait_poll_cb, trk);
     prte_event_evtimer_add(&trk->ev, &initial_delay);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -140,11 +140,17 @@ static int init(void)
         goto cleanup;
     }
 
+    err = prte_ras_slurm_modify_extend_init();
+    if (PRTE_SUCCESS != err) {
+        goto cleanup;
+    }
+
 cleanup:
 
     if (PRTE_SUCCESS != err) {
         prte_ras_slurm_modify_release_finalize();
         prte_ras_slurm_modify_cancel_finalize();
+        prte_ras_slurm_modify_extend_finalize();
         if (NULL != prte_slurm_session_stack) {
             PMIX_RELEASE(prte_slurm_session_stack);
             prte_slurm_session_stack = NULL;
@@ -330,7 +336,10 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
 
 static int prte_ras_slurm_finalize(void)
 {
+    /* Cancel first: scancel is what gives the resources back, and killing a
+     * salloc child is not */
     prte_ras_slurm_modify_cancel_finalize();
+    prte_ras_slurm_modify_extend_finalize();
     prte_ras_slurm_modify_release_finalize();
     if (NULL != prte_slurm_session_stack) {
         prte_ras_slurm_drain_session_stack();


### PR DESCRIPTION
Between `salloc` naming its job and the poll absorbing it, an extend owns a
pending-request record, an armed poll timer holding a retained
`prte_pmix_server_req_t`, and a live `salloc` child. Finalize dropped all
three: the Slurm job stood until its time limit, and the child was orphaned
holding an allocation nobody could revoke.

Nothing else can pick that up. By the time the `ras` framework closes,
`prte_finalize` has stopped the event base, so the poll timer cannot fire
again and neither can the SIGCHLD that reaps the child. Each half therefore
keeps a registry of what is in flight and empties it inline: cancel
`scancel`s every job still listed, then extend deletes the timers and kills
and reaps the children.

The children are sent SIGKILL. Their allocations are given back
by the cancel half or by the session drain, and `salloc` does not reliably
act on a `SIGTERM` — one whose allocation has just been revoked can sit
blocked with the signal caught, which is how this was found. They are then
reaped, because an orphan is only cleaned up by whatever adopts it and PID 1
is not always something that reaps.

The requester is deliberately not told: `pmix_server_finalize()` has already
run, so the tracker holds the last reference to its request and the callback
would reach into a server that no longer exists.

The second commit is a separate bug found while testing the first. An extend
whose job is cancelled outside PRRTE is detected by the poll, which answers
the requester `JOB_CANCELLED` — but nothing removed the pending record, since
that path skips `cancel_pending_req` and there is no job left to cancel. The
record outlived its job, so the id stayed on the cancellable list and was
scancelled again later.