### PR TITLE
Read the MCA param files before registering the params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ test/unit/rmaps/Makefile
 test/unit/rmaps/test_rmaps
 test/unit/runtime/Makefile
 test/unit/runtime/test_runtime
+# written and removed by test_runtime; left behind only if it dies partway
+test/unit/runtime/test_runtime_mca_params.conf
 test/unit/errmgr/Makefile
 test/unit/errmgr/test_errmgr
 test/unit/ess/Makefile

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -21,7 +21,7 @@ Five separable things share the directory:
 |------|-------|------------|
 | **Object model & globals** | `prte_globals.[ch]` | The three central data structures (`prte_job_t`, `prte_node_t`, `prte_proc_t`), plus `prte_session_t`, `prte_app_context_t`, `prte_topology_t`, the launch-fence campaign objects — their class instances, and the global registries (`prte_job_data`, `prte_node_pool`, `prte_sessions`, ...) with the lookup functions over them. |
 | **Lifecycle** | `prte_init.c`, `prte_finalize.c`, `prte_quit.[ch]`, `prte_locks.[ch]` | The three-stage startup (`prte_init_minimum` → `prte_init_util` → `prte_init`), teardown, the "stop looping the event base" path, and the one-shot mutexes that keep re-entrant shutdown from bouncing. |
-| **MCA parameters** | `prte_mca_params.c` | `prte_register_params()` — every `prte_*` MCA variable, registered once. |
+| **MCA parameters** | `prte_mca_params.c` | `prte_register_paramfile_params()` — the parameters naming the MCA parameter files, registered ahead of those files being read — and `prte_register_params()`, every other `prte_*` MCA variable, registered once afterwards. |
 | **Threads & timers** | `prte_progress_threads.[ch]`, `prte_wait.[ch]` | Named progress threads (event base + engine thread + refcount), the SIGCHLD/waitpid plumbing, and the `PRTE_DETECT_TIMEOUT`/`PRTE_TIMER_EVENT` macros. |
 | **Sub-directories** | [`data_server/`](data_server/AGENTS.md), [`data_type_support/`](data_type_support/AGENTS.md) | The PMIx publish/lookup service, and the pack/unpack/copy/print functions for the objects above. Each has its own AGENTS.md. |
 
@@ -34,7 +34,8 @@ Tools do not all need the same amount of runtime, and some of them need a
 
 ```
 prte_init_minimum()   PMIx version check, installdirs, MCA var system,
-                      prte_register_params(), MCA param files preloaded.
+                      prte_register_paramfile_params(), MCA param files
+                      preloaded, bootstrap params, prte_register_params().
                       No event base, no frameworks, no globals.
         │
         ▼
@@ -61,6 +62,23 @@ own `passed_thru` guard because `mpirun` reaches it twice.
   That is why the bootstrap daemon has to publish the DVM-wide parameters it
   reads out of `prte.conf` (`prte_ess_base_bootstrap_params()`) *before*
   `prte_register_params()` runs, and why that call sits where it does.
+- **Registration is in two phases, and the order is load-bearing.** The MCA
+  parameter files are applied by publishing their contents into the
+  environment (`prte_preload_default_mca_params()` — it never touches the
+  variable system directly), so by the rule above, anything registered
+  *before* the preload reads an environment that does not yet hold the files'
+  values and ignores the file entirely. Every `prte_*` parameter used to do
+  exactly that, along with all of RML, OOB and grpcomm — the same file could
+  set `plm_ssh_num_concurrent` (registered later, at framework open) and be
+  obeyed, and set `rml_base_radix` and be ignored. Swapping the two calls is
+  not the fix, because `prte_param_files` and `prte_override_param_file` are
+  themselves MCA parameters and say which files to read. So
+  `prte_register_paramfile_params()` registers just those (plus
+  `prte_suppress_override_warning` and `prte_bootstrap`, which
+  `prte_init_minimum` acts on before phase two), the files are preloaded, and
+  `prte_register_params()` registers everything else afterwards. **Register a
+  new parameter in phase two** unless it is needed to find the files — a
+  parameter registered in phase one cannot be set from a parameter file.
 - The global arrays (`prte_job_data`, `prte_node_pool`, `prte_sessions`,
   `prte_node_topologies`) are **NULL** until `prte_init()`. Any function
   reachable from a tool or a parser has to tolerate that.
@@ -278,7 +296,11 @@ map with more nodes than one array block, and the refcount arithmetic when
 both maps are released), the pack/unpack round trips for job/app/proc/node/map
 and the GLOBAL-vs-LOCAL attribute split, object lifetimes and the borrowed
 backpointer contract, the exit-status macros, the data server's range checks
-and object construction, and the progress-thread cpu parser and lifecycle.
+and object construction, the progress-thread cpu parser and lifecycle, and
+the two-phase parameter registration (it writes a parameter file and points
+`prte_param_files` at it *before* calling `prte_init_util`, then checks that
+a core `prte_*` parameter and an RML one came back carrying the file's
+values).
 
 It builds the global arrays by hand (`prte_init_util` does not) and calls
 `PMIx_server_init` because `PMIx_Data_pack` refuses to run until PMIx is up.

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -306,12 +306,48 @@ int prte_init_minimum(void)
         return ret;
     }
 
+    /* Registration happens in two phases, and the order below is the whole
+     * point of splitting it: an MCA variable evaluates its environment exactly
+     * once, when it is first registered, and the parameter files are applied
+     * by publishing their contents into the environment.  So anything
+     * registered before that publication would ignore the files entirely -
+     * which is precisely what every prte_* parameter used to do.
+     *
+     * Phase one therefore registers only the parameters that say where the
+     * files are (they cannot come from the files they locate); the files are
+     * then read; and everything else is registered afterwards, so it sees an
+     * environment that already carries the files' values.  The install
+     * directories - and thus the default config-file path - are known by now,
+     * so this is the earliest point at which any of it can run. */
+    ret = prte_register_paramfile_params();
+    if (PRTE_SUCCESS != ret) {
+        if (PRTE_ERR_SILENT != ret) {
+            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+                           "prte register paramfile params", PRTE_ERROR_NAME(ret), ret);
+        }
+        return 1;
+    }
+
+    /* pre-load any default mca param files. A malformed file has to be
+     * fatal: the values in it steer component selection and launch, so
+     * silently carrying on with a partial set - which is what discarding
+     * this return did - starts a DVM configured differently from what the
+     * files say. */
+    ret = prte_preload_default_mca_params();
+    if (PRTE_SUCCESS != ret) {
+        if (PRTE_ERR_SILENT != ret) {
+            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+                           "prte preload mca params", PRTE_ERROR_NAME(ret), ret);
+        }
+        return ret;
+    }
+
     /* A bootstrapping daemon must publish the DVM-wide MCA parameters it reads
-     * from prte.conf before those parameters are first registered below (an
-     * MCA variable evaluates its environment only on first registration).  The
-     * install directories - and thus the config-file path - are known by now,
-     * so this is the earliest correct point.  prte_bootstrap_setup is set from
-     * the argument vector in prted before prte_init_util was called. */
+     * from prte.conf before those parameters are first registered below.  It
+     * runs after the param files so that its own overwrite=true settings win
+     * over them, as a DVM-wide configuration must.  prte_bootstrap_setup comes
+     * either from the argument vector (prted sets it before prte_init_util was
+     * called) or from the parameter registered in phase one above. */
     if (prte_bootstrap_setup) {
         if (PRTE_SUCCESS != (ret = prte_ess_base_bootstrap_params())) {
             if (PRTE_ERR_SILENT != ret) {
@@ -330,20 +366,6 @@ int prte_init_minimum(void)
                            PRTE_ERROR_NAME(ret), ret);
         }
         return 1;
-    }
-
-    /* pre-load any default mca param files. A malformed file has to be
-     * fatal: the values in it steer component selection and launch, so
-     * silently carrying on with a partial set - which is what discarding
-     * this return did - starts a DVM configured differently from what the
-     * files say. */
-    ret = prte_preload_default_mca_params();
-    if (PRTE_SUCCESS != ret) {
-        if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
-                           "prte preload mca params", PRTE_ERROR_NAME(ret), ret);
-        }
-        return ret;
     }
 
     return PRTE_SUCCESS;

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -51,8 +51,10 @@
 
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
+#include "src/runtime/runtime_internals.h"
 
 static bool passed_thru = false;
+static bool paramfiles_passed_thru = false;
 static int prte_progress_thread_debug_level = -1;
 static char *prte_tmpdir_base = NULL;
 static char *prte_local_tmpdir_base = NULL;
@@ -74,6 +76,82 @@ char *prte_param_files = NULL;
 char *prte_override_param_file = NULL;
 bool prte_suppress_override_warning = false;
 
+/* Register the handful of parameters that say where PRRTE's MCA parameter
+ * files are and how they are combined.
+ *
+ * These have to be registered in a phase of their own, ahead of everything
+ * else, because prte_preload_default_mca_params() reads them to find the
+ * files and then publishes each file's contents into the environment - and an
+ * MCA variable evaluates its environment exactly once, when it is first
+ * registered.  Anything registered before the preload therefore reads an
+ * environment that does not yet hold the files' values and silently ignores
+ * them.  Splitting these out lets prte_init_minimum() register them, preload
+ * the files, and only then register everything else in prte_register_params().
+ *
+ * The corollary is that the parameters registered *here* cannot themselves be
+ * set from a parameter file - they are what locates those files - so they
+ * remain settable only from the environment or the command line.
+ */
+int prte_register_paramfile_params(void)
+{
+    char *string = NULL;
+#if PRTE_WANT_HOME_CONFIG_FILES
+    char *home;
+#endif
+
+    /* as with prte_register_params below, only go thru this once */
+    if (paramfiles_passed_thru) {
+        return PRTE_SUCCESS;
+    }
+    paramfiles_passed_thru = true;
+
+#if PRTE_WANT_HOME_CONFIG_FILES
+    home = (char *) pmix_home_directory(geteuid());
+    pmix_asprintf(&prte_param_files,
+                   "%s" PMIX_PATH_SEP ".prte" PMIX_PATH_SEP "mca-params.conf%c%s" PMIX_PATH_SEP
+                   "prte-mca-params.conf",
+                   home, ',', prte_install_dirs.sysconfdir);
+#else
+    /* --disable-per-user-config-files: only the system file is consulted */
+    pmix_asprintf(&prte_param_files, "%s" PMIX_PATH_SEP "prte-mca-params.conf",
+                  prte_install_dirs.sysconfdir);
+#endif
+    /* the var system takes the current value as the default and then hands
+     * back a string of its own, so keep a handle on ours to release - the
+     * same pattern used for every other computed string param here */
+    string = prte_param_files;
+
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "param_files",
+                                      "Path for MCA configuration files containing "
+                                      "variable values",
+                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                      &prte_param_files);
+    free(string);
+
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "override_param_file",
+                                      "Variables set in this file will override any value "
+                                      "set in the environment or another configuration file",
+                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                      &prte_override_param_file);
+
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "suppress_override_warning",
+                                      "Suppress warnings when attempting to set an "
+                                      "overridden value (default: false)",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_suppress_override_warning);
+
+    /* bootstrap belongs in this phase as well: prte_init_minimum() acts on it
+     * (publishing the DVM-wide parameters out of prte.conf) before the rest of
+     * the parameters are registered, so learning it any later than this would
+     * be learning it too late to be obeyed */
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "bootstrap",
+                                      "Self-construct the DVM based on a configuration file (default: false)",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_bootstrap_setup);
+
+    return PRTE_SUCCESS;
+}
+
 int prte_register_params(void)
 {
     int ret;
@@ -81,9 +159,6 @@ int prte_register_params(void)
     char *string = NULL;
     char *fstype = NULL;
     char cwd[MAXPATHLEN];
-#if PRTE_WANT_HOME_CONFIG_FILES
-    char *home;
-#endif
 
     /* only go thru this once - mpirun calls it twice, which causes
      * any error messages to show up twice
@@ -92,6 +167,13 @@ int prte_register_params(void)
         return PRTE_SUCCESS;
     }
     passed_thru = true;
+
+    /* a caller that reaches us without having gone thru prte_init_minimum()
+     * still needs these; the guard inside makes it a no-op when it has */
+    ret = prte_register_paramfile_params();
+    if (PRTE_SUCCESS != ret) {
+        return ret;
+    }
 
     /*
      * This string is going to be used in prte/util/stacktrace.c
@@ -534,46 +616,9 @@ int prte_register_params(void)
         return PRTE_ERROR;
     }
 
-#if PRTE_WANT_HOME_CONFIG_FILES
-    home = (char *) pmix_home_directory(geteuid());
-    pmix_asprintf(&prte_param_files,
-                   "%s" PMIX_PATH_SEP ".prte" PMIX_PATH_SEP "mca-params.conf%c%s" PMIX_PATH_SEP
-                   "prte-mca-params.conf",
-                   home, ',', prte_install_dirs.sysconfdir);
-#else
-    /* --disable-per-user-config-files: only the system file is consulted */
-    pmix_asprintf(&prte_param_files, "%s" PMIX_PATH_SEP "prte-mca-params.conf",
-                  prte_install_dirs.sysconfdir);
-#endif
-    /* the var system takes the current value as the default and then hands
-     * back a string of its own, so keep a handle on ours to release - the
-     * same pattern used for every other computed string param here */
-    string = prte_param_files;
-
-   (void) pmix_mca_base_var_register("prte", "prte", NULL, "param_files",
-                                      "Path for MCA configuration files containing "
-                                      "variable values",
-                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                      &prte_param_files);
-    free(string);
-    string = NULL;
-
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "override_param_file",
-                                      "Variables set in this file will override any value "
-                                      "set in the environment or another configuration file",
-                                      PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                      &prte_override_param_file);
-
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "suppress_override_warning",
-                                      "Suppress warnings when attempting to set an "
-                                      "overridden value (default: false)",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                      &prte_suppress_override_warning);
-
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "bootstrap",
-                                      "Self-construct the DVM based on a configuration file (default: false)",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                      &prte_bootstrap_setup);
+    /* the parameters naming the MCA parameter files, and prte_bootstrap, are
+     * registered ahead of us in prte_register_paramfile_params() - see the
+     * comment there for why they cannot live in this phase */
 
     /* How a DAEMON learns whether its DVM is persistent. The HNP decides
      * this for itself in prte() - which runs long after this registration,

--- a/src/runtime/runtime_internals.h
+++ b/src/runtime/runtime_internals.h
@@ -39,6 +39,15 @@ PRTE_EXPORT int prte_dt_init(void);
 
 PRTE_EXPORT int prte_preload_default_mca_params(void);
 
+/**
+ * Register the parameters that locate PRRTE's MCA parameter files.
+ *
+ * Must run before prte_preload_default_mca_params(), which reads them;
+ * prte_register_params() registers everything else afterwards.  See the
+ * comment on the implementation in prte_mca_params.c.
+ */
+PRTE_EXPORT int prte_register_paramfile_params(void);
+
 END_C_DECLS
 
 #endif /* PRTE_RUNTIME_INTERNALS_H */

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -57,7 +57,9 @@
 
 #include "prte_config.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "constants.h"
 #include "types.h"
@@ -67,6 +69,8 @@
 #include "src/mca/ras/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/pmix/pmix-internal.h"
+#include "src/rml/oob/oob.h"
+#include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_progress_threads.h"
 #include "src/runtime/runtime.h"
@@ -1257,6 +1261,70 @@ static int test_progress_thread_cpus(void)
     return failures;
 }
 
+/* ------------------------------------------------------------------ */
+/* MCA parameter files                                                */
+/* ------------------------------------------------------------------ */
+
+/* The parameter files are applied by publishing their contents into the
+ * environment, and an MCA variable reads its environment exactly once, when
+ * it is first registered.  So the registration of everything that is not
+ * itself needed to *find* the files has to happen after they are read.  It
+ * did not: prte_init_minimum() registered every prte_* parameter - plus all
+ * of RML, OOB and grpcomm - before preloading the files, so a value set in
+ * mca-params.conf was read, published, and then ignored by the variable it
+ * named.  The same line in the same file was honored or not depending only
+ * on whether the variable behind it happened to be registered here or later,
+ * at framework open.
+ *
+ * setup_paramfile() below runs before prte_init_util(), so the whole
+ * ordering is what is under test.
+ */
+static const char *paramfile = "test_runtime_mca_params.conf";
+static bool paramfile_written = false;
+
+static void setup_paramfile(void)
+{
+    FILE *fp;
+
+    fp = fopen(paramfile, "w");
+    if (NULL == fp) {
+        /* nothing to test against, and not worth failing the suite over -
+         * test_paramfile_ordering reports the skip */
+        return;
+    }
+    /* one core prte_* parameter, and one from each of the two subsystems
+     * prte_register_params() registers on its way out */
+    fprintf(fp, "# written by test_runtime\n");
+    fprintf(fp, "prte_max_msg_size = 55\n");
+    fprintf(fp, "rml_base_radix = 3\n");
+    fprintf(fp, "prte_uniform_nodes = 1\n");
+    fclose(fp);
+    paramfile_written = true;
+
+    /* replace the default list (the developer's own ~/.prte/mca-params.conf
+     * must not be able to influence this) */
+    setenv("PRTE_MCA_prte_param_files", paramfile, 1);
+}
+
+static int test_paramfile_ordering(void)
+{
+    int failures = 0;
+
+    if (!paramfile_written) {
+        fprintf(stderr, "SKIP [paramfile]: could not write %s\n", paramfile);
+        return 0;
+    }
+
+    /* registered in prte_register_params() itself */
+    CHECK("paramfile: a core prte_* param takes the file's value",
+          55 == prte_oob_base.max_msg_size);
+    CHECK("paramfile: a bool param takes the file's value", prte_homo_nodes);
+    /* registered by prte_rml_register(), on the way out of the same call */
+    CHECK("paramfile: an rml param takes the file's value", 3 == prte_rml_base.radix);
+
+    return failures;
+}
+
 static int test_progress_thread_lifecycle(void)
 {
     int failures = 0;
@@ -1305,6 +1373,10 @@ int main(void)
 {
     int rc, failures = 0;
     pmix_status_t prc;
+
+    /* must precede prte_init_util: it is the parameter-file handling inside
+     * prte_init_minimum() that is under test */
+    setup_paramfile();
 
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
@@ -1355,6 +1427,11 @@ int main(void)
     failures += test_data_server_range();
     failures += test_progress_thread_cpus();
     failures += test_progress_thread_lifecycle();
+    failures += test_paramfile_ordering();
+
+    if (paramfile_written) {
+        unlink(paramfile);
+    }
 
     (void) pmix_mca_base_framework_close(&prte_ras_base_framework);
     prte_event_base_close();


### PR DESCRIPTION
### The problem

Every MCA parameter registered inside `prte_register_params()` silently ignores the MCA parameter files, in every process.

`prte_preload_default_mca_params()` implements the parameter file by `setenv("PRTE_MCA_<var>", value)` — it never touches the variable system directly. And `prte_init_minimum()` called `prte_register_params()` first, the preload second. An MCA variable reads its environment exactly once, at registration. So anything registered before the preload had already read an environment that did not yet contain the file's values.

`prte_register_params()` ends by calling `prte_rml_register()` (which calls `prte_oob_register()`) and `prte_grpcomm_register()`, so the affected set is all the core `prte_*` parameters plus all of RML, OOB and grpcomm.

Two lines in the same file, one honoured and one not:

```
$ printf 'plm_ssh_num_concurrent = 17\nprte_max_msg_size = 55\n' > ~/.prte/mca-params.conf
$ prte_info --all | grep -E "plm_ssh_num_concurrent|prte_max_msg_size"
  "prte_max_msg_size"      (current value: "100", data source: default)      <-- ignored
  "plm_ssh_num_concurrent" (current value: "17",  data source: environment)  <-- honoured (registered later, at framework open)
$ PRTE_MCA_prte_max_msg_size=55 prte_info --all | grep prte_max_msg_size
  "prte_max_msg_size"      (current value: "55",  data source: environment)  <-- perfectly settable, just not from a file
```

A DVM looks mixed, because the daemons get the value by a different route: the HNP's `setenv` does land in time for `prte_plm_base_prted_append_basic_args` to forward `PRTE_MCA_*` onto the prted command line, where it is parsed before registration. Hence `rml_base_radix = 2` in the file → HNP at radix 64 talking to daemons at radix 2.

### The fix

Swapping the two calls does not work — `prte_param_files` and `prte_override_param_file`, which say *which* files to read, are themselves registered inside `prte_register_params()`. So registration is split into two phases:

1. `prte_register_paramfile_params()` — `prte_param_files`, `prte_override_param_file`, `prte_suppress_override_warning`, and `prte_bootstrap` (`prte_init_minimum` acts on bootstrap before phase two, so learning it any later would be learning it too late to obey).
2. `prte_preload_default_mca_params()` — the files are read and published.
3. `prte_register_params()` — everything else, now against an environment that carries the files' values.

The corollary is documented in the code and in `src/runtime/AGENTS.md`: a parameter registered in phase one cannot itself be set from a parameter file, so new parameters go in phase two.

The bootstrap daemon's parameter publication moves to after the preload as well. Its `overwrite=true` settings still win over the files, as a DVM-wide configuration must, while the two defaults it sets with `overwrite=false` now yield to an operator's file rather than the other way round.

Precedence is otherwise unchanged: the environment still overrides the files, and `prte_override_param_file` still overrides the environment (with its warning).

### Testing

- `test_runtime` gains a case that writes a parameter file and points `prte_param_files` at it *before* calling `prte_init_util()`, then checks that a core `prte_*` parameter, a bool, and an RML parameter came back carrying the file's values. Confirmed it fails on exactly those three checks with the old ordering restored, and passes with the fix.
- Clean warning-free `--enable-debug` build; all `make check` suites pass.
- Live smoke test (`prte --daemonize` → `prun` → `pterm`) with a parameter file in place, plus manual checks of the default `~/.prte/mca-params.conf` location, `PRTE_MCA_prte_param_files`, environment precedence, and `prte_override_param_file`.
