### PR TITLE
Tell a launched daemon which vpids have already departed

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5861,6 +5861,59 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "elastic DVM: a daemon re-grown into a vpid hole gets a live parent"
+    # The same shape as the case above, but at a radix small enough for the
+    # daemon tree to have depth -- which is the only way this defect is
+    # visible. A daemon launched into a DVM that has already shrunk starts with
+    # an EMPTY departed-rank set, so it computes its first routing tree from
+    # raw radix math and can pick a retired vpid as its parent. Everything it
+    # then sends upward is addressed to a rank nothing can contact, including
+    # the warm-up that asks for the nidmap that would have corrected the set --
+    # so it never learns, never reports in, and every job touching that node
+    # hangs. The launcher therefore carries the departed set on the prted
+    # command line (rml_base_dead_dmns), which is the only moment early enough.
+    #
+    # At the DEFAULT radix every daemon's parent is rank 0, which is always
+    # alive, so the whole thing is invisible -- the case above passes with the
+    # DVM in exactly this state. Hence the explicit radix here: without it this
+    # suite never exercises the fix at all.
+    #
+    # The vpids matter. grow node2,node3 -> shrink node3 -> grow node4 ->
+    # re-grow node3 gives node1=0, node2=1, node3(old)=2 (retired), node4=3,
+    # node3(new)=4 -- and at radix 2 the raw parent of rank 4 is rank 2.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 \
+                    --prtemca rml_base_radix 2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        RUN 'timeout 90 elastic grow node2:2,node3:2' >/dev/null 2>&1
+        RUN 'timeout 90 elastic shrink node3' >/dev/null 2>&1; sleep 3
+        RUN 'timeout 90 elastic grow node4:2' >/dev/null 2>&1; sleep 3
+        out=$(RUN 'timeout 90 elastic grow node3:2' 2>&1); sleep 3
+        echo "$out" | grep -q "SUCCESS\|PMIX_DVM_IS_READY" \
+            && ok "the re-grow into the vpid hole completed at radix 2" \
+            || bad "re-grow into the vpid hole did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        [ "$(prted_count 3)" = 1 ] && ok "a daemon is running on the re-grown node" \
+                                   || bad "no daemon on the re-grown node"
+        # The proof: a job spanning every node. The re-grown daemon can only
+        # report its procs launched if its lifeline is a rank that still
+        # exists, so a node missing from this output is the stranded daemon.
+        out=$(RUN 'timeout 60 prun -n 4 --map-by ppr:1:node hostname' 2>&1)
+        for n in node1 node2 node3 node4; do
+            echo "$out" | grep -qw "$n" \
+                && ok "$n ran its proc after the deep-tree re-grow" \
+                || bad "$n launched nothing after the deep-tree re-grow (departed set not carried at launch)"
+        done
+        # ...and the DVM is still usable afterwards, so a wedged daemon cannot
+        # pass the above by having merely delayed
+        out=$(RUN 'timeout 60 prun --host node3 -n 1 hostname' 2>&1 | tr -d '\r')
+        [ "$out" = node3 ] && ok "the re-grown node serves a job of its own" \
+                           || bad "the re-grown node is wedged: $out"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the deep-tree re-grow test"
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: a grow launches ONLY on the nodes it was given"
     # An allocation request naming node4 must start a daemon on node4 and
     # nowhere else. Shrink node2 first so the DVM holds a node that is in the

--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -210,6 +210,21 @@ transport layers:
   routes around the hole instead of addressing a reused-looking but dead vpid.
   (The DVM never reuses a daemon vpid.)
 
+* **The departure set reaches a new daemon at launch, not by message.**  A
+  daemon started into a DVM that has already shrunk needs those holes *before*
+  it computes its first routing tree, and no message can deliver them: with the
+  wrong tree, everything it sends upward — including the warm-up that asks for
+  the nidmap that would correct it — is addressed to a retired vpid nothing can
+  contact, so it never learns, never reports in, and every job placed on it
+  hangs.  The launcher therefore renders the set onto the ``prted`` command
+  line as ``rml_base_dead_dmns`` — a range-collapsed list such as ``2,7:9``,
+  colon-separated because a released PMIx refuses an MCA value whose second
+  character is a dash — and the daemon adopts it in ``prte_rml_open`` before
+  the first tree is built.  The daemon this strands is the one whose
+  fault-free radix parent *is* a retired vpid, so at the default radix, where
+  every daemon's parent is the HNP, the problem does not arise; it needs a
+  tree with depth.
+
 * **A leaving daemon departs on the first lost route.**  When
   ``prte_dvm_leaving`` is set — this daemon was named as a shrink target —
   ``prte_rml_route_lost`` terminates immediately on *any* dropped connection

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2123,6 +2123,25 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
     pmix_argv_append(argc, argv, "prte_hnp_uri");
     pmix_argv_append(argc, argv, prte_process_info.my_hnp_uri);
 
+    /* Pass the ranks that have permanently departed this DVM, if any. The vpid
+     * span above says how big the DVM is, but not which vpids inside it are
+     * holes, and a daemon we are launching into a DVM that has already shrunk
+     * needs both to compute its first routing tree correctly. It cannot be told
+     * afterwards: with the wrong tree its every message upward - including the
+     * warm-up that asks for the nidmap - is addressed to a retired vpid that
+     * nothing can contact, so it never hears the correction and never reports
+     * in. The daemon whose raw-radix parent happens to BE the retired vpid is
+     * the one this strands, which is why it stays invisible at the default
+     * radix, where every daemon's parent is rank 0 (#2491). */
+    param = prte_rml_render_dead_dmns();
+    if (NULL != param) {
+        pmix_argv_append(argc, argv, "--prtemca");
+        pmix_argv_append(argc, argv, "rml_base_dead_dmns");
+        pmix_argv_append(argc, argv, param);
+        free(param);
+        param = NULL;
+    }
+
     /* Tell the daemon whether this DVM is persistent. Only the HNP knows -
      * it is decided in prte(), which no daemon runs - and a daemon that is
      * not told simply assumes the default. Pass it only when true, since

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -267,6 +267,28 @@ connection path.
   (#2491). The DVM never reuses a daemon vpid, so a hole in `[0, num_daemons)`
   is permanent.
 
+- **A daemon we LAUNCH is told the departure set on its command line**, by
+  `prte_plm_base_prted_append_basic_args` (`rml_base_dead_dmns`, a
+  range-collapsed list such as `2,7:9` — colon-separated, because every
+  released PMIx refuses an MCA value whose second character is a dash), and
+  adopts it in `prte_rml_open` **before** the first
+  `compute_routing_tree`. That ordering is the whole point and is not a
+  convenience: a newcomer with an empty set computes its lifeline from raw
+  radix math, and if that lands on a retired vpid then everything it sends
+  upward — including the warm-up that requests the nidmap that would correct
+  the set — is addressed to a rank nothing can contact. It never learns, never
+  reports in, and every job placed on it hangs. **So do not "simplify" this
+  into a message.** There is no message early enough; the correction would have
+  to travel over the tree it is meant to correct. `ess_base_num_procs` travels
+  the same way for the same reason — the span and the holes in it are both
+  needed to build the first tree, and both can only arrive at launch.
+
+  Only the daemon whose fault-free parent *is* a retired vpid is stranded, so
+  at the default radix (every daemon's parent is rank 0) nothing goes wrong and
+  the whole class of bug is invisible. The swarm case that covers it therefore
+  forces `rml_base_radix 2` explicitly; a suite run at the default radix does
+  not exercise this at all.
+
 - **A leaving daemon exits on the first lost route.** `prte_rml_route_lost`
   checks `prte_dvm_leaving` first: if this daemon has been named as a shrink
   target, it activates `PRTE_JOB_STATE_DAEMONS_TERMINATED` on *any* dropped

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -65,6 +65,9 @@ prte_rml_base_t prte_rml_base = {
 uint64_t prte_rml_boot_epoch = 0;
 
 static int verbosity = 0;
+/* the departed-rank list handed to us on the command line, if any - owned by
+ * the MCA variable system, not by us */
+static char *dead_dmns_spec = NULL;
 
 /* The incarnation table is the one piece of RML state a peer's socket handler
  * reaches directly, and that handler runs on whichever base is servicing the
@@ -149,6 +152,95 @@ uint64_t prte_rml_get_epoch(pmix_rank_t rank)
     return 0;
 }
 
+char *prte_rml_render_dead_dmns(void)
+{
+    char **entries = NULL;
+    char *result, *tmp;
+    int n, sz, start;
+
+    sz = pmix_bitmap_size(&prte_rml_base.dead_dmns);
+    for (n = 0; n < sz; n++) {
+        if (!pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, n)) {
+            continue;
+        }
+        /* Collapse a run into "first:last". A DVM that has shrunk repeatedly
+         * can otherwise put hundreds of numbers onto a command line that is
+         * already measured against _SC_ARG_MAX by every launcher.
+         *
+         * The separator is a colon rather than the dash such a range is
+         * usually written with, because this value goes on a command line:
+         * every released PMIx that PRRTE accepts (>= 6.1.0) refuses an MCA
+         * value whose second character is a dash, reading it as a missing
+         * argument, so "2-3" would fail to launch. The fix for that is on PMIx
+         * master only and in no tag. */
+        start = n;
+        while (n + 1 < sz && pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, n + 1)) {
+            ++n;
+        }
+        if (start == n) {
+            pmix_asprintf(&tmp, "%d", start);
+        } else {
+            pmix_asprintf(&tmp, "%d:%d", start, n);
+        }
+        PMIx_Argv_append_nosize(&entries, tmp);
+        free(tmp);
+    }
+
+    if (NULL == entries) {
+        return NULL;
+    }
+    result = PMIx_Argv_join(entries, ',');
+    PMIx_Argv_free(entries);
+    return result;
+}
+
+void prte_rml_load_dead_dmns(const char *spec)
+{
+    char **entries;
+    int n;
+    long r, first, last;
+    char *end;
+    bool ok;
+
+    if (NULL == spec || '\0' == spec[0]) {
+        return;
+    }
+
+    entries = PMIx_Argv_split(spec, ',');
+    if (NULL == entries) {
+        return;
+    }
+    for (n = 0; NULL != entries[n]; n++) {
+        ok = false;
+        end = NULL;
+        first = strtol(entries[n], &end, 10);
+        if (end != entries[n] && 0 <= first) {
+            if (':' == *end) {
+                char *p = end + 1;
+                last = strtol(p, &end, 10);
+                ok = (end != p && last >= first);
+            } else {
+                last = first;
+                ok = true;
+            }
+            /* the whole entry has to be consumed, and a rank outside the DVM's
+             * vpid span is not a hole in it */
+            if (ok && ('\0' != *end || (long) prte_process_info.num_daemons <= last)) {
+                ok = false;
+            }
+        }
+        if (!ok) {
+            pmix_output(0, "PRRTE: ignoring malformed departed-daemon rank \"%s\"",
+                        entries[n]);
+            continue;
+        }
+        for (r = first; r <= last; r++) {
+            pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, (int) r);
+        }
+    }
+    PMIx_Argv_free(entries);
+}
+
 void prte_rml_register(void)
 {
     int ret;
@@ -194,6 +286,19 @@ void prte_rml_register(void)
                        " - using 2", prte_rml_base.radix);
         prte_rml_base.radix = 2;
     }
+
+    /* The ranks that had already departed the DVM when we were launched. Only
+     * a launcher sets this, on the prted command line: a daemon started into a
+     * DVM that has lost ranks has to know which they are BEFORE it computes its
+     * first routing tree, and no message can tell it - the request would have
+     * to travel over the very tree it has not got right. See prte_rml_open. */
+    dead_dmns_spec = NULL;
+    pmix_mca_base_var_register("prte", "rml", "base", "dead_dmns",
+                               "Comma-separated daemon vpids (ranges as first:last, e.g. \"2,7:9\")"
+                               " that had permanently departed the DVM when this daemon was"
+                               " launched. Set by the launcher; not intended for users",
+                               PMIX_MCA_BASE_VAR_TYPE_STRING,
+                               &dead_dmns_spec);
 
     prte_oob_register();
 
@@ -289,6 +394,16 @@ int prte_rml_open(void)
                   prte_rml_recv_return_request, NULL);
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_REVIVED, true,
                   prte_rml_recv_revival_notice, NULL);
+
+    /* Adopt the departed ranks our launcher told us about, BEFORE the first
+     * tree computation below. A daemon launched into a DVM that has already
+     * shrunk starts with an empty dead set, so the raw radix math can hand it a
+     * retired vpid as its parent - and then every message it sends upward,
+     * including the warm-up that asks for the nidmap that would have corrected
+     * the set, is addressed to a rank nothing can contact. The DVM never reuses
+     * a daemon vpid, so the hole is permanent and this is the only moment the
+     * newcomer can learn of it (#2491). */
+    prte_rml_load_dead_dmns(dead_dmns_spec);
 
     /* compute the routing tree - only thing we need to know is the
      * number of daemons in the DVM */

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -386,6 +386,13 @@ PRTE_EXPORT uint64_t prte_rml_get_epoch(pmix_rank_t rank);
 PRTE_EXPORT void prte_rml_register(void);
 PRTE_EXPORT void prte_rml_close(void);
 PRTE_EXPORT int prte_rml_open(void);
+/* Render dead_dmns as a compact, range-collapsed list ("2,7:9") for the prted
+ * command line, or NULL when nothing has departed. The caller frees it. The
+ * partner routine loads such a list back into dead_dmns; it is what a daemon
+ * launched into a DVM that has already lost ranks uses to build its FIRST
+ * routing tree, since nothing it could receive would arrive in time. */
+PRTE_EXPORT char *prte_rml_render_dead_dmns(void);
+PRTE_EXPORT void prte_rml_load_dead_dmns(const char *spec);
 /* common implementations */
 PRTE_EXPORT void prte_rml_base_post_recv(int sd, short args, void *cbdata);
 PRTE_EXPORT void prte_rml_base_process_msg(int fd, short flags, void *cbdata);

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -465,6 +465,110 @@ static int test_departed_ranks_survive_recompute(void)
 }
 
 /*
+ * The departed set has to reach a daemon we are LAUNCHING, on its command
+ * line, because nothing it could receive would arrive in time: with an empty
+ * dead set the raw radix math can make a retired vpid its parent, and then
+ * every message it sends upward -- including the warm-up that asks for the
+ * nidmap that would correct the set -- is addressed to a rank nothing can
+ * contact.  prte_rml_render_dead_dmns() writes the list, and
+ * prte_rml_load_dead_dmns() reads it back before the first tree computation.
+ */
+static int test_dead_dmns_round_trip(void)
+{
+    int failures = 0;
+    char *spec;
+
+    /* nothing departed renders as nothing at all, so the launcher adds no
+     * argument to the ordinary case */
+    bitmaps_reset();
+    prte_process_info.num_daemons = 8;
+    spec = prte_rml_render_dead_dmns();
+    CHECK("an intact DVM renders no departed list", NULL == spec);
+    free(spec);
+
+    /* isolated ranks and runs, collapsed -- a repeatedly-shrunk DVM must not
+     * put hundreds of numbers on a command line measured against _SC_ARG_MAX */
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 2);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 7);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 8);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 9);
+    prte_process_info.num_daemons = 16;
+    spec = prte_rml_render_dead_dmns();
+    CHECK("a departed list is rendered", NULL != spec);
+    if (NULL != spec) {
+        CHECK("runs are collapsed into ranges", 0 == strcmp(spec, "2,7:9"));
+        /* This value goes on a command line, and every RELEASED PMIx that
+         * PRRTE accepts refuses an MCA value whose second character is a dash
+         * -- it reads it as a missing argument -- so a range written "2-3"
+         * would fail to launch.  Guard the separator, not just the shape. */
+        CHECK("no dash is used as the range separator", NULL == strchr(spec, '-'));
+    }
+
+    /* and reading it back into a fresh daemon reproduces the set exactly */
+    bitmaps_reset();
+    prte_rml_load_dead_dmns(spec);
+    free(spec);
+    CHECK("a single departed rank round-trips",
+          pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, 2));
+    CHECK("a range round-trips at its start",
+          pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, 7));
+    CHECK("a range round-trips in its middle",
+          pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, 8));
+    CHECK("a range round-trips at its end",
+          pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, 9));
+    CHECK("a live rank is not marked departed",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, 3));
+
+    /* garbage must not take the daemon down, and must not be believed */
+    bitmaps_reset();
+    prte_rml_load_dead_dmns(NULL);
+    prte_rml_load_dead_dmns("");
+    prte_rml_load_dead_dmns("bogus,3x,9:4,,-2,4:");
+    CHECK("a malformed list marks nothing",
+          pmix_bitmap_is_clear(&prte_rml_base.dead_dmns));
+    /* a rank outside the DVM's vpid span is not a hole in it */
+    prte_process_info.num_daemons = 4;
+    prte_rml_load_dead_dmns("9");
+    CHECK("a rank beyond the vpid span is refused",
+          pmix_bitmap_is_clear(&prte_rml_base.dead_dmns));
+
+    /*
+     * The case the whole mechanism exists for: a daemon launched as rank 4
+     * into a radix-2 DVM of 5 whose rank 2 was shrunk out.  Told nothing, it
+     * parents onto the retired vpid; told the list, it does not.  At the
+     * default radix every daemon's parent is rank 0, which is why this stayed
+     * invisible for so long -- so assert the default-radix case is unaffected
+     * too, rather than only that the fix fires.
+     */
+    bitmaps_reset();
+    build_dvm(2, 5, 4);
+    CHECK("without the departed list a newcomer parents onto the retired vpid",
+          2 == prte_rml_base.lifeline);
+
+    bitmaps_reset();
+    prte_process_info.num_daemons = 5;
+    prte_rml_load_dead_dmns("2");
+    build_dvm(2, 5, 4);
+    CHECK("with the departed list it does not",
+          2 != prte_rml_base.lifeline);
+    CHECK("and its lifeline is a live rank",
+          prte_rml_is_node_up(prte_rml_base.lifeline));
+
+    bitmaps_reset();
+    prte_process_info.num_daemons = 5;
+    prte_rml_load_dead_dmns("2");
+    build_dvm(64, 5, 4);
+    CHECK("at the default radix the newcomer still parents onto the HNP",
+          0 == prte_rml_base.lifeline);
+
+    bitmaps_reset();
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_dead_dmns_round_trip\n");
+    }
+    return failures;
+}
+
+/*
  * get_num_contributors counts how many of my child subtrees a set of daemons
  * falls into -- what a collective uses to know how many reports to expect.
  * Failed ranks contribute nothing.
@@ -717,6 +821,7 @@ int main(void)
     failures += test_radix_traversal();
     failures += test_routing_tree();
     failures += test_departed_ranks_survive_recompute();
+    failures += test_dead_dmns_round_trip();
     failures += test_num_contributors();
     failures += test_lateral_links();
     failures += test_epoch_guard();


### PR DESCRIPTION
A daemon started into a DVM that has already shrunk is told how big the DVM is
— `ess_base_num_procs` carries the vpid span — but not which vpids inside that
span are holes. It therefore begins with an empty departed set, computes its
first routing tree from the fault-free radix positions, and can be handed the
vpid of a daemon that was shrunk out. Everything it then sends upward is
addressed to a rank nothing can contact, including the warm-up that asks for the
nidmap that would have told it about the hole. It never learns, never reports
in, and every job placed on that node hangs.

The set has to be in hand *before* the first tree is computed, and no message
can deliver it: the correction would have to travel over the tree it is meant to
correct. So `dead_dmns` is rendered onto the prted command line beside the span
it belongs with, and adopted in `prte_rml_open` ahead of
`prte_rml_compute_routing_tree` — which already restores those marks into the
failed set and routes around them, so the fix is the ordering rather than any
new routing logic.

Measured on the same daemon in `contrib/dockerswarm`, before and after
(grow node2,node3 → shrink node3 → grow node4 → re-grow node3, at radix 2):

| | before | after |
|---|---|---|
| `dead_dmns` | `0x0` | `0x4` |
| lifeline | 2 (a retired vpid) | 0 |
| node pool | empty | all four nodes |
| `prun -n 4 --map-by ppr:1:node` | no output | node1–node4 |

The node pool filling is the confirmation: with a live parent the daemon can
reach the HNP at last, so the nidmap finally arrives.

**Only the daemon whose fault-free parent is itself a retired vpid is
stranded**, so at the default radix — where every daemon's parent is the HNP —
nothing goes wrong and the whole class of failure is invisible. The swarm case
added here therefore sets `rml_base_radix` explicitly rather than relying on the
suite's default; without that, this is never exercised. Note that CI runs at the
default radix, so CI cannot catch a regression here either.

It also clears the neighbouring case in which a grown node appeared not to
inherit its topology from a survivor. That was never a topology problem — it was
the same daemon being unable to talk upward.

Ranges in the rendered list are written `first:last` rather than `first-last`
because the value travels on a command line, and every released PMIx this
accepts refuses an MCA value whose second character is a dash, reading it as a
missing argument (the parser fix is on PMIx master only, in no tag). The unit
test asserts that no dash is emitted, so that cannot quietly come back.

### Testing

* `make check` 20/20. A new `test_dead_dmns_round_trip` covers the render/parse
  round trip, malformed input, refusal of a rank outside the vpid span, and the
  failure shape itself — radix 2, five daemons, rank 4: lifeline 2 without the
  list, not 2 with it, and still 0 at the default radix.
* `make -C test/offline check-offline` 1180/0.
* Docs build clean.
* `contrib/dockerswarm` full suite, ten nodes: **533 passed / 1 failed at the
  default radix and with `rml_base_radix=2` forced swarm-wide** — the two now
  agree. Before this change the radix-2 run was 519 / 8.

The one remaining failure is unrelated to this branch and reproduces on master
at both radices: `ras/slurm`'s `PMIX_ALLOC_EXTEND` answers
`PMIX_OPERATION_IN_PROGRESS` with an empty info array, so no `PMIX_ALLOC_ID`
reaches the requester and phase two never arrives. It appears to have arrived
with the recent two-phase extend work. Worth knowing that `run-tests.sh` returns
out of the whole `ras/slurm` section on it, so five later slurm phases stop
running and the failure count understates it.

### Relationship to #2640

Independent of #2640, which touches a disjoint set of files
(`src/mca/state/base`) and can merge in either order. They are worth mentioning
together only because the suite figures above were measured with **both**
applied: without #2640 the suite carries an intermittent failure in its
recoverable-failure case, so reproducing a clean 533/1 from this branch alone
needs #2640 as well.
