### PR TITLE
Count a terminated proc once, even when it failed

### DIFF
--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -514,13 +514,35 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             PRTE_ACTIVATE_PROC_STATE(proc, PRTE_PROC_STATE_TERMINATED);
         }
     } else if (PRTE_PROC_STATE_TERMINATED == state) {
-        if (pdata->state == state) {
+        /* Have we already counted this proc?  Ask the flag, not the state
+         * word.  Testing "pdata->state == state" looks equivalent and is not,
+         * for exactly the procs this matters most for: every failure state is
+         * PRTE_PROC_STATE_ERROR (50) + n, i.e. GREATER than
+         * PRTE_PROC_STATE_TERMINATED (20), so the assignment below - guarded
+         * by "< TERMINATED" so a terminal diagnosis is never overwritten by
+         * the generic one - deliberately leaves such a proc's state above
+         * TERMINATED.  The comparison therefore never matches for a proc that
+         * failed, and every repeat activation counted it again.
+         *
+         * A repeat is not hypothetical on the HNP: for a *remote* failed proc
+         * errmgr/dvm force-marks WAITPID_FIRED and IOF_COMPLETE ("we won't
+         * hear anything more about it"), and its daemon then relays the real
+         * pair as well - two completions, two counts, for one proc.
+         * num_terminated then reaches num_procs while a survivor is still
+         * running, the job is declared NORMALLY TERMINATED, and the DVM is
+         * torn down under that survivor: its final output is discarded and it
+         * never terminates properly.  Seen as an intermittently missing last
+         * line from a random rank whenever a job had a failure in it.
+         *
+         * state/prted has always used the flag here; this is the same test. */
+        if (PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_RECORDED)) {
             pmix_output_verbose(5, prte_state_base_framework.framework_output,
-                                "%s state:base:track_procs proc %s already in state %s. Skip transition.",
+                                "%s state:base:track_procs proc %s already recorded as %s. Skip transition.",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
                                 prte_proc_state_to_str(state));
             goto cleanup;
         }
+        PRTE_FLAG_SET(pdata, PRTE_PROC_FLAG_RECORDED);
 
         /* update the proc state */
         PRTE_FLAG_UNSET(pdata, PRTE_PROC_FLAG_ALIVE);


### PR DESCRIPTION
`prte_state_base_track_procs` guarded its `num_terminated` accounting with
`pdata->state == PRTE_PROC_STATE_TERMINATED`, which is not the same question as
"have we already counted it". Every failure state is
`PRTE_PROC_STATE_ERROR + n`, i.e. *greater* than `TERMINATED`, and the
assignment below it is guarded by `< TERMINATED` so that a terminal diagnosis is
not overwritten by the generic one. A failed proc's state therefore stays above
`TERMINATED` for good, the guard never matches it, and every repeat activation
counts it again.

Repeats are routine on the HNP. For a remote failed proc `errmgr/dvm`
force-marks `WAITPID_FIRED` and `IOF_COMPLETE` — "we won't hear anything more
about it" — and the owning daemon then relays the genuine pair as well. So
`num_terminated` overshoots, reaches `num_procs` while a survivor is still
running, and the job is declared normally terminated with the DVM coming down
underneath that survivor. Which rank loses out is simply whichever was slowest,
which is why this presented as a rank *intermittently* losing its last line of
output rather than as anything that looked like an accounting bug.

The fix is to test `PRTE_PROC_FLAG_RECORDED` instead. `state/prted` already did;
this makes the DVM side agree.

### Testing

`make check` passes. In `contrib/dockerswarm`, a job with a deliberately failing
rank lost a line in 7 of 8 runs before and 0 of 10 after; the harness's
recoverable-failure case went from intermittently failing to 0/20, and now shows
all 14 expected lines rather than the 12–13 it used to "pass" with.

### Relationship to #2641

Independent of #2641, which touches a disjoint set of files (`src/rml`,
`plm/base`) and can merge in either order. The two are worth mentioning in the
same breath only because the full ten-node suite results quoted in #2641 were
measured with **both** applied: without this fix, that suite carries an
intermittent failure in its recoverable-failure case, so a clean run of #2641 on
its own should not be expected until this one lands.
