### PR TITLE
Service each OOB peer's socket on its own progress thread

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4505,6 +4505,91 @@ test_rml() {
         bad "could not start a DVM for the lost-daemon test"
     fi
     cleanup_swarm
+
+    banner "rml/oob: peer sockets serviced by dedicated OOB progress threads"
+    # prte_oob_progress_threads (default 0) moves each peer's send/recv socket
+    # events off the main progress thread onto one of N worker bases, chosen
+    # round-robin at peer construction.  The connection state machine, routing,
+    # message delivery and every send completion stay on the main thread.  This
+    # is the only place that threaded path runs at all, so all four things it
+    # could break are checked here rather than assumed.
+    cleanup_swarm
+
+    # (a) the parameter has to reach the *daemons*, not just the HNP -- the
+    # whole point is remote sockets.  oob_base_verbose 5 makes each daemon
+    # announce the pool it built; --leave-session-attached is what gets a
+    # prted's stderr back to us.
+    out=$(RUN 'timeout -k 5 90 prterun --prtemca prte_oob_progress_threads 4 \
+                  --prtemca oob_base_verbose 5 --leave-session-attached \
+                  --host node1:1,node2:1,node3:1 -np 3 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -c 'starting 4 OOB progress threads')
+    [ "$n" -ge 2 ] \
+        && ok "the daemons started their OOB progress-thread pools ($n reported)" \
+        || bad "the thread pool was not built on the daemons: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    cleanup_swarm
+
+    # (b) a relayed tree still delivers.  radix 2 over 7 nodes means every leaf
+    # is reached through an interior daemon, so a message crosses a worker base
+    # on the way in (recv handler) and again on the way out (relay -> send).
+    out=$(RUN 'timeout -k 5 120 prterun --prtemca rml_base_radix 2 \
+                  --prtemca prte_oob_progress_threads 4 \
+                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
+                  -np 7 --map-by node hostname' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^node[1-7]$')
+    [ "$rc" = 0 ] && [ "$n" = 7 ] \
+        && ok "7 procs relayed across a radix-2 tree with worker bases" \
+        || bad "worker bases broke the relay (rc=$rc, lines=$n): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    cleanup_swarm
+
+    # (c) the partial-write/partial-read bookkeeping is per-peer state that a
+    # second thread is exactly what could corrupt, and a byte count is the only
+    # check that catches a corrupted one -- a truncated relay still "runs".
+    out=$(RUN 'timeout -k 5 120 prterun --prtemca rml_base_radix 2 \
+                  --prtemca prte_oob_progress_threads 4 \
+                  --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
+                  -np 7 --map-by node \
+                  sh -c "head -c 500000 /dev/zero | tr \"\\0\" \"x\""' 2>&1)
+    n=$(echo "$out" | tr -cd 'x' | wc -c | tr -d ' ')
+    [ "$n" = 3500000 ] \
+        && ok "3.5 MB relayed intact with the sockets on worker bases" \
+        || bad "worker bases truncated the payload (got $n bytes of 3500000)"
+    cleanup_swarm
+
+    # (d) the race the design is actually exposed to: prte_oob_tcp_peer_close
+    # runs on the main thread while a worker may be inside that peer's send or
+    # recv handler.  Killing a daemon under a live job is what drives it.  A
+    # missed handshake there is a hang, a use-after-free, or a leaked send --
+    # so the observable is that the job is released and the HNP lives.
+    # Deliberately at the default radix, matching the non-threaded case above:
+    # a *small* radix does not release the job on a daemon loss even with no
+    # worker threads at all, so adding one here would only re-report that.
+    if prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1' \
+           '--prtemca prte_oob_progress_threads 4'; then
+        PRUN_BG /tmp/rml-thr-longrun.out '--host node7:1 -n 1 sleep 120'
+        sleep 6
+        if ! RUN 'pgrep -x prun' >/dev/null 2>&1; then
+            bad "the long-running job never started under worker bases: $(RUN 'cat /tmp/rml-thr-longrun.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        elif ! ON 7 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node7 has no daemon to kill -- the job did not land where expected"
+        else
+            ON 7 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 45 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            [ "$n" -lt 45 ] \
+                && ok "peer_close raced a worker handler and still released the job (${n}s)" \
+                || bad "prun never returned after its daemon died with worker bases on"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "...and the HNP survived" \
+                || bad "the HNP died along with the lost daemon"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM with OOB progress threads"
+    fi
+    cleanup_swarm
 }
 
 ########################################################################

--- a/docs/how-things-work/rml/oob.rst
+++ b/docs/how-things-work/rml/oob.rst
@@ -122,6 +122,33 @@ Connection loss.  When a socket drops, ``oob_tcp_component.c`` fires its
 event into a routing event: the RML is told to treat the peer as lost so the
 tree can be repaired (see :ref:`rml-label`).
 
+Which thread moves the bytes
+----------------------------
+
+By default every part of the transport runs on the one PRRTE progress thread,
+and this section describes something you can turn on rather than something that
+is already happening.
+
+``prte_oob_progress_threads`` (default ``0``) starts that many additional
+progress threads and assigns each peer one of them, round-robin, when the peer
+is created.  Only the peer's **send and recv socket handlers** move there, and
+only once the connection is established.  Everything those handlers hand
+onwards — delivering a message to the RML, relaying one on, running a send's
+completion callback, reacting to a lost connection — comes back to the main
+progress thread, as does the whole connection state machine.
+
+The reason to want this is not raw bandwidth.  A single thread copies into the
+kernel several times faster than a 10-25 GbE link drains, so the transport is
+not thread-starved for throughput.  What it is short of is *occupancy*: while
+the main thread is compressing a broadcast, registering a namespace, or forking
+local processes, no socket is being serviced at all, and the link simply idles
+for that fraction of the launch.  Giving the sockets their own threads keeps
+them busy across those stalls.  It also lifts a real ceiling on 100 GbE and on
+nodes with several NICs, where one thread's copy rate *is* the limit.
+
+Start with ``0`` (the default, and identical to the behavior that predates the
+option) and raise it only where a launch is demonstrably stalling the wire.
+
 Bootstrap specifics
 -------------------
 

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -312,10 +312,21 @@ worth stating rather than re-deriving:
 
 ## Gotchas before you edit
 
-- **Single progress thread.** All RML/OOB state is owned by the progress
-  thread. Cross-thread work uses a *caddy* + `PRTE_PMIX_THREADSHIFT` (see
-  `PRTE_OOB_SEND`, `prte_rml_recv_buffer_nb`). Never read or write shared RML
-  state off that thread, and never block on it.
+- **RML state is owned by the progress thread.** Cross-thread work uses a
+  *caddy* + `PRTE_PMIX_THREADSHIFT` (see `PRTE_OOB_SEND`,
+  `prte_rml_recv_buffer_nb`). Never read or write shared RML state off that
+  thread, and never block on it. The one exception is deliberate and bounded:
+  a peer's *socket* send/recv handlers can be put on a worker progress thread
+  (`prte_oob_progress_threads`, default 0 — off), so that the wire keeps moving
+  while the main thread computes. Everything those handlers hand upward —
+  message delivery, relaying, send completions, the connection state machine —
+  still comes back to `prte_event_base`. See [`oob/AGENTS.md`](oob/AGENTS.md),
+  *Which thread services a peer's socket*, before adding anything to those
+  handlers' reach.
+- **`prte_rml_epoch_ok` runs off the progress thread.** It is called straight
+  from the OOB recv handler, so it - alone in this directory - takes a mutex
+  around the `peer_epochs` table it reallocates. Anything else a socket handler
+  is made to call has to be safe the same way, or has to be thread-shifted.
 - **The wire header is not an ABI.** `prte_oob_tcp_hdr_t` is exchanged only
   among daemons of the *same* DVM, which all run the same build. You may change
   its layout, but every daemon must agree — there is no versioning. It *is*

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -127,19 +127,88 @@ In a launcher-less (bootstrapped) DVM daemons boot independently, so:
   `prte_rml_route_lost` (promoting to the next ancestor, a `COMM_FAILED`
   recovery) rather than raising `FAILED_TO_CONNECT`.
 
+## Which thread services a peer's socket
+
+By default, all of it runs on `prte_event_base` — one progress thread, exactly
+as it always did. `prte_oob_progress_threads` (`prte_oob_base.num_progress_threads`,
+default **0**) starts N worker progress threads and hands each peer one of them,
+round-robin, at construction (`peer->evbase`). The point is not extra bandwidth —
+one thread's `writev` copy rate is several times a 10-25 GbE link — it is
+**occupancy**: while the main thread is deflating an xcast, registering a
+namespace, or running the odls fork path, nothing services a socket at all.
+
+The split is deliberate and narrow:
+
+| Runs on `prte_event_base`, always | Runs on `peer->evbase` |
+|---|---|
+| the connection state machine (`try_connect`, `complete_connect`, the IDENT handshake, `accept`) | the send handler and the recv handler, once **CONNECTED** |
+| routing (`prte_rml_get_route`), the peer table, `prte_oob_base_send_nb` | `MCA_OOB_TCP_QUEUE_MSG` and the send queue |
+| every send **completion** callback, and the `lost_connection` notice | the `writev`/`read` themselves |
+
+Four rules keep that safe, and all four are load-bearing:
+
+- **Events start on the main base and move at CONNECTED.** `tcp_peer_event_init`
+  binds to `prte_event_base`; `tcp_peer_connected` calls `tcp_peer_rebind_events`,
+  which deletes both events and re-`event_set`s them on `peer->evbase`. libevent
+  will not re-target a *pending* event, so the delete is not optional — and it
+  clears the `*_ev_active` flags, which is why every caller re-adds afterwards.
+- **`peer->lock` guards `send_msg`/`send_queue`/`send_ev_active`**, and the
+  once-only state transition at the top of `prte_oob_tcp_peer_close`. It is held
+  across queue manipulation only — **never** across a `writev` and never across a
+  callback. The lock is always the *outer* lock: a holder may take a libevent
+  base lock (`event_add`/`event_del`), never the reverse.
+- **`prte_event_del` is the synchronization with a running handler.** Deleting an
+  event whose callback is executing on another thread blocks until that callback
+  returns. That is what makes the rest of `peer_close` safe — once both socket
+  events are gone, no handler for that peer can be in flight, so `recv_msg` and
+  the socket are the closer's alone. It is also why `peer_close` must release
+  `peer->lock` *before* those deletes: the handler it is waiting for may be
+  waiting for the lock.
+- **A worker never writes the peer's connection state.** `prte_oob_tcp_queue_msg`
+  finding the peer unconnected posts `prte_oob_tcp_peer_start_connect` to the
+  main base rather than setting `MCA_OOB_TCP_CONNECTING` itself.
+- **Whoever observes CONNECTED last arms the send event.** Both
+  `prte_oob_tcp_queue_msg` and `tcp_peer_connected` end by checking "peer is
+  CONNECTED and has a message on deck with no send event running — arm it",
+  and *both* checks are required because they now race. `MCA_OOB_TCP_QUEUE_PENDING`
+  passes `activate = false`, which used to mean "the connection machinery will
+  start this send" — true only while the queueing ran on the same thread. If
+  `tcp_peer_connected` wins the race it finds an empty queue and arms nothing;
+  the pending `queue_msg` then arrives, parks the message on deck, and, seeing
+  `activate` false, arms nothing either. The message sits on a live connection
+  behind a dead event forever. That is not a slow path — it wedged an 8-node
+  radix-2 launch roughly one run in three, with every thread idle in
+  `epoll_wait` and a single peer showing `send_msg != NULL, send_ev_active ==
+  false`. If you add a third place that queues onto a peer, it needs the same
+  tail.
+
+With `num_progress_threads == 0`, `peer->evbase` **is** `prte_event_base`:
+`PRTE_OOB_COMPLETE_SEND` completes inline instead of posting, the rebind is a
+delete/re-set onto the base the events were already on, and the mutex is
+uncontended. `prte_oob_base.ev_bases` still exists and still holds one entry, so
+every call site indexes it unconditionally — do not "optimize" that array away.
+
+The one piece of state outside this directory that a worker touches directly is
+the RML's incarnation table (`prte_rml_epoch_ok`, bootstrap only), which
+reallocates; it carries its own mutex in `src/rml/rml.c`. Anything else you make
+a socket handler call has to be safe off the main thread or has to be shifted.
+
 ## Gotchas before you edit
 
-- **Single progress thread.** All OOB state — peers, sockets, send queues — is
-  owned by the progress thread. Cross-thread entry goes through `PRTE_OOB_SEND`
-  (a caddy + `PRTE_PMIX_THREADSHIFT`). Never touch peer/socket state off that
-  thread, and never block on it.
+- **Peer/socket state belongs to one thread at a time.** Cross-thread entry into
+  the OOB goes through `PRTE_OOB_SEND` (a caddy + `PRTE_PMIX_THREADSHIFT`), which
+  always lands on `prte_event_base`. Never touch peer state from an arbitrary
+  thread, and never block on any of these threads. See the section above for
+  what the worker bases are allowed to touch.
 - **The header is not an ABI.** See above; do not add versioning, but do keep
   every daemon in a build in sync.
 - **Finish a send, never just free it.** A `prte_rml_send_t` that is abandoned
   — no route, no peer, the connection torn down — must go through
   `PRTE_RML_SEND_COMPLETE` so the caller's callback runs with a status.
   `PMIX_RELEASE` frees the buffer and tells nobody, which is invisible for the
-  default callback and a lost message for RELM.
+  default callback and a lost message for RELM. From inside the transport, use
+  `PRTE_OOB_COMPLETE_SEND(peer, msg)` instead: it completes inline when the peer
+  is on the main base and posts the completion there when it is not.
 - **The recv object owns its payload.** `prte_oob_tcp_recv_t`'s destructor
   frees `data`; the paths that hand the payload on (`PMIx_Data_load` for local
   delivery, the relay) null the pointer first. Add a third path and it has to

--- a/src/rml/oob/oob.h
+++ b/src/rml/oob/oob.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -104,6 +104,18 @@ typedef struct {
                                delay backs off exponentially up to this value (0 => fixed delay) */
     int connect_max_time;   /**< max seconds to keep retrying a non-lifeline peer before giving up
                                and letting the routing tree heal to an ancestor (0 => forever) */
+
+    /* Worker progress threads servicing peer socket events.  Each peer's
+     * send/recv events are bound to one of these bases (round-robin), so the
+     * wire keeps moving while the main progress thread is busy computing.
+     * num_progress_threads == 0 (the default) means "no worker threads": the
+     * array still exists, holding exactly one entry - prte_event_base - so
+     * every call site can index it unconditionally and the code path is
+     * bit-for-bit the one that ran before any of this existed. */
+    int num_progress_threads;      /**< number of dedicated worker progress threads */
+    prte_event_base_t **ev_bases;  /**< the bases peers are assigned to */
+    char **ev_threads;             /**< names of the threads we started (NULL when none) */
+    int next_base;                 /**< round-robin cursor into ev_bases */
 } prte_oob_base_t;
 PRTE_EXPORT extern prte_oob_base_t prte_oob_base;
 
@@ -111,6 +123,13 @@ PRTE_EXPORT extern prte_oob_base_t prte_oob_base;
 PRTE_EXPORT int prte_oob_open(void);
 PRTE_EXPORT void prte_oob_close(void);
 PRTE_EXPORT int prte_oob_register(void);
+
+/* Build and tear down the pool of bases that peer sockets are serviced on.
+ * Called by prte_oob_open/prte_oob_close; exported (rather than left static)
+ * so the unit test can drive the sizing and the round-robin assignment
+ * without standing up listeners. */
+PRTE_EXPORT int prte_oob_start_progress_threads(void);
+PRTE_EXPORT void prte_oob_harvest_progress_threads(void);
 
 /* Simulate this node's failure better than simply killing the process */
 PRTE_EXPORT void prte_oob_simulate_node_failure(void);
@@ -147,6 +166,34 @@ PRTE_EXPORT void prte_oob_base_send_nb(int fd, short args, void *cbdata);
         prte_oob_send_cd = PMIX_NEW(prte_oob_send_t);                                             \
         prte_oob_send_cd->msg = (m);                                                              \
         PRTE_PMIX_THREADSHIFT(prte_oob_send_cd, prte_event_base, prte_oob_base_send_nb);          \
+    } while (0)
+
+/* Complete a send that a peer's socket handler has finished with.
+ *
+ * PRTE_RML_SEND_COMPLETE runs the originator's callback, and those callbacks
+ * reach well beyond the transport - proc-state activation, the collectives'
+ * forward_lost handling, RELM's completion tracking - all of which is PRRTE
+ * state owned by the main progress thread.  So a send that was serviced on a
+ * worker base posts the completion back to prte_event_base instead of running
+ * it there.  With no worker threads the peer's base IS prte_event_base and the
+ * completion runs inline, exactly as it always did - no extra event hop on the
+ * default path.
+ *
+ * p => pointer to prte_oob_tcp_peer_t
+ * m => the prte_rml_send_t to complete (its status must already be set)
+ */
+PRTE_EXPORT void prte_oob_base_complete_send(int fd, short args, void *cbdata);
+#define PRTE_OOB_COMPLETE_SEND(p, m)                                                      \
+    do {                                                                                  \
+        if (prte_event_base == (p)->evbase) {                                             \
+            PRTE_RML_SEND_COMPLETE((m));                                                  \
+        } else {                                                                          \
+            prte_oob_send_t *prte_oob_cmp_cd;                                             \
+            prte_oob_cmp_cd = PMIX_NEW(prte_oob_send_t);                                  \
+            prte_oob_cmp_cd->msg = (m);                                                   \
+            PRTE_PMIX_THREADSHIFT(prte_oob_cmp_cd, prte_event_base,                       \
+                                  prte_oob_base_complete_send);                           \
+        }                                                                                 \
     } while (0)
 
 /* Build this process's contact URI: our name followed by the TCP

--- a/src/rml/oob/oob_base_stubs.c
+++ b/src/rml/oob/oob_base_stubs.c
@@ -34,6 +34,28 @@
 
 static prte_oob_tcp_peer_t* process_uri(char *uri);
 
+/* Run a send's completion callback on the main progress thread.
+ *
+ * Reached only when a peer's socket is being serviced by one of the OOB
+ * worker progress threads (see PRTE_OOB_COMPLETE_SEND): the callback belongs
+ * to whoever originated the message and touches PRRTE state that only
+ * prte_event_base may touch.  Posting them all through this one handler also
+ * keeps a peer's completions in the order its socket produced them, since
+ * libevent runs a base's active events first-in first-out.
+ */
+void prte_oob_base_complete_send(int fd, short args, void *cbdata)
+{
+    prte_oob_send_t *cd = (prte_oob_send_t *) cbdata;
+    prte_rml_send_t *msg;
+    PRTE_HIDE_UNUSED_PARAMS(fd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+    msg = cd->msg;
+    PMIX_RELEASE(cd);
+
+    PRTE_RML_SEND_COMPLETE(msg);
+}
+
 void prte_oob_base_send_nb(int fd, short args, void *cbdata)
 {
     prte_oob_send_t *cd = (prte_oob_send_t *) cbdata;

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -108,8 +108,80 @@ prte_oob_base_t prte_oob_base = {
     .keepalive_time = 0,
     .keepalive_intvl = 0,
     .retry_delay = 0,
-    .max_recon_attempts = 0
+    .max_recon_attempts = 0,
+    .num_progress_threads = 0,
+    .ev_bases = NULL,
+    .ev_threads = NULL,
+    .next_base = 0
 };
+
+/* Stand up the pool of event bases that peer sockets are serviced on.
+ *
+ * The zero case deliberately still allocates a one-element array holding
+ * prte_event_base, so every call site can index ev_bases unconditionally and
+ * a peer assigned "worker 0" with no workers configured is simply a peer on
+ * the main progress thread - the behavior that predates this pool.
+ */
+int prte_oob_start_progress_threads(void)
+{
+    int i;
+    char *tmp;
+
+    prte_oob_base.next_base = 0;
+    if (0 >= prte_oob_base.num_progress_threads) {
+        /* a negative value only reaches here if the user asked for one;
+         * treat it as "no worker threads" rather than sizing an array with it */
+        prte_oob_base.num_progress_threads = 0;
+        prte_oob_base.ev_bases = (prte_event_base_t **) malloc(sizeof(prte_event_base_t *));
+        if (NULL == prte_oob_base.ev_bases) {
+            return PRTE_ERR_OUT_OF_RESOURCE;
+        }
+        prte_oob_base.ev_bases[0] = prte_event_base;
+        return PRTE_SUCCESS;
+    }
+
+    pmix_output_verbose(5, prte_oob_base.output,
+                        "%s oob:tcp: starting %d OOB progress threads",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_oob_base.num_progress_threads);
+    prte_oob_base.ev_bases = (prte_event_base_t **)
+        malloc(prte_oob_base.num_progress_threads * sizeof(prte_event_base_t *));
+    if (NULL == prte_oob_base.ev_bases) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    for (i = 0; i < prte_oob_base.num_progress_threads; i++) {
+        pmix_asprintf(&tmp, "PRTE-OOB-%d", i);
+        prte_oob_base.ev_bases[i] = prte_progress_thread_init(tmp);
+        if (NULL == prte_oob_base.ev_bases[i]) {
+            /* fall back to the main base for this slot rather than leaving a
+             * NULL that every peer assigned to it would dereference */
+            prte_oob_base.ev_bases[i] = prte_event_base;
+            free(tmp);
+            continue;
+        }
+        PMIx_Argv_append_nosize(&prte_oob_base.ev_threads, tmp);
+        free(tmp);
+    }
+    return PRTE_SUCCESS;
+}
+
+void prte_oob_harvest_progress_threads(void)
+{
+    int i;
+
+    if (NULL != prte_oob_base.ev_threads) {
+        for (i = 0; NULL != prte_oob_base.ev_threads[i]; i++) {
+            prte_progress_thread_finalize(prte_oob_base.ev_threads[i]);
+        }
+        PMIx_Argv_free(prte_oob_base.ev_threads);
+        prte_oob_base.ev_threads = NULL;
+    }
+    if (NULL != prte_oob_base.ev_bases) {
+        free(prte_oob_base.ev_bases);
+        prte_oob_base.ev_bases = NULL;
+    }
+    prte_oob_base.num_progress_threads = 0;
+    prte_oob_base.next_base = 0;
+}
 
 int prte_oob_open(void)
 {
@@ -304,6 +376,14 @@ int prte_oob_open(void)
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
+    /* stand up the pool of bases peer sockets will be serviced on.  This has
+     * to precede the listeners: the first thing an accepted connection does is
+     * build a peer, and peer construction assigns it a base from this pool. */
+    if (PRTE_SUCCESS != (rc = prte_oob_start_progress_threads())) {
+        PRTE_ERROR_LOG(rc);
+        return rc;
+    }
+
     // start the listeners
     if (PRTE_SUCCESS != (rc = prte_oob_tcp_start_listening())) {
         prte_show_help("help-oob-tcp.txt", "no-listeners", true);
@@ -328,6 +408,11 @@ void prte_oob_close(void)
         close(prte_oob_base.stop_thread[1]);
 
     }
+
+    /* stop servicing peer sockets before the peers themselves go away - a
+     * worker still in a send handler would be reading a peer we are about to
+     * destruct */
+    prte_oob_harvest_progress_threads();
 
     PMIX_LIST_DESTRUCT(&prte_oob_base.local_ifs);
     PMIX_LIST_DESTRUCT(&prte_oob_base.peers);
@@ -580,6 +665,12 @@ int prte_oob_register(void)
                                         "Maximum time (in sec) to keep retrying a connection to a non-lifeline peer before giving up so the routing tree can heal to an ancestor; 0 means retry forever",
                                         PMIX_MCA_BASE_VAR_TYPE_INT,
                                         &prte_oob_base.connect_max_time);
+
+    prte_oob_base.num_progress_threads = 0;
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "oob_progress_threads",
+                                        "Number of dedicated progress threads to service peer socket send/recv events (0 = service them on the main progress thread, as before)",
+                                        PMIX_MCA_BASE_VAR_TYPE_INT,
+                                        &prte_oob_base.num_progress_threads);
 
     prte_oob_base.max_msg_size = 100;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "max_msg_size",

--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -21,7 +21,7 @@
  * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -163,6 +163,21 @@ static void peer_cons(prte_oob_tcp_peer_t *peer)
 {
     peer->auth_method = NULL;
     peer->sd = -1;
+    /* claim the next base in the pool.  Peers are only ever built on the main
+     * progress thread (the send path, the URI parser, the accept handler), so
+     * the cursor needs no protection.  prte_oob_open always leaves ev_bases
+     * holding at least one entry, but a peer built before it ran - or after
+     * prte_oob_close harvested the pool - has to land somewhere. */
+    if (NULL == prte_oob_base.ev_bases) {
+        peer->evbase = prte_event_base;
+    } else {
+        peer->evbase = prte_oob_base.ev_bases[prte_oob_base.next_base];
+        if (0 < prte_oob_base.num_progress_threads) {
+            prte_oob_base.next_base = (prte_oob_base.next_base + 1)
+                                      % prte_oob_base.num_progress_threads;
+        }
+    }
+    PMIX_CONSTRUCT(&peer->lock, pmix_mutex_t);
     PMIX_CONSTRUCT(&peer->addrs, pmix_list_t);
     peer->active_addr = NULL;
     peer->state = MCA_OOB_TCP_UNCONNECTED;
@@ -203,6 +218,7 @@ static void peer_des(prte_oob_tcp_peer_t *peer)
         PMIX_RELEASE(peer->send_msg);
     }
     PMIX_LIST_DESTRUCT(&peer->send_queue);
+    PMIX_DESTRUCT(&peer->lock);
 }
 PMIX_CLASS_INSTANCE(prte_oob_tcp_peer_t, pmix_list_item_t, peer_cons, peer_des);
 

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2016      Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -154,6 +154,8 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
     prte_socklen_t addrlen = 0;
     prte_oob_tcp_peer_t *peer;
     prte_oob_tcp_addr_t *addr;
+    prte_oob_tcp_send_t *snd;
+    pmix_list_t doomed;
     bool connected = false;
     pmix_pif_t *intf;
     char *host;
@@ -466,13 +468,32 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
          * from us if we are in our own progress thread
          */
         PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_failed_to_connect);
-        /* FIXME: post any messages in the send queue back to the OOB
-         * level for reassignment
-         */
+        /* Nothing queued for this peer can ever go out, so finish each of
+         * those sends as unreachable.  Completing them - rather than dropping
+         * them on the floor, which is what this used to do - is what lets the
+         * originator learn the message died; RELM in particular is waiting on
+         * exactly that callback.  Lift them off the peer under its lock, then
+         * complete them outside it. */
+        PMIX_CONSTRUCT(&doomed, pmix_list_t);
+        pmix_mutex_lock(&peer->lock);
         if (NULL != peer->send_msg) {
+            pmix_list_append(&doomed, &peer->send_msg->super);
+            peer->send_msg = NULL;
         }
-        while (NULL != pmix_list_remove_first(&peer->send_queue)) {
+        while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue))) {
+            pmix_list_append(&doomed, &snd->super);
         }
+        pmix_mutex_unlock(&peer->lock);
+        while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&doomed))) {
+            if (NULL != snd->msg) {
+                prte_rml_send_t *m = snd->msg;
+                m->status = PRTE_ERR_UNREACH;
+                snd->msg = NULL; // the completion owns it now
+                PRTE_OOB_COMPLETE_SEND(peer, m);
+            }
+            PMIX_RELEASE(snd);
+        }
+        PMIX_DESTRUCT(&doomed);
         goto cleanup;
     }
 
@@ -646,6 +667,12 @@ static int tcp_peer_send_connect_nack(int sd, pmix_proc_t *name)
 
 /*
  * Initialize events to be used by the peer instance for TCP select/poll callbacks.
+ *
+ * These start out on prte_event_base whatever base the peer was assigned:
+ * connect completion and the IDENT handshake run the connection state machine,
+ * which owns the peer table and the routing tree and therefore belongs to the
+ * main progress thread.  Once the handshake succeeds, tcp_peer_connected()
+ * moves both events onto peer->evbase for the life of the connection.
  */
 static void tcp_peer_event_init(prte_oob_tcp_peer_t *peer)
 {
@@ -665,6 +692,84 @@ static void tcp_peer_event_init(prte_oob_tcp_peer_t *peer)
             peer->send_ev_active = false;
         }
     }
+}
+
+/*
+ * Hand this peer's socket over to the base that will service it for the rest
+ * of the connection's life.
+ *
+ * Called from tcp_peer_connected() - i.e. on the main progress thread, at the
+ * one moment when the handshake is finished and no data event has yet fired.
+ * Both events are deleted first: libevent will not re-target a pending event,
+ * and deleting the event whose callback we are inside (the recv event, on the
+ * connect-ack path) is explicitly allowed.  The caller re-adds whichever
+ * events it wants live, which is why the active flags are cleared here.
+ *
+ * When no OOB worker threads were requested peer->evbase IS prte_event_base
+ * and this is a delete/re-set onto the base the events were already on - a few
+ * instructions once per connection, and nothing else changes.
+ */
+static void tcp_peer_rebind_events(prte_oob_tcp_peer_t *peer)
+{
+    if (0 > peer->sd) {
+        return;
+    }
+    if (peer->recv_ev_active) {
+        prte_event_del(&peer->recv_event);
+        peer->recv_ev_active = false;
+    }
+    if (peer->send_ev_active) {
+        prte_event_del(&peer->send_event);
+        peer->send_ev_active = false;
+    }
+    prte_event_set(peer->evbase, &peer->recv_event, peer->sd, PRTE_EV_READ | PRTE_EV_PERSIST,
+                   prte_oob_tcp_recv_handler, peer);
+    prte_event_set(peer->evbase, &peer->send_event, peer->sd, PRTE_EV_WRITE | PRTE_EV_PERSIST,
+                   prte_oob_tcp_send_handler, peer);
+}
+
+/*
+ * Start the connection state machine for a peer that a socket-servicing thread
+ * found unconnected.
+ *
+ * The state word, the address list and the retry bookkeeping all belong to the
+ * main progress thread, so a worker that has a message to send but no live
+ * connection posts here rather than driving the machine itself.  Runs on
+ * prte_event_base and consumes the conn op it was handed.
+ */
+void prte_oob_tcp_peer_start_connect(int fd, short args, void *cbdata)
+{
+    prte_oob_tcp_conn_op_t *op = (prte_oob_tcp_conn_op_t *) cbdata;
+    prte_oob_tcp_peer_t *peer;
+
+    PMIX_ACQUIRE_OBJECT(op);
+    peer = op->peer;
+
+    if (MCA_OOB_TCP_CONNECTING == peer->state || MCA_OOB_TCP_CONNECT_ACK == peer->state) {
+        /* somebody beat us to it */
+        PMIX_RELEASE(op);
+        return;
+    }
+    if (MCA_OOB_TCP_CONNECTED == peer->state) {
+        /* it came up while we were in flight - just make sure the queued
+         * message will actually go out */
+        pmix_mutex_lock(&peer->lock);
+        if (NULL == peer->send_msg) {
+            peer->send_msg = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue);
+        }
+        if (NULL != peer->send_msg && !peer->send_ev_active) {
+            peer->send_ev_active = true;
+            PMIX_POST_OBJECT(peer);
+            prte_event_add(&peer->send_event, 0);
+        }
+        pmix_mutex_unlock(&peer->lock);
+        PMIX_RELEASE(op);
+        return;
+    }
+
+    peer->state = MCA_OOB_TCP_CONNECTING;
+    /* hand the op straight on - try_connect owns it from here */
+    prte_oob_tcp_peer_try_connect(fd, args, op);
 }
 
 /*
@@ -1086,10 +1191,27 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
         prte_event_del(&peer->timer_event);
         peer->timer_ev_active = false;
     }
-    peer->state = MCA_OOB_TCP_CONNECTED;
     if (NULL != peer->active_addr) {
         peer->active_addr->retries = 0;
     }
+
+    /* Publishing CONNECTED is what makes this peer reachable from a worker
+     * base: prte_oob_base_send_nb tests the state and MCA_OOB_TCP_QUEUE_MSG
+     * then posts to peer->evbase, where prte_oob_tcp_queue_msg adds the send
+     * event.  So the events must already BE on that base before the state is
+     * published, and nothing may be re-targeting them while a worker adds
+     * one - libevent's event_assign on an event another thread is adding is
+     * undefined, and what it produced here was an event registered on nothing:
+     * the send never fired and every thread in the DVM parked in epoll_wait.
+     *
+     * Hence: rebind, publish, and start the pending sends as one step under
+     * the peer lock.  Taking the lock across the rebind is safe precisely
+     * because the events are still on prte_event_base at this point and we
+     * are on it, so those event_del calls cannot block waiting for another
+     * thread's callback (which is the deadlock peer_close has to avoid). */
+    pmix_mutex_lock(&peer->lock);
+    tcp_peer_rebind_events(peer);
+    peer->state = MCA_OOB_TCP_CONNECTED;
 
     /* initiate send of first message on queue */
     if (NULL == peer->send_msg) {
@@ -1100,6 +1222,7 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
         PMIX_POST_OBJECT(peer);
         prte_event_add(&peer->send_event, 0);
     }
+    pmix_mutex_unlock(&peer->lock);
 }
 
 /*
@@ -1109,7 +1232,19 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
  */
 void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
 {
+    prte_oob_tcp_state_t old_state;
+    prte_oob_tcp_send_t *send;
+    pmix_list_t doomed;
+    int err;
+
+    /* Take the state transition under the peer lock so exactly one caller
+     * performs the teardown.  Reachable from both the main progress thread
+     * (the connection state machine) and, once the socket has been handed to
+     * a worker base, from that worker's send/recv handler - and an unguarded
+     * read-then-write of the state word lets both through. */
+    pmix_mutex_lock(&peer->lock);
     if (MCA_OOB_TCP_CLOSED == peer->state) {
+        pmix_mutex_unlock(&peer->lock);
         return;
     }
 
@@ -1121,6 +1256,7 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
     /* if we were CONNECTING, then we need to mark the address as
      * failed and cycle back to try the next address */
     if (MCA_OOB_TCP_CONNECTING == peer->state) {
+        pmix_mutex_unlock(&peer->lock);
         close(peer->sd);
         peer->sd = -1;
         if (NULL != peer->active_addr) {
@@ -1130,13 +1266,20 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
         return;
     }
 
-    prte_oob_tcp_state_t old_state = peer->state;
+    old_state = peer->state;
     peer->state = MCA_OOB_TCP_CLOSED;
+    pmix_mutex_unlock(&peer->lock);
+
     if (NULL != peer->active_addr) {
         peer->active_addr->state = MCA_OOB_TCP_CLOSED;
     }
 
-    /* unregister active events */
+    /* Unregister active events.  This must not be done holding the peer lock:
+     * deleting an event whose handler is running on another thread blocks
+     * until that handler returns, and the handler may be waiting for this very
+     * lock.  It is also what makes the rest of this function safe - once both
+     * socket events are gone, no handler for this peer can be in flight, so
+     * the partial send/recv state below is ours alone. */
     if (peer->recv_ev_active) {
         prte_event_del(&peer->recv_event);
         peer->recv_ev_active = false;
@@ -1158,28 +1301,40 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
         PMIX_RELEASE(peer->recv_msg);
         peer->recv_msg = NULL;
     }
+
+    /* Lift everything still queued off the peer in one guarded step - a
+     * message can still be queued onto it from another thread - and complete
+     * it outside the lock, since completion runs the originator's callback. */
+    PMIX_CONSTRUCT(&doomed, pmix_list_t);
+    pmix_mutex_lock(&peer->lock);
     if (NULL != peer->send_msg) {
-        /* Just add to send_queue to handle w/ the rest */
-        pmix_list_prepend(&peer->send_queue, &peer->send_msg->super);
+        /* Just add to the doomed list to handle w/ the rest */
+        pmix_list_append(&doomed, &peer->send_msg->super);
         peer->send_msg = NULL;
     }
+    while (NULL != (send = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue))) {
+        pmix_list_append(&doomed, &send->super);
+    }
+    pmix_mutex_unlock(&peer->lock);
 
     /* inform rml of all queued sends' completion (as failures)
      * do not try to re-queue messages at this level - risking message loss is
      * unavoidable when a node in the communication tree dies, so safely
      * replaying messages must be handled at a higher level.
      */
-    int err = prte_rml_is_node_up(peer->name.rank) ?
+    err = prte_rml_is_node_up(peer->name.rank) ?
         PRTE_ERR_UNREACH : PRTE_ERR_NODE_DOWN;
-    prte_oob_tcp_send_t *send, *next;
-    PMIX_LIST_FOREACH_SAFE(send, next, &peer->send_queue, prte_oob_tcp_send_t){
-        send->msg->status = err;
-        PRTE_RML_SEND_COMPLETE(send->msg);
-        send->msg = NULL; // completion released it
-        pmix_list_remove_item(&peer->send_queue, &send->super);
+    while (NULL != (send = (prte_oob_tcp_send_t *) pmix_list_remove_first(&doomed))) {
+        if (NULL != send->msg) {
+            prte_rml_send_t *snd = send->msg;
+            snd->status = err;
+            send->msg = NULL; // the completion owns it now
+            PRTE_OOB_COMPLETE_SEND(peer, snd);
+        }
         PMIX_RELEASE(send);
     }
-    
+    PMIX_DESTRUCT(&doomed);
+
     /* inform the component-level that we have lost a connection so
      * it can decide what to do about it.
      */

--- a/src/rml/oob/oob_tcp_connection.h
+++ b/src/rml/oob/oob_tcp_connection.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -89,6 +89,11 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_conn_op_t);
     } while (0);
 
 PRTE_EXPORT void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata);
+/* Ask the main progress thread to (re)start the connection to a peer. Use
+ * this rather than try_connect when the caller may not be on that thread:
+ * it makes the "is it already coming up?" test and the state transition
+ * where the state word lives. */
+PRTE_EXPORT void prte_oob_tcp_peer_start_connect(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_oob_tcp_peer_dump(prte_oob_tcp_peer_t *peer, const char *msg);
 PRTE_EXPORT bool prte_oob_tcp_peer_accept(prte_oob_tcp_peer_t *peer);
 PRTE_EXPORT void prte_oob_tcp_peer_complete_connect(prte_oob_tcp_peer_t *peer);

--- a/src/rml/oob/oob_tcp_peer.h
+++ b/src/rml/oob/oob_tcp_peer.h
@@ -17,7 +17,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Amazon.com, Inc. or its affiliates.  All Rights
  *                         reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +62,16 @@ typedef struct {
                                retry sequence; 0 until the first retry is scheduled.  Used to
                                bound how long we chase a non-lifeline peer before healing to an
                                ancestor (see prte_oob_base.connect_max_time). */
+    prte_event_base_t *evbase; /**< the base servicing this peer's socket once connected.
+                                    Assigned round-robin at construction from
+                                    prte_oob_base.ev_bases; equal to prte_event_base when no
+                                    worker progress threads were requested.  The connection
+                                    state machine and the handshake always run on
+                                    prte_event_base - the events move here at CONNECTED. */
+    pmix_mutex_t lock;         /**< guards send_msg/send_queue/send_ev_active, and the
+                                    once-only state transition in prte_oob_tcp_peer_close.
+                                    Held across queue manipulation only - never across a
+                                    writev, and never across a callback. */
     prte_event_t send_event; /**< registration with event thread for send events */
     bool send_ev_active;
     prte_event_t recv_event; /**< registration with event thread for recv events */

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2013-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -85,11 +85,13 @@ void prte_oob_tcp_queue_msg(int sd, short args, void *cbdata)
 {
     prte_oob_tcp_send_t *snd = (prte_oob_tcp_send_t *) cbdata;
     prte_oob_tcp_peer_t *peer;
+    bool connect_needed = false;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(snd);
     peer = (prte_oob_tcp_peer_t *) snd->peer;
 
+    pmix_mutex_lock(&peer->lock);
     /* if there is no message on-deck, put this one there */
     if (NULL == peer->send_msg) {
         peer->send_msg = snd;
@@ -97,19 +99,43 @@ void prte_oob_tcp_queue_msg(int sd, short args, void *cbdata)
         /* add it to the queue */
         pmix_list_append(&peer->send_queue, &snd->super);
     }
-    if (snd->activate) {
-        /* if we aren't connected, then start connecting */
-        if (MCA_OOB_TCP_CONNECTED != peer->state) {
-            peer->state = MCA_OOB_TCP_CONNECTING;
-            PRTE_ACTIVATE_TCP_CONN_STATE(peer, prte_oob_tcp_peer_try_connect);
-        } else {
-            /* ensure the send event is active */
-            if (!peer->send_ev_active) {
-                peer->send_ev_active = true;
-                PMIX_POST_OBJECT(peer);
-                prte_event_add(&peer->send_event, 0);
-            }
+
+    /* Whether or not the caller asked us to activate, a CONNECTED peer must
+     * have its send event running - the last of us to observe the connection
+     * is the one that has to start it.
+     *
+     * This is not the same test as `snd->activate`, and the difference is a
+     * hang.  A message queued as *pending* (activate false) is one the send
+     * path found unconnected, and the connection is being driven for it
+     * already.  That used to mean "somebody else will start the send", which
+     * was true while this ran on the same thread as the connection state
+     * machine: tcp_peer_connected() pulled the pending message off the queue
+     * and armed the event.  Now that we run on the peer's own base the two
+     * interleave, and if tcp_peer_connected() gets there FIRST it finds an
+     * empty queue, arms nothing, and publishes CONNECTED - after which we
+     * arrive, park the message on deck, and, seeing activate false, arm
+     * nothing either.  The message then sits on a connected peer with a dead
+     * send event forever, which is exactly how an 8-node radix-2 launch was
+     * observed to wedge with every thread idle in epoll_wait.
+     */
+    if (MCA_OOB_TCP_CONNECTED == peer->state) {
+        if (NULL != peer->send_msg && !peer->send_ev_active) {
+            peer->send_ev_active = true;
+            PMIX_POST_OBJECT(peer);
+            prte_event_add(&peer->send_event, 0);
         }
+    } else if (snd->activate) {
+        /* the peer went away between the time the send path found it
+         * connected and the time we got here.  The connection state
+         * machine belongs to the main progress thread, so ask for it
+         * there rather than reaching into the peer's state word from
+         * whichever thread is servicing this socket. */
+        connect_needed = true;
+    }
+    pmix_mutex_unlock(&peer->lock);
+
+    if (connect_needed) {
+        PRTE_ACTIVATE_TCP_CONN_STATE(peer, prte_oob_tcp_peer_start_connect);
     }
 }
 
@@ -207,7 +233,11 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
     PRTE_HIDE_UNUSED_PARAMS(sd, flags);
 
     PMIX_ACQUIRE_OBJECT(peer);
+    /* the on-deck message can be swapped out from under us by a close running
+     * on the main progress thread, so take a guarded look at it */
+    pmix_mutex_lock(&peer->lock);
     msg = peer->send_msg;
+    pmix_mutex_unlock(&peer->lock);
 
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s tcp:send_handler called to send to peer %s",
@@ -216,6 +246,9 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
     switch (peer->state) {
     case MCA_OOB_TCP_CONNECTING:
     case MCA_OOB_TCP_CLOSED:
+        /* the socket is still being connected, so its events are still bound
+         * to prte_event_base - the connection state machine never runs on a
+         * worker base */
         pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                             "%s tcp:send_handler %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                             prte_oob_tcp_state_print(peer->state));
@@ -244,20 +277,27 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                         PRTE_NAME_PRINT(&(peer->name)),
                                         (int) ntohl(msg->hdr.nbytes), peer->sd);
-                    PMIX_RELEASE(msg);
+                    pmix_mutex_lock(&peer->lock);
                     peer->send_msg = NULL;
+                    pmix_mutex_unlock(&peer->lock);
+                    PMIX_RELEASE(msg);
                 } else {
                     /* we are done - notify the RML */
+                    prte_rml_send_t *snd = msg->msg;
                     pmix_output_verbose(2, prte_oob_base.output,
                                         "%s MESSAGE SEND COMPLETE TO %s OF %d BYTES ON SOCKET %d",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                         PRTE_NAME_PRINT(&(peer->name)),
                                         (int) ntohl(msg->hdr.nbytes), peer->sd);
-                    msg->msg->status = PRTE_SUCCESS;
-                    PRTE_RML_SEND_COMPLETE(msg->msg);
-                    msg->msg = NULL; // completion released it
-                    PMIX_RELEASE(msg);
+                    snd->status = PRTE_SUCCESS;
+                    msg->msg = NULL; // the completion owns it now
+                    pmix_mutex_lock(&peer->lock);
                     peer->send_msg = NULL;
+                    pmix_mutex_unlock(&peer->lock);
+                    PMIX_RELEASE(msg);
+                    /* the callback runs on the main progress thread - never
+                     * under the peer lock, and never on a worker base */
+                    PRTE_OOB_COMPLETE_SEND(peer, snd);
                 }
                 /* fall thru to queue the next message */
             } else if (PRTE_ERR_RESOURCE_BUSY == rc || PRTE_ERR_WOULD_BLOCK == rc) {
@@ -282,24 +322,32 @@ void prte_oob_tcp_send_handler(int sd, short flags, void *cbdata)
              * wait for another send_event to fire before doing so. This gives
              * us a chance to service any pending recvs.
              */
-            peer->send_msg = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue);
+            pmix_mutex_lock(&peer->lock);
+            if (NULL == peer->send_msg) {
+                peer->send_msg = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue);
+            }
+            pmix_mutex_unlock(&peer->lock);
         }
 
         /* if nothing else to do unregister for send event notifications */
+        pmix_mutex_lock(&peer->lock);
         if (NULL == peer->send_msg && peer->send_ev_active) {
             prte_event_del(&peer->send_event);
             peer->send_ev_active = false;
         }
+        pmix_mutex_unlock(&peer->lock);
         break;
     default:
         pmix_output(
             0, "%s-%s prte_oob_tcp_peer_send_handler: invalid connection state (%d) on socket %d",
             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(peer->name)), peer->state,
             peer->sd);
+        pmix_mutex_lock(&peer->lock);
         if (peer->send_ev_active) {
             prte_event_del(&peer->send_event);
             peer->send_ev_active = false;
         }
+        pmix_mutex_unlock(&peer->lock);
         break;
     }
 }
@@ -385,7 +433,13 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
             pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                                 "%s:tcp:recv:handler starting send/recv events",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-            /* we connected! Start the send/recv events */
+            /* we connected! Start the send/recv events.
+             *
+             * tcp_peer_connected() has already run beneath the ack: the peer
+             * is CONNECTED, its socket events now live on peer->evbase, and a
+             * worker may already be queueing onto it.  So everything below
+             * that touches the send queue or the send event has to be guarded
+             * - it is no longer this thread's alone. */
             if (!peer->recv_ev_active) {
                 peer->recv_ev_active = true;
                 PMIX_POST_OBJECT(peer);
@@ -396,6 +450,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                 peer->timer_ev_active = false;
             }
             /* if there is a message waiting to be sent, queue it */
+            pmix_mutex_lock(&peer->lock);
             if (NULL == peer->send_msg) {
                 peer->send_msg = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue);
             }
@@ -406,6 +461,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
             }
             /* update our state */
             peer->state = MCA_OOB_TCP_CONNECTED;
+            pmix_mutex_unlock(&peer->lock);
         } else if (PRTE_ERR_UNREACH != rc) {
             /* we get an unreachable error returned if a connection
              * completes but is rejected - otherwise, we don't want

--- a/src/rml/oob/oob_tcp_sendrecv.h
+++ b/src/rml/oob/oob_tcp_sendrecv.h
@@ -15,7 +15,7 @@
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -78,6 +78,11 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
  * it as "pending" for later transmission - e.g., after the
  * connection procedure is completed
  *
+ * The queue lives with the thread that services the peer's socket, so this
+ * shifts onto the peer's own base rather than prte_event_base.  With no OOB
+ * worker threads the two are the same object and this is the shift it always
+ * was.
+ *
  * p => pointer to prte_oob_tcp_peer_t
  * s => pointer to prte_oob_tcp_send_t
  * f => true if send event is to be activated
@@ -86,7 +91,7 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
     do {                                                                        \
         (s)->peer = (struct prte_oob_tcp_peer_t *) (p);                         \
         (s)->activate = (f);                                                    \
-        PRTE_PMIX_THREADSHIFT((s), prte_event_base, prte_oob_tcp_queue_msg);    \
+        PRTE_PMIX_THREADSHIFT((s), (p)->evbase, prte_oob_tcp_queue_msg);        \
     } while (0)
 
 /* queue a message for transmission to a connected peer - must

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -66,9 +66,18 @@ uint64_t prte_rml_boot_epoch = 0;
 
 static int verbosity = 0;
 
+/* The incarnation table is the one piece of RML state a peer's socket handler
+ * reaches directly, and that handler runs on whichever base is servicing the
+ * peer - one of the OOB progress threads when any were configured (see
+ * prte_oob_base.num_progress_threads).  Two of them arriving at once would
+ * both realloc the array.  The lock is taken only on the bootstrap incarnation
+ * check, which is a handful of instructions per message and uncontended
+ * whenever the OOB is running on the main thread alone. */
+static pmix_mutex_t epoch_lock = PMIX_MUTEX_STATIC_INIT;
+
 /* Grow the per-rank epoch table so index rank is valid, zero-filling new slots
  * (0 = unknown). Ranks are dense and small, so a flat array indexed by rank is
- * ample. Runs only on the progress thread, like all RML state. */
+ * ample. Caller must hold epoch_lock. */
 static void ensure_epoch_slot(pmix_rank_t rank)
 {
     if ((size_t) rank < prte_rml_base.peer_epochs_size) {
@@ -89,27 +98,34 @@ static void ensure_epoch_slot(pmix_rank_t rank)
 
 bool prte_rml_epoch_ok(pmix_rank_t rank, uint64_t epoch)
 {
+    uint64_t known;
+    bool ok = true;
+
     /* an unstamped message (epoch 0) carries no incarnation claim - accept */
     if (0 == epoch) {
         return true;
     }
+    pmix_mutex_lock(&epoch_lock);
     ensure_epoch_slot(rank);
     if ((size_t) rank >= prte_rml_base.peer_epochs_size) {
         /* allocation failed - fail open rather than drop live traffic */
-        return true;
+        goto done;
     }
-    uint64_t known = prte_rml_base.peer_epochs[rank];
+    known = prte_rml_base.peer_epochs[rank];
     if (0 == known) {
         /* first time we have seen this rank - learn its epoch */
         prte_rml_base.peer_epochs[rank] = epoch;
-        return true;
+        goto done;
     }
     if (epoch < known) {
         /* stale incarnation - drop. A newer epoch passes but does not advance
          * the table here; the arbitrated revival advances it authoritatively. */
-        return false;
+        ok = false;
     }
-    return true;
+
+done:
+    pmix_mutex_unlock(&epoch_lock);
+    return ok;
 }
 
 void prte_rml_record_epoch(pmix_rank_t rank, uint64_t epoch)
@@ -117,10 +133,12 @@ void prte_rml_record_epoch(pmix_rank_t rank, uint64_t epoch)
     if (0 == epoch) {
         return;
     }
+    pmix_mutex_lock(&epoch_lock);
     ensure_epoch_slot(rank);
     if ((size_t) rank < prte_rml_base.peer_epochs_size) {
         prte_rml_base.peer_epochs[rank] = epoch;
     }
+    pmix_mutex_unlock(&epoch_lock);
 }
 
 uint64_t prte_rml_get_epoch(pmix_rank_t rank)

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -67,8 +67,10 @@
 #include "src/util/pmix_if.h"
 
 #include "src/pmix/pmix-internal.h"
-#include "src/rml/oob/oob_tcp.h"
 #include "src/rml/rml.h"
+#include "src/rml/oob/oob.h"
+#include "src/rml/oob/oob_tcp.h"
+#include "src/rml/oob/oob_tcp_peer.h"
 
 #define CHECK(label, cond)                                    \
     do {                                                      \
@@ -421,6 +423,91 @@ static int test_payload_outlives_sends(void)
     return failures;
 }
 
+/*
+ * The pool of event bases that peer sockets are serviced on.
+ *
+ * Two properties matter and neither needs a socket to check.  First, the
+ * "no worker threads" case - which is the default, and therefore the shape
+ * every existing deployment runs - must still leave ev_bases holding exactly
+ * one entry, prte_event_base, because every call site indexes the array
+ * unconditionally; a NULL array or a zero-length one is a segfault on the
+ * first peer.  Second, peers must be handed out round-robin and the cursor
+ * must wrap, since a cursor that ran off the end would index past the array.
+ *
+ * The multi-thread case is driven with a hand-built array rather than by
+ * asking for real threads: prte_progress_thread_init spins an actual engine
+ * thread per base, which a bare test process has no business starting.  What
+ * is under test here is the assignment arithmetic, not libevent.
+ */
+static int test_progress_thread_pool(void)
+{
+    int failures = 0, i;
+    prte_event_base_t *fake[3];
+    prte_oob_tcp_peer_t *peers[7];
+
+    /* the default: no dedicated threads */
+    prte_oob_base.num_progress_threads = 0;
+    prte_oob_base.ev_bases = NULL;
+    prte_oob_base.ev_threads = NULL;
+    prte_oob_base.next_base = 0;
+    CHECK("pool starts", PRTE_SUCCESS == prte_oob_start_progress_threads());
+    CHECK("array exists with no threads", NULL != prte_oob_base.ev_bases);
+    CHECK("no threads means the main base",
+          NULL != prte_oob_base.ev_bases && prte_event_base == prte_oob_base.ev_bases[0]);
+    CHECK("no threads recorded", 0 == prte_oob_base.num_progress_threads);
+    CHECK("no thread names recorded", NULL == prte_oob_base.ev_threads);
+
+    /* every peer lands on that one entry, and the cursor does not move */
+    for (i = 0; i < 3; i++) {
+        peers[i] = PMIX_NEW(prte_oob_tcp_peer_t);
+        CHECK("peer takes the main base", prte_event_base == peers[i]->evbase);
+    }
+    CHECK("cursor pinned with no threads", 0 == prte_oob_base.next_base);
+    for (i = 0; i < 3; i++) {
+        PMIX_RELEASE(peers[i]);
+    }
+
+    prte_oob_harvest_progress_threads();
+    CHECK("harvest clears the array", NULL == prte_oob_base.ev_bases);
+    CHECK("harvest clears the count", 0 == prte_oob_base.num_progress_threads);
+
+    /* a negative request is a request for none, not an array sized -1 */
+    prte_oob_base.num_progress_threads = -4;
+    CHECK("negative pool starts", PRTE_SUCCESS == prte_oob_start_progress_threads());
+    CHECK("negative clamps to none", 0 == prte_oob_base.num_progress_threads);
+    CHECK("negative still yields the main base",
+          NULL != prte_oob_base.ev_bases && prte_event_base == prte_oob_base.ev_bases[0]);
+    prte_oob_harvest_progress_threads();
+
+    /* three bases, seven peers: 0,1,2,0,1,2,0 */
+    for (i = 0; i < 3; i++) {
+        /* distinct non-NULL values are all the assignment arithmetic sees */
+        fake[i] = (prte_event_base_t *) &fake[i];
+    }
+    prte_oob_base.num_progress_threads = 3;
+    prte_oob_base.ev_bases = fake;
+    prte_oob_base.next_base = 0;
+    for (i = 0; i < 7; i++) {
+        peers[i] = PMIX_NEW(prte_oob_tcp_peer_t);
+    }
+    for (i = 0; i < 7; i++) {
+        CHECK("peer assigned round-robin", fake[i % 3] == peers[i]->evbase);
+    }
+    CHECK("cursor wrapped", 1 == prte_oob_base.next_base);
+    for (i = 0; i < 7; i++) {
+        PMIX_RELEASE(peers[i]);
+    }
+    /* the array is on our stack - do not let harvest free it */
+    prte_oob_base.ev_bases = NULL;
+    prte_oob_base.num_progress_threads = 0;
+    prte_oob_base.next_base = 0;
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_progress_thread_pool\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -440,6 +527,7 @@ int main(void)
     failures += test_bad_subnets_dropped();
     failures += test_subnet_resolves_and_dedupes();
     failures += test_payload_outlives_sends();
+    failures += test_progress_thread_pool();
 
     prte_finalize();
 


### PR DESCRIPTION
### The problem

PRRTE's main progress thread has long stalls exactly where the wire should be
busy: the xcast deflate, PMIx namespace registration, the odls fork/exec path,
the launch state machine. While any of those runs, **no socket is serviced at
all**, so the link simply idles for that fraction of a launch.

The cost here is *occupancy*, not throughput. A single thread copies into the
kernel at 5-9 GB/s, several times faster than a 10-25 GbE link drains, so the
transport is not bandwidth-starved — it is just not being run. If the main
thread is busy a fraction phi of the launch window, the link idles for phi of
it, and no amount of extra bandwidth recovers that.

### The change

`prte_oob_progress_threads` (**default 0 — nothing changes unless asked for**)
starts that many worker progress threads and assigns each peer one of them
round-robin when the peer is built. Only the peer's send and recv handlers
move there, and only once the connection is up. Everything those handlers hand
onwards — delivering a message to the RML, relaying one on, running a send's
completion callback, reacting to a lost connection — still comes back to
`prte_event_base`, as does the whole connection state machine, so routing and
the peer table stay single-threaded and workers never read the routing tree.

Five rules make that safe, and they are written up in
`src/rml/oob/AGENTS.md` under *Which thread services a peer's socket*:

1. The socket events are created on the main base and moved to the peer's base
   at CONNECTED — libevent will not re-target a pending event, and the
   handshake must not run on a worker. CONNECTED is published only *after*
   that move, and the move, the publication and the start of any pending send
   are one step under the peer lock: publishing first lets a worker call
   `event_add` on the very event this thread is re-assigning, and
   `event_assign` against a concurrent `event_add` is undefined.
2. A per-peer mutex guards `send_msg`/`send_queue`/`send_ev_active` and the
   once-only state transition in `prte_oob_tcp_peer_close`, held across queue
   manipulation only — never across a `writev` or a callback. It is always the
   *outer* lock: a holder may take a libevent base lock, never the reverse.
3. `peer_close` deletes both socket events *before* taking that mutex.
   Deleting an event whose handler runs on another thread blocks until it
   returns, which is what makes the rest of the teardown exclusive — and
   holding the mutex across it would deadlock against the handler being
   waited for.
4. A worker never writes the peer's state word; finding a peer unconnected it
   posts `prte_oob_tcp_peer_start_connect` to the main base.
5. Whoever observes CONNECTED **last** arms the send event. Both `queue_msg`
   and `tcp_peer_connected` end with "connected, something on deck, no send
   event running — arm it", because the two now race: a message queued as
   *pending* carries `activate=false`, meaning "the connection machinery will
   start this send", which held only while both ran on one thread.

The RML's incarnation table is the one piece of state outside the transport a
socket handler reaches directly, and it reallocates, so it gains a mutex.

Two failure paths that were already wrong are fixed in passing: the give-up
path in `try_connect` dropped its queued sends on the floor rather than
completing them (a lost message for RELM, and a leak), and `peer_close`'s
drain would have dereferenced a send carrying no message.

With no worker threads the peer's base *is* `prte_event_base`: the completion
runs inline, the rebind is a delete and re-set onto the base the events were
already on, and the mutex is uncontended — the default path is the one that
ran before.

### Testing

`test/unit/rml/test_rml` gains a case for the pool sizing and the round-robin
assignment (the zero case, the negative clamp, cursor wrap). The dockerswarm
suite gains a `test_rml` case that turns the feature on and checks that the
daemons really build their pools, that a radix-2 tree still relays, that a
payload large enough to force partial writes arrives intact, and that killing
a daemon under a live job still releases it.

Because the default is off, the suite was then run with the parameter forced
on globally, flat and at depth:

| | flat (radix 64) | deep (radix 2 forced globally) |
|---|---|---|
| threads 0 | 562 pass / 1 fail (a known IOF flake) | 538 / 23 |
| threads 4 | **563 / 0** | 538 / **23 — the same 23 cases** |

The two deep arms' failure sets are identical, so worker threads change
nothing at depth; those 23 are pre-existing small-radix problems reproduced
with the feature off (and separately reproduced on an unmodified master).

That sweep is what caught rule 5 above: with the threads on, an 8-node radix-2
launch wedged roughly one run in three, every thread idle in `epoll_wait`,
with one peer showing `send_msg != NULL, send_ev_active == false` — a message
parked on a live connection behind an event nobody had armed. 0 of 25 after
the fix, and 0 of 15 again after rebasing onto the shared-payload work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)