### PR TITLE
Report what each broadcast compresses to

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -1530,6 +1530,42 @@ with a flat one at the same size, and how much of the total is payload
 values as meaningful only against another run on the same host with the same
 load.
 
+**A debug build measures itself, not PRRTE.** `build.sh` configures PRRTE with
+`--enable-debug`, which is right for the functional suites and wrong for any
+number you intend to quote. It configures PMIx with `--prefix` alone, and that
+distinction matters more than it looks: `PMIX_ENABLE_DEBUG` is what selects
+`PMIX_BFROP_BUFFER_FULLY_DESC`, under which every value packed into a buffer
+carries a type descriptor it would not carry in production. A debug PMIx
+therefore inflates every launch message, nidmap and fence bucket *and* flatters
+their compression ratio, because those descriptors are repetitive. So a
+measurement taken here is representative only while PMIx is built without debug
+— check with `grep PMIX_ENABLE_DEBUG <build>/src/include/pmix_config.h` before
+quoting a size, and remember `PMIX_SRC` builds PMIx from your checkout with
+whatever arguments `build.sh` passes.
+
+**And know the noise floor before you go looking for a small effect.** At 40
+nodes the collect fence's wall clock has a run-to-run coefficient of variation
+of 35–50% over five iterations. Anything under about a third is simply not
+measurable here, no matter how many arms the sweep has: an attempt to settle
+whether compressing the xcast payload helps (an effect of 1–7%) produced
+ON/OFF pairs whose ranges overlapped completely and whose *sign* flipped
+between radix 4 and radix 64. If what you are after is small, measure the
+mechanism directly — `--prtemca grpcomm_base_verbose 1` reports the size,
+ratio and microseconds of every broadcast — rather than hoping it will surface
+in an end-to-end fence.
+
+### The payload is a ramp, and that matters for anything about compression
+
+`scaletest`'s default fill is `payload[n] = (rank + n) & 0xff` — a repeating
+256-byte ramp. It is a fine stand-in for *moving* bytes, and a terrible one for
+*compressing* them: deflate squashes it by roughly 250:1, so any compression
+ratio measured on it is an upper bound that no real data approaches.
+`--entropy` (`./scaletest.sh run --entropy`) fills from an xorshift stream
+seeded per rank instead. That is the opposite extreme — deflate cannot shrink
+it at all — and a real modex, which is network endpoints, keys and addresses in
+a thin frame of repetitive text, sits much closer to that floor than to the
+ramp. Run both and the truth is bracketed.
+
 ### Checking a fence still *delivers*, not just that it is fast
 
 `scaletest --verify` reads one key back from two peers each iteration: a

--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make \
         autoconf automake libtool m4 flex \
         perl python3 git \
-        libevent-dev libhwloc-dev zlib1g-dev \
+        libevent-dev libhwloc-dev zlib1g-dev libzstd-dev \
         libjansson-dev \
         openssh-server openssh-client \
         iproute2 iputils-ping procps less vim ca-certificates \

--- a/contrib/dockerswarm/scaletest.c
+++ b/contrib/dockerswarm/scaletest.c
@@ -14,6 +14,7 @@
  *
  *   scaletest [--nkeys N] [--sizes A,B,C] [--iters N] [--warmup N]
  *             [--scope global|remote|local] [--tag STR] [--verify] [--neighbors]
+ *             [--entropy]
  *
  * Each iteration is three timed phases:
  *
@@ -128,7 +129,7 @@ static void usage(const char *argv0)
     fprintf(stderr,
             "usage: %s [--nkeys N] [--sizes A,B,C] [--iters N] [--warmup N]\n"
             "          [--scope global|remote|local] [--tag STR] [--verify]\n"
-            "          [--neighbors]\n",
+            "          [--neighbors] [--entropy]\n",
             argv0);
 }
 
@@ -144,6 +145,7 @@ int main(int argc, char **argv)
     const char *tag = "run";
     bool verify = false;
     bool neighbors = false;
+    bool entropy = false;
     char hostname[256];
     char key[PMIX_MAX_KEYLEN + 1];
     char *payload = NULL;
@@ -181,6 +183,8 @@ int main(int argc, char **argv)
             verify = true;
         } else if (0 == strcmp(argv[a], "--neighbors")) {
             neighbors = true;
+        } else if (0 == strcmp(argv[a], "--entropy")) {
+            entropy = true;
         } else if (0 == strcmp(argv[a], "--scope") && a + 1 < argc) {
             ++a;
             if (0 == strcmp(argv[a], "global")) {
@@ -252,8 +256,31 @@ int main(int argc, char **argv)
             PMIx_Finalize(NULL, 0);
             return 1;
         }
-        for (n = 0; n < maxsize; n++) {
-            payload[n] = (char) ((myproc.rank + n) & 0xff);
+        if (entropy) {
+            /* Incompressible.  The default payload below is a 256-byte ramp
+             * repeated to length, which zlib squashes by roughly 250:1 - so
+             * any measurement of a compressed collective taken on it reports
+             * a saving that no real modex would ever see.  A real modex is
+             * network endpoints, keys and addresses: high-entropy bytes in a
+             * thin frame of repetitive text.  This fills with an xorshift
+             * stream, which is the floor - deflate cannot shrink it at all,
+             * and is left paying its own cost for nothing.  Run both and the
+             * truth about compression is bracketed between them.
+             *
+             * Seeded from the rank so no two ranks contribute the same bytes;
+             * a shared stream would be compressible across the gathered blob
+             * even though each rank's own slice was not. */
+            uint64_t s = 88172645463325252ULL + 0x9e3779b97f4a7c15ULL * (uint64_t) myproc.rank;
+            for (n = 0; n < maxsize; n++) {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                payload[n] = (char) s;
+            }
+        } else {
+            for (n = 0; n < maxsize; n++) {
+                payload[n] = (char) ((myproc.rank + n) & 0xff);
+            }
         }
     }
 

--- a/contrib/dockerswarm/scaletest.sh
+++ b/contrib/dockerswarm/scaletest.sh
@@ -302,6 +302,7 @@ cmd_run() {
     local max_total_bytes=$((2 * 1024 * 1024 * 1024))
     local scope=global
     local neighbors=""
+    local entropy=""
     local dry=0
     local swarm_n
 
@@ -319,6 +320,11 @@ cmd_run() {
             --max-bytes)       max_bytes=$2; shift 2 ;;
             --max-total-bytes) max_total_bytes=$2; shift 2 ;;
             --neighbors) neighbors=1; shift ;;
+            # Incompressible payload.  The client's default fill is a repeating
+            # 256-byte ramp, which deflate squashes by ~250:1 -- fine for
+            # measuring how a collective moves bytes, useless for measuring
+            # what compressing them is worth.  See scaletest.c.
+            --entropy)   entropy=1; shift ;;
             --dry-run)   dry=1; shift ;;
             *) die "unknown option $1" ;;
         esac
@@ -404,7 +410,8 @@ cmd_run() {
                                     --map-by ppr:$ppn:node --bind-to none -n $nprocs \
                                     $BIN --tag $tag --nkeys $nkeys --sizes $cs \
                                          --iters $iters --warmup $warmup --scope $scope \
-                                         ${neighbors:+--neighbors}" \
+                                         ${neighbors:+--neighbors} \
+                                         ${entropy:+--entropy}" \
                                  > "$capture" 2>&1; then
                             echo "    FAILED: $(tail -3 "$capture" | tr '\n' ' ')" >&2
                             rm -f "$capture"

--- a/contrib/slurmswarm/Dockerfile
+++ b/contrib/slurmswarm/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make \
         autoconf automake libtool m4 flex \
         perl python3 git curl bzip2 \
-        libevent-dev libhwloc-dev zlib1g-dev \
+        libevent-dev libhwloc-dev zlib1g-dev libzstd-dev \
         libjansson-dev \
         munge libmunge-dev libjson-c-dev libyaml-dev \
         openssh-server openssh-client \

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -231,6 +231,183 @@ lateral movement was built to remove, and
 [`docs/plans/scalable_collectives.rst`](../../docs/plans/scalable_collectives.rst)
 records both the attempt and why it was withdrawn.
 
+### Compression, and why the threshold is not a size
+
+`xcast_nb()` compresses the payload **once, at the originator**, via
+`PMIx_Data_compress`; the compressed bytes are what every hop forwards, and
+only the local delivery in `process_msg()` inflates. So the DVM pays one
+deflate and one inflate per daemon, the latter off the forwarding path. The
+`msg_compressed` bool travels beside the byte object so the receiver knows
+which it got.
+
+Whether that is worth doing is not a property of the payload's size alone.
+Five quantities decide it, and it is worth naming them before the arithmetic:
+
+| | meaning |
+|---|---|
+| `M` | the payload, in bytes |
+| `rho` | the fraction the compressor leaves — `rho = 0.5` means it halved it |
+| `B` | bandwidth of **one** link, in bytes/sec |
+| `d` | depth of the routing tree (levels below the HNP) |
+| `k` | radix of the tree — how many children a daemon forwards to (64 by default) |
+| `R` | the compressor's throughput, in bytes/sec |
+
+Shrinking the payload saves `(1 - rho) * M / B` on **every link the broadcast
+crosses**, and the critical path holds `d * k` of them, because each of the `d`
+levels serialises `k` full copies onto one outbound link. So the saving carries
+a `d * k` multiplier that the compressor knows nothing about. Deflate is linear
+in `M` above a few KB, so writing its cost as `M / R` makes `M` cancel from
+both sides:
+
+```
+compress iff   R  >  B / (d * k * (1 - rho))
+```
+
+A comparison of two rates, not a size. **This is why there is no
+PRRTE-side size threshold and should not be one.** A size limit buys only
+protection from the compressor's fixed start-up cost and from the poor ratios
+of tiny inputs — and that is the compressor's own business: every `pcompress`
+component already declines an input below its configured `pcompress_base_limit`
+and declines any result that is not actually smaller. There is nothing for this
+layer to add. Hand the payload over and let the component judge it.
+
+**Scale is what decides it, so do not calibrate this on a small DVM.** `d * k`
+is 39 on a 40-node DVM but 128 at 1000 nodes and 192 at 10000 (radix 64), and
+the payloads grow with the process count on top of that. The answer at 40 nodes
+is "barely, maybe not"; the answer at 10000 is "overwhelmingly yes".
+
+The launch message measures **8.1 bytes per process** (`grpcomm_base_verbose 1`
+against `prterun -n N`, slope taken at N = 800 to 1600), so 1.28M processes is a
+~10 MB broadcast. A full-data fence release carries the aggregated modex, which
+is the application's size rather than PRRTE's — at a modest 200 B/proc that is
+25 MB at 1000 nodes and 256 MB at 10000.
+
+At 10000 nodes and 128 processes per node (`d = 3`, `k = 64`, so `d * k = 192`),
+broadcasting that 256 MB release over 10 Gb/s (`B` = 1.25 GB/s), with zstd's
+measured `R` = 434 MB/s and `rho` = 0.63:
+
+| | deflate | wire raw | wire compressed | net |
+|---|---|---|---|---|
+| zstd | 0.6 s | 39.3 s | 24.8 s | **+13.9 s** |
+| zlib (`R` = 103 MB/s, `rho` = 0.65) | 2.5 s | 39.3 s | 25.5 s | **+11.3 s** |
+
+So compression is not marginal here — it is the difference between a
+40-second broadcast and a 25-second one. Two things that decision rests on:
+
+- **`B` is the assumption to check.** At 100 Gb/s (`B` = 12.5 GB/s) the same
+  broadcast needs `d * k > 78` with zstd to stay ahead — which 1000- and
+  10000-node DVMs still clear, but a small one does not. PRRTE's OOB is TCP and
+  on most clusters rides the management network rather than the compute fabric,
+  which is the case worth designing for.
+- **The deflate blocks the progress thread.** `xcast_nb()` compresses *before*
+  it thread-shifts to `begin_xcast`, and every caller (`fence_recv`, the plm
+  launch path, the state machine) is already on the progress thread. At 256 MB
+  that is a sub-second stall with zstd but several seconds with zlib at a high
+  level, during which the HNP services no RML message, no PMIx connection and no
+  tool request. The wire time it buys back is larger, so the trade is right, but
+  the cost lands as one stall rather than as evenly spread bandwidth.
+
+### The fence path compresses twice, and that is correct — do not "fix" it
+
+The collect blob is compressed **before** xcast ever sees it:
+`pmix_server_fence.c` deflates each daemon's bucket, PRRTE concatenates those
+opaque blocks up the tree, and the HNP deflates the concatenation again in
+`xcast_nb()`. That looks redundant and the obvious cleanup — drop the
+per-bucket pass and compress once over the whole aggregate, where all the
+cross-rank redundancy is — has been measured and it is a **regression on both
+axes**:
+
+| 1000 daemons x 128 ppn, 200 B/proc | broadcast | rollup |
+|---|---|---|
+| per-bucket + xcast (today) | 15.40 MB | 15.51 MB |
+| xcast only | 15.62 MB (**+1.4%**) | 25.60 MB (**+65%**) |
+
+The reason is mechanical: **deflate's sliding window is 32 KB**. A bucket of
+128 ranks at 200 B/proc is 25.6 KB — already inside one window — so the
+per-bucket pass finds essentially everything zlib is capable of finding, and
+compressing the aggregate in one shot gives it no matches it could not already
+see. Chunking only costs where a bucket is far *below* the window (at 8 ppn the
+single pass wins 1.5%, still against a 46% larger rollup).
+
+And there is no long-range redundancy waiting for a bigger window either. On
+the same corpus, `xz -9` with a 64 MB dictionary reaches 0.576 against `gzip
+-9`'s 0.600, and `zstd -19 --long=27` (128 MB window) manages only 0.591. The
+floor is set by the opaque per-rank value bytes — endpoints, keys, addresses —
+which do not compress at all. Roughly 60% of a modex is incompressible no
+matter how it is framed.
+
+So the per-bucket pass is free ratio-wise and buys a 65% smaller rollup. Leave
+it alone.
+
+**What does move the needle is the compressor, not the layering.** Measured on
+the same 25.6 MB aggregate, single-threaded: `zstd -1` matches `gzip -9`'s
+ratio (0.600) at **640 MB/s against 64 MB/s**, and `zstd -3` beats it (0.588)
+at 427 MB/s. That is the lever on the progress-thread stall above — the same
+256 MB release that costs 5.5 s of blocked HNP under `gzip -9` would cost
+around 0.4 s. PMIx's `pcompress` framework is where such a component would go;
+it already carries `zlib` and `zlibng`.
+
+### Measuring it
+
+`grpcomm_base_verbose 1` reports raw size, on-wire size and ratio for **every**
+broadcast, compressed or not, so the line is a complete census of what a DVM
+broadcasts. Adding `grpcomm_enable_timing 1` appends what the deflate cost the
+originator:
+
+```sh
+prterun --prtemca grpcomm_base_verbose 1 --prtemca grpcomm_enable_timing 1 ...
+```
+
+Timing is off by default because the clock reads it needs sit directly in the
+broadcast path. There is no separate size gate to sweep — the compressor's own
+`pcompress_base_limit` and `pcompress_*_level` are the knobs, so vary those:
+
+```sh
+--pmixmca pcompress zstd --pmixmca pcompress_zstd_level 1
+```
+
+### Timing runs want an optimized build — a debug build measures itself
+
+**Do not draw conclusions about sizes or times from a `--enable-debug` build.**
+The overhead is not a uniform tax that cancels out of a comparison; it changes
+the very quantities being measured.
+
+The one that matters most here is that **a debug PMIx describes its buffers**.
+`pmix_bfrops_globals.default_type` is `PMIX_BFROP_BUFFER_FULLY_DESC` under
+`PMIX_ENABLE_DEBUG` and `PMIX_BFROP_BUFFER_NON_DESC` otherwise, so every value
+packed into a buffer carries a type descriptor it would not carry in
+production. A launch message, a nidmap and a fence bucket are all built that
+way, so in a debug build they are **larger** — and their compression ratio is
+flattered too, because those descriptors are highly repetitive and deflate eats
+them. Both halves of `raw` and `wire` in the census line move, in opposite
+directions from the truth.
+
+Note this is **PMIx's** debug flag, not PRRTE's: the buffer type is compiled
+into `libpmix`. A PRRTE built `--enable-debug` against a PMIx built without it
+still packs production-sized buffers, which is the usual development setup and
+is fine to measure. Check what you actually have before trusting a number:
+
+```sh
+grep PMIX_ENABLE_DEBUG <pmix-build>/src/include/pmix_config.h
+```
+
+The rest of a debug build — assertions, `PRTE_ERROR_LOG` paths, unoptimized
+code — inflates times everywhere and is the ordinary reason not to benchmark
+one.
+
+**`scaletest` cannot resolve a small effect either**, whatever the build. At 40
+nodes the collect fence's wall clock has a run-to-run coefficient of variation
+of 35-50%; a four-arm sweep (compression on/off crossed with compressible and
+incompressible payloads) put every ON/OFF pair fully inside the other's range,
+with the *sign* flipping between radix 4 and radix 64. That is consistent with
+the model — the swarm's wire is loopback, so `B` is enormous and no `d * k` a
+40-container swarm can reach compensates — but it settles nothing on its own.
+
+`scaletest`'s default payload is a repeating 256-byte ramp that deflate squashes
+by ~250:1. Any compression number read off it is fiction; `--entropy` fills with
+an xorshift stream instead, which is the floor. Real modex data — endpoints,
+keys, addresses — sits much closer to the floor than to the ramp.
+
 ### Ordering and fault tolerance
 
 The in-file comments are the real spec — read them. The load-bearing ideas:

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -69,6 +69,19 @@ void prte_grpcomm_register(void)
         prte_grpcomm_globals.output = pmix_output_open(NULL);
         pmix_output_set_verbosity(prte_grpcomm_globals.output, verbosity);
     }
+
+    /* Timing is a measurement aid rather than production instrumentation, so
+     * it is off unless asked for: the clock reads it needs sit directly in the
+     * broadcast path.  Note that a timing run wants a NON-debug build - see
+     * src/grpcomm/AGENTS.md, "Timing runs want an optimized build". */
+    prte_grpcomm_globals.enable_timing = false;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "enable_timing",
+                               "Measure and report how long the collectives spend "
+                               "in the operations worth timing (today, an xcast's "
+                               "compression of its payload). Reported at "
+                               "grpcomm_base_verbose 1.",
+                               PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                               &prte_grpcomm_globals.enable_timing);
 }
 
 /**

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -77,6 +77,12 @@ typedef struct {
     // failure can be recognized as stale. Shared by fence and group: one
     // failure, one restart, one epoch.
     uint32_t recovery_epoch;
+    // Measure and report how long the collectives spend in the operations
+    // worth timing - today, the deflate an xcast performs on its payload.
+    // Off by default: it is a measurement aid, not production instrumentation,
+    // and the clock reads it needs sit directly in the broadcast path.
+    // Set with the grpcomm_enable_timing MCA parameter.
+    bool enable_timing;
 } prte_grpcomm_globals_t;
 
 #define PRTE_GRPCOMM_GROUP_MEMO_MAX 64

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -22,6 +22,7 @@
 #include "types.h"
 
 #include <string.h>
+#include <sys/time.h>
 
 #include "src/class/pmix_list.h"
 #include "src/pmix/pmix-internal.h"
@@ -170,12 +171,92 @@ int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
     op->cbdata = cbdata;
     /* Make a (possibly compressed) copy of this message in a new op - this is
      * non-destructive, so our caller is still responsible for releasing any
-     * memory in the buffer they gave us
-     */
-    op->msg_compressed = (bool) PMIx_Data_compress(
-        (uint8_t*) msg->base_ptr, msg->bytes_used,
-        (uint8_t**) &op->msg.bytes, &op->msg.size
-    );
+     * memory in the buffer they gave us.
+     *
+     * The payload is compressed exactly once, here at the originator, and the
+     * compressed bytes are what every hop forwards; only the local delivery in
+     * process_msg() inflates.  So the sender pays one deflate and each daemon
+     * pays one inflate, off the forwarding path.
+     *
+     * Whether that is worth doing is not a property of the payload's size
+     * alone.  Write M for the payload in bytes, rho for the fraction the
+     * compressor leaves (so 0.5 means it halved it), B for the bandwidth of one
+     * link in bytes/sec, d for the depth of the routing tree and k for its
+     * radix - the number of children a daemon forwards to.  Shrinking the
+     * payload saves (1 - rho) * M / B on every link the broadcast crosses, and
+     * the critical path holds d * k of them, because each of the d levels
+     * serialises k full copies onto one outbound link.  Deflate is linear in M
+     * above a few KB, so writing its cost as M / R for a compressor rate R in
+     * bytes/sec makes M cancel from both sides and leaves
+     *
+     *     compress iff   R  >  B / (d * k * (1 - rho))
+     *
+     * a comparison of two rates, not a size.  A size threshold cannot express
+     * that; it buys only protection from the fixed cost of starting the
+     * compressor and from the poor ratios of tiny inputs, which is worth having
+     * but is the compressor's own business - every pcompress component already
+     * declines an input below its configured limit, and declines any result
+     * that is not actually smaller.  So there is nothing for this layer to add:
+     * hand the payload over and let the component judge it.
+     *
+     * At the scales this runtime is built for the answer is a clear yes.  A
+     * 10000-node DVM at 128 processes per node has d = 3 and k = 64 (the
+     * default radix), so d * k = 192, and its fence release carries the
+     * aggregated modex of 1.28M processes - hundreds of megabytes.  Measured on
+     * a modex-shaped corpus, zstd reaches rho = 0.63 at R = 434 MB/s where
+     * zlib manages 0.65 at 103 MB/s.  Broadcasting 256 MB over 10 Gb/s
+     * (B = 1.25 GB/s): 39 s raw against 20 s compressed, for well under a
+     * second of deflate.  Compression halves it.
+     *
+     * The one thing to keep in mind is that this deflate runs BEFORE the
+     * thread-shift below, so it is serial on the caller's thread - and every
+     * caller is already the progress thread.  At 256 MB the HNP stalls for the
+     * duration, servicing no RML message and no PMIx connection while it works.
+     * The wire time it buys back is larger, so the trade is right, but the cost
+     * lands as one stall rather than as evenly spread bandwidth. */
+    {
+        struct timeval t0, t1;
+        char timing[32];
+
+        timing[0] = '\0';
+        if (prte_grpcomm_globals.enable_timing) {
+            gettimeofday(&t0, NULL);
+        }
+
+        op->msg_compressed = (bool) PMIx_Data_compress(
+            (uint8_t*) msg->base_ptr, msg->bytes_used,
+            (uint8_t**) &op->msg.bytes, &op->msg.size
+        );
+
+        if (prte_grpcomm_globals.enable_timing) {
+            gettimeofday(&t1, NULL);
+            snprintf(timing, sizeof(timing), " in %ld us",
+                     (long) ((t1.tv_sec - t0.tv_sec) * 1000000L
+                             + (t1.tv_usec - t0.tv_usec)));
+        }
+
+        /* What the compressor decided and what it bought - raw size, on-wire
+         * size, and the ratio - for every broadcast, so the line is a complete
+         * census of what a DVM broadcasts rather than only of what it
+         * compressed.  The deflate time is appended only when timing is
+         * enabled; it is the term that has to be weighed against the wire time
+         * saved on every link of the tree. */
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:xcast: tag %u raw %lu wire %lu "
+                             "ratio %.4f %s%s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             (unsigned) tag,
+                             (unsigned long) msg->bytes_used,
+                             (unsigned long) (op->msg_compressed ? op->msg.size
+                                                                 : msg->bytes_used),
+                             (0 == msg->bytes_used) ? 1.0
+                                 : (double) (op->msg_compressed ? op->msg.size
+                                                                : msg->bytes_used)
+                                   / (double) msg->bytes_used,
+                             op->msg_compressed ? "compressed" : "uncompressed",
+                             timing));
+    }
+
     if(!op->msg_compressed){
         pmix_data_buffer_t msg_copy;
         PMIx_Data_buffer_construct(&msg_copy);


### PR DESCRIPTION
`xcast` has compressed its payload for years — once at the originator, with
the compressed bytes forwarded down the whole tree — but nothing reported the
size before, the size after, or whether the compressor took the job at all. So
every question about it had to be answered by reasoning rather than by
measurement. This makes it observable, and records what the observation says.

Pairs with openpmix/openpmix#4103, which adds a zstd `pcompress` component and
makes each component's compression level tunable. This side needs neither, and
works unchanged against a PMIx without them.

### Report what each broadcast compresses to

Every broadcast now emits one line at `grpcomm_base_verbose 1` with the raw
size, the on-wire size and the ratio — compressed or not, so the log is a
complete census rather than a record of what happened to compress. Adding
`grpcomm_enable_timing 1` appends what the deflate cost the originator. Timing
is a separate parameter and off by default, because the clock reads it needs
sit directly in the broadcast path; the census itself is free.

What it shows on a 40-node DVM:

| tag | payload | ratio | |
|---|---|---|---|
| `WIREUP` | ~5.7 KB | 0.19 | once per DVM |
| `DAEMON_LAUNCH` | ~1.1 KB | — | under the compressor's limit |
| `FENCE_RELEASE` (barrier) | ~350 B | — | under the limit; the vast majority of broadcasts |
| `FENCE_RELEASE` (collect) | 39–105 KB | 0.18 | the only one costing real time |

**No size gate is added, and the guide says why at length**, because it is the
obvious thing to reach for and it is wrong. Compressing `M` bytes to `rho*M`
saves `(1-rho)*M/B` on every link the broadcast crosses, and the critical path
of a tree of depth `d` and radix `k` holds `d*k` of them — so the saving
carries a multiplier the compressor knows nothing about, while deflate is
linear in `M` above a few KB. Writing its cost as `M/R` for a compressor rate
`R` makes `M` cancel from both sides:

```
compress iff   R  >  B / (d * k * (1 - rho))
```

A comparison of rates, not a size. And what a size threshold *does* buy —
protection from the compressor's start-up cost and from the poor ratios of tiny
inputs — is already the compressor's own business: every `pcompress` component
declines an input below its configured limit and declines any result that is
not actually smaller.

The guide also records the arithmetic at 1000 and 10000 nodes (`d*k` is 128 and
192 at the default radix, so compression wins comfortably there and marginally
at 40 nodes), and two things easy to get wrong: the deflate runs *before* the
thread-shift and so stalls the progress thread, and a debug PMIx packs
fully-described buffers, which inflates every payload measured and flatters its
ratio at the same time.

### dockerswarm: give scaletest an incompressible payload

`scaletest` fills every contribution with `(rank + n) & 0xff` — a 256-byte ramp
that deflate squashes by ~250:1. Any compression figure read off it is an upper
bound no real data approaches. `--entropy` fills from a per-rank xorshift
stream instead, which deflate cannot shrink at all; run both and the truth is
bracketed. The default is unchanged, so existing measurements stay comparable.

Two warnings added to the guide, both of which cost time to learn. A debug
build measures itself — `PMIX_ENABLE_DEBUG` selects fully-described buffers, and
note that is **PMIx's** flag rather than PRRTE's, since the buffer type is
compiled into `libpmix`; the usual setup here (PRRTE debug, PMIx not) still
measures production-sized buffers. And the noise floor: at 40 nodes the collect
fence's wall clock varies 35–50% run to run, so nothing under about a third is
measurable there at all. An attempt to settle a 1–7% effect produced fully
overlapping ranges whose *sign* flipped between radix 4 and radix 64. Measure
the mechanism directly instead — which is what the census is for.

### Install libzstd in both swarm images

A `pcompress` component is compiled only if configure found its library, so
without this a PMIx built inside either harness would quietly fall back to
zlib — and quietly is the problem, since nothing in a test run says which
compressor is in use. Note `build.sh` does not rebuild the image: an existing
swarm needs `docker build --no-cache` and a `--force-recreate`.

### Testing

- Warning-free build with `--enable-debug`; `make check` 21 pass / 0 fail.
- Census and timing verified end to end; timing absent by default and present
  with `grpcomm_enable_timing 1`.
- Launch-message size measured across process counts through the census
  (8.1 bytes/proc, slope at N = 800→1600), which is where the scale arithmetic
  in the guide comes from.
- Mapping, ranking and binding untouched, so the offline harness is unaffected.
