### PR TITLE
ras/slurm: stop returning an RM name a caller may never see

### DIFF
--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1312,11 +1312,14 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     req->pstatus = prte_pmix_convert_rc(err);
 
-    /* Report back: job ID and resource manager used */
+    /* Report back the job ID. Only a phase one that stays PMIX_SUCCESS
+     * delivers it: a client stops unpacking a reply whose status is anything
+     * else, so nothing sent with PMIX_OPERATION_IN_PROGRESS arrives. Where
+     * that happens the completion event carries the id instead. */
     if (PMIX_SUCCESS == req->pstatus) {
         pmix_info_t *result_info = NULL;
 
-        PMIX_INFO_CREATE(result_info, 2);
+        PMIX_INFO_CREATE(result_info, 1);
         if (NULL == result_info) {
             req->pstatus = PMIX_ERR_NOMEM;
         } else {
@@ -1324,9 +1327,8 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
                 PMIX_INFO_FREE(req->info, req->ninfo);
             }
             PMIX_INFO_LOAD(&result_info[0], PMIX_ALLOC_ID, job_id, PMIX_STRING);
-            PMIX_INFO_LOAD(&result_info[1], PMIX_RM_NAME, "slurm", PMIX_STRING);
             req->info = result_info;
-            req->ninfo = 2;
+            req->ninfo = 1;
             req->copy = true;
         }
     }


### PR DESCRIPTION
An extend's phase one reported the allocation id and the resource manager that served it. Since the extend began answering PMIX_OPERATION_IN_PROGRESS, neither reaches the caller: a PMIx client stops unpacking a reply whose status is not PMIX_SUCCESS. The allocation id survives because the completion event carries it too, so it still arrives wherever it matters, and phase one still delivers it on a build or a run without the DVM modification events. The RM name has no such second path, so it is delivered only when those events are absent - present or missing depending on how PRRTE was built, which is worse than not offering it. Drop it; a query can serve it later if anything needs it.

Credits: AccelCom @ Barcelona Supercomputing Center