### PR TITLE
Pack an xcast forward once rather than once per child

### DIFF
--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -113,6 +113,13 @@ static op_t* insert_forwarded_op(signature_t *sig);
 static void forward_op(op_t *op);
 // Forward to specific destination
 static void forward_op_to(op_t *op, pmix_rank_t dest);
+// Pack the forward once, ready to be sent to any number of children.  NULL on
+// failure, already reported
+static prte_rml_payload_t* build_forward_payload(op_t *op);
+// Send an already-packed forward to one destination; the payload is shared,
+// so this takes no ownership of it
+static void forward_payload_to(op_t *op, prte_rml_payload_t *payload,
+                               pmix_rank_t dest);
 // Send-completion callback: a message to a child that never arrives means that
 // subtree's ack is never coming, so stop expecting it
 static void forward_lost(int status, pmix_proc_t *peer,
@@ -134,9 +141,10 @@ static void tree_whole_forward(op_t *op);
 // Is an op ahead of this one in op-id order still waiting on its payload?
 
 
-// Pack the xcast message forwarded to one of our children
-static int pack_forward_msg(pmix_data_buffer_t *buffer, op_t *op,
-                            pmix_rank_t dest);
+// Pack the xcast message forwarded to our children.  Takes no destination:
+// the forward is identical for all of them, which is what lets one packed
+// buffer be shared by every send (see tree_whole_forward)
+static int pack_forward_msg(pmix_data_buffer_t *buffer, op_t *op);
 // Pack the initiating relay from an originator to the controller
 static int pack_relay_msg(pmix_data_buffer_t *buffer, op_t *op);
 // (un)pack components
@@ -792,9 +800,7 @@ static int pack_relay_msg(pmix_data_buffer_t* buffer, op_t* op){
     return rc;
 }
 
-static int pack_forward_msg(pmix_data_buffer_t* buffer, op_t* op,
-                            pmix_rank_t dest){
-    PRTE_HIDE_UNUSED_PARAMS(dest);
+static int pack_forward_msg(pmix_data_buffer_t* buffer, op_t* op){
     int rc = pack_sig(buffer, &op->sig);
     if(PMIX_SUCCESS == rc) rc = pack_ack_id(buffer, &op->ack_id_down);
     if(PMIX_SUCCESS == rc) rc = pack_msg(buffer, op);
@@ -841,13 +847,50 @@ static op_t* insert_forwarded_op(signature_t* sig) {
  * high radix makes that 1 or 2 hops.  Wrong for a large one: a node with r
  * children serializes r full copies of the payload on its outbound link, at
  * every level, so the bandwidth term is d*r*M*beta - which is the entire cost
- * of broadcasting a launch message or a preload chunk at scale. */
+ * of broadcasting a launch message or a preload chunk at scale.
+ *
+ * The forward is byte-for-byte identical for every child - it carries the
+ * op-id, the ack-id and the payload, none of which depend on the destination -
+ * so it is packed once here and shared by every send.  Packing it per child
+ * cost a full copy of the payload per child, and all of those copies were made
+ * on the progress thread inside this one event callback, before any of them
+ * could reach the wire: at the default radix, 64 copies of a launch message
+ * made and held before the first byte moved.
+ *
+ * That is why pack_forward_msg takes no destination.  If a forward ever does
+ * need to differ per child, this is the loop that has to go back to packing
+ * inside it - the sharing is not an optimization the RML can make on its own. */
 static void tree_whole_forward(op_t* op){
     pmix_rank_t* children = (pmix_rank_t*) prte_rml_base.children.array;
-    for(size_t i = 0; i < prte_rml_base.children.size; i++){
-        if(children[i] == PMIX_RANK_INVALID) continue;
-        forward_op_to(op, children[i]);
+    prte_rml_payload_t* payload;
+    size_t i;
+    bool any = false;
+
+    for (i = 0; i < prte_rml_base.children.size; i++) {
+        if (PMIX_RANK_INVALID != children[i]) {
+            any = true;
+            break;
+        }
     }
+    if (!any) {
+        return;
+    }
+
+    payload = build_forward_payload(op);
+    if (NULL == payload) {
+        return;
+    }
+
+    for (i = 0; i < prte_rml_base.children.size; i++) {
+        if (PMIX_RANK_INVALID == children[i]) {
+            continue;
+        }
+        forward_payload_to(op, payload, children[i]);
+    }
+
+    /* every child that accepted the payload holds its own reference now; drop
+     * ours, so the buffer dies with the last send rather than with this loop */
+    PMIX_RELEASE(payload);
 }
 
 static void forward_op(op_t* op){
@@ -936,35 +979,58 @@ static void forward_lost(int status, pmix_proc_t *peer,
     drive_completions();
 }
 
-static void forward_op_to(op_t* op, pmix_rank_t dest){
+/* Pack the forward once.  Returns NULL having already reported the failure -
+ * a forward we cannot build is not something any caller can carry on past. */
+static prte_rml_payload_t* build_forward_payload(op_t* op){
     pmix_data_buffer_t* xcast_msg = PMIx_Data_buffer_create();
+    prte_rml_payload_t* payload;
 
-    int rc = pack_forward_msg(xcast_msg, op, dest);
-    if(PMIX_SUCCESS != rc){
+    int rc = pack_forward_msg(xcast_msg, op);
+    if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
-        return;
+        return NULL;
     }
+
+    payload = PMIX_NEW(prte_rml_payload_t);
+    payload->dbuf = xcast_msg;
+    return payload;
+}
+
+static void forward_payload_to(op_t* op, prte_rml_payload_t* payload,
+                               pmix_rank_t dest){
+    int rc;
 
     PMIX_OUTPUT_VERBOSE((
         5, prte_grpcomm_globals.output,
         "%s grpcomm:send_relay sending relay msg of %d bytes to %s",
-        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) xcast_msg->bytes_used,
+        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) payload->dbuf->bytes_used,
         PRTE_VPID_PRINT(dest)
     ));
 
     /* The op-id is carried by value rather than by pointer: the send outlives
      * the op on precisely the paths that matter, so the callback has to be
      * able to look the op up and find it gone. */
-    PRTE_RML_SEND_CB(rc, dest, xcast_msg, PRTE_RML_TAG_XCAST,
-                     forward_lost, (void *) (intptr_t) op->sig.op_id);
+    PRTE_RML_SEND_PAYLOAD_CB(rc, dest, payload, PRTE_RML_TAG_XCAST,
+                             forward_lost, (void *) (intptr_t) op->sig.op_id);
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
-        PMIX_DATA_BUFFER_RELEASE(xcast_msg);
+        /* a refused send took no reference, so there is nothing to unwind -
+         * the payload is still the caller's to release */
         return;
     }
+}
+
+static void forward_op_to(op_t* op, pmix_rank_t dest){
+    prte_rml_payload_t* payload = build_forward_payload(op);
+
+    if (NULL == payload) {
+        return;
+    }
+    forward_payload_to(op, payload, dest);
+    PMIX_RELEASE(payload);
 }
 
 static void process_wireup(pmix_data_buffer_t *msg){

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -387,6 +387,10 @@ static void send_cons(prte_rml_send_t *ptr)
     ptr->cbfunc = prte_rml_send_callback;
     ptr->cbdata = NULL;
     ptr->dbuf = NULL;
+    /* an ordinary send owns its own buffer - PMIX_NEW mallocs rather than
+     * zeroing, so leaving this unset would have the destructor release a
+     * garbage pointer as if it were a shared payload */
+    ptr->payload = NULL;
     ptr->seq_num = 0xFFFFFFFF;
     /* Default to this process's own epoch: a message built here originates
      * here. The relay path overrides this with the origin's epoch carried in
@@ -398,10 +402,28 @@ static void send_cons(prte_rml_send_t *ptr)
 }
 static void send_des(prte_rml_send_t *ptr)
 {
-    if (ptr->dbuf != NULL)
+    if (NULL != ptr->payload) {
+        /* the buffer belongs to the payload, which may still be in flight to
+         * other destinations - drop our reference and let the last one out
+         * free it */
+        PMIX_RELEASE(ptr->payload);
+    } else if (NULL != ptr->dbuf) {
         PMIX_DATA_BUFFER_RELEASE(ptr->dbuf);
+    }
 }
 PMIX_CLASS_INSTANCE(prte_rml_send_t, pmix_list_item_t, send_cons, send_des);
+
+static void payload_cons(prte_rml_payload_t *ptr)
+{
+    ptr->dbuf = NULL;
+}
+static void payload_des(prte_rml_payload_t *ptr)
+{
+    if (NULL != ptr->dbuf) {
+        PMIX_DATA_BUFFER_RELEASE(ptr->dbuf);
+    }
+}
+PMIX_CLASS_INSTANCE(prte_rml_payload_t, pmix_object_t, payload_cons, payload_des);
 
 static void send_req_cons(prte_rml_send_request_t *ptr)
 {

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -116,6 +116,50 @@ PRTE_EXPORT int prte_rml_send_buffer_cb_nb(pmix_rank_t rank,
     } while(0)
 
 /**
+ * As prte_rml_send_buffer_cb_nb, but transmit a *shared* payload that the send
+ * does not own.
+ *
+ * This is what a broadcast wants.  The ordinary send owns its buffer, so
+ * sending identical bytes to every routing-tree child means building one
+ * buffer per child - a full copy of the payload each, all of them made on the
+ * progress thread before the first byte reaches the wire.  At the default
+ * radix that is 64 copies of a launch message, 64 allocations of it, and 64x
+ * its size resident on the sender at once.  A payload is packed once and
+ * handed to every child.
+ *
+ * Ownership: the caller holds the reference PMIX_NEW gave it and must release
+ * that reference once it has finished handing the payload out.  Each call that
+ * returns PRTE_SUCCESS takes a reference of its own, dropped when that send
+ * completes; a call that returns an error takes none.  So the buffer lives
+ * until the last destination is done with it, whether that is a send or the
+ * caller.
+ *
+ * The payload must not be modified once it has been handed to a send - several
+ * sends read it concurrently.
+ *
+ * A message to *self* cannot share: the local receive path takes ownership of
+ * the buffer it delivers.  Rather than making that a rule callers have to know,
+ * a self-send here copies the payload and proceeds normally.
+ *
+ * cbfunc is called with a NULL buffer (see PRTE_RML_SEND_COMPLETE) because
+ * there is nothing for it to dispose of.
+ */
+PRTE_EXPORT int prte_rml_send_payload_cb_nb(pmix_rank_t rank,
+                                            prte_rml_payload_t *payload,
+                                            prte_rml_tag_t tag,
+                                            prte_rml_buffer_callback_fn_t cbfunc,
+                                            void *cbdata);
+
+#define PRTE_RML_SEND_PAYLOAD_CB(_r, r, p, t, cf, cd)               \
+    do {                                                            \
+        pmix_output_verbose(2, prte_rml_base.rml_output,            \
+                            "RML-SEND-PAYLOAD-CB(%s:%d): %s:%s:%d", \
+                            PMIX_RANK_PRINT(r), t,                  \
+                            __FILE__, __func__, __LINE__);          \
+        (_r) = prte_rml_send_payload_cb_nb(r, p, t, cf, cd);        \
+    } while (0)
+
+/**
  * As prte_rml_send_buffer_nb, but bypass the routing tree and deliver straight
  * to the named peer.
  *
@@ -415,11 +459,18 @@ PRTE_EXPORT bool prte_rml_is_node_up(pmix_rank_t node);
  * buffer the callback has already released. Nobody else holds a reference
  * to the send object at this point, so the caller must not touch it after
  * completing it.
+ *
+ * A send carrying a *shared payload* is the exception: its buffer belongs to
+ * the payload and other destinations may still be transmitting it, so the
+ * callback is handed no buffer at all and the send's reference is dropped by
+ * the destructor below. A callback that wants to inspect the payload must
+ * therefore tolerate a NULL buffer - which the default one does, and which is
+ * the honest statement of the situation: this callback has nothing to free.
  */
 #define PRTE_RML_SEND_COMPLETE(m)                                                             \
     do {                                                                                      \
         prte_rml_send_t *_snd = (m);                                                          \
-        pmix_data_buffer_t *_dbuf = _snd->dbuf;                                               \
+        pmix_data_buffer_t *_dbuf = (NULL == _snd->payload) ? _snd->dbuf : NULL;              \
         pmix_output_verbose(5, prte_rml_base.rml_output,                                      \
                             "%s-%s Send message complete at %s:%d",                           \
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(_snd->dst)),\

--- a/src/rml/rml_send.c
+++ b/src/rml/rml_send.c
@@ -39,8 +39,12 @@
 #include "src/rml/oob/oob.h"
 #include "src/rml/relm/relm.h"
 
+/* One send path for both the owned and the shared case.  When payload is
+ * non-NULL it supplies the buffer and buffer must be NULL; the send takes a
+ * reference to it rather than ownership of its bytes. */
 static int send_buffer(pmix_rank_t rank,
                        pmix_data_buffer_t *buffer,
+                       prte_rml_payload_t *payload,
                        prte_rml_tag_t tag,
                        bool direct,
                        prte_rml_buffer_callback_fn_t cbfunc,
@@ -48,6 +52,10 @@ static int send_buffer(pmix_rank_t rank,
 {
     prte_rml_recv_t *rcv;
     prte_rml_send_t *snd;
+
+    if (NULL != payload) {
+        buffer = payload->dbuf;
+    }
 
     PMIX_OUTPUT_VERBOSE((1, prte_rml_base.rml_output,
          "%s rml_send_buffer%s to peer %s at tag %d",
@@ -77,6 +85,25 @@ static int send_buffer(pmix_rank_t rank,
         PMIX_OUTPUT_VERBOSE((1, prte_rml_base.rml_output,
                              "%s rml_send_buffer_to_self at tag %d",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), tag));
+        if (NULL != payload) {
+            /* the receive takes ownership of what it is handed, and a shared
+             * payload has other destinations still to reach - so this one
+             * destination gets a copy of its own.  Making it a copy here rather
+             * than a rule the caller has to know keeps a self-send from being
+             * a special case anywhere else. */
+            pmix_data_buffer_t *copy;
+            int rc;
+
+            PMIX_DATA_BUFFER_CREATE(copy);
+            rc = PMIx_Data_copy_payload(copy, buffer);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(copy);
+                /* every other exit from this function reports a PRRTE code */
+                return prte_pmix_convert_status(rc);
+            }
+            buffer = copy;
+        }
         /* copy the message for the recv */
         rcv = PMIX_NEW(prte_rml_recv_t);
         PMIX_LOAD_PROCID(&rcv->sender, PRTE_PROC_MY_NAME->nspace, rank);
@@ -94,6 +121,13 @@ static int send_buffer(pmix_rank_t rank,
     snd->origin = *PRTE_PROC_MY_NAME;
     snd->tag = tag;
     snd->dbuf = buffer;
+    if (NULL != payload) {
+        /* our own reference, dropped when this send completes.  Taken here,
+         * after every way out above has already returned, so a refused send
+         * leaves the caller's reference count exactly as it found it. */
+        PMIX_RETAIN(payload);
+        snd->payload = payload;
+    }
     snd->direct = direct;
     /* the constructor installs prte_rml_send_callback; only override it when
      * the caller actually asked to be told how the send ended */
@@ -112,7 +146,7 @@ int prte_rml_send_buffer_nb(pmix_rank_t rank,
                             pmix_data_buffer_t *buffer,
                             prte_rml_tag_t tag)
 {
-    return send_buffer(rank, buffer, tag, false, NULL, NULL);
+    return send_buffer(rank, buffer, NULL, tag, false, NULL, NULL);
 }
 
 int prte_rml_send_buffer_cb_nb(pmix_rank_t rank,
@@ -121,14 +155,27 @@ int prte_rml_send_buffer_cb_nb(pmix_rank_t rank,
                                prte_rml_buffer_callback_fn_t cbfunc,
                                void *cbdata)
 {
-    return send_buffer(rank, buffer, tag, false, cbfunc, cbdata);
+    return send_buffer(rank, buffer, NULL, tag, false, cbfunc, cbdata);
+}
+
+int prte_rml_send_payload_cb_nb(pmix_rank_t rank,
+                                prte_rml_payload_t *payload,
+                                prte_rml_tag_t tag,
+                                prte_rml_buffer_callback_fn_t cbfunc,
+                                void *cbdata)
+{
+    if (NULL == payload || NULL == payload->dbuf) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+    return send_buffer(rank, NULL, payload, tag, false, cbfunc, cbdata);
 }
 
 int prte_rml_send_buffer_direct_nb(pmix_rank_t rank,
                                    pmix_data_buffer_t *buffer,
                                    prte_rml_tag_t tag)
 {
-    return send_buffer(rank, buffer, tag, true, NULL, NULL);
+    return send_buffer(rank, buffer, NULL, tag, true, NULL, NULL);
 }
 
 int prte_rml_send_buffer_reliable_nb(pmix_rank_t rank,

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -238,6 +238,35 @@ typedef struct {
 } prte_rml_recv_cb_t;
 PMIX_CLASS_DECLARATION(prte_rml_recv_cb_t);
 
+/* A payload that several sends transmit without any of them owning it.
+ *
+ * The ordinary send owns its buffer: exactly one prte_rml_send_t points at a
+ * pmix_data_buffer_t and disposes of it when the send completes.  That is the
+ * right rule for point-to-point traffic and the wrong one for a broadcast,
+ * where the same bytes go to every routing-tree child.  Building one buffer
+ * per child costs a full copy of the payload per child, all of it on the
+ * progress thread and all of it ahead of the first byte reaching the wire -
+ * at the default radix that is 64 identical copies of a launch message the
+ * daemon then sends 64 times.
+ *
+ * A payload is a reference-counted wrapper around one such buffer.  Each send
+ * that accepts it takes its own reference and drops it on completion; the
+ * originator drops the reference it got from PMIX_NEW once it has handed the
+ * payload to everyone it means to.  The buffer dies with the last reference,
+ * whichever send that turns out to be.
+ *
+ * Nothing about the transport had to change to allow this: the OOB reads
+ * base_ptr/bytes_used and keeps all of its per-destination progress
+ * (sdptr/sdbytes/hdr_sent) in the send object, so several sends can read one
+ * buffer concurrently.  The one rule is the obvious one - a shared payload is
+ * immutable from the moment it is first handed to a send.
+ */
+typedef struct {
+    pmix_object_t super;
+    pmix_data_buffer_t *dbuf;
+} prte_rml_payload_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_rml_payload_t);
+
 /* structure to send RML messages - used internally */
 typedef struct {
     pmix_list_item_t super;
@@ -253,6 +282,11 @@ typedef struct {
 
     /* data buffer */
     pmix_data_buffer_t *dbuf;
+    /* When non-NULL, dbuf is this payload's buffer and is NOT owned by this
+     * send: the send holds a reference to the payload instead, dropped in the
+     * destructor, and completion hands the callback no buffer to dispose of.
+     * NULL for every ordinary send, which owns its dbuf outright. */
+    prte_rml_payload_t *payload;
     /* msg seq number */
     uint32_t seq_num;
     /* boot epoch (incarnation) of the origin. Defaults to this process's own

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -66,7 +66,9 @@
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_if.h"
 
+#include "src/pmix/pmix-internal.h"
 #include "src/rml/oob/oob_tcp.h"
+#include "src/rml/rml.h"
 
 #define CHECK(label, cond)                                    \
     do {                                                      \
@@ -336,6 +338,89 @@ static int test_subnet_resolves_and_dedupes(void)
     return failures;
 }
 
+/*
+ * A shared payload outlives the sends that transmit it.
+ *
+ * This is the one ownership rule in the RML that differs from every other:
+ * an ordinary prte_rml_send_t owns its dbuf and frees it in its destructor,
+ * while a send carrying a payload owns only a *reference* and must leave the
+ * buffer alone.  Getting that backwards is a use-after-free in the middle of
+ * a broadcast -- the second child would transmit a buffer the first child's
+ * completion had already freed -- and it would show up as corruption on the
+ * wire under load rather than as anything a smoke test notices.  So pin it
+ * here, where it needs no DVM: build the send by hand, release it, and
+ * confirm the payload and its bytes are still there.
+ */
+static int test_payload_outlives_sends(void)
+{
+    int failures = 0;
+    prte_rml_payload_t *payload;
+    prte_rml_send_t *snd;
+    pmix_data_buffer_t *dbuf;
+    pmix_byte_object_t bo;
+    static const char pattern[] = "shared-payload-canary";
+    pmix_status_t prc;
+    int rc;
+
+    /* PMIx refuses to move bytes into a buffer until it is up, and a daemon
+     * reaches that state through PMIx_server_init - so do the same, and only
+     * around this test, since nothing else in this binary needs it */
+    prc = PMIx_server_init(NULL, NULL, 0);
+    if (PMIX_SUCCESS != prc) {
+        fprintf(stderr, "FAIL [payload test]: PMIx_server_init: %s\n",
+                PMIx_Error_string(prc));
+        return 1;
+    }
+
+    payload = PMIX_NEW(prte_rml_payload_t);
+    CHECK("payload constructs with no buffer", NULL == payload->dbuf);
+    CHECK("payload starts at one reference", 1 == payload->super.obj_reference_count);
+
+    PMIX_DATA_BUFFER_CREATE(dbuf);
+    bo.size = sizeof(pattern);
+    bo.bytes = malloc(bo.size);
+    memcpy(bo.bytes, pattern, bo.size);
+    rc = PMIx_Data_load(dbuf, &bo);
+    CHECK("payload loads", PMIX_SUCCESS == rc);
+    payload->dbuf = dbuf;
+
+    /* what a send does when it accepts the payload */
+    snd = PMIX_NEW(prte_rml_send_t);
+    CHECK("a send starts with no payload", NULL == snd->payload);
+    PMIX_RETAIN(payload);
+    snd->payload = payload;
+    snd->dbuf = payload->dbuf;
+    CHECK("send took a reference", 2 == payload->super.obj_reference_count);
+
+    /* ...and what it must do when it completes */
+    PMIX_RELEASE(snd);
+    CHECK("send dropped its reference", 1 == payload->super.obj_reference_count);
+    CHECK("payload still holds its buffer", dbuf == payload->dbuf);
+    CHECK("payload bytes survived the send", sizeof(pattern) == payload->dbuf->bytes_used);
+    CHECK("payload contents survived the send",
+          NULL != payload->dbuf->base_ptr
+              && 0 == memcmp(pattern, payload->dbuf->base_ptr, sizeof(pattern)));
+
+    /* the last reference is the one that frees the buffer */
+    PMIX_RELEASE(payload);
+
+    /* a payload with nothing in it is refused rather than sent */
+    rc = prte_rml_send_payload_cb_nb(1, NULL, PRTE_RML_TAG_XCAST, NULL, NULL);
+    CHECK("NULL payload refused", PRTE_ERR_BAD_PARAM == rc);
+    payload = PMIX_NEW(prte_rml_payload_t);
+    rc = prte_rml_send_payload_cb_nb(1, payload, PRTE_RML_TAG_XCAST, NULL, NULL);
+    CHECK("empty payload refused", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("a refused send takes no reference", 1 == payload->super.obj_reference_count);
+    PMIX_RELEASE(payload);
+
+    PMIx_server_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_payload_outlives_sends\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -354,6 +439,7 @@ int main(void)
                     " the warnings it prints are expected --\n");
     failures += test_bad_subnets_dropped();
     failures += test_subnet_resolves_and_dedupes();
+    failures += test_payload_outlives_sends();
 
     prte_finalize();
 


### PR DESCRIPTION
## The problem

Forwarding a broadcast built a separate buffer for every routing-tree child, and those buffers were byte-for-byte identical. The forward carries the op-id, the ack-id and the payload — none of which depend on the destination — and `pack_forward_msg()` has taken a `dest` argument all along without ever looking at it.

So a daemon with `k` children made `k` allocations and `k` full copies of the payload to send the same bytes `k` times. All of it runs on the progress thread inside a single event callback, and none of it overlaps the wire: the first byte cannot leave until the last copy is made. At the default radix of 64 that is 64 copies of a launch message built and held before the broadcast starts moving, and 64 times the payload resident on the sender while it is in flight.

## The change

Two commits:

1. **`prte_rml_payload_t`** — a reference-counted wrapper around one `pmix_data_buffer_t`, plus `prte_rml_send_payload_cb_nb()` to transmit it. The caller packs once, hands the payload to as many destinations as it likes, and drops its own reference; each send takes a reference and drops it on completion, so the buffer dies with whichever send finishes last.

2. **`tree_whole_forward()`** builds one payload and gives it to every child. `pack_forward_msg()` loses the `dest` it was ignoring, so the invariant the sharing rests on is visible in the signature. The single-destination path stays — the fault handler replays an op to one specific child when the tree changes shape.

Nothing in the transport needed to change: `send_msg()` already `writev`s straight out of `dbuf->base_ptr`, and all per-destination progress (`sdptr`, `sdbytes`, `hdr_sent`) lives in the send object rather than the buffer, so several sends can read one buffer concurrently. Nothing on the wire changes either — this alters only how many times the sender builds bytes it was already sending.

The fence release rides the same broadcast, so an aggregated modex is now copied once per daemon rather than once per child of that daemon, which is where the payload is largest.

## What it costs and what it buys

Measured on this machine, the per-child pack (fresh-page `malloc` + `memcpy`) runs at 7–12 GB/s. Writing the level's cost as `kM/C_p + kM/B`, this change removes the first term outright rather than dividing it.

For a 10 MB on-wire launch message at 10 000 nodes, radix 64, depth 3: ~80 ms of serial prologue per level, and the forwarder's peak resident payload drops from 640 MB to 10 MB.

## Two things a reviewer should look at

**The ownership rule is the one that differs from every other in the RML.** An ordinary send owns its `dbuf` and frees it in its destructor; a send carrying a payload owns only a reference and must leave the buffer alone. Getting that backwards is a use-after-free in the middle of a broadcast — the second child transmits memory the first child's completion already freed — and it would show up as corruption on the wire under load rather than as anything a smoke test notices. `test/unit/rml/test_rml.c::test_payload_outlives_sends` pins it directly.

**Completion hands a shared send's callback a NULL buffer**, since there is nothing for it to dispose of. `prte_rml_send_callback` already tolerates that, and `forward_lost` chains to it.

A message to self cannot share (the local receive path takes ownership of what it is handed), so a self-send copies rather than making that a rule callers have to know.

## Testing

- `--enable-debug` build, warning-free.
- `make check`: 21/21, including the new `test_payload_outlives_sends`.
- `prterun -n 4`; `prte --daemonize` → `prun -n 4` → `pterm`.
- `contrib/dockerswarm/run-tests.sh linux`: **558 passed, 0 failed, 3 skipped**. The relevant case is the radix-2 deep-tree grow/shrink over 8 nodes — radix 2 is what puts real children under interior daemons, so the shared payload is forwarded by daemons that merely received it rather than only by the HNP, while the tree is reshaped underneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)