### PR TITLE
ras/slurm: name the expander jobs it submits

### DIFF
--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -842,6 +842,7 @@ static int prte_ras_slurm_launch_expander_job(pmix_hash_table_t *fields)
     const char * const initial_args[] = {"salloc",
                                 "--no-shell",
                                 "--exclusive",
+                                "--job-name=prrte",
                                 NULL };
 
     for (int i = 0; initial_args[i] != NULL; i++) {


### PR DESCRIPTION
`salloc` names a job after the command it was given. The expander job supplies
none, so every allocation PRRTE creates shows up as `no-shell`:

```
   JOBID     STATE         NAME     NODELIST
     268   RUNNING     no-shell     mc-slurmd-[2-4]     <- PRRTE's
     267   RUNNING  interactive     mc-slurmd-1
```

Pass `--job-name=prrte` so it is identifiable, and distinguishable from anyone
else's bare `salloc` on a shared cluster.

Credits: AccelCom @ Barcelona Supercomputing Center