### PR TITLE
Answer a Slurm extend when the DVM has grown, not when Slurm has granted

### DIFF
--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -19,6 +19,8 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2023      Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -2280,6 +2282,95 @@ void prte_plm_base_wrap_args(char **args)
     }
 }
 
+/* True if the session still holds this node. PRTE_NODE_ALLOC_ID outlives the
+ * membership it records - a node shrunk out of an allocation keeps the tag -
+ * so the session's own list is what says whether the tag is still current. */
+static bool session_holds_node(prte_session_t *sess, prte_node_t *node)
+{
+    int i;
+
+    if (NULL == sess->nodes) {
+        return false;
+    }
+    for (i = 0; i < sess->nodes->size; i++) {
+        if (node == (prte_node_t *) pmix_pointer_array_get_item(sess->nodes, i)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* The allocation this node arrived in, if it was tagged with one. */
+static bool node_alloc_id(prte_node_t *node, uint32_t *alloc_id)
+{
+    void *data = alloc_id;
+
+    return prte_get_attribute(&node->attributes, PRTE_NODE_ALLOC_ID, &data, PMIX_UINT32);
+}
+
+/* The session naming who asked for the grow that brought this node in.
+ *
+ * A reserved node points at its session directly. A node an RM added to the
+ * general pool does not - ras/slurm's extend leaves node->session NULL by
+ * design - but still carries the allocation it arrived in, whose session
+ * records the requestor. Resolving through the node is what keeps concurrent
+ * grows correct: each node names its own request. */
+static prte_session_t *grow_requester_session(prte_node_t *node)
+{
+    prte_session_t *sess;
+    uint32_t alloc_id;
+
+    if (NULL == node) {
+        return NULL;
+    }
+    sess = node->session;
+    if (NULL == sess && node_alloc_id(node, &alloc_id)) {
+        sess = prte_get_session_object(alloc_id);
+        if (NULL != sess && !session_holds_node(sess, node)) {
+            return NULL;
+        }
+    }
+    if (NULL == sess || PMIX_RANK_INVALID == sess->requestor.rank) {
+        return NULL;
+    }
+    return sess;
+}
+
+/* Add a requester to a campaign unless already listed. On failure the campaign
+ * keeps what it had, costing one requester its event rather than the launch. */
+static int campaign_add_requester(prte_grow_campaign_t *camp, prte_session_t *sess)
+{
+    prte_grow_requester_t *tmp;
+    int r;
+
+    for (r = 0; r < camp->nrequesters; r++) {
+        const char *a = camp->requesters[r].alloc_id, *b = sess->alloc_refid;
+
+        if (!PMIX_CHECK_PROCID(&camp->requesters[r].requester, &sess->requestor)) {
+            continue;
+        }
+        /* one process may have several grows here, so the allocation
+         * distinguishes them */
+        if ((NULL == a && NULL == b) || (NULL != a && NULL != b && 0 == strcmp(a, b))) {
+            return PRTE_SUCCESS;
+        }
+    }
+
+    tmp = (prte_grow_requester_t *) realloc(camp->requesters,
+                                            (camp->nrequesters + 1) * sizeof(*tmp));
+    if (NULL == tmp) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    camp->requesters = tmp;
+    tmp = &camp->requesters[camp->nrequesters];
+    PMIX_XFER_PROCID(&tmp->requester, &sess->requestor);
+    tmp->alloc_id = (NULL != sess->alloc_refid) ? strdup(sess->alloc_refid) : NULL;
+    tmp->req_id = (NULL != sess->user_refid) ? strdup(sess->user_refid) : NULL;
+    camp->nrequesters++;
+
+    return PRTE_SUCCESS;
+}
+
 int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
 {
     prte_node_t *node, *nptr;
@@ -2298,7 +2389,7 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
     bool have_grow_requester = false;
     pmix_rank_t vpid;
     pmix_proc_t grow_requester;
-    char *grow_alloc_id = NULL, *grow_req_id = NULL;
+    const char *grow_alloc_id = NULL, *grow_req_id = NULL;
     /* the vpids THIS pass assigned, recorded as they are handed out (elastic
      * mode only - they are what a grow campaign must name) */
     pmix_rank_t *new_vpids = NULL;
@@ -2397,11 +2488,11 @@ int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
          * timeout on an operation that had in fact already succeeded. */
         grow_request = true;
         PMIX_LIST_FOREACH(nptr, &nodes, prte_node_t) {
-            if (NULL != nptr->session &&
-                PMIX_RANK_INVALID != nptr->session->requestor.rank) {
-                PMIX_XFER_PROCID(&grow_requester, &nptr->session->requestor);
-                grow_alloc_id = nptr->session->alloc_refid;
-                grow_req_id = nptr->session->user_refid;
+            prte_session_t *sess = grow_requester_session(nptr);
+            if (NULL != sess) {
+                PMIX_XFER_PROCID(&grow_requester, &sess->requestor);
+                grow_alloc_id = sess->alloc_refid;
+                grow_req_id = sess->user_refid;
                 have_grow_requester = true;
                 break;
             }
@@ -2938,37 +3029,52 @@ process:
         gcamp->targets = new_vpids;
         new_vpids = NULL;
         n_new_vpids = 0;
-        /* Record the requester for the spec's phase-two completion event.  The
-         * RAS reservation machinery sets each reserved node's ->session
-         * backpointer (add_nodes_to_session), and that session carries the
-         * requestor and the allocation ids.
+        /* Every requester this campaign answers for, from ALL the targets.
          *
-         * Scan ALL the targets for the first one carrying a requestor rather
-         * than trusting the first: a grow launches a daemon onto every node
-         * that lacks one, which is not necessarily limited to the nodes this
-         * request reserved.  In particular a node that was shrunk out of the
-         * DVM reverts to the default pool with its ->session cleared, and the
-         * next grow re-absorbs it - taking the lowest new vpid, and hence the
-         * daemon_vpid_start slot.  Reading only that node left the campaign
-         * with no requester, so a perfectly successful grow emitted no
-         * completion event at all and the requester waited forever.
+         * Not just the first: a grow launches onto every node lacking a daemon,
+         * which need not be limited to the nodes one request brought in, and a
+         * campaign can cover several grows outright - activating a grow only
+         * posts LAUNCH_DAEMONS, so two requests granted in the same breath are
+         * swept into one campaign and both must be answered.
          *
-         * The initial DVM bring-up and a scheduler-driven push have no
-         * requestor on any node (the default session, or an invalid requestor
-         * rank), so have_requester stays false and grow_drain() emits no event
-         * for them - which is correct, as nobody asked for those. */
+         * The initial bring-up and a scheduler-driven push name no requestor,
+         * so the list stays empty and grow_drain() emits nothing. */
         {
-            int gt;
-            for (gt = 0; gt < gcamp->ntargets && !gcamp->have_requester; gt++) {
+            int gt, arc;
+            uint32_t alloc_id, answered_alloc_id = 0;
+            bool have_answered_alloc_id = false;
+
+            for (gt = 0; gt < gcamp->ntargets; gt++) {
                 prte_proc_t *dproc = (prte_proc_t *)
                     pmix_pointer_array_get_item(daemons->procs, gcamp->targets[gt]);
-                prte_session_t *sess =
-                    (NULL != dproc && NULL != dproc->node) ? dproc->node->session : NULL;
-                if (NULL != sess && PMIX_RANK_INVALID != sess->requestor.rank) {
-                    PMIX_XFER_PROCID(&gcamp->requester, &sess->requestor);
-                    gcamp->alloc_id = (NULL != sess->alloc_refid) ? strdup(sess->alloc_refid) : NULL;
-                    gcamp->req_id = (NULL != sess->user_refid) ? strdup(sess->user_refid) : NULL;
-                    gcamp->have_requester = true;
+                prte_node_t *tnode = (NULL != dproc) ? dproc->node : NULL;
+                prte_session_t *sess;
+
+                if (NULL == tnode) {
+                    continue;
+                }
+                /* The targets of one grow share an allocation, and the campaign
+                 * holds one entry per requester, so a target naming an
+                 * allocation already answered for cannot change the outcome.
+                 * Skipping it keeps this off a per-target walk of that session's
+                 * node array, which is quadratic in the size of the grow. */
+                if (NULL == tnode->session && have_answered_alloc_id
+                    && node_alloc_id(tnode, &alloc_id)
+                    && alloc_id == answered_alloc_id) {
+                    continue;
+                }
+                sess = grow_requester_session(tnode);
+                if (NULL == sess) {
+                    continue;
+                }
+                arc = campaign_add_requester(gcamp, sess);
+                if (PRTE_SUCCESS != arc) {
+                    PRTE_ERROR_LOG(arc);
+                    continue;
+                }
+                if (NULL == tnode->session && node_alloc_id(tnode, &alloc_id)) {
+                    answered_alloc_id = alloc_id;
+                    have_answered_alloc_id = true;
                 }
             }
         }
@@ -3124,6 +3230,7 @@ void prte_plm_base_abort_premap_held(void)
 void prte_plm_base_grow_drain(bool success)
 {
     prte_grow_campaign_t *camp;
+    int r;
 
     /* Resolve all in-progress grow campaigns at once and drop their entire
      * contribution from the launch fence.  This is called from exactly the
@@ -3135,12 +3242,13 @@ void prte_plm_base_grow_drain(bool success)
     while (NULL != (camp = (prte_grow_campaign_t *)
                                pmix_list_remove_first(&prte_grow_campaigns))) {
         prte_dvm_launch_fence -= camp->ntargets;
-        if (camp->have_requester) {
+        for (r = 0; r < camp->nrequesters; r++) {
             /* the specific daemon-failure status is not threaded down to this
              * layer yet, so report a generic cause on failure (reconcile by
              * passing the dying daemon's status as a follow-up) */
-            prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
-                                         camp->req_id, success,
+            prte_plm_base_dvm_mod_notify(&camp->requesters[r].requester,
+                                         camp->requesters[r].alloc_id,
+                                         camp->requesters[r].req_id, success,
                                          success ? PMIX_SUCCESS : PMIX_ERROR);
         }
         PMIX_RELEASE(camp);
@@ -3316,7 +3424,7 @@ static void grow_rollback(prte_grow_campaign_t *camp, pmix_rank_t trigger)
 bool prte_plm_base_grow_target_failed(pmix_rank_t rank)
 {
     prte_grow_campaign_t *camp;
-    int t;
+    int t, r;
 
     /* Outside elastic mode there are no grow campaigns and the daemon loss is
      * the errmgr's to handle exactly as it always has — never report it as
@@ -3341,11 +3449,13 @@ bool prte_plm_base_grow_target_failed(pmix_rank_t rank)
             pmix_list_remove_item(&prte_grow_campaigns, &camp->super);
             prte_dvm_launch_fence -= camp->ntargets;
             grow_rollback(camp, rank);
-            if (camp->have_requester) {
+            for (r = 0; r < camp->nrequesters; r++) {
                 /* the specific daemon-failure status is not threaded down to
                  * this layer yet, so report a generic cause */
-                prte_plm_base_dvm_mod_notify(&camp->requester, camp->alloc_id,
-                                             camp->req_id, false, PMIX_ERROR);
+                prte_plm_base_dvm_mod_notify(&camp->requesters[r].requester,
+                                             camp->requesters[r].alloc_id,
+                                             camp->requesters[r].req_id,
+                                             false, PMIX_ERROR);
             }
             PMIX_RELEASE(camp);
             /* any grow failure fails the whole pre-map held-job set */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -130,6 +130,15 @@ The `modify()` path has its own protocol (`prte_ras_base_modify`):
 `modify` requests can be keyed to a single component via `req->key`
 (matched case-insensitively against the component name).
 
+A module that grows the DVM answers `OPERATION_IN_PROGRESS` and lets the grow
+campaign's `PMIX_DVM_IS_READY` be the result, since the nodes are unusable until
+daemons are up on them. `setup_virtual_machine` resolves that event's recipients
+**from the new nodes** — `node->session`, else the session named by the node's
+`PRTE_NODE_ALLOC_ID` — so a module whose nodes join the general pool must record
+`session->requestor` on whatever session tracks the allocation, or neither the
+completion nor a launch failure reaches anyone. A campaign collects every
+distinct requester among its targets: one campaign can cover several grows.
+
 ---
 
 ## Component selection is not "pick one"

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -84,12 +84,32 @@ deviation* and the framework guide.
   mem-per-node, time, threads-per-core — each gated by a `propagate_*`
   MCA param, all default true), builds `salloc` args, launches an
   **expander job**, waits for its `salloc` to exit, then adds the modified
-  resources.
+  resources. Answers in two phases — see below.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
   with `scontrol update job`, removing nodes by count while protecting
   the launching node (`SLURMD_NODENAME`).
 - **`PMIX_ALLOC_REQ_CANCEL`** → `serve_cancel_req`: cancels a pending
   extend by request id, and answers it (see below).
+
+### An extend is answered when the DVM has grown, not when Slurm has granted
+
+No daemon runs on the new nodes until the grow campaign drains, so phase one
+reports `PMIX_OPERATION_IN_PROGRESS` with the allocation id and
+`PMIX_DVM_IS_READY` is the answer — the shape a release already has.
+
+- **The campaign finds its requester through the nodes.** `extend_wait_complete`
+  records `session->requestor` on the per-jobid tracking session, and
+  `setup_virtual_machine` resolves it from the node's `PRTE_NODE_ALLOC_ID`
+  because `node->session` is NULL by design. Keeping the association on the node
+  is what makes concurrent extends correct: each node names its own request, and
+  one campaign can cover several.
+- **Without a requester a failed grow is silent.** `grow_target_failed` notifies
+  only a campaign that has one.
+- **Outside `prte_elastic_mode` phase one stays terminal.** No campaign is
+  recorded, so no event can come. Unlike `serve_release_req` the extend does not
+  refuse there — it has already done what was asked of Slurm.
+- **Both phase-one statuses are `#if PRTE_HAVE_DVM_MOD_EVENTS`.**
+  `prte_plm_base_dvm_mod_notify` compiles away without the event codes.
 
 ### The salloc child outlives the call that forked it
 
@@ -277,11 +297,11 @@ a case. Two things that trip people up:
   `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and `PMIX_ALLOC_REQ_CANCEL`. A
   node-naming `PMIX_ALLOC_NEW` never reaches this component — the base
   serves it.
-- **An extend emits no phase-two completion event.** Its nodes go into the
-  general pool (`node->session` stays NULL, by design — see above), and the
-  directed event is addressed to the requestor recorded on a *reservation*.
-  Phase one carries the result. A release does go through a shrink campaign,
-  so it does emit `PMIX_DVM_IS_READY`.
+- **An extend answers in two phases, like a release.** Phase one reports
+  `PMIX_OPERATION_IN_PROGRESS` with the allocation id once Slurm grants;
+  `PMIX_DVM_IS_READY` (or `PMIX_ERR_DVM_MOD`) follows when the grow campaign
+  drains and the daemons are wired up. A case asserting on the phase-one
+  status has to expect that, not `PMIX_SUCCESS`.
 
 Some slot counts are asserted from `ras_base_verbose` output rather than
 from the node pool: the verbose line is what *this component* computed,

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1177,6 +1177,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     bool have_added_nodes = false;
     bool have_reused_nodes = false;
     bool resources_added = false;
+    bool requester_recorded = false;
     int added_node_count = 0;
     int reused_node_count = 0;
     
@@ -1257,6 +1258,7 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
         prte_session_t *session = prte_get_session_object_from_id(job_id);
         if (NULL != session) {
             PMIX_XFER_PROCID(&session->requestor, &req->tproc);
+            requester_recorded = true;
         }
     }
 
@@ -1332,6 +1334,17 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
     /* Launch daemons on the newly secured resources */
     if (PMIX_SUCCESS == req->pstatus) {
         prte_ras_base_activate_dvm_grow();
+
+        /* A grant is not usable nodes, so the campaign's PMIX_DVM_IS_READY is
+         * the answer, as it is for a release. Only where that event can
+         * arrive: outside elastic mode no campaign is recorded, so the grant
+         * stays the answer. Unlike serve_release_req the extend does not
+         * refuse there - it has already done what was asked of Slurm. */
+#if PRTE_HAVE_DVM_MOD_EVENTS
+        if (prte_elastic_mode && requester_recorded) {
+            req->pstatus = PMIX_OPERATION_IN_PROGRESS;
+        }
+#endif
     }
 
     /* Execute callback if necessary */

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1249,6 +1249,17 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
         goto complete;
     }
 
+    /* Record who asked. The grow campaign resolves its requesters through the
+     * node's PRTE_NODE_ALLOC_ID to this session, so without it neither the
+     * completion nor a launch failure reaches anyone. Only for an extend: an
+     * allocation discovered at startup was requested by no one. */
+    {
+        prte_session_t *session = prte_get_session_object_from_id(job_id);
+        if (NULL != session) {
+            PMIX_XFER_PROCID(&session->requestor, &req->tproc);
+        }
+    }
+
     err = prte_ras_slurm_add_reused_nodes_to_session(job_id, &reused_nodes);
 
     if (PRTE_SUCCESS != err) {

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -434,11 +434,19 @@ cleanup:
 /**
  * @brief Return phase-one release acceptance to the requester.
  *
+ * IN_PROGRESS promises a phase two, so only say it where one can be sent:
+ * prte_plm_base_dvm_mod_notify compiles away when the PMIx in use defines
+ * neither DVM modification event code.
+ *
  * @param[in] req PMIx release request.
  */
 static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req)
 {
+#if PRTE_HAVE_DVM_MOD_EVENTS
     req->pstatus = PMIX_OPERATION_IN_PROGRESS;
+#else
+    req->pstatus = PMIX_SUCCESS;
+#endif
     if (NULL != req->infocbfunc) {
         req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
                         prte_pmix_server_req_release, req);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -107,16 +107,19 @@ static void grow_campaign_construct(prte_grow_campaign_t *p)
 {
     p->targets = NULL;
     p->ntargets = 0;
-    PMIX_PROC_LOAD(&p->requester, NULL, PMIX_RANK_INVALID);
-    p->alloc_id = NULL;
-    p->req_id = NULL;
-    p->have_requester = false;
+    p->requesters = NULL;
+    p->nrequesters = 0;
 }
 static void grow_campaign_destruct(prte_grow_campaign_t *p)
 {
+    int r;
+
     free(p->targets);
-    free(p->alloc_id);
-    free(p->req_id);
+    for (r = 0; r < p->nrequesters; r++) {
+        free(p->requesters[r].alloc_id);
+        free(p->requesters[r].req_id);
+    }
+    free(p->requesters);
 }
 PMIX_CLASS_INSTANCE(prte_grow_campaign_t, pmix_list_item_t,
                     grow_campaign_construct, grow_campaign_destruct);

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -18,6 +18,8 @@
  * Copyright (c) 2017-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -675,17 +677,23 @@ PRTE_EXPORT extern pmix_list_t prte_shrink_campaigns;
  * the WIREUP xcast, or on failure when one of the targets dies — so that
  * jobs held at the VM_READY → MAP boundary are not admitted before the new
  * daemons are wired up. */
+/* One recipient of a grow's phase-two completion event, with the ids naming
+ * which of its requests completed. */
+typedef struct {
+    pmix_proc_t      requester;
+    char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation, or NULL */
+    char            *req_id;         /* requester's PMIX_ALLOC_REQ_ID, or NULL */
+} prte_grow_requester_t;
+
 typedef struct {
     pmix_list_item_t super;
     pmix_rank_t     *targets;   /* daemon ranks being launched */
     int              ntargets;  /* count, == this campaign's fence contribution */
-    /* requester recorded so the spec's phase-two completion event can be
-     * directed at the process that drove the grow; left unset
-     * (have_requester == false) for a scheduler-driven push */
-    pmix_proc_t      requester;
-    char            *alloc_id;       /* PMIX_ALLOC_ID of the allocation, or NULL */
-    char            *req_id;         /* requester's PMIX_ALLOC_REQ_ID, or NULL */
-    bool             have_requester;
+    /* Everyone this campaign answers for. A campaign covers whatever awaited
+     * a daemon when setup_virtual_machine ran, which can be several grows.
+     * Empty for the initial bring-up or a scheduler-driven push. */
+    prte_grow_requester_t *requesters;
+    int              nrequesters;
 } prte_grow_campaign_t;
 PMIX_CLASS_DECLARATION(prte_grow_campaign_t);
 

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -963,8 +963,8 @@ static int test_object_lifetimes(void)
               NULL == sc->targets && NULL == sc->alloc_id && NULL == sc->req_id
                   && 0 == sc->ntargets && !sc->have_requester);
         CHECK("lifetime: grow campaign starts empty",
-              NULL == gc->targets && NULL == gc->alloc_id && NULL == gc->req_id
-                  && 0 == gc->ntargets && !gc->have_requester);
+              NULL == gc->targets && NULL == gc->requesters
+                  && 0 == gc->ntargets && 0 == gc->nrequesters);
         /* destructing an untouched campaign must not free garbage */
         PMIX_RELEASE(sc);
         PMIX_RELEASE(gc);


### PR DESCRIPTION
## Problem

A `PMIX_ALLOC_EXTEND` served by `ras/slurm` answers `PMIX_SUCCESS` the moment
Slurm grants the nodes — before `setup_virtual_machine` has run, let alone
before a daemon is up on any of them. The requester is told it has resources
it cannot yet use.

A spawn issued in that window is safe, because the launch fence parks it at
the `VM_READY → MAP` boundary, so for spawn this is only a reporting gap. The
real defect is the failure case. `prte_plm_base_grow_target_failed` rolls the
campaign back and notifies only `if (camp->have_requester)`, and
`have_requester` came from scanning the campaign's targets for
`node->session->requestor`. A Slurm extend's nodes deliberately carry
`node->session == NULL` — they belong in the general pool — and its tracking
session never set `requestor`. So a daemon that failed to start on a newly
granted node produced a **silent** rollback: the requester had been told
`SUCCESS`, holds an allocation id, and the nodes it believes it has are gone.

Shrink has done this correctly all along — phase one
`PMIX_OPERATION_IN_PROGRESS`, phase two `PMIX_DVM_IS_READY` when the campaign
drains. The asymmetry is an artifact of *where* each campaign is built (the
shrink's in `ras/base` with the request in hand, the grow's in
`setup_virtual_machine`, two state transitions later), not a decision anyone
made about grows.

## What this does

An extend now answers `PMIX_OPERATION_IN_PROGRESS` with the allocation id when
Slurm grants and the grow begins, then `PMIX_DVM_IS_READY` — or
`PMIX_ERR_DVM_MOD`, the case that reported nothing at all before — when the DVM
has actually resized.

The association between a grow and whoever asked for it lives **on the nodes**,
not in a global slot. `ras/slurm` records `session->requestor` on the per-jobid
tracking session, and `setup_virtual_machine` resolves it from each target's
`PRTE_NODE_ALLOC_ID` when `node->session` is NULL. That is what makes
concurrent extends correct: each node names its own request, so one campaign
can answer several. A single-slot pending requester would have let a second
extend overwrite the first, and the first would then hang forever — strictly
worse than the terminal `SUCCESS` it replaced.

A campaign therefore holds N requesters rather than one. `prte_grow_campaign_t`
grows a `prte_grow_requester_t` array, and both `grow_drain` and
`grow_target_failed` loop over it.

## Deliberate constraints

- **Extends keep working with `prte_elastic_mode` off.** No campaign is
  recorded there, so no event could ever arrive; phase one stays terminal.
  Note the asymmetry with `serve_release_req`, which *refuses* outright
  outside elastic mode — the extend does not, because it has already done what
  was asked of Slurm.
- **Both phase-one statuses are behind `#if PRTE_HAVE_DVM_MOD_EVENTS`.**
  `prte_plm_base_dvm_mod_notify` compiles away without the event codes, so
  promising a phase two there would strand the requester.
- **The flip is gated on the requestor actually being recorded.** If the
  tracking session cannot be found, the extend falls back to terminal
  `PMIX_SUCCESS` rather than promising an event nothing can send.
- **Changes outside `ras/slurm` are additive.** `plm/base` gains three static
  helpers and a wider campaign scan; no existing branch moved.

Nodes carry `PRTE_NODE_ALLOC_ID` after they leave the allocation that set it,
so the resolver checks the session's own node list before trusting the tag —
otherwise a node shrunk out of one allocation and re-absorbed by a later,
unrelated grow would attribute that grow to the wrong requester.

## Incidental fix (separate commit)

`prte_ras_slurm_complete_release_request` returned `PMIX_OPERATION_IN_PROGRESS`
unconditionally, so on a build without the event codes a release was answered
once and never again. Same `#if`, falling back to `PMIX_SUCCESS`.