### PR TITLE
examples/slurm: wait for the DVM to resize, and make cancel usable

### DIFF
--- a/examples/slurm/README
+++ b/examples/slurm/README
@@ -13,10 +13,21 @@ count, allocation ID, or node list. After every request it queries PRRTE's
 allocation state and displays the corresponding Slurm jobs; a separate `dvm`
 command uses prun to verify reachability across the active DVM.
 
-The client treats the PMIx allocation callback as request acceptance and uses
-allocation queries to observe the resulting state. It does not require the
-application to wait for a PMIX_DVM_IS_READY event because PRRTE coordinates
-launches internally with the DVM launch fence.
+Extend and shrink are answered in two phases. The allocation callback reports
+PMIX_OPERATION_IN_PROGRESS with the allocation id once the scheduler has acted;
+PMIX_DVM_IS_READY (or PMIX_ERR_DVM_MOD) follows when the DVM itself has been
+resized and the nodes can carry work. The client registers a handler for both
+and correlates them with the request by PMIX_ALLOC_REQ_ID. Built against a PMIx
+that does not define those codes, it falls back to treating the grant as the
+answer.
+
+Only an extend can be cancelled, and only while the scheduler still has it
+queued; after the grant the resources are held and giving them back is a
+shrink. A shrink is never cancellable: ras/slurm records a cancellable request
+on the extend path alone.
+
+Requests are submitted and watched in the background, so the prompt returns at
+once and `cancel` can be typed during that window.
 
 Build from the examples directory with:
 
@@ -35,10 +46,12 @@ Then run inside a Slurm allocation with one initial node:
 
 At the coord prompt, available commands are:
 
-    extend count N
+    extend count N [as REQUEST_NAME]
     shrink count N
     shrink alloc SLURM_JOB_ID
     shrink list NODE1,NODE2
+    cancel [REQUEST_NAME]
+    pending
     prun [ARGS...]
     dvm
     refresh
@@ -49,9 +62,27 @@ same and then also runs a `prun`-based reachability probe (one process
 per node, echoing back its hostname) to confirm every daemon in the DVM
 is actually reachable.
 
+Every request carries a name, which is what `cancel` takes. An extend accepts
+`as REQUEST_NAME`; otherwise the name is generated, counting requests in the
+session: `extend-1`, `shrink-2`. Only an extend accepts a name, because only an
+extend can be cancelled. `pending` lists what is in flight and whether it can
+still be cancelled; `cancel` with no argument withdraws the only cancellable
+request.
+
+`cancel` reports PMIX_ERR_NOT_FOUND both for a name that was never submitted
+and for one the scheduler has already granted; ras/slurm does not distinguish
+them.
+
+The program refuses to start outside a Slurm job, or when PRRTE does not know
+that job's allocation. It cannot check elastic mode - the parameter has no PMIx
+query, and PRRTE strips PRTE_* from a launched process's environment - so a
+note at startup reminds you. Without elastic mode an extend still adds nodes
+but answers in one phase and raises no completion event.
+
 The program invokes squeue and prun for diagnostics, so both commands must be
 available in PATH.
 
-The program may not tolerate delays while acquiring additional resources. It
-is therefore best run in a containerized Slurm environment where requested
-resources are available immediately.
+A request the scheduler has not answered within five minutes is abandoned by
+its watcher; the request itself stays live with PRRTE. The program is easiest
+to follow in a containerized Slurm environment where requested resources are
+available immediately.

--- a/examples/slurm/elastic-coordination.c
+++ b/examples/slurm/elastic-coordination.c
@@ -37,10 +37,15 @@ static void trace_point(const char *msg)
     fflush(stdout);
 }
 
+/* Reference counted because a timeout does not withdraw the request: PMIx
+ * keeps the cbdata pointer and still runs the callback whenever the scheduler
+ * answers, which may be long after the submitting call has given up. The
+ * submitter and the callback each hold a reference; the last one out frees. */
 typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t cond;
     int done;
+    int refs;
     pmix_status_t status;
 } wait_t;
 
@@ -56,18 +61,34 @@ typedef struct {
     size_t size;
 } alloc_snapshot_t;
 
-static void wait_init(wait_t *w)
+static wait_t *wait_new(void)
 {
+    wait_t *w = calloc(1, sizeof(*w));
+
+    if (NULL == w) {
+        return NULL;
+    }
     pthread_mutex_init(&w->lock, NULL);
     pthread_cond_init(&w->cond, NULL);
     w->done = 0;
+    w->refs = 2;
     w->status = PMIX_SUCCESS;
+    return w;
 }
 
-static void wait_destroy(wait_t *w)
+static void wait_release(wait_t *w)
 {
+    int last;
+
+    pthread_mutex_lock(&w->lock);
+    last = (0 == --w->refs);
+    pthread_mutex_unlock(&w->lock);
+    if (!last) {
+        return;
+    }
     pthread_cond_destroy(&w->cond);
     pthread_mutex_destroy(&w->lock);
+    free(w);
 }
 
 static int wait_for_callback(wait_t *w, int seconds)
@@ -142,6 +163,8 @@ static void alloc_cbfunc(pmix_status_t status, pmix_info_t *results,
     w->done = 1;
     pthread_cond_signal(&w->cond);
     pthread_mutex_unlock(&w->lock);
+
+    wait_release(w);
 }
 
 static void snapshot_init(alloc_snapshot_t *snap)
@@ -698,29 +721,36 @@ static pmix_status_t submit_alloc_request(pmix_alloc_directive_t directive,
                                           const char *description)
 {
     pmix_status_t rc;
-    wait_t w;
+    wait_t *w;
 
-    wait_init(&w);
+    w = wait_new();
+    if (NULL == w) {
+        return PMIX_ERR_NOMEM;
+    }
+
     record_message("\nSubmitting %s\n", description);
     trace_point("allocation request: submit");
-    rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cbfunc, &w);
+    rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cbfunc, w);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "PMIx_Allocation_request_nb failed immediately: %s\n",
                 PMIx_Error_string(rc));
-        wait_destroy(&w);
+        /* The callback will not run, so drop its reference here too. */
+        wait_release(w);
+        wait_release(w);
         return rc;
     }
 
     trace_point("allocation request: waiting for callback");
-    if (0 != wait_for_callback(&w, REQUEST_TIMEOUT)) {
+    if (0 != wait_for_callback(w, REQUEST_TIMEOUT)) {
+        /* Still live: the wait object stays alive for the late callback. */
         fprintf(stderr, "timed out waiting for PMIx allocation callback\n");
-        wait_destroy(&w);
+        wait_release(w);
         return PMIX_ERR_TIMEOUT;
     }
     trace_point("allocation request: callback received");
 
-    rc = w.status;
-    wait_destroy(&w);
+    rc = w->status;
+    wait_release(w);
     return rc;
 }
 

--- a/examples/slurm/elastic-coordination.c
+++ b/examples/slurm/elastic-coordination.c
@@ -25,22 +25,37 @@
 
 #define VERIFY_TIMEOUT 10
 #define REQUEST_TIMEOUT 10
+/* Phase one blocks nobody, so it can outlast a queued request. */
+#define REQUEST_WATCH_TIMEOUT 300
+#define DVM_READY_TIMEOUT 60
 #define PRUN_TIMEOUT 10
 #define LINE_MAX_LEN 1024
+#define MAX_PENDING 8
+#define REQID_LEN 128
+
+/* PMIx defines the two-phase completion events together or not at all. */
+#if defined(PMIX_DVM_IS_READY) && defined(PMIX_ERR_DVM_MOD)
+#    define HAVE_DVM_MOD_EVENTS 1
+#else
+#    define HAVE_DVM_MOD_EVENTS 0
+#endif
+
+static pthread_mutex_t output_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* The verify polls re-query once a second for up to VERIFY_TIMEOUT, which
+ * traces enough to bury the result. Only the poll loops set this. */
+static int queries_quiet = 0;
 
 static void record_message(const char *fmt, ...);
 static int line_seen(char **lines, const char *line);
 
 static void trace_point(const char *msg)
 {
-    printf("[tester] %s\n", msg);
-    fflush(stdout);
+    record_message("[tester] %s\n", msg);
 }
 
-/* Reference counted because a timeout does not withdraw the request: PMIx
- * keeps the cbdata pointer and still runs the callback whenever the scheduler
- * answers, which may be long after the submitting call has given up. The
- * submitter and the callback each hold a reference; the last one out frees. */
+/* Refcounted: a timeout does not withdraw the request, so the callback may run
+ * long after the submitter gave up. Last reference out frees. */
 typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t cond;
@@ -116,6 +131,8 @@ static int wait_for_callback(wait_t *w, int seconds)
     return 0;
 }
 
+/* Applied to the outcome of both phases, so PMIX_OPERATION_IN_PROGRESS here
+ * means phase two could not be observed and the grant stood as the answer. */
 static int status_is_accepted(pmix_status_t status)
 {
     if (PMIX_SUCCESS == status) {
@@ -131,7 +148,27 @@ static int status_is_accepted(pmix_status_t status)
         return 1;
     }
 #endif
+#if HAVE_DVM_MOD_EVENTS
+    if (PMIX_DVM_IS_READY == status) {
+        return 1;
+    }
+#endif
     return 0;
+}
+
+/* Three ways to fail, needing different responses: still running, consumed
+ * resources, did nothing. */
+static const char *outcome_phrase(pmix_status_t rc)
+{
+    if (PMIX_ERR_TIMEOUT == rc) {
+        return "is still outstanding";
+    }
+#if HAVE_DVM_MOD_EVENTS
+    if (PMIX_ERR_DVM_MOD == rc) {
+        return "was granted, but the DVM could not be resized";
+    }
+#endif
+    return "was rejected";
 }
 
 static void alloc_cbfunc(pmix_status_t status, pmix_info_t *results,
@@ -165,6 +202,283 @@ static void alloc_cbfunc(pmix_status_t status, pmix_info_t *results,
     pthread_mutex_unlock(&w->lock);
 
     wait_release(w);
+}
+
+/* Phase two: PMIX_DVM_IS_READY (or PMIX_ERR_DVM_MOD) once the DVM has resized.
+ * Correlated with the request by PMIX_ALLOC_REQ_ID. */
+typedef struct {
+    char *reqid;         /* NULL when the slot is free */
+    char what[64];       /* what was asked for, for the 'pending' listing */
+    char allocid[64];    /* the allocation phase two named, if it named one */
+    int submitted;       /* phase one has not answered yet */
+    int cancellable;     /* only an extend ever is - see pending_report */
+    int done;            /* phase two arrived */
+    pmix_status_t status;
+} pending_t;
+
+static pthread_mutex_t pending_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t pending_cond = PTHREAD_COND_INITIALIZER;
+static pending_t pending[MAX_PENDING];
+static int dvm_events_available = 0;
+
+static int pending_register(const char *reqid, const char *what, int cancellable)
+{
+    int slot = -1;
+
+    pthread_mutex_lock(&pending_lock);
+    for (int i = 0; i < MAX_PENDING; i++) {
+        if (NULL == pending[i].reqid) {
+            pending[i].reqid = strdup(reqid);
+            pending[i].done = 0;
+            pending[i].submitted = 1;
+            pending[i].cancellable = cancellable;
+            pending[i].status = PMIX_SUCCESS;
+            pending[i].allocid[0] = '\0';
+            snprintf(pending[i].what, sizeof(pending[i].what), "%s",
+                     NULL == what ? "request" : what);
+            slot = NULL == pending[i].reqid ? -1 : i;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&pending_lock);
+
+    if (0 > slot) {
+        record_message("no free slot to track request %s; its completion "
+                       "event will be reported but not waited for\n", reqid);
+    }
+    return slot;
+}
+
+/* The allocation phase two named for this request, empty if none. */
+static void pending_allocid(int slot, char *buf, size_t size)
+{
+    buf[0] = '\0';
+    if (0 > slot) {
+        return;
+    }
+    pthread_mutex_lock(&pending_lock);
+    snprintf(buf, size, "%s", pending[slot].allocid);
+    pthread_mutex_unlock(&pending_lock);
+}
+
+/* The scheduler has acted; a cancel can no longer reach the request. */
+static void pending_mark_granted(int slot)
+{
+    if (0 > slot) {
+        return;
+    }
+    pthread_mutex_lock(&pending_lock);
+    pending[slot].submitted = 0;
+    pthread_mutex_unlock(&pending_lock);
+}
+
+/* Only an extend is ever cancellable: ras/slurm registers a cancellable record
+ * on the extend path alone. */
+static void pending_report(void)
+{
+    int found = 0;
+
+    pthread_mutex_lock(&pending_lock);
+    for (int i = 0; i < MAX_PENDING; i++) {
+        if (NULL == pending[i].reqid) {
+            continue;
+        }
+        if (!found) {
+            printf("outstanding requests:\n");
+            found = 1;
+        }
+        printf("  %-24s %-14s %s\n", pending[i].reqid, pending[i].what,
+               !pending[i].cancellable
+                   ? "not cancellable"
+                   : pending[i].submitted
+                         ? "queued at the scheduler - cancellable"
+                         : "granted, DVM resizing - too late to cancel");
+    }
+    if (!found) {
+        printf("no outstanding requests\n");
+    }
+    fflush(stdout);
+    pthread_mutex_unlock(&pending_lock);
+}
+
+/* Reports an unknown name separately, so a typo does not read as "too late". */
+static int pending_is_cancellable(const char *reqid, int *known)
+{
+    int cancellable = 0;
+
+    *known = 0;
+    pthread_mutex_lock(&pending_lock);
+    for (int i = 0; i < MAX_PENDING; i++) {
+        if (NULL != pending[i].reqid && 0 == strcmp(pending[i].reqid, reqid)) {
+            *known = 1;
+            cancellable = pending[i].cancellable && pending[i].submitted;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&pending_lock);
+
+    return cancellable;
+}
+
+/* The name 'cancel' means with no argument. Unambiguous only when one request
+ * is still cancellable. */
+static int pending_sole_cancellable(char *buf, size_t size)
+{
+    int found = -1;
+
+    pthread_mutex_lock(&pending_lock);
+    for (int i = 0; i < MAX_PENDING; i++) {
+        if (NULL != pending[i].reqid && pending[i].submitted
+            && pending[i].cancellable) {
+            if (0 <= found) {
+                pthread_mutex_unlock(&pending_lock);
+                return -1;
+            }
+            found = i;
+        }
+    }
+    if (0 <= found) {
+        snprintf(buf, size, "%s", pending[found].reqid);
+    }
+    pthread_mutex_unlock(&pending_lock);
+
+    return 0 <= found ? 0 : -1;
+}
+
+static void pending_drop(int slot)
+{
+    if (0 > slot) {
+        return;
+    }
+    pthread_mutex_lock(&pending_lock);
+    free(pending[slot].reqid);
+    pending[slot].reqid = NULL;
+    pthread_cond_broadcast(&pending_cond);
+    pthread_mutex_unlock(&pending_lock);
+}
+
+static void pending_forget_reqid(const char *reqid)
+{
+    pthread_mutex_lock(&pending_lock);
+    for (int i = 0; i < MAX_PENDING; i++) {
+        if (NULL != pending[i].reqid && 0 == strcmp(pending[i].reqid, reqid)) {
+            free(pending[i].reqid);
+            pending[i].reqid = NULL;
+        }
+    }
+    pthread_cond_broadcast(&pending_cond);
+    pthread_mutex_unlock(&pending_lock);
+}
+
+static pmix_status_t pending_wait(int slot, int seconds)
+{
+    struct timespec deadline;
+    pmix_status_t status = PMIX_ERR_TIMEOUT;
+    int rc = 0;
+
+    if (0 != clock_gettime(CLOCK_REALTIME, &deadline)) {
+        return PMIX_ERROR;
+    }
+    deadline.tv_sec += seconds;
+
+    pthread_mutex_lock(&pending_lock);
+    while (!pending[slot].done && 0 == rc) {
+        rc = pthread_cond_timedwait(&pending_cond, &pending_lock, &deadline);
+    }
+    if (pending[slot].done) {
+        status = pending[slot].status;
+    }
+    pthread_mutex_unlock(&pending_lock);
+
+    /* A slot left registered on timeout is deliberate: the operation is still
+     * running, and a late event should still be matched to it. */
+    return status;
+}
+
+#if HAVE_DVM_MOD_EVENTS
+static void dvm_mod_evhandler(size_t evhdlr_registration_id,
+                              pmix_status_t status, const pmix_proc_t *source,
+                              pmix_info_t info[], size_t ninfo,
+                              pmix_info_t results[], size_t nresults,
+                              pmix_event_notification_cbfunc_fn_t cbfunc,
+                              void *cbdata)
+{
+    const char *allocid = NULL;
+    const char *reqid = NULL;
+
+    (void) evhdlr_registration_id;
+    (void) source;
+    (void) results;
+    (void) nresults;
+
+    for (size_t n = 0; n < ninfo; n++) {
+        if (PMIX_STRING != info[n].value.type) {
+            continue;
+        }
+        if (PMIx_Check_key(info[n].key, PMIX_ALLOC_ID)) {
+            allocid = info[n].value.data.string;
+        } else if (PMIx_Check_key(info[n].key, PMIX_ALLOC_REQ_ID)) {
+            reqid = info[n].value.data.string;
+        }
+    }
+
+    record_message("\n"
+                   "======================================================\n"
+                   "  EVENT %s\n"
+                   "  %s\n"
+                   "  request    %s\n"
+                   "  allocation %s\n"
+                   "======================================================\n",
+                   PMIx_Error_string(status),
+                   PMIX_DVM_IS_READY == status
+                       ? "the DVM has finished resizing; the nodes can carry work"
+                       : "the scheduler granted, but the DVM could not be resized",
+                   NULL == reqid ? "unnamed" : reqid,
+                   NULL == allocid ? "unknown" : allocid);
+
+    if (NULL != reqid) {
+        pthread_mutex_lock(&pending_lock);
+        for (int i = 0; i < MAX_PENDING; i++) {
+            if (NULL != pending[i].reqid &&
+                0 == strcmp(pending[i].reqid, reqid)) {
+                pending[i].status = status;
+                pending[i].done = 1;
+                if (NULL != allocid) {
+                    snprintf(pending[i].allocid, sizeof(pending[i].allocid),
+                             "%s", allocid);
+                }
+                break;
+            }
+        }
+        pthread_cond_broadcast(&pending_cond);
+        pthread_mutex_unlock(&pending_lock);
+    }
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+#endif
+
+static void register_dvm_mod_handler(void)
+{
+#if HAVE_DVM_MOD_EVENTS
+    pmix_status_t codes[2] = {PMIX_DVM_IS_READY, PMIX_ERR_DVM_MOD};
+    pmix_status_t rc;
+
+    rc = PMIx_Register_event_handler(codes, 2, NULL, 0, dvm_mod_evhandler,
+                                     NULL, NULL);
+    if (0 > rc) {
+        fprintf(stderr, "could not register DVM modification handler: %s\n",
+                PMIx_Error_string(rc));
+        return;
+    }
+    dvm_events_available = 1;
+    printf("Registered for PMIX_DVM_IS_READY / PMIX_ERR_DVM_MOD\n");
+#else
+    printf("This PMIx has no DVM modification event codes; allocation "
+           "requests will be treated as complete when the scheduler answers\n");
+#endif
 }
 
 static void snapshot_init(alloc_snapshot_t *snap)
@@ -286,13 +600,17 @@ static char **snapshot_unique_nodes(const alloc_snapshot_t *snap)
     return nodes;
 }
 
+/* Watcher threads and the PMIx event handler can all print at once. */
 static void record_message(const char *fmt, ...)
 {
     va_list ap;
 
+    pthread_mutex_lock(&output_lock);
     va_start(ap, fmt);
     vprintf(fmt, ap);
     va_end(ap);
+    fflush(stdout);
+    pthread_mutex_unlock(&output_lock);
 }
 
 static pmix_status_t query_one(const char *key, const char *allocid,
@@ -315,14 +633,17 @@ static pmix_status_t query_one(const char *key, const char *allocid,
                        PMIX_STRING);
     }
 
-    printf("[tester] query begin: %s%s%s\n", key,
-           NULL == allocid ? "" : " alloc=", NULL == allocid ? "" : allocid);
-    fflush(stdout);
+    if (!queries_quiet) {
+        record_message("[tester] query begin: %s%s%s\n", key,
+                       NULL == allocid ? "" : " alloc=",
+                       NULL == allocid ? "" : allocid);
+    }
     rc = PMIx_Query_info(query, 1, results, nresults);
-    printf("[tester] query end: %s -> %s (%zu result%s)\n", key,
-           PMIx_Error_string(rc), NULL == nresults ? 0 : *nresults,
-           NULL != nresults && 1 == *nresults ? "" : "s");
-    fflush(stdout);
+    if (!queries_quiet) {
+        record_message("[tester] query end: %s -> %s (%zu result%s)\n", key,
+                       PMIx_Error_string(rc), NULL == nresults ? 0 : *nresults,
+                       NULL != nresults && 1 == *nresults ? "" : "s");
+    }
     PMIX_QUERY_FREE(query, 1);
     return rc;
 }
@@ -716,9 +1037,11 @@ static void handle_dvm(void)
     }
 }
 
-static pmix_status_t submit_alloc_request(pmix_alloc_directive_t directive,
-                                          pmix_info_t *info, size_t ninfo,
-                                          const char *description)
+/* For single-phase requests. A cancel is answered from the daemon's own
+ * records, so nothing follows it. */
+static pmix_status_t submit_and_wait(pmix_alloc_directive_t directive,
+                                     pmix_info_t *info, size_t ninfo,
+                                     const char *description)
 {
     pmix_status_t rc;
     wait_t *w;
@@ -729,40 +1052,328 @@ static pmix_status_t submit_alloc_request(pmix_alloc_directive_t directive,
     }
 
     record_message("\nSubmitting %s\n", description);
-    trace_point("allocation request: submit");
     rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cbfunc, w);
     if (PMIX_SUCCESS != rc) {
-        fprintf(stderr, "PMIx_Allocation_request_nb failed immediately: %s\n",
-                PMIx_Error_string(rc));
+        record_message("PMIx_Allocation_request_nb failed immediately: %s\n",
+                       PMIx_Error_string(rc));
         /* The callback will not run, so drop its reference here too. */
         wait_release(w);
         wait_release(w);
         return rc;
     }
 
-    trace_point("allocation request: waiting for callback");
     if (0 != wait_for_callback(w, REQUEST_TIMEOUT)) {
-        /* Still live: the wait object stays alive for the late callback. */
-        fprintf(stderr, "timed out waiting for PMIx allocation callback\n");
+        record_message("timed out waiting for the PMIx allocation callback\n");
         wait_release(w);
         return PMIX_ERR_TIMEOUT;
     }
-    trace_point("allocation request: callback received");
 
     rc = w->status;
     wait_release(w);
+
     return rc;
 }
 
-static void make_reqid(char *buf, size_t size, const char *prefix)
+/* A size change is watched on its own thread so the prompt returns at once.
+ * ras/slurm drops a request's cancellable record when the scheduler grants,
+ * and phase one does not answer until then, so blocking the command reader
+ * across that wait would hold the prompt for the whole cancellable window. */
+typedef enum {
+    VERIFY_NONE = 0,
+    VERIFY_NODES_AT_LEAST,
+    VERIFY_NODES_AT_MOST,
+    VERIFY_ALLOC_GONE,
+    VERIFY_NODES_ABSENT
+} verify_kind_t;
+
+typedef struct {
+    pmix_info_t *info;
+    size_t ninfo;
+    char reqid[REQID_LEN];
+    char description[64];
+    int slot;
+    wait_t *w;
+    verify_kind_t verify;
+    size_t target;
+    size_t requested;    /* nodes this request asked for */
+    char subject[256];   /* allocation id or node list, per verify kind */
+    int was_in_squeue;
+} watch_t;
+
+static int wait_until_alloc_count_at_least(size_t min_count);
+static int wait_until_total_nodes_at_most(size_t max_count);
+static int wait_until_alloc_removed(const char *allocid);
+
+/* Nodes PRRTE has under one allocation. Polls, since the snapshot may lag the
+ * event by a moment. Returns -1 if the allocation never appears. */
+static ssize_t wait_for_alloc_nodes(const char *allocid)
+{
+    ssize_t nnodes = -1;
+
+    queries_quiet = 1;
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+
+        if (0 == query_snapshot(&snap)) {
+            alloc_record_t *rec = snapshot_find_alloc(&snap, allocid);
+
+            if (NULL != rec) {
+                nnodes = (ssize_t) rec->nnodes;
+            }
+            snapshot_free(&snap);
+        }
+        if (0 <= nnodes) {
+            break;
+        }
+        sleep(1);
+    }
+    queries_quiet = 0;
+
+    return nnodes;
+}
+
+/* What PRRTE currently reports, so a verify can say what it found and not just
+ * what it wanted. Returns 0 if the query fails. */
+static size_t current_total_nodes(void)
+{
+    alloc_snapshot_t snap;
+    size_t total = 0;
+
+    queries_quiet = 1;
+    if (0 == query_snapshot(&snap)) {
+        total = snapshot_total_nodes(&snap);
+        snapshot_free(&snap);
+    }
+    queries_quiet = 0;
+
+    return total;
+}
+static int wait_until_nodes_absent(char **nodes);
+static int squeue_job_exists(const char *jobid);
+
+static void watch_finish(watch_t *ctx, pmix_status_t rc)
+{
+    if (!status_is_accepted(rc)) {
+        record_message("VERIFY %s: request %s (%s)\n", ctx->description,
+                       outcome_phrase(rc), PMIx_Error_string(rc));
+    } else {
+        switch (ctx->verify) {
+        case VERIFY_NODES_AT_LEAST: {
+            char allocid[64];
+
+            /* Check the allocation this request was granted, not the DVM
+             * total. A total is a snapshot taken before submitting, and
+             * anything else that resizes the DVM meanwhile invalidates it -
+             * concurrent requests are the point of this program. */
+            pending_allocid(ctx->slot, allocid, sizeof(allocid));
+            if ('\0' != allocid[0]) {
+                ssize_t got = wait_for_alloc_nodes(allocid);
+
+                if (0 > got) {
+                    record_message("VERIFY %s: WARN (PRRTE has no allocation "
+                                   "%s)\n", ctx->description, allocid);
+                } else {
+                    record_message("VERIFY %s: %s (allocation %s holds %zd "
+                                   "nodes, asked for %zu)\n", ctx->description,
+                                   (size_t) got >= ctx->requested
+                                       ? "PASS" : "WARN",
+                                   allocid, got, ctx->requested);
+                }
+                break;
+            }
+            /* No event named an allocation, so the total is all there is. */
+            record_message("VERIFY %s: %s (PRRTE knows %zu nodes, expected at "
+                           "least %zu)\n", ctx->description,
+                           0 == wait_until_alloc_count_at_least(ctx->target)
+                               ? "PASS" : "WARN",
+                           current_total_nodes(), ctx->target);
+            break;
+        }
+        case VERIFY_NODES_AT_MOST:
+            if (0 == wait_until_total_nodes_at_most(ctx->target)) {
+                record_message("VERIFY %s: PASS (PRRTE knows %zu nodes, "
+                               "expected at most %zu)\n", ctx->description,
+                               current_total_nodes(), ctx->target);
+            } else {
+                record_message("VERIFY %s: WARN (PRRTE knows %zu nodes, "
+                               "expected at most %zu)\n", ctx->description,
+                               current_total_nodes(), ctx->target);
+            }
+            break;
+        case VERIFY_ALLOC_GONE: {
+            int gone = (0 == wait_until_alloc_removed(ctx->subject));
+
+            record_message("VERIFY %s: %s (PRRTE allocation %s %s)\n",
+                           ctx->description, gone ? "PASS" : "WARN",
+                           ctx->subject, gone ? "gone" : "still present");
+            if (0 == ctx->was_in_squeue) {
+                record_message("VERIFY %s: INFO job %s was not visible in "
+                               "squeue before the request\n", ctx->description,
+                               ctx->subject);
+            } else {
+                record_message("VERIFY %s: %s (squeue job %s)\n",
+                               ctx->description,
+                               squeue_job_exists(ctx->subject) ? "WARN" : "PASS",
+                               ctx->subject);
+            }
+            break;
+        }
+        case VERIFY_NODES_ABSENT: {
+            char **nodes = PMIx_Argv_split(ctx->subject, ',');
+            int gone = (NULL != nodes && 0 == wait_until_nodes_absent(nodes));
+
+            record_message("VERIFY %s: %s (requested nodes %s in PRRTE)\n",
+                           ctx->description, gone ? "PASS" : "WARN",
+                           gone ? "absent" : "still present");
+            if (NULL != nodes) {
+                PMIx_Argv_free(nodes);
+            }
+            break;
+        }
+        default:
+            record_message("VERIFY %s: PASS (%s)\n", ctx->description,
+                           PMIx_Error_string(rc));
+            break;
+        }
+    }
+
+    show_state();
+
+    PMIX_INFO_FREE(ctx->info, ctx->ninfo);
+    pending_drop(ctx->slot);
+    free(ctx);
+}
+
+static void *request_watcher(void *arg)
+{
+    watch_t *ctx = (watch_t *) arg;
+    pmix_status_t rc;
+
+    if (0 != wait_for_callback(ctx->w, REQUEST_WATCH_TIMEOUT)) {
+        record_message("\n[%s] no answer within %d seconds; giving up on it\n",
+                       ctx->reqid, REQUEST_WATCH_TIMEOUT);
+        wait_release(ctx->w);
+        watch_finish(ctx, PMIX_ERR_TIMEOUT);
+        return NULL;
+    }
+
+    rc = ctx->w->status;
+    wait_release(ctx->w);
+
+    if (PMIX_OPERATION_IN_PROGRESS == rc) {
+        /* Phase one says only that the scheduler acted. The DVM has not
+         * resized yet, so the nodes named by the allocation cannot carry work
+         * - and the request is now past cancelling: the resources are held,
+         * and giving them back is a shrink, not a cancel. */
+        pending_mark_granted(ctx->slot);
+        record_message("\n[%s] scheduler has acted; waiting for the DVM to "
+                       "resize\n", ctx->reqid);
+
+        if (0 <= ctx->slot && dvm_events_available) {
+            rc = pending_wait(ctx->slot, DVM_READY_TIMEOUT);
+            if (PMIX_ERR_TIMEOUT == rc) {
+                record_message("[%s] no DVM completion event within %d "
+                               "seconds\n", ctx->reqid, DVM_READY_TIMEOUT);
+            }
+        } else {
+            record_message("[%s] no completion event can be matched to this "
+                           "request; treating the grant as the answer\n",
+                           ctx->reqid);
+        }
+    }
+
+    watch_finish(ctx, rc);
+    return NULL;
+}
+
+/* Takes ownership of info either way, so the caller must not free it. */
+static void submit_watched(pmix_alloc_directive_t directive, pmix_info_t *info,
+                           size_t ninfo, const char *description,
+                           const char *reqid, verify_kind_t verify,
+                           size_t target, size_t requested, const char *subject,
+                           int was_in_squeue, int cancellable)
+{
+    watch_t *ctx;
+    pthread_t tid;
+    pmix_status_t rc;
+
+    ctx = calloc(1, sizeof(*ctx));
+    if (NULL == ctx) {
+        PMIX_INFO_FREE(info, ninfo);
+        return;
+    }
+    ctx->info = info;
+    ctx->ninfo = ninfo;
+    ctx->verify = verify;
+    ctx->target = target;
+    ctx->requested = requested;
+    ctx->was_in_squeue = was_in_squeue;
+    snprintf(ctx->reqid, sizeof(ctx->reqid), "%s", reqid);
+    snprintf(ctx->description, sizeof(ctx->description), "%s", description);
+    snprintf(ctx->subject, sizeof(ctx->subject), "%s",
+             NULL == subject ? "" : subject);
+
+    ctx->w = wait_new();
+    if (NULL == ctx->w) {
+        PMIX_INFO_FREE(info, ninfo);
+        free(ctx);
+        return;
+    }
+
+    /* Claim the correlation slot before submitting. Nothing on this side
+     * orders the phase-two event after the phase-one callback. */
+    ctx->slot = pending_register(reqid, description, cancellable);
+
+    if (cancellable) {
+        record_message("\nSubmitting %s as request id %s\n"
+                       "  while the scheduler still has it queued, withdraw "
+                       "it with:  cancel %s\n",
+                       description, reqid, reqid);
+    } else {
+        record_message("\nSubmitting %s as request id %s\n",
+                       description, reqid);
+    }
+
+    rc = PMIx_Allocation_request_nb(directive, info, ninfo, alloc_cbfunc,
+                                    ctx->w);
+    if (PMIX_SUCCESS != rc) {
+        record_message("PMIx_Allocation_request_nb failed immediately: %s\n",
+                       PMIx_Error_string(rc));
+        pending_drop(ctx->slot);
+        /* The callback will not run, so drop its reference here too. */
+        wait_release(ctx->w);
+        wait_release(ctx->w);
+        PMIX_INFO_FREE(info, ninfo);
+        free(ctx);
+        return;
+    }
+
+    if (0 != pthread_create(&tid, NULL, request_watcher, ctx)) {
+        record_message("could not start a watcher thread; waiting inline "
+                       "(the prompt will not return until this finishes)\n");
+        request_watcher(ctx);
+        return;
+    }
+    pthread_detach(tid);
+}
+
+/* A name has to be short enough to type before the scheduler grants. A
+ * caller-supplied one is used verbatim; the generated form counts requests. */
+static void make_reqid(char *buf, size_t size, const char *prefix,
+                       const char *name)
 {
     static unsigned int next_id = 1;
 
-    snprintf(buf, size, "%s-%ld-%u", prefix, (long) getpid(), next_id++);
+    if (NULL != name && '\0' != name[0]) {
+        snprintf(buf, size, "%s", name);
+        return;
+    }
+    snprintf(buf, size, "%s-%u", prefix, next_id++);
 }
 
 static int wait_until_alloc_count_at_least(size_t min_count)
 {
+    queries_quiet = 1;
     for (int i = 0; i < VERIFY_TIMEOUT; i++) {
         alloc_snapshot_t snap;
         int ok = 0;
@@ -772,15 +1383,18 @@ static int wait_until_alloc_count_at_least(size_t min_count)
             snapshot_free(&snap);
         }
         if (ok) {
+            queries_quiet = 0;
             return 0;
         }
         sleep(1);
     }
+    queries_quiet = 0;
     return -1;
 }
 
 static int wait_until_alloc_removed(const char *allocid)
 {
+    queries_quiet = 1;
     for (int i = 0; i < VERIFY_TIMEOUT; i++) {
         alloc_snapshot_t snap;
         int gone = 0;
@@ -790,15 +1404,18 @@ static int wait_until_alloc_removed(const char *allocid)
             snapshot_free(&snap);
         }
         if (gone) {
+            queries_quiet = 0;
             return 0;
         }
         sleep(1);
     }
+    queries_quiet = 0;
     return -1;
 }
 
 static int wait_until_nodes_absent(char **nodes)
 {
+    queries_quiet = 1;
     for (int i = 0; i < VERIFY_TIMEOUT; i++) {
         alloc_snapshot_t snap;
         int absent = 1;
@@ -815,15 +1432,18 @@ static int wait_until_nodes_absent(char **nodes)
             absent = 0;
         }
         if (absent) {
+            queries_quiet = 0;
             return 0;
         }
         sleep(1);
     }
+    queries_quiet = 0;
     return -1;
 }
 
 static int wait_until_total_nodes_at_most(size_t max_count)
 {
+    queries_quiet = 1;
     for (int i = 0; i < VERIFY_TIMEOUT; i++) {
         alloc_snapshot_t snap;
         int ok = 0;
@@ -833,48 +1453,35 @@ static int wait_until_total_nodes_at_most(size_t max_count)
             snapshot_free(&snap);
         }
         if (ok) {
+            queries_quiet = 0;
             return 0;
         }
         sleep(1);
     }
+    queries_quiet = 0;
     return -1;
 }
 
-static void handle_extend_count(uint64_t count)
+static void handle_extend_count(uint64_t count, const char *name)
 {
     alloc_snapshot_t before;
     size_t before_nodes = 0;
     pmix_info_t *info;
-    pmix_status_t rc;
-    char reqid[128];
+    char reqid[REQID_LEN];
 
     if (0 == query_snapshot(&before)) {
         before_nodes = snapshot_total_nodes(&before);
         snapshot_free(&before);
     }
 
-    make_reqid(reqid, sizeof(reqid), "coord-extend");
+    make_reqid(reqid, sizeof(reqid), "extend", name);
     PMIX_INFO_CREATE(info, 2);
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &count, PMIX_UINT64);
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
 
-    rc = submit_alloc_request(PMIX_ALLOC_EXTEND, info, 2, "extend count");
-    PMIX_INFO_FREE(info, 2);
-
-    if (status_is_accepted(rc)) {
-        size_t expected = before_nodes + (size_t) count;
-
-        if (0 == wait_until_alloc_count_at_least(expected)) {
-            record_message("VERIFY extend count: PASS (PRRTE knows at least %zu nodes)\n",
-                           expected);
-        } else {
-            record_message("VERIFY extend count: WARN expected at least %zu PRRTE nodes\n",
-                           expected);
-        }
-    } else {
-        record_message("VERIFY extend count: request was rejected with %s\n",
-                       PMIx_Error_string(rc));
-    }
+    submit_watched(PMIX_ALLOC_EXTEND, info, 2, "extend count", reqid,
+                   VERIFY_NODES_AT_LEAST, before_nodes + (size_t) count,
+                   (size_t) count, NULL, 0, 1);
 }
 
 static void handle_shrink_count(uint64_t count)
@@ -882,111 +1489,92 @@ static void handle_shrink_count(uint64_t count)
     alloc_snapshot_t before;
     size_t before_nodes = 0;
     pmix_info_t *info;
-    pmix_status_t rc;
-    char reqid[128];
+    char reqid[REQID_LEN];
 
     if (0 == query_snapshot(&before)) {
         before_nodes = snapshot_total_nodes(&before);
         snapshot_free(&before);
     }
 
-    make_reqid(reqid, sizeof(reqid), "coord-shrink-count");
+    make_reqid(reqid, sizeof(reqid), "shrink", NULL);
     PMIX_INFO_CREATE(info, 2);
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &count, PMIX_UINT64);
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
 
-    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink count");
-    PMIX_INFO_FREE(info, 2);
-
-    if (status_is_accepted(rc)) {
-        size_t expected_max = count >= before_nodes ? 0 : before_nodes - count;
-
-        if (0 == wait_until_total_nodes_at_most(expected_max)) {
-            record_message("VERIFY shrink count: PASS (PRRTE total nodes <= %zu)\n",
-                           expected_max);
-        } else {
-            record_message("VERIFY shrink count: WARN expected PRRTE total nodes <= %zu\n",
-                           expected_max);
-        }
-    } else {
-        record_message("VERIFY shrink count: request was rejected with %s\n",
-                       PMIx_Error_string(rc));
-    }
+    submit_watched(PMIX_ALLOC_RELEASE, info, 2, "shrink count", reqid,
+                   VERIFY_NODES_AT_MOST,
+                   count >= before_nodes ? 0 : before_nodes - count,
+                   (size_t) count, NULL, 0, 0);
 }
 
 static void handle_shrink_alloc(const char *allocid)
 {
     pmix_info_t *info;
-    pmix_status_t rc;
     int before_squeue;
-    char reqid[128];
+    char reqid[REQID_LEN];
 
     before_squeue = squeue_job_exists(allocid);
-    make_reqid(reqid, sizeof(reqid), "coord-shrink-alloc");
+    make_reqid(reqid, sizeof(reqid), "shrink", NULL);
     PMIX_INFO_CREATE(info, 2);
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, allocid, PMIX_STRING);
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
 
-    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink alloc");
-    PMIX_INFO_FREE(info, 2);
-
-    if (status_is_accepted(rc)) {
-        int after_squeue;
-
-        if (0 == wait_until_alloc_removed(allocid)) {
-            record_message("VERIFY shrink alloc: PASS (PRRTE allocation %s gone)\n",
-                           allocid);
-        } else {
-            record_message("VERIFY shrink alloc: WARN PRRTE allocation %s still visible\n",
-                           allocid);
-        }
-
-        after_squeue = squeue_job_exists(allocid);
-        if (1 == before_squeue && 0 == after_squeue) {
-            record_message("VERIFY shrink alloc: PASS (squeue job %s disappeared)\n",
-                           allocid);
-        } else if (0 == before_squeue) {
-            record_message("VERIFY shrink alloc: INFO job %s was not visible in squeue before request\n",
-                           allocid);
-        } else {
-            record_message("VERIFY shrink alloc: WARN job %s still visible in squeue\n",
-                           allocid);
-        }
-    } else {
-        record_message("VERIFY shrink alloc: request was rejected with %s\n",
-                       PMIx_Error_string(rc));
-    }
+    submit_watched(PMIX_ALLOC_RELEASE, info, 2, "shrink alloc", reqid,
+                   VERIFY_ALLOC_GONE, 0, 0, allocid, before_squeue, 0);
 }
 
 static void handle_shrink_list(const char *list)
 {
     pmix_info_t *info;
-    pmix_status_t rc;
-    char **nodes;
-    char reqid[128];
+    char reqid[REQID_LEN];
 
-    nodes = PMIx_Argv_split(list, ',');
-    make_reqid(reqid, sizeof(reqid), "coord-shrink-list");
+    make_reqid(reqid, sizeof(reqid), "shrink", NULL);
     PMIX_INFO_CREATE(info, 2);
     PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, list, PMIX_STRING);
     PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
 
-    rc = submit_alloc_request(PMIX_ALLOC_RELEASE, info, 2, "shrink list");
-    PMIX_INFO_FREE(info, 2);
+    submit_watched(PMIX_ALLOC_RELEASE, info, 2, "shrink list", reqid,
+                   VERIFY_NODES_ABSENT, 0, 0, list, 0, 0);
+}
 
-    if (status_is_accepted(rc)) {
-        if (NULL != nodes && 0 == wait_until_nodes_absent(nodes)) {
-            record_message("VERIFY shrink list: PASS (requested nodes absent from PRRTE)\n");
-        } else {
-            record_message("VERIFY shrink list: WARN requested nodes still visible in PRRTE\n");
-        }
-    } else {
-        record_message("VERIFY shrink list: request was rejected with %s\n",
-                       PMIx_Error_string(rc));
+/* Withdraw an extend the scheduler has not yet granted. After the grant the
+ * resources are held and handing them back is a shrink. A shrink is never
+ * cancellable, so refuse locally rather than send a request that can only come
+ * back PMIX_ERR_NOT_FOUND. */
+static void handle_cancel(const char *reqid)
+{
+    pmix_info_t *info;
+    pmix_status_t rc;
+    char description[256];
+    int known;
+
+    if (!pending_is_cancellable(reqid, &known) && known) {
+        record_message("VERIFY cancel: %s is not cancellable; only an extend "
+                       "the scheduler has not yet granted can be withdrawn\n",
+                       reqid);
+        return;
     }
 
-    if (NULL != nodes) {
-        PMIx_Argv_free(nodes);
+    snprintf(description, sizeof(description), "cancel of %s", reqid);
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    rc = submit_and_wait(PMIX_ALLOC_REQ_CANCEL, info, 1, description);
+    PMIX_INFO_FREE(info, 1);
+
+    if (status_is_accepted(rc)) {
+        /* No completion event can follow a request that no longer exists. The
+         * cancelled request is answered separately, on its own callback. */
+        pending_forget_reqid(reqid);
+        record_message("VERIFY cancel: PASS (request %s withdrawn)\n", reqid);
+    } else if (PMIX_ERR_NOT_FOUND == rc) {
+        record_message("VERIFY cancel: no pending request %s. It was never "
+                       "submitted, or the scheduler has already granted it - "
+                       "a granted request can only be given back with a "
+                       "shrink.\n", reqid);
+    } else {
+        record_message("VERIFY cancel: request was rejected with %s\n",
+                       PMIx_Error_string(rc));
     }
 }
 
@@ -994,14 +1582,30 @@ static void usage(const char *argv0)
 {
     printf("Usage: %s\n\n", argv0);
     printf("Run inside a Slurm job and under PRRTE/PMIx, then enter commands:\n");
-    printf("  extend count N\n");
+    printf("  extend count N [as REQUEST_NAME]\n");
     printf("  shrink count N\n");
     printf("  shrink alloc SLURM_JOB_ID\n");
     printf("  shrink list NODE1,NODE2\n");
+    printf("  cancel [REQUEST_NAME]\n");
+    printf("  pending\n");
     printf("  prun [ARGS...]\n");
     printf("  dvm\n");
     printf("  refresh\n");
     printf("  quit\n");
+}
+
+/* Consume a trailing "as NAME", continuing the caller's strtok walk. */
+static const char *parse_as_name(void)
+{
+    char *keyword = strtok(NULL, " \t");
+    char *name;
+
+    if (NULL == keyword || 0 != strcmp(keyword, "as")) {
+        return NULL;
+    }
+    name = strtok(NULL, " \t");
+
+    return (NULL != name && '\0' != name[0]) ? name : NULL;
 }
 
 static int parse_u64(const char *s, uint64_t *out)
@@ -1021,6 +1625,50 @@ static int parse_u64(const char *s, uint64_t *out)
     return 0;
 }
 
+/* Elastic mode cannot be checked: it has no PMIx query, and PRRTE strips
+ * PRTE_* from a launched process's environment. */
+static void note_elastic_mode_requirement(void)
+{
+    fprintf(stderr,
+            "NOTE: remember to toggle prte_elastic_mode, for example by\n"
+            "exporting PRTE_MCA_prte_elastic_mode=1, if you didn't already.\n"
+            "\n");
+}
+
+/* If PRRTE does not know this job, the DVM never discovered the allocation.
+ * Checked once: the allocation set changes on purpose after startup. */
+static int check_jobid_known(const char *slurm_jobid)
+{
+    alloc_snapshot_t snap;
+    int known;
+
+    if (0 != query_snapshot(&snap)) {
+        fprintf(stderr, "Could not query PRRTE for its allocations; the DVM is "
+                        "not answering.\n");
+        return -1;
+    }
+
+    known = (NULL != snapshot_find_alloc(&snap, slurm_jobid));
+    if (!known) {
+        fprintf(stderr,
+                "PRRTE does not know Slurm job %s. The DVM did not discover "
+                "this\nallocation, so it cannot grow or shrink it.\n",
+                slurm_jobid);
+        if (0 == snap.nallocs) {
+            fprintf(stderr, "PRRTE reports no allocations at all.\n");
+        } else {
+            fprintf(stderr, "PRRTE reports these instead:");
+            for (size_t i = 0; i < snap.nallocs; i++) {
+                fprintf(stderr, " %s", snap.allocs[i].id);
+            }
+            fprintf(stderr, "\n");
+        }
+    }
+    snapshot_free(&snap);
+
+    return known ? 0 : -1;
+}
+
 int main(int argc, char **argv)
 {
     pmix_proc_t myproc;
@@ -1035,9 +1683,12 @@ int main(int argc, char **argv)
 
     slurm_jobid = getenv("SLURM_JOB_ID");
     if (NULL == slurm_jobid || '\0' == slurm_jobid[0]) {
-        fprintf(stderr, "This program must run inside a Slurm job (SLURM_JOB_ID is unset).\n");
+        fprintf(stderr, "SLURM_JOB_ID is unset: this program must run inside "
+                        "a Slurm job.\n");
         return 1;
     }
+
+    note_elastic_mode_requirement();
 
     rc = PMIx_Init(&myproc, NULL, 0);
     if (PMIX_SUCCESS != rc) {
@@ -1047,6 +1698,13 @@ int main(int argc, char **argv)
 
     printf("PMIx client %s:%u inside Slurm job %s\n",
            myproc.nspace, myproc.rank, slurm_jobid);
+    register_dvm_mod_handler();
+
+    if (0 != check_jobid_known(slurm_jobid)) {
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+
     usage(argv[0]);
     show_state();
 
@@ -1089,6 +1747,29 @@ int main(int argc, char **argv)
             handle_dvm();
             continue;
         }
+        if (0 == strcmp(cmd, "pending")) {
+            pending_report();
+            continue;
+        }
+        if (0 == strcmp(cmd, "cancel")) {
+            char sole[REQID_LEN];
+
+            arg = strtok(NULL, " \t");
+            if (NULL == arg) {
+                /* Typing the name is the hard part of cancelling in time. */
+                if (0 != pending_sole_cancellable(sole, sizeof(sole))) {
+                    printf("usage: cancel REQUEST_NAME   ('pending' lists them; "
+                           "the bare form works only when exactly one request "
+                           "is still cancellable)\n");
+                    continue;
+                }
+                arg = sole;
+                printf("cancelling the only cancellable request: %s\n", arg);
+            }
+            handle_cancel(arg);
+            show_state();
+            continue;
+        }
         if (0 == strcmp(cmd, "extend")) {
             uint64_t count;
 
@@ -1096,11 +1777,10 @@ int main(int argc, char **argv)
             arg = strtok(NULL, " \t");
             if (NULL == type || NULL == arg || 0 != strcmp(type, "count") ||
                 0 != parse_u64(arg, &count)) {
-                printf("usage: extend count N\n");
+                printf("usage: extend count N [as REQUEST_NAME]\n");
                 continue;
             }
-            handle_extend_count(count);
-            show_state();
+            handle_extend_count(count, parse_as_name());
             continue;
         }
         if (0 == strcmp(cmd, "shrink")) {
@@ -1126,7 +1806,6 @@ int main(int argc, char **argv)
                 printf("usage: shrink count N | shrink alloc ID | shrink list NODE1,NODE2\n");
                 continue;
             }
-            show_state();
             continue;
         }
 


### PR DESCRIPTION
## Problem

`examples/slurm/elastic-coordination.c` treated the PMIx allocation callback as
the final answer to a size change. A Slurm extend now answers in two phases, so
the example reported success while the nodes it had just been granted could not
yet carry work. It also had no way to withdraw a pending request, and kept an
allocation request's wait object on the caller's stack.

## Changes

**`examples/slurm: keep an allocation request's wait object alive`**

A timeout does not withdraw the request: PMIx still runs the callback whenever
the scheduler answers, by which time the submitting call may have returned and
taken its stack frame with it. The wait object is reference counted now.
Pre-existing bug, so it lands separately.

**`examples/slurm: wait for the DVM to resize, and make cancel usable`**

- Registers for `PMIX_DVM_IS_READY` / `PMIX_ERR_DVM_MOD`, correlating by
  `PMIX_ALLOC_REQ_ID` and claiming the slot before submitting — nothing orders
  the event after the phase-one callback.
- Watches each request on its own thread so the prompt returns at once. This is
  what makes `cancel` reachable: `ras/slurm` drops a request's cancellable
  record when the scheduler grants, and phase one does not answer until then,
  so waiting inline held the prompt for exactly as long as the request could
  still be withdrawn.
- Adds `cancel [REQUEST_NAME]` and `pending`, and `extend count N as
  REQUEST_NAME` 
so the name is short enough to type inside that window.
  Generated names count requests in the session (`extend-1`, `shrink-2`).
- Only an extend is cancellable, so only an extend takes a name; a cancel
  naming anything else is refused locally rather than sent to return
  `PMIX_ERR_NOT_FOUND`, which is indistinguishable from a typo.
- Verifies an extend against the allocation its completion event names rather
  than the DVM total, which is a snapshot any concurrent request invalidates.
- Refuses to start outside a Slurm job, or when PRRTE does not already know
  that job's allocation.
- Serializes output behind a lock, and silences the verify polls.