### PR TITLE
Derive a remote proc's data instead of publishing it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ component that successfully opens wins selection.
 
 ## PRRTE's Relationship with PMIx
 
-PRRTE depends on PMIx (minimum version `6.1.0`) and uses PMIx internals
+PRRTE depends on PMIx (minimum version `7.0.0`) and uses PMIx internals
 extensively.  This is not the same as calling the PMIx public library API.
 
 **What PRRTE takes from PMIx:**
@@ -460,7 +460,15 @@ Common configure options:
 | `--enable-devel-check` | Enable strict compiler warnings (treat warnings as errors); on by default when `--enable-debug` is used in a git repo build |
 | `--enable-testbuild-launchers` | **Compile-only.** Build the `plm`/`ras`/`ess` components that an ordinary developer machine cannot, so they are compiled somewhere. Two shapes: the `plm`/`ras` launchers that need third-party headers (LSF, Flux, jansson) are built against declaration-only stubs, and must be run-time loadable plugins (the default `--enable-mca-dso` list) because a stub's unresolved symbols only fail to `dlopen`, whereas in `libprrte` they break the link of every tool. `ess/lsf` and `ess/pals` need no stubs and link nothing — their entire dependency on that RM is a `getenv` — so they build straight into `libprrte`; the gate is all that was keeping them from being compiled, which is exactly why they had drifted into not compiling at all. Such a tree builds and runs, but the stubbed components can do no actual work; don't install one over a good installation. See [`src/mca/ras/AGENTS.md`](src/mca/ras/AGENTS.md). |
 
-Version requirements: PMIx ≥ 6.1.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
+Version requirements: PMIx ≥ 7.0.0, hwloc ≥ 2.1.0, libevent ≥ 2.0.21.
+The PMIx floor is `pmix_min_version` in [`VERSION`](VERSION), and it is
+enforced twice — `configure` refuses an older library, and the daemon
+re-checks `PMIX_VERSION_NUMERIC` against `PRTE_PMIX_MINIMUM_VERSION` at
+startup.  So a PMIx capability flag introduced in the 7.0 development
+series tells you nothing a PRRTE build can act on: every PMIx that gets
+this far defines it.  The `PRTE_CHECK_PMIX_CAP` machinery below is for
+flags that genuinely straddle a supported range, not for recording which
+PMIx commit added a feature.
 
 ### GOLDEN RULE: build with `make` from the top of your build tree — never try to short-circuit the build
 

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -56,6 +56,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
 | `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
+| `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives grpcomm's `grp_release` on daemons that merely *received* the broadcast. See §15. |
 | `envspawn.c` | A PMIx client that spawns a child job carrying one of every **envar directive** (`envspawn` in the install): SET/ADD/UNSET/PREPEND/APPEND, pinned to a named host, with the child reporting the environment it actually got into a file on its own node. Those directives have no command-line surface — they arrive only on a spawn request — and `odls` applies them on whichever daemon forks the process, so the child has to land somewhere the parent is not. Drives `prte_odls_base_process_envars`. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
@@ -1697,3 +1698,72 @@ indistinguishable from a correctly-counted one that forgot
 prterun ... --prtemca pmix_server_verbose 2 --leave-session-attached \
     /opt/prte/ompi/bin/mpinoop --all 2>&1 | grep -c "DMODX REQ FOR"
 ```
+
+## 20. Asking a peer where it is (`peerinfo`, `test_pmix`)
+
+A daemon does not have to publish, to its local PMIx server, everything it
+knows about every proc of a job. `prte_pmix_lazy_procdata` publishes only
+the procs that daemon hosts and derives the rest out of its own job object
+when PMIx brings it a request — see
+[`src/prted/pmix/AGENTS.md`](../../src/prted/pmix/AGENTS.md), *What a daemon
+publishes, and what it derives*.
+
+**Nothing else in this harness asks one rank about another rank.** Every
+other client either puts its own data and reads it back, or asks about the
+job rather than about a peer, and both are answered out of the local
+server's cache without the daemon ever being consulted. So the derivation
+could be switched on, the whole suite run green, and the path never once
+have executed — which is exactly what happened the first time it was
+written, and why the change sat unproven.
+
+Read that as a hole in the coverage and not as a finding about workloads.
+PRRTE is not one MPI's runtime; several programming libraries build on it,
+and what any of them asks a peer for is not something this tree can know.
+The harness can show the derived answer is right and that it is what
+answered — it cannot say how often anything wants it.
+
+`peerinfo` is the missing shape: an MPI initialization, in which every rank
+looks up where its peers are. Each rank prints one `SELF` line about itself
+and one `PEER` line about each of the others, in the same field order:
+
+```
+SELF <rank> <fields...>
+PEER <myrank> <peerrank> <fields...>
+```
+
+so the assertion is a string compare — what rank *r* was told about rank
+*p* must be what *p* says about itself. Three things about that:
+
+- **It is the A/B, inside one job.** A `SELF` line is what a proc's own
+  daemon published about it, which a daemon does for its own procs either
+  way; the `PEER` lines about it are what other daemons derived. Comparing
+  two separate *runs* would not work — a second job has a different
+  `PMIX_GLOBAL_RANK` offset, so the tables legitimately differ.
+- **Run it `--map-by node`, across at least two nodes.** On one node every
+  proc is local, nothing is derived, and the case is vacuous. The test
+  asserts the span rather than assuming it.
+- **`PMIX_RANK` is deliberately not in the compared set.** A process does
+  not hold its own rank in its datastore, so a rank asking about itself
+  gets `NOT_FOUND` where a rank asking about a peer gets the value. That is
+  PMIx, not PRRTE. It is checked separately against the one thing that
+  makes it worth checking: the answer has to be the rank that was asked
+  about — which is what catches a derivation that walked to the wrong
+  entry and produced a whole line of plausible values.
+
+A consistent table still cannot tell the two implementations apart, so a
+second case watches the daemon say it did the work:
+
+```sh
+prterun --host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node \
+    --leave-session-attached --prtemca prte_pmix_server_verbose 2 \
+    /opt/prte/prte/bin/peerinfo 2>&1 | grep -c "ANSWERED LOCALLY"
+```
+
+It must be **one per remote proc per daemon** — 24 for that command (four
+daemons, six remote procs each), *not* one per lookup: PMIx caches the
+modex reply, so the second rank on a node asking about the same peer never
+reaches the daemon at all. A count equal to the number of lookups would
+mean the caching is not working; a count of zero means the path did not
+run and everything above it proved nothing. `--leave-session-attached` is
+required, and for the same reason it is in §19: a daemonized `prted` has no
+stderr to read, so without it only the master's traces come back.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -531,6 +531,21 @@ build_linux() {
                 /prrte-src/examples/sessionctrl.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # peerinfo: every rank asks every other rank in its own job where
+            # it is.  Nothing else here does that.  The other clients either
+            # put their own data and read it back, or ask about the job rather
+            # than about a peer, and both of those are answered without the
+            # request ever reaching the daemon -- so the daemon path that
+            # answers for a proc it does not host can be switched on, run the
+            # whole suite green, and never once have executed.  This is the
+            # shape of an MPI initialization, and it needs the peers to be on
+            # other nodes to mean anything.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> peerinfo (peer reserved-key lookup) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/peerinfo \
+                /prrte-src/contrib/dockerswarm/peerinfo.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # Open MPI, if a checkout was bind-mounted.  This is the only
             # thing in the harness that produces a modex an application
             # actually reads back: every other client here puts data because

--- a/contrib/dockerswarm/peerinfo.c
+++ b/contrib/dockerswarm/peerinfo.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * peerinfo -- ask every other rank in my own job where it is, and say what
+ * I was told.
+ *
+ * Each rank prints one SELF line describing itself and one PEER line per
+ * other rank in the job, both in the same field order:
+ *
+ *   SELF <rank> <fields...>
+ *   PEER <myrank> <peerrank> <fields...>
+ *
+ * so the harness can assert the whole thing with a string compare: for
+ * every pair of ranks r and p, the tail of "PEER r p" must equal the tail
+ * of "SELF p".  A rank that cannot answer at all prints
+ * "PEERFAIL <myrank> <peerrank> <key> <status>", and the process exits
+ * non-zero, so a silent partial answer cannot pass.
+ *
+ * Why this exists:
+ *
+ * These are the keys PRRTE decided when it mapped the job - rank, app rank,
+ * local and node rank, node id, hostname, cpuset, locality string.  Every
+ * daemon used to publish all of them, for every proc in the job, to its
+ * local PMIx server, which is a table that grows with the whole job on a
+ * node that will only ever run its own slice of it.  A daemon can instead
+ * publish only the procs it hosts and answer for the rest out of its own
+ * job object when somebody asks, which is what prte_pmix_lazy_procdata
+ * turns on.
+ *
+ * Nothing else in this harness ever asks one rank about another rank's
+ * reserved keys.  Every other client here either puts its own data and
+ * fetches it back, or asks about the job rather than about a peer, and
+ * both of those are answered without the request ever reaching the daemon.
+ * So the whole derive-on-demand path could be switched on, run the entire
+ * suite green, and never once have executed.  This client is the shape of
+ * an MPI initialization - each rank asking where its peers are - and it is
+ * the only thing here that drives a PMIx_Get for a reserved key of a proc
+ * this daemon does not host.
+ *
+ * That is a statement about this harness and nothing more.  PRRTE is not
+ * one MPI's runtime, several programming libraries build on it, and what
+ * any of them asks a peer for is not knowable from this tree - so read the
+ * gap as missing coverage, not as evidence that these keys go unwanted.
+ *
+ * Run it with --map-by node so the peers are genuinely elsewhere; on one
+ * node every answer comes out of the local publication and the interesting
+ * path is not entered.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+static int nfail = 0;
+
+/* Every field is printed even when absent, as "-", so the SELF and PEER
+ * lines line up positionally and can be compared as strings.  An absent
+ * value is a legitimate answer for several of these - an unbound proc has
+ * no cpuset - and the point of the compare is that a rank sees the same
+ * absence about a peer that the peer sees about itself. */
+#define FIELD_MAX 512
+
+static void note_fail(pmix_rank_t peer, const char *key, pmix_status_t rc)
+{
+    printf("PEERFAIL %u %u %s %s\n", myproc.rank, peer, key,
+           PMIx_Error_string(rc));
+    fflush(stdout);
+    ++nfail;
+}
+
+/* Fetch one key and render it into buf.  A key that is simply not there
+ * renders as "-" and is not a failure: whether, say, a cpuset exists is a
+ * property of how the job was bound, and the comparison downstream is what
+ * decides whether the two sides agree about it.  Any other status is a
+ * failure, because it means the question could not be answered at all.
+ *
+ * "self" selects which of those two readings applies to NOT_FOUND when we
+ * are asking about ourselves - it does not change the fetch. */
+static void fetch(pmix_proc_t *target, const char *key, char *buf, size_t sz)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+
+    snprintf(buf, sz, "-");
+    rc = PMIx_Get(target, key, NULL, 0, &val);
+    if (PMIX_ERR_NOT_FOUND == rc) {
+        return;
+    }
+    if (PMIX_SUCCESS != rc) {
+        note_fail(target->rank, key, rc);
+        return;
+    }
+    if (NULL == val) {
+        note_fail(target->rank, key, PMIX_ERR_BAD_PARAM);
+        return;
+    }
+    switch (val->type) {
+    case PMIX_PROC_RANK:
+        snprintf(buf, sz, "%u", val->data.rank);
+        break;
+    case PMIX_UINT32:
+        snprintf(buf, sz, "%u", val->data.uint32);
+        break;
+    case PMIX_UINT16:
+        snprintf(buf, sz, "%u", (unsigned) val->data.uint16);
+        break;
+    case PMIX_STRING:
+        snprintf(buf, sz, "%s",
+                 (NULL == val->data.string) ? "-" : val->data.string);
+        break;
+    default:
+        snprintf(buf, sz, "?type%d", (int) val->type);
+        break;
+    }
+    PMIX_VALUE_RELEASE(val);
+}
+
+/* The keys PRRTE is the authority for.  This list is deliberately the same
+ * set the daemon can derive: a key added to the derivation and not to this
+ * list is a key nothing tests, and a key on this list that the daemon
+ * cannot derive shows up here as a disagreement rather than as silence.
+ *
+ * PMIX_RANK is deliberately absent.  A process does not hold its own
+ * PMIX_RANK in its datastore - it was handed its identity at init and there
+ * is nothing there to look up - so a rank asking about itself gets
+ * NOT_FOUND where a rank asking about a peer gets the value.  That is a
+ * property of PMIx and has nothing to do with what is under test here, but
+ * it would make every SELF/PEER pair disagree on the first field.  It is
+ * checked separately, against the one thing that makes it worth checking:
+ * the answer has to be the rank we asked about. */
+static const char *keys[] = {
+    PMIX_GLOBAL_RANK,
+    PMIX_APP_RANK,
+    PMIX_APPNUM,
+    PMIX_LOCAL_RANK,
+    PMIX_NODE_RANK,
+    PMIX_NODEID,
+    PMIX_HOSTNAME,
+    PMIX_CPUSET,
+    PMIX_LOCALITY_STRING,
+    NULL
+};
+
+static void describe(pmix_proc_t *target, char *out, size_t sz)
+{
+    char field[FIELD_MAX];
+    size_t used = 0;
+    int k, n;
+
+    out[0] = '\0';
+    for (k = 0; NULL != keys[k]; k++) {
+        fetch(target, keys[k], field, sizeof(field));
+        /* snprintf reports what it WOULD have written, so accumulating its
+         * return value walks `used` past the buffer on the first truncation
+         * and every pointer built from it afterwards is out of bounds. Stop
+         * at the truncation instead. The caller sizes `out` for the whole
+         * line, so this is a backstop rather than an expected path - but a
+         * line that silently ran short would read as a disagreement. */
+        n = snprintf(out + used, sz - used, "%s%s", (0 == k) ? "" : " ", field);
+        if (0 > n || (size_t) n >= sz - used) {
+            break;
+        }
+        used += (size_t) n;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_proc_t wildcard, target;
+    pmix_value_t *val = NULL;
+    uint32_t jobsize = 0, r;
+    char line[FIELD_MAX * 12];
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+    rc = PMIx_Get(&wildcard, PMIX_JOB_SIZE, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        fprintf(stderr, "ERROR job size: %s\n", PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    jobsize = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+
+    /* describe myself first.  This is answered out of what my own daemon
+     * published about me, which it publishes either way, so it is the
+     * fixed point the peers' answers are judged against */
+    describe(&myproc, line, sizeof(line));
+    printf("SELF %u %s\n", myproc.rank, line);
+    fflush(stdout);
+
+    for (r = 0; r < jobsize; r++) {
+        if ((pmix_rank_t) r == myproc.rank) {
+            continue;
+        }
+        PMIX_LOAD_PROCID(&target, myproc.nspace, (pmix_rank_t) r);
+        describe(&target, line, sizeof(line));
+        printf("PEER %u %u %s\n", myproc.rank, r, line);
+        fflush(stdout);
+        /* the one field with a right answer known here rather than by
+         * comparison: whoever answered has to have answered about the proc
+         * we named.  A derivation that walked to the wrong entry produces a
+         * whole line of plausible values, and this is what catches it. */
+        fetch(&target, PMIX_RANK, line, sizeof(line));
+        if (0 != strcmp(line, "-") && (unsigned long) r != strtoul(line, NULL, 10)) {
+            printf("PEERFAIL %u %u %s answered for rank %s\n", myproc.rank, r,
+                   PMIX_RANK, line);
+            fflush(stdout);
+            ++nfail;
+        }
+    }
+
+    printf("PEERINFO-DONE %u %d\n", myproc.rank, nfail);
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return (0 == nfail) ? 0 : 1;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1440,9 +1440,34 @@ test_runtime() {
 # Absolute path -- an app launched into the DVM inherits the daemon PATH,
 # which does not contain the install bindir.  See the note on $DS.
 PT=/opt/prte/prte/bin/proctable
+# ...and the client that asks a peer where it is, for the same reason.
+PI=/opt/prte/prte/bin/peerinfo
+
+# Cross-check one peerinfo run.  Every rank prints a SELF line about itself
+# and a PEER line about each of the others, in the same field order, so the
+# assertion is a string compare: what rank r was told about rank p must be
+# what rank p says about itself.  Prints nothing when the run is consistent,
+# and one line per disagreement otherwise.
+peerinfo_mismatches() {
+    echo "$1" | tr -d '\r' | awk '
+        $1 == "SELF" { r = $2; s = ""; for (i = 3; i <= NF; i++) { s = s " " $i }
+                       self[r] = s; next }
+        $1 == "PEER" { n++; who[n] = $2 " about " $3; tgt[n] = $3;
+                       s = ""; for (i = 4; i <= NF; i++) { s = s " " $i }
+                       got[n] = s; next }
+        END {
+            for (k = 1; k <= n; k++) {
+                if (!(tgt[k] in self)) {
+                    print "rank " who[k] ": that rank printed no SELF line"
+                } else if (got[k] != self[tgt[k]]) {
+                    print "rank " who[k] ": got [" got[k] " ] but it says [" self[tgt[k]] " ]"
+                }
+            }
+        }'
+}
 
 test_pmix() {
-    local out rc n hosts undef
+    local out rc n hosts undef peers lazyout eagerout mism a b vrb
 
     banner "pmix: the queried proc table carries a real state for every proc"
     # PMIX_QUERY_PROC_TABLE is the only caller of prte_pmix_convert_state(),
@@ -1644,6 +1669,113 @@ test_pmix() {
             fi
         fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "pmix: a rank can locate every peer in its job, on any node"
+    # This is the one case in the suite where a process asks about ANOTHER
+    # process's reserved keys.  Everything else either puts its own data and
+    # reads it back, or asks about the job rather than about a peer -- and
+    # both of those are satisfied without the request ever reaching a daemon.
+    #
+    # It matters because of what the daemon may legitimately not have
+    # published.  Registering a PMIx entry for every proc in the job, on every
+    # daemon, builds a table that grows with the whole job on a node that runs
+    # a fixed slice of it, so prte_pmix_lazy_procdata publishes only the procs
+    # this daemon hosts and derives the rest from its own job object when
+    # somebody asks.  The derivation is reached through the direct-modex
+    # up-call, which is a path no single-host run has: on one node every proc
+    # is local and there is nothing to derive.
+    #
+    # The assertion is a cross-check rather than a spot value, because the
+    # interesting failure is not "no answer" but "a plausible wrong answer" --
+    # a derived field taken from the wrong proc still prints.  Every rank says
+    # what it thinks about itself and about each of its peers, and the two
+    # accounts of any given rank must agree word for word.
+    cleanup_swarm
+    if ! RUN "test -x $PI"; then
+        skp "peerinfo client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the peer-lookup tests"
+        cleanup_swarm
+    else
+        peers="--host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node"
+        lazyout=$(PRUN "$peers $PI" 2>&1)
+        n=$(echo "$lazyout" | grep -c '^PEERINFO-DONE')
+        [ "$n" = 8 ] \
+            && ok "all 8 ranks completed their peer lookups" \
+            || bad "$n of 8 ranks finished: $(echo "$lazyout" | tr '\n' ' ' | tail -c 400)"
+        n=$(echo "$lazyout" | grep -c '^PEERFAIL')
+        [ "$n" = 0 ] \
+            && ok "...with no lookup failing" \
+            || bad "$n peer lookups failed: $(echo "$lazyout" | grep '^PEERFAIL' | tr '\n' ' ' | tail -c 400)"
+        # 8 ranks each describing the other 7
+        n=$(echo "$lazyout" | grep -c '^PEER ')
+        [ "$n" = 56 ] \
+            && ok "...and all 56 peer descriptions were produced" \
+            || bad "got $n of 56 peer descriptions"
+        # ...and the run has to actually span nodes, or a green result here
+        # says nothing: every answer would have come from local publication.
+        hosts=$(echo "$lazyout" | awk '$1=="SELF"' | tr -d '\r' | awk '{print $(NF-2)}' | sort -u | grep -c '^node')
+        [ "${hosts:-0}" -ge 2 ] \
+            && ok "...across $hosts nodes (so the peers really are remote)" \
+            || bad "the job did not span nodes -- this case would be vacuous"
+        mism=$(peerinfo_mismatches "$lazyout")
+        [ -z "$mism" ] \
+            && ok "...and every rank's account of a peer matches that peer's own" \
+            || bad "peer descriptions disagree: $(echo "$mism" | head -3 | tr '\n' ' ' | tail -c 500)"
+
+        # Note what that comparison already is: a SELF line is what the
+        # proc's OWN daemon published about it -- which a daemon does for
+        # its own procs either way -- while the PEER lines about it are what
+        # other daemons derived.  So the check above is the A/B, run inside
+        # one job where the offsets and the mapping are fixed.  Comparing
+        # two separate runs would not be: a second job has a different
+        # PMIX_GLOBAL_RANK offset, so the tables legitimately differ.
+        #
+        # The same job with the derivation off is therefore a control on the
+        # client rather than a second reading: it must pass here too, or a
+        # failure above says nothing about the derivation.
+        eagerout=$(PRUN "$peers --prtemca prte_pmix_lazy_procdata 0 $PI" 2>&1)
+        mism=$(peerinfo_mismatches "$eagerout")
+        n=$(echo "$eagerout" | grep -c '^PEERFAIL')
+        if [ -z "$mism" ] && [ "$n" = 0 ]; then
+            ok "eager publication (prte_pmix_lazy_procdata 0) passes the same check"
+        else
+            bad "the check fails with the derivation off, so it is not testing the derivation: $(echo "$mism" | head -2 | tr '\n' ' ' | tail -c 400)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "pmix: the derivation is actually what answered"
+    # Consistency alone cannot tell the two implementations apart -- a
+    # derivation that never ran would leave the eager publication answering
+    # and every check above would still pass.  So watch the daemon say it.
+    # This has to be prterun rather than a prun into a standing DVM: the
+    # verbosity is a daemon-side setting, and only the launch that starts the
+    # daemons can carry it.  --leave-session-attached because a daemonized
+    # prted has no stderr to read.
+    if ! RUN "test -x $PI"; then
+        skp "peerinfo client not installed -- re-run ./build.sh"
+    else
+        vrb="--leave-session-attached --prtemca prte_pmix_server_verbose 2"
+        out=$(RUN "timeout -k 5 150 prterun --host node1:2,node2:2,node3:2,node4:2 \
+                     -n 8 --map-by node $vrb $PI" 2>&1)
+        n=$(echo "$out" | grep -c 'ANSWERED LOCALLY')
+        [ "${n:-0}" -gt 0 ] \
+            && ok "a daemon answered $n peer lookups out of its own job object" \
+            || bad "no lookup was answered by the derivation -- the path did not run: $(echo "$out" | grep -c 'DMODX REQ') dmodex requests seen"
+        n=$(echo "$out" | grep -c '^PEERFAIL')
+        [ "$n" = 0 ] \
+            && ok "...and none of the lookups failed" \
+            || bad "$n lookups failed while the derivation was in use"
+        # ...and with it off, nothing may claim to have derived anything.
+        out=$(RUN "timeout -k 5 150 prterun --host node1:2,node2:2,node3:2,node4:2 \
+                     -n 8 --map-by node $vrb --prtemca prte_pmix_lazy_procdata 0 $PI" 2>&1)
+        echo "$out" | grep -q 'ANSWERED LOCALLY' \
+            && bad "the derivation ran even though prte_pmix_lazy_procdata was 0" \
+            || ok "prte_pmix_lazy_procdata 0 turns the derivation off completely"
     fi
     cleanup_swarm
 }

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -189,6 +189,76 @@ client hangs forever.
 
 ---
 
+## What a daemon publishes, and what it derives
+
+`prte_pmix_server_register_nspace()` used to hand its local PMIx server a
+`PMIX_PROC_INFO_ARRAY` for **every** proc of a job — rank, global rank,
+app rank, appnum, local and node rank, node id, hostname, cpuset and the
+locality string generated from it. Every daemon, for the whole job. That
+is a table proportional to the job on a node that will only ever run its
+own slice of it, and `prte_hostname_cutoff` — which drops one field of it
+above a thousand nodes — is the record of that wall having been met once
+already.
+
+With `prte_pmix_lazy_procdata` (the default where PMIx allows it) a daemon
+publishes only the procs it hosts. Everything it withheld is still in its
+own job object, so when PMIx asks for one of those procs through the
+`direct_modex` upcall, `dmodex_req()` answers out of `jdata->procs[rank]`
+instead of going to the hosting daemon. Four things about that are load
+bearing:
+
+- **The key set is what PRRTE is the authority for, not what an app wants.**
+  `derivable_key()` lists the placement and binding this DVM computed —
+  a closed set. Everything else on a proc was put there by the application,
+  and PRRTE knows nothing about it, so those requests go out on the wire
+  exactly as before. Do not extend the list by guessing at what some MPI
+  asks for.
+- **`derive_proc_data()` mirrors the per-proc section of
+  `register_nspace()`.** A key added to one and not the other is a key
+  that becomes a wire round trip (harmless, but a silent loss of the
+  point), or worse, one whose two spellings disagree. `PMIX_PARENT_ID` and
+  `PMIX_DEVICE_DISTANCES` are deliberately *not* derived: they are still
+  published by the daemon that hosts the proc, so a request for one falls
+  through to that daemon and is answered there.
+- **The answer is a packed blob of `pmix_kval_t`, not a bare success.**
+  PMIx stores a modex reply itself, and for a specific rank it stores it
+  under `PMIX_REMOTE` — which is where the re-satisfy after a reply then
+  looks. Storing the values here with `PMIx_Data_store_internal` would put
+  them in `PMIX_INTERNAL`, which that lookup does not reach, and the
+  request would fail with the data sitting in memory. (The empty-blob
+  answer is correct only for `PMIX_RANK_WILDCARD`, where PMIx assumes
+  `register_nspace` supplied it.)
+- **A refresh must not be answered from here.** `PMIX_GET_REFRESH_CACHE` is
+  the caller saying our copy may be stale, which is exactly when we must
+  go and ask.
+
+**This depends on a PMIx that surfaces the request at all**, which is why
+it could not have been written earlier: a client's get for a reserved key
+its server did not hold used to have `PMIX_IMMEDIATE` forced onto it,
+confining the search to that server and answering `PMIX_ERR_NOT_FOUND`
+without ever up-calling. Not a live concern — PRRTE requires PMIx 7.0 at
+configure *and* at runtime (`pmix_server.c`, `PRTE_PMIX_MINIMUM_VERSION`),
+and every PMIx that clears that bar surfaces the request.
+
+**What a peer may ask for is not knowable from this tree.** PRRTE is not
+one MPI's runtime; several programming libraries build on it, and any of
+them may read a reserved key of a proc on another node. That is the whole
+reason the split is drawn at *what PRRTE is the authority for* rather than
+at what anything has been observed to want, and it is why the wire path
+below the derivation has to stay correct rather than becoming vestigial.
+In particular, do not read the test coverage below as evidence that these
+keys are rarely wanted — it says what the harness does, and nothing about
+what an application does.
+
+Nothing on one node exercises any of this — every proc is local and there
+is nothing to derive. `contrib/dockerswarm`'s `peerinfo` client is what
+does: each rank asks every other rank in its job where it is, and the
+harness asserts that what a rank was told about a peer is what that peer
+says about itself. That comparison *is* the A/B, because a proc's own
+daemon publishes its data either way.
+
+---
+
 ## Info-array expansion
 
 Several relays add an entry (usually `PMIX_REQUESTOR`) to an info array

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -448,6 +448,20 @@ void pmix_server_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_pmix_server_globals.allow_client_clones);
 
+    /* Publish per-proc data only for the procs we host, and derive the rest on
+     * demand.  Every daemon registering a PMIx entry for every proc in the job
+     * is a table that grows with the job while the work on the node does not;
+     * the placement it describes is derivable here from the job object, so the
+     * direct-modex upcall can answer for a proc we do not host without any
+     * wire traffic.  See derive_proc_data() in pmix_server_fence.c. */
+    prte_pmix_server_globals.lazy_procdata = true;
+    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "lazy_procdata",
+                                      "Publish per-proc data to the local PMIx server only "
+                                      "for procs this daemon hosts, deriving data for other "
+                                      "procs on demand",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_pmix_server_globals.lazy_procdata);
+
     /* whether or not to drop a session-level tool rendezvous point */
     prte_pmix_server_globals.session_server = false;
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "session_server",

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -33,6 +33,7 @@
 #    include <unistd.h>
 #endif
 
+#include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/util/pmix_output.h"
 
@@ -87,6 +88,13 @@ static void wildcard_reg_complete(pmix_status_t status, void *cbdata)
     }
     PMIX_RELEASE(req);
 }
+
+/* answering a dmodex from the job object rather than from the hosting
+ * daemon - defined below, next to the key set they cover */
+static bool derivable_key(const char *key);
+static pmix_status_t derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
+                                      pmix_data_buffer_t *buf);
+static void derived_relfn(void *cbdata);
 
 static void dmodex_req(int sd, short args, void *cbdata)
 {
@@ -202,11 +210,65 @@ static void dmodex_req(int sd, short args, void *cbdata)
     }
 
     /* A proc object exists from the moment the job is created, and it is the
-     * mapper that gives it a node - so a request arriving for a job whose
+     * mapper that gives it a node - so a request that arrives for a job whose
      * mapping has not finished finds one with nothing to say about where it
-     * is.  That is the same answer as a proc whose node has no daemon, and it
-     * has to be reached the same way rather than by dereferencing NULL. */
-    if (NULL == proct->node || NULL == (dmn = proct->node->daemon)) {
+     * is.  Nothing below can be answered without that, derived or fetched. */
+    if (NULL == proct->node) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        prc = PMIX_ERR_NOT_FOUND;
+        goto callback;
+    }
+
+    /* If what they want is something we decided when we mapped this job, we
+     * already know it - asking the daemon that hosts the proc would be asking
+     * it to read back our own answer.  This is the other half of the lazy
+     * registration in prte_pmix_server_register_nspace(): that one declines to
+     * publish what nobody may ever want, and this one produces it the moment
+     * somebody does.  A refresh is the caller telling us our copy may be
+     * stale, which is exactly when we must not answer from it.
+     *
+     * This is deliberately ahead of resolving the hosting daemon, because it
+     * does not need one.  A proc whose daemon has gone - a lost node, a
+     * shrink - can still be said to have been placed where it was placed, and
+     * that is an answer eager publication would have had in hand.  Requiring
+     * a live daemon here would turn it into a failure. */
+    if (prte_pmix_server_globals.lazy_procdata && !refresh_cache &&
+        derivable_key(req->key)) {
+        pmix_data_buffer_t dbuf;
+        pmix_byte_object_t bo;
+
+        PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+        prc = derive_proc_data(jdata, proct, &dbuf);
+        if (PMIX_SUCCESS == prc) {
+            PMIX_DATA_BUFFER_UNLOAD(&dbuf, bo.bytes, bo.size);
+            PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s DMODX REQ FOR %s:%u KEY %s ANSWERED LOCALLY (%lu bytes)",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                req->tproc.nspace, req->tproc.rank, req->key,
+                                (unsigned long) bo.size);
+            if (NULL != req->mdxcbfunc) {
+                req->mdxcbfunc(PMIX_SUCCESS, bo.bytes, bo.size, req->cbdata,
+                               derived_relfn, bo.bytes);
+            } else {
+                free(bo.bytes);
+            }
+            /* we answered before ever being tracked, so there is usually
+             * nothing to clear - the constructor leaves local_index at -1 */
+            if (0 <= req->local_index) {
+                pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                            req->local_index, NULL);
+            }
+            PMIX_RELEASE(req);
+            return;
+        }
+        /* we could not build it - fall through and ask the host daemon, which
+         * is what we would have done anyway */
+        PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+        prc = PMIX_ERROR;
+    }
+
+    if (NULL == (dmn = proct->node->daemon)) {
         /* we don't know where this proc is located - since we already
          * found the job, and therefore know about its locations, this
          * must be an error */
@@ -214,6 +276,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
         prc = PMIX_ERR_NOT_FOUND;
         goto callback;
     }
+
     /* point the request to the daemon that is hosting the
      * target process */
     req->proxy = dmn->name;
@@ -278,6 +341,173 @@ callback:
         req->mdxcbfunc(prc, NULL, 0, req->cbdata, NULL, NULL);
     }
     PMIX_RELEASE(req);
+}
+
+/* ---- deriving a remote proc's data instead of fetching it -------------
+ *
+ * With prte_pmix_server_globals.lazy_procdata set, register_nspace publishes
+ * per-proc data only for the procs this daemon hosts.  Everything it would
+ * have published about the others is still right here, in the job object the
+ * launch message built, so a request for one of them is answered from local
+ * memory rather than by asking the daemon that hosts it.
+ *
+ * These are exactly the keys PRRTE is the *authority* for - the placement and
+ * binding it decided when it mapped the job.  Anything else a proc holds was
+ * put there by the application, which PRRTE knows nothing about, so those
+ * requests still go out on the wire as they always did.  That is what makes
+ * the split safe without knowing anything about who is asking or why: we are
+ * not guessing which keys matter, only answering for the ones we own.
+ *
+ * The answer goes back as a packed blob of pmix_kval_t, byte-identical in
+ * shape to what a real direct modex returns, because PMIx stores the reply
+ * itself and the scope it stores it in has to match what the re-satisfy after
+ * a dmodex reply then looks in (PMIX_REMOTE, for a specific rank).  Storing
+ * the values ourselves with PMIx_Data_store_internal would put them in the
+ * INTERNAL scope, which that lookup does not reach.
+ */
+static bool derivable_key(const char *key)
+{
+    if (NULL == key) {
+        /* no key named means "everything you have", and we do not have the
+         * application's half of it */
+        return false;
+    }
+    return PMIx_Check_key(key, PMIX_RANK) ||
+           PMIx_Check_key(key, PMIX_GLOBAL_RANK) ||
+           PMIx_Check_key(key, PMIX_APP_RANK) ||
+           PMIx_Check_key(key, PMIX_APPNUM) ||
+           PMIx_Check_key(key, PMIX_LOCAL_RANK) ||
+           PMIx_Check_key(key, PMIX_NODE_RANK) ||
+           PMIx_Check_key(key, PMIX_NODEID) ||
+           PMIx_Check_key(key, PMIX_HOSTNAME) ||
+           PMIx_Check_key(key, PMIX_CPUSET) ||
+           PMIx_Check_key(key, PMIX_LOCALITY_STRING) ||
+           PMIx_Check_key(key, PMIX_REINCARNATION);
+}
+
+static pmix_status_t pack_derived(pmix_data_buffer_t *buf, const char *key,
+                                  pmix_value_t *val)
+{
+    pmix_kval_t kv;
+    pmix_status_t rc;
+
+    /* a stack kval is fine here: the packer reads only key and value, and the
+     * value's storage belongs to our caller either way */
+    kv.key = (char *) key;
+    kv.value = val;
+    rc = PMIx_Data_pack(NULL, buf, &kv, 1, PMIX_KVAL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+    return rc;
+}
+
+#define PACK_DERIVED(r, b, k, t, d)                     \
+    do {                                                \
+        pmix_value_t _v = PMIX_VALUE_STATIC_INIT;       \
+        _v.type = (t);                                  \
+        _v.d;                                           \
+        (r) = pack_derived((b), (k), &_v);              \
+    } while (0)
+
+/* Build the blob describing one proc.  Mirrors the per-proc section of
+ * prte_pmix_server_register_nspace() - if a key is added there and a peer can
+ * ask for it, it belongs here too, or that key becomes a wire round trip. */
+static pmix_status_t derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
+                                      pmix_data_buffer_t *buf)
+{
+    pmix_status_t rc;
+    pmix_rank_t vpid;
+    uint32_t ui32;
+
+    PACK_DERIVED(rc, buf, PMIX_RANK, PMIX_PROC_RANK, data.rank = proct->name.rank);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    vpid = proct->name.rank + jdata->offset;
+    PACK_DERIVED(rc, buf, PMIX_GLOBAL_RANK, PMIX_PROC_RANK, data.rank = vpid);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    PACK_DERIVED(rc, buf, PMIX_APP_RANK, PMIX_PROC_RANK, data.rank = proct->app_rank);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    PACK_DERIVED(rc, buf, PMIX_APPNUM, PMIX_UINT32, data.uint32 = proct->app_idx);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    if (PRTE_LOCAL_RANK_INVALID != proct->local_rank) {
+        PACK_DERIVED(rc, buf, PMIX_LOCAL_RANK, PMIX_UINT16, data.uint16 = proct->local_rank);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+    if (PRTE_NODE_RANK_INVALID != proct->node_rank) {
+        PACK_DERIVED(rc, buf, PMIX_NODE_RANK, PMIX_UINT16, data.uint16 = proct->node_rank);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+    PACK_DERIVED(rc, buf, PMIX_NODEID, PMIX_UINT32, data.uint32 = proct->node->index);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    /* the hostname is gated by prte_hostname_cutoff in the eager registration,
+     * because there it is paid for every proc in the job whether or not anyone
+     * wants it.  Here it is paid only when somebody asks, so there is nothing
+     * to ration. */
+    PACK_DERIVED(rc, buf, PMIX_HOSTNAME, PMIX_STRING, data.string = proct->node->name);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    ui32 = 0;
+    PACK_DERIVED(rc, buf, PMIX_REINCARNATION, PMIX_UINT32, data.uint32 = ui32);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    if (NULL != proct->cpuset) {
+        char *locality = NULL;
+        pmix_cpuset_t cpuset;
+
+        PACK_DERIVED(rc, buf, PMIX_CPUSET, PMIX_STRING, data.string = proct->cpuset);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        PMIX_CPUSET_CONSTRUCT(&cpuset);
+        cpuset.source = "hwloc";
+        cpuset.bitmap = hwloc_bitmap_alloc();
+        hwloc_bitmap_list_sscanf(cpuset.bitmap, proct->cpuset);
+        rc = PMIx_server_generate_locality_string(&cpuset, &locality);
+        hwloc_bitmap_free(cpuset.bitmap);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+        PACK_DERIVED(rc, buf, PMIX_LOCALITY_STRING, PMIX_STRING, data.string = locality);
+        if (NULL != locality) {
+            free(locality);
+        }
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    } else {
+        /* an unbound proc still has to answer the locality question, and the
+         * answer is "nothing to say" - the eager path registers a NULL for
+         * exactly this case */
+        PACK_DERIVED(rc, buf, PMIX_LOCALITY_STRING, PMIX_STRING, data.string = NULL);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* PMIx is done with the blob we synthesized */
+static void derived_relfn(void *cbdata)
+{
+    free(cbdata);
 }
 
 /* the local PMIx embedded server will use this function to call

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -201,7 +201,12 @@ static void dmodex_req(int sd, short args, void *cbdata)
         goto callback;
     }
 
-    if (NULL == (dmn = proct->node->daemon)) {
+    /* A proc object exists from the moment the job is created, and it is the
+     * mapper that gives it a node - so a request arriving for a job whose
+     * mapping has not finished finds one with nothing to say about where it
+     * is.  That is the same answer as a proc whose node has no daemon, and it
+     * has to be reached the same way rather than by dereferencing NULL. */
+    if (NULL == proct->node || NULL == (dmn = proct->node->daemon)) {
         /* we don't know where this proc is located - since we already
          * found the job, and therefore know about its locations, this
          * must be an error */

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -480,6 +480,12 @@ typedef struct {
     char *report_uri;
     char *singleton;
     pmix_device_type_t generate_dist;
+    /* Publish per-proc data to the local PMIx server only for the procs this
+     * daemon actually hosts, and derive the rest on demand when PMIx asks for
+     * them through the direct-modex upcall.  Registering every proc in the job
+     * on every daemon costs a table that grows with the total process count on
+     * a node that will run a fixed slice of it. */
+    bool lazy_procdata;
     pmix_list_t psets;
     pmix_list_t groups;
 } prte_pmix_server_globals_t;


### PR DESCRIPTION
## Problem

Every daemon publishes a PMIx proc-data entry for **every** process in the job — rank, cpuset and the locality string generated from it, app rank, local rank, node rank, node id, reincarnation. That is a table which grows with the whole job on a node that will only ever run its own slice of it. `prte_hostname_cutoff` exists to keep one field of that table out of the picture above a thousand nodes, which says the wall has been met once already.

None of it is knowledge the hosting daemon has and we lack: it is the placement this DVM decided when it mapped the job, and the launch message already put all of it in our own job object.

## What this does

Publish only the procs we host, and answer for the others when somebody asks — the direct-modex upcall already has the target's `prte_proc_t` in hand at the point where it decides to go out on the wire. PMIx caches what a modex returns, so the cost is one local upcall per remote proc anybody on that node genuinely wants, not one per query.

Notes on the shape of it:

- **The key set is what PRRTE is the authority for**, not a guess at what matters. PRRTE is not a runtime for one MPI, and no runtime can know what an application will ask its peers for. What it can know is which keys it is itself the source of — the placement and binding it computed — and that is a closed set. Everything else on a proc was put there by the application and still goes out on the wire exactly as before, as do the two keys the hosting daemon remains the only one to publish (parent ID, device distances). Nothing here narrows what a peer can ask for; it changes only which daemon answers, and only for keys this one owns.
- **The reply is a packed blob of `pmix_kval_t`, not a bare success.** PMIx stores a modex reply itself, and for a specific rank it stores it in the `REMOTE` scope — which is where it looks when it re-satisfies the request afterwards. Storing the values with `PMIx_Store_internal` would put them in `INTERNAL`, which that lookup does not reach, and the request would fail with the data sitting in memory.
- **The derivation is reached before the hosting daemon is resolved**, because it does not need one: a proc whose daemon has gone can still be said to have been placed where it was placed, and that is an answer eager publication would have had in hand.
- Gated on `prte_pmix_lazy_procdata` (default on) so it can be turned off and compared.

This could not have been written against an older PMIx, which forced `PMIX_IMMEDIATE` onto a get for a reserved key the local server did not hold and so answered `NOT_FOUND` without ever asking the host. Not a case this has to carry — PRRTE requires PMIx 7.0 at configure and re-checks it at runtime.

## Testing

What kept this parked was that nothing could be shown to exercise it. No client in the test harness asks one rank about **another** rank — they read back what they put themselves, or ask about the job, and both are answered from the local server's cache — so the path could be on, the suite green, and the code never run. That was a hole in the coverage, not a finding about workloads.

`contrib/dockerswarm/peerinfo.c` fills it: every rank asks every other rank in its job where it is (the shape of an MPI initialization). The harness asserts that what a rank was told about a peer is what that peer says about itself — that comparison **is** the A/B, inside one job, because a proc's own daemon publishes its data either way. A second case reads the daemons' traces and requires the derivation to have answered once per remote proc **per daemon** — 24 for eight ranks over four nodes, not once per lookup, which is what shows the caching works.

- macOS `--enable-debug` build: warning-free; `make check` passes
- Full `contrib/dockerswarm` suite: **530 passed, 0 failed, 0 skipped**

## Also here

Two small commits that stand on their own:

- a dmodex request naming a proc the mapper has not yet placed dereferenced a NULL `proct->node`
- `AGENTS.md` still named PMIx 6.1.0 as the minimum in two places; it is 7.0.0, enforced at configure and at runtime